### PR TITLE
Make queries mostly immutable

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/parser/Autocomplete.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/parser/Autocomplete.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.api.parser;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.mindmaps.core.dao.MindmapsTransaction;
 import io.mindmaps.core.model.Concept;
@@ -39,7 +40,7 @@ import java.util.stream.Stream;
  */
 public class Autocomplete {
 
-    private final Set<String> candidates;
+    private final ImmutableSet<String> candidates;
     private final int cursorPosition;
 
     /**
@@ -73,7 +74,7 @@ public class Autocomplete {
      */
     private Autocomplete(MindmapsTransaction transaction, String query, int cursorPosition) {
         Optional<? extends Token> optToken = getCursorToken(query, cursorPosition);
-        candidates = findCandidates(transaction, query, optToken);
+        candidates = ImmutableSet.copyOf(findCandidates(transaction, query, optToken));
         this.cursorPosition = findCursorPosition(cursorPosition, optToken);
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/AskQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/AskQuery.java
@@ -33,7 +33,7 @@ public interface AskQuery {
 
     /**
      * @param transaction the transaction to execute the query on
-     * @return this
+     * @return a new AskQuery with the transaction set
      */
     AskQuery withTransaction(MindmapsTransaction transaction);
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/DeleteQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/DeleteQuery.java
@@ -41,7 +41,7 @@ public interface DeleteQuery {
 
     /**
      * @param transaction the transaction to execute the query on
-     * @return this
+     * @return a new DeleteQuery with the transaction set
      */
     DeleteQuery withTransaction(MindmapsTransaction transaction);
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/InsertQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/InsertQuery.java
@@ -38,7 +38,7 @@ public interface InsertQuery extends Streamable<Concept> {
 
     /**
      * @param transaction the transaction to execute the query on
-     * @return this
+     * @return a new InsertQuery with the transaction set
      */
     InsertQuery withTransaction(MindmapsTransaction transaction);
 
@@ -70,5 +70,10 @@ public interface InsertQuery extends Streamable<Concept> {
          * @return a collection of Vars to insert, including any nested vars
          */
         Collection<Var.Admin> getAllVars();
+
+        /**
+         * @return the transaction set on this query, if it was provided one
+         */
+        Optional<MindmapsTransaction> getTransaction();
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/MatchQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/MatchQuery.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.api.query;
 
+import com.google.common.collect.Sets;
 import io.mindmaps.core.dao.MindmapsTransaction;
 import io.mindmaps.core.model.Concept;
 import io.mindmaps.core.model.Type;
@@ -44,17 +45,17 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
 
     /**
      * @param names an array of variable names to select
-     * @return this
+     * @return a new MatchQuery that selects the given variables
      */
     default MatchQuery select(String... names) {
-        return select(Arrays.asList(names));
+        return select(Sets.newHashSet(names));
     }
 
     /**
-     * @param names a collection of variable names to select
-     * @return this
+     * @param names a set of variable names to select
+     * @return a new MatchQuery that selects the given variables
      */
-    MatchQuery select(Collection<String> names);
+    MatchQuery select(Set<String> names);
 
     /**
      * @param name a variable name to get
@@ -106,32 +107,32 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
 
     /**
      * @param transaction the transaction to execute the query on
-     * @return this
+     * @return a new MatchQuery with the transaction set
      */
     MatchQuery withTransaction(MindmapsTransaction transaction);
 
     /**
      * @param limit the maximum number of results the query should return
-     * @return this
+     * @return a new MatchQuery with the limit set
      */
     MatchQuery limit(long limit);
 
     /**
      * @param offset the number of results to skip
-     * @return this
+     * @return a new MatchQuery with the offset set
      */
     MatchQuery offset(long offset);
 
     /**
      * remove any duplicate results from the query
-     * @return this
+     * @return a new MatchQuery without duplicate results
      */
     MatchQuery distinct();
 
     /**
      * Order the results by degree in ascending order
      * @param varName the variable name to order the results by
-     * @return this
+     * @return a new MatchQuery with the given ordering
      */
     default MatchQuery orderBy(String varName) {
         return orderBy(varName, true);
@@ -141,7 +142,7 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
      * Order the results by degree
      * @param varName the variable name to order the results by
      * @param asc whether to use ascending order
-     * @return this
+     * @return a new MatchQuery with the given ordering
      */
     MatchQuery orderBy(String varName, boolean asc);
 
@@ -149,7 +150,7 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
      * Order the results by a resource in ascending order
      * @param varName the variable name to order the results by
      * @param resourceType the resource type attached to the variable to use for ordering
-     * @return this
+     * @return a new MatchQuery with the given ordering
      */
     default MatchQuery orderBy(String varName, String resourceType) {
         return orderBy(varName, resourceType, true);
@@ -160,7 +161,7 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
      * @param varName the variable name to order the results by
      * @param resourceType the resource type attached to the variable to use for ordering
      * @param asc whether to use ascending order
-     * @return this
+     * @return a new MatchQuery with the given ordering
      */
     MatchQuery orderBy(String varName, String resourceType, boolean asc);
 
@@ -187,5 +188,10 @@ public interface MatchQuery extends Streamable<Map<String, Concept>> {
          * @return the pattern to match in the graph
          */
         Pattern.Conjunction<Pattern.Admin> getPattern();
+
+        /**
+         * @return the transaction the query operates on, if one was provided
+         */
+        Optional<MindmapsTransaction> getTransaction();
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/QueryBuilder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/QueryBuilder.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.api.query;
 
+import com.google.common.collect.ImmutableSet;
 import io.mindmaps.core.dao.MindmapsTransaction;
 import io.mindmaps.graql.internal.AdminConverter;
 import io.mindmaps.graql.internal.query.InsertQueryImpl;
@@ -27,6 +28,7 @@ import io.mindmaps.graql.internal.query.VarImpl;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * A starting point for creating queries.
@@ -72,7 +74,7 @@ public class QueryBuilder {
      * @return a match query that will find matches of the given patterns
      */
     public MatchQuery match(Collection<? extends Pattern> patterns) {
-        return new MatchQueryImpl(transaction, Pattern.Admin.conjunction(AdminConverter.getPatternAdmins(patterns)));
+        return new MatchQueryImpl(Pattern.Admin.conjunction(AdminConverter.getPatternAdmins(patterns)), transaction);
     }
 
     /**
@@ -88,7 +90,8 @@ public class QueryBuilder {
      * @return an insert query that will insert the given variables into the graph
      */
     public InsertQuery insert(Collection<? extends Var> vars) {
-        return new InsertQueryImpl(transaction, AdminConverter.getVarAdmins(vars));
+        ImmutableSet<Var.Admin> varAdmins = ImmutableSet.copyOf(AdminConverter.getVarAdmins(vars));
+        return new InsertQueryImpl(varAdmins, Optional.empty(), Optional.ofNullable(transaction));
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/parser/MatchQueryPrinter.java
@@ -21,10 +21,7 @@ package io.mindmaps.graql.internal.parser;
 import io.mindmaps.core.model.Concept;
 import io.mindmaps.graql.api.query.MatchQuery;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
@@ -33,13 +30,14 @@ import java.util.stream.Stream;
 public class MatchQueryPrinter {
 
     private MatchQuery matchQuery;
-    private final Map<String, List<Getter>> getters = new HashMap<>();
+    private final Map<String, List<Getter>> getters;
 
     /**
      * @param matchQuery the match query whose results should be printed
      */
-    public MatchQueryPrinter(MatchQuery matchQuery) {
+    public MatchQueryPrinter(MatchQuery matchQuery, Map<String, List<Getter>> getters) {
         this.matchQuery = matchQuery;
+        this.getters = getters;
     }
 
     public void setMatchQuery(MatchQuery matchQuery) {
@@ -51,14 +49,6 @@ public class MatchQueryPrinter {
      */
     public MatchQuery getMatchQuery() {
         return matchQuery;
-    }
-
-    /**
-     * @param name the variable name to apply the getter to
-     * @param getter the getter to apply to the results of the query
-     */
-    public void addGetter(String name, Getter getter) {
-        getters.computeIfAbsent(name, k -> new ArrayList<>()).add(getter);
     }
 
     /**
@@ -81,7 +71,7 @@ public class MatchQueryPrinter {
     }
 
     private List<Getter> getGetters(String name) {
-        List<Getter> getterList = this.getters.computeIfAbsent(name, k -> new ArrayList<>());
+        List<Getter> getterList = getters.computeIfAbsent(name, k -> new ArrayList<>());
 
         // Add default getters if none provided
         if (getterList.isEmpty()) {

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/AskQueryImpl.java
@@ -43,8 +43,7 @@ public class AskQueryImpl implements AskQuery.Admin {
 
     @Override
     public AskQuery withTransaction(MindmapsTransaction transaction) {
-        matchQuery.withTransaction(transaction);
-        return this;
+        return new AskQueryImpl(matchQuery.withTransaction(transaction));
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryExecutor.java
@@ -1,0 +1,406 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query;
+
+import com.google.common.collect.ImmutableMap;
+import io.mindmaps.core.dao.MindmapsTransaction;
+import io.mindmaps.core.implementation.Data;
+import io.mindmaps.core.implementation.DataType;
+import io.mindmaps.core.model.*;
+import io.mindmaps.graql.api.query.Var;
+import io.mindmaps.graql.internal.GraqlType;
+import io.mindmaps.graql.internal.validation.ErrorMessage;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A class for executing insert queries.
+ *
+ * This behaviour is moved to its own class to allow InsertQueryImpl to have fewer mutable fields.
+ */
+class InsertQueryExecutor {
+
+    private final MindmapsTransaction transaction;
+    private final Collection<Var.Admin> vars;
+    private final Map<String, Concept> concepts = new HashMap<>();
+    private final Stack<String> visitedVars = new Stack<>();
+    private final ImmutableMap<String, List<Var.Admin>> varsByName;
+    private final ImmutableMap<String, List<Var.Admin>> varsById;
+
+    public InsertQueryExecutor(Collection<Var.Admin> vars, MindmapsTransaction transaction) {
+        this.vars = vars;
+        this.transaction = transaction;
+
+        // Group variables by name
+        varsByName = ImmutableMap.copyOf(
+                vars.stream().collect(Collectors.groupingBy(Var.Admin::getName))
+        );
+
+        // Group variables by id (if they have one defined)
+        varsById = ImmutableMap.copyOf(
+                vars.stream()
+                        .filter(var -> var.getId().isPresent())
+                        .collect(Collectors.groupingBy(var -> var.getId().get()))
+        );
+    }
+
+    /**
+     * Insert all the Vars
+     */
+    public Stream<Concept> insertAll() {
+        return insertAll(new HashMap<>());
+    }
+
+    /**
+     * Insert all the Vars
+     * @param results the result of a match query
+     */
+    public Stream<Concept> insertAll(Map<String, Concept> results) {
+        concepts.clear();
+        concepts.putAll(new HashMap<>(results));
+
+        // First insert each var
+        vars.stream().forEach(this::insertVar);
+
+        // Then add resources to each var, streaming out the results.
+        // It is necessary to add resources last to be sure that any 'has-resource' information in the query has
+        // already been added.
+        // TODO: Fix this so this step is no longer necessary (can be done by correctly expanding 'has-resource')
+        return vars.stream().map(this::insertVarResources);
+    }
+
+    /**
+     * @param var the Var to insert into the graph
+     */
+    private Concept insertVar(Var.Admin var) {
+        Concept concept = getConcept(var);
+
+        if (var.getAbstract()) concept.asType().setAbstract(true);
+
+        setValue(var);
+
+        var.getLhs().ifPresent(lhs -> concept.asRule().setLHS(lhs));
+        var.getRhs().ifPresent(rhs -> concept.asRule().setRHS(rhs));
+
+        var.getHasRoles().stream().forEach(role -> concept.asRelationType().hasRole(getConcept(role).asRoleType()));
+        var.getPlaysRoles().stream().forEach(role -> concept.asType().playsRole(getConcept(role).asRoleType()));
+        var.getScopes().stream().forEach(scope -> concept.asRelation().scope(getConcept(scope).asInstance()));
+
+        var.getHasResourceTypes().forEach(resourceType -> addResourceType(var, resourceType));
+
+        var.getCastings().forEach(casting -> addCasting(var, casting));
+
+        return concept;
+    }
+
+    /**
+     * Add all the resources of the given var
+     * @param var the var to add resources to
+     */
+    private Concept insertVarResources(Var.Admin var) {
+        Concept concept = getConcept(var);
+
+        if (!var.getResourceEqualsPredicates().isEmpty()) {
+            Instance instance = concept.asInstance();
+            var.getResourceEqualsPredicates().forEach((type, values) -> addResources(instance, type, values));
+        }
+
+        return concept;
+    }
+
+    /**
+     * @param var the Var that is represented by a concept in the graph
+     * @return the same as addConcept, but using an internal map to remember previous calls
+     */
+    private Concept getConcept(Var.Admin var) {
+        String name = var.getName();
+        if (visitedVars.contains(name)) {
+            throw new IllegalStateException(ErrorMessage.INSERT_RECURSIVE.getMessage(var.getPrintableName()));
+        }
+
+        visitedVars.push(name);
+        Concept concept = concepts.computeIfAbsent(name, n -> addConcept(var));
+        visitedVars.pop();
+        return concept;
+    }
+
+    /**
+     * @param var the Var that is to be added into the graph
+     * @return the concept representing the given Var, creating it if it doesn't exist
+     */
+    private Concept addConcept(Var.Admin var) {
+        var = mergeVar(var);
+
+        Optional<Var.Admin> type = var.getType();
+        Optional<Var.Admin> ako = var.getAko();
+
+        if (type.isPresent() && ako.isPresent()) {
+            String printableName = var.getPrintableName();
+            throw new IllegalStateException(ErrorMessage.INSERT_ISA_AND_AKO.getMessage(printableName));
+        }
+
+        Concept concept;
+
+        // If 'ako' provided, use that, else use 'isa', else get existing concept by id
+        if (ako.isPresent()) {
+            String id = getTypeIdOrThrow(var.getId());
+            concept = putConceptBySuperType(id, getConcept(ako.get()).asType());
+        } else if (type.isPresent()) {
+            concept = putConceptByType(var.getId(), var, getConcept(type.get()).asType());
+        } else {
+            concept = var.getId().map(transaction::getConcept).orElse(null);
+        }
+
+        if (concept == null) {
+            System.out.println(varsById);
+            throw new IllegalStateException(
+                    var.getId().map(ErrorMessage.INSERT_GET_NON_EXISTENT_ID::getMessage)
+                            .orElse(ErrorMessage.INSERT_UNDEFINED_VARIABLE.getMessage(var.getName()))
+            );
+        }
+
+        return concept;
+    }
+
+    /**
+     * Merge a variable with any other variables referred to with the same variable name or id
+     * @param var the variable to merge
+     * @return the merged variable
+     */
+    private Var.Admin mergeVar(Var.Admin var) {
+        boolean changed = true;
+        Set<Var.Admin> varsToMerge = new HashSet<>();
+
+        // Keep merging until the set of merged variables stops changing
+        // This handles cases when variables are referred to with multiple degrees of separation
+        // e.g.
+        // "123" isa movie; $x id "123"; $y id "123"; ($y, $z)
+        while (changed) {
+            // Merge variable referred to by name...
+            boolean byNameChange = varsToMerge.addAll(varsByName.get(var.getName()));
+            var = new VarImpl(varsToMerge);
+
+            // Then merge variables referred to by id...
+            boolean byIdChange = var.getId().map(id -> varsToMerge.addAll(varsById.get(id))).orElse(false);
+            var = new VarImpl(varsToMerge);
+
+            changed = byNameChange | byIdChange;
+        }
+
+        return var;
+    }
+
+    /**
+     * @param id the ID of the concept
+     * @param var the Var representing the concept in the insert query
+     * @param type the type of the concept
+     * @return a concept with the given ID and the specified type
+     */
+    private Concept putConceptByType(Optional<String> id, Var.Admin var, Type type) {
+        String typeId = type.getId();
+
+        if (typeId.equals(DataType.ConceptMeta.ENTITY_TYPE.getId())) {
+            return transaction.putEntityType(getTypeIdOrThrow(id));
+        } else if (typeId.equals(DataType.ConceptMeta.RELATION_TYPE.getId())) {
+            return transaction.putRelationType(getTypeIdOrThrow(id));
+        } else if (typeId.equals(DataType.ConceptMeta.ROLE_TYPE.getId())) {
+            return transaction.putRoleType(getTypeIdOrThrow(id));
+        } else if (typeId.equals(DataType.ConceptMeta.RESOURCE_TYPE.getId())) {
+            return transaction.putResourceType(getTypeIdOrThrow(id), getDataType(var));
+        } else if (typeId.equals(DataType.ConceptMeta.RULE_TYPE.getId())) {
+            return transaction.putRuleType(getTypeIdOrThrow(id));
+        } else if (type.isEntityType()) {
+            return putInstance(id, type.asEntityType(), transaction::putEntity, transaction::addEntity);
+        } else if (type.isRelationType()) {
+            return putInstance(id, type.asRelationType(), transaction::putRelation, transaction::addRelation);
+        } else if (type.isResourceType()) {
+            return putInstance(id, type.asResourceType(), transaction::putResource, transaction::addResource);
+        } else if (type.isRuleType()) {
+            return putInstance(id, type.asRuleType(), transaction::putRule, transaction::addRule);
+        } else {
+            throw new RuntimeException("Unrecognized type " + type.getId());
+        }
+    }
+
+    /**
+     * @param id the ID of the concept
+     * @param superType the supertype of the concept
+     * @return a concept with the given ID and the specified supertype
+     */
+    private <T> Concept putConceptBySuperType(String id, Type superType) {
+        if (superType.isEntityType()) {
+            return transaction.putEntityType(id).superType(superType.asEntityType());
+        } else if (superType.isRelationType()) {
+            return transaction.putRelationType(id).superType(superType.asRelationType());
+        } else if (superType.isRoleType()) {
+            return transaction.putRoleType(id).superType(superType.asRoleType());
+        } else if (superType.isResourceType()) {
+            ResourceType<T> superResource = superType.asResourceType();
+            return transaction.putResourceType(id, superResource.getDataType()).superType(superResource);
+        } else if (superType.isRuleType()) {
+            return transaction.putRuleType(id).superType(superType.asRuleType());
+        } else {
+            throw new IllegalStateException(ErrorMessage.INSERT_METATYPE.getMessage(id, superType.getId()));
+        }
+    }
+
+    /**
+     * Put an instance of a type which may or may not have an ID specified
+     * @param id the ID of the instance to create, or empty to not specify an ID
+     * @param type the type of the instance
+     * @param putInstance a 'put' method on a MindmapsTransaction, such as transaction::putEntity
+     * @param addInstance an 'add' method on a MindmapsTransaction such a transaction::addEntity
+     * @param <T> the class of the type of the instance, e.g. EntityType
+     * @param <S> the class of the instance, e.g. Entity
+     * @return an instance of the specified type, with the given ID if one was specified
+     */
+    private <T extends Type, S extends Instance> S putInstance(
+            Optional<String> id, T type, BiFunction<String, T, S> putInstance, Function<T, S> addInstance
+    ) {
+        return id.map(i -> putInstance.apply(i, type)).orElseGet(() -> addInstance.apply(type));
+    }
+
+    /**
+     * Get an ID from an optional for a type, throwing an exception if it is not present.
+     * This is because types must have specified IDs.
+     * @param id an optional ID to get
+     * @return the ID, if present
+     * @throws IllegalStateException if the ID was not present
+     */
+    private String getTypeIdOrThrow(Optional<String> id) throws IllegalStateException {
+        return id.orElseThrow(() -> new IllegalStateException(ErrorMessage.INSERT_TYPE_WITHOUT_ID.getMessage()));
+    }
+
+    /**
+     * Add a roleplayer to the given relation
+     * @param var the variable representing the relation
+     * @param casting a casting between a role type and role player
+     */
+    private void addCasting(Var.Admin var, Var.Casting casting) {
+        Relation relation = getConcept(var).asRelation();
+
+        RoleType roleType = getConcept(casting.getRoleType().get()).asRoleType();
+        Instance roleplayer = getConcept(casting.getRolePlayer()).asInstance();
+        relation.putRolePlayer(roleType, roleplayer);
+    }
+
+    /**
+     * Set the values specified in the Var, on the concept represented by the given Var
+     * @param var the Var containing values to set on the concept
+     */
+    private void setValue(Var.Admin var) {
+        Iterator<?> values = var.getValueEqualsPredicates().iterator();
+
+        if (values.hasNext()) {
+            Object value = values.next();
+
+            if (values.hasNext()) {
+                throw new IllegalStateException(ErrorMessage.INSERT_MULTIPLE_VALUES.getMessage(value, values.next()));
+            }
+
+            Concept concept = getConcept(var);
+
+            if (concept.isType()) {
+                concept.asType().setValue((String) value);
+            } else if (concept.isEntity()) {
+                concept.asEntity().setValue((String) value);
+            } else if (concept.isRelation()) {
+                concept.asRelation().setValue((String) value);
+            } else if (concept.isRule()) {
+                concept.asRule().setValue((String) value);
+            } else if (concept.isResource()) {
+                // If the value we provide is not supported by this resource, core will throw an exception back
+                //noinspection unchecked
+                concept.asResource().setValue(value);
+            } else {
+                throw new RuntimeException("Unrecognized type " + concept.type().getId());
+            }
+        }
+    }
+
+    /**
+     * Get the datatype of a Var if specified, else throws an IllegalStateException
+     * @return the datatype of the given var
+     */
+    private Data<?> getDataType(Var.Admin var) {
+        return var.getDatatype().orElseThrow(
+                () -> new IllegalStateException(ErrorMessage.INSERT_NO_DATATYPE.getMessage(var.getPrintableName()))
+        );
+    }
+
+    /**
+     * @param var the var representing a type that can own the given resource type
+     * @param resourceVar the var representing the resource type
+     */
+    private void addResourceType(Var.Admin var, Var.Admin resourceVar) {
+        Type type = getConcept(var).asType();
+        ResourceType resourceType = getConcept(resourceVar).asResourceType();
+
+        RoleType owner = transaction.putRoleType(GraqlType.HAS_RESOURCE_OWNER.getId(resourceType.getId()));
+        RoleType value = transaction.putRoleType(GraqlType.HAS_RESOURCE_VALUE.getId(resourceType.getId()));
+        transaction.putRelationType(GraqlType.HAS_RESOURCE.getId(resourceType.getId()))
+                .hasRole(owner).hasRole(value);
+
+        type.playsRole(owner);
+        resourceType.playsRole(value);
+    }
+
+    /**
+     * Add resources to the given instance, using the has-resource relation
+     * @param instance the instance to add resources to
+     * @param resourceType the variable representing the resource type
+     * @param values a set of values to set on the resource instances
+     * @param <D> the type of the resources
+     */
+    private <D> void addResources(Instance instance, Var.Admin resourceType, Set<D> values) {
+        // We assume the resource type has the correct datatype. If it does not, core will catch the problem
+        //noinspection unchecked
+        ResourceType<D> type = getConcept(resourceType).asResourceType();
+        values.forEach(value -> addResource(instance, type, value));
+    }
+
+    /**
+     * Add a resource to the given instance, using the has-resource relation
+     * @param instance the instance to add a resource to
+     * @param type the resource type
+     * @param value the value to set on the resource instance
+     * @param <D> the type of the resource
+     */
+    private <D> void addResource(Instance instance, ResourceType<D> type, D value) {
+        Resource resource = transaction.addResource(type).setValue(value);
+
+        RelationType hasResource = transaction.getRelationType(GraqlType.HAS_RESOURCE.getId(type.getId()));
+        RoleType hasResourceTarget = transaction.getRoleType(GraqlType.HAS_RESOURCE_OWNER.getId(type.getId()));
+        RoleType hasResourceValue = transaction.getRoleType(GraqlType.HAS_RESOURCE_VALUE.getId(type.getId()));
+
+        if (hasResource == null || hasResourceTarget == null || hasResourceValue == null) {
+            throw new IllegalStateException(
+                    ErrorMessage.INSERT_NO_RESOURCE_RELATION.getMessage(instance.type().getId(), type.getId())
+            );
+        }
+
+        Relation relation = transaction.addRelation(hasResource);
+        relation.putRolePlayer(hasResourceTarget, instance);
+        relation.putRolePlayer(hasResourceValue, resource);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
@@ -18,20 +18,18 @@
 
 package io.mindmaps.graql.internal.query;
 
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableSet;
 import io.mindmaps.core.dao.MindmapsTransaction;
-import io.mindmaps.core.implementation.Data;
-import io.mindmaps.core.implementation.DataType;
-import io.mindmaps.core.model.*;
+import io.mindmaps.core.model.Concept;
 import io.mindmaps.graql.api.query.InsertQuery;
 import io.mindmaps.graql.api.query.MatchQuery;
 import io.mindmaps.graql.api.query.Var;
-import io.mindmaps.graql.internal.GraqlType;
 import io.mindmaps.graql.internal.validation.ErrorMessage;
 import io.mindmaps.graql.internal.validation.InsertQueryValidator;
 
-import java.util.*;
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -43,52 +41,32 @@ import static java.util.stream.Collectors.toSet;
 public class InsertQueryImpl implements InsertQuery.Admin {
 
     private final Optional<MatchQuery> matchQuery;
-    private MindmapsTransaction transaction;
-    private final Collection<Var.Admin> originalVars;
-    private final Collection<Var.Admin> vars;
-    private final Map<String, List<Var.Admin>> varsByName;
-    private final Map<String, List<Var.Admin>> varsById;
-    private Map<String, Concept> concepts = new HashMap<>();
-    private Stack<String> visitedVars = new Stack<>();
+    private final Optional<MindmapsTransaction> transaction;
+    private final ImmutableCollection<Var.Admin> originalVars;
+    private final ImmutableCollection<Var.Admin> vars;
 
     /**
      * @param transaction the transaction to execute on
      * @param vars a collection of Vars to insert
      * @param matchQuery the match query to insert for each result
      */
-    public InsertQueryImpl(MindmapsTransaction transaction, Collection<Var.Admin> vars, MatchQuery matchQuery) {
+    public InsertQueryImpl(ImmutableCollection<Var.Admin> vars, Optional<MatchQuery> matchQuery, Optional<MindmapsTransaction> transaction) {
         this.transaction = transaction;
 
         this.originalVars = vars;
-        this.matchQuery = Optional.ofNullable(matchQuery);
+        this.matchQuery = matchQuery;
 
         // Get all variables, including ones nested in other variables
-        this.vars = vars.stream().flatMap(v -> v.getInnerVars().stream()).collect(toSet());
+        this.vars = ImmutableSet.copyOf(vars.stream().flatMap(v -> v.getInnerVars().stream()).collect(toSet()));
 
-        // Group variables by name
-        varsByName = this.vars.stream().collect(Collectors.groupingBy(Var.Admin::getName));
 
-        // Group variables by id (if they have one defined)
-        varsById = this.vars.stream()
-                .filter(var -> var.getId().isPresent())
-                .collect(Collectors.groupingBy(var -> var.getId().get()));
-
-        new InsertQueryValidator(this).validate(transaction);
-    }
-
-    /**
-     * @param transaction the transaction to execute on
-     * @param vars a collection of Vars to insert
-     */
-    public InsertQueryImpl(MindmapsTransaction transaction, Collection<Var.Admin> vars) {
-        this(transaction, vars, null);
+        transaction.ifPresent(t -> new InsertQueryValidator(this).validate(t));
     }
 
     @Override
     public InsertQuery withTransaction(MindmapsTransaction transaction) {
-        matchQuery.ifPresent(query -> query.withTransaction(transaction));
-        this.transaction = Objects.requireNonNull(transaction);
-        return this;
+        Optional<MatchQuery> newMatchQuery = matchQuery.map(m -> m.withTransaction(transaction));
+        return new InsertQueryImpl(vars, newMatchQuery, Optional.of(transaction));
     }
 
     @Override
@@ -99,12 +77,15 @@ public class InsertQueryImpl implements InsertQuery.Admin {
 
     @Override
     public Stream<Concept> stream() {
-        if (transaction == null) throw new IllegalStateException(ErrorMessage.NO_TRANSACTION.getMessage());
+        MindmapsTransaction theTransaction =
+                transaction.orElseThrow(() -> new IllegalStateException(ErrorMessage.NO_TRANSACTION.getMessage()));
+
+        InsertQueryExecutor executor = new InsertQueryExecutor(vars, theTransaction);
 
         return matchQuery.map(
-                query -> query.stream().flatMap(this::insertAll)
+                query -> query.stream().flatMap(executor::insertAll)
         ).orElseGet(
-                this::insertAll
+                executor::insertAll
         );
     }
 
@@ -128,343 +109,9 @@ public class InsertQueryImpl implements InsertQuery.Admin {
         return vars;
     }
 
-    /**
-     * Insert all the Vars
-     */
-    private Stream<Concept> insertAll() {
-        return insertAll(new HashMap<>());
-    }
-
-    /**
-     * Insert all the Vars
-     * @param results the result of a match query
-     */
-    private Stream<Concept> insertAll(Map<String, Concept> results) {
-        concepts = new HashMap<>(results);
-
-        // First insert each var
-        getAllVars().stream().forEach(this::insertVar);
-
-        // Then add resources to each var, streaming out the results.
-        // It is necessary to add resources last to be sure that any 'has-resource' information in the query has
-        // already been added.
-        // TODO: Fix this so this step is no longer necessary (can be done by correctly expanding 'has-resource')
-        return getAllVars().stream().map(this::insertVarResources);
-    }
-
-    /**
-     * @param var the Var to insert into the graph
-     */
-    private Concept insertVar(Var.Admin var) {
-        Concept concept = getConcept(var);
-
-        if (var.getAbstract()) concept.asType().setAbstract(true);
-
-        setValue(var);
-
-        var.getLhs().ifPresent(lhs -> concept.asRule().setLHS(lhs));
-        var.getRhs().ifPresent(rhs -> concept.asRule().setRHS(rhs));
-
-        var.getHasRoles().stream().forEach(role -> concept.asRelationType().hasRole(getConcept(role).asRoleType()));
-        var.getPlaysRoles().stream().forEach(role -> concept.asType().playsRole(getConcept(role).asRoleType()));
-        var.getScopes().stream().forEach(scope -> concept.asRelation().scope(getConcept(scope).asInstance()));
-
-        var.getHasResourceTypes().forEach(resourceType -> addResourceType(var, resourceType));
-
-        var.getCastings().forEach(casting -> addCasting(var, casting));
-
-        return concept;
-    }
-
-    /**
-     * Add all the resources of the given var
-     * @param var the var to add resources to
-     */
-    private Concept insertVarResources(Var.Admin var) {
-        Concept concept = getConcept(var);
-
-        if (!var.getResourceEqualsPredicates().isEmpty()) {
-            Instance instance = concept.asInstance();
-            var.getResourceEqualsPredicates().forEach((type, values) -> addResources(instance, type, values));
-        }
-
-        return concept;
-    }
-
-    /**
-     * @param var the Var that is represented by a concept in the graph
-     * @return the same as addConcept, but using an internal map to remember previous calls
-     */
-    private Concept getConcept(Var.Admin var) {
-        String name = var.getName();
-        if (visitedVars.contains(name)) {
-            throw new IllegalStateException(ErrorMessage.INSERT_RECURSIVE.getMessage(var.getPrintableName()));
-        }
-
-        visitedVars.push(name);
-        Concept concept = concepts.computeIfAbsent(name, n -> addConcept(var));
-        visitedVars.pop();
-        return concept;
-    }
-
-    /**
-     * @param var the Var that is to be added into the graph
-     * @return the concept representing the given Var, creating it if it doesn't exist
-     */
-    private Concept addConcept(Var.Admin var) {
-        var = mergeVar(var);
-
-        Optional<Var.Admin> type = var.getType();
-        Optional<Var.Admin> ako = var.getAko();
-
-        if (type.isPresent() && ako.isPresent()) {
-            String printableName = var.getPrintableName();
-            throw new IllegalStateException(ErrorMessage.INSERT_ISA_AND_AKO.getMessage(printableName));
-        }
-
-        Concept concept;
-
-        // If 'ako' provided, use that, else use 'isa', else get existing concept by id
-        if (ako.isPresent()) {
-            String id = getTypeIdOrThrow(var.getId());
-            concept = putConceptBySuperType(id, getConcept(ako.get()).asType());
-        } else if (type.isPresent()) {
-            concept = putConceptByType(var.getId(), var, getConcept(type.get()).asType());
-        } else {
-            concept = var.getId().map(transaction::getConcept).orElse(null);
-        }
-
-        if (concept == null) {
-            System.out.println(varsById);
-            throw new IllegalStateException(
-                    var.getId().map(ErrorMessage.INSERT_GET_NON_EXISTENT_ID::getMessage)
-                            .orElse(ErrorMessage.INSERT_UNDEFINED_VARIABLE.getMessage(var.getName()))
-            );
-        }
-
-        return concept;
-    }
-
-    /**
-     * Merge a variable with any other variables referred to with the same variable name or id
-     * @param var the variable to merge
-     * @return the merged variable
-     */
-    private Var.Admin mergeVar(Var.Admin var) {
-        boolean changed = true;
-        Set<Var.Admin> varsToMerge = new HashSet<>();
-
-        // Keep merging until the set of merged variables stops changing
-        // This handles cases when variables are referred to with multiple degrees of separation
-        // e.g.
-        // "123" isa movie; $x id "123"; $y id "123"; ($y, $z)
-        while (changed) {
-            // Merge variable referred to by name...
-            boolean byNameChange = varsToMerge.addAll(varsByName.get(var.getName()));
-            var = new VarImpl(varsToMerge);
-
-            // Then merge variables referred to by id...
-            boolean byIdChange = var.getId().map(id -> varsToMerge.addAll(varsById.get(id))).orElse(false);
-            var = new VarImpl(varsToMerge);
-
-            changed = byNameChange | byIdChange;
-        }
-
-        return var;
-    }
-
-    /**
-     * @param id the ID of the concept
-     * @param var the Var representing the concept in the insert query
-     * @param type the type of the concept
-     * @return a concept with the given ID and the specified type
-     */
-    private Concept putConceptByType(Optional<String> id, Var.Admin var, Type type) {
-        String typeId = type.getId();
-
-        if (typeId.equals(DataType.ConceptMeta.ENTITY_TYPE.getId())) {
-            return transaction.putEntityType(getTypeIdOrThrow(id));
-        } else if (typeId.equals(DataType.ConceptMeta.RELATION_TYPE.getId())) {
-            return transaction.putRelationType(getTypeIdOrThrow(id));
-        } else if (typeId.equals(DataType.ConceptMeta.ROLE_TYPE.getId())) {
-            return transaction.putRoleType(getTypeIdOrThrow(id));
-        } else if (typeId.equals(DataType.ConceptMeta.RESOURCE_TYPE.getId())) {
-            return transaction.putResourceType(getTypeIdOrThrow(id), getDataType(var));
-        } else if (typeId.equals(DataType.ConceptMeta.RULE_TYPE.getId())) {
-            return transaction.putRuleType(getTypeIdOrThrow(id));
-        } else if (type.isEntityType()) {
-            return putInstance(id, type.asEntityType(), transaction::putEntity, transaction::addEntity);
-        } else if (type.isRelationType()) {
-            return putInstance(id, type.asRelationType(), transaction::putRelation, transaction::addRelation);
-        } else if (type.isResourceType()) {
-            return putInstance(id, type.asResourceType(), transaction::putResource, transaction::addResource);
-        } else if (type.isRuleType()) {
-            return putInstance(id, type.asRuleType(), transaction::putRule, transaction::addRule);
-        } else {
-            throw new RuntimeException("Unrecognized type " + type.getId());
-        }
-    }
-
-    /**
-     * @param id the ID of the concept
-     * @param superType the supertype of the concept
-     * @return a concept with the given ID and the specified supertype
-     */
-    private <T> Concept putConceptBySuperType(String id, Type superType) {
-        if (superType.isEntityType()) {
-            return transaction.putEntityType(id).superType(superType.asEntityType());
-        } else if (superType.isRelationType()) {
-            return transaction.putRelationType(id).superType(superType.asRelationType());
-        } else if (superType.isRoleType()) {
-            return transaction.putRoleType(id).superType(superType.asRoleType());
-        } else if (superType.isResourceType()) {
-            ResourceType<T> superResource = superType.asResourceType();
-            return transaction.putResourceType(id, superResource.getDataType()).superType(superResource);
-        } else if (superType.isRuleType()) {
-            return transaction.putRuleType(id).superType(superType.asRuleType());
-        } else {
-            throw new IllegalStateException(ErrorMessage.INSERT_METATYPE.getMessage(id, superType.getId()));
-        }
-    }
-
-    /**
-     * Put an instance of a type which may or may not have an ID specified
-     * @param id the ID of the instance to create, or empty to not specify an ID
-     * @param type the type of the instance
-     * @param putInstance a 'put' method on a MindmapsTransaction, such as transaction::putEntity
-     * @param addInstance an 'add' method on a MindmapsTransaction such a transaction::addEntity
-     * @param <T> the class of the type of the instance, e.g. EntityType
-     * @param <S> the class of the instance, e.g. Entity
-     * @return an instance of the specified type, with the given ID if one was specified
-     */
-    private <T extends Type, S extends Instance> S putInstance(
-            Optional<String> id, T type, BiFunction<String, T, S> putInstance, Function<T, S> addInstance
-    ) {
-        return id.map(i -> putInstance.apply(i, type)).orElseGet(() -> addInstance.apply(type));
-    }
-
-    /**
-     * Get an ID from an optional for a type, throwing an exception if it is not present.
-     * This is because types must have specified IDs.
-     * @param id an optional ID to get
-     * @return the ID, if present
-     * @throws IllegalStateException if the ID was not present
-     */
-    private String getTypeIdOrThrow(Optional<String> id) throws IllegalStateException {
-        return id.orElseThrow(() -> new IllegalStateException(ErrorMessage.INSERT_TYPE_WITHOUT_ID.getMessage()));
-    }
-
-    /**
-     * Add a roleplayer to the given relation
-     * @param var the variable representing the relation
-     * @param casting a casting between a role type and role player
-     */
-    private void addCasting(Var.Admin var, Var.Casting casting) {
-        Relation relation = getConcept(var).asRelation();
-
-        RoleType roleType = getConcept(casting.getRoleType().get()).asRoleType();
-        Instance roleplayer = getConcept(casting.getRolePlayer()).asInstance();
-        relation.putRolePlayer(roleType, roleplayer);
-    }
-
-    /**
-     * Set the values specified in the Var, on the concept represented by the given Var
-     * @param var the Var containing values to set on the concept
-     */
-    private void setValue(Var.Admin var) {
-        Iterator<?> values = var.getValueEqualsPredicates().iterator();
-
-        if (values.hasNext()) {
-            Object value = values.next();
-
-            if (values.hasNext()) {
-                throw new IllegalStateException(ErrorMessage.INSERT_MULTIPLE_VALUES.getMessage(value, values.next()));
-            }
-
-            Concept concept = getConcept(var);
-
-            if (concept.isType()) {
-                concept.asType().setValue((String) value);
-            } else if (concept.isEntity()) {
-                concept.asEntity().setValue((String) value);
-            } else if (concept.isRelation()) {
-                concept.asRelation().setValue((String) value);
-            } else if (concept.isRule()) {
-                concept.asRule().setValue((String) value);
-            } else if (concept.isResource()) {
-                // If the value we provide is not supported by this resource, core will throw an exception back
-                //noinspection unchecked
-                concept.asResource().setValue(value);
-            } else {
-                throw new RuntimeException("Unrecognized type " + concept.type().getId());
-            }
-        }
-    }
-
-    /**
-     * Get the datatype of a Var if specified, else throws an IllegalStateException
-     * @return the datatype of the given var
-     */
-    private Data<?> getDataType(Var.Admin var) {
-        return var.getDatatype().orElseThrow(
-                () -> new IllegalStateException(ErrorMessage.INSERT_NO_DATATYPE.getMessage(var.getPrintableName()))
-        );
-    }
-
-    /**
-     * @param var the var representing a type that can own the given resource type
-     * @param resourceVar the var representing the resource type
-     */
-    private void addResourceType(Var.Admin var, Var.Admin resourceVar) {
-        Type type = getConcept(var).asType();
-        ResourceType resourceType = getConcept(resourceVar).asResourceType();
-
-        RoleType owner = transaction.putRoleType(GraqlType.HAS_RESOURCE_OWNER.getId(resourceType.getId()));
-        RoleType value = transaction.putRoleType(GraqlType.HAS_RESOURCE_VALUE.getId(resourceType.getId()));
-        transaction.putRelationType(GraqlType.HAS_RESOURCE.getId(resourceType.getId()))
-                .hasRole(owner).hasRole(value);
-
-        type.playsRole(owner);
-        resourceType.playsRole(value);
-    }
-
-    /**
-     * Add resources to the given instance, using the has-resource relation
-     * @param instance the instance to add resources to
-     * @param resourceType the variable representing the resource type
-     * @param values a set of values to set on the resource instances
-     * @param <D> the type of the resources
-     */
-    private <D> void addResources(Instance instance, Var.Admin resourceType, Set<D> values) {
-        // We assume the resource type has the correct datatype. If it does not, core will catch the problem
-        //noinspection unchecked
-        ResourceType<D> type = getConcept(resourceType).asResourceType();
-        values.forEach(value -> addResource(instance, type, value));
-    }
-
-    /**
-     * Add a resource to the given instance, using the has-resource relation
-     * @param instance the instance to add a resource to
-     * @param type the resource type
-     * @param value the value to set on the resource instance
-     * @param <D> the type of the resource
-     */
-    private <D> void addResource(Instance instance, ResourceType<D> type, D value) {
-        Resource resource = transaction.addResource(type).setValue(value);
-
-        RelationType hasResource = transaction.getRelationType(GraqlType.HAS_RESOURCE.getId(type.getId()));
-        RoleType hasResourceTarget = transaction.getRoleType(GraqlType.HAS_RESOURCE_OWNER.getId(type.getId()));
-        RoleType hasResourceValue = transaction.getRoleType(GraqlType.HAS_RESOURCE_VALUE.getId(type.getId()));
-
-        if (hasResource == null || hasResourceTarget == null || hasResourceValue == null) {
-            throw new IllegalStateException(
-                    ErrorMessage.INSERT_NO_RESOURCE_RELATION.getMessage(instance.type().getId(), type.getId())
-            );
-        }
-
-        Relation relation = transaction.addRelation(hasResource);
-        relation.putRolePlayer(hasResourceTarget, instance);
-        relation.putRolePlayer(hasResourceValue, resource);
+    @Override
+    public Optional<MindmapsTransaction> getTransaction() {
+        return transaction;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/MatchOrder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/MatchOrder.java
@@ -1,0 +1,112 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query;
+
+import io.mindmaps.core.dao.MindmapsTransaction;
+import io.mindmaps.core.implementation.DataType;
+import io.mindmaps.core.implementation.MindmapsTransactionImpl;
+import org.apache.tinkerpop.gremlin.process.traversal.Order;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.mindmaps.core.implementation.DataType.ConceptPropertyUnique.ITEM_IDENTIFIER;
+import static io.mindmaps.core.implementation.DataType.EdgeLabel.SHORTCUT;
+import static io.mindmaps.core.implementation.DataType.EdgeProperty.TO_TYPE;
+
+/**
+ * A class for handling ordering match queries.
+ */
+class MatchOrder {
+
+    private final String var;
+    private final Optional<String> resourceType;
+    private final boolean asc;
+
+    public MatchOrder(String var, Optional<String> resourceType, boolean asc) {
+        this.var = var;
+        this.resourceType = resourceType;
+        this.asc = asc;
+    }
+
+    public String getVar() {
+        return var;
+    }
+
+    /**
+     * Order the traversal
+     * @param traversal the traversal to order
+     */
+    public void orderTraversal(MindmapsTransaction transaction, GraphTraversal<Vertex, Map<String, Vertex>> traversal) {
+        if (resourceType.isPresent()) {
+            // Order by resource type
+
+            // Look up datatype of resource type
+            String typeId = resourceType.get();
+            DataType.ConceptProperty valueProp = transaction.getResourceType(typeId).getDataType().getConceptProperty();
+
+            Comparator<Optional<Comparable>> comparator = new ResourceComparator();
+            if (!asc) comparator = comparator.reversed();
+
+            traversal.select(var).order().by(v -> getResourceValue(transaction, v, typeId, valueProp), comparator);
+        } else {
+            // Order by ITEM_IDENTIFIER by default
+            Order order = asc ? Order.incr : Order.decr;
+            traversal.select(var).order().by(ITEM_IDENTIFIER.name(), order);
+        }
+    }
+
+    /**
+     * Get the value of an attached resource, used for ordering by resource
+     * @param elem the element in the graph (a gremlin object)
+     * @param resourceTypeId the ID of a resource type
+     * @param value the VALUE property to use on the vertex
+     * @return the value of an attached resource, or nothing if there is no resource of this type
+     */
+    private Optional<Comparable> getResourceValue(MindmapsTransaction transaction, Object elem, String resourceTypeId, DataType.ConceptProperty value) {
+        return ((MindmapsTransactionImpl) transaction).getTinkerPopGraph().traversal().V(elem)
+                .outE(SHORTCUT.getLabel()).has(TO_TYPE.name(), resourceTypeId).inV().values(value.name())
+                .tryNext().map(o -> (Comparable) o);
+    }
+
+    @Override
+    public String toString() {
+        String resourceString = resourceType.map(r -> "(has " + r + ")").orElse("");
+        return "order by $" + var + resourceString + " ";
+    }
+
+    /**
+     * A comparator that parses (optionally present) resources into the correct datatype for comparison
+     */
+    static class ResourceComparator implements Comparator<Optional<Comparable>> {
+
+        @Override
+        public int compare(Optional<Comparable> value1, Optional<Comparable> value2) {
+            if (!value1.isPresent() && !value2.isPresent()) return 0;
+            if (!value1.isPresent()) return -1;
+            if (!value2.isPresent()) return 1;
+
+            //noinspection unchecked
+            return value1.get().compareTo(value2.get());
+        }
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ValuePredicateImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/ValuePredicateImpl.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.internal.query;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.mindmaps.graql.api.query.ValuePredicate;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -32,7 +33,7 @@ public class ValuePredicateImpl implements ValuePredicate.Admin {
     private final P<Object> predicate;
     private final String repr;
     private final boolean equals;
-    private final Set<Object> innerValues;
+    private final ImmutableSet<Object> innerValues;
 
     /**
      * @param predicate the gremlin predicate to use
@@ -41,27 +42,27 @@ public class ValuePredicateImpl implements ValuePredicate.Admin {
      * @param equals true only if the predicate is an "equals" predicate
      */
     public ValuePredicateImpl(P<Object> predicate, String repr, Object innerValue, boolean equals) {
-        this(predicate, repr, equals, Collections.singleton(innerValue));
+        this(predicate, repr, equals, ImmutableSet.of(innerValue));
     }
 
-    private ValuePredicateImpl(P<Object> predicate, String repr, boolean equals, Collection<Object> innerValues) {
+    private ValuePredicateImpl(P<Object> predicate, String repr, boolean equals, ImmutableSet<Object> innerValues) {
         this.predicate = predicate;
         this.repr = repr;
         this.equals = equals;
-        this.innerValues = new HashSet<>(innerValues);
+        this.innerValues = innerValues;
     }
 
     @Override
     public ValuePredicate and(ValuePredicate other) {
         P<Object> and = predicate.and(other.admin().getPredicate());
-        Sets.SetView<Object> innerUnion = Sets.union(innerValues, other.admin().getInnerValues());
+        ImmutableSet<Object> innerUnion = ImmutableSet.copyOf(Sets.union(innerValues, other.admin().getInnerValues()));
         return new ValuePredicateImpl(and, "(" + repr + " and " + other.admin().toString() + ")", false, innerUnion);
     }
 
     @Override
     public ValuePredicate or(ValuePredicate other) {
         P<Object> or = predicate.or(other.admin().getPredicate());
-        Sets.SetView<Object> innerUnion = Sets.union(innerValues, other.admin().getInnerValues());
+        ImmutableSet<Object> innerUnion = ImmutableSet.copyOf(Sets.union(innerValues, other.admin().getInnerValues()));
         return new ValuePredicateImpl(or, "(" + repr + " or " + other.admin().toString() + ")", false, innerUnion);
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/reasoner/internal/container/Query.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/reasoner/internal/container/Query.java
@@ -41,7 +41,7 @@ public class Query {
     private final Set<Atomic> atomSet;
     private final Map<Type, Set<Atomic>> typeAtomMap;
 
-    private final MatchQuery matchQuery;
+    private MatchQuery matchQuery;
 
     private Atomic parentAtom = null;
     private Rule rule = null;
@@ -212,12 +212,12 @@ public class Query {
 
     private void updateSelectedVars(String from, String to)
     {
-        Set<String> selectedVars = matchQuery.admin().getSelectedNames();
+        Set<String> selectedVars = new HashSet<>(matchQuery.admin().getSelectedNames());
         if (selectedVars.contains(from))
         {
             selectedVars.remove(from);
             selectedVars.add(to);
-            matchQuery.select(selectedVars);
+            matchQuery = matchQuery.select(selectedVars);
         }
     }
 

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryBuilderTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryBuilderTest.java
@@ -127,6 +127,6 @@ public class QueryBuilderTest {
     public void testValidationWhenTransactionProvided() {
         MatchQuery query = QueryBuilder.build().match(var("x").isa("not-a-thing"));
         exception.expect(IllegalStateException.class);
-        query.withTransaction(transaction);
+        query.withTransaction(transaction).stream();
     }
 }

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
@@ -56,21 +56,21 @@ public class QueryErrorTest {
     public void testErrorNonExistentConceptType() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("film");
-        qb.match(var("x").isa("film"));
+        qb.match(var("x").isa("film")).stream();
     }
 
     @Test
     public void testErrorNotARole() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(containsString("role"), containsString("person"), containsString("isa person")));
-        qb.match(var("x").isa("movie"), var().rel("person", "y").rel("x"));
+        qb.match(var("x").isa("movie"), var().rel("person", "y").rel("x")).stream();
     }
 
     @Test
     public void testErrorNonExistentResourceType() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("thingy");
-        qb.match(var("x").has("thingy", "value")).delete("x");
+        qb.match(var("x").has("thingy", "value")).delete("x").execute();
     }
 
     @Test
@@ -78,7 +78,7 @@ public class QueryErrorTest {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(
                 containsString("relation"), containsString("movie"), containsString("separate"), containsString(";")));
-        qb.match(var().isa("movie").rel("x").rel("y"));
+        qb.match(var().isa("movie").rel("x").rel("y")).stream();
     }
 
     @Test
@@ -89,7 +89,7 @@ public class QueryErrorTest {
                 containsString("production-with-cast"), containsString("character-being-played"),
                 containsString("actor")
         ));
-        qb.match(var().isa("has-cast").rel("director", "x"));
+        qb.match(var().isa("has-cast").rel("director", "x")).stream();
     }
 
     @Test
@@ -100,7 +100,7 @@ public class QueryErrorTest {
                 containsString("production-with-cast"), containsString("character-being-played"),
                 containsString("actor")
         ));
-        qb.match(var().isa("has-cast").rel("character-in-production", "x"));
+        qb.match(var().isa("has-cast").rel("character-in-production", "x")).stream();
     }
 
     @Test
@@ -118,7 +118,7 @@ public class QueryErrorTest {
         // 'has genre' is not allowed because genre is an entity type
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(containsString("genre"), containsString("resource")));
-        qb.match(var("x").isa("movie").has("genre", "Drama"));
+        qb.match(var("x").isa("movie").has("genre", "Drama")).stream();
     }
 
     @Test
@@ -139,7 +139,7 @@ public class QueryErrorTest {
     public void testExceptionWhenSelectVariableNotInQuery() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(containsString("$x"), containsString("match")));
-        qb.match(var("y").isa("movie")).select("x");
+        qb.match(var("y").isa("movie")).select("x").stream();
     }
 
     @Test
@@ -174,6 +174,6 @@ public class QueryErrorTest {
                 containsString("actor"),
                 containsString("role")
         ));
-        qb.match(var("x").isa("actor"));
+        qb.match(var("x").isa("actor")).stream();
     }
 }


### PR DESCRIPTION
All query methods (such as withTransaction) now return a new query object.

Most fields on query objects are now immutable.

The only exception are Pattern objects, which can still be accessed and then modified. Reasoner currently depends on this behaviour and changing it would require a large refactor (and may impact the performance of reasoner).
