### PR TITLE
Remove confusing print lines

### DIFF
--- a/mindmaps-dist/src/bin/migration.sh
+++ b/mindmaps-dist/src/bin/migration.sh
@@ -7,24 +7,19 @@ SCRIPTPATH=`cd "$(dirname "$0")" && pwd -P`
 
 if [ $1 == "csv" ]
 then
-  echo "csv migration starting"
   java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.csv.Main ${1+"$@"}
 elif [ $1 == "sql" ]
 then
-  echo "sql migration starting"
   java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.sql.Main ${1+"$@"}
 elif [ $1 == "json" ]
 then
-  echo "json migration starting"
   java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.json.Main ${1+"$@"}
 elif [ $1 == "owl" ]
 then
-  echo "owl migration starting"
   java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.owl.Main ${1+"$@"}
 elif [ $1 == "export" ]
 then
-  echo "owl migration starting"
-  java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.owl.Main ${1+"$@"}
+  java -cp ${CONCATCLASSPATH} -Dmindmaps.dir=${SCRIPTPATH} io.mindmaps.migration.export.Main ${1+"$@"}
 else
   echo "usage: ./migration.sh {owl, sql, csv, json, export} <params>"
 fi


### PR DESCRIPTION
+ Remove confusing print lines in migration shell script (they were executing before any migration was run)
+ Use the proper main class for migration-export 