### PR TITLE
Dashboard with Reasoner and Analytics:

### DIFF
--- a/conf/main/logback.xml
+++ b/conf/main/logback.xml
@@ -40,8 +40,8 @@
     <root level="INFO">
         <!--<appender-ref ref="STDOUT"/>-->
     </root>
-    <logger name="org.eclipse.jetty" level="${jetty.log.level}:-ERROR">
-        <appender-ref ref="${jetty.log.appender}:-ROLLING"/>
+    <logger name="org.eclipse.jetty" level="${jetty.log.level:-ERROR}">
+        <appender-ref ref="${jetty.log.appender:-ROLLING}"/>
     </logger>
 
     <logger name="ai.grakn" level="${grakn.log.level}">

--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -29,6 +29,9 @@ public class REST {
         public static final String META_TYPE_INSTANCES_URI = "/shell/metaTypeInstances";
         public static final String MATCH_QUERY_URI = "/shell/match";
         public static final String GRAPH_MATCH_QUERY_URI = "/graph/match";
+        public static final String GRAPH_ANALYTICS_QUERY_URI = "/graph/analytics";
+        public static final String GRAPH_PRE_MATERIALISE_QUERY_URI = "/graph/preMaterialiseAll";
+
 
         public static final String CONCEPT_BY_ID_URI = "/graph/concept/" ;
         public static final String CONCEPT_BY_ID_ONTOLOGY_URI = "/graph/concept/ontology/" ;

--- a/grakn-dashboard/src/components/config.vue
+++ b/grakn-dashboard/src/components/config.vue
@@ -22,10 +22,18 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
     <div class="row">
         <div class="col-xs-12">
             <div class="panel panel-filled" v-if="response">
-                <div class="panel-heading">
-                    Current Configuration
-                </div>
                 <div class="panel-body">
+                  <div class="table-responsive">
+                      <table class="table table-hover table-stripped">
+                          <thead>
+                              <tr><th>Inference settings</th><th>Value</th><tr>
+                          <thead>
+                          <tbody>
+                              <tr><td>Activate Inference</td><td><input type="checkbox" value="" @click="checkedReasoner(useReasoner)" v-model="useReasoner"></td></tr>
+                              <tr><td>Materialisation</td><td><button @click="materialiseAll" class="btn btn-default">Materialise All</button></td></tr>
+                          </tbody>
+                      </table>
+                  </div>
                     <div class="table-responsive">
                         <table class="table table-hover table-stripped">
                             <thead>
@@ -91,6 +99,7 @@ export default {
         return {
             response: undefined,
             errorMessage: undefined,
+            useReasoner:window.useReasoner,
             engineClient: {}
         };
     },
@@ -109,11 +118,19 @@ export default {
             this.errorMessage = msg;
         },
 
+        checkedReasoner(status){
+          window.useReasoner=!status;
+        },
+
         engineStatus(resp, err) {
             if(resp != null)
                 this.response = resp
             else
                 this.showError(err);
+        },
+
+        materialiseAll(){
+          engineClient.preMaterialiseAll();
         },
 
         retry() {

--- a/grakn-dashboard/src/components/main.vue
+++ b/grakn-dashboard/src/components/main.vue
@@ -63,7 +63,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
                 </li>
 
                 <li v-link-active>
-                    <a v-link="{ path: '/status' }">Status</a>
+                    <a v-link="{ path: '/config' }">Config</a>
                 </li>
 
                 <li v-link-active>
@@ -115,6 +115,7 @@ export default {
 
     created() {
         engineClient = new EngineClient();
+        window.useReasoner=false;
     },
 
     attached() {

--- a/grakn-dashboard/src/components/visualiser.vue
+++ b/grakn-dashboard/src/components/visualiser.vue
@@ -74,7 +74,18 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
         <div class="col-xs-12">
             <div class="panel panel-filled" v-bind:class="errorPanelClass">
                 <div class="panel-body">
-                    {{errorMessage}} <a href="#" @click="resetMsg"><i class="pe-7s-close-circle" id="close-error"></i></a>
+                    {{errorMessage}} <a href="#" @click="resetMsg"><i class="pe-7s-close-circle grakn-icon"></i></a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row" v-show="analyticsStringResponse">
+        <div class="col-xs-12">
+            <div class="panel panel-filled" class="analyticsStringPanel">
+              <div class="panel-heading">Analytics Results</div>
+                <div class="panel-body">
+                    <pre class="language-graql">{{analyticsStringResponse}}</pre>
                 </div>
             </div>
         </div>
@@ -108,7 +119,10 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
                                         </div>
                                         <span v-show="numOfResources>0">Resources:</span>
                                         <div class="dd-item" v-for="(key, value) in allNodeResources">
-                                            <div class="dd-handle" @dblclick="addResourceNodeWithOwners(value.link)"><span class="list-key">{{key}}:</span> {{value.label}}</div>
+                                            <div class="dd-handle" @dblclick="addResourceNodeWithOwners(value.link)"><span class="list-key">{{key}}:</span>
+                                              <a v-if="value.href" href="{{value.label}}" style="word-break: break-all;" target="_blank">{{value.label}}</a>
+                                              <span v-else> {{value.label}}</span>
+                                            </div>
                                         </div>
                                         <span v-show="numOfLinks>0">Links:</span>
                                         <div class="dd-item" v-for="(key, value) in allNodeLinks">

--- a/grakn-dashboard/src/js/EngineClient.js
+++ b/grakn-dashboard/src/js/EngineClient.js
@@ -47,16 +47,21 @@ export default class EngineClient {
      */
     request(requestData) {
         $.ajax({
-            type: requestData.requestType || this.requestType,
-            contentType: requestData.contentType || this.contentType,
-            dataType: requestData.dataType || this.dataType,
-            cache: requestData.cache || this.cache,
-            data: requestData.data,
-            url: requestData.url,
-
-            error: (errObj, _, eText) => { requestData.callback(null, errObj.responseText); },
-            success: r => { requestData.callback(r, null) }
-        });
+                type: requestData.requestType || this.requestType,
+                contentType: requestData.contentType || this.contentType,
+                dataType: requestData.dataType || this.dataType,
+                cache: requestData.cache || this.cache,
+                data: requestData.data,
+                url: requestData.url
+            }).done(function(r) {
+                //sometimes we might not have a callback function
+                if(typeof requestData.callback == 'function')
+                    requestData.callback(r, null)
+            })
+            .fail(function(errObj) {
+                if(typeof requestData.callback == 'function')
+                    requestData.callback(null, errObj.responseText);
+            });
     }
 
     /**
@@ -64,7 +69,7 @@ export default class EngineClient {
      */
     conceptsByType(type, fn) {
         this.request({
-            url: "/graph/concept/"+type,
+            url: "/graph/concept/" + type,
             callback: fn
         });
     }
@@ -74,7 +79,19 @@ export default class EngineClient {
      */
     graqlShell(query, fn) {
         this.request({
-            url: "/shell/match?query="+query,
+            url: "/shell/match?query=" + query,
+            callback: fn,
+            dataType: "text",
+            contentType: "application/text"
+        });
+    }
+
+    /**
+     * Pre materialise
+     */
+    preMaterialiseAll(fn) {
+        this.request({
+            url: "/graph/preMaterialiseAll",
             callback: fn,
             dataType: "text",
             contentType: "application/text"
@@ -84,9 +101,19 @@ export default class EngineClient {
     /**
      * Send graql query to Engine, returns an array of HAL objects.
      */
-    graqlHAL(query, fn) {
+    graqlHAL(query, useReasoner, fn) {
         this.request({
-            url: "/graph/match?query="+query,
+            url: "/graph/match?query=" + query + "&reasoner=" + useReasoner,
+            callback: fn
+        });
+    }
+
+    /**
+     * Send graql query to Engine, returns an array of HAL objects.
+     */
+    graqlAnalytics(query, fn) {
+        this.request({
+            url: "/graph/analytics?query=" + query,
             callback: fn
         });
     }

--- a/grakn-dashboard/src/js/HAL/APITerms.js
+++ b/grakn-dashboard/src/js/HAL/APITerms.js
@@ -28,6 +28,7 @@ export const ROLE_TYPE = "role-type";
 export const ENTITY_TYPE = "entity-type";
 export const GENERATED_RELATION_TYPE = "generated-relation";
 
+export const KEY_EMPTY_ROLE_NAME = "EMPTY-GRAKN-ROLE";
 export const KEY_ID = "_id";
 export const KEY_EMBEDDED = "_embedded";
 export const KEY_TYPE = "_type";

--- a/grakn-dashboard/src/js/HAL/APIUtils.js
+++ b/grakn-dashboard/src/js/HAL/APIUtils.js
@@ -29,7 +29,7 @@ export function edgeLeftToRight(a, b) {
     if (API.KEY_DIRECTION in b)
         if (b[API.KEY_DIRECTION] === "OUT")
             return false;
-            
+
     return true;
 }
 
@@ -85,14 +85,13 @@ function buildLabel(resource) {
             label = resource[API.KEY_TYPE] + ": " + resource[API.KEY_ID];
             break;
         case API.RELATION_TYPE:
-            label = resource[API.KEY_BASE_TYPE] + ": " + resource[API.KEY_TYPE];
+            label = resource[API.KEY_BASE_TYPE].substring(0,3) + ": " + resource[API.KEY_TYPE];
             break;
         case API.RESOURCE_TYPE:
             label = resource[API.KEY_VALUE];
             break;
         case API.GENERATED_RELATION_TYPE:
-            let value = (resource[API.KEY_TYPE].length === 0) ? "" : ": " + resource[API.KEY_TYPE];
-            label = resource[API.KEY_BASE_TYPE] + value;
+            label = resource[API.KEY_TYPE] || "";
             break;
 
         default:

--- a/grakn-dashboard/src/js/codemirrorGraql.js
+++ b/grakn-dashboard/src/js/codemirrorGraql.js
@@ -6,9 +6,11 @@ CodeMirror.defineSimpleMode("graql", {
 
     {regex: /#.*/, token: "comment"},
     {regex: /".*?"/, token: "string"},
-    {regex: /(match|ask|insert|delete|select|isa|sub|plays-role|has-role|has-scope|datatype|is-abstract|has|value|id|of|limit|offset|order|by)(?![-a-zA-Z_0-9])/,
+    {regex: /(match|ask|insert|delete|select|isa|sub|plays-role|has-role|has-scope|datatype|is-abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in)(?![-a-zA-Z_0-9])/,
      token: "keyword"},
+    {regex: /true|false/, token: "number"},
     {regex: /\$[-a-zA-Z_0-9]+/, token: "variable"},
+    {regex: /[-a-zA-Z_][-a-zA-Z_0-9]*/, token: "identifier"},
     {regex: /[0-9]+(\.[0-9][0-9]*)?/, token: "number"},
     {regex: /=|!=|>|<|>=|<=|contains|regex/, token: "operator"}
   ],

--- a/grakn-dashboard/src/js/visualiser/Style.js
+++ b/grakn-dashboard/src/js/visualiser/Style.js
@@ -47,7 +47,7 @@ export default class Style {
                 highlight: "#a1d884"
             },
             font: {
-                color: "#bbbcbc",
+                color: "#ffad33",
                 background: "none",
                 strokeWidth: 0
             }
@@ -72,6 +72,7 @@ export default class Style {
 
         // User defined ontology & instances
         switch(baseType) {
+            case API.GENERATED_RELATION_TYPE:
             case API.RELATION_TYPE:
                 return {
                     background: this.node.colour.background,

--- a/grakn-dashboard/src/main.js
+++ b/grakn-dashboard/src/main.js
@@ -23,7 +23,7 @@ var VueRouter = require('vue-router')
 var graknapp = require('./components/main.vue');
 var visualiser = require('./components/visualiser.vue')
 var console = require('./components/console.vue')
-var status =  require('./components/status.vue')
+var config =  require('./components/config.vue')
 
 Vue.use(VueRouter)
 
@@ -32,8 +32,8 @@ var router = new VueRouter({
     linkActiveClass: 'active'
 })
 router.map({
-    '/status': {
-        component: status
+    '/config': {
+        component: config
     },
     '/graph': {
         component: visualiser

--- a/grakn-dashboard/static/index.html
+++ b/grakn-dashboard/static/index.html
@@ -35,6 +35,7 @@
     <link rel="stylesheet" href="vendor/jquery-ui/jquery-ui.min.css"/>
 
 
+
     <!-- App styles -->
     <link rel="stylesheet" href="styles/pe-icons/pe-icon-7-stroke.css"/>
     <link rel="stylesheet" href="styles/pe-icons/helper.css"/>
@@ -55,6 +56,7 @@
 <script src="vendor/jquery/dist/jquery.min.js"></script>
 <script src="vendor/jquery-ui/jquery-ui.min.js"></script>
 <script src="vendor/bootstrap/js/bootstrap.min.js"></script>
+
 
 <!-- App scripts -->
 <script src="scripts/luna.js"></script>

--- a/grakn-dashboard/static/styles/style.css
+++ b/grakn-dashboard/static/styles/style.css
@@ -48,6 +48,11 @@ h4 {
 
 body {
     -moz-user-select: none;
+    -ms-overflow-style: none;  // IE 10+
+    overflow: -moz-scrollbars-none;  // Firefox
+}
+body::-webkit-scrollbar {
+   display: none;  // Safari and Chrome
 }
 
 div {
@@ -72,8 +77,12 @@ div {
     margin-bottom: 0px;
 }
 
-.panel-body {
+.properties-tab .panel-body {
     overflow: scroll;
+}
+
+.properties-tab .panel-body::-webkit-scrollbar {
+   display: none;
 }
 
 .graph-div {
@@ -90,7 +99,7 @@ div {
     margin-right: 10px;
 }
 
-#close-error{
+.grakn-icon{
   margin-left:10px;
   font-size:150%;
   margin-top:15px;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/ImportController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/ImportController.java
@@ -190,12 +190,14 @@ public class ImportController {
                     var = consumeInsertEntity(batchIterator, loaderParam);
                 }
                 loaderParam.waitToFinish();
-
                 // ---- RELATIONS --- //
                 while (var.equals(MATCH_KEYWORD)) {
-                    var = consumeInsertRelation(batchIterator,loaderParam);
+                    var = consumeInsertRelation(batchIterator, loaderParam);
                 }
             }
+            loaderParam.waitToFinish();
+            LOG.info("Data loading complete:");
+            checkLoadingStatus();
             printingState.cancel(true);
             processedEntities.set(0);
             processedRelations.set(0);
@@ -245,6 +247,7 @@ public class ImportController {
             } else
                 break;
         }
+
 
         loader.add(Graql.match(insertQueryMatch).insert(insertQuery));
         processedRelations.incrementAndGet();

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/RemoteShellController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/RemoteShellController.java
@@ -24,7 +24,9 @@ import ai.grakn.engine.session.RemoteSession;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknEngineServerException;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.Printer;
+import ai.grakn.graql.Reasoner;
 import ai.grakn.graql.internal.printer.Printers;
 import ai.grakn.util.REST;
 import io.swagger.annotations.Api;
@@ -114,7 +116,9 @@ public class RemoteShellController {
         Printer printer = Printers.graql();
 
         try(GraknGraph graph = GraphFactory.getInstance().getGraph(currentGraphName)) {
-            return graph.graql().parse(req.queryParams(REST.Request.QUERY_FIELD))
+            MatchQuery matchQuery = graph.graql().parse(req.queryParams(REST.Request.QUERY_FIELD));
+            MatchQuery inferQuery = new Reasoner(graph).resolveToQuery(matchQuery);
+            return inferQuery
                     .resultsString(printer)
                     .map(x -> x.replaceAll("\u001B\\[\\d+[m]", ""))
                     .collect(Collectors.joining("\n"));

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
@@ -24,13 +24,17 @@ import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.engine.visualiser.HALConceptRepresentationBuilder;
 import ai.grakn.exception.GraknEngineServerException;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.MatchQuery;
+import ai.grakn.graql.Reasoner;
+import ai.grakn.graql.internal.printer.Printers;
 import ai.grakn.util.REST;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
@@ -40,6 +44,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -55,6 +60,10 @@ public class VisualiserController {
 
     private String defaultGraphName;
     private int separationDegree;
+    private final static String SHORTEST_PATH_QUERY = "path";
+    private final static String COMPUTE_RESPONSE_TYPE = "type";
+    private final static String COMPUTE_RESPONSE_FIELD = "response";
+
     //TODO: implement a pagination system.
 
     public VisualiserController() {
@@ -66,6 +75,8 @@ public class VisualiserController {
         get(REST.WebPath.CONCEPT_BY_ID_ONTOLOGY_URI + REST.Request.ID_PARAMETER, this::getConceptByIdOntology);
 
         get(REST.WebPath.GRAPH_MATCH_QUERY_URI, this::matchQuery);
+        get(REST.WebPath.GRAPH_ANALYTICS_QUERY_URI, this::computeQuery);
+        get(REST.WebPath.GRAPH_PRE_MATERIALISE_QUERY_URI, this::preMaterialiseAll);
 
     }
 
@@ -119,20 +130,37 @@ public class VisualiserController {
             value = "Executes match query on the server and build HAL representation for each concept in the query result.")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "graphName", value = "Name of graph to use", dataType = "string", paramType = "query"),
-            @ApiImplicitParam(name = "query", value = "Match query to execute", required = true, dataType = "string", paramType = "query")
+            @ApiImplicitParam(name = "query", value = "Match query to execute", required = true, dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "reasoner", value = "Boolean used to decide whether run reasoner together with the current query.", required = true, dataType = "sting/boolean", paramType = "query")
+
     })
     private String matchQuery(Request req, Response res) {
 
         String currentGraphName = req.queryParams(REST.Request.GRAPH_NAME_PARAM);
         if (currentGraphName == null) currentGraphName = defaultGraphName;
 
+        boolean useReasoner = Boolean.parseBoolean(req.queryParams("reasoner"));
+
         try (GraknGraph graph = GraphFactory.getInstance().getGraph(currentGraphName)) {
 
             LOG.debug("Start querying for: [{}]", req.queryParams(REST.Request.QUERY_FIELD));
             MatchQuery matchQuery = graph.graql().parse(req.queryParams(REST.Request.QUERY_FIELD));
-            Collection<Map<String, Concept>> graqlResultsList = matchQuery
-                    .stream().collect(Collectors.toList());
-            LOG.debug("Done querying.");
+
+            MatchQuery currentMatchQuery;
+
+            if (useReasoner) {
+                currentMatchQuery = new Reasoner(graph).resolveToQuery(matchQuery, true);
+                graph.commit();
+            } else {
+                currentMatchQuery = matchQuery;
+            }
+
+            Collection<Map<String, Concept>> graqlResultsList = currentMatchQuery
+                    .stream()
+                    .collect(Collectors.toList());
+            graph.commit();
+            LOG.debug("Done querying, " + graqlResultsList.size() + " results found");
+
             JSONArray halArray = HALConceptRepresentationBuilder.renderHALArrayData(matchQuery, graqlResultsList);
             LOG.debug("Done building resources.");
 
@@ -142,5 +170,64 @@ public class VisualiserController {
         }
     }
 
+    @GET
+    @Path("/analytics")
+    @ApiOperation(
+            value = "Executes compute query on the server and build HAL representation of result or returns string containing statistics.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "graphName", value = "Name of graph to use", dataType = "string", paramType = "query"),
+            @ApiImplicitParam(name = "query", value = "Compute query to execute", required = true, dataType = "string", paramType = "query")
+    })
+    private String computeQuery(Request req, Response res) {
+
+        String currentGraphName = req.queryParams(REST.Request.GRAPH_NAME_PARAM);
+        if (currentGraphName == null) currentGraphName = defaultGraphName;
+
+        try (GraknGraph graph = GraphFactory.getInstance().getGraph(currentGraphName)) {
+
+            String query = req.queryParams(REST.Request.QUERY_FIELD);
+            LOG.debug("Start querying for: [{}]", query);
+            JSONObject responseObject = new JSONObject();
+            ComputeQuery computeQuery = graph.graql().parse(req.queryParams(REST.Request.QUERY_FIELD));
+
+            if (query.contains(SHORTEST_PATH_QUERY)) {
+                responseObject.put(COMPUTE_RESPONSE_TYPE, "HAL");
+                JSONArray array = new JSONArray();
+                ((List<Concept>)computeQuery.execute()).iterator().forEachRemaining(concept ->
+                       array.put(HALConceptRepresentationBuilder.renderHALConceptData(concept, 0)));
+                responseObject.put(COMPUTE_RESPONSE_FIELD,array);
+            } else {
+                responseObject.put(COMPUTE_RESPONSE_TYPE, "string");
+                responseObject.put(COMPUTE_RESPONSE_FIELD,
+                        computeQuery.resultsString(Printers.graql())
+                                .map(x -> x.replaceAll("\u001B\\[\\d+[m]", ""))
+                                .collect(Collectors.joining())
+                );
+            }
+            return responseObject.toString();
+        } catch (Exception e) {
+            throw new GraknEngineServerException(500, e);
+        }
+    }
+
+    @GET
+    @Path("/preMaterialiseAll")
+    @ApiOperation(
+            value = "Pre materialise all the rules on the graph.")
+    @ApiImplicitParams({
+            @ApiImplicitParam(name = "graphName", value = "Name of graph to use", dataType = "string", paramType = "query"),
+    })
+    private String preMaterialiseAll(Request req, Response res) {
+
+        String currentGraphName = req.queryParams(REST.Request.GRAPH_NAME_PARAM);
+        if (currentGraphName == null) currentGraphName = defaultGraphName;
+
+        try (GraknGraph graph = GraphFactory.getInstance().getGraph(currentGraphName)) {
+            new Reasoner(graph).precomputeInferences();
+            return "Done.";
+        } catch (Exception e) {
+            throw new GraknEngineServerException(500, e);
+        }
+    }
 
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -624,7 +624,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph 
     }
 
     void closePermanent(){
-        System.out.println("HERE---------> Thread [" + Thread.currentThread().getId() + "] is PERMANENTLY closing graph [" + getTinkerPopGraph().hashCode() + "]");
         try {
             getTinkerPopGraph().close();
         } catch (Exception e) {


### PR DESCRIPTION
  - resources containing URLs are now clickable links
  - Status page becomes Config
  - in Config useReasoner toggle
  - in Config Materialise all button
  - labels on edges are now orange
  - distinction between single and double click on canvas
  - RHS and LHS are now resources of Rules nodes in HAL
  - relation-type label changed to rel
  - Engine now uses Reasoner when enabled in the APIs
  - Engine uses Analytics on compute queries - new endpoint
  - new endpoint in Engine to MaterialiseAll rules
  - Dashboard makes a different call when query starts with 'compute'
  - Display role-names on edges in generated-relations
  - minor bug fixing