### PR TITLE
Don't remove PID file. stderr from kill to null.

### DIFF
--- a/grakn-dist/src/bin/grakn-cassandra.sh
+++ b/grakn-dist/src/bin/grakn-cassandra.sh
@@ -98,10 +98,9 @@ stop)
     if [[ -e $CASSANDRA_PS ]]; then
         pid=`cat $CASSANDRA_PS`
         kill "$pid"
-        while kill -0 "$pid"; do
+        while kill -0 "$pid" 2>/dev/null; do
             sleep 0.5
         done
-        rm $CASSANDRA_PS
     fi
     ;;
 


### PR DESCRIPTION
Cassandra cleans up after itself and we wait for it to do so.