### PR TITLE
Graph refactoring

### DIFF
--- a/conf/main/mindmaps-analytics.properties
+++ b/conf/main/mindmaps-analytics.properties
@@ -17,7 +17,7 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsTitanHadoopInternalFactory
+factory.internal=io.mindmaps.factory.TitanHadoopInternalFactory
 
 # Graph Computer
 graph.computer=org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer

--- a/conf/main/mindmaps-batch.properties
+++ b/conf/main/mindmaps-batch.properties
@@ -17,7 +17,7 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsTitanInternalFactory
+factory.internal=io.mindmaps.factory.TitanInternalFactory
 
 # Storage Backend
 storage.backend=cassandra

--- a/conf/main/mindmaps.properties
+++ b/conf/main/mindmaps.properties
@@ -17,7 +17,7 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsTitanInternalFactory
+factory.internal=io.mindmaps.factory.TitanInternalFactory
 
 # Computer
 graph.computer=org.apache.tinkerpop.gremlin.spark.process.computer.SparkGraphComputer

--- a/conf/test/orientdb/mindmaps-orientdb.properties
+++ b/conf/test/orientdb/mindmaps-orientdb.properties
@@ -17,5 +17,5 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsOrientDBInternalFactory
+factory.internal=io.mindmaps.factory.OrientDBInternalFactory
 

--- a/conf/test/tinker/mindmaps-tinker.properties
+++ b/conf/test/tinker/mindmaps-tinker.properties
@@ -17,7 +17,7 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsTinkerInternalFactory
+factory.internal=io.mindmaps.factory.TinkerInternalFactory
 
 # Computer
 graph.computer=org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer

--- a/mindmaps-core/src/main/java/io/mindmaps/Mindmaps.java
+++ b/mindmaps-core/src/main/java/io/mindmaps/Mindmaps.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class Mindmaps {
     public static final String DEFAULT_URI = "localhost:4567";
-    private static final String ENGINE_CONTROLLED_IMPLEMENTATION = "io.mindmaps.factory.MindmapsGraphFactoryImpl";
+    private static final String ENGINE_CONTROLLED_IMPLEMENTATION = "io.mindmaps.factory.MindmapsGraphFactoryPersistent";
     
     public static final String IN_MEMORY = "in-memory";
     private static final String IN_MEMORY_IMPLEMENTATION = "io.mindmaps.factory.MindmapsGraphFactoryInMemory";

--- a/mindmaps-engine/src/main/java/io/mindmaps/engine/controller/GraphFactoryController.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/engine/controller/GraphFactoryController.java
@@ -34,7 +34,7 @@ import static spark.Spark.get;
 
 
 /**
- * REST controller used by MindmapsGraphFactoryImpl to retrieve graph configuration for a given graph name.
+ * REST controller used by MindmapsGraphFactoryPersistent to retrieve graph configuration for a given graph name.
  */
 
 public class GraphFactoryController {

--- a/mindmaps-engine/src/main/java/io/mindmaps/factory/GraphFactory.java
+++ b/mindmaps-engine/src/main/java/io/mindmaps/factory/GraphFactory.java
@@ -40,10 +40,10 @@ public class GraphFactory {
     }
 
     public synchronized MindmapsGraph getGraph(String keyspace) {
-        return MindmapsFactoryBuilder.getFactory(keyspace, null, graphConfig).getGraph(false);
+        return FactoryBuilder.getFactory(keyspace, null, graphConfig).getGraph(false);
     }
     public synchronized MindmapsGraph getGraphBatchLoading(String keyspace) {
-        return MindmapsFactoryBuilder.getFactory(keyspace, null, graphBatchConfig).getGraph(true);
+        return FactoryBuilder.getFactory(keyspace, null, graphBatchConfig).getGraph(true);
     }
 }
 

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/AbstractInternalFactory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/AbstractInternalFactory.java
@@ -21,7 +21,7 @@ package io.mindmaps.factory;
 import io.mindmaps.graph.internal.AbstractMindmapsGraph;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 
-abstract class AbstractMindmapsInternalFactory<M extends AbstractMindmapsGraph<G>, G extends Graph> implements MindmapsInternalFactory<M, G> {
+abstract class AbstractInternalFactory<M extends AbstractMindmapsGraph<G>, G extends Graph> implements InternalFactory<M, G> {
     protected final String keyspace;
     protected final String engineUrl;
     protected final String config;
@@ -32,7 +32,7 @@ abstract class AbstractMindmapsInternalFactory<M extends AbstractMindmapsGraph<G
     protected G graph = null;
     private G batchLoadingGraph = null;
 
-    AbstractMindmapsInternalFactory(String keyspace, String engineUrl, String config){
+    AbstractInternalFactory(String keyspace, String engineUrl, String config){
         this.keyspace = keyspace.toLowerCase();
         this.engineUrl = engineUrl;
         this.config = config;

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/FactoryBuilder.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/FactoryBuilder.java
@@ -29,15 +29,15 @@ import java.util.MissingResourceException;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 
-class MindmapsFactoryBuilder {
+class FactoryBuilder {
     private static final String FACTORY = "factory.internal";
-    private static final Map<String, MindmapsInternalFactory> openFactories = new HashMap<>();
+    private static final Map<String, InternalFactory> openFactories = new HashMap<>();
 
-    private MindmapsFactoryBuilder(){
+    private FactoryBuilder(){
         throw new UnsupportedOperationException();
     }
 
-    static MindmapsInternalFactory getFactory(String keyspace, String engineUrl, String config){
+    static InternalFactory getFactory(String keyspace, String engineUrl, String config){
         try{
             FileInputStream fis = new FileInputStream(config);
             ResourceBundle bundle = new PropertyResourceBundle(fis);
@@ -54,22 +54,22 @@ class MindmapsFactoryBuilder {
     /**
      *
      * @param factoryType The string defining which factory should be used for creating the mindmaps graph.
-     *                    A valid example includes: io.mindmaps.factory.MindmapsTinkerInternalFactory
+     *                    A valid example includes: io.mindmaps.factory.TinkerInternalFactory
      * @return A graph factory which produces the relevant expected graph.
     */
-    private static MindmapsInternalFactory getMindmapsGraphFactory(String factoryType, String keyspace, String engineUrl, String config){
+    private static InternalFactory getMindmapsGraphFactory(String factoryType, String keyspace, String engineUrl, String config){
         String key = factoryType + keyspace;
         if(!openFactories.containsKey(key)) {
-            MindmapsInternalFactory mindmapsInternalFactory;
+            InternalFactory internalFactory;
             try {
-                //mindmapsInternalFactory = (MindmapsInternalFactory) Class.forName(factoryType).newInstance();
-                mindmapsInternalFactory = (MindmapsInternalFactory) Class.forName(factoryType)
+                //internalFactory = (InternalFactory) Class.forName(factoryType).newInstance();
+                internalFactory = (InternalFactory) Class.forName(factoryType)
                         .getDeclaredConstructor(String.class, String.class, String.class)
                         .newInstance(keyspace, engineUrl, config);
             } catch (ClassNotFoundException | InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
                 throw new IllegalArgumentException(ErrorMessage.INVALID_FACTORY.getMessage(factoryType), e);
             }
-            openFactories.put(key, mindmapsInternalFactory);
+            openFactories.put(key, internalFactory);
         }
         return openFactories.get(key);
     }

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/InternalFactory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/InternalFactory.java
@@ -25,7 +25,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
  * The interface used to build new graphs from different vendors.
  * Adding new vendor support means implementing this interface.
  */
-interface MindmapsInternalFactory<M extends MindmapsGraph, T extends Graph> {
+interface InternalFactory<M extends MindmapsGraph, T extends Graph> {
     /**
      *
      * @param batchLoading A flag which indicates if the graph has batch loading enabled or not.

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryImpl.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryImpl.java
@@ -108,7 +108,7 @@ public class MindmapsGraphFactoryImpl implements MindmapsGraphFactory{
                 computer = bundle.getString(COMPUTER);
             }
 
-            return new ConfigureFactory(path, computer, MindmapsFactoryBuilder.getFactory(keyspace, engineUrl, path));
+            return new ConfigureFactory(path, computer, FactoryBuilder.getFactory(keyspace, engineUrl, path));
         } catch (IOException e) {
             throw new IllegalArgumentException(ErrorMessage.CONFIG_NOT_FOUND.getMessage(engineUrl, e.getMessage()));
         }
@@ -117,9 +117,9 @@ public class MindmapsGraphFactoryImpl implements MindmapsGraphFactory{
     static class ConfigureFactory {
         String path;
         String graphComputer;
-        MindmapsInternalFactory factory;
+        InternalFactory factory;
 
-        ConfigureFactory(String path, String graphComputer, MindmapsInternalFactory factory){
+        ConfigureFactory(String path, String graphComputer, InternalFactory factory){
             this.path = path;
             this.graphComputer = graphComputer;
             this.factory = factory;

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryInMemory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryInMemory.java
@@ -30,10 +30,10 @@ import io.mindmaps.graph.internal.MindmapsComputerImpl;
  */
 public class MindmapsGraphFactoryInMemory implements MindmapsGraphFactory {
     private static final String TINKER_GRAPH_COMPUTER = "org.apache.tinkerpop.gremlin.tinkergraph.process.computer.TinkerGraphComputer";
-    private final MindmapsTinkerInternalFactory factory;
+    private final TinkerInternalFactory factory;
 
     public MindmapsGraphFactoryInMemory(String keyspace, String ignored){
-        factory = new MindmapsTinkerInternalFactory(keyspace, null, null);
+        factory = new TinkerInternalFactory(keyspace, null, null);
     }
 
     @Override

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryPersistent.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/MindmapsGraphFactoryPersistent.java
@@ -42,12 +42,12 @@ import static io.mindmaps.util.REST.WebPath.GRAPH_FACTORY_URI;
  * This is to abstract away factories and the backend from the user.
  * The deployer of engine decides on the backend and this class will handle producing the correct graphs.
  */
-public class MindmapsGraphFactoryImpl implements MindmapsGraphFactory{
+public class MindmapsGraphFactoryPersistent implements MindmapsGraphFactory{
     private static final String COMPUTER = "graph.computer";
     private final String uri;
     private final String keyspace;
 
-    public MindmapsGraphFactoryImpl(String keyspace, String uri){
+    public MindmapsGraphFactoryPersistent(String keyspace, String uri){
         this.uri = uri;
         this.keyspace = keyspace;
     }

--- a/mindmaps-graph/src/main/java/io/mindmaps/factory/TinkerInternalFactory.java
+++ b/mindmaps-graph/src/main/java/io/mindmaps/factory/TinkerInternalFactory.java
@@ -28,10 +28,10 @@ import org.slf4j.LoggerFactory;
 /**
  * A graph factory which provides a mindmaps graph with a tinker graph backend.
  */
-class MindmapsTinkerInternalFactory extends AbstractMindmapsInternalFactory<MindmapsTinkerGraph, TinkerGraph> {
-    private final Logger LOG = LoggerFactory.getLogger(MindmapsTinkerInternalFactory.class);
+class TinkerInternalFactory extends AbstractInternalFactory<MindmapsTinkerGraph, TinkerGraph> {
+    private final Logger LOG = LoggerFactory.getLogger(TinkerInternalFactory.class);
 
-    MindmapsTinkerInternalFactory(String keyspace, String engineUrl, String config){
+    TinkerInternalFactory(String keyspace, String engineUrl, String config){
         super(keyspace, engineUrl, config);
     }
 

--- a/mindmaps-graph/src/test/java/io/mindmaps/factory/FactoryBuilderTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/factory/FactoryBuilderTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
-public class MindmapsFactoryBuilderTest {
+public class FactoryBuilderTest {
     private final static String TEST_CONFIG = "../conf/test/tinker/mindmaps-tinker.properties";
     private final static String KEYSPACE = "keyspace";
     private final static String ENGINE_URL = "rubbish";
@@ -43,23 +43,23 @@ public class MindmapsFactoryBuilderTest {
 
     @Test(expected=InvocationTargetException.class)
     public void testConstructorIsPrivate() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<MindmapsFactoryBuilder> c = MindmapsFactoryBuilder.class.getDeclaredConstructor();
+        Constructor<FactoryBuilder> c = FactoryBuilder.class.getDeclaredConstructor();
         c.setAccessible(true);
         c.newInstance();
     }
 
     @Test
     public void testBuildMindmapsFactory(){
-        MindmapsInternalFactory mgf = MindmapsFactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
-        assertThat(mgf, instanceOf(MindmapsTinkerInternalFactory.class));
+        InternalFactory mgf = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
+        assertThat(mgf, instanceOf(TinkerInternalFactory.class));
     }
 
     @Test
     public void testSingleton(){
-        MindmapsInternalFactory mgf1 = MindmapsFactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
-        MindmapsInternalFactory mgf2 = MindmapsFactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
-        MindmapsInternalFactory mgf3 = MindmapsFactoryBuilder.getFactory("key", ENGINE_URL, TEST_CONFIG);
-        MindmapsInternalFactory mgf4 = MindmapsFactoryBuilder.getFactory("key", ENGINE_URL, TEST_CONFIG);
+        InternalFactory mgf1 = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
+        InternalFactory mgf2 = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_CONFIG);
+        InternalFactory mgf3 = FactoryBuilder.getFactory("key", ENGINE_URL, TEST_CONFIG);
+        InternalFactory mgf4 = FactoryBuilder.getFactory("key", ENGINE_URL, TEST_CONFIG);
 
         assertEquals(mgf1, mgf2);
         assertEquals(mgf3, mgf4);
@@ -74,7 +74,7 @@ public class MindmapsFactoryBuilderTest {
         expectedException.expectMessage(allOf(
                 containsString(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage("rubbish"))
         ));
-        MindmapsFactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, "rubbish");
+        FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, "rubbish");
     }
 
 }

--- a/mindmaps-graph/src/test/java/io/mindmaps/factory/MindmapsTinkerGraphFactoryTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/factory/MindmapsTinkerGraphFactoryTest.java
@@ -36,13 +36,13 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 
 public class MindmapsTinkerGraphFactoryTest {
-    private MindmapsInternalFactory tinkerGraphFactory;
+    private InternalFactory tinkerGraphFactory;
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setTinkerGraphFactory(){
-        tinkerGraphFactory = new MindmapsTinkerInternalFactory("test", null, null);
+        tinkerGraphFactory = new TinkerInternalFactory("test", null, null);
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/CastingTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/CastingTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Relation;
@@ -27,11 +26,8 @@ import io.mindmaps.exception.NoEdgeException;
 import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.UUID;
 
@@ -41,31 +37,22 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class CastingTest {
+public class CastingTest extends GraphTestBase{
 
-    private AbstractMindmapsGraph mindmapsGraph;
     private CastingImpl casting;
     private RoleTypeImpl role;
     private RelationImpl relation;
     private InstanceImpl rolePlayer;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
         role = (RoleTypeImpl) mindmapsGraph.putRoleType("Role");
         EntityTypeImpl conceptType = (EntityTypeImpl) mindmapsGraph.putEntityType("A thing");
         rolePlayer = (InstanceImpl) mindmapsGraph.addEntity(conceptType);
         RelationTypeImpl relationType = (RelationTypeImpl) mindmapsGraph.putRelationType("A type");
         relation = (RelationImpl) mindmapsGraph.addRelation(relationType);
         casting = mindmapsGraph.putCasting(role, rolePlayer, relation);
-    }
-    @After
-    public void destroyGraphAccessManager() throws Exception {
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ConceptTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ConceptTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
@@ -36,15 +35,11 @@ import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -55,23 +50,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ConceptTest {
+public class ConceptTest extends GraphTestBase{
 
-    private AbstractMindmapsGraph mindmapsGraph;
     private ConceptImpl concept;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setUp(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
         concept = (ConceptImpl) mindmapsGraph.putEntityType("main_concept");
-    }
-    @After
-    public void destroyGraphAccessManager() throws Exception {
-        mindmapsGraph.close();
     }
 
     @Test(expected=MoreThanOneEdgeException.class)

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/EdgeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/EdgeTest.java
@@ -18,40 +18,29 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
-public class EdgeTest {
+public class EdgeTest extends GraphTestBase{
 
-    private AbstractMindmapsGraph mindmapsGraph;
     private EntityType entityType;
     private Entity entity;
     private EdgeImpl edge;
 
     @Before
     public void setUp(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
         entityType = mindmapsGraph.putEntityType("My Entity Type");
         entity = mindmapsGraph.addEntity(entityType);
         Edge tinkerEdge = (Edge) mindmapsGraph.getTinkerTraversal().has(Schema.ConceptProperty.ITEM_IDENTIFIER.name(), entity.getId()).outE().next();
         edge = new EdgeImpl(tinkerEdge, mindmapsGraph);
-    }
-
-    @After
-    public void destroyGraphAccessManager() throws Exception {
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/EntityTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/EntityTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -31,13 +30,9 @@ import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.RuleType;
 import io.mindmaps.exception.ConceptException;
 import io.mindmaps.util.Schema;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Set;
-import java.util.UUID;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
@@ -45,21 +40,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-public class EntityTest {
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @org.junit.Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void buildGraph(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-    }
-    @After
-    public void destroyGraph()  throws Exception{
-        mindmapsGraph.close();
-    }
+public class EntityTest extends GraphTestBase{
 
     @Test
     public void testDeleteScope() throws ConceptException {

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/GraphTestBase.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/GraphTestBase.java
@@ -1,0 +1,26 @@
+package io.mindmaps.graph.internal;
+
+import io.mindmaps.Mindmaps;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.UUID;
+
+public class GraphTestBase {
+    protected AbstractMindmapsGraph mindmapsGraph;
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUpGraph() {
+        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
+    }
+
+    @After
+    public void destroyGraphAccessManager() throws Exception {
+        mindmapsGraph.close();
+    }
+}

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphHighLevelTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphHighLevelTest.java
@@ -19,7 +19,6 @@
 package io.mindmaps.graph.internal;
 
 import io.mindmaps.Mindmaps;
-import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -33,11 +32,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,10 +55,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class MindmapsGraphHighLevelTest {
+public class MindmapsGraphHighLevelTest extends GraphTestBase{
 
-    private MindmapsGraph mindmapsGraph;
-    private AbstractMindmapsGraph graph;
     private EntityType type;
     private RelationTypeImpl relationType;
     private RoleTypeImpl role1;
@@ -72,27 +66,16 @@ public class MindmapsGraphHighLevelTest {
     private InstanceImpl rolePlayer2;
     private InstanceImpl rolePlayer3;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Before
     public void buildGraphAccessManager(){
-        mindmapsGraph = Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        graph = (AbstractMindmapsGraph) mindmapsGraph;
-        graph.initialiseMetaConcepts();
-
-        type = graph.putEntityType("Test");
-        relationType = (RelationTypeImpl) graph.putRelationType("relationType");
-        role1 = (RoleTypeImpl) graph.putRoleType("role1");
-        role2 = (RoleTypeImpl) graph.putRoleType("role2");
-        role3 = (RoleTypeImpl) graph.putRoleType("role3");
-        rolePlayer1 = (InstanceImpl) graph.addEntity(type);
-        rolePlayer2 = (InstanceImpl) graph.addEntity(type);
-        rolePlayer3 = (InstanceImpl) graph.addEntity(type);
-    }
-    @After
-    public void destroyGraphAccessManager()  throws Exception{
-        graph.close();
+        type = mindmapsGraph.putEntityType("Test");
+        relationType = (RelationTypeImpl) mindmapsGraph.putRelationType("relationType");
+        role1 = (RoleTypeImpl) mindmapsGraph.putRoleType("role1");
+        role2 = (RoleTypeImpl) mindmapsGraph.putRoleType("role2");
+        role3 = (RoleTypeImpl) mindmapsGraph.putRoleType("role3");
+        rolePlayer1 = (InstanceImpl) mindmapsGraph.addEntity(type);
+        rolePlayer2 = (InstanceImpl) mindmapsGraph.addEntity(type);
+        rolePlayer3 = (InstanceImpl) mindmapsGraph.addEntity(type);
     }
 
     //---------------------------------------------Higher Level Functionality-------------------------------------------
@@ -107,25 +90,25 @@ public class MindmapsGraphHighLevelTest {
         relationType.hasRole(role1);
         relationType.hasRole(role2);
         relationType.hasRole(role3);
-        RelationImpl assertion = (RelationImpl) graph.addRelation(relationType).
+        RelationImpl assertion = (RelationImpl) mindmapsGraph.addRelation(relationType).
                 putRolePlayer(role1, rolePlayer1).
                 putRolePlayer(role2, rolePlayer2).
                 putRolePlayer(role3, rolePlayer3);
 
         //Checking it
         //Counts
-        assertEquals(20, graph.getTinkerPopGraph().traversal().V().toList().size());
-        assertEquals(34, graph.getTinkerPopGraph().traversal().E().toList().size());
+        assertEquals(20, mindmapsGraph.getTinkerPopGraph().traversal().V().toList().size());
+        assertEquals(34, mindmapsGraph.getTinkerPopGraph().traversal().E().toList().size());
 
         assertion.getMappingCasting().forEach(casting ->{
-            Edge edge = graph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).inE(Schema.EdgeLabel.CASTING.getLabel()).next();
+            Edge edge = mindmapsGraph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).inE(Schema.EdgeLabel.CASTING.getLabel()).next();
             assertEquals(casting.getRole().getId(), edge.property(Schema.EdgeProperty.ROLE_TYPE.name()).value().toString());
-            edge = graph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+            edge = mindmapsGraph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
             assertEquals(casting.getRole().getId(), edge.property(Schema.EdgeProperty.ROLE_TYPE.name()).value().toString());
         });
 
         //First Check if Roles are set correctly.
-        GraphTraversal<Vertex, Vertex> traversal = graph.getTinkerPopGraph().traversal().V(relationType.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_ROLE.getLabel());
+        GraphTraversal<Vertex, Vertex> traversal = mindmapsGraph.getTinkerPopGraph().traversal().V(relationType.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_ROLE.getLabel());
         List<Vertex> relationType_to_roles = traversal.toList();
 
         boolean rolesCorrect = true;
@@ -139,25 +122,25 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(rolesCorrect);
 
         //Check Roles and Role Players lead to castings
-        Vertex casting1 = graph.getTinkerPopGraph().traversal().V(role1.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
-        Vertex casting1_copy = graph.getTinkerPopGraph().traversal().V(rolePlayer1.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+        Vertex casting1 = mindmapsGraph.getTinkerPopGraph().traversal().V(role1.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex casting1_copy = mindmapsGraph.getTinkerPopGraph().traversal().V(rolePlayer1.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
         assertEquals(casting1, casting1_copy);
 
-        Vertex casting2 = graph.getTinkerPopGraph().traversal().V(role2.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
-        Vertex casting2_copy = graph.getTinkerPopGraph().traversal().V(rolePlayer2.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+        Vertex casting2 = mindmapsGraph.getTinkerPopGraph().traversal().V(role2.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex casting2_copy = mindmapsGraph.getTinkerPopGraph().traversal().V(rolePlayer2.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
         assertEquals(casting2, casting2_copy);
 
-        Vertex casting3 = graph.getTinkerPopGraph().traversal().V(role3.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
-        Vertex casting3_copy = graph.getTinkerPopGraph().traversal().V(rolePlayer3.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+        Vertex casting3 = mindmapsGraph.getTinkerPopGraph().traversal().V(role3.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex casting3_copy = mindmapsGraph.getTinkerPopGraph().traversal().V(rolePlayer3.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
         assertEquals(casting3, casting3_copy);
 
         assertNotEquals(casting1, casting2);
         assertNotEquals(casting1, casting3);
 
         //Check all castings go to the same assertion and check assertion
-        Vertex assertion1 = graph.getTinkerPopGraph().traversal().V(casting1.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
-        Vertex assertion2 = graph.getTinkerPopGraph().traversal().V(casting2.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
-        Vertex assertion3 = graph.getTinkerPopGraph().traversal().V(casting3.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex assertion1 = mindmapsGraph.getTinkerPopGraph().traversal().V(casting1.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex assertion2 = mindmapsGraph.getTinkerPopGraph().traversal().V(casting2.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex assertion3 = mindmapsGraph.getTinkerPopGraph().traversal().V(casting3.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
 
         assertEquals(assertion1, assertion2);
         assertEquals(assertion2, assertion3);
@@ -186,18 +169,18 @@ public class MindmapsGraphHighLevelTest {
         relationType.hasRole(role1);
         relationType.hasRole(role2);
         relationType.hasRole(role3);
-        RelationImpl relationConcept1 = (RelationImpl) graph.addRelation(relationType).
+        RelationImpl relationConcept1 = (RelationImpl) mindmapsGraph.addRelation(relationType).
                 putRolePlayer(role1, rolePlayer1).putRolePlayer(role2, rolePlayer2).putRolePlayer(role3, null);
 
         //Checking it
         //Counts
-        long value = graph.getTinkerPopGraph().traversal().V().count().next();
+        long value = mindmapsGraph.getTinkerPopGraph().traversal().V().count().next();
         assertEquals(19, value);
-        value = graph.getTinkerPopGraph().traversal().E().count().next();
+        value = mindmapsGraph.getTinkerPopGraph().traversal().E().count().next();
         assertEquals(27, value);
 
         //First Check if Roles are set correctly.
-        GraphTraversal<Vertex, Vertex> traversal = graph.getTinkerPopGraph().traversal().V(relationType.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_ROLE.getLabel());
+        GraphTraversal<Vertex, Vertex> traversal = mindmapsGraph.getTinkerPopGraph().traversal().V(relationType.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_ROLE.getLabel());
         List<Vertex> relationType_to_roles = traversal.toList();
 
         boolean rolesCorrect = true;
@@ -211,19 +194,19 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(rolesCorrect);
 
         //Check Roles and Role Players lead to castings
-        Vertex casting1 = graph.getTinkerPopGraph().traversal().V(role1.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
-        Vertex casting1_copy = graph.getTinkerPopGraph().traversal().V(rolePlayer1.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+        Vertex casting1 = mindmapsGraph.getTinkerPopGraph().traversal().V(role1.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex casting1_copy = mindmapsGraph.getTinkerPopGraph().traversal().V(rolePlayer1.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
         assertEquals(casting1, casting1_copy);
 
-        Vertex casting2 = graph.getTinkerPopGraph().traversal().V(role2.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
-        Vertex casting2_copy = graph.getTinkerPopGraph().traversal().V(rolePlayer2.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+        Vertex casting2 = mindmapsGraph.getTinkerPopGraph().traversal().V(role2.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex casting2_copy = mindmapsGraph.getTinkerPopGraph().traversal().V(rolePlayer2.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
         assertEquals(casting2, casting2_copy);
 
         assertNotEquals(casting1, casting2);
 
         //Check all castings go to the same assertion
-        Vertex assertion1 = graph.getTinkerPopGraph().traversal().V(casting1.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
-        Vertex assertion2 = graph.getTinkerPopGraph().traversal().V(casting2.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex assertion1 = mindmapsGraph.getTinkerPopGraph().traversal().V(casting1.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex assertion2 = mindmapsGraph.getTinkerPopGraph().traversal().V(casting2.id()).in(Schema.EdgeLabel.CASTING.getLabel()).next();
 
         assertEquals(assertion1, assertion2);
         assertEquals(relationConcept1.getBaseIdentifier(), assertion1.id());
@@ -249,7 +232,7 @@ public class MindmapsGraphHighLevelTest {
                 containsString(ErrorMessage.ROLE_IS_NULL.getMessage(rolePlayer1))
         ));
 
-        graph.addRelation(relationType).putRolePlayer(null, rolePlayer1);
+        mindmapsGraph.addRelation(relationType).putRolePlayer(null, rolePlayer1);
     }
 
     @Test
@@ -258,19 +241,19 @@ public class MindmapsGraphHighLevelTest {
         roleMap.put(role1, rolePlayer1);
         roleMap.put(role2, rolePlayer2);
 
-        RelationImpl assertion = (RelationImpl) graph.addRelation(relationType).
+        RelationImpl assertion = (RelationImpl) mindmapsGraph.addRelation(relationType).
                 putRolePlayer(role1, rolePlayer1).putRolePlayer(role2, rolePlayer2);
-        Relation relationFound = graph.getRelation(relationType, roleMap);
+        Relation relationFound = mindmapsGraph.getRelation(relationType, roleMap);
         assertEquals(assertion, relationFound);
 
         assertion.getMappingCasting().forEach(casting -> {
-            Edge edge = graph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).inE(Schema.EdgeLabel.CASTING.getLabel()).next();
+            Edge edge = mindmapsGraph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).inE(Schema.EdgeLabel.CASTING.getLabel()).next();
             assertEquals(casting.getRole().getId(), edge.property(Schema.EdgeProperty.ROLE_TYPE.name()).value().toString());
-            edge = graph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
+            edge = mindmapsGraph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).next();
             assertEquals(casting.getRole().getId(), edge.property(Schema.EdgeProperty.ROLE_TYPE.name()).value().toString());
         });
 
-        RelationImpl relationFound2 = (RelationImpl) graph.getRelation(relationType, roleMap);
+        RelationImpl relationFound2 = (RelationImpl) mindmapsGraph.getRelation(relationType, roleMap);
         assertEquals(Schema.BaseType.RELATION.name(), relationFound2.getBaseType());
         assertThat(relationFound2, instanceOf(Relation.class));
     }
@@ -279,34 +262,34 @@ public class MindmapsGraphHighLevelTest {
     public void testAddLargeAndMultipleRelationships(){
 
         //Actual Concepts To Appear Linked In Graph
-        Type relationType = graph.putEntityType("Relation Type");
-        RelationTypeImpl cast = (RelationTypeImpl) graph.putRelationType("Cast");
-        EntityType roleType = graph.putEntityType("Role Type");
-        EntityType type = graph.putEntityType("Concept Type");
-        RoleTypeImpl feature = (RoleTypeImpl) graph.putRoleType("Feature");
-        RoleTypeImpl actor = (RoleTypeImpl) graph.putRoleType("Actor");
-        EntityType movie = graph.putEntityType("Movie");
-        EntityType person = graph.putEntityType("Person");
-        InstanceImpl pacino = (InstanceImpl) graph.addEntity(person);
-        InstanceImpl godfather = (InstanceImpl) graph.addEntity(movie);
-        EntityType genre = graph.putEntityType("Genre");
-        RoleTypeImpl movieOfGenre = (RoleTypeImpl) graph.putRoleType("Movie of Genre");
-        RoleTypeImpl movieGenre = (RoleTypeImpl) graph.putRoleType("Movie Genre");
-        InstanceImpl crime = (InstanceImpl) graph.addEntity(genre);
-        RelationTypeImpl movieHasGenre = (RelationTypeImpl) graph.putRelationType("Movie Has Genre");
+        Type relationType = mindmapsGraph.putEntityType("Relation Type");
+        RelationTypeImpl cast = (RelationTypeImpl) mindmapsGraph.putRelationType("Cast");
+        EntityType roleType = mindmapsGraph.putEntityType("Role Type");
+        EntityType type = mindmapsGraph.putEntityType("Concept Type");
+        RoleTypeImpl feature = (RoleTypeImpl) mindmapsGraph.putRoleType("Feature");
+        RoleTypeImpl actor = (RoleTypeImpl) mindmapsGraph.putRoleType("Actor");
+        EntityType movie = mindmapsGraph.putEntityType("Movie");
+        EntityType person = mindmapsGraph.putEntityType("Person");
+        InstanceImpl pacino = (InstanceImpl) mindmapsGraph.addEntity(person);
+        InstanceImpl godfather = (InstanceImpl) mindmapsGraph.addEntity(movie);
+        EntityType genre = mindmapsGraph.putEntityType("Genre");
+        RoleTypeImpl movieOfGenre = (RoleTypeImpl) mindmapsGraph.putRoleType("Movie of Genre");
+        RoleTypeImpl movieGenre = (RoleTypeImpl) mindmapsGraph.putRoleType("Movie Genre");
+        InstanceImpl crime = (InstanceImpl) mindmapsGraph.addEntity(genre);
+        RelationTypeImpl movieHasGenre = (RelationTypeImpl) mindmapsGraph.putRelationType("Movie Has Genre");
 
         //Construction
         cast.hasRole(feature);
         cast.hasRole(actor);
 
-        RelationImpl assertion = (RelationImpl) graph.addRelation(cast).
+        RelationImpl assertion = (RelationImpl) mindmapsGraph.addRelation(cast).
                 putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
 
         Map<RoleType, Instance> roleMap = new HashMap<>();
         roleMap.clear();
         roleMap.put(movieOfGenre, godfather);
         roleMap.put(movieGenre, crime);
-        graph.addRelation(movieHasGenre).
+        mindmapsGraph.addRelation(movieHasGenre).
                 putRolePlayer(movieOfGenre, godfather).putRolePlayer(movieGenre, crime);
 
         movieHasGenre.hasRole(movieOfGenre);
@@ -314,8 +297,8 @@ public class MindmapsGraphHighLevelTest {
 
         //Validation
         //Counts
-        assertEquals(37, graph.getTinkerPopGraph().traversal().V().toList().size());
-        assertEquals(52, graph.getTinkerPopGraph().traversal().E().toList().size());
+        assertEquals(37, mindmapsGraph.getTinkerPopGraph().traversal().V().toList().size());
+        assertEquals(52, mindmapsGraph.getTinkerPopGraph().traversal().E().toList().size());
 
         assertEdgeCountOfVertex(type, Schema.EdgeLabel.ISA, 0, 1);
         assertEdgeCountOfVertex(relationType, Schema.EdgeLabel.ISA, 0, 1);
@@ -350,7 +333,7 @@ public class MindmapsGraphHighLevelTest {
         assertEdgeCountOfVertex(godfather, Schema.EdgeLabel.ROLE_PLAYER, 2, 0);
 
         //More Specific Checks
-        List<Vertex> assertionsTypes = graph.getTinkerPopGraph().traversal().V(godfather.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).in(Schema.EdgeLabel.CASTING.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).toList();
+        List<Vertex> assertionsTypes = mindmapsGraph.getTinkerPopGraph().traversal().V(godfather.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).in(Schema.EdgeLabel.CASTING.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).toList();
         assertEquals(2, assertionsTypes.size());
         
         List<Object> assertTypeIds = assertionsTypes.stream().map(Vertex::id).collect(Collectors.toList());
@@ -358,7 +341,7 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(assertTypeIds.contains(cast.getBaseIdentifier()));
         assertTrue(assertTypeIds.contains(movieHasGenre.getBaseIdentifier()));
 
-        List<Vertex> collection = graph.getTinkerPopGraph().traversal().V(cast.getBaseIdentifier(), movieHasGenre.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).out(Schema.EdgeLabel.CASTING.getLabel()).out().toList();
+        List<Vertex> collection = mindmapsGraph.getTinkerPopGraph().traversal().V(cast.getBaseIdentifier(), movieHasGenre.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).out(Schema.EdgeLabel.CASTING.getLabel()).out().toList();
         assertEquals(8, collection.size());
 
         HashSet<Object> uniqueCollection = new HashSet<>();
@@ -375,10 +358,10 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(uniqueCollection.contains(movieGenre.getBaseIdentifier()));
         assertTrue(uniqueCollection.contains(crime.getBaseIdentifier()));
 
-        graph.getRelation(movieHasGenre, roleMap);
-        graph.getRelation(movieHasGenre, roleMap);
-        graph.getRelation(movieHasGenre, roleMap);
-        graph.getRelation(movieHasGenre, roleMap);
+        mindmapsGraph.getRelation(movieHasGenre, roleMap);
+        mindmapsGraph.getRelation(movieHasGenre, roleMap);
+        mindmapsGraph.getRelation(movieHasGenre, roleMap);
+        mindmapsGraph.getRelation(movieHasGenre, roleMap);
 
         assertEquals(Schema.BaseType.ENTITY.name(), pacino.getBaseType());
         for(CastingImpl casting: assertion.getMappingCasting()){
@@ -387,7 +370,7 @@ public class MindmapsGraphHighLevelTest {
 
     }
     private void assertEdgeCountOfVertex(Concept concept , Schema.EdgeLabel type, int inCount, int outCount){
-        Vertex v= graph.getTinkerPopGraph().traversal().V(((ConceptImpl) concept).getBaseIdentifier()).next();
+        Vertex v= mindmapsGraph.getTinkerPopGraph().traversal().V(((ConceptImpl) concept).getBaseIdentifier()).next();
         assertEquals(inCount, getIteratorCount(v.edges(Direction.IN, type.getLabel())));
         assertEquals(outCount, getIteratorCount(v.edges(Direction.OUT, type.getLabel())));
     }
@@ -404,30 +387,30 @@ public class MindmapsGraphHighLevelTest {
     //------------------------------------ hasAssertion
     @Test
     public void hasRelationComplexTestMultipleRelations(){
-        RelationTypeImpl cast = (RelationTypeImpl) graph.putRelationType("Cast");
-        EntityType type = graph.putEntityType("Concept Type");
-        RoleTypeImpl feature = (RoleTypeImpl) graph.putRoleType("Feature");
-        RoleTypeImpl actor = (RoleTypeImpl) graph.putRoleType("Actor");
-        EntityType movie = graph.putEntityType("Movie");
-        EntityType person = graph.putEntityType("Person");
-        InstanceImpl pacino = (InstanceImpl) graph.addEntity(person);
-        InstanceImpl godfather = (InstanceImpl) graph.addEntity(movie);
-        EntityType genre = graph.putEntityType("Genre");
-        RoleTypeImpl movieOfGenre = (RoleTypeImpl) graph.putRoleType("Movie of Genre");
-        RoleTypeImpl movieGenre = (RoleTypeImpl) graph.putRoleType("Movie Genre");
-        InstanceImpl crime = (InstanceImpl) graph.addEntity(genre);
-        RelationTypeImpl movieHasGenre = (RelationTypeImpl) graph.putRelationType("Movie Has Genre");
+        RelationTypeImpl cast = (RelationTypeImpl) mindmapsGraph.putRelationType("Cast");
+        EntityType type = mindmapsGraph.putEntityType("Concept Type");
+        RoleTypeImpl feature = (RoleTypeImpl) mindmapsGraph.putRoleType("Feature");
+        RoleTypeImpl actor = (RoleTypeImpl) mindmapsGraph.putRoleType("Actor");
+        EntityType movie = mindmapsGraph.putEntityType("Movie");
+        EntityType person = mindmapsGraph.putEntityType("Person");
+        InstanceImpl pacino = (InstanceImpl) mindmapsGraph.addEntity(person);
+        InstanceImpl godfather = (InstanceImpl) mindmapsGraph.addEntity(movie);
+        EntityType genre = mindmapsGraph.putEntityType("Genre");
+        RoleTypeImpl movieOfGenre = (RoleTypeImpl) mindmapsGraph.putRoleType("Movie of Genre");
+        RoleTypeImpl movieGenre = (RoleTypeImpl) mindmapsGraph.putRoleType("Movie Genre");
+        InstanceImpl crime = (InstanceImpl) mindmapsGraph.addEntity(genre);
+        RelationTypeImpl movieHasGenre = (RelationTypeImpl) mindmapsGraph.putRelationType("Movie Has Genre");
 
-        graph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
-        graph.addRelation(movieHasGenre).putRolePlayer(movieOfGenre, godfather).putRolePlayer(movieGenre, crime);
+        mindmapsGraph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
+        mindmapsGraph.addRelation(movieHasGenre).putRolePlayer(movieOfGenre, godfather).putRolePlayer(movieGenre, crime);
 
         //Validation
         HashMap<RoleType, Instance> roleMap = new HashMap<>();
         roleMap.put(feature, godfather);
         roleMap.put(actor, pacino);
-        assertNotNull(graph.getRelation(cast, roleMap));
+        assertNotNull(mindmapsGraph.getRelation(cast, roleMap));
         roleMap.put(actor, null);
-        assertNull(graph.getRelation(cast, roleMap));
+        assertNull(mindmapsGraph.getRelation(cast, roleMap));
 
         assertEquals(godfather, pacino.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT).iterator().next());
         assertTrue(godfather.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT).contains(pacino));
@@ -435,9 +418,9 @@ public class MindmapsGraphHighLevelTest {
         roleMap.clear();
         roleMap.put(movieOfGenre, godfather);
         roleMap.put(movieGenre, crime);
-        assertNotNull(graph.getRelation(movieHasGenre, roleMap));
+        assertNotNull(mindmapsGraph.getRelation(movieHasGenre, roleMap));
         roleMap.put(actor, null);
-        assertNull(graph.getRelation(cast, roleMap));
+        assertNull(mindmapsGraph.getRelation(cast, roleMap));
         assertEquals(cast.getBaseType(), Schema.BaseType.RELATION_TYPE.name());
         assertEquals(feature.getBaseType(), Schema.BaseType.ROLE_TYPE.name());
         assertEquals(actor.getBaseType(), Schema.BaseType.ROLE_TYPE.name());
@@ -452,7 +435,7 @@ public class MindmapsGraphHighLevelTest {
 
     @Test
     public void hasRelationComplexMissingRolePlayersTest(){
-        RelationType relationType2 = graph.putRelationType("relationType2");
+        RelationType relationType2 = mindmapsGraph.putRelationType("relationType2");
 
         Map<RoleType, Instance> roleMap = new HashMap<>();
         roleMap.put(role1, null);
@@ -462,24 +445,24 @@ public class MindmapsGraphHighLevelTest {
         relationType.hasRole(role1);
         relationType.hasRole(role2);
         relationType.hasRole(role3);
-        Relation relation = graph.addRelation(relationType).
+        Relation relation = mindmapsGraph.addRelation(relationType).
                 putRolePlayer(role1, null).putRolePlayer(role2, rolePlayer2).putRolePlayer(role3, null);
 
-        assertNotNull(graph.getRelation(relationType, roleMap));
-        assertNull(graph.getRelation(relationType2, roleMap));
+        assertNotNull(mindmapsGraph.getRelation(relationType, roleMap));
+        assertNull(mindmapsGraph.getRelation(relationType2, roleMap));
     }
 
     @Test
     public void addRolePlayerToExistingRelation(){
-        RelationType cast = graph.putRelationType("Cast");
-        RoleType feature = graph.putRoleType("Feature");
-        RoleType actor = graph.putRoleType("Actor");
-        EntityType movie = graph.putEntityType("Movie");
-        EntityType person = graph.putEntityType("Person");
-        Instance pacino = graph.addEntity(person);
-        Instance godfather = graph.addEntity(movie);
+        RelationType cast = mindmapsGraph.putRelationType("Cast");
+        RoleType feature = mindmapsGraph.putRoleType("Feature");
+        RoleType actor = mindmapsGraph.putRoleType("Actor");
+        EntityType movie = mindmapsGraph.putEntityType("Movie");
+        EntityType person = mindmapsGraph.putEntityType("Person");
+        Instance pacino = mindmapsGraph.addEntity(person);
+        Instance godfather = mindmapsGraph.addEntity(movie);
 
-        RelationImpl assertion = (RelationImpl) graph.addRelation(cast).
+        RelationImpl assertion = (RelationImpl) mindmapsGraph.addRelation(cast).
                 putRolePlayer(feature, null).putRolePlayer(actor, pacino);
         assertion.putRolePlayer(feature, godfather);
         assertEquals(2, assertion.getMappingCasting().size());
@@ -489,20 +472,20 @@ public class MindmapsGraphHighLevelTest {
 
     @Test
     public void testPutShortcutEdge(){
-        RelationTypeImpl cast = (RelationTypeImpl) graph.putRelationType("Cast");
-        EntityType type = graph.putEntityType("Concept Type");
-        RoleTypeImpl feature = (RoleTypeImpl) graph.putRoleType("Feature");
-        RoleTypeImpl actor = (RoleTypeImpl) graph.putRoleType("Actor");
-        EntityType movie = graph.putEntityType("Movie");
-        EntityType person = graph.putEntityType("Person");
-        InstanceImpl<?, ?> pacino = (InstanceImpl) graph.addEntity(person);
-        InstanceImpl<?, ?> godfather = (InstanceImpl) graph.addEntity(movie);
-        RoleType actor2 = graph.putRoleType("Actor 2");
-        RoleType actor3 = graph.putRoleType("Actor 3");
-        RoleType character = graph.putRoleType("Character");
-        Instance thing = graph.addEntity(type);
+        RelationTypeImpl cast = (RelationTypeImpl) mindmapsGraph.putRelationType("Cast");
+        EntityType type = mindmapsGraph.putEntityType("Concept Type");
+        RoleTypeImpl feature = (RoleTypeImpl) mindmapsGraph.putRoleType("Feature");
+        RoleTypeImpl actor = (RoleTypeImpl) mindmapsGraph.putRoleType("Actor");
+        EntityType movie = mindmapsGraph.putEntityType("Movie");
+        EntityType person = mindmapsGraph.putEntityType("Person");
+        InstanceImpl<?, ?> pacino = (InstanceImpl) mindmapsGraph.addEntity(person);
+        InstanceImpl<?, ?> godfather = (InstanceImpl) mindmapsGraph.addEntity(movie);
+        RoleType actor2 = mindmapsGraph.putRoleType("Actor 2");
+        RoleType actor3 = mindmapsGraph.putRoleType("Actor 3");
+        RoleType character = mindmapsGraph.putRoleType("Character");
+        Instance thing = mindmapsGraph.addEntity(type);
 
-        RelationImpl relation = (RelationImpl) graph.addRelation(cast).
+        RelationImpl relation = (RelationImpl) mindmapsGraph.addRelation(cast).
                 putRolePlayer(feature, godfather).putRolePlayer(actor, pacino).putRolePlayer(actor2, pacino);
 
         Set<EdgeImpl> edges = pacino.getEdgesOfType(Direction.OUT, Schema.EdgeLabel.SHORTCUT);
@@ -520,7 +503,7 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(pacinoToOthers.contains(godfather));
         assertTrue(pacinoToOthers.contains(pacino));
 
-        graph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor3, pacino).putRolePlayer(character, thing);
+        mindmapsGraph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor3, pacino).putRolePlayer(character, thing);
 
         godfatherToOthers = godfather.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT);
         pacinoToOthers = pacino.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT);
@@ -534,7 +517,7 @@ public class MindmapsGraphHighLevelTest {
         assertTrue(pacinoToOthers.contains(pacino));
         assertTrue(pacinoToOthers.contains(thing));
 
-        graph.getTinkerPopGraph().traversal().V(pacino.getIncomingNeighbours(Schema.EdgeLabel.ROLE_PLAYER).iterator().next().getBaseIdentifier()).next().remove();
+        mindmapsGraph.getTinkerPopGraph().traversal().V(pacino.getIncomingNeighbours(Schema.EdgeLabel.ROLE_PLAYER).iterator().next().getBaseIdentifier()).next().remove();
 
         godfatherToOthers = godfather.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT);
         pacinoToOthers = pacino.getOutgoingNeighbours(Schema.EdgeLabel.SHORTCUT);
@@ -574,31 +557,31 @@ public class MindmapsGraphHighLevelTest {
 
     @Test
     public void testCollapsedCasting(){
-        RelationTypeImpl cast = (RelationTypeImpl) graph.putRelationType("Cast");
-        EntityType type = graph.putEntityType("Concept Type");
-        RoleType feature = graph.putRoleType("Feature");
-        RoleTypeImpl actor = (RoleTypeImpl) graph.putRoleType("Actor");
-        EntityType movie = graph.putEntityType("Movie");
-        EntityType person = graph.putEntityType("Person");
-        InstanceImpl pacino = (InstanceImpl) graph.addEntity(person);
-        InstanceImpl godfather = (InstanceImpl) graph.addEntity(movie);
-        InstanceImpl godfather2 = (InstanceImpl) graph.addEntity(movie);
-        InstanceImpl godfather3 = (InstanceImpl) graph.addEntity(movie);
+        RelationTypeImpl cast = (RelationTypeImpl) mindmapsGraph.putRelationType("Cast");
+        EntityType type = mindmapsGraph.putEntityType("Concept Type");
+        RoleType feature = mindmapsGraph.putRoleType("Feature");
+        RoleTypeImpl actor = (RoleTypeImpl) mindmapsGraph.putRoleType("Actor");
+        EntityType movie = mindmapsGraph.putEntityType("Movie");
+        EntityType person = mindmapsGraph.putEntityType("Person");
+        InstanceImpl pacino = (InstanceImpl) mindmapsGraph.addEntity(person);
+        InstanceImpl godfather = (InstanceImpl) mindmapsGraph.addEntity(movie);
+        InstanceImpl godfather2 = (InstanceImpl) mindmapsGraph.addEntity(movie);
+        InstanceImpl godfather3 = (InstanceImpl) mindmapsGraph.addEntity(movie);
 
-        graph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
-        graph.addRelation(cast).putRolePlayer(feature, godfather2).putRolePlayer(actor, pacino);
-        graph.addRelation(cast).putRolePlayer(feature, godfather3).putRolePlayer(actor, pacino);
+        mindmapsGraph.addRelation(cast).putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
+        mindmapsGraph.addRelation(cast).putRolePlayer(feature, godfather2).putRolePlayer(actor, pacino);
+        mindmapsGraph.addRelation(cast).putRolePlayer(feature, godfather3).putRolePlayer(actor, pacino);
 
-        Vertex pacinoVertex = graph.getTinkerPopGraph().traversal().V(pacino.getBaseIdentifier()).next();
-        Vertex godfatherVertex = graph.getTinkerPopGraph().traversal().V(godfather.getBaseIdentifier()).next();
-        Vertex godfather2Vertex = graph.getTinkerPopGraph().traversal().V(godfather2.getBaseIdentifier()).next();
-        Vertex godfather3Vertex = graph.getTinkerPopGraph().traversal().V(godfather3.getBaseIdentifier()).next();
+        Vertex pacinoVertex = mindmapsGraph.getTinkerPopGraph().traversal().V(pacino.getBaseIdentifier()).next();
+        Vertex godfatherVertex = mindmapsGraph.getTinkerPopGraph().traversal().V(godfather.getBaseIdentifier()).next();
+        Vertex godfather2Vertex = mindmapsGraph.getTinkerPopGraph().traversal().V(godfather2.getBaseIdentifier()).next();
+        Vertex godfather3Vertex = mindmapsGraph.getTinkerPopGraph().traversal().V(godfather3.getBaseIdentifier()).next();
 
-        assertEquals(3, graph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.RELATION.name()).count().next().intValue());
-        assertEquals(4, graph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.CASTING.name()).count().next().intValue());
-        assertEquals(7, graph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.ENTITY.name()).count().next().intValue());
-        assertEquals(5, graph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.ROLE_TYPE.name()).count().next().intValue());
-        assertEquals(2, graph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.RELATION_TYPE.name()).count().next().intValue());
+        assertEquals(3, mindmapsGraph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.RELATION.name()).count().next().intValue());
+        assertEquals(4, mindmapsGraph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.CASTING.name()).count().next().intValue());
+        assertEquals(7, mindmapsGraph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.ENTITY.name()).count().next().intValue());
+        assertEquals(5, mindmapsGraph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.ROLE_TYPE.name()).count().next().intValue());
+        assertEquals(2, mindmapsGraph.getTinkerPopGraph().traversal().V().hasLabel(Schema.BaseType.RELATION_TYPE.name()).count().next().intValue());
 
         Iterator<Edge> pacinoCastings = pacinoVertex.edges(Direction.IN, Schema.EdgeLabel.ROLE_PLAYER.getLabel());
         Iterator<Edge> godfatherCastings = godfatherVertex.edges(Direction.IN, Schema.EdgeLabel.ROLE_PLAYER.getLabel());
@@ -610,7 +593,7 @@ public class MindmapsGraphHighLevelTest {
         checkEdgeCount(1, godfather2Castings);
         checkEdgeCount(1, godfather3Castings);
 
-        Vertex actorVertex = graph.getTinkerPopGraph().traversal().V(pacino.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).next();
+        Vertex actorVertex = mindmapsGraph.getTinkerPopGraph().traversal().V(pacino.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).next();
 
         assertEquals(actor.getBaseIdentifier(), actorVertex.id());
     }

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphLowLevelTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphLowLevelTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
@@ -36,47 +35,21 @@ import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.Veri
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
 import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class MindmapsGraphLowLevelTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void buildGraphAccessManager(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-    }
-    @After
-    public void destroyGraphAccessManager()  throws Exception{
-        mindmapsGraph.close();
-    }
-
-    @Test
-    public void testGetGraph(){
-        assertThat(mindmapsGraph.getTinkerPopGraph(), instanceOf(Graph.class));
-    }
+public class MindmapsGraphLowLevelTest extends GraphTestBase{
 
     @Test
     public void testPutConcept() throws Exception {
@@ -86,7 +59,6 @@ public class MindmapsGraphLowLevelTest {
         assertEquals(22, mindmapsGraph.getTinkerPopGraph().traversal().V().toList().size());
     }
 
-    //----------------------------------------------Concept Functionality-----------------------------------------------
     @Test(expected=RuntimeException.class)
     public void testTooManyNodesForId() {
         Graph graph = mindmapsGraph.getTinkerPopGraph();

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphTrackingTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsGraphTrackingTest.java
@@ -18,20 +18,17 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
 import io.mindmaps.concept.Type;
 import io.mindmaps.exception.ConceptException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.Stack;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -44,24 +41,14 @@ import static org.junit.Assert.assertTrue;
  *
  */
 
-public class MindmapsGraphTrackingTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
+public class MindmapsGraphTrackingTest extends GraphTestBase{
     private Set<ConceptImpl> modifiedConcepts;
     private Stack<Concept> newConcepts;
 
     @Before
     public void buildGraphAccessManager() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        // start standard rootGraph access manager
-        mindmapsGraph.initialiseMetaConcepts();
         modifiedConcepts = new HashSet<>();
         newConcepts = new Stack<>();
-    }
-
-    @After
-    public void destroyGraphAccessManager()  throws Exception{
-        mindmapsGraph.close();
     }
 
     @Test
@@ -92,7 +79,7 @@ public class MindmapsGraphTrackingTest {
 
         // check the concept tracker is empty
         modifiedConcepts = mindmapsGraph.getModifiedConcepts();
-        assertEquals(4, modifiedConcepts.size());
+        assertEquals(3, modifiedConcepts.size());
 
         // add primitive edges in as many ways as possible
         c1.superType(c2);

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsTinkerGraphTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/MindmapsTinkerGraphTest.java
@@ -18,11 +18,9 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.exception.MindmapsValidationException;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -37,14 +35,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-public class MindmapsTinkerGraphTest {
-    private MindmapsGraph mindmapsGraph;
-
-    @Before
-    public void setup() throws MindmapsValidationException {
-        mindmapsGraph = Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.commit();
-    }
+public class MindmapsTinkerGraphTest extends GraphTestBase{
 
     @Test
     public void testMultithreading(){

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/OntologyMutationTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/OntologyMutationTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
 import io.mindmaps.concept.Relation;
@@ -26,20 +25,15 @@ import io.mindmaps.concept.RelationType;
 import io.mindmaps.concept.RoleType;
 import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.util.ErrorMessage;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Map;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.core.StringContains.containsString;
 
-public class OntologyMutationTest {
-    private AbstractMindmapsGraph mindmapsGraph;
+public class OntologyMutationTest extends GraphTestBase{
     private RoleType husband;
     private RoleType wife;
     private RelationType marriage;
@@ -51,22 +45,15 @@ public class OntologyMutationTest {
     private Instance bob;
     private Relation relation;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Before
     public void buildGraph() throws MindmapsValidationException {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-
-        //spouse = mindmapsGraph.putRoleType("Spouse");
-        husband = mindmapsGraph.putRoleType("Husband");//.superType(spouse);
+        husband = mindmapsGraph.putRoleType("Husband");
         wife = mindmapsGraph.putRoleType("Wife");
         RoleType driver = mindmapsGraph.putRoleType("Driver");
         RoleType driven = mindmapsGraph.putRoleType("Driven");
 
-        //union = mindmapsGraph.putRelationType("Union").hasRole(spouse).hasRole(wife);
         marriage = mindmapsGraph.putRelationType("marriage").hasRole(husband).hasRole(wife);
-        RelationType carBeingDrivenBy = mindmapsGraph.putRelationType("car being driven by").hasRole(driven).hasRole(driver);
+        mindmapsGraph.putRelationType("car being driven by").hasRole(driven).hasRole(driver);
 
         person = mindmapsGraph.putEntityType("Person").playsRole(husband).playsRole(wife);
         man = mindmapsGraph.putEntityType("Man").superType(person);
@@ -77,10 +64,6 @@ public class OntologyMutationTest {
         bob = mindmapsGraph.addEntity(man);
         relation = mindmapsGraph.addRelation(marriage).putRolePlayer(wife, alice).putRolePlayer(husband, bob);
         mindmapsGraph.commit();
-    }
-    @After
-    public void destroyGraph()  throws Exception{
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RelationTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RelationTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -33,11 +32,8 @@ import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,7 +41,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -54,10 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class RelationTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
-
+public class RelationTest extends GraphTestBase{
     private RelationImpl relation;
     private RoleTypeImpl role1;
     private InstanceImpl rolePlayer1;
@@ -71,14 +63,8 @@ public class RelationTest {
     private CastingImpl casting1;
     private CastingImpl casting2;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Before
     public void buildGraph(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-
         type = mindmapsGraph.putEntityType("Main concept Type");
         relationType = mindmapsGraph.putRelationType("Main relation type");
 
@@ -92,10 +78,6 @@ public class RelationTest {
 
         casting1 = mindmapsGraph.putCasting(role1, rolePlayer1, relation);
         casting2 = mindmapsGraph.putCasting(role2, rolePlayer2, relation);
-    }
-    @After
-    public void destroyGraph()  throws Exception{
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RelationTypeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RelationTypeTest.java
@@ -18,19 +18,14 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.RelationType;
 import io.mindmaps.concept.RoleType;
 import io.mindmaps.exception.ConceptException;
 import io.mindmaps.util.ErrorMessage;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -39,22 +34,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class RelationTypeTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
+public class RelationTypeTest extends GraphTestBase{
     private RelationType relationType;
     private RoleType role1;
     private RoleType role2;
     private RoleType role3;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Before
     public void setUp() throws ConceptException {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-
         //Building
         relationType = mindmapsGraph.putRelationType("relationType");
         role1 = mindmapsGraph.putRoleType("role1");
@@ -64,10 +51,6 @@ public class RelationTypeTest {
         relationType.hasRole(role1);
         relationType.hasRole(role2);
         relationType.hasRole(role3);
-    }
-    @After
-    public void destroyGraphAccessManager() throws Exception {
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -28,11 +27,7 @@ import io.mindmaps.concept.ResourceType;
 import io.mindmaps.concept.RoleType;
 import io.mindmaps.exception.ConceptNotUniqueException;
 import io.mindmaps.util.ErrorMessage;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.UUID;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
@@ -41,19 +36,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class ResourceTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @org.junit.Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void buildGraph() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-    }
-
+public class ResourceTest extends GraphTestBase{
     @Test
     public void testDataType() throws Exception {
         ResourceType resourceType = mindmapsGraph.putResourceType("resourceType", ResourceType.DataType.STRING);

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTypeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ResourceTypeTest.java
@@ -18,17 +18,13 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Resource;
 import io.mindmaps.concept.ResourceType;
 import io.mindmaps.exception.InvalidConceptValueException;
 import io.mindmaps.util.ErrorMessage;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.util.UUID;
 import java.util.regex.PatternSyntaxException;
 
 import static junit.framework.TestCase.assertNull;
@@ -40,18 +36,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class ResourceTypeTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
+public class ResourceTypeTest extends GraphTestBase{
     private ResourceType<String> resourceType;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void buildGraph() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
         resourceType = mindmapsGraph.putResourceType("Resource Type", ResourceType.DataType.STRING);
     }
 

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RoleTypeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RoleTypeTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.RelationType;
@@ -27,13 +26,8 @@ import io.mindmaps.concept.Type;
 import io.mindmaps.exception.MoreThanOneEdgeException;
 import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.util.Schema;
-import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -41,25 +35,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class RoleTypeTest {
-    private AbstractMindmapsGraph mindmapsGraph;
+public class RoleTypeTest extends GraphTestBase {
     private RoleType roleType;
     private RelationType relationType;
 
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
     @Before
     public void buildGraph(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-
         roleType = mindmapsGraph.putRoleType("RoleType");
         relationType = mindmapsGraph.putRelationType("RelationType");
-    }
-    @After
-    public void destroyGraph()  throws Exception{
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RuleTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/RuleTest.java
@@ -18,32 +18,20 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.RuleType;
 import io.mindmaps.concept.Type;
 import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.junit.Before;
 import org.junit.Test;
-
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class RuleTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @Before
-    public void buildGraph() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
-    }
+public class RuleTest extends GraphTestBase{
 
     @Test
     public void testType() {

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/TypeTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/TypeTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -32,15 +31,12 @@ import io.mindmaps.exception.ConceptException;
 import io.mindmaps.exception.InvalidConceptTypeException;
 import io.mindmaps.util.ErrorMessage;
 import io.mindmaps.util.Schema;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.allOf;
@@ -53,17 +49,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
-public class TypeTest {
-
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @org.junit.Rule
-    public final ExpectedException expectedException = ExpectedException.none();
+public class TypeTest extends GraphTestBase{
 
     @Before
     public void buildGraph(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-        mindmapsGraph.initialiseMetaConcepts();
         EntityType top = mindmapsGraph.putEntityType("top");
         EntityType middle1 = mindmapsGraph.putEntityType("mid1");
         EntityType middle2 = mindmapsGraph.putEntityType("mid2");
@@ -74,10 +63,6 @@ public class TypeTest {
         middle1.superType(top);
         middle2.superType(top);
         middle3.superType(top);
-    }
-    @After
-    public void destroyGraph()  throws Exception{
-        mindmapsGraph.close();
     }
 
     @Test

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ValidateGlobalRulesTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ValidateGlobalRulesTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -27,33 +26,15 @@ import io.mindmaps.concept.RoleType;
 import io.mindmaps.concept.Type;
 import io.mindmaps.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class ValidateGlobalRulesTest {
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @org.junit.Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void buildGraphAccessManager() {
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-    }
-
-    @After
-    public void destroyGraphAccessManager() throws Exception {
-        mindmapsGraph.close();
-    }
+public class ValidateGlobalRulesTest extends GraphTestBase{
 
     @Test(expected = InvocationTargetException.class)
     public void testConstructor() throws Exception { //Checks that you cannot initialise it.

--- a/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ValidatorTest.java
+++ b/mindmaps-graph/src/test/java/io/mindmaps/graph/internal/ValidatorTest.java
@@ -18,7 +18,6 @@
 
 package io.mindmaps.graph.internal;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.concept.Entity;
 import io.mindmaps.concept.EntityType;
 import io.mindmaps.concept.Instance;
@@ -28,16 +27,11 @@ import io.mindmaps.concept.RoleType;
 import io.mindmaps.exception.InvalidConceptTypeException;
 import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.util.ErrorMessage;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.slf4j.Logger;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -47,21 +41,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class ValidatorTest {
-    private final Logger LOG = org.slf4j.LoggerFactory.getLogger(ValidatorTest.class);
-    private AbstractMindmapsGraph mindmapsGraph;
-
-    @org.junit.Rule
-    public final ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void buildGraphAccessManager(){
-        mindmapsGraph = (AbstractMindmapsGraph) Mindmaps.factory(Mindmaps.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
-    }
-    @After
-    public void destroyGraphAccessManager()  throws Exception{
-        mindmapsGraph.close();
-    }
+public class ValidatorTest extends GraphTestBase{
 
     @Test
     public void testGetErrorsFound() throws Exception {

--- a/mindmaps-orientdb-factory/src/main/java/io/mindmaps/factory/OrientDBInternalFactory.java
+++ b/mindmaps-orientdb-factory/src/main/java/io/mindmaps/factory/OrientDBInternalFactory.java
@@ -16,14 +16,14 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-public class MindmapsOrientDBInternalFactory extends AbstractMindmapsInternalFactory<MindmapsOrientDBGraph, OrientGraph> {
-    private final Logger LOG = LoggerFactory.getLogger(MindmapsOrientDBInternalFactory.class);
+public class OrientDBInternalFactory extends AbstractInternalFactory<MindmapsOrientDBGraph, OrientGraph> {
+    private final Logger LOG = LoggerFactory.getLogger(OrientDBInternalFactory.class);
     private final Map<String, OrientGraphFactory> openFactories;
     private static final String KEY_TYPE = "keytype";
     private static final String UNIQUE = "type";
     private static final String SPECIAL_IN_MEMORY = "memory";
 
-    public MindmapsOrientDBInternalFactory(String keyspace, String engineUrl, String config) {
+    public OrientDBInternalFactory(String keyspace, String engineUrl, String config) {
         super(keyspace, engineUrl, config);
         openFactories = new HashMap<>();
     }

--- a/mindmaps-orientdb-factory/src/test/java/io/mindmaps/factory/MindmapsOrientDBGraphFactoryTest.java
+++ b/mindmaps-orientdb-factory/src/test/java/io/mindmaps/factory/MindmapsOrientDBGraphFactoryTest.java
@@ -20,11 +20,11 @@ import static org.junit.Assert.assertThat;
 public class MindmapsOrientDBGraphFactoryTest {
     private final static String TEST_NAME = "MyGraph";
     private final static String TEST_URI = "memory";
-    private static MindmapsOrientDBInternalFactory orientGraphFactory ;
+    private static OrientDBInternalFactory orientGraphFactory ;
 
     @Before
     public void setUp() throws Exception {
-        orientGraphFactory = new MindmapsOrientDBInternalFactory(TEST_NAME, TEST_URI, null);
+        orientGraphFactory = new OrientDBInternalFactory(TEST_NAME, TEST_URI, null);
     }
 
     @After

--- a/mindmaps-orientdb-factory/src/test/java/io/mindmaps/graph/internal/MindmapsOrientDBGraphTest.java
+++ b/mindmaps-orientdb-factory/src/test/java/io/mindmaps/graph/internal/MindmapsOrientDBGraphTest.java
@@ -1,7 +1,7 @@
 package io.mindmaps.graph.internal;
 
 import io.mindmaps.MindmapsGraph;
-import io.mindmaps.factory.MindmapsOrientDBInternalFactory;
+import io.mindmaps.factory.OrientDBInternalFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -27,7 +27,7 @@ public class MindmapsOrientDBGraphTest {
 
     @Before
     public void setup(){
-        mindmapsGraph = new MindmapsOrientDBInternalFactory(TEST_NAME, TEST_URI, null).getGraph(TEST_BATCH_LOADING);
+        mindmapsGraph = new OrientDBInternalFactory(TEST_NAME, TEST_URI, null).getGraph(TEST_BATCH_LOADING);
     }
 
     @After

--- a/mindmaps-test/src/test/java/io/mindmaps/factory/MindmapsGraphFactoryMock.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/factory/MindmapsGraphFactoryMock.java
@@ -24,7 +24,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 /**
  *
  */
-public class MindmapsGraphFactoryMock extends MindmapsGraphFactoryImpl {
+public class MindmapsGraphFactoryMock extends MindmapsGraphFactoryPersistent {
     private final String keyspace;
     private final String uri;
 

--- a/mindmaps-titan-factory/conf/mindmaps-titan-test.properties
+++ b/mindmaps-titan-factory/conf/mindmaps-titan-test.properties
@@ -17,7 +17,7 @@
 #
 
 # Internal Factory Definition
-factory.internal=io.mindmaps.factory.MindmapsTitanInternalFactory
+factory.internal=io.mindmaps.factory.TitanInternalFactory
 
 # Computer
 graph.computer=com.thinkaurelius.titan.graphdb.olap.computer.FulgoraGraphComputer

--- a/mindmaps-titan-factory/src/main/java/io/mindmaps/factory/TitanHadoopInternalFactory.java
+++ b/mindmaps-titan-factory/src/main/java/io/mindmaps/factory/TitanHadoopInternalFactory.java
@@ -30,12 +30,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
-public class MindmapsTitanHadoopInternalFactory extends AbstractMindmapsInternalFactory<AbstractMindmapsGraph<HadoopGraph>, HadoopGraph> {
+public class TitanHadoopInternalFactory extends AbstractInternalFactory<AbstractMindmapsGraph<HadoopGraph>, HadoopGraph> {
     private static final String CLUSTER_KEYSPACE = "titanmr.ioformat.conf.storage.cassandra.keyspace";
     private static final String INPUT_KEYSPACE = "cassandra.input.keyspace";
-    private final Logger LOG = LoggerFactory.getLogger(MindmapsTitanHadoopInternalFactory.class);
+    private final Logger LOG = LoggerFactory.getLogger(TitanHadoopInternalFactory.class);
 
-    MindmapsTitanHadoopInternalFactory(String keyspace, String engineUrl, String config) {
+    TitanHadoopInternalFactory(String keyspace, String engineUrl, String config) {
         super(keyspace, engineUrl, config);
     }
 

--- a/mindmaps-titan-factory/src/main/java/io/mindmaps/factory/TitanInternalFactory.java
+++ b/mindmaps-titan-factory/src/main/java/io/mindmaps/factory/TitanInternalFactory.java
@@ -43,11 +43,11 @@ import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-class MindmapsTitanInternalFactory extends AbstractMindmapsInternalFactory<MindmapsTitanGraph, TitanGraph> {
-    protected final Logger LOG = LoggerFactory.getLogger(MindmapsTitanInternalFactory.class);
+class TitanInternalFactory extends AbstractInternalFactory<MindmapsTitanGraph, TitanGraph> {
+    protected final Logger LOG = LoggerFactory.getLogger(TitanInternalFactory.class);
     private final static String DEFAULT_CONFIG = "backend-default";
 
-    MindmapsTitanInternalFactory(String keyspace, String engineUrl, String config) {
+    TitanInternalFactory(String keyspace, String engineUrl, String config) {
         super(keyspace, engineUrl, config);
     }
 

--- a/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanGraphFactoryTest.java
+++ b/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanGraphFactoryTest.java
@@ -68,7 +68,7 @@ public class MindmapsTitanGraphFactoryTest {
     private static TitanGraph noIndexGraph;
     private static TitanGraph indexGraph;
 
-    private static MindmapsInternalFactory titanGraphFactory ;
+    private static InternalFactory titanGraphFactory ;
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
@@ -77,7 +77,7 @@ public class MindmapsTitanGraphFactoryTest {
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.OFF);
 
-        titanGraphFactory = new MindmapsTitanInternalFactory(TEST_SHARED, TEST_URI, TEST_CONFIG);
+        titanGraphFactory = new TitanInternalFactory(TEST_SHARED, TEST_URI, TEST_CONFIG);
 
         sharedGraph = ((MindmapsTitanGraph) titanGraphFactory.getGraph(TEST_BATCH_LOADING)).getTinkerPopGraph();
 
@@ -331,7 +331,7 @@ public class MindmapsTitanGraphFactoryTest {
 
     private static TitanGraph getGraph() {
         String name = UUID.randomUUID().toString();
-        titanGraphFactory = new MindmapsTitanInternalFactory(name, TEST_URI, TEST_CONFIG);
+        titanGraphFactory = new TitanInternalFactory(name, TEST_URI, TEST_CONFIG);
         Graph graph = ((MindmapsTitanGraph) titanGraphFactory.getGraph(TEST_BATCH_LOADING)).getTinkerPopGraph();
         assertThat(graph, instanceOf(TitanGraph.class));
         return (TitanGraph) graph;

--- a/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanGraphTest.java
+++ b/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanGraphTest.java
@@ -46,7 +46,7 @@ public class MindmapsTitanGraphTest {
 
     @Before
     public void setup(){
-        mindmapsGraph = new MindmapsTitanInternalFactory(TEST_NAME, TEST_URI, TEST_CONFIG).getGraph(TEST_BATCH_LOADING);
+        mindmapsGraph = new TitanInternalFactory(TEST_NAME, TEST_URI, TEST_CONFIG).getGraph(TEST_BATCH_LOADING);
     }
 
     @After
@@ -118,8 +118,8 @@ public class MindmapsTitanGraphTest {
 
     @Test
     public void testCaseSensitiveKeyspaces(){
-        MindmapsTitanInternalFactory factory1 = new MindmapsTitanInternalFactory("case", TEST_URI, TEST_CONFIG);
-        MindmapsTitanInternalFactory factory2 = new MindmapsTitanInternalFactory("Case", TEST_URI, TEST_CONFIG);
+        TitanInternalFactory factory1 = new TitanInternalFactory("case", TEST_URI, TEST_CONFIG);
+        TitanInternalFactory factory2 = new TitanInternalFactory("Case", TEST_URI, TEST_CONFIG);
         MindmapsTitanGraph case1 = factory1.getGraph(TEST_BATCH_LOADING);
         MindmapsTitanGraph case2 = factory2.getGraph(TEST_BATCH_LOADING);
 

--- a/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanHadoopGraphFactoryTest.java
+++ b/mindmaps-titan-factory/src/test/java/io/mindmaps/factory/MindmapsTitanHadoopGraphFactoryTest.java
@@ -29,11 +29,11 @@ import static org.junit.Assert.assertThat;
 public class MindmapsTitanHadoopGraphFactoryTest {
     private final String TEST_CONFIG = "../conf/main/mindmaps-analytics.properties";
 
-    private MindmapsTitanHadoopInternalFactory factory;
+    private TitanHadoopInternalFactory factory;
 
     @Before
     public void setUp() throws Exception {
-        factory = new MindmapsTitanHadoopInternalFactory("rubbish", "rubbish", TEST_CONFIG);
+        factory = new TitanHadoopInternalFactory("rubbish", "rubbish", TEST_CONFIG);
     }
 
     @Test(expected=UnsupportedOperationException.class)


### PR DESCRIPTION
- Rename internal classes. Mindmaps does not need to be in front of everything
- Cleanup Graph API Tests