### PR TITLE
Fix bug where IDs were not quoted when converting queries to strings

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/StringConverter.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/StringConverter.java
@@ -44,14 +44,37 @@ public class StringConverter {
     }
 
     /**
+     * @param string a string to quote and escape
+     * @return a string, surrounded with double quotes and escaped
+     */
+    private static String quoteString(String string) {
+        return "\"" + escapeString(string) + "\"";
+    }
+
+    /**
      * @param value a value in the graph
      * @return the string representation of the value (using quotes if it is already a string)
      */
     public static String valueToString(Object value) {
         if (value instanceof String) {
-            return "\"" + escapeString((String) value) + "\"";
+            return quoteString((String) value);
         } else {
             return value.toString();
+        }
+    }
+
+    /**
+     * @param id an id of a concept
+     * @return
+     * The id of the concept correctly escaped in graql.
+     * If the ID doesn't begin with a number and is only comprised of alphanumeric characters, underscores and dashes,
+     * then it will be returned as-is, otherwise it will be quoted and escaped.
+     */
+    public static String idToString(String id) {
+        if (id.matches("^[a-zA-Z_][a-zA-Z0-9_-]*$")) {
+            return id;
+        } else {
+            return quoteString(id);
         }
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/VarImpl.java
@@ -366,7 +366,7 @@ public class VarImpl implements Var.Admin {
         if (userDefinedName) {
             return "$" + name;
         } else {
-            return getId().orElse("$" + name);
+            return getId().map(StringConverter::idToString).orElse("$" + name);
         }
     }
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/parser/QueryToStringTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/parser/QueryToStringTest.java
@@ -28,6 +28,7 @@ import io.mindmaps.graql.api.query.QueryBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.mindmaps.graql.api.query.QueryBuilder.id;
 import static io.mindmaps.graql.api.query.QueryBuilder.or;
 import static io.mindmaps.graql.api.query.QueryBuilder.var;
 import static io.mindmaps.graql.api.query.ValuePredicate.lte;
@@ -119,6 +120,22 @@ public class QueryToStringTest {
     @Test
     public void testEscapeStrings() {
         assertEquals("insert $x value \"hello\\nworld\";", qb.insert(var("x").value("hello\nworld")).toString());
+    }
+
+    @Test
+    public void testQuoteIds() {
+        assertEquals(
+                "match $a (\"hello\\tworld\")",
+                QueryBuilder.build().match(var("a").rel(id("hello\tworld"))).toString()
+        );
+    }
+
+    @Test
+    public void testQuoteIdsNumbers() {
+        assertEquals(
+                "match $a (\"1hi\")",
+                QueryBuilder.build().match(var("a").rel(id("1hi"))).toString()
+        );
     }
 
     @Test(expected=UnsupportedOperationException.class)


### PR DESCRIPTION
Some IDs must be quoted in Graql, for example if they contain spaces, newlines, punctuation or other illegal characters.
