### PR TITLE
Move kafka dependency

### DIFF
--- a/grakn-engine/pom.xml
+++ b/grakn-engine/pom.xml
@@ -94,17 +94,22 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>0.10.1.0</version>
+            <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka_2.10</artifactId>
+            <version>${kafka.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
-            <version>2.11.1</version>
+            <version>${curator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.4.9</version>
+            <version>${zookeeper.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/KafkaLogger.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/KafkaLogger.java
@@ -65,26 +65,30 @@ public class KafkaLogger {
     }
 
     public void debug(String msg) {
-        if(logLevel.level() <= LogLevel.DEBUG.level())
+        if(logLevel.level() <= LogLevel.DEBUG.level()) {
             sendMsg(LogLevel.DEBUG.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        }
         LOG.debug(msg);
     }
 
     public void info(String msg) {
-        if(logLevel.level() <= LogLevel.INFO.level())
+        if(logLevel.level() <= LogLevel.INFO.level()) {
             sendMsg(LogLevel.INFO.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        }
         LOG.info(msg);
     }
 
     public void warn(String msg) {
-        if(logLevel.level() <= LogLevel.WARN.level())
-        sendMsg(LogLevel.WARN.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        if(logLevel.level() <= LogLevel.WARN.level()) {
+            sendMsg(LogLevel.WARN.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        }
         LOG.warn(msg);
     }
 
     public void error(String msg) {
-        if(logLevel.level() <= LogLevel.ERROR.level())
-        sendMsg(LogLevel.ERROR.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        if(logLevel.level() <= LogLevel.ERROR.level()) {
+            sendMsg(LogLevel.ERROR.toString(), Thread.currentThread().getStackTrace()[2].toString(), msg);
+        }
         LOG.error(msg);
     }
     
@@ -110,7 +114,7 @@ public class KafkaLogger {
     }
 
     private void sendMsg(String level, String caller, String msg) {
-    	System.out.println("LOG from " + caller + ": " + msg);
+//    	System.out.println("LOG from " + caller + ": " + msg);
 //        ProducerRecord record = new ProducerRecord(LOG_TOPIC, level + " - " + caller + " - " + msg);
 //        producer.send(record);
     }

--- a/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
@@ -45,8 +45,6 @@ public class GraphFactory {
 
         try(FileInputStream input = new FileInputStream(pathToConfig)){
             properties.load(input);
-            System.out.println("Path to graph config is: " + pathToConfig);
-            System.out.println("Properties are: " + properties);
         } catch (IOException e) {
             throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage(pathToConfig), e);
         }

--- a/grakn-test/pom.xml
+++ b/grakn-test/pom.xml
@@ -267,17 +267,12 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <scope>test</scope>
-            <version>2.11.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.10</artifactId>
-            <version>0.10.1.0</version>
+            <version>${curator.version}</version>
         </dependency>
         <dependency>
             <groupId>info.batey.kafka</groupId>
             <artifactId>kafka-unit</artifactId>
-            <version>0.6</version>
+            <version>${kafka-unit.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,10 @@
         <owl-api.version>5.0.2</owl-api.version>
         <systen-rules.version>1.16.0</systen-rules.version>
         <java-jwt.version>2.2.1</java-jwt.version>
+        <kafka.version>0.10.1.0</kafka.version>
+        <kafka-unit.version>0.6</kafka-unit.version>
+        <curator.version>2.11.1</curator.version>
+        <zookeeper.version>3.4.9</zookeeper.version>
     </properties>
 
     <organization>


### PR DESCRIPTION
+ `grakn.sh` was not connecting to Kafka because of a dependency placed in the `grakn-test` pom instead of `grakn-engine`
+ logs no longer print to standard out