### PR TITLE
Turn reasoner off during migration

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/LoaderTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/LoaderTask.java
@@ -21,17 +21,14 @@ package ai.grakn.engine.loader;
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.backgroundtasks.BackgroundTask;
-import ai.grakn.engine.postprocessing.Cache;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknValidationException;
-import ai.grakn.factory.GraphFactory;
-import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.InsertQuery;
+import ai.grakn.graql.QueryBuilder;
 import org.json.JSONObject;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory
-;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -56,6 +53,7 @@ public class LoaderTask implements BackgroundTask {
 
     private static final Logger LOG = LoggerFactory.getLogger(Loader.class);
     private static int repeatCommits = ConfigProperties.getInstance().getPropertyAsInt(LOADER_REPEAT_COMMITS);
+    private final QueryBuilder builder = Graql.withoutGraph().setInference(false);
 
     @Override
     public void start(Consumer<String> saveCheckpoint, JSONObject configuration) {
@@ -163,8 +161,7 @@ public class LoaderTask implements BackgroundTask {
             configuration.getJSONArray(TASK_LOADER_INSERTS).forEach(i -> inserts.add((String) i));
 
             return inserts.stream()
-                    .map(Graql::parse)
-                    .map(p -> (InsertQuery) p)
+                    .map(builder::<InsertQuery>parse)
                     .collect(toList());
         }
 

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/AbstractMigrator.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/AbstractMigrator.java
@@ -33,7 +33,7 @@ import java.util.stream.StreamSupport;
 public abstract class AbstractMigrator implements Migrator {
 
     public static final int BATCH_SIZE = 25;
-    public final QueryBuilderImpl queryBuilder = (QueryBuilderImpl) Graql.withoutGraph();
+    public final QueryBuilderImpl queryBuilder = (QueryBuilderImpl) Graql.withoutGraph().setInference(false);
 
     /**
      * Register a macro to use in templating


### PR DESCRIPTION
+ This is a fix for the `migration.sh` hanging issue which was being cause by reasoner. The next thing we will look into is exactly what in reasoner is causing the hang. 