### PR TITLE
Bug #11044 testRestart concurrency issue

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/AbstractTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/AbstractTaskManager.java
@@ -60,7 +60,6 @@ public abstract class AbstractTaskManager implements TaskManager {
         state.setStatus(TaskStatus.STOPPED)
              .setStatusChangeMessage(message)
              .setStatusChangedBy(requesterName);
-        uuid = updateTaskState(uuid, state);
 
         ScheduledFuture<BackgroundTask> future = getTaskExecutionStatus(uuid);
         try {
@@ -68,6 +67,7 @@ public abstract class AbstractTaskManager implements TaskManager {
                 instantiateTask(state.getName()).stop();
 
             future.cancel(true);
+            updateTaskState(uuid, state);
         } catch(ClassNotFoundException | IllegalAccessException | InstantiationException e) {
             LOG.error("Could not run .stop() on task "+state.getName()+" id: "+uuid.toString()+" the error was: "+e.getMessage());
         }
@@ -115,7 +115,7 @@ public abstract class AbstractTaskManager implements TaskManager {
             return this;
         }
 
-        state.setStatus(TaskStatus.RUNNING)
+        state.setStatus(TaskStatus.SCHEDULED)
             .setStatusChangeMessage(message)
             .setStatusChangedBy(requesterName);
         uuid = updateTaskState(uuid, state);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/InMemoryTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/InMemoryTaskManager.java
@@ -109,12 +109,18 @@ public class InMemoryTaskManager extends AbstractTaskManager {
     }
 
     protected void executeSingle(UUID uuid, BackgroundTask task, long delay) {
+        if(delay < 100)
+            delay = 100;
+
         ScheduledFuture<BackgroundTask> f = (ScheduledFuture<BackgroundTask>) executorService.schedule(
                 runTask(uuid, task::start), delay, TimeUnit.MILLISECONDS);
         taskStorage.put(uuid, f);
     }
 
     protected void executeRecurring(UUID uuid, BackgroundTask task, long delay, long interval) {
+        if(delay < 100)
+            delay = 100;
+
         ScheduledFuture<BackgroundTask> f = (ScheduledFuture<BackgroundTask>) executorService.scheduleAtFixedRate(
                 runTask(uuid, task::start), delay, interval, TimeUnit.MILLISECONDS);
         taskStorage.put(uuid, f);

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/BackgroundTaskControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/BackgroundTaskControllerTest.java
@@ -93,8 +93,7 @@ public class BackgroundTaskControllerTest extends GraknEngineTestBase {
         get("/backgroundtasks/task/"+uuid)
                 .then().statusCode(200)
                 .and().contentType(ContentType.JSON)
-                .and().body("status", anyOf(equalTo(RUNNING.toString()),
-                                                  equalTo(COMPLETED.toString())));
+                .and().body("status", equalTo(SCHEDULED.toString()));
     }
 
     @Test

--- a/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTaskTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTaskTest.java
@@ -66,7 +66,7 @@ public class PostProcessingTaskTest extends GraknEngineTestBase {
         Assert.assertEquals(TaskStatus.PAUSED, taskManager.getTaskState(uuid).getStatus());
 
         taskManager.resumeTask(uuid);
-        Assert.assertEquals(TaskStatus.RUNNING, taskManager.getTaskState(uuid).getStatus());
+        Assert.assertEquals(TaskStatus.SCHEDULED, taskManager.getTaskState(uuid).getStatus());
     }
 
     @Test


### PR DESCRIPTION
This bug crops up only when scheduling and cancelling a task in quick
succession.

When cancelling thread runTask would be executed (the thread wakes up).
This causes it to try and set its state to RUNNING at the same time as
the stop method tries to update it to STOPPED. Whichever thread does so
later overwrites the others TaskStatus update.

This fix adds a 100ms minimum delay before any task can be executed.