### PR TITLE
Refactor system keyspace factory and Bring OrientDB back form the dead

### DIFF
--- a/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
@@ -71,7 +71,7 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
             systemKeyspace = new SystemKeyspace<M, G>(getSystemFactory());
     }
 
-    private InternalFactory<M, G> getSystemFactory(){
+    InternalFactory<M, G> getSystemFactory(){
         //noinspection unchecked
         return FactoryBuilder.getGraknGraphFactory(this.getClass().getName(), SystemKeyspace.SYSTEM_GRAPH_NAME, engineUrl, properties);
     }

--- a/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
@@ -57,12 +57,6 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
     private Boolean lastGraphBuiltBatchLoading = null;
     
     private SystemKeyspace<M, G> systemKeyspace;
-    
-    private SystemKeyspace<M, G> systemSpace() {
-    	if (this.systemKeyspace == null)
-    		this.systemKeyspace = new SystemKeyspace<M, G>(this.engineUrl, this.properties);
-    	return this.systemKeyspace;
-    }
 
     AbstractInternalFactory(String keyspace, String engineUrl, Properties properties){
         if(keyspace == null) {
@@ -72,6 +66,14 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
         this.keyspace = keyspace.toLowerCase();
         this.engineUrl = engineUrl;
         this.properties = properties;
+
+        if(!keyspace.equals(SystemKeyspace.SYSTEM_GRAPH_NAME))
+            systemKeyspace = new SystemKeyspace<M, G>(getSystemFactory());
+    }
+
+    private InternalFactory<M, G> getSystemFactory(){
+        //noinspection unchecked
+        return FactoryBuilder.getGraknGraphFactory(this.getClass().getName(), SystemKeyspace.SYSTEM_GRAPH_NAME, engineUrl, properties);
     }
 
     abstract boolean isClosed(G innerGraph);
@@ -116,7 +118,7 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
         if(graknGraph == null){
             graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading), batchLoading);
             if (!SystemKeyspace.SYSTEM_GRAPH_NAME.equalsIgnoreCase(this.keyspace))
-            	systemSpace().keyspaceOpened(this.keyspace);
+                systemKeyspace.keyspaceOpened(this.keyspace);
         } else {
             if(graknGraph.isClosed()){
                 graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading), batchLoading);

--- a/grakn-graph/src/main/java/ai/grakn/factory/FactoryBuilder.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/FactoryBuilder.java
@@ -90,7 +90,7 @@ class FactoryBuilder {
             Log.debug("New factory created " + internalFactory);
             if (keyspace.equalsIgnoreCase(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             	Log.debug("This is a system factory, loading system ontology.");
-            	new SystemKeyspace(engineUrl, properties).loadSystemOntology();
+            	new SystemKeyspace(internalFactory).loadSystemOntology();
             }
             else
             	Log.debug("This is not a system factory, not loading system ontology.");

--- a/grakn-graph/src/main/java/ai/grakn/factory/SystemKeyspace.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/SystemKeyspace.java
@@ -62,7 +62,11 @@ public class SystemKeyspace<M extends GraknGraph, T extends Graph> {
 	private Properties properties;
 	private static final ConcurrentHashMap<String, Boolean> openSpaces = new ConcurrentHashMap<String, Boolean>();
 	private InternalFactory<M, T> factory;
-	
+
+    public SystemKeyspace(InternalFactory<M, T> factory){
+        this.factory = factory;
+    }
+
 	public SystemKeyspace(String engineUrl, Properties properties) {
 		this.engineUrl = engineUrl;
 		this.properties = properties;

--- a/grakn-graph/src/main/java/ai/grakn/factory/SystemKeyspace.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/SystemKeyspace.java
@@ -1,6 +1,5 @@
 package ai.grakn.factory;
 
-import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
@@ -13,7 +12,6 @@ import org.slf4j.LoggerFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -58,23 +56,12 @@ public class SystemKeyspace<M extends GraknGraph, T extends Graph> {
 	
     protected final Logger LOG = LoggerFactory.getLogger(SystemKeyspace.class);
     
-	private String engineUrl;
-	private Properties properties;
 	private static final ConcurrentHashMap<String, Boolean> openSpaces = new ConcurrentHashMap<String, Boolean>();
 	private InternalFactory<M, T> factory;
 
     public SystemKeyspace(InternalFactory<M, T> factory){
         this.factory = factory;
     }
-
-	public SystemKeyspace(String engineUrl, Properties properties) {
-		this.engineUrl = engineUrl;
-		this.properties = properties;
-		if (properties != null)
-			this.factory = FactoryBuilder.getFactory(SystemKeyspace.SYSTEM_GRAPH_NAME, engineUrl, properties);
-		else
-			this.factory = 	FactoryBuilder.getFactory(SystemKeyspace.SYSTEM_GRAPH_NAME, Grakn.IN_MEMORY, properties);
-	}
 
 	/**
 	 * Notify that we just opened a keyspace with the same engineUrl & config.
@@ -104,7 +91,7 @@ public class SystemKeyspace<M extends GraknGraph, T extends Graph> {
 	 * multiple times.
 	 */
 	public void loadSystemOntology() {
-		try (GraknGraph graph = FactoryBuilder.getFactory(SYSTEM_GRAPH_NAME, engineUrl, properties).getGraph(false)) {
+		try (GraknGraph graph = factory.getGraph(false)) {
 			if (graph.getEntityType(KEYSPACE_ENTITY) != null)
 				return;
 			ClassLoader loader = this.getClass().getClassLoader();

--- a/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
+++ b/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
@@ -118,7 +118,9 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
                 OType orientDataType = getOrientDataType(property);
                 BaseConfiguration indexConfig = new BaseConfiguration();
                 indexConfig.setProperty("keytype", orientDataType);
+                //TODO: Figure out why this is not working when the Orient Guys say it should
                 //indexConfig.setProperty("metadata.ignoreNullValues", true);
+
                 if(isUnique){
                     indexConfig.setProperty("type", "UNIQUE");
                 }

--- a/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
+++ b/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
@@ -42,9 +42,6 @@ import static ai.grakn.util.ErrorMessage.INVALID_DATATYPE;
 public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrientDBGraph, OrientGraph> {
     private final Logger LOG = LoggerFactory.getLogger(OrientDBInternalFactory.class);
     private final Map<String, OrientGraphFactory> openFactories;
-    private static final String KEY_TYPE = "keytype";
-    private static final String UNIQUE = "type";
-
 
     public OrientDBInternalFactory(String keyspace, String engineUrl, Properties properties) {
         super(keyspace, engineUrl, properties);
@@ -120,9 +117,10 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
 
                 OType orientDataType = getOrientDataType(property);
                 BaseConfiguration indexConfig = new BaseConfiguration();
-                indexConfig.setProperty(KEY_TYPE, orientDataType);
+                indexConfig.setProperty("keytype", orientDataType);
+                //indexConfig.setProperty("metadata.ignoreNullValues", true);
                 if(isUnique){
-                    indexConfig.setProperty(UNIQUE, "UNIQUE");
+                    indexConfig.setProperty("type", "UNIQUE");
                 }
 
                 if(!graph.getVertexIndexedKeys(label).contains(property.name())) {

--- a/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
+++ b/grakn-orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
@@ -41,7 +41,6 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
     private final Map<String, OrientGraphFactory> openFactories;
     private static final String KEY_TYPE = "keytype";
     private static final String UNIQUE = "type";
-    private static final String SPECIAL_IN_MEMORY = "memory";
 
 
     public OrientDBInternalFactory(String keyspace, String engineUrl, Properties properties) {
@@ -56,10 +55,7 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
 
     @Override
     GraknOrientDBGraph buildGraknGraphFromTinker(OrientGraph graph, boolean batchLoading) {
-        String engineUrl = super.engineUrl;
-        if(engineUrl.equals(SPECIAL_IN_MEMORY))
-            engineUrl = null;
-        return new GraknOrientDBGraph(graph, super.keyspace, engineUrl, batchLoading);
+        return new GraknOrientDBGraph(graph, super.keyspace, super.engineUrl, batchLoading);
     }
 
     @Override
@@ -70,8 +66,6 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
 
     private OrientGraph configureGraph(String name, String address){
         boolean schemaDefinitionRequired = false;
-        if (Grakn.IN_MEMORY.equals(address))
-        	address = "memory";
         OrientGraphFactory factory = getFactory(name, address);
         OrientGraph graph = factory.getNoTx();
 
@@ -147,8 +141,9 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
     }
 
     private OrientGraphFactory getFactory(String name, String address){
-        if(SPECIAL_IN_MEMORY.equals(name)){
-            address = SPECIAL_IN_MEMORY; //Secret way of creating in-memory graphs.
+        if (Grakn.IN_MEMORY.equals(address)){
+            address = "plocal";
+            name = "/tmp/" + name;
         }
 
         String key = name + address;

--- a/grakn-orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
+++ b/grakn-orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
@@ -30,6 +30,8 @@ public class GraknOrientDBGraph extends AbstractGraknGraph<OrientGraph> {
         super(graph, name, engineUrl, batchLoading);
     }
 
+
+
     @Override
     protected void commitTx(){
         getTinkerPopGraph().commit();

--- a/grakn-orientdb-factory/src/main/resources/indices-vertices.properties
+++ b/grakn-orientdb-factory/src/main/resources/indices-vertices.properties
@@ -28,6 +28,7 @@ ENTITY_TYPE=ID:true,NAME:true
 RELATION=ID:true,INDEX:true
 CASTING=ID:true,INDEX:true
 ENTITY=ID:true
+# The Value indices should be true but due to orient indecxing nulls we can't do that right now.
 RESOURCE=ID:true,INDEX:true,VALUE_STRING:false,VALUE_LONG:false,VALUE_DOUBLE:false,VALUE_BOOLEAN:false
 RULE=ID:true
 

--- a/grakn-orientdb-factory/src/main/resources/indices-vertices.properties
+++ b/grakn-orientdb-factory/src/main/resources/indices-vertices.properties
@@ -16,11 +16,19 @@
 # along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 #
 
+# Ontological Elements
+TYPE=ID:true,NAME:true
+ROLE_TYPE=ID:true,NAME:true
+RELATION_TYPE=ID:true,NAME:true
+RESOURCE_TYPE=ID:true,NAME:true
+RULE_TYPE=ID:true,NAME:true
+ENTITY_TYPE=ID:true,NAME:true
 
-# This next index should be true but we can't because null's are apparently indexed.
-NAME=String,true
-INDEX=String,false
-VALUE_STRING=String,false
-VALUE_LONG=Long,false
-VALUE_DOUBLE=Double,false
-VALUE_BOOLEAN=Boolean,false
+# Data Instances
+RELATION=ID:true,INDEX:true
+CASTING=ID:true,INDEX:true
+ENTITY=ID:true
+RESOURCE=ID:true,INDEX:true,VALUE_STRING:false,VALUE_LONG:false,VALUE_DOUBLE:false,VALUE_BOOLEAN:false
+RULE=ID:true
+
+

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
@@ -53,7 +53,6 @@ public class GraknOrientDBGraphFactoryTest {
         graph.clear();
     }
 
-    @Ignore
     @Test
     public void testBuildSimpleGraph() throws Exception {
         AbstractGraknGraph graknGraph = orientGraphFactory.getGraph(false);
@@ -61,7 +60,6 @@ public class GraknOrientDBGraphFactoryTest {
         assertEquals(8, graknGraph.getTinkerPopGraph().traversal().V().toList().size());
     }
 
-    @Ignore
     @Test
     public void testBuildSingletonGraphs(){
         AbstractGraknGraph<OrientGraph> graknGraph1 = orientGraphFactory.getGraph(false);
@@ -98,7 +96,6 @@ public class GraknOrientDBGraphFactoryTest {
         assertEquals(15, graknGraph.getTinkerPopGraph().traversal().V().toList().size());
     }
 
-    @Ignore
     @Test
     public void testVertexIndices(){
         GraknOrientDBGraph graknOrientDBGraph = orientGraphFactory.getGraph(false);

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
@@ -18,17 +18,16 @@
 
 package ai.grakn.factory;
 
-import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.Grakn;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.exception.GraknValidationException;
+import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.graph.internal.GraknOrientDBGraph;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.orientdb.OrientGraph;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
@@ -74,7 +73,6 @@ public class GraknOrientDBGraphFactoryTest {
         assertEquals(8, graknGraph3.getTinkerPopGraph().traversal().V().toList().size());
     }
 
-    @Ignore// Null index does not work on orientDB
     @Test
     public void testBuildGraph() throws GraknValidationException {
         GraknOrientDBGraph graknGraph = orientGraphFactory.getGraph(false);

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/factory/GraknOrientDBGraphFactoryTest.java
@@ -98,16 +98,19 @@ public class GraknOrientDBGraphFactoryTest {
 
     @Test
     public void testVertexIndices(){
-        GraknOrientDBGraph graknOrientDBGraph = orientGraphFactory.getGraph(false);
-        for (Schema.BaseType baseType : Schema.BaseType.values()) {
-            assertEquals(6, graknOrientDBGraph.getTinkerPopGraph().getVertexIndexedKeys(baseType.name()).size());
-        }
+        OrientGraph graknOrientDBGraph = orientGraphFactory.getGraph(false).getTinkerPopGraph();
 
-        assertNotNull(graknOrientDBGraph.getMetaEntityType());
-        assertNotNull(graknOrientDBGraph.getMetaRelationType());
-        assertNotNull(graknOrientDBGraph.getMetaConcept());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.TYPE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.ENTITY_TYPE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RELATION_TYPE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RESOURCE_TYPE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.ROLE_TYPE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RULE_TYPE.name()).size());
+
+        assertEquals(1, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.ENTITY.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RELATION.name()).size());
+        assertEquals(6, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RESOURCE.name()).size());
+        assertEquals(2, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.CASTING.name()).size());
+        assertEquals(1, graknOrientDBGraph.getVertexIndexedKeys(Schema.BaseType.RULE.name()).size());
     }
-
-
-
 }

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
@@ -23,6 +23,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.factory.OrientDBInternalFactory;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -78,6 +79,7 @@ public class GraknOrientDBGraphTest {
         assertEquals(9, graknGraph.admin().getTinkerTraversal().toList().size());
     }
 
+    @Ignore
     @Test
     public void testRollback() {
         assertNull(graknGraph.getEntityType("X"));

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graph.internal;
 
+import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.factory.OrientDBInternalFactory;
 import org.junit.After;
@@ -38,7 +39,7 @@ import static org.junit.Assert.assertNull;
 
 public class GraknOrientDBGraphTest {
     private static final String TEST_NAME = "grakntest";
-    private static final String TEST_URI = "memory";
+    private final static String TEST_URI = Grakn.IN_MEMORY;
     private static final boolean TEST_BATCH_LOADING = false;
     private GraknGraph graknGraph;
 

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
@@ -22,7 +22,6 @@ import ai.grakn.GraknGraph;
 import ai.grakn.factory.OrientDBInternalFactory;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashSet;
@@ -53,7 +52,6 @@ public class GraknOrientDBGraphTest {
         graknGraph.clear();
     }
 
-    @Ignore
     @Test
     public void testTestThreadLocal(){
         ExecutorService pool = Executors.newFixedThreadPool(10);
@@ -79,7 +77,6 @@ public class GraknOrientDBGraphTest {
         assertEquals(9, graknGraph.admin().getTinkerTraversal().toList().size());
     }
 
-    @Ignore
     @Test
     public void testRollback() {
         assertNull(graknGraph.getEntityType("X"));

--- a/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
+++ b/grakn-orientdb-factory/src/test/java/ai/grakn/graph/internal/GraknOrientDBGraphTest.java
@@ -54,6 +54,7 @@ public class GraknOrientDBGraphTest {
         graknGraph.clear();
     }
 
+    @Ignore // Failing remotely only
     @Test
     public void testTestThreadLocal(){
         ExecutorService pool = Executors.newFixedThreadPool(10);

--- a/grakn-titan-factory/src/main/java/ai/grakn/factory/TitanHadoopInternalFactory.java
+++ b/grakn-titan-factory/src/main/java/ai/grakn/factory/TitanHadoopInternalFactory.java
@@ -57,6 +57,11 @@ public class TitanHadoopInternalFactory extends AbstractInternalFactory<Abstract
     }
 
     @Override
+    InternalFactory<AbstractGraknGraph<HadoopGraph>, HadoopGraph> getSystemFactory(){
+        return null;
+    }
+
+    @Override
     boolean isClosed(HadoopGraph innerGraph) {
         return false;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <websocket.version>1.1</websocket.version>
         <jetty.version>9.3.6.v20151106</jetty.version>
         <mjson.version>1.4.0</mjson.version>
-        <orientdb.version>3.2.1.2</orientdb.version>
+        <orientdb.version>3.2.3.0</orientdb.version>
         <orientdb-gremlin-core.version>3.2.1</orientdb-gremlin-core.version>
         <logback.version>1.1.7</logback.version>
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
- Refactor System Keyspace Factory so AbstractInternal Factory produces it on construction
- Bring base OrientDB functionality back from the dead. Still a lot to do there. 