### PR TITLE
New transaction handling

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -244,13 +244,13 @@ public interface GraknGraph extends AutoCloseable{
     void rollback();
 
     /**
-     * Closes the current graph, rendering it unusable.
-     *
+     * Closes the current transaction. If no transactions remain open the graph connection is closed permanently and
+     * the {@link GraknGraphFactory} must be used to get a new connection.
      */
     void close();
 
     /**
-     * Opens the graph. This must be called before a thread can use the graph
+     * Opens the graph. This must be called before a new thread can use the graph.
      */
     void open();
 }

--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -248,4 +248,9 @@ public interface GraknGraph extends AutoCloseable{
      *
      */
     void close();
+
+    /**
+     * Opens the graph. This must be called before a thread can use the graph
+     */
+    void open();
 }

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -41,7 +41,7 @@ public enum ErrorMessage {
             "duplicate values"),
     INVALID_EDGE("The edge [%s] between concept [%s] and [%s] is invalid"),
     NOT_SUPPORTED("Not supported with a [%s] backend"),
-    CLOSED_USER("You have closed this graph and it can no longer be used"),
+    CLOSED_USER("You have closed this graph"),
     CLOSED_FACTORY("This graph has been closed due to a transaction being committed and invalidating this graph"),
     CLOSED_CLEAR("This graph has been closed due to clearing it"),
     TRANSACTIONS_NOT_SUPPORTED("The graph backend [%s] does not actually support transactions. The graph was not committed or refreshed."),

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -58,6 +58,7 @@ public enum ErrorMessage {
     ROLE_TYPE_ERROR("The role type [%s] cannot play itself"),
     BACKEND_EXCEPTION("Unknown Backend Exception."),
     GRAPH_CLOSED("The Graph for keyspace [%s] is closed"),
+    GRAPH_PERMANENTLY_CLOSED("The Graph for keyspace [%s] is closed. Use the factory to get a new graph."),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -57,6 +57,7 @@ public enum ErrorMessage {
     INVALID_SYSTEM_KEYSPACE("The system keyspace appears to be corrupted: [%s]."),
     ROLE_TYPE_ERROR("The role type [%s] cannot play itself"),
     BACKEND_EXCEPTION("Unknown Backend Exception."),
+    GRAPH_CLOSED("The Graph for keyspace [%s] is closed"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -619,17 +619,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     public void open(){
         localIsOpen.set(true);
         localClosedReason.remove();
-        openGraph();
+        getTinkerPopGraph();//Used to check graph is truly open.
     }
 
     //Standard Close Operation Overridden by Vendor
     public void closeGraph(String closedReason){
         finaliseClose(this::closePermanent, closedReason);
-    }
-
-    //Standard Open Operation Overridden by Vendor
-    public void openGraph(){
-
     }
 
     public void finaliseClose(Runnable closer, String closedReason){
@@ -642,7 +637,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     public void closePermanent(){
         try {
-            getTinkerPopGraph().close();
+            graph.close();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -617,12 +617,19 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      */
     @Override
     public void open(){
-
+        localIsOpen.set(true);
+        localClosedReason.remove();
+        openGraph();
     }
 
-    //Standard Close Operation Overridden in Titan
+    //Standard Close Operation Overridden by Vendor
     public void closeGraph(String closedReason){
         finaliseClose(this::closePermanent, closedReason);
+    }
+
+    //Standard Open Operation Overridden by Vendor
+    public void openGraph(){
+
     }
 
     public void finaliseClose(Runnable closer, String closedReason){

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -607,6 +607,14 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         closeGraph(ErrorMessage.CLOSED_USER.getMessage());
     }
 
+    /**
+     * Opens the graph. This must be called before a thread can use the graph
+     */
+    @Override
+    public void open(){
+
+    }
+
     //Standard Close Operation Overridden in Titan
     public void closeGraph(String closedReason){
         finaliseClose(this::closePermanent, closedReason);

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -1,5 +1,7 @@
 package ai.grakn.graph.internal;
 
+import ai.grakn.Grakn;
+import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
@@ -9,6 +11,7 @@ import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
+import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.VerificationException;
@@ -18,6 +21,8 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static ai.grakn.graql.Graql.var;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -263,5 +268,18 @@ public class GraknGraphTest extends GraphTestBase {
         assertEquals(1, resourceType.playsRoles().size());
         assertEquals(2, graknGraph.getMetaRelationType().subTypes().size());
         assertEquals(3, graknGraph.getMetaRoleType().subTypes().size());
+    }
+
+    @Test
+    public void testGraphIsClosed(){
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        GraknGraph graph = Grakn.factory(Grakn.IN_MEMORY, "testing").getGraph();
+
+        expectedException.expect(GraphRuntimeException.class);
+        expectedException.expectMessage(allOf(
+                containsString(ErrorMessage.GRAPH_CLOSED.getMessage(graph.getKeyspace()))
+        ));
+
+        pool.submit(() -> graph.putEntityType("A Thing"));
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -299,4 +299,24 @@ public class GraknGraphTest extends GraphTestBase {
         assertTrue("Error not thrown when graph is closed in another thread", errorThrown[0]);
         assertTrue("Error thrown even after opening graph", errorNotThrown[0]);
     }
+
+    @Test
+    public void testCloseAndReOpenGraph(){
+        GraknGraph graph = Grakn.factory(Grakn.IN_MEMORY, "testing").getGraph();
+        graph.close();
+
+        boolean errorThrown = false;
+        try{
+            graph.putEntityType("A Thing");
+        } catch (GraphRuntimeException e){
+            if(e.getMessage().equals(ErrorMessage.CLOSED_USER.getMessage())){
+                errorThrown = true;
+            }
+        }
+        assertTrue("Graph not correctly closed", errorThrown);
+
+        graph.open();
+
+        graph.putEntityType("A Thing");
+    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknTinkerGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknTinkerGraphTest.java
@@ -63,6 +63,7 @@ public class GraknTinkerGraphTest extends GraphTestBase{
         assertEquals(108, ((AbstractGraknGraph<Graph>) graknGraph).getTinkerPopGraph().traversal().V().toList().size());
     }
     private void addEntityType(GraknGraph graknGraph){
+        graknGraph.open();
         graknGraph.putEntityType(UUID.randomUUID().toString());
         try {
             graknGraph.commit();
@@ -82,6 +83,7 @@ public class GraknTinkerGraphTest extends GraphTestBase{
         for(int i = 0; i < 100; i ++){
             futures.add(pool.submit(() -> {
                 GraknGraph innerTranscation = graknGraph;
+                innerTranscation.open();
                 innerTranscation.putEntityType(UUID.randomUUID().toString());
             }));
         }

--- a/grakn-titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -19,6 +19,8 @@
 package ai.grakn.graph.internal;
 
 import ai.grakn.exception.GraknBackendException;
+import ai.grakn.exception.GraphRuntimeException;
+import ai.grakn.util.ErrorMessage;
 import com.thinkaurelius.titan.core.TitanException;
 import com.thinkaurelius.titan.core.TitanGraph;
 import com.thinkaurelius.titan.core.util.TitanCleanup;
@@ -53,6 +55,16 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
     @Override
     public void closeGraph(String reason){
         finaliseClose(this::closeTitan, reason);
+    }
+
+    @Override
+    public TitanGraph getTinkerPopGraph(){
+        TitanGraph graph =  super.getTinkerPopGraph();
+        if(graph.isClosed()){
+            throw new GraphRuntimeException(ErrorMessage.GRAPH_PERMANENTLY_CLOSED.getMessage(getKeyspace()));
+        } else {
+            return graph;
+        }
     }
 
     @Override

--- a/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
+++ b/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
@@ -141,6 +141,18 @@ public class GraknTitanGraphTest extends TitanTestBase{
     }
 
     @Test
+    public void testTransactionHandling(){
+        String entityTypeName = "Hello";
+
+        graknGraph.putEntityType(entityTypeName);
+        assertNotNull(graknGraph.getEntityType(entityTypeName));
+
+        graknGraph.close();
+        graknGraph.open();
+        assertNull(graknGraph.getEntityType(entityTypeName));
+    }
+
+    @Test
     public void testStableTransactions() throws GraknValidationException {
         GraknTitanGraph graph = new TitanInternalFactory("stabletransactions", Grakn.IN_MEMORY, TEST_PROPERTIES).getGraph(false);
         assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());

--- a/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
+++ b/grakn-titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
@@ -76,6 +76,7 @@ public class GraknTitanGraphTest extends TitanTestBase{
         assertEquals(108, graknGraph.admin().getTinkerTraversal().toList().size());
     }
     private void addEntityType(GraknGraph graknGraph){
+        graknGraph.open();
         graknGraph.putEntityType(UUID.randomUUID().toString());
         try {
             graknGraph.commit();


### PR DESCRIPTION
- Threads no longer automatically open transactions
- When passing the graph to a new thread you must start with a `.open()` in order to use the graph