### PR TITLE
Refactor MatchQuery implementations

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/InsertQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/InsertQuery.java
@@ -59,7 +59,7 @@ public interface InsertQuery extends Streamable<Concept> {
         /**
          * @return the match query that this insert query is using, if it was provided one
          */
-        Optional<MatchQuery> getMatchQuery();
+        Optional<? extends MatchQuery> getMatchQuery();
 
         /**
          * @return the variables to insert in the insert query

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/QueryBuilder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/api/query/QueryBuilder.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import io.mindmaps.core.MindmapsTransaction;
 import io.mindmaps.graql.internal.AdminConverter;
 import io.mindmaps.graql.internal.query.InsertQueryImpl;
-import io.mindmaps.graql.internal.query.MatchQueryImpl;
+import io.mindmaps.graql.internal.query.match.MatchQueryBase;
 import io.mindmaps.graql.internal.query.VarImpl;
 
 import java.util.Arrays;
@@ -74,7 +74,7 @@ public class QueryBuilder {
      * @return a match query that will find matches of the given patterns
      */
     public MatchQuery match(Collection<? extends Pattern> patterns) {
-        return new MatchQueryImpl(Pattern.Admin.conjunction(AdminConverter.getPatternAdmins(patterns)), transaction);
+        return new MatchQueryBase(Pattern.Admin.conjunction(AdminConverter.getPatternAdmins(patterns)), transaction);
     }
 
     /**
@@ -91,7 +91,7 @@ public class QueryBuilder {
      */
     public InsertQuery insert(Collection<? extends Var> vars) {
         ImmutableSet<Var.Admin> varAdmins = ImmutableSet.copyOf(AdminConverter.getVarAdmins(vars));
-        return new InsertQueryImpl(varAdmins, Optional.empty(), Optional.ofNullable(transaction));
+        return new InsertQueryImpl(varAdmins, Optional.ofNullable(transaction));
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchOrder.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchOrder.java
@@ -16,7 +16,7 @@
  * along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package io.mindmaps.graql.internal.query;
+package io.mindmaps.graql.internal.query.match;
 
 import io.mindmaps.core.MindmapsTransaction;
 import io.mindmaps.core.implementation.DataType;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryDefault.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryDefault.java
@@ -1,0 +1,94 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query.match;
+
+import io.mindmaps.core.MindmapsTransaction;
+import io.mindmaps.core.model.Type;
+import io.mindmaps.graql.api.query.MatchQuery;
+import io.mindmaps.graql.api.query.Pattern;
+
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Default MatchQuery implementation, which contains an 'inner' MatchQuery.
+ *
+ * This class behaves like a singly-linked list, referencing another MatchQuery until it reaches a MatchQueryBase.
+ *
+ * Query modifiers should extend this class and implement a stream() method that modifies the inner query.
+ */
+public abstract class MatchQueryDefault implements MatchQuery.Admin {
+
+    protected final MatchQuery.Admin inner;
+
+    protected MatchQueryDefault(MatchQuery.Admin inner) {
+        this.inner = inner;
+    }
+
+    @Override
+    public final MatchQuery withTransaction(MindmapsTransaction transaction) {
+        return setInner(inner.withTransaction(transaction).admin());
+    }
+
+    @Override
+    public final MatchQuery orderBy(String varName, boolean asc) {
+        return setInner(inner.orderBy(varName, asc).admin());
+    }
+
+    @Override
+    public final MatchQuery orderBy(String varName, String resourceType, boolean asc) {
+        return setInner(inner.orderBy(varName, resourceType, asc).admin());
+    }
+
+    @Override
+    public final Admin admin() {
+        return this;
+    }
+
+    @Override
+    public final Set<Type> getTypes() {
+        return inner.getTypes();
+    }
+
+    @Override
+    public Set<String> getSelectedNames() {
+        return inner.getSelectedNames();
+    }
+
+    @Override
+    public final Pattern.Conjunction<Pattern.Admin> getPattern() {
+        return inner.getPattern();
+    }
+
+    @Override
+    public final Optional<MindmapsTransaction> getTransaction() {
+        return inner.getTransaction();
+    }
+
+    /**
+     * Set the inner query of this MatchQuery.
+     *
+     * This method should be implemented by subclasses, returning an instance of that subclass with the same fields,
+     * only the 'inner' query changed.
+     *
+     * @param inner the inner query to set
+     * @return a new instance of the class
+     */
+    protected abstract MatchQuery setInner(MatchQuery.Admin inner);
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryDistinct.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryDistinct.java
@@ -1,0 +1,50 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query.match;
+
+import io.mindmaps.core.model.Concept;
+import io.mindmaps.graql.api.query.MatchQuery;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * "Distinct" modifier for a match query that eliminates duplicate results.
+ */
+public class MatchQueryDistinct extends MatchQueryDefault {
+
+    public MatchQueryDistinct(MatchQuery.Admin inner) {
+        super(inner);
+    }
+
+    @Override
+    public Stream<Map<String, Concept>> stream() {
+        return inner.stream().distinct();
+    }
+
+    @Override
+    public String toString() {
+        return inner.toString() + " distinct";
+    }
+
+    @Override
+    protected MatchQuery setInner(MatchQuery.Admin inner) {
+        return new MatchQueryDistinct(inner);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryLimit.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryLimit.java
@@ -1,0 +1,53 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query.match;
+
+import io.mindmaps.core.model.Concept;
+import io.mindmaps.graql.api.query.MatchQuery;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * "Limit" modifier for match query that limits the results of a query.
+ */
+public class MatchQueryLimit extends MatchQueryDefault {
+
+    private final long limit;
+
+    public MatchQueryLimit(MatchQuery.Admin inner, long limit) {
+        super(inner);
+        this.limit = limit;
+    }
+
+    @Override
+    public Stream<Map<String, Concept>> stream() {
+        return inner.stream().limit(limit);
+    }
+
+    @Override
+    public String toString() {
+        return inner.toString() + " limit " + limit;
+    }
+
+    @Override
+    protected MatchQuery setInner(MatchQuery.Admin inner) {
+        return new MatchQueryLimit(inner, limit);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryOffset.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryOffset.java
@@ -1,0 +1,53 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query.match;
+
+import io.mindmaps.core.model.Concept;
+import io.mindmaps.graql.api.query.MatchQuery;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * "Offset" modifier for match query that offsets (skips) some number of results.
+ */
+public class MatchQueryOffset extends MatchQueryDefault {
+
+    private final long offset;
+
+    public MatchQueryOffset(MatchQuery.Admin inner, long offset) {
+        super(inner);
+        this.offset = offset;
+    }
+
+    @Override
+    public Stream<Map<String, Concept>> stream() {
+        return inner.stream().skip(offset);
+    }
+
+    @Override
+    public String toString() {
+        return inner.toString() + " offset " + offset;
+    }
+
+    @Override
+    protected MatchQuery setInner(MatchQuery.Admin inner) {
+        return new MatchQueryOffset(inner, offset);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQuerySelect.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQuerySelect.java
@@ -1,0 +1,68 @@
+/*
+ * MindmapsDB - A Distributed Semantic Database
+ * Copyright (C) 2016  Mindmaps Research Ltd
+ *
+ * MindmapsDB is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MindmapsDB is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with MindmapsDB. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package io.mindmaps.graql.internal.query.match;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import io.mindmaps.core.model.Concept;
+import io.mindmaps.graql.api.query.MatchQuery;
+import io.mindmaps.graql.internal.validation.ErrorMessage;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * "Select" modifier for a match query that selects particular variables from the result.
+ */
+public class MatchQuerySelect extends MatchQueryDefault {
+
+    private final ImmutableSet<String> names;
+
+    public MatchQuerySelect(MatchQuery.Admin inner, ImmutableSet<String> names) {
+        super(inner);
+
+        if (names.isEmpty()) {
+            throw new IllegalArgumentException(ErrorMessage.SELECT_NONE_SELECTED.getMessage());
+        }
+
+        this.names = names;
+    }
+
+    @Override
+    public Stream<Map<String, Concept>> stream() {
+        return inner.stream().map(result -> Maps.filterKeys(result, names::contains));
+    }
+
+    @Override
+    public String toString() {
+        return inner.toString() + " select " + names.stream().map(s -> "$" + s).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public Set<String> getSelectedNames() {
+        return names;
+    }
+
+    @Override
+    protected MatchQuery setInner(MatchQuery.Admin inner) {
+        return new MatchQuerySelect(inner, names);
+    }
+}

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/validation/MatchQueryValidator.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/validation/MatchQueryValidator.java
@@ -20,14 +20,8 @@ package io.mindmaps.graql.internal.validation;
 
 import io.mindmaps.core.MindmapsTransaction;
 import io.mindmaps.graql.api.query.MatchQuery;
-import io.mindmaps.graql.api.query.Var;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * A validator for a MatchQuery
@@ -45,20 +39,6 @@ public class MatchQueryValidator implements Validator {
 
     @Override
     public Stream<String> getErrors(MindmapsTransaction transaction) {
-        List<String> errors = new ArrayList<>();
-
-        new PatternValidator(matchQuery.getPattern()).getErrors(transaction).forEach(errors::add);
-
-        Collection<String> patternNames = matchQuery.getPattern().getVars().stream()
-                .flatMap(v -> v.getInnerVars().stream()).map(Var.Admin::getName)
-                .collect(toList());
-
-        // Find any missing names
-        Collection<String> missingNames = new ArrayList<>(matchQuery.getSelectedNames());
-        missingNames.removeAll(patternNames);
-
-        missingNames.forEach(missingName -> errors.add(ErrorMessage.SELECT_VAR_NOT_IN_MATCH.getMessage(missingName)));
-
-        return errors.stream();
+        return new PatternValidator(matchQuery.getPattern()).getErrors(transaction);
     }
 }

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/AdminTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/AdminTest.java
@@ -71,10 +71,17 @@ public class AdminTest {
     }
 
     @Test
-    public void testGetSelectedNamesInQuery() {
+    public void testDefaultGetSelectedNamesInQuery() {
         MatchQuery query = qb.match(var("x").isa(var("y")));
 
         assertEquals(Sets.newHashSet("x", "y"), query.admin().getSelectedNames());
+    }
+
+    @Test
+    public void testExplicitGetSelectedNamesInQuery() {
+        MatchQuery query = qb.match(var("x").isa(var("y"))).select("x");
+
+        assertEquals(Sets.newHashSet("x"), query.admin().getSelectedNames());
     }
 
     @Test

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryModifierTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryModifierTest.java
@@ -95,7 +95,7 @@ public class MatchQueryModifierTest {
                         var("y").isa("person"),
                         var("y").isa("genre").value(neq("crime"))
                 )
-        ).orderBy("y").limit(8).offset(4).select("x");
+        ).orderBy("y").offset(4).limit(8).select("x");
 
         QueryUtil.assertResultsMatch(
                 query, "x", "movie", "Hocus-Pocus", "Spy", "The-Muppets", "Godfather", "Apocalypse-Now"

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/MatchQueryTest.java
@@ -269,7 +269,7 @@ public class MatchQueryTest {
                         and(var("y").isa("genre").value("drama"), var().rel("x").rel("y")),
                         var("x").value("The Muppets")
                 )
-        ).select("x");
+        );
 
         QueryUtil.assertResultsMatch(query, "x", "movie", "Godfather", "Apocalypse-Now", "Heat", "The-Muppets", "Chinese-Coffee");
     }

--- a/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
+++ b/mindmaps-graql/src/test/java/io/mindmaps/graql/api/query/QueryErrorTest.java
@@ -136,13 +136,6 @@ public class QueryErrorTest {
     }
 
     @Test
-    public void testExceptionWhenSelectVariableNotInQuery() {
-        exception.expect(IllegalStateException.class);
-        exception.expectMessage(allOf(containsString("$x"), containsString("match")));
-        qb.match(var("y").isa("movie")).select("x").stream();
-    }
-
-    @Test
     public void testExceptionWhenNullValue() {
         exception.expect(NullPointerException.class);
         var("x").value(null);


### PR DESCRIPTION
MatchQuery implementations are now split into several classes:
- MatchQueryBase, representing a match query from a gremlin traversal
- MatchQueryDefault, which modifies an "inner" MatchQuery

Several classes implement MatchQueryDefault, providing different ways to modify the underlying MatchQuery.
