### PR TITLE
Lock ontology when using a batch graph

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -52,6 +52,7 @@ public enum ErrorMessage {
     UNSUPPORTED_GRAPH("The graph backend of [%s] does not support an [%s] operation."),
     CANNOT_SUBCLASS_META("The Meta Concept [%s] cannot be a super type of [%s]."),
     RESOURCE_TYPE_UNIQUE("The resource [%s] is unique and is already attached to [%s]."),
+    SCHEMA_LOCKED("Schema cannot be modified when using a batch loading graph"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -50,7 +50,6 @@ public enum ErrorMessage {
     CANNOT_LOAD_EXAMPLE("Cannot load example to this graph. Please try a new empty graph."),
     META_TYPE_IMMUTABLE("The meta type [%s] is immutable"),
     UNSUPPORTED_GRAPH("The graph backend of [%s] does not support an [%s] operation."),
-    CANNOT_SUBCLASS_META("The Meta Concept [%s] cannot be a super type of [%s]."),
     RESOURCE_TYPE_UNIQUE("The resource [%s] is unique and is already attached to [%s]."),
     SCHEMA_LOCKED("Schema cannot be modified when using a batch loading graph"),
 

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -52,6 +52,7 @@ public enum ErrorMessage {
     UNSUPPORTED_GRAPH("The graph backend of [%s] does not support an [%s] operation."),
     RESOURCE_TYPE_UNIQUE("The resource [%s] is unique and is already attached to [%s]."),
     SCHEMA_LOCKED("Schema cannot be modified when using a batch loading graph"),
+    HAS_RESOURCE_INVALID("The type [%s] is not allowed to have a resource of type [%s]"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraphFactoryControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraphFactoryControllerTest.java
@@ -84,4 +84,15 @@ public class GraphFactoryControllerTest extends GraknEngineTestBase {
 
     }
 
+    @Test
+    public void testGraphSingleton(){
+        String keyspace = "grakntest";
+        AbstractGraknGraph graphNormal = (AbstractGraknGraph) Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
+        AbstractGraknGraph graphBatch = (AbstractGraknGraph) Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraphBatchLoading();
+
+        assertNotEquals(graphNormal, graphBatch);
+        //This is only true for tinkergraph
+        assertEquals(graphNormal.getTinkerPopGraph(), graphBatch.getTinkerPopGraph());
+    }
+
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/ImportControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/ImportControllerTest.java
@@ -123,7 +123,7 @@ public class ImportControllerTest extends GraknEngineTestBase {
     }
 
     private void importOntology(String ontologyFile, String graphNameParam){
-        GraknGraph graph = GraphFactory.getInstance().getGraphBatchLoading(graphNameParam);
+        GraknGraph graph = GraphFactory.getInstance().getGraph(graphNameParam);
 
         List<String> lines = null;
         try {

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/TaskControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/TaskControllerTest.java
@@ -18,11 +18,13 @@
 
 package ai.grakn.engine.controller;
 
-import ai.grakn.engine.backgroundtasks.*;
-import com.jayway.restassured.http.ContentType;
 import ai.grakn.engine.GraknEngineTestBase;
+import ai.grakn.engine.backgroundtasks.InMemoryTaskManager;
+import ai.grakn.engine.backgroundtasks.LongRunningTask;
+import ai.grakn.engine.backgroundtasks.TaskManager;
+import ai.grakn.engine.backgroundtasks.TestTask;
+import com.jayway.restassured.http.ContentType;
 import com.jayway.restassured.response.Response;
-import org.hamcrest.Matchers;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -33,8 +35,12 @@ import java.util.Date;
 
 import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
-import static com.jayway.restassured.RestAssured.*;
-import static org.hamcrest.Matchers.*;
+import static com.jayway.restassured.RestAssured.get;
+import static com.jayway.restassured.RestAssured.given;
+import static com.jayway.restassured.RestAssured.put;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 
 public class TaskControllerTest extends GraknEngineTestBase {
@@ -49,6 +55,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testTasksByStatus() {
         System.out.println("testTasksByStatus");
         Response response = given().queryParam("status", COMPLETED.toString())
@@ -66,6 +73,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testTasksByClassName() {
         System.out.println("testTasksByClassName");
         Response response = given().queryParam("className", TestTask.class.getName())
@@ -83,6 +91,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testTasksByCreator() {
         System.out.println("testTasksByCreator");
        Response response = given().queryParam("creator", this.getClass().getName())
@@ -100,6 +109,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testGetAllTasks() {
         System.out.println("testGetAllTasks");
         taskManager.storage().clear();
@@ -113,6 +123,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testGetTask() throws Exception {
         System.out.println("testGetTask");
         get("/tasks/"+singleTask)
@@ -123,6 +134,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testScheduleWithoutOptional() {
         System.out.println("testScheduleWithoutOptional");
         given().queryParam("className", TestTask.class.getName())
@@ -135,6 +147,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     }
 
     @Ignore
+    @Test
     public void testScheduleStopTask() {
         System.out.println("testScheduleStopTask");
         Response response = given().queryParam("className", LongRunningTask.class.getName())

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/TransactionControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/TransactionControllerTest.java
@@ -38,12 +38,12 @@ import static org.junit.Assert.assertTrue;
 
 public class TransactionControllerTest extends GraknEngineTestBase {
 
-    private String graphName;
+    private String keyspace;
 
     @Before
     public void setUp() throws Exception {
-        graphName = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
-        GraknGraph graph = GraphFactory.getInstance().getGraphBatchLoading(graphName);
+        keyspace = ConfigProperties.getInstance().getProperty(ConfigProperties.DEFAULT_GRAPH_NAME_PROPERTY);
+        GraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
         graph.putEntityType("Man");
         graph.commit();
     }
@@ -52,7 +52,7 @@ public class TransactionControllerTest extends GraknEngineTestBase {
     public void insertValidQuery() {
         Json exampleInsertQuery = Json.array("insert $x isa Man;");
         String transactionUUID = given().body(exampleInsertQuery.toString()).
-                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?graphName=grakntest").body().asString();
+                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?keyspace=grakntest").body().asString();
         int i = 0;
         String status = "QUEUED";
         while (i < 5 && !status.equals("FINISHED")) {
@@ -65,14 +65,14 @@ public class TransactionControllerTest extends GraknEngineTestBase {
             }
         }
 
-        assertNotNull(GraphFactory.getInstance().getGraphBatchLoading(graphName).getEntityType("Man").instances().iterator().next());
+        assertNotNull(GraphFactory.getInstance().getGraphBatchLoading(keyspace).getEntityType("Man").instances().iterator().next());
     }
 
     @Test
     public void insertInvalidQuery() {
         Json exampleInvalidInsertQuery = Json.array("insert id ?Cdcs;w4. '' ervalue;");
         String transactionUUID = given().body(exampleInvalidInsertQuery.toString()).
-                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?graphName=grakntest").body().asString();
+                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?keyspace=grakntest").body().asString();
         int i = 0;
         String status = "QUEUED";
         while (i < 10 && !status.equals("ERROR")) {
@@ -92,7 +92,7 @@ public class TransactionControllerTest extends GraknEngineTestBase {
     public void checkLoaderStateTest() {
         String exampleInvalidInsertQuery = "insert id ?Cdcs;w4. '' ervalue;";
         given().body(exampleInvalidInsertQuery).
-                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?graphName=grakntest").body().asString();
+                when().post(REST.WebPath.NEW_TRANSACTION_URI + "?keyspace=grakntest").body().asString();
         JSONObject resultObj = new JSONObject(get(REST.WebPath.LOADER_STATE_URI).then().statusCode(200).and().extract().body().asString());
         assertTrue(resultObj.has(TransactionState.State.QUEUED.name()));
         assertTrue(resultObj.has(TransactionState.State.ERROR.name()));
@@ -103,6 +103,6 @@ public class TransactionControllerTest extends GraknEngineTestBase {
 
     @After
     public void cleanGraph() {
-        GraphFactory.getInstance().getGraphBatchLoading(graphName).clear();
+        GraphFactory.getInstance().getGraphBatchLoading(keyspace).clear();
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/loader/DistributedLoaderTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/loader/DistributedLoaderTest.java
@@ -96,7 +96,7 @@ public class DistributedLoaderTest extends GraknEngineTestBase {
     }
 
     private void loadOntologyFromFile() {
-        GraknGraph graph = GraphFactory.getInstance().getGraphBatchLoading(graphName);
+        GraknGraph graph = GraphFactory.getInstance().getGraph(graphName);
         ClassLoader classLoader = getClass().getClassLoader();
 
         LOG.info("Loading new ontology .. ");

--- a/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTest.java
@@ -56,7 +56,7 @@ public class PostProcessingTest extends GraknEngineTestBase {
         cache = Cache.getInstance();
         keyspace = UUID.randomUUID().toString().replaceAll("-", "a");
         postProcessing = PostProcessing.getInstance();
-        graknGraph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraphBatchLoading();
+        graknGraph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
     }
 
     @After
@@ -70,8 +70,15 @@ public class PostProcessingTest extends GraknEngineTestBase {
         //Create Scenario
         RoleType roleType1 = graknGraph.putRoleType("role 1");
         RoleType roleType2 = graknGraph.putRoleType("role 2");
-        RelationType relationType = graknGraph.putRelationType("rel type").hasRole(roleType1).hasRole(roleType2);
-        EntityType thing = graknGraph.putEntityType("thing").playsRole(roleType1).playsRole(roleType2);
+        graknGraph.putRelationType("rel type").hasRole(roleType1).hasRole(roleType2);
+        graknGraph.putEntityType("thing").playsRole(roleType1).playsRole(roleType2);
+
+        graknGraph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraphBatchLoading();
+        roleType1 = graknGraph.getRoleType("role 1");
+        roleType2 = graknGraph.getRoleType("role 2");
+        RelationType relationType = graknGraph.getRelationType("rel type");
+        EntityType thing = graknGraph.getEntityType("thing");
+
         Instance instance1 = thing.addEntity();
         Instance instance2 = thing.addEntity();
         Instance instance3 = thing.addEntity();
@@ -149,8 +156,12 @@ public class PostProcessingTest extends GraknEngineTestBase {
         ExecutorService pool = Executors.newFixedThreadPool(10);
 
         //Create Graph With Duplicate Resources
-        GraknGraph graph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraphBatchLoading();
-        ResourceType<String> resourceType = graph.putResourceType(sample, ResourceType.DataType.STRING);
+        GraknGraph graph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
+        graph.putResourceType(sample, ResourceType.DataType.STRING);
+
+        graph = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraphBatchLoading();
+        ResourceType<String> resourceType = graph.getResourceType(sample);
+
         Resource<String> resource = resourceType.putResource(value);
         graph.commit();
         assertEquals(1, resourceType.instances().size());

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -140,11 +140,11 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
             ruleType.setType(type.getId());
             entityType.setType(type.getId());
 
-            relationType.superType(type);
-            roleType.superType(type);
-            resourceType.superType(type);
-            ruleType.superType(type);
-            entityType.superType(type);
+            relationType.putEdge(type, Schema.EdgeLabel.SUB);
+            roleType.putEdge(type, Schema.EdgeLabel.SUB);
+            resourceType.putEdge(type, Schema.EdgeLabel.SUB);
+            ruleType.putEdge(type, Schema.EdgeLabel.SUB);
+            entityType.putEdge(type, Schema.EdgeLabel.SUB);
 
             return true;
         }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -226,6 +226,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
         return conceptLog;
     }
 
+    public void checkOntologyMutation(){
+        if(isBatchLoadingEnabled()){
+            throw new GraphRuntimeException(ErrorMessage.SCHEMA_LOCKED.getMessage());
+        }
+    }
+
     //----------------------------------------------Concept Functionality-----------------------------------------------
     //------------------------------------ Construction
     public Vertex addVertex(Schema.BaseType baseType){
@@ -257,6 +263,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
     }
 
     private TypeImpl putConceptType(String itemIdentifier, Schema.BaseType baseType, Type metaType) {
+        checkOntologyMutation();
         return elementFactory.buildSpecificConceptType(putVertex(itemIdentifier, baseType), metaType);
     }
     @Override

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -397,48 +397,44 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
         return validConceptOfType(getConcept(id), RuleTypeImpl.class);
     }
 
-    private Type getConceptType(String id){
-        return validConceptOfType(getConcept(id), TypeImpl.class);
-    }
-
     @Override
     public Type getMetaType() {
-        return getConceptType(Schema.MetaSchema.TYPE.getId());
+        return getType(Schema.MetaSchema.TYPE.getId());
     }
 
     @Override
     public Type getMetaRelationType() {
-        return getConceptType(Schema.MetaSchema.RELATION_TYPE.getId());
+        return getType(Schema.MetaSchema.RELATION_TYPE.getId());
     }
 
     @Override
     public Type getMetaRoleType() {
-        return getConceptType(Schema.MetaSchema.ROLE_TYPE.getId());
+        return getType(Schema.MetaSchema.ROLE_TYPE.getId());
     }
 
     @Override
     public Type getMetaResourceType() {
-        return getConceptType(Schema.MetaSchema.RESOURCE_TYPE.getId());
+        return getType(Schema.MetaSchema.RESOURCE_TYPE.getId());
     }
 
     @Override
     public Type getMetaEntityType() {
-        return getConceptType(Schema.MetaSchema.ENTITY_TYPE.getId());
+        return getType(Schema.MetaSchema.ENTITY_TYPE.getId());
     }
 
     @Override
     public Type getMetaRuleType(){
-        return getConceptType(Schema.MetaSchema.RULE_TYPE.getId());
+        return getType(Schema.MetaSchema.RULE_TYPE.getId());
     }
 
     @Override
     public RuleType getMetaRuleInference() {
-        return getConceptType(Schema.MetaSchema.INFERENCE_RULE.getId()).asRuleType();
+        return getType(Schema.MetaSchema.INFERENCE_RULE.getId()).asRuleType();
     }
 
     @Override
     public RuleType getMetaRuleConstraint() {
-        return getConceptType(Schema.MetaSchema.CONSTRAINT_RULE.getId()).asRuleType();
+        return getType(Schema.MetaSchema.CONSTRAINT_RULE.getId()).asRuleType();
     }
 
     //-----------------------------------------------Casting Functionality----------------------------------------------

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -79,7 +79,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
         this.graph = graph;
         this.keyspace = keyspace;
         this.engine = engine;
-        this.batchLoadingEnabled = batchLoadingEnabled;
         elementFactory = new ElementFactory(this);
 
         if(initialiseMetaConcepts()) {
@@ -90,6 +89,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
             }
         }
 
+        this.batchLoadingEnabled = batchLoadingEnabled;
         this.committed = false;
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -152,7 +152,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
         return false;
     }
 
-    public boolean isMetaOntologyNotInitialised(){
+    private boolean isMetaOntologyNotInitialised(){
         return getMetaType() == null;
     }
 
@@ -604,7 +604,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
         }
     }
     protected void closeGraphTransaction() throws Exception {
-        graph.close();
+        getTinkerPopGraph().close();
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
@@ -151,9 +151,9 @@ abstract class InstanceImpl<T extends Instance, V extends Type> extends ConceptI
     public Relation hasResource(Resource resource){
         ResourceType type = resource.type();
 
-        RelationType hasResource = getGraknGraph().putRelationType(Schema.Resource.HAS_RESOURCE.getId(type.getId()));
-        RoleType hasResourceTarget = getGraknGraph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getId(type.getId()));
-        RoleType hasResourceValue = getGraknGraph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getId(type.getId()));
+        RelationType hasResource = getGraknGraph().getRelationType(Schema.Resource.HAS_RESOURCE.getId(type.getId()));
+        RoleType hasResourceTarget = getGraknGraph().getRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getId(type.getId()));
+        RoleType hasResourceValue = getGraknGraph().getRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getId(type.getId()));
 
         Relation relation = hasResource.addRelation();
         relation.putRolePlayer(hasResourceTarget, this);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
@@ -26,6 +26,8 @@ import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Type;
+import ai.grakn.exception.ConceptException;
+import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
@@ -154,6 +156,10 @@ abstract class InstanceImpl<T extends Instance, V extends Type> extends ConceptI
         RelationType hasResource = getGraknGraph().getRelationType(Schema.Resource.HAS_RESOURCE.getId(type.getId()));
         RoleType hasResourceTarget = getGraknGraph().getRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getId(type.getId()));
         RoleType hasResourceValue = getGraknGraph().getRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getId(type.getId()));
+
+        if(hasResource == null || hasResourceTarget == null || hasResourceValue == null){
+            throw new ConceptException(ErrorMessage.HAS_RESOURCE_INVALID.getMessage(type().getId(), resource.type().getId()));
+        }
 
         Relation relation = hasResource.addRelation();
         relation.putRolePlayer(hasResourceTarget, this);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
@@ -67,6 +67,7 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
      */
     @Override
     public RelationType hasRole(RoleType roleType) {
+        getGraknGraph().checkOntologyMutation();
         putEdge(roleType, Schema.EdgeLabel.HAS_ROLE);
         return this;
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
@@ -79,6 +79,7 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
      */
     @Override
     public RelationType deleteHasRole(RoleType roleType) {
+        checkTypeMutation();
         deleteEdgeTo(Schema.EdgeLabel.HAS_ROLE, roleType);
         //Add castings of roleType to make sure relations are still valid
         ((RoleTypeImpl) roleType).castings().forEach(casting -> getGraknGraph().getConceptLog().putConcept(casting));

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
@@ -67,7 +67,7 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
      */
     @Override
     public RelationType hasRole(RoleType roleType) {
-        getGraknGraph().checkOntologyMutation();
+        checkTypeMutation();
         putEdge(roleType, Schema.EdgeLabel.HAS_ROLE);
         return this;
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -25,7 +25,6 @@ import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.Type;
 import ai.grakn.exception.ConceptException;
-import ai.grakn.exception.InvalidConceptTypeException;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -242,11 +241,8 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
      * @return The Type itself
      */
     public T superType(T type) {
+        ((TypeImpl) type).checkTypeMutation();
         checkTypeMutation();
-        if(Schema.MetaSchema.isMetaId(type.getId()) && !Schema.MetaSchema.isMetaId(getId())){
-            throw new InvalidConceptTypeException(ErrorMessage.CANNOT_SUBCLASS_META.getMessage(type.getId(), getId()));
-        }
-
 
         //Track any existing data if there is some
         Type currentSuperType = superType();

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -280,6 +280,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
      */
     @Override
     public T deletePlaysRole(RoleType roleType) {
+        checkTypeMutation();
         deleteEdgeTo(Schema.EdgeLabel.PLAYS_ROLE, roleType);
 
         //Add castings to tracking to make sure they can still be played.

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -245,6 +245,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
         if(Schema.MetaSchema.isMetaId(type.getId()) && !Schema.MetaSchema.isMetaId(getId())){
             throw new InvalidConceptTypeException(ErrorMessage.CANNOT_SUBCLASS_META.getMessage(type.getId(), getId()));
         }
+        getGraknGraph().checkOntologyMutation();
 
         //Track any existing data if there is some
         Type currentSuperType = superType();
@@ -270,6 +271,7 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
      * @return The Type itself.
      */
     public T playsRole(RoleType roleType) {
+        getGraknGraph().checkOntologyMutation();
         checkMetaType();
         putEdge(roleType, Schema.EdgeLabel.PLAYS_ROLE);
         return getThis();

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -317,6 +317,9 @@ class TypeImpl<T extends Type, V extends Concept> extends ConceptImpl<T, Type> i
         return getThis();
     }
 
+    /**
+     * Checks if we are mutating a met type
+     */
     private void checkMetaType(){
         for (Schema.MetaSchema metaSchema : Schema.MetaSchema.values()) {
             if(metaSchema.getId().equals(getId())){

--- a/grakn-graph/src/test/java/ai/grakn/GraknTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/GraknTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn;
 
+import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.graph.internal.GraknTinkerGraph;
 import org.junit.Test;
 
@@ -56,5 +57,15 @@ public class GraknTest {
     @Test
     public void testComputer(){
         assertThat(Grakn.factory(Grakn.IN_MEMORY, "bob").getGraphComputer(), instanceOf(GraknComputer.class));
+    }
+
+    @Test
+    public void testSingletonBetweenBatchAndNormalInMemory(){
+        String keyspace = "test1";
+        AbstractGraknGraph graph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraph();
+        AbstractGraknGraph batchGraph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraphBatchLoading();
+
+        assertNotEquals(graph, batchGraph);
+        assertEquals(graph.getTinkerPopGraph(), batchGraph.getTinkerPopGraph());
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
@@ -19,24 +19,28 @@
 package ai.grakn.graph.internal;
 
 import ai.grakn.concept.Entity;
+import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.Relation;
 import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
 import ai.grakn.exception.ConceptException;
+import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.graql.Pattern;
+import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
-import ai.grakn.concept.EntityType;
-import ai.grakn.concept.RoleType;
 import org.junit.Test;
 
 import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -270,5 +274,21 @@ public class EntityTest extends GraphTestBase{
                 assertEquals(Schema.Resource.HAS_RESOURCE_VALUE.getId(resourceTypeId), roleType.getId());
             }
         });
+    }
+
+    @Test
+    public void testHasResourceWithNoSchema(){
+        EntityType entityType = graknGraph.putEntityType("A Thing");
+        ResourceType resourceType = graknGraph.putResourceType("A Resource Thing", ResourceType.DataType.STRING);
+
+        Entity entity = entityType.addEntity();
+        Resource resource = resourceType.putResource("A resource thing");
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.HAS_RESOURCE_INVALID.getMessage(entityType.getId(), resourceType.getId()))
+        ));
+
+        entity.hasResource(resource);
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphHighLevelTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphHighLevelTest.java
@@ -529,13 +529,23 @@ public class GraknGraphHighLevelTest extends GraphTestBase{
 
     @Test
     public void testPutRelationSimple(){
-        AbstractGraknGraph graph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraphBatchLoading();
-
-        EntityType type = graph.putEntityType("Test");
+        //Load Ontology
+        String keyspace = UUID.randomUUID().toString().replaceAll("-", "a");
+        AbstractGraknGraph graph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraph();
+        graph.putEntityType("Test");
         RoleType actor = graph.putRoleType("Actor");
         RoleType actor2 = graph.putRoleType("Actor 2");
         RoleType actor3 = graph.putRoleType("Actor 3");
-        RelationType cast = graph.putRelationType("Cast").hasRole(actor).hasRole(actor2).hasRole(actor3);
+        graph.putRelationType("Cast").hasRole(actor).hasRole(actor2).hasRole(actor3);
+
+        //Fetch Ontology
+        graph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraphBatchLoading();
+        EntityType type = graph.getEntityType("Test");
+        actor = graph.getRoleType("Actor");
+        actor2 = graph.getRoleType("Actor 2");
+        actor3 = graph.getRoleType("Actor 3");
+        RelationType cast = graph.getRelationType("Cast");
+
         Instance pacino = type.addEntity();
         Instance thing = type.addEntity();
         Instance godfather = type.addEntity();

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraphTestBase.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraphTestBase.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import java.util.UUID;
 
 public class GraphTestBase {
+    protected AbstractGraknGraph graknGraphBatch;
     protected AbstractGraknGraph graknGraph;
 
     @Rule
@@ -34,7 +35,9 @@ public class GraphTestBase {
 
     @Before
     public void setUpGraph() {
-        graknGraph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a")).getGraph();
+        String keyspace = UUID.randomUUID().toString().replaceAll("-", "a");
+        graknGraph = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraph();
+        graknGraphBatch = (AbstractGraknGraph) Grakn.factory(Grakn.IN_MEMORY, keyspace).getGraphBatchLoading();
     }
 
     @After

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
@@ -231,4 +231,41 @@ public class OntologyMutationTest extends GraphTestBase{
 
         entityType1.superType(entityType2);
     }
+
+
+    @Test
+    public void testDeletingPlaysRoleWhileBatchLoading(){
+        String roleTypeId = "role";
+        String entityTypeId = "entityType";
+        RoleType roleType = graknGraph.putRoleType(roleTypeId);
+        graknGraph.putEntityType(entityTypeId).playsRole(roleType);
+
+        roleType = graknGraphBatch.getRoleType(roleTypeId);
+        EntityType entityType = graknGraphBatch.getEntityType(entityTypeId);
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        entityType.deletePlaysRole(roleType);
+    }
+
+    @Test
+    public void testDeletingHasRolesWhileBatchLoading(){
+        String roleTypeId = "role";
+        String relationTypeId = "relationtype";
+        RoleType roleType = graknGraph.putRoleType(roleTypeId);
+        graknGraph.putRelationType(relationTypeId).hasRole(roleType);
+
+        roleType = graknGraphBatch.getRoleType(roleTypeId);
+        RelationType relationType = graknGraphBatch.getRelationType(relationTypeId);
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        relationType.deleteHasRole(roleType);
+    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
@@ -176,4 +176,59 @@ public class OntologyMutationTest extends GraphTestBase{
 
         graknGraphBatch.putRelationType("This Will Fail");
     }
+
+    @Test
+    public void testAddingHasRolesWhileBatchLoading(){
+        String roleTypeId = "role";
+        String relationTypeId = "relationtype";
+        graknGraph.putRoleType(roleTypeId);
+        graknGraph.putRelationType(relationTypeId);
+
+        RoleType roleType = graknGraphBatch.getRoleType(roleTypeId);
+        RelationType relationType = graknGraphBatch.getRelationType(relationTypeId);
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        relationType.hasRole(roleType);
+    }
+
+    @Test
+    public void testAddingPlaysRoleWhileBatchLoading(){
+        String roleTypeId = "role";
+        String entityTypeId = "entityType";
+        graknGraph.putRoleType(roleTypeId);
+        graknGraph.putEntityType(entityTypeId);
+
+        RoleType roleType = graknGraphBatch.getRoleType(roleTypeId);
+        EntityType entityType = graknGraphBatch.getEntityType(entityTypeId);
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        entityType.playsRole(roleType);
+    }
+
+    @Test
+    public void testAkoingWhileBatchLoading(){
+        String entityTypeId1 = "entityType1";
+        String entityTypeId2 = "entityType2";
+
+        graknGraph.putEntityType(entityTypeId1);
+        graknGraph.putEntityType(entityTypeId2);
+
+        EntityType entityType1 = graknGraphBatch.getEntityType(entityTypeId1);
+        EntityType entityType2 = graknGraphBatch.getEntityType(entityTypeId2);
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        entityType1.superType(entityType2);
+    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/OntologyMutationTest.java
@@ -18,12 +18,14 @@
 
 package ai.grakn.graph.internal;
 
-import ai.grakn.concept.Relation;
-import ai.grakn.concept.RelationType;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Instance;
+import ai.grakn.concept.Relation;
+import ai.grakn.concept.RelationType;
+import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.exception.GraknValidationException;
+import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.util.ErrorMessage;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,4 +127,53 @@ public class OntologyMutationTest extends GraphTestBase{
         graknGraph.commit();
     }
 
+    @Test
+    public void testAddingEntityTypeWhileBatchLoading(){
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        graknGraphBatch.putEntityType("This Will Fail");
+    }
+
+    @Test
+    public void testAddingRoleTypeWhileBatchLoading(){
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        graknGraphBatch.putRoleType("This Will Fail");
+    }
+
+    @Test
+    public void testAddingResourceTypeWhileBatchLoading(){
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        graknGraphBatch.putResourceType("This Will Fail", ResourceType.DataType.STRING);
+    }
+
+    @Test
+    public void testAddingRuleTypeWhileBatchLoading(){
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        graknGraphBatch.putRuleType("This Will Fail");
+    }
+
+    @Test
+    public void testAddingRelationTypeWhileBatchLoading(){
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.SCHEMA_LOCKED.getMessage())
+        ));
+
+        graknGraphBatch.putRelationType("This Will Fail");
+    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/TypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/TypeTest.java
@@ -18,20 +18,19 @@
 
 package ai.grakn.graph.internal;
 
+import ai.grakn.concept.Concept;
+import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.RelationType;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Rule;
+import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
 import ai.grakn.exception.ConceptException;
-import ai.grakn.exception.InvalidConceptTypeException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
-import ai.grakn.concept.Concept;
-import ai.grakn.concept.EntityType;
-import ai.grakn.concept.RoleType;
-import ai.grakn.concept.RuleType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -143,9 +142,9 @@ public class TypeTest extends GraphTestBase{
         RuleType metaType = graknGraph.getMetaRuleInference();
         RuleType superType = graknGraph.putRuleType("An Entity Type");
 
-        expectedException.expect(InvalidConceptTypeException.class);
+        expectedException.expect(ConceptException.class);
         expectedException.expectMessage(allOf(
-                containsString(ErrorMessage.CANNOT_SUBCLASS_META.getMessage(metaType.getId(), superType.getId()))
+                containsString(ErrorMessage.META_TYPE_IMMUTABLE.getMessage(metaType.getId()))
         ));
 
         superType.superType(metaType);

--- a/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
@@ -19,7 +19,7 @@ public class GraphTest extends AbstractRollbackGraphTest {
         graph.putEntityType(thing);
         graph.commit();
 
-        graph = factory.getGraphBatchLoading();
+        graph = factory.getGraph();
         assertNotNull(graph.getEntityType(thing));
 
         String related = "related";

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/InsertQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/InsertQueryTest.java
@@ -18,16 +18,6 @@
 
 package ai.grakn.test.graql.query;
 
-import ai.grakn.concept.Resource;
-import ai.grakn.concept.ResourceType;
-import ai.grakn.concept.RuleType;
-import ai.grakn.example.MovieGraphFactory;
-import ai.grakn.graql.InsertQuery;
-import ai.grakn.graql.Pattern;
-import ai.grakn.graql.Var;
-import ai.grakn.test.AbstractMovieGraphTest;
-import ai.grakn.util.Schema;
-import com.google.common.collect.Sets;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Resource;
@@ -40,6 +30,8 @@ import ai.grakn.graql.Pattern;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.Var;
 import ai.grakn.test.AbstractMovieGraphTest;
+import ai.grakn.util.Schema;
+import com.google.common.collect.Sets;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,16 +41,9 @@ import org.junit.rules.ExpectedException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static ai.grakn.concept.ResourceType.DataType.LONG;
-import static ai.grakn.concept.ResourceType.DataType.STRING;
 import static ai.grakn.graql.Graql.gt;
 import static ai.grakn.graql.Graql.id;
 import static ai.grakn.graql.Graql.var;
-import static ai.grakn.util.Schema.MetaSchema.ENTITY_TYPE;
-import static ai.grakn.util.Schema.MetaSchema.RELATION_TYPE;
-import static ai.grakn.util.Schema.MetaSchema.RESOURCE_TYPE;
-import static ai.grakn.util.Schema.MetaSchema.ROLE_TYPE;
-import static ai.grakn.util.Schema.MetaSchema.RULE_TYPE;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
@@ -396,9 +381,9 @@ public class InsertQueryTest extends AbstractMovieGraphTest {
     @Test
     public void testInsertResourceTypeAndInstance() {
         qb.insert(
-                var("x").isa("movie").has("my-resource", "look a string"),
+                id("movie").hasResource("my-resource"),
                 id("my-resource").isa("resource-type").datatype(ResourceType.DataType.STRING),
-                id("movie").hasResource("my-resource")
+                var("x").isa("movie").has("my-resource", "look a string")
         ).execute();
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
@@ -20,6 +20,7 @@ package ai.grakn.test.graql.query;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.exception.ConceptException;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
@@ -141,14 +142,12 @@ public class QueryErrorTest extends AbstractMovieGraphTest {
                 Graql.id("name").isa("resource-type").datatype(ResourceType.DataType.STRING)
         ).execute();
 
-        exception.expect(GraknValidationException.class);
+        exception.expect(ConceptException.class);
         exception.expectMessage(allOf(
                 containsString("person"),
                 containsString("name")
         ));
         emptyQb.insert(Graql.var().isa("person").has("name", "Bob")).execute();
-
-        empty.commit();
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
@@ -20,16 +20,15 @@ package ai.grakn.test.graql.query;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.ResourceType;
-import ai.grakn.graql.Graql;
-import ai.grakn.test.AbstractMovieGraphTest;
 import ai.grakn.exception.GraknValidationException;
+import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.test.AbstractMovieGraphTest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static ai.grakn.graql.Graql.var;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.StringContains.containsString;
 


### PR DESCRIPTION
- Fail mutations when adding types
- Fail mutations when adding/removing hasRoles
- Fail mutations when adding/removing playsRoles
- Fail mutations when akoin
