### PR TITLE
Post processing better fix

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ConceptFixer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ConceptFixer.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.engine.postprocessing;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.util.ErrorMessage;
@@ -35,9 +34,9 @@ class ConceptFixer {
         boolean notDone = true;
         int retry = 0;
         while (notDone) {
-            try (GraknGraph graph = GraphFactory.getInstance().getGraph(keyspace)) {
-                if (((AbstractGraknGraph) graph).fixDuplicateCasting(castingId)) {
-                    graph.commit();
+            try (AbstractGraknGraph graph = (AbstractGraknGraph) GraphFactory.getInstance().getGraph(keyspace)) {
+                if (graph.fixDuplicateCasting(castingId)) {
+                    graph.commit(false);
                 }
                 cache.deleteJobCasting(graph.getKeyspace(), castingId);
                 notDone = false;
@@ -58,9 +57,9 @@ class ConceptFixer {
         int retry = 0;
 
         while (notDone) {
-            try(GraknGraph graph = GraphFactory.getInstance().getGraph(keyspace))  {
-                if (((AbstractGraknGraph) graph).fixDuplicateResources(resourceIds)) {
-                    graph.commit();
+            try(AbstractGraknGraph graph = (AbstractGraknGraph) GraphFactory.getInstance().getGraph(keyspace))  {
+                if (graph.fixDuplicateResources(resourceIds)) {
+                    graph.commit(false);
                 }
                 resourceIds.forEach(resourceId -> cache.deleteJobResource(graph.getKeyspace(), resourceId));
                 notDone = false;

--- a/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.factory;
 
+import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.util.ErrorMessage;
@@ -50,7 +51,7 @@ public class GraphFactory {
     }
 
     public synchronized GraknGraph getGraph(String keyspace) {
-        return FactoryBuilder.getFactory(keyspace, null, properties).getGraph(false);
+        return FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(false);
     }
 }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -684,8 +684,8 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         LOG.debug("Response from engine [" + result + "]");
     }
     private String getCommitLogEndPoint(){
-        if(engine == null || Grakn.IN_MEMORY.equals(engine))
-            return null;
+        if(Grakn.IN_MEMORY.equals(engine))
+            return Grakn.IN_MEMORY;
         return engine + REST.WebPath.COMMIT_LOG_URI + "?" + REST.Request.KEYSPACE_PARAM + "=" + keyspace;
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -619,6 +619,9 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      */
     @Override
     public void commit() throws GraknValidationException {
+        commit(true);
+    }
+    public void commit(boolean submitLogs) throws GraknValidationException {
         validateGraph();
 
         Map<Schema.BaseType, Set<String>> modifiedConcepts = new HashMap<>();
@@ -635,7 +638,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         LOG.debug("Graph committed.");
         getConceptLog().clearTransaction();
 
-        if(modifiedConcepts.size() > 0)
+        if(submitLogs && modifiedConcepts.size() > 0)
             submitCommitLogs(modifiedConcepts);
     }
     protected void commitTx(){
@@ -680,7 +683,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         String result = EngineCommunicator.contactEngine(getCommitLogEndPoint(), REST.HttpConn.POST_METHOD, postObject.toString());
         LOG.debug("Response from engine [" + result + "]");
     }
-    String getCommitLogEndPoint(){
+    private String getCommitLogEndPoint(){
         if(engine == null || Grakn.IN_MEMORY.equals(engine))
             return null;
         return engine + REST.WebPath.COMMIT_LOG_URI + "?" + REST.Request.KEYSPACE_PARAM + "=" + keyspace;

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/EngineCommunicator.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/EngineCommunicator.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graph.internal;
 
+import ai.grakn.Grakn;
 import ai.grakn.util.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,8 +46,8 @@ public class EngineCommunicator {
      * @return The result of the request
      */
     public static String contactEngine(String engineUrl, String restType, String body){
-        if(engineUrl == null)
-            return "Engine Not Contacted";
+        if(engineUrl.equals(Grakn.IN_MEMORY))
+            return "Engine not contacted due to in memory graph being used";
 
         for(int i = 0; i < MAX_RETRY; i++) {
             try {

--- a/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
@@ -4,6 +4,7 @@ import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.RoleType;
+import ai.grakn.factory.GraphFactory;
 import ai.grakn.test.AbstractRollbackGraphTest;
 import org.junit.Test;
 
@@ -96,5 +97,13 @@ public class GraphTest extends AbstractRollbackGraphTest {
         } catch (Exception e){
             throw new RuntimeException(e);
         }
+    }
+
+    @Test
+    public void testSameGraphs(){
+        String key = "mykeyspace";
+        GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, key).getGraph();
+        GraknGraph graph2 = GraphFactory.getInstance().getGraph(key);
+        assertEquals(graph1, graph2);
     }
 }

--- a/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphFactoryTest.java
+++ b/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphFactoryTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.factory;
 
+import ai.grakn.Grakn;
 import ai.grakn.graph.internal.GraknTitanGraph;
 import ai.grakn.util.Schema;
 import ch.qos.logback.classic.Level;
@@ -62,17 +63,12 @@ public class GraknTitanGraphFactoryTest extends TitanTestBase{
     private static TitanGraph noIndexGraph;
     private static TitanGraph indexGraph;
 
-    private static InternalFactory titanGraphFactory ;
-
-
     @BeforeClass
     public static void setupClass() throws InterruptedException {
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.OFF);
 
-        titanGraphFactory = new TitanInternalFactory(TEST_SHARED, TEST_URI, TEST_PROPERTIES);
-
-        sharedGraph = ((GraknTitanGraph) titanGraphFactory.getGraph(TEST_BATCH_LOADING)).getTinkerPopGraph();
+        sharedGraph = titanGraphFactory.getGraph(TEST_BATCH_LOADING).getTinkerPopGraph();
 
         int max = 1000;
         noIndexGraph = getGraph();
@@ -113,9 +109,9 @@ public class GraknTitanGraphFactoryTest extends TitanTestBase{
 
     @Test
     public void testSingleton(){
-        GraknTitanGraph mg1 = (GraknTitanGraph) titanGraphFactory.getGraph(true);
-        GraknTitanGraph mg2 = (GraknTitanGraph) titanGraphFactory.getGraph(false);
-        GraknTitanGraph mg3 = (GraknTitanGraph) titanGraphFactory.getGraph(true);
+        GraknTitanGraph mg1 = titanGraphFactory.getGraph(true);
+        GraknTitanGraph mg2 = titanGraphFactory.getGraph(false);
+        GraknTitanGraph mg3 = titanGraphFactory.getGraph(true);
 
         assertEquals(mg1, mg3);
         assertEquals(mg1.getTinkerPopGraph(), mg3.getTinkerPopGraph());
@@ -186,7 +182,7 @@ public class GraknTitanGraphFactoryTest extends TitanTestBase{
     public void testMultithreadedRetrievalOfGraphs(){
         Set<Future> futures = new HashSet<>();
         ExecutorService pool = Executors.newFixedThreadPool(10);
-        TitanInternalFactory factory = new TitanInternalFactory("simplekeyspace", TEST_URI, TEST_PROPERTIES);
+        TitanInternalFactory factory = new TitanInternalFactory("simplekeyspace", Grakn.IN_MEMORY, TEST_PROPERTIES);
 
         for(int i = 0; i < 200; i ++) {
             futures.add(pool.submit(() -> {
@@ -215,12 +211,12 @@ public class GraknTitanGraphFactoryTest extends TitanTestBase{
 
     @Test
     public void testGraphNotClosed(){
-        GraknTitanGraph graph = (GraknTitanGraph) titanGraphFactory.getGraph(false);
+        GraknTitanGraph graph = titanGraphFactory.getGraph(false);
         assertFalse(graph.getTinkerPopGraph().isClosed());
         graph.putEntityType("A Thing");
         graph.close();
 
-        graph = (GraknTitanGraph) titanGraphFactory.getGraph(false);
+        graph = titanGraphFactory.getGraph(false);
         assertFalse(graph.getTinkerPopGraph().isClosed());
         graph.putEntityType("A Thing");
     }
@@ -228,8 +224,8 @@ public class GraknTitanGraphFactoryTest extends TitanTestBase{
 
     private static TitanGraph getGraph() {
         String name = UUID.randomUUID().toString().replaceAll("-", "");
-        titanGraphFactory = new TitanInternalFactory(name, TEST_URI, TEST_PROPERTIES);
-        Graph graph = ((GraknTitanGraph) titanGraphFactory.getGraph(TEST_BATCH_LOADING)).getTinkerPopGraph();
+        titanGraphFactory = new TitanInternalFactory(name, Grakn.IN_MEMORY, TEST_PROPERTIES);
+        Graph graph = titanGraphFactory.getGraph(TEST_BATCH_LOADING).getTinkerPopGraph();
         assertThat(graph, instanceOf(TitanGraph.class));
         return (TitanGraph) graph;
     }

--- a/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
+++ b/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.factory;
 
+import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.GraphRuntimeException;
@@ -43,12 +44,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class GraknTitanGraphTest extends TitanTestBase{
-    private static final String TEST_NAME = "grakntest";
     private GraknGraph graknGraph;
 
     @Before
     public void setup(){
-        graknGraph = FactoryBuilder.getFactory(TEST_NAME, TEST_URI, TEST_PROPERTIES).getGraph(TEST_BATCH_LOADING);
+        graknGraph = titanGraphFactory.getGraph(TEST_BATCH_LOADING);
     }
 
     @After
@@ -120,8 +120,8 @@ public class GraknTitanGraphTest extends TitanTestBase{
 
     @Test
     public void testCaseSensitiveKeyspaces(){
-        TitanInternalFactory factory1 = (TitanInternalFactory)FactoryBuilder.getFactory("case", TEST_URI, TEST_PROPERTIES);
-        TitanInternalFactory factory2 = (TitanInternalFactory)FactoryBuilder.getFactory("Case", TEST_URI, TEST_PROPERTIES);
+        TitanInternalFactory factory1 =  new TitanInternalFactory("case", Grakn.IN_MEMORY, TEST_PROPERTIES);
+        TitanInternalFactory factory2 = new TitanInternalFactory("Case", Grakn.IN_MEMORY, TEST_PROPERTIES);
         GraknTitanGraph case1 = factory1.getGraph(TEST_BATCH_LOADING);
         GraknTitanGraph case2 = factory2.getGraph(TEST_BATCH_LOADING);
 
@@ -130,7 +130,7 @@ public class GraknTitanGraphTest extends TitanTestBase{
 
     @Test
     public void testClearTitanGraph(){
-        GraknTitanGraph graph = (GraknTitanGraph)FactoryBuilder.getFactory("case", TEST_URI, TEST_PROPERTIES).getGraph(false);
+        GraknTitanGraph graph = new TitanInternalFactory("case", Grakn.IN_MEMORY, TEST_PROPERTIES).getGraph(false);
         graph.clear();
         expectedException.expect(GraphRuntimeException.class);
         expectedException.expectMessage(allOf(
@@ -141,7 +141,7 @@ public class GraknTitanGraphTest extends TitanTestBase{
 
     @Test
     public void testStableTransactions() throws GraknValidationException {
-        GraknTitanGraph graph = (GraknTitanGraph)FactoryBuilder.getFactory("stabletransactions", TEST_URI, TEST_PROPERTIES).getGraph(false);
+        GraknTitanGraph graph = new TitanInternalFactory("stabletransactions", Grakn.IN_MEMORY, TEST_PROPERTIES).getGraph(false);
         assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
 
         graph.putEntityType("name 1");

--- a/grakn-titan-factory/src/test/java/ai/grakn/factory/TitanTestBase.java
+++ b/grakn-titan-factory/src/test/java/ai/grakn/factory/TitanTestBase.java
@@ -1,5 +1,6 @@
 package ai.grakn.factory;
 
+import ai.grakn.Grakn;
 import ai.grakn.util.ErrorMessage;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -16,8 +17,8 @@ import java.util.Properties;
 
 public abstract class TitanTestBase {
     final static boolean TEST_BATCH_LOADING = false;
-    final static String TEST_CONFIG = "../conf/main/grakn.properties";
-    final static String TEST_URI = null;
+    private final static String TEST_SHARED = "shared";
+    static TitanInternalFactory titanGraphFactory;
     final static Properties TEST_PROPERTIES = new Properties();
 
     @Rule
@@ -33,11 +34,13 @@ public abstract class TitanTestBase {
             throw new RuntimeException(e);
         }
 
-        try (InputStream in = new FileInputStream(TEST_CONFIG)){
+        try (InputStream in = new FileInputStream("../conf/main/grakn.properties")){
             TEST_PROPERTIES.load(in);
         } catch (IOException e) {
-            throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage(TEST_CONFIG), e);
+            throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage("../conf/main/grakn.properties"), e);
         }
+
+        titanGraphFactory = new TitanInternalFactory(TEST_SHARED, Grakn.IN_MEMORY, TEST_PROPERTIES);
     }
 
     @AfterClass


### PR DESCRIPTION
The "big" changes:
- `Grakn.factory(uri, keyspace)` now produces the same graph as `GraphFactory` with a valid engineUrl passed in.
- This ensures that commit logs are submitted all the time. The bug we are fixing is where GraphFactory would sometimes override the engineUrl to be null.

What is left to do to make this better:
- Define an internal Graph API used by engine which bypasses commit log submission. Right now this is done via dirty casting to `AbstractGraknGraph`. This internal API will also nicely resolve how we expose the post processing methods which actually resolve the duplicates.
- Get `GraphFactory` to use the above API. 
- Make sure engine graph commits bypass sommit log submission. The above API should make this easier to ensure. 

This should resolve the issue where analytics would sometimes NOT submit commit logs. 