### PR TITLE
Migration export require arguments

### DIFF
--- a/mindmaps-migration/base/src/main/java/io/mindmaps/migration/base/io/MigrationCLI.java
+++ b/mindmaps-migration/base/src/main/java/io/mindmaps/migration/base/io/MigrationCLI.java
@@ -180,7 +180,7 @@ public class MigrationCLI {
         return Mindmaps.factory(getEngineURI(), getKeyspace()).getGraph();
     }
 
-    public void addOptions(Options options){
+    public void addOptions(Options options) {
         options.getOptions().forEach(defaultOptions::addOption);
     }
 

--- a/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/GraphWriter.java
+++ b/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/GraphWriter.java
@@ -72,7 +72,7 @@ public class GraphWriter {
         return stream
                 .map(Object::toString)
                 .filter(s -> !s.isEmpty())
-                .collect(joining(EOL));
+                .collect(joining(EOL, "", EOL));
     }
 
     /**

--- a/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/GraphWriter.java
+++ b/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/GraphWriter.java
@@ -34,7 +34,6 @@ import static java.util.stream.Collectors.joining;
 public class GraphWriter {
 
     private static final String EOL = ";\n";
-    private static final String INSERT = "insert\n";
 
     private final MindmapsGraph graph;
     private final List<String> reserved = Arrays.asList("inference-rule", "constraint-rule");
@@ -48,7 +47,7 @@ public class GraphWriter {
      * @return Graql insert query with ontology of given graph
      */
     public String dumpOntology(){
-        return joinAsInsert(types().map(TypeMapper::map));
+        return join(types().map(TypeMapper::map));
     }
 
     /**
@@ -56,7 +55,7 @@ public class GraphWriter {
      * @return Graql insert query with data in given graph
      */
     public String dumpData(){
-        return joinAsInsert(types()
+        return join(types()
                 .filter(t -> t.superType() == null)
                 .filter(t -> !t.isRoleType())
                 .flatMap(c -> c.instances().stream())
@@ -69,11 +68,11 @@ public class GraphWriter {
      * @param stream stream of Graql patterns
      * @return Graql patterns as a string
      */
-    private String joinAsInsert(Stream<Var> stream){
+    private String join(Stream<Var> stream){
         return stream
                 .map(Object::toString)
                 .filter(s -> !s.isEmpty())
-                .collect(joining(EOL, INSERT, EOL));
+                .collect(joining(EOL));
     }
 
     /**

--- a/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/Main.java
+++ b/mindmaps-migration/export/src/main/java/io/mindmaps/migration/export/Main.java
@@ -36,10 +36,13 @@ public class Main {
 
         MigrationCLI cli = new MigrationCLI(args, options);
 
-        String outputFile = cli.getOption("destination");
+        if(!cli.hasOption("ontology") && !cli.hasOption("data")) {
+            cli.writeToSout("Missing arguments -ontology and/or -data");
+            cli.exit();
+        }
 
-        System.out.println("Writing graph " + cli.getKeyspace() + " using MM Engine " +
-                cli.getEngineURI() + " to " + (outputFile == null ? "System.out" : outputFile));
+        cli.writeToSout("Writing graph " + cli.getKeyspace() + " using MM Engine " +
+                cli.getEngineURI() + " to System.out");
 
         MindmapsGraph graph = cli.getGraph();
         GraphWriter graphWriter = new GraphWriter(graph);

--- a/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/GraphWriterTestBase.java
+++ b/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/GraphWriterTestBase.java
@@ -51,7 +51,7 @@ public abstract class GraphWriterTestBase {
     }
 
     public void insert(MindmapsGraph graph, String query){
-        graph.graql().parse("insert " + query + ";").execute();
+        graph.graql().parse("insert " + query).execute();
     }
 
     public void assertDataEqual(MindmapsGraph one, MindmapsGraph two){

--- a/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/GraphWriterTestBase.java
+++ b/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/GraphWriterTestBase.java
@@ -17,7 +17,6 @@
  */
 package io.mindmaps.migration.export;
 
-import io.mindmaps.Mindmaps;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.concept.Entity;
@@ -29,7 +28,6 @@ import io.mindmaps.concept.RoleType;
 import io.mindmaps.concept.Rule;
 import io.mindmaps.concept.Type;
 import org.junit.After;
-import org.junit.Before;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -50,6 +48,10 @@ public abstract class GraphWriterTestBase {
     public void clear(){
         copy.clear();
         original.clear();
+    }
+
+    public void insert(MindmapsGraph graph, String query){
+        graph.graql().parse("insert " + query + ";").execute();
     }
 
     public void assertDataEqual(MindmapsGraph one, MindmapsGraph two){

--- a/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/MovieGraphWriterTest.java
+++ b/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/MovieGraphWriterTest.java
@@ -36,7 +36,7 @@ public class MovieGraphWriterTest extends GraphWriterTestBase {
     @Test
     public void testWritingMovieGraphOntology() {
         String ontology = writer.dumpOntology();
-        copy.graql().parse(ontology).execute();
+        insert(copy, ontology);
 
         assertOntologiesEqual(original, copy);
     }
@@ -44,11 +44,10 @@ public class MovieGraphWriterTest extends GraphWriterTestBase {
     @Test
     public void testWritingMovieGraphData() {
         String ontology = writer.dumpOntology();
-        System.out.println(ontology);
-        copy.graql().parse(ontology).execute();
+        insert(copy, ontology);
 
         String data = writer.dumpData();
-        copy.graql().parse(data).execute();
+        insert(copy, data);
 
         assertDataEqual(original, copy);
     }

--- a/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/PokemonGraphWriterTest.java
+++ b/mindmaps-migration/export/src/test/java/io/mindmaps/migration/export/PokemonGraphWriterTest.java
@@ -36,7 +36,7 @@ public class PokemonGraphWriterTest extends GraphWriterTestBase {
     @Test
     public void testWritingPokemonGraphOntology(){
         String ontology = writer.dumpOntology();
-        copy.graql().parse(ontology).execute();
+        insert(copy, ontology);
 
         assertOntologiesEqual(original, copy);
     }
@@ -44,10 +44,10 @@ public class PokemonGraphWriterTest extends GraphWriterTestBase {
     @Test
     public void testWritingPokemonGraphData(){
         String ontology = writer.dumpOntology();
-        copy.graql().parse(ontology).execute();
+        insert(copy, ontology);
 
         String data = writer.dumpData();
-        copy.graql().parse(data).execute();
+        insert(copy, data);
 
         assertDataEqual(original, copy);
     }


### PR DESCRIPTION
+ Migration export module will require user to specify -ontology or -data
+ Migration export will no longer return an insert query