### PR TITLE
Add `MatchQuery#getAllVariableNames`

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
@@ -60,4 +60,9 @@ public interface MatchQueryAdmin extends MatchQuery {
      * @return all selected variable names in the query
      */
     Set<String> getSelectedNames();
+
+    /**
+     * @return all variable names in the query, including any generated variable names
+     */
+    Set<String> getAllVariableNames();
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GremlinQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GremlinQuery.java
@@ -77,7 +77,7 @@ public class GremlinQuery {
         this.names = names;
         this.order = order;
 
-        innerQueries = patterns.stream().map(ConjunctionQuery::new).collect(toList());
+        innerQueries = patterns.stream().map(p -> new ConjunctionQuery(p, names)).collect(toList());
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
@@ -42,13 +42,13 @@ class MatchQueryGraph extends MatchQueryModifier {
 
     @Override
     public Stream<Map<String, Concept>> stream(
-            Optional<GraknGraph> graph, Optional<MatchOrder> order
+            Optional<GraknGraph> graph, Optional<MatchOrder> order, boolean selectAll
     ) {
         if (graph.isPresent()) {
             throw new IllegalStateException(ErrorMessage.MULTIPLE_GRAPH.getMessage());
         }
 
-        return inner.stream(Optional.of(this.graph), order);
+        return inner.stream(Optional.of(this.graph), order, selectAll);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
@@ -40,7 +40,7 @@ class MatchQueryInfer extends MatchQueryModifier {
 
     @Override
     public Stream<Map<String, Concept>> stream(
-            Optional<GraknGraph> optionalGraph, Optional<MatchOrder> order
+            Optional<GraknGraph> optionalGraph, Optional<MatchOrder> order, boolean selectAll
     ) {
         GraknGraph graph = optionalOr(optionalGraph, inner.getGraph()).orElseThrow(
                 () -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage())

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInternal.java
@@ -81,13 +81,14 @@ public interface MatchQueryInternal extends MatchQueryAdmin {
      * Execute the query using the given graph.
      * @param graph the graph to use to execute the query
      * @param order how to order the resulting stream
+     * @param selectAll whether to select all variables in the query
      * @return a stream of results
      */
-    Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order);
+    Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order, boolean selectAll);
 
     @Override
     default Stream<Map<String, Concept>> stream() {
-        return stream(Optional.empty(), Optional.empty());
+        return stream(Optional.empty(), Optional.empty(), false);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryModifier.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryModifier.java
@@ -45,8 +45,8 @@ abstract class MatchQueryModifier implements MatchQueryInternal {
     }
 
     @Override
-    public Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order) {
-        return transformStream(inner.stream(graph, order));
+    public Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order, boolean selectAll) {
+        return transformStream(inner.stream(graph, order, selectAll(selectAll)));
     }
 
     @Override
@@ -74,6 +74,11 @@ abstract class MatchQueryModifier implements MatchQueryInternal {
         return inner.getSelectedNames();
     }
 
+    @Override
+    public final Set<String> getAllVariableNames() {
+        return inner.getAllVariableNames();
+    }
+
     /**
      * Transform the given stream. This should be overridden in subclasses to perform modifier behaviour.
      * The default implementation returns the stream unmodified.
@@ -82,6 +87,10 @@ abstract class MatchQueryModifier implements MatchQueryInternal {
      */
     protected Stream<Map<String, Concept>> transformStream(Stream<Map<String, Concept>> stream) {
         return stream;
+    }
+
+    protected boolean selectAll(boolean selectAll) {
+        return selectAll;
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
@@ -40,13 +40,13 @@ class MatchQueryOrder extends MatchQueryModifier {
 
     @Override
     public Stream<Map<String, Concept>> stream(
-            Optional<GraknGraph> graph, Optional<MatchOrder> order
+            Optional<GraknGraph> graph, Optional<MatchOrder> order, boolean selectAll
     ) {
         if (order.isPresent()) {
             throw new IllegalStateException(ErrorMessage.MULTIPLE_ORDER.getMessage());
         }
 
-        return inner.stream(graph, Optional.of(this.order));
+        return inner.stream(graph, Optional.of(this.order), selectAll);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
@@ -18,10 +18,10 @@
 
 package ai.grakn.graql.internal.query.match;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import ai.grakn.concept.Concept;
 import ai.grakn.util.ErrorMessage;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 
 import java.util.Map;
 import java.util.Set;
@@ -49,6 +49,11 @@ class MatchQuerySelect extends MatchQueryModifier {
     @Override
     public Stream<Map<String, Concept>> transformStream(Stream<Map<String, Concept>> stream) {
         return stream.map(result -> Maps.filterKeys(result, names::contains));
+    }
+
+    @Override
+    protected boolean selectAll(boolean selectAll) {
+        return true;
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/Query.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/Query.java
@@ -110,10 +110,15 @@ public class Query implements MatchQueryInternal {
     public Set<String> getSelectedNames() { return Sets.newHashSet(selectVars);}
 
     @Override
+    public Set<String> getAllVariableNames() {
+        return getMatchQuery().admin().getAllVariableNames();
+    }
+
+    @Override
     public MatchQuery select(Set<String> vars){ return this;}
 
     @Override
-    public Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order) {
+    public Stream<Map<String, Concept>> stream(Optional<GraknGraph> graph, Optional<MatchOrder> order, boolean selectAll) {
         return getMatchQuery().stream();
     }
 


### PR DESCRIPTION
Add a method to get all variable names mentioned in the query, including anything with an "implicit" variable name (such as a type or a relation).

Also add support for using this with the `MatchQuery#select` method.