### PR TITLE
Functionality #11206 Limit results when requesting multiple tasks

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -64,6 +64,7 @@ public class REST {
         public static final String TASK_RUN_INTERVAL_PARAMETER = "interval";
         public static final String TASK_CONFIGURATION_PARAMETER = "configuration";
         public static final String TASK_STOP = "/stop";
+        public static final String LIMIT_PARAM = "limit";
     }
 
     public static class GraphConfig{

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/InMemoryTaskStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/InMemoryTaskStateStorage.java
@@ -100,8 +100,11 @@ public class InMemoryTaskStateStorage implements TaskStateStorage {
         return newState;
     }
 
-    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy) {
+    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit) {
         Set<Pair<String, TaskState>> res = new HashSet<>();
+
+
+        int count = 0;
         for(Map.Entry<String, TaskState> x: storage.entrySet()) {
             TaskState state = x.getValue();
 
@@ -113,13 +116,13 @@ public class InMemoryTaskStateStorage implements TaskStateStorage {
             if(createdBy != null && !Objects.equals(state.creator(), createdBy))
                 continue;
 
-            res.add(new Pair<>(x.getKey(), getState(x.getKey())));
+            if(limit > 0 && count >= limit)
+                break;
+            count++;
+
+            res.add(new Pair<>(x.getKey(), state));
         }
 
         return res;
-    }
-
-    public void clear() {
-        storage.clear();
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
@@ -82,11 +82,5 @@ public interface TaskStateStorage {
      * @param createdBy String containing created by. See TaskState.
      * @return Set<Pair<String, TaskState> of task IDs and corresponding TaskState *copies*.
      */
-    Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy);
-
-
-    /**
-     * Clear all stored tasks.
-     */
-    void clear();
+    Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit);
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
@@ -32,10 +32,7 @@ import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
+import javax.ws.rs.*;
 
 import java.util.Date;
 
@@ -68,20 +65,33 @@ public class TasksController {
     @ApiImplicitParams({
         @ApiImplicitParam(name = "status", value = "TaskStatus as string", dataType = "string", paramType = "query"),
         @ApiImplicitParam(name = "className", value = "Class name of BackgroundTask Object", dataType = "string", paramType = "query"),
-        @ApiImplicitParam(name = "creator", value = "Who instantiated these tasks.", dataType = "string", paramType = "query")
+        @ApiImplicitParam(name = "creator", value = "Who instantiated these tasks.", dataType = "string", paramType = "query"),
+        @ApiImplicitParam(name = "limit", value = "Limit the number of entries in the returned result", dataType = "integer", paramType = "query")
     })
     private JSONArray getTasks(Request request, Response response) {
         TaskStatus status = null;
         String className = request.queryParams(TASK_CLASS_NAME_PARAMETER);
         String creator = request.queryParams(TASK_CREATOR_PARAMETER);
+        int limit = 0;
 
-        if(request.queryParams(TASK_STATUS_PARAMETER) != null)
+        if(request.queryParams(LIMIT_PARAM) != null)
+            limit = Integer.valueOf(request.queryParams(LIMIT_PARAM));
+
+        if(request.queryParams(TASK_STATUS_PARAMETER) != null) {
             status = TaskStatus.valueOf(request.queryParams(TASK_STATUS_PARAMETER));
+        }
+        else if(className == null && creator == null && limit == 0) {
+            //TODO: pagination
+            limit = 200;
+        }
 
         JSONArray result = new JSONArray();
-        for (Pair<String, TaskState> pair : taskStateStorage.getTasks(status, className, creator)) {
-            result.put(serialiseState(pair.getKey(), pair.getValue()));
+        for (Pair<String, TaskState> pair : taskStateStorage.getTasks(status, className, creator, limit)) {
+            result.put(serialiseStateSubset(pair.getKey(), pair.getValue()));
         }
+
+        System.out.println("result length: "+result.length());
+        System.out.println(" all response: "+result.toString());
 
         response.type("application/json");
         return result;
@@ -94,8 +104,10 @@ public class TasksController {
     private String getTask(Request request, Response response) {
         try {
             String id = request.params(ID_PARAMETER);
-            JSONObject result = serialiseState(id, taskStateStorage.getState(id));
+            JSONObject result = serialiseStateFull(id, taskStateStorage.getState(id));
             response.type("application/json");
+
+            System.out.println("get one response: "+result.toString());
             return result.toString();
         } catch(Exception e) {
             throw new GraknEngineServerException(500, e);
@@ -166,17 +178,22 @@ public class TasksController {
         }
     }
 
-    private JSONObject serialiseState(String id, TaskState state) {
+
+    private JSONObject serialiseStateSubset(String id, TaskState state) {
         return new JSONObject().put("id", id)
-                               .put("status", state.status())
-                               .put("creator", state.creator())
-                               .put("className", state.taskClassName())
-                               .put("runAt", state.runAt())
-                               .put("recurring", state.isRecurring())
-                               .put("interval", state.interval())
-                               .put("isFailed", state.isFailed())
-                               .put("failure", state.failure())
-                               .put("executingHostname", state.executingHostname())
-                               .put("configuration", state.configuration());
+                .put("status", state.status())
+                .put("creator", state.creator())
+                .put("className", state.taskClassName())
+                .put("runAt", state.runAt())
+                .put("recurring", state.isRecurring())
+                .put("isFailed", state.isFailed());
+    }
+
+    private JSONObject serialiseStateFull(String id, TaskState state) {
+        return serialiseStateSubset(id, state)
+                       .put("interval", state.interval())
+                       .put("failure", state.failure())
+                       .put("executingHostname", state.executingHostname())
+                       .put("configuration", state.configuration());
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/backgroundtasks/InMemoryTaskManagerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/backgroundtasks/InMemoryTaskManagerTest.java
@@ -21,7 +21,6 @@ package ai.grakn.engine.backgroundtasks;
 import ai.grakn.engine.GraknEngineTestBase;
 import org.json.JSONObject;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -62,11 +61,10 @@ public class InMemoryTaskManagerTest extends GraknEngineTestBase {
             if (storage.getState(id).status() == COMPLETED)
                 break;
 
-            System.out.println("created: "+storage.getTasks(CREATED, null, null).size());
-            System.out.println("scheduled: "+storage.getTasks(SCHEDULED, null, null).size());
-            System.out.println("completed: "+storage.getTasks(COMPLETED, null, null).size());
-            System.out.println("running: "+storage.getTasks(RUNNING, null, null).size());
-
+            System.out.println("created: "+storage.getTasks(CREATED, null, null, 0).size());
+            System.out.println("scheduled: "+storage.getTasks(SCHEDULED, null, null,0 ).size());
+            System.out.println("completed: "+storage.getTasks(COMPLETED, null, null,0).size());
+            System.out.println("running: "+storage.getTasks(RUNNING, null, null,0 ).size());
 
             try {
                 Thread.sleep(100);

--- a/grakn-engine/src/test/java/ai/grakn/engine/backgroundtasks/LongRunningTask.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/backgroundtasks/LongRunningTask.java
@@ -35,6 +35,7 @@ public class LongRunningTask implements BackgroundTask {
             try {
                 Thread.sleep(100);
             } catch (InterruptedException ignored) {
+                break;
             }
         }
     }

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/TaskControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/TaskControllerTest.java
@@ -22,7 +22,6 @@ import ai.grakn.engine.backgroundtasks.*;
 import com.jayway.restassured.http.ContentType;
 import ai.grakn.engine.GraknEngineTestBase;
 import com.jayway.restassured.response.Response;
-import org.hamcrest.Matchers;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Before;
@@ -30,11 +29,11 @@ import org.junit.Test;
 
 import java.util.Date;
 
-import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
 import static com.jayway.restassured.RestAssured.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class TaskControllerTest extends GraknEngineTestBase {
     private TaskManager taskManager;
@@ -43,14 +42,15 @@ public class TaskControllerTest extends GraknEngineTestBase {
     @Before
     public void setUp() throws Exception {
         taskManager = InMemoryTaskManager.getInstance();
-        singleTask = taskManager.scheduleTask(new TestTask(), this.getClass().getName(), new Date(), 0, new JSONObject());
+        singleTask = taskManager.scheduleTask(new LongRunningTask(), this.getClass().getName(), new Date(), 0, new JSONObject());
         taskManager.stopTask(singleTask, this.getClass().getName());
     }
 
     @Test
     public void testTasksByStatus() {
         System.out.println("testTasksByStatus");
-        Response response = given().queryParam("status", COMPLETED.toString())
+        Response response = given().queryParam("status", STOPPED.toString())
+                                   .queryParam("limit", 10)
                                    .get("/tasks/all");
 
         response.then().statusCode(200)
@@ -60,7 +60,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
         JSONArray array = new JSONArray(response.body().asString());
         array.forEach(x -> {
             JSONObject o = (JSONObject)x;
-            assertEquals(COMPLETED.toString(), o.get("status"));
+            assertEquals(STOPPED.toString(), o.get("status"));
         });
     }
 
@@ -68,6 +68,7 @@ public class TaskControllerTest extends GraknEngineTestBase {
     public void testTasksByClassName() {
         System.out.println("testTasksByClassName");
         Response response = given().queryParam("className", TestTask.class.getName())
+                                   .queryParam("limit", 10)
                                    .get("/tasks/all");
 
         response.then().statusCode(200)
@@ -84,7 +85,8 @@ public class TaskControllerTest extends GraknEngineTestBase {
     @Test
     public void testTasksByCreator() {
         System.out.println("testTasksByCreator");
-       Response response = given().queryParam("creator", this.getClass().getName())
+        Response response = given().queryParam("creator", this.getClass().getName())
+                                   .queryParam("limit", 10)
                                    .get("/tasks/all");
 
         response.then().statusCode(200)
@@ -101,12 +103,11 @@ public class TaskControllerTest extends GraknEngineTestBase {
     @Test
     public void testGetAllTasks() {
         System.out.println("testGetAllTasks");
-        taskManager.storage().clear();
+        Response response = given().queryParam("limit", 10).get("/tasks/all");
 
-        singleTask = taskManager.scheduleTask(new TestTask(), this.getClass().getName(), new Date(), 0, new JSONObject());
-        taskManager.stopTask(singleTask, this.getClass().getName());
-        get("/tasks/all")
-                .then().statusCode(200)
+        System.out.println(response.body().asString());
+
+        response.then().statusCode(200)
                 .and().contentType(ContentType.JSON)
                 .and().body("list.size()", greaterThanOrEqualTo(1));
     }
@@ -141,6 +142,8 @@ public class TaskControllerTest extends GraknEngineTestBase {
                 .queryParam("runAt", new Date())
                 .queryParam("interval", 5000)
                 .post("/tasks/schedule");
+
+        System.out.println(response.body().asString());
 
         response.then().statusCode(200)
                 .and().contentType(ContentType.JSON);

--- a/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTaskTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/postprocessing/PostProcessingTaskTest.java
@@ -19,20 +19,16 @@
 package ai.grakn.engine.postprocessing;
 
 import ai.grakn.engine.backgroundtasks.InMemoryTaskManager;
-import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.GraknEngineTestBase;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Date;
-import java.util.UUID;
 
 import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.CREATED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 public class PostProcessingTaskTest extends GraknEngineTestBase {
     private InMemoryTaskManager taskManager;


### PR DESCRIPTION
REST API allows limits (and imposes a hard limit of 200 when none
specified) when requesting multiple tasks.

All the properties of TaskState are not returned when requesting
multiple states.

This fixes the hanging unit tests on Travis which were hitting memory
limitations when processing large response bodies.