### PR TITLE
Add variables for custom log level/appender.

### DIFF
--- a/conf/main/logback.xml
+++ b/conf/main/logback.xml
@@ -40,8 +40,8 @@
     <root level="INFO">
         <!--<appender-ref ref="STDOUT"/>-->
     </root>
-    <logger name="org.eclipse.jetty" level="ERROR">
-        <appender-ref ref="ROLLING"/>
+    <logger name="org.eclipse.jetty" level="${jetty.log.level}:-ERROR">
+        <appender-ref ref="${jetty.log.appender}:-ROLLING"/>
     </logger>
 
     <logger name="ai.grakn" level="${grakn.log.level}">


### PR DESCRIPTION
jetty.log.level and jetty.log.appender

Will make it easier to debug clashing ports in Jetty on Jenkins (fatal error is displayed as a WARNING).
Might help with the VM crash/system.exit issues.

Use: mvn test -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT