### PR TITLE
Add brute-force query optimisation method

### DIFF
--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/Graql.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/Graql.java
@@ -20,6 +20,7 @@
 package io.mindmaps.graql;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.mindmaps.concept.Concept;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.Disjunction;
@@ -157,7 +158,8 @@ public class Graql {
      * @return a pattern that will match only when all contained patterns match
      */
     public static Pattern and(Collection<? extends Pattern> patterns) {
-        Conjunction<PatternAdmin> conjunction = Patterns.conjunction(AdminConverter.getPatternAdmins(patterns));
+        Collection<PatternAdmin> patternAdmins = AdminConverter.getPatternAdmins(patterns);
+        Conjunction<PatternAdmin> conjunction = Patterns.conjunction(Sets.newHashSet(patternAdmins));
 
         return () -> conjunction;
     }
@@ -175,7 +177,8 @@ public class Graql {
      * @return a pattern that will match when any contained pattern matches
      */
     public static Pattern or(Collection<? extends Pattern> patterns) {
-        Disjunction<PatternAdmin> disjunction = Patterns.disjunction(AdminConverter.getPatternAdmins(patterns));
+        Collection<PatternAdmin> patternAdmins = AdminConverter.getPatternAdmins(patterns);
+        Disjunction<PatternAdmin> disjunction = Patterns.disjunction(Sets.newHashSet(patternAdmins));
 
         return () -> disjunction;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilderImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/QueryBuilderImpl.java
@@ -18,7 +18,8 @@
 
 package io.mindmaps.graql;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.parser.QueryParser;
@@ -79,7 +80,7 @@ public class QueryBuilderImpl implements QueryBuilder{
      */
     @Override
     public MatchQuery match(Collection<? extends Pattern> patterns) {
-        MatchQuery query = Queries.match(Patterns.conjunction(AdminConverter.getPatternAdmins(patterns)));
+        MatchQuery query = Queries.match(Patterns.conjunction(Sets.newHashSet(AdminConverter.getPatternAdmins(patterns))));
         return graph.map(query::withGraph).orElse(query);
     }
 
@@ -98,7 +99,7 @@ public class QueryBuilderImpl implements QueryBuilder{
      */
     @Override
     public InsertQuery insert(Collection<? extends Var> vars) {
-        ImmutableSet<VarAdmin> varAdmins = ImmutableSet.copyOf(AdminConverter.getVarAdmins(vars));
+        ImmutableList<VarAdmin> varAdmins = ImmutableList.copyOf(AdminConverter.getVarAdmins(vars));
         return Queries.insert(varAdmins, graph);
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/ConjunctionQuery.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.internal.gremlin;
 
+import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -41,6 +42,7 @@ import java.util.stream.Stream;
 import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableSet;
 import static java.util.Comparator.naturalOrder;
 import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -59,6 +61,7 @@ import static java.util.stream.Collectors.toSet;
 class ConjunctionQuery {
 
     private final Set<VarAdmin> vars;
+
     private final ImmutableSet<EquivalentFragmentSet> equivalentFragmentSets;
     private final ImmutableList<Fragment> sortedFragments;
 
@@ -76,6 +79,22 @@ class ConjunctionQuery {
                 vars.stream().flatMap(ConjunctionQuery::equivalentFragmentSetsRecursive).collect(toImmutableSet());
 
         this.sortedFragments = sortFragments();
+    }
+
+    /**
+     * Get all possible orderings of fragments
+     */
+    Set<List<Fragment>> allFragmentOrders() {
+        Collection<List<EquivalentFragmentSet>> fragmentSetPermutations = Collections2.permutations(equivalentFragmentSets);
+        return fragmentSetPermutations.stream().flatMap(fragmentSet -> foo(fragmentSet).stream()).collect(toSet());
+    }
+
+    private static Set<List<Fragment>> foo(List<EquivalentFragmentSet> fragmentSets) {
+        // Get fragments in each set
+        List<Set<Fragment>> fragments = fragmentSets.stream()
+                .map(set -> set.getFragments().collect(toSet()))
+                .collect(toList());
+        return Sets.cartesianProduct(fragments);
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/EquivalentFragmentSet.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/EquivalentFragmentSet.java
@@ -18,10 +18,9 @@
 
 package io.mindmaps.graql.internal.gremlin;
 
+import com.google.common.collect.ImmutableSet;
 import io.mindmaps.graql.internal.gremlin.fragment.Fragment;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.stream.Stream;
 
 /**
@@ -33,7 +32,7 @@ import java.util.stream.Stream;
  */
 public class EquivalentFragmentSet {
 
-    private final Collection<Fragment> fragments;
+    private final ImmutableSet<Fragment> fragments;
 
     public static EquivalentFragmentSet create(Fragment... fragments) {
         return new EquivalentFragmentSet(fragments);
@@ -43,7 +42,7 @@ public class EquivalentFragmentSet {
      * @param fragments an array of Fragments that this EquivalentFragmentSet contains
      */
     private EquivalentFragmentSet(Fragment... fragments) {
-        this.fragments = Arrays.asList(fragments);
+        this.fragments = ImmutableSet.copyOf(fragments);
         this.fragments.forEach(f -> f.setEquivalentFragmentSet(this));
     }
 
@@ -52,5 +51,21 @@ public class EquivalentFragmentSet {
      */
     Stream<Fragment> getFragments() {
         return fragments.stream();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EquivalentFragmentSet that = (EquivalentFragmentSet) o;
+
+        return fragments != null ? fragments.equals(that.fragments) : that.fragments == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return fragments != null ? fragments.hashCode() : 0;
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.internal.gremlin.fragment.Fragment;
+import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -152,7 +153,7 @@ public class GraqlTraversal {
                 if (!fragment.getStart().equals(currentName)) {
                     if (currentName != null) sb.append(" ");
 
-                    sb.append("$").append(fragment.getStart());
+                    sb.append("$").append(StringUtils.left(fragment.getStart(), 3));
                     currentName = fragment.getStart();
                 }
 
@@ -160,7 +161,7 @@ public class GraqlTraversal {
 
                 Optional<String> end = fragment.getEnd();
                 if (end.isPresent()) {
-                    sb.append("$").append(end.get());
+                    sb.append("$").append(StringUtils.left(end.get(), 3));
                     currentName = end.get();
                 }
             }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
@@ -10,10 +10,12 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableSet;
 import static java.util.stream.Collectors.joining;
 
 /**
@@ -31,12 +33,12 @@ public class GraqlTraversal {
     private final ImmutableSet<ImmutableList<Fragment>> fragments;
     private final MindmapsGraph graph;
 
-    private GraqlTraversal(MindmapsGraph graph, ImmutableSet<ImmutableList<Fragment>> fragments) {
+    private GraqlTraversal(MindmapsGraph graph, Set<? extends List<Fragment>> fragments) {
         this.graph = graph;
-        this.fragments = fragments;
+        this.fragments = fragments.stream().map(ImmutableList::copyOf).collect(toImmutableSet());
     }
 
-    public static GraqlTraversal create(MindmapsGraph graph, ImmutableSet<ImmutableList<Fragment>> fragments) {
+    public static GraqlTraversal create(MindmapsGraph graph, Set<? extends List<Fragment>> fragments) {
         return new GraqlTraversal(graph, fragments);
     }
 
@@ -165,5 +167,24 @@ public class GraqlTraversal {
 
             return sb.toString();
         }).collect(joining(", ")) + "}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GraqlTraversal that = (GraqlTraversal) o;
+
+        if (fragments != null ? !fragments.equals(that.fragments) : that.fragments != null) return false;
+        return graph != null ? graph.equals(that.graph) : that.graph == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = fragments != null ? fragments.hashCode() : 0;
+        result = 31 * result + (graph != null ? graph.hashCode() : 0);
+        return result;
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
@@ -125,6 +125,11 @@ public class GraqlTraversal {
      * Get the estimated complexity of the traversal.
      */
     public long getComplexity() {
+
+        // TODO: Find a better way to represent these values
+        // Just a pretend big number
+        long NUM_VERTICES_ESTIMATE = 1_000;
+
         Set<String> names = new HashSet<>();
 
         long totalCost = 0;
@@ -140,7 +145,9 @@ public class GraqlTraversal {
                 if (names.contains(start)) {
                     currentCost = fragment.fragmentCost(previousCost);
                 } else {
-                    currentCost = fragment.indexCost() * previousCost;
+                    // Restart traversal, meaning we are navigating from all vertices
+                    // The constant '1' cost is to discourage constant restarting, even when indexed
+                    currentCost = fragment.fragmentCost(NUM_VERTICES_ESTIMATE) * previousCost + 1;
                 }
 
                 names.add(start);

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
@@ -130,19 +130,24 @@ public class GraqlTraversal {
         long totalCost = 0;
 
         for (List<Fragment> list : fragments) {
+            long currentCost;
+            long previousCost = 1;
             long listCost = 0;
 
             for (Fragment fragment : list) {
                 String start = fragment.getStart();
 
                 if (names.contains(start)) {
-                    listCost += fragment.fragmentCost(listCost);
+                    currentCost = fragment.fragmentCost(previousCost);
                 } else {
-                    listCost += fragment.indexCost();
+                    currentCost = fragment.indexCost() * previousCost;
                 }
 
-                names.add(fragment.getStart());
+                names.add(start);
                 fragment.getEnd().ifPresent(names::add);
+
+                listCost += currentCost;
+                previousCost = currentCost;
             }
 
             totalCost += listCost;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GraqlTraversal.java
@@ -125,22 +125,30 @@ public class GraqlTraversal {
      * Get the estimated complexity of the traversal.
      */
     public long getComplexity() {
-        return fragments.stream().mapToLong(list -> {
+        Set<String> names = new HashSet<>();
+
+        long totalCost = 0;
+
+        for (List<Fragment> list : fragments) {
             long listCost = 0;
-            String currentName = null;
 
             for (Fragment fragment : list) {
-                if (fragment.getStart().equals(currentName)) {
+                String start = fragment.getStart();
+
+                if (names.contains(start)) {
                     listCost += fragment.fragmentCost(listCost);
                 } else {
                     listCost += fragment.indexCost();
                 }
 
-                currentName = fragment.getEnd().orElse(fragment.getStart());
+                names.add(fragment.getStart());
+                fragment.getEnd().ifPresent(names::add);
             }
 
-            return listCost;
-        }).sum();
+            totalCost += listCost;
+        }
+
+        return totalCost;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GremlinQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GremlinQuery.java
@@ -20,6 +20,7 @@ package io.mindmaps.graql.internal.gremlin;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.graql.admin.Conjunction;
 import io.mindmaps.graql.admin.PatternAdmin;
@@ -31,12 +32,15 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableSet;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * A class for building gremlin traversals from patterns.
@@ -110,4 +114,9 @@ public class GremlinQuery {
         return innerQueries.stream().flatMap(ConjunctionQuery::getConcepts);
     }
 
+    public Set<GraqlTraversal> allGraqlTraversals() {
+        List<Set<List<Fragment>>> collect = innerQueries.stream().map(ConjunctionQuery::allFragmentOrders).collect(toList());
+        Set<List<List<Fragment>>> lists = Sets.cartesianProduct(collect);
+        return lists.stream().map(list -> GraqlTraversal.create(graph, Sets.newHashSet(list))).collect(toSet());
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GremlinQuery.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/GremlinQuery.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 
 import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableSet;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 
 /**
  * A class for building gremlin traversals from patterns.
@@ -114,9 +113,9 @@ public class GremlinQuery {
         return innerQueries.stream().flatMap(ConjunctionQuery::getConcepts);
     }
 
-    public Set<GraqlTraversal> allGraqlTraversals() {
+    public Stream<GraqlTraversal> allGraqlTraversals() {
         List<Set<List<Fragment>>> collect = innerQueries.stream().map(ConjunctionQuery::allFragmentOrders).collect(toList());
         Set<List<List<Fragment>>> lists = Sets.cartesianProduct(collect);
-        return lists.stream().map(list -> GraqlTraversal.create(graph, Sets.newHashSet(list))).collect(toSet());
+        return lists.stream().map(list -> GraqlTraversal.create(graph, Sets.newHashSet(list)));
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
@@ -65,18 +65,21 @@ abstract class AbstractFragment implements Fragment{
     }
 
     @Override
-    public int hashCode() {
-        return toString().hashCode();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
         AbstractFragment that = (AbstractFragment) o;
 
-        return start != null ? toString().equals(that.toString()) : that.start == null;
+        if (start != null ? !start.equals(that.start) : that.start != null) return false;
+        return end != null ? end.equals(that.end) : that.end == null;
 
+    }
+
+    @Override
+    public int hashCode() {
+        int result = start != null ? start.hashCode() : 0;
+        result = 31 * result + (end != null ? end.hashCode() : 0);
+        return result;
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
@@ -63,4 +63,20 @@ abstract class AbstractFragment implements Fragment{
     public String toString() {
         return "$" + start + getName() + end.map(e -> "$" + e).orElse("");
     }
+
+    @Override
+    public int hashCode() {
+        return toString().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AbstractFragment that = (AbstractFragment) o;
+
+        return start != null ? toString().equals(that.toString()) : that.start == null;
+
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
@@ -7,10 +7,10 @@ import java.util.Optional;
 abstract class AbstractFragment implements Fragment{
 
     // TODO: Find a better way to represent these values (either abstractly, or better estimates)
-    static final long NUM_INSTANCES_PER_TYPE = 1_000;
-    static final long NUM_INSTANCES_PER_SCOPE = 1_000;
+    static final long NUM_INSTANCES_PER_TYPE = 1_000_000;
+    static final long NUM_INSTANCES_PER_SCOPE = 1_000_000;
     static final long NUM_RELATION_PER_CASTING = 1_000;
-    static final long NUM_SHORTCUT_EDGES_PER_INSTANCE = 10;
+    static final long NUM_SHORTCUT_EDGES_PER_INSTANCE = 1_000;
     static final long NUM_SUBTYPES_PER_TYPE = 10;
     static final long NUM_CASTINGS_PER_INSTANCE = 10;
     static final long NUM_SCOPES_PER_INSTANCE = 10;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/AbstractFragment.java
@@ -7,15 +7,15 @@ import java.util.Optional;
 abstract class AbstractFragment implements Fragment{
 
     // TODO: Find a better way to represent these values (either abstractly, or better estimates)
-    static final long NUM_INSTANCES_PER_TYPE = 1_000_000;
-    static final long NUM_INSTANCES_PER_SCOPE = 1_000_000;
-    static final long NUM_RELATION_PER_CASTING = 1_000;
-    static final long NUM_SHORTCUT_EDGES_PER_INSTANCE = 1_000;
-    static final long NUM_SUBTYPES_PER_TYPE = 10;
-    static final long NUM_CASTINGS_PER_INSTANCE = 10;
-    static final long NUM_SCOPES_PER_INSTANCE = 10;
-    static final long NUM_TYPES_PER_ROLE = 10;
-    static final long NUM_ROLES_PER_TYPE = 10;
+    static final long NUM_INSTANCES_PER_TYPE = 100;
+    static final long NUM_INSTANCES_PER_SCOPE = 100;
+    static final long NUM_RELATION_PER_CASTING = 10;
+    static final long NUM_SHORTCUT_EDGES_PER_INSTANCE = 10;
+    static final long NUM_SUBTYPES_PER_TYPE = 3;
+    static final long NUM_CASTINGS_PER_INSTANCE = 3;
+    static final long NUM_SCOPES_PER_INSTANCE = 3;
+    static final long NUM_TYPES_PER_ROLE = 3;
+    static final long NUM_ROLES_PER_TYPE = 3;
     static final long NUM_ROLES_PER_RELATION = 2;
 
     private final String start;
@@ -72,8 +72,9 @@ abstract class AbstractFragment implements Fragment{
         AbstractFragment that = (AbstractFragment) o;
 
         if (start != null ? !start.equals(that.start) : that.start != null) return false;
-        return end != null ? end.equals(that.end) : that.end == null;
+        if (end != null ? !end.equals(that.end) : that.end != null) return false;
 
+        return true;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/DataTypeFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/DataTypeFragment.java
@@ -35,4 +35,23 @@ class DataTypeFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost / ResourceType.DataType.SUPPORTED_TYPES.size();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        DataTypeFragment that = (DataTypeFragment) o;
+
+        return dataType != null ? dataType.equals(that.dataType) : that.dataType == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (dataType != null ? dataType.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/DistinctCastingFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/DistinctCastingFragment.java
@@ -33,4 +33,23 @@ class DistinctCastingFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost / NUM_ROLES_PER_RELATION;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        DistinctCastingFragment that = (DistinctCastingFragment) o;
+
+        return otherCastingName != null ? otherCastingName.equals(that.otherCastingName) : that.otherCastingName == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (otherCastingName != null ? otherCastingName.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
@@ -85,7 +85,7 @@ public interface Fragment extends Comparable<Fragment> {
     default long indexCost() {
         // TODO: Find a better way to represent these values
         // Just a big number
-        return fragmentCost(1_000_000);
+        return fragmentCost(1_000_000_000);
     }
 
     long fragmentCost(long previousCost);

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
@@ -82,11 +82,5 @@ public interface Fragment extends Comparable<Fragment> {
      */
     FragmentPriority getPriority();
 
-    default long indexCost() {
-        // TODO: Find a better way to represent these values
-        // Just a big number
-        return fragmentCost(1_000);
-    }
-
     long fragmentCost(long previousCost);
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/Fragment.java
@@ -85,7 +85,7 @@ public interface Fragment extends Comparable<Fragment> {
     default long indexCost() {
         // TODO: Find a better way to represent these values
         // Just a big number
-        return fragmentCost(1_000_000_000);
+        return fragmentCost(1_000);
     }
 
     long fragmentCost(long previousCost);

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
@@ -54,11 +54,6 @@ class IdFragment extends AbstractFragment {
     }
 
     @Override
-    public long indexCost() {
-        return 2;
-    }
-
-    @Override
     public long fragmentCost(long previousCost) {
         return 1;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
@@ -35,6 +35,25 @@ class IdFragment extends AbstractFragment {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        IdFragment that = (IdFragment) o;
+
+        return id != null ? id.equals(that.id) : that.id == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (id != null ? id.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     public long indexCost() {
         return 2;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/IdFragment.java
@@ -36,7 +36,7 @@ class IdFragment extends AbstractFragment {
 
     @Override
     public long indexCost() {
-        return 1;
+        return 2;
     }
 
     @Override

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/InIsaFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/InIsaFragment.java
@@ -42,4 +42,22 @@ class InIsaFragment extends AbstractFragment {
         return previousCost * NUM_INSTANCES_PER_TYPE;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        InIsaFragment that = (InIsaFragment) o;
+
+        return allowCastings == that.allowCastings;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (allowCastings ? 1 : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/LhsFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/LhsFragment.java
@@ -35,4 +35,23 @@ class LhsFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        LhsFragment that = (LhsFragment) o;
+
+        return lhs != null ? lhs.equals(that.lhs) : that.lhs == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (lhs != null ? lhs.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/OutIsaFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/OutIsaFragment.java
@@ -42,4 +42,22 @@ class OutIsaFragment extends AbstractFragment {
         return previousCost;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        OutIsaFragment that = (OutIsaFragment) o;
+
+        return allowCastings == that.allowCastings;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (allowCastings ? 1 : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/RegexFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/RegexFragment.java
@@ -35,4 +35,23 @@ class RegexFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        RegexFragment that = (RegexFragment) o;
+
+        return regex != null ? regex.equals(that.regex) : that.regex == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (regex != null ? regex.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/RhsFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/RhsFragment.java
@@ -35,4 +35,23 @@ class RhsFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        RhsFragment that = (RhsFragment) o;
+
+        return rhs != null ? rhs.equals(that.rhs) : that.rhs == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (rhs != null ? rhs.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ShortcutFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ShortcutFragment.java
@@ -55,4 +55,27 @@ class ShortcutFragment extends AbstractFragment {
     public long fragmentCost(long previousCost) {
         return previousCost * NUM_SHORTCUT_EDGES_PER_INSTANCE;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ShortcutFragment that = (ShortcutFragment) o;
+
+        if (relationType != null ? !relationType.equals(that.relationType) : that.relationType != null) return false;
+        if (roleStart != null ? !roleStart.equals(that.roleStart) : that.roleStart != null) return false;
+        return roleEnd != null ? roleEnd.equals(that.roleEnd) : that.roleEnd == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (relationType != null ? relationType.hashCode() : 0);
+        result = 31 * result + (roleStart != null ? roleStart.hashCode() : 0);
+        result = 31 * result + (roleEnd != null ? roleEnd.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
@@ -37,15 +37,6 @@ class ValueFragment extends AbstractFragment {
     }
 
     @Override
-    public long indexCost() {
-        if (predicate.isSpecific()) {
-            return 2;
-        } else {
-            return super.indexCost();
-        }
-    }
-
-    @Override
     public long fragmentCost(long previousCost) {
         if (predicate.isSpecific()) {
             return 1;

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
@@ -61,4 +61,23 @@ class ValueFragment extends AbstractFragment {
         Object value = predicate.getInnerValues().iterator().next();
         return ResourceType.DataType.SUPPORTED_TYPES.get(value.getClass().getTypeName()).getConceptProperty();
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+
+        ValueFragment that = (ValueFragment) o;
+
+        return predicate != null ? predicate.equals(that.predicate) : that.predicate == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (predicate != null ? predicate.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/gremlin/fragment/ValueFragment.java
@@ -39,7 +39,7 @@ class ValueFragment extends AbstractFragment {
     @Override
     public long indexCost() {
         if (predicate.isSpecific()) {
-            return 1;
+            return 2;
         } else {
             return super.indexCost();
         }
@@ -47,7 +47,11 @@ class ValueFragment extends AbstractFragment {
 
     @Override
     public long fragmentCost(long previousCost) {
-        return previousCost;
+        if (predicate.isSpecific()) {
+            return 1;
+        } else {
+            return previousCost;
+        }
     }
 
     /**

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -494,14 +494,13 @@ class VarImpl implements VarAdmin {
 
         if (userDefinedName != var.userDefinedName) return false;
         if (!properties.equals(var.properties)) return false;
-        return !userDefinedName || name.equals(var.name);
-
+        return name.equals(var.name);
     }
 
     @Override
     public int hashCode() {
         int result = properties.hashCode();
-        if (userDefinedName) result = 31 * result + name.hashCode();
+        result = 31 * result + name.hashCode();
         result = 31 * result + (userDefinedName ? 1 : 0);
         return result;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/pattern/VarImpl.java
@@ -494,13 +494,14 @@ class VarImpl implements VarAdmin {
 
         if (userDefinedName != var.userDefinedName) return false;
         if (!properties.equals(var.properties)) return false;
-        return name.equals(var.name);
+        return !userDefinedName || name.equals(var.name);
+
     }
 
     @Override
     public int hashCode() {
         int result = properties.hashCode();
-        result = 31 * result + name.hashCode();
+        if (userDefinedName) result = 31 * result + name.hashCode();
         result = 31 * result + (userDefinedName ? 1 : 0);
         return result;
     }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/InsertQueryImpl.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableSet;
+import static io.mindmaps.graql.internal.util.CommonUtil.toImmutableList;
 
 /**
  * A query that will insert a collection of variables into a graph
@@ -66,7 +66,7 @@ class InsertQueryImpl implements InsertQueryAdmin {
         this.originalVars = vars;
 
         // Get all variables, including ones nested in other variables
-        this.vars = vars.stream().flatMap(v -> v.getImplicitInnerVars().stream()).collect(toImmutableSet());
+        this.vars = vars.stream().flatMap(v -> v.getImplicitInnerVars().stream()).collect(toImmutableList());
 
         for (VarAdmin var : this.vars) {
             var.getProperties().forEach(property -> ((VarPropertyInternal) property).checkInsertable(var));

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/Queries.java
@@ -25,10 +25,20 @@ import io.mindmaps.graql.Aggregate;
 import io.mindmaps.graql.AggregateQuery;
 import io.mindmaps.graql.ComputeQuery;
 import io.mindmaps.graql.MatchQuery;
-import io.mindmaps.graql.admin.*;
+import io.mindmaps.graql.admin.AskQueryAdmin;
+import io.mindmaps.graql.admin.Conjunction;
+import io.mindmaps.graql.admin.DeleteQueryAdmin;
+import io.mindmaps.graql.admin.InsertQueryAdmin;
+import io.mindmaps.graql.admin.MatchQueryAdmin;
+import io.mindmaps.graql.admin.PatternAdmin;
+import io.mindmaps.graql.admin.VarAdmin;
 import io.mindmaps.graql.internal.query.match.MatchQueryBase;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Internal query factory

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/match/MatchQueryInternal.java
@@ -19,6 +19,7 @@
 
 package io.mindmaps.graql.internal.query.match;
 
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 import io.mindmaps.MindmapsGraph;
 import io.mindmaps.concept.Concept;
@@ -131,7 +132,7 @@ public interface MatchQueryInternal extends MatchQueryAdmin {
 
     @Override
     default InsertQuery insert(Collection<? extends Var> vars) {
-        ImmutableSet<VarAdmin> varAdmins = ImmutableSet.copyOf(AdminConverter.getVarAdmins(vars));
+        ImmutableMultiset<VarAdmin> varAdmins = ImmutableMultiset.copyOf(AdminConverter.getVarAdmins(vars));
         return Queries.insert(varAdmins, admin());
     }
 

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/AndPredicate.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/AndPredicate.java
@@ -42,4 +42,23 @@ class AndPredicate extends AbstractValuePredicate {
     public String toString() {
         return "(" + predicate1 + " and " + predicate2 + ")";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AndPredicate that = (AndPredicate) o;
+
+        if (predicate1 != null ? !predicate1.equals(that.predicate1) : that.predicate1 != null) return false;
+        return predicate2 != null ? predicate2.equals(that.predicate2) : that.predicate2 == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = predicate1 != null ? predicate1.hashCode() : 0;
+        result = 31 * result + (predicate2 != null ? predicate2.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/ComparatorPredicate.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/ComparatorPredicate.java
@@ -38,4 +38,20 @@ abstract class ComparatorPredicate extends AbstractValuePredicate {
     public String toString() {
         return getSymbol() + " " + StringConverter.valueToString(value);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ComparatorPredicate that = (ComparatorPredicate) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/EqPredicate.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/EqPredicate.java
@@ -55,4 +55,20 @@ class EqPredicate extends AbstractValuePredicate {
     public String toString() {
         return StringConverter.valueToString(value);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EqPredicate that = (EqPredicate) o;
+
+        return value != null ? value.equals(that.value) : that.value == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/OrPredicate.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/OrPredicate.java
@@ -42,4 +42,23 @@ class OrPredicate extends AbstractValuePredicate {
     public String toString() {
         return "(" + predicate1 + " or " + predicate2 + ")";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OrPredicate that = (OrPredicate) o;
+
+        if (predicate1 != null ? !predicate1.equals(that.predicate1) : that.predicate1 != null) return false;
+        return predicate2 != null ? predicate2.equals(that.predicate2) : that.predicate2 == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = predicate1 != null ? predicate1.hashCode() : 0;
+        result = 31 * result + (predicate2 != null ? predicate2.hashCode() : 0);
+        return result;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/RegexPredicate.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/query/predicate/RegexPredicate.java
@@ -43,4 +43,20 @@ class RegexPredicate extends AbstractValuePredicate {
     public String toString() {
         return "/" + StringConverter.escapeString(pattern) + "/";
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        RegexPredicate that = (RegexPredicate) o;
+
+        return pattern != null ? pattern.equals(that.pattern) : that.pattern == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return pattern != null ? pattern.hashCode() : 0;
+    }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/util/AdminConverter.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/util/AdminConverter.java
@@ -24,9 +24,8 @@ import io.mindmaps.graql.admin.PatternAdmin;
 import io.mindmaps.graql.admin.VarAdmin;
 
 import java.util.Collection;
-import java.util.Set;
 
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Helper methods for converting classes to admin equivalents
@@ -37,15 +36,15 @@ public class AdminConverter {
      * @param patterns a collection of patterns to change to admin
      * @return a collection of Pattern.Admin from the given patterns
      */
-    public static Set<PatternAdmin> getPatternAdmins(Collection<? extends Pattern> patterns) {
-        return patterns.stream().map(Pattern::admin).collect(toSet());
+    public static Collection<PatternAdmin> getPatternAdmins(Collection<? extends Pattern> patterns) {
+        return patterns.stream().map(Pattern::admin).collect(toList());
     }
 
     /**
      * @param patterns a collection of vars to change to admin
      * @return a collection of Var.Admin from the given patterns
      */
-    public static Set<VarAdmin> getVarAdmins(Collection<? extends Var> patterns) {
-        return patterns.stream().map(Var::admin).collect(toSet());
+    public static Collection<VarAdmin> getVarAdmins(Collection<? extends Var> patterns) {
+        return patterns.stream().map(Var::admin).collect(toList());
     }
 }

--- a/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/util/CommonUtil.java
+++ b/mindmaps-graql/src/main/java/io/mindmaps/graql/internal/util/CommonUtil.java
@@ -18,6 +18,7 @@
 
 package io.mindmaps.graql.internal.util;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.ImmutableSet;
 
@@ -84,6 +85,35 @@ public class CommonUtil {
             @Override
             public Function<ImmutableSet.Builder<T>, ImmutableSet<T>> finisher() {
                 return ImmutableSet.Builder::build;
+            }
+
+            @Override
+            public Set<Characteristics> characteristics() {
+                return ImmutableSet.of();
+            }
+        };
+    }
+
+    public static <T> Collector<T, ImmutableList.Builder<T>, ImmutableList<T>> toImmutableList() {
+        return new Collector<T, ImmutableList.Builder<T>, ImmutableList<T>>() {
+            @Override
+            public Supplier<ImmutableList.Builder<T>> supplier() {
+                return ImmutableList::builder;
+            }
+
+            @Override
+            public BiConsumer<ImmutableList.Builder<T>, T> accumulator() {
+                return ImmutableList.Builder::add;
+            }
+
+            @Override
+            public BinaryOperator<ImmutableList.Builder<T>> combiner() {
+                return (b1, b2) -> b1.addAll(b2.build());
+            }
+
+            @Override
+            public Function<ImmutableList.Builder<T>, ImmutableList<T>> finisher() {
+                return ImmutableList.Builder::build;
             }
 
             @Override

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/GraqlTraversalTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/GraqlTraversalTest.java
@@ -29,6 +29,7 @@ import static io.mindmaps.graql.internal.gremlin.fragment.Fragments.outRolePlaye
 import static io.mindmaps.graql.internal.gremlin.fragment.Fragments.shortcut;
 import static io.mindmaps.graql.internal.gremlin.fragment.Fragments.value;
 import static io.mindmaps.graql.internal.pattern.Patterns.var;
+import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -117,7 +118,7 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
         Var pattern = var("x").id("Titanic").isa(var("y").id("movie"));
         GremlinQuery query = new GremlinQuery(graph, pattern.admin(), ImmutableSet.of("x"), Optional.empty());
 
-        Set<GraqlTraversal> traversals = query.allGraqlTraversals();
+        Set<GraqlTraversal> traversals = query.allGraqlTraversals().collect(toSet());
 
         assertEquals(12, traversals.size());
 
@@ -144,7 +145,7 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
         Pattern pattern = or(var("x").id("Titanic").value("hello"), var().rel("x").rel("y"));
         GremlinQuery query = new GremlinQuery(graph, pattern.admin(), ImmutableSet.of("x"), Optional.empty());
 
-        Set<GraqlTraversal> traversals = query.allGraqlTraversals();
+        Set<GraqlTraversal> traversals = query.allGraqlTraversals().collect(toSet());
 
         // Expect all combinations of both disjunctions
         Set<GraqlTraversal> expected = ImmutableSet.of(

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/GraqlTraversalTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/GraqlTraversalTest.java
@@ -97,23 +97,6 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
     }
 
     @Test
-    public void testRestartTraversalSlower() {
-        // This distinct casting will require restarting the traversal with a new V() step
-        Fragment distinctCasting = distinctCasting("c1", "c2");
-        Fragment inRolePlayer = inRolePlayer("x", "c1");
-        Fragment inCasting = inCasting("c1", "r");
-        Fragment outCasting = outCasting("r", "c2");
-        Fragment outRolePlayer = outRolePlayer("c2", "y");
-
-        GraqlTraversal distinctEarly =
-                traversal(xId, inRolePlayer, inCasting, outCasting, distinctCasting, outRolePlayer);
-        GraqlTraversal distinctLate =
-                traversal(xId, inRolePlayer, inCasting, outCasting, outRolePlayer, distinctCasting);
-
-        assertFaster(distinctLate, distinctEarly);
-    }
-
-    @Test
     public void testAllTraversalsSimpleQuery() {
         Var pattern = var("x").id("Titanic").isa(var("y").id("movie"));
         GremlinQuery query = new GremlinQuery(graph, pattern.admin(), ImmutableSet.of("x"), Optional.empty());

--- a/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/graql/query/MatchQueryTest.java
@@ -554,6 +554,11 @@ public class MatchQueryTest extends AbstractMovieGraphTest {
         assertEquals(0, query.stream().count());
     }
 
+    @Test
+    public void testQueryDoesNotCrash() {
+        qb.parse("match $m isa movie; (actor: $a1, $m); (actor: $a2, $m); select $a1, $a2;").execute();
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testMatchEmpty() {
         qb.match().execute();


### PR DESCRIPTION
Allows listing all possible query plans, from which the most optimal can be chosen.

This method is not currently in use because it is too slow, but it's a step in the right direction.