### PR TITLE
Used bigger number

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
@@ -117,10 +117,10 @@ public class GraqlTraversal {
             numFragments -= 1;
         }
 
-        long cost = 1;
+        double cost = 1;
 
         while (!fragmentSets.isEmpty()) {
-            Pair<Long, List<Fragment>> pair = findPlan(fragmentSets, names, cost, depth);
+            Pair<Double, List<Fragment>> pair = findPlan(fragmentSets, names, cost, depth);
             cost = pair.getValue0();
             List<Fragment> newFragments = Lists.reverse(pair.getValue1());
 
@@ -146,15 +146,15 @@ public class GraqlTraversal {
      * @param depth the maximum depth the plan is allowed to descend in the tree
      * @return a pair, containing the cost of the plan and a list of fragments comprising the traversal plan
      */
-    private static Pair<Long, List<Fragment>> findPlan(
-            Set<EquivalentFragmentSet> fragmentSets, Set<String> names, long cost, long depth
+    private static Pair<Double, List<Fragment>> findPlan(
+            Set<EquivalentFragmentSet> fragmentSets, Set<String> names, double cost, long depth
     ) {
         // Base case
-        Pair<Long, List<Fragment>> baseCase = Pair.with(cost, Lists.newArrayList());
+        Pair<Double, List<Fragment>> baseCase = Pair.with(cost, Lists.newArrayList());
 
         if (depth == 0) return baseCase;
 
-        Comparator<Pair<Long, List<Fragment>>> byCost = comparing(Pair::getValue0);
+        Comparator<Pair<Double, List<Fragment>>> byCost = comparing(Pair::getValue0);
 
         // Try every fragment that has its dependencies met, then select the lowest cost fragment
         return fragments(fragmentSets)
@@ -164,11 +164,11 @@ public class GraqlTraversal {
                 .orElse(baseCase);
     }
 
-    private static Pair<Long, List<Fragment>> findPlanWithFragment(
-            Fragment fragment, Set<EquivalentFragmentSet> fragmentSets, Set<String> names, long cost, long depth
+    private static Pair<Double, List<Fragment>> findPlanWithFragment(
+            Fragment fragment, Set<EquivalentFragmentSet> fragmentSets, Set<String> names, double cost, long depth
     ) {
         // Calculate the new costs, fragment sets and variable names when using this fragment
-        long newCost = fragmentCost(fragment, cost, names);
+        double newCost = fragmentCost(fragment, cost, names);
 
         EquivalentFragmentSet fragmentSet = fragment.getEquivalentFragmentSet();
         Set<EquivalentFragmentSet> newFragmentSets = Sets.difference(fragmentSets, ImmutableSet.of(fragmentSet));
@@ -176,7 +176,7 @@ public class GraqlTraversal {
         Set<String> newNames = Sets.union(names, fragment.getVariableNames().collect(toSet()));
 
         // Recursively find a plan
-        Pair<Long, List<Fragment>> pair = findPlan(newFragmentSets, newNames, newCost, depth - 1);
+        Pair<Double, List<Fragment>> pair = findPlan(newFragmentSets, newNames, newCost, depth - 1);
 
         // Add this fragment and cost and return
         pair.getValue1().add(fragment);
@@ -264,15 +264,15 @@ public class GraqlTraversal {
     /**
      * Get the estimated complexity of the traversal.
      */
-    public long getComplexity() {
+    public double getComplexity() {
 
-        long totalCost = 0;
+        double totalCost = 0;
 
         for (List<Fragment> list : fragments) {
             Set<String> names = new HashSet<>();
 
-            long cost = 1;
-            long listCost = 0;
+            double cost = 1;
+            double listCost = 0;
 
             for (Fragment fragment : list) {
                 cost = fragmentCost(fragment, cost, names);
@@ -286,7 +286,7 @@ public class GraqlTraversal {
         return totalCost;
     }
 
-    private static long fragmentCost(Fragment fragment, long previousCost, Set<String> names) {
+    private static double fragmentCost(Fragment fragment, double previousCost, Set<String> names) {
         if (names.contains(fragment.getStart())) {
             return fragment.fragmentCost(previousCost);
         } else {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
@@ -64,7 +64,7 @@ public class GraqlTraversal {
 
     // TODO: Find a better way to represent these values
     // Just a pretend big number
-    private static final long NUM_VERTICES_ESTIMATE = 1_000;
+    private static final long NUM_VERTICES_ESTIMATE = 10_000;
 
     private static final long MAX_TRAVERSAL_ATTEMPTS = 1_000;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/DataTypeFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/DataTypeFragment.java
@@ -44,7 +44,7 @@ class DataTypeFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost / ResourceType.DataType.SUPPORTED_TYPES.size();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/DistinctCastingFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/DistinctCastingFragment.java
@@ -50,7 +50,7 @@ class DistinctCastingFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost / NUM_ROLES_PER_RELATION;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragment.java
@@ -96,5 +96,5 @@ public interface Fragment {
         return false;
     }
 
-    long fragmentCost(long previousCost);
+    double fragmentCost(double previousCost);
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IdFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IdFragment.java
@@ -66,7 +66,7 @@ class IdFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return 1;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InCastingFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InCastingFragment.java
@@ -39,7 +39,7 @@ class InCastingFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_RELATION_PER_CASTING;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InHasRoleFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InHasRoleFragment.java
@@ -40,7 +40,7 @@ class InHasRoleFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InHasScopeFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InHasScopeFragment.java
@@ -40,7 +40,7 @@ class InHasScopeFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_SCOPES_PER_INSTANCE;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
@@ -47,7 +47,7 @@ class InIsaFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_INSTANCES_PER_TYPE;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InPlaysRoleFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InPlaysRoleFragment.java
@@ -40,7 +40,7 @@ class InPlaysRoleFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_TYPES_PER_ROLE;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InRolePlayerFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InRolePlayerFragment.java
@@ -39,7 +39,7 @@ class InRolePlayerFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_CASTINGS_PER_INSTANCE;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InSubFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InSubFragment.java
@@ -38,7 +38,7 @@ class InSubFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_SUBTYPES_PER_TYPE;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IsAbstractFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IsAbstractFragment.java
@@ -39,7 +39,7 @@ class IsAbstractFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/NeqFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/NeqFragment.java
@@ -25,7 +25,7 @@ class NeqFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/NotCastingFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/NotCastingFragment.java
@@ -45,7 +45,7 @@ class NotCastingFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutCastingFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutCastingFragment.java
@@ -40,7 +40,7 @@ class OutCastingFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_ROLES_PER_RELATION;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutHasRoleFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutHasRoleFragment.java
@@ -40,7 +40,7 @@ class OutHasRoleFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_ROLES_PER_RELATION;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutHasScopeFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutHasScopeFragment.java
@@ -40,7 +40,7 @@ class OutHasScopeFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_INSTANCES_PER_SCOPE;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutIsaFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutIsaFragment.java
@@ -49,7 +49,7 @@ class OutIsaFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutPlaysRoleFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutPlaysRoleFragment.java
@@ -40,7 +40,7 @@ class OutPlaysRoleFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_ROLES_PER_TYPE;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutRolePlayerFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutRolePlayerFragment.java
@@ -40,7 +40,7 @@ class OutRolePlayerFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutSubFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutSubFragment.java
@@ -38,7 +38,7 @@ class OutSubFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/RegexFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/RegexFragment.java
@@ -44,7 +44,7 @@ class RegexFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ShortcutFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ShortcutFragment.java
@@ -64,7 +64,7 @@ class ShortcutFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost * NUM_SHORTCUT_EDGES_PER_INSTANCE;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFlagFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFlagFragment.java
@@ -49,7 +49,7 @@ class ValueFlagFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         return previousCost;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFragment.java
@@ -45,7 +45,7 @@ class ValueFragment extends AbstractFragment {
     }
 
     @Override
-    public long fragmentCost(long previousCost) {
+    public double fragmentCost(double previousCost) {
         if (predicate.isSpecific()) {
             return NUM_RESOURCES_PER_VALUE;
         } else {

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/GraqlTraversalTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/GraqlTraversalTest.java
@@ -86,6 +86,15 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
     }
 
     @Test
+    public void testResourceWithTypeFasterFromType() {
+        GraqlTraversal fromInstance =
+                traversal(outIsa("x", "X"), id("X", "_"), makeShortcut("x", "y"), outIsa("y", "Y"), id("Y", "_"));
+        GraqlTraversal fromType =
+                traversal(id("X", "_"), inIsa("X", "x"), makeShortcut("x", "y"), outIsa("y", "Y"), id("Y", "_"));
+        assertFaster(fromType, fromInstance);
+    }
+
+    @Test
     public void testCheckDistinctCastingEarlyFaster() {
         Fragment distinctCasting = distinctCasting("c2", "c1");
         Fragment inRolePlayer = inRolePlayer("x", "c1");
@@ -180,6 +189,10 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
     private static GraqlTraversal traversal(ImmutableList<Fragment>... fragments) {
         ImmutableSet<ImmutableList<Fragment>> fragmentsSet = ImmutableSet.copyOf(fragments);
         return GraqlTraversal.create(graph, fragmentsSet);
+    }
+
+    private static Fragment makeShortcut(String x, String y) {
+        return shortcut(Optional.empty(), Optional.empty(), Optional.empty(), x, y);
     }
 
     private static void assertNearlyOptimal(Pattern pattern) {

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/GraqlTraversalTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/GraqlTraversalTest.java
@@ -203,8 +203,8 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
         //noinspection OptionalGetWithoutIsPresent
         GraqlTraversal globalOptimum = query.allGraqlTraversals().min(comparing(GraqlTraversal::getComplexity)).get();
 
-        long globalComplexity = globalOptimum.getComplexity();
-        long complexity = traversal.getComplexity();
+        double globalComplexity = globalOptimum.getComplexity();
+        double complexity = traversal.getComplexity();
 
         assertTrue(
                 "Expected\n " +
@@ -215,8 +215,8 @@ public class GraqlTraversalTest extends AbstractRollbackGraphTest {
     }
 
     private static void assertFaster(GraqlTraversal fast, GraqlTraversal slow) {
-        long fastComplexity = fast.getComplexity();
-        long slowComplexity = slow.getComplexity();
+        double fastComplexity = fast.getComplexity();
+        double slowComplexity = slow.getComplexity();
         boolean condition = fastComplexity < slowComplexity;
 
         assertTrue(


### PR DESCRIPTION
For query optimisation I couldn't give a very high estimate for the number of vertices in the graph because the complexity calculation would overflow and go negative (and thus super-slow traversals would be considered _very_ efficient).

If I use doubles, I don't have that problem anymore! Doubles can get very big, plus they overflow into `Double.POSITIVE_INFINITY`, which is at least not negative.