### PR TITLE
Migration tinker tests will run on one thread

### DIFF
--- a/mindmaps-test/src/test/java/io/mindmaps/test/migration/AbstractMindmapsMigratorTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/migration/AbstractMindmapsMigratorTest.java
@@ -29,6 +29,7 @@ import io.mindmaps.concept.Resource;
 import io.mindmaps.concept.ResourceType;
 import io.mindmaps.concept.RoleType;
 import io.mindmaps.concept.Type;
+import io.mindmaps.engine.loader.BlockingLoader;
 import io.mindmaps.engine.loader.Loader;
 import io.mindmaps.exception.MindmapsValidationException;
 import io.mindmaps.migration.base.Migrator;
@@ -73,7 +74,13 @@ public class AbstractMindmapsMigratorTest extends AbstractGraphTest {
     }
 
     protected void migrate(Migrator migrator){
-        MigrationLoader.load(graph, migrator);
+        int numberThreads = 8;
+        if(usingTinker()){
+            numberThreads = 1;
+        }
+
+        MigrationLoader.load(
+                new BlockingLoader(graph.getKeyspace()).setThreadsNumber(numberThreads), migrator);
     }
 
     protected void load(File ontology) {

--- a/mindmaps-test/src/test/java/io/mindmaps/test/migration/csv/CSVMigratorTest.java
+++ b/mindmaps-test/src/test/java/io/mindmaps/test/migration/csv/CSVMigratorTest.java
@@ -36,6 +36,8 @@ import static java.util.stream.Collectors.joining;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 public class CSVMigratorTest extends AbstractMindmapsMigratorTest {
 
@@ -143,8 +145,6 @@ public class CSVMigratorTest extends AbstractMindmapsMigratorTest {
         String templated = new CSVMigrator(pokemonTypeTemplate, getFile("csv", "multi-file/data/types.csv")).migrate()
                 .map(InsertQuery::toString)
                 .collect(joining("\n"));
-
-        System.out.println(templated);
 
         String expected = "id \"17-type\"";
         assertTrue(templated.contains(expected));


### PR DESCRIPTION
This is an attempt to fix the periodic tinker failures on master. We are limiting the loader to run on only one thread when testing using a tinker graph. Titan will use the normal default number of threads, 8. 