### PR TITLE
Engine cleanups

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -78,8 +78,8 @@ public class GraknEngineServer {
     private static ClusterManager clusterManager;
 
     public static void main(String[] args) {
-        startCluster();
         startHTTP();
+        startCluster();
         startPostprocessing();
         printStartMessage(prop.getProperty(ConfigProperties.SERVER_HOST_NAME), prop.getProperty(ConfigProperties.SERVER_PORT_NUMBER), prop.getLogFilePath());
     }

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskManager.java
@@ -59,6 +59,4 @@ public interface TaskManager extends AutoCloseable {
      * @return A StateStorage instance.
      */
     StateStorage storage();
-
-    TaskManager open();
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
@@ -27,7 +27,6 @@ import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter
 
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_WATCH;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.SCHEDULER;
-import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
@@ -92,8 +92,8 @@ public class ClusterManager extends LeaderSelectorListenerAdapter {
      *  3. Shutdown Zookeeper storage connection on this machine
      */
     public void stop() throws Exception {
-        noThrow(leaderSelector::interruptLeadership, "Could not interrupt leadership.");
-        noThrow(leaderSelector::close, "Could not close leaderSelector.");
+        leaderSelector.interruptLeadership();
+        leaderSelector.close();
 
         stopScheduler();
         stopTaskManager();
@@ -175,7 +175,6 @@ public class ClusterManager extends LeaderSelectorListenerAdapter {
      */
     private void startTaskRunner() throws Exception {
         taskRunner = new TaskRunner(zookeeperStorage);
-        taskRunner.open();
 
         taskRunnerThread = new Thread(taskRunner, TASKRUNNER_THREAD_NAME + taskRunner.hashCode());
         taskRunnerThread.start();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
@@ -95,9 +95,6 @@ public class ClusterManager extends LeaderSelectorListenerAdapter {
         noThrow(leaderSelector::interruptLeadership, "Could not interrupt leadership.");
         noThrow(leaderSelector::close, "Could not close leaderSelector.");
 
-        // wait for failover to be completed
-        Thread.sleep(10000);
-
         stopScheduler();
         stopTaskManager();
         stopTaskRunner();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
@@ -25,132 +25,217 @@ import org.apache.curator.framework.recipes.cache.TreeCache;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
 
-import java.util.concurrent.CountDownLatch;
-
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_WATCH;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.SCHEDULER;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
- * Scheduler will be constantly running on the "Leader" machine. The "takeLeadership"
- * function in this class will be called if it is needed to take over.
+ *
+ * ClusterManager controls the behaviour of the entire Grakn Engine cluster.
+ *
+ * There is one "Scheduler" that will be constantly running on the "Leader" machine.
+ *
+ * This class begins the TaskRunner instance that will be running on this machine.
+ * This class registers this instance of Engine with Zookeeper & the Leader election process.
+ *
+ * If this machine is required to take over the Scheduler, the "takeLeadership" function will be called.
+ * If this machine controls the Scheduler and leadership is relinquished/lost, the "stateChanged" function is called
+ * and the Scheduler is stopped before a error is thrown.
+ *
+ * The Scheduler thread is a daemon thread
+ *
+ * @author Denis Lobanov, alexandraorth
  */
 public class ClusterManager extends LeaderSelectorListenerAdapter {
-    private static ClusterManager instance = null;
-    private final KafkaLogger LOG = KafkaLogger.getInstance();
-    private final String engineID;
+    private static final String SCHEDULER_THREAD_NAME = "scheduler-";
+    private static final String TASKRUNNER_THREAD_NAME = "taskrunner-";
 
+    private static final KafkaLogger LOG = KafkaLogger.getInstance();
+    private static final String ENGINE_ID = EngineID.getInstance().id();
+
+    // Threads in which to run task manager & scheduler
+    private Thread taskRunnerThread;
+    private Thread schedulerThread;
+
+    private DistributedTaskManager taskManager;
+    private SynchronizedStateStorage zookeeperStorage;
     private LeaderSelector leaderSelector;
     private Scheduler scheduler;
     private TreeCache cache;
     private TaskRunner taskRunner;
-    private Thread taskRunnerThread;
-    private SynchronizedStateStorage zookeeperStorage;
-    private final CountDownLatch leaderInitLatch = new CountDownLatch(1);
-    
-    public static synchronized ClusterManager getInstance() {
-        if(instance == null) {
-            instance = new ClusterManager();
-        }
+    private TaskFailover failover;
 
-        return instance;
-    }
-
-    private ClusterManager() {
-        this.engineID = EngineID.getInstance().id();
-    }
-
-    public void start() {
+    public ClusterManager() {
         try {
-            LOG.debug("Starting Cluster manager, called by "+Thread.currentThread().getStackTrace()[1]);
+            LOG.debug("Starting Cluster manager on " + ENGINE_ID);
 
-            zookeeperStorage = SynchronizedStateStorage.getInstance();
-
-            // Call close() in case there is an exception during open().
-            taskRunner = new TaskRunner();//countDownLatch);
-            taskRunner.open();
-            taskRunnerThread = new Thread(taskRunner);
-            taskRunnerThread.start();
-
-            leaderSelector = new LeaderSelector(zookeeperStorage.connection(), SCHEDULER, this);
-            leaderSelector.autoRequeue();
-
-            // the selection for this instance doesn't start until the leader selector is started
-            // leader selection is done in the background so this call to leaderSelector.start() returns immediately
-            leaderSelector.start();
-            while (!leaderSelector.getLeader().isLeader()) {
-                Thread.sleep(1000);
-            }
-            if (leaderSelector.hasLeadership()) {
-                leaderInitLatch.await();
-            }
+            startZookeeperConnection();
+            electLeader();
+            startTaskManager();
+            startTaskRunner();
         }
         catch (Exception e) {
-            LOG.error(getFullStackTrace(e));
-            throw new RuntimeException(e);
+            throw new RuntimeException("Could not start ClusterManager on " + ENGINE_ID + getFullStackTrace(e));
         }
 
-        LOG.debug("ClusterManager started, a leader has been elected.");
-    }
-
-    public void stop() {
-        noThrow(leaderSelector::interruptLeadership, "Could not interrupt leadership.");
-        noThrow(leaderSelector::close, "Could not close leaderSelector.");
-        if(scheduler != null) {
-            noThrow(scheduler::close, "Could not stop scheduler.");
-        }
-
-        if(cache != null) {
-            noThrow(cache::close, "Could not close ZK Tree Cache.");
-        }
-
-        noThrow(taskRunner::close, "Could not stop TaskRunner.");
-
-        // Lambdas cant throw exceptions
-        try {
-            taskRunnerThread.join();
-        } catch(Throwable t) {
-            LOG.error("Exception whilst waiting for TaskRunner thread to join - "+getFullStackTrace(t));
-        }
-
-        noThrow(zookeeperStorage::close, "Could not close ZK storage.");
-        zookeeperStorage = null;
+        LOG.debug("ClusterManager started & a leader elected on " + ENGINE_ID);
     }
 
     /**
-     * When you take over leadership start a new Scheduler instance and wait for it to complete.
+     * When stopping the ClusterManager we must:
+     *  1. Interrupt the Scheduler on whichever machine it is running on. We do this by interrupting the leadership.
+     *      When leadership is interrupted it will shut down the Scheduler on that machine.
+     *
+     *  2. Shutdown the TaskRunner on this machine.
+     *
+     *  3. Shutdown Zookeeper storage connection on this machine
+     */
+    public void stop() throws Exception {
+        noThrow(leaderSelector::interruptLeadership, "Could not interrupt leadership.");
+        noThrow(leaderSelector::close, "Could not close leaderSelector.");
+
+        // wait for failover to be completed
+        Thread.sleep(10000);
+
+        stopScheduler();
+        stopTaskManager();
+        stopTaskRunner();
+        stopZookeeperConnection();
+    }
+
+    /**
+     * On leadership takeover, start a new Scheduler instance and wait for it to complete.
+     * The method should not return until leadership is relinquished.
      * @throws Exception
      */
+    @Override
     public void takeLeadership(CuratorFramework client) throws Exception {
         registerFailover(client);
-        
-        // Call close() in case of exceptions during open()
-        scheduler = new Scheduler();
-        scheduler.open();
 
-        LOG.info(engineID + " has taken over the scheduler.");
-        Thread schedulerThread = new Thread(scheduler);
-        schedulerThread.setDaemon(true);
-        schedulerThread.start();
-        leaderInitLatch.countDown();        
+        // start the scheduler
+        startScheduler();
+
+        // wait for scheduler to fail
         schedulerThread.join();
     }
 
     /**
-     * Get the scheduler object
-     * @return scheduler
+     * Get the scheduler object that is running on this machine
      */
     public Scheduler getScheduler() {
         return scheduler;
     }
 
+    /**
+     * Get the Zookeeper storage connection for this machine
+     */
+    public SynchronizedStateStorage getStorage(){
+        return zookeeperStorage;
+    }
+
+    /**
+     * Get the task manager for this machine
+     */
+    public DistributedTaskManager getTaskManager(){
+        return taskManager;
+    }
+
+    /**
+     *
+     * This method blocks until the leader has been elected.
+     * @throws Exception Any error connecting to Zookeeper while waiting for Leader
+     */
+    private void electLeader() throws Exception {
+        leaderSelector = new LeaderSelector(zookeeperStorage.connection(), SCHEDULER, this);
+        leaderSelector.autoRequeue();
+
+        // the selection for this instance doesn't start until the leader selector is started
+        // leader selection is done in the background so this call to leaderSelector.start() returns immediately
+        leaderSelector.start();
+        while (!leaderSelector.getLeader().isLeader()) {
+            Thread.sleep(1000);
+        }
+    }
+
+    /**
+     * Instantiate an instance of the distributed task manager to accept and run tasks
+     */
+    private void startTaskManager() {
+        taskManager = new DistributedTaskManager(zookeeperStorage);
+    }
+
+    /**
+     * Close this instance of the distributed task manager
+     */
+    private void stopTaskManager(){
+        taskManager.close();
+    }
+
+    /**
+     * Instantiate an instance of task runner and start running it in a thread.
+     * @throws Exception If an exception is thrown opening the TaskRunner
+     */
+    private void startTaskRunner() throws Exception {
+        taskRunner = new TaskRunner(zookeeperStorage);
+        taskRunner.open();
+
+        taskRunnerThread = new Thread(taskRunner, TASKRUNNER_THREAD_NAME + taskRunner.hashCode());
+        taskRunnerThread.start();
+    }
+
+    /**
+     * Close the instance of TaskRunner on this machine and wait for the TaskRunner thread to die
+     * @throws InterruptedException If any thread has interrupted the shutting down of the TaskRunner thread
+     */
+    private void stopTaskRunner() throws InterruptedException {
+        taskRunner.close();
+        taskRunnerThread.join();
+    }
+
+    /**
+     * Return the connection to Zookeeper for this machine
+     * @throws Exception If there was a problem instantiating connection to Zookeeper
+     */
+    private void startZookeeperConnection() throws Exception{
+        zookeeperStorage = new SynchronizedStateStorage();
+    }
+
+    /**
+     * Close all connections to Zookeeper
+     */
+    private void stopZookeeperConnection(){
+        cache.close();
+        failover.close();
+        zookeeperStorage.close();
+    }
+
+    /**
+     * Instantiate a Scheduler object and start running it in a daemon thread
+     * @throws Exception If an exception is thrown opening the Scheduler
+     */
+    private void startScheduler() throws Exception {
+        LOG.info(ENGINE_ID + " has taken over the scheduler");
+
+        scheduler = new Scheduler(zookeeperStorage);
+        scheduler.open();
+
+        schedulerThread = new Thread(scheduler, SCHEDULER_THREAD_NAME + scheduler.hashCode());
+        schedulerThread.setDaemon(true);
+        schedulerThread.start();
+    }
+
+    /**
+     * Close this instance of the Scheduler.
+     */
+    private void stopScheduler(){
+        scheduler.close();
+    }
+
     private void registerFailover(CuratorFramework client) throws Exception {
         cache = new TreeCache(client, RUNNERS_WATCH);
-        try(TaskFailover failover = TaskFailover.getInstance().open(client, cache)) {
-            cache.getListenable().addListener(failover);
-        }
-
+        failover = new TaskFailover(client, cache, zookeeperStorage);
+        cache.getListenable().addListener(failover);
         cache.start();
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ClusterManager.java
@@ -213,7 +213,6 @@ public class ClusterManager extends LeaderSelectorListenerAdapter {
         LOG.info(ENGINE_ID + " has taken over the scheduler");
 
         scheduler = new Scheduler(zookeeperStorage);
-        scheduler.open();
 
         schedulerThread = new Thread(scheduler, SCHEDULER_THREAD_NAME + scheduler.hashCode());
         schedulerThread.setDaemon(true);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
@@ -152,7 +152,7 @@ public class Scheduler implements Runnable, AutoCloseable {
                 LOG.error("Exception whilst waiting for scheduler run() thread to finish - " + getFullStackTrace(t));
             }
 
-            noThrow(schedulingService::shutdown, "Could not shutdown scheduling service.");
+            noThrow(schedulingService::shutdownNow, "Could not shutdown scheduling service.");
 
             noThrow(producer::flush, "Could not flush Kafka producer in scheduler.");
             noThrow(producer::close, "Could not close Kafka producer in scheduler.");

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
@@ -65,14 +65,19 @@ public class Scheduler implements Runnable, AutoCloseable {
     private final KafkaLogger LOG = KafkaLogger.getInstance();
     private final AtomicBoolean OPENED = new AtomicBoolean(false);
 
+    private final SynchronizedStateStorage zkStorage;
+
     private GraknStateStorage stateStorage;
-    private SynchronizedStateStorage zkStorage;
     private KafkaConsumer<String, String> consumer;
     private KafkaProducer<String, String> producer;
     private ScheduledExecutorService schedulingService;
     private CountDownLatch waitToClose;
     private boolean initialised = false;
     private volatile boolean running = false;
+
+    public Scheduler(SynchronizedStateStorage zkStorage){
+        this.zkStorage = zkStorage;
+    }
 
     public void run() {
         running = true;
@@ -122,9 +127,6 @@ public class Scheduler implements Runnable, AutoCloseable {
             // Kafka writer
             producer = kafkaProducer();
 
-            // ZooKeeper client
-            zkStorage = SynchronizedStateStorage.getInstance();
-
             waitToClose = new CountDownLatch(1);
 
             schedulingService = Executors.newScheduledThreadPool(1);
@@ -154,11 +156,6 @@ public class Scheduler implements Runnable, AutoCloseable {
 
             noThrow(producer::flush, "Could not flush Kafka producer in scheduler.");
             noThrow(producer::close, "Could not close Kafka producer in scheduler.");
-
-            stateStorage = null;
-
-            // Closed by ClusterManager
-            zkStorage = null;
 
             noThrow(() -> LOG.debug("Scheduler stopped."), "Kafka logging error.");
         }

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskFailover.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskFailover.java
@@ -47,8 +47,6 @@ import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.TASKS_PATH_P
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 
 public class TaskFailover implements TreeCacheListener, AutoCloseable {
-    private static TaskFailover instance = null;
-
     private final KafkaLogger LOG = KafkaLogger.getInstance();
     private final AtomicBoolean OPENED = new AtomicBoolean(false);
 
@@ -58,30 +56,21 @@ public class TaskFailover implements TreeCacheListener, AutoCloseable {
     private StateStorage stateStorage;
     private SynchronizedStateStorage synchronizedStateStorage;
 
-    public static synchronized TaskFailover getInstance() {
-        if(instance == null) {
-            instance = new TaskFailover();
-        }
-
-        return instance;
-    }
-
-    public TaskFailover open(CuratorFramework client, TreeCache cache) throws Exception {
+    public TaskFailover(CuratorFramework client, TreeCache cache, SynchronizedStateStorage synchronizedStateStorage) throws Exception {
         if(OPENED.compareAndSet(false, true)) {
             this.cache = cache;
             current = cache.getCurrentChildren(RUNNERS_WATCH);
             producer = kafkaProducer();
 
             stateStorage = new GraknStateStorage();
-            synchronizedStateStorage = SynchronizedStateStorage.getInstance();
+
+            this.synchronizedStateStorage = synchronizedStateStorage;
 
             scanStaleStates(client);
         }
         else {
             LOG.error("TaskFailover already opened!");
         }
-
-        return this;
     }
 
     @Override
@@ -89,10 +78,6 @@ public class TaskFailover implements TreeCacheListener, AutoCloseable {
         if(OPENED.compareAndSet(true, false)) {
             noThrow(producer::flush, "Could not flush Kafka Producer.");
             noThrow(producer::close, "Could not close Kafka Producer.");
-
-            current = null;
-            stateStorage = null;
-            synchronizedStateStorage = null;
         }
         else {
             LOG.error("TaskFailover close() called before open().");

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -69,6 +69,8 @@ public class TaskRunner implements Runnable, AutoCloseable {
     private final KafkaLogger LOG = KafkaLogger.getInstance();
     private final static ConfigProperties properties = ConfigProperties.getInstance();
 
+    private final static int POLLING_FREQUENCY = properties.getPropertyAsInt(TASKRUNNER_POLLING_FREQ);
+
     private ExecutorService executor;
     private final Integer allowableRunningTasks;
     private final Set<String> runningTasks = new HashSet<>();
@@ -96,17 +98,15 @@ public class TaskRunner implements Runnable, AutoCloseable {
             while (running) {
                 printInitialization();
                 LOG.debug("TaskRunner polling, size of new tasks " + consumer.endOffsets(consumer.partitionsFor(WORK_QUEUE_TOPIC).stream().map(i -> new TopicPartition(WORK_QUEUE_TOPIC, i.partition())).collect(toSet())));
+
                 // Poll for new tasks only when we know we have space to accept them.
                 if (getRunningTasksCount() < allowableRunningTasks) {
-                    ConsumerRecords<String, String> records = consumer.poll(properties.getPropertyAsInt(TASKRUNNER_POLLING_FREQ));
-                    processRecords(records);
-                } else {
-                    Thread.sleep(500);
+                    processRecords(consumer.poll(POLLING_FREQUENCY));
                 }
             }
 
         }
-        catch (WakeupException|InterruptedException e) {
+        catch (WakeupException e) {
             if (running) {
                 LOG.error("TaskRunner interrupted unexpectedly (without clearing 'running' flag first", e);
             } else {
@@ -155,7 +155,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
 
             // Wait for thread calling run() to wakeup and close consumer.
             try {
-                waitToClose.await(5*properties.getPropertyAsLong(TASKRUNNER_POLLING_FREQ), MILLISECONDS);
+                waitToClose.await(5*POLLING_FREQUENCY, MILLISECONDS);
             } catch (Throwable t) {
                 LOG.error("Exception whilst waiting for scheduler run() thread to finish - " + getFullStackTrace(t));
             }
@@ -217,9 +217,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
      * @return Boolean, true if task could be marked as running (and we should run), false otherwise.
      */
     private TaskStatus getStatus(String id) {
-        SynchronizedState state = zkStorage.getState(id);
-
-        return state.status();
+        return zkStorage.getState(id).status();
     }
 
     /**
@@ -259,10 +257,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
      * @return A Consumer<String> function that can be called by the background task on demand to save its checkpoint.
      */
     private Consumer<String> saveCheckpoint(String id) {
-        return checkpoint -> {
-            LOG.debug("Writing checkpoint");
-            updateTaskState(id, null, null, null, null, checkpoint);
-        };
+        return checkpoint -> updateTaskState(id, null, null, null, null, checkpoint);
     }
 
     private void updateTaskState(String id, TaskStatus status, String statusChangeBy, String engineID,

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -222,7 +222,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
 
     /**
      * Persists a Background Task's checkpoint to ZK and graph.
-     * @param id ID of task
+     * @param id LID of task
      * @return A Consumer<String> function that can be called by the background task on demand to save its checkpoint.
      */
     private Consumer<String> saveCheckpoint(String id) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -35,6 +35,7 @@ import org.apache.zookeeper.CreateMode;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -241,7 +242,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
         out.put(runningTasks);
 
         try {
-            zkStorage.connection().setData().forPath(RUNNERS_STATE+"/"+ ENGINE_ID, out.toString().getBytes());
+            zkStorage.connection().setData().forPath(RUNNERS_STATE+"/"+ ENGINE_ID, out.toString().getBytes(StandardCharsets.UTF_8));
         }
         catch (Exception e) {
             LOG.error("Could not update TaskRunner taskstorage in ZooKeeper! " + e);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/SynchronizedStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/SynchronizedStateStorage.java
@@ -44,37 +44,22 @@ import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
  */
 public class SynchronizedStateStorage {
     private final KafkaLogger LOG = KafkaLogger.getInstance();
-    private static SynchronizedStateStorage instance = null;
 
-    private final CuratorFramework zookeeperConnection;
+    private final CuratorFramework zookeeperConnection = ConfigHelper.client();
 
-    private SynchronizedStateStorage() throws Exception {
-        zookeeperConnection = ConfigHelper.client();
+    public SynchronizedStateStorage() throws Exception {
         zookeeperConnection.start();
         zookeeperConnection.blockUntilConnected();
 
         createZKPaths();
     }
 
-    public static synchronized SynchronizedStateStorage getInstance() throws Exception {
-        if(instance == null){
-            instance = new SynchronizedStateStorage();
-        }
-
-        return instance;
+    public void close() {
+        zookeeperConnection.close();
     }
 
     public CuratorFramework connection(){
         return zookeeperConnection;
-    }
-
-    public void close() {
-        zookeeperConnection.close();
-        removeInstance();
-    }
-
-    private static void removeInstance() {
-        instance = null;
     }
 
     public void newState(String id, TaskStatus status, String engineID, String checkpoint) throws Exception {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/ImportController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/ImportController.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.engine.controller;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.loader.Loader;
 import ai.grakn.engine.postprocessing.PostProcessing;
 import ai.grakn.exception.GraknEngineServerException;
@@ -65,11 +66,14 @@ public class ImportController {
 
     private final Logger LOG = LoggerFactory.getLogger(ImportController.class);
     private final AtomicBoolean loadingInProgress = new AtomicBoolean(false);
+    private final ClusterManager manager;
 
     private static final String INSERT_KEYWORD = "insert";
     private static final String MATCH_KEYWORD = "match";
 
-    public ImportController() {
+    public ImportController(ClusterManager manager) {
+        this.manager = manager;
+
         before(REST.WebPath.IMPORT_DATA_URI, (req, res) -> {
             if (loadingInProgress.get()) {
                 halt(423, "Another loading process is still running.\n");
@@ -120,7 +124,7 @@ public class ImportController {
      * @return Loader configured to the provided keyspace
      */
     private Loader getLoader(String keyspace){
-        return new Loader(keyspace);
+        return new Loader(manager, keyspace);
     }
 
     /**

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
@@ -19,14 +19,9 @@
 package ai.grakn.engine.controller;
 
 import ai.grakn.engine.backgroundtasks.BackgroundTask;
-import ai.grakn.engine.backgroundtasks.StateStorage;
-import ai.grakn.engine.backgroundtasks.TaskManager;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
-import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
-import ai.grakn.engine.backgroundtasks.standalone.StandaloneTaskManager;
-import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknEngineServerException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
@@ -46,7 +41,6 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import java.time.Instant;
 
-import static ai.grakn.engine.util.ConfigProperties.TASK_MANAGER_INSTANCE;
 import static ai.grakn.util.REST.Request.ID_PARAMETER;
 import static ai.grakn.util.REST.Request.LIMIT_PARAM;
 import static ai.grakn.util.REST.Request.OFFSET_PARAM;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
@@ -71,15 +71,7 @@ public class TasksController {
     private ClusterManager manager;
 
     public TasksController(ClusterManager manager) {
-        String mgr = ConfigProperties.getInstance().getProperty(TASK_MANAGER_INSTANCE, "ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager");
         this.manager = manager;
-//        if(mgr.equals(DistributedTaskManager.class.getName())){
-//            taskManager = manager.getTaskManager();
-//        } else if(mgr.equals(StandaloneTaskManager.class.getName())){
-//            taskManager = StandaloneTaskManager.getInstance();
-//        } else {
-//            throw new RuntimeException("Unrecognized class: " + mgr);
-//        }
 
         get(ALL_TASKS_URI, this::getTasks);
         get(TASKS_URI + "/" + ID_PARAMETER, this::getTask);

--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
@@ -19,6 +19,7 @@
 package ai.grakn.engine.loader;
 
 import ai.grakn.engine.backgroundtasks.TaskStatus;
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.graql.InsertQuery;
@@ -61,11 +62,11 @@ public class Loader {
     private final Collection<InsertQuery> queries;
     private final String keyspace;
 
-    public Loader(String keyspace){
+    public Loader(ClusterManager manager, String keyspace){
         this.keyspace = keyspace;
         this.queries = new HashSet<>();
 
-        this.manager = DistributedTaskManager.getInstance().open();
+        this.manager = manager.getTaskManager();
         setBatchSize(properties.getPropertyAsInt(BATCH_SIZE_PROPERTY));
     }
 

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/io/MigrationLoader.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/io/MigrationLoader.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.migration.base.io;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.loader.Loader;
 import ai.grakn.migration.base.AbstractMigrator;
 import ai.grakn.migration.base.Migrator;
@@ -28,8 +29,8 @@ import ai.grakn.migration.base.Migrator;
  */
 public class MigrationLoader {
 
-    public static void load(String keyspace, int batchSize, Migrator migrator){
-        Loader loader = new Loader(keyspace);
+    public static void load(ClusterManager manager, String keyspace, int batchSize, Migrator migrator){
+        Loader loader = new Loader(manager, keyspace);
         loader.setBatchSize(batchSize);
 
         try{
@@ -40,7 +41,7 @@ public class MigrationLoader {
         }
     }
 
-    public static void load(String keyspace, Migrator migrator) {
-        load(keyspace, AbstractMigrator.BATCH_SIZE, migrator);
+    public static void load(ClusterManager manager, String keyspace, Migrator migrator) {
+        load(manager, keyspace, AbstractMigrator.BATCH_SIZE, migrator);
     }
 }

--- a/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
+++ b/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
@@ -40,16 +40,23 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  */
 public class Main {
 
-    private static final ClusterManager manager = new ClusterManager();
-
     public static void main(String[] args) {
+        start(null, args);
+    }
+
+    public static void start(ClusterManager manager, String[] args){
+        if(manager == null){
+            manager = new ClusterManager();
+        }
+
+        ClusterManager finalManager = manager;
         MigrationCLI.init(args, CSVMigrationOptions::new).stream()
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .forEach(Main::runCSV);
+                .forEach((options) -> runCSV(finalManager, options));
     }
 
-    public static void runCSV(CSVMigrationOptions options){
+    public static void runCSV(ClusterManager manager, CSVMigrationOptions options){
         // get files
         File csvDataFile = new File(options.getInput());
         File csvTemplate = new File(options.getTemplate());

--- a/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
+++ b/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.migration.csv;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.migration.base.io.MigrationCLI;
 import ai.grakn.migration.base.io.MigrationLoader;
 
@@ -38,6 +39,8 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  * @author alexandraorth
  */
 public class Main {
+
+    private static final ClusterManager manager = new ClusterManager();
 
     public static void main(String[] args) {
         MigrationCLI.init(args, CSVMigrationOptions::new).stream()
@@ -73,7 +76,7 @@ public class Main {
             if (options.isNo()) {
                 writeToSout(csvMigrator.migrate());
             } else {
-                MigrationLoader.load(options.getKeyspace(), options.getBatch(), csvMigrator);
+                MigrationLoader.load(manager, options.getKeyspace(), options.getBatch(), csvMigrator);
                 printWholeCompletionMessage(options);
             }
         } catch (Throwable throwable) {

--- a/grakn-migration/json/src/main/java/ai/grakn/migration/json/Main.java
+++ b/grakn-migration/json/src/main/java/ai/grakn/migration/json/Main.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.migration.json;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.migration.base.io.MigrationLoader;
 import ai.grakn.migration.base.io.MigrationCLI;
 
@@ -39,6 +40,8 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  * @author alexandraorth
  */
 public class Main {
+
+    private static final ClusterManager manager = new ClusterManager();
 
     public static void main(String[] args){
         MigrationCLI.init(args, JsonMigrationOptions::new).stream()
@@ -67,7 +70,7 @@ public class Main {
             if(options.isNo()){
                 writeToSout(jsonMigrator.migrate());
             } else {
-                MigrationLoader.load(options.getKeyspace(), options.getBatch(), jsonMigrator);
+                MigrationLoader.load(manager, options.getKeyspace(), options.getBatch(), jsonMigrator);
                 printWholeCompletionMessage(options);
             }
         } catch (Throwable throwable){

--- a/grakn-migration/json/src/main/java/ai/grakn/migration/json/Main.java
+++ b/grakn-migration/json/src/main/java/ai/grakn/migration/json/Main.java
@@ -41,16 +41,23 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  */
 public class Main {
 
-    private static final ClusterManager manager = new ClusterManager();
+    public static void main(String[] args) {
+        start(null, args);
+    }
 
-    public static void main(String[] args){
+    public static void start(ClusterManager manager, String[] args){
+        if(manager == null){
+            manager = new ClusterManager();
+        }
+
+        ClusterManager finalManager = manager;
         MigrationCLI.init(args, JsonMigrationOptions::new).stream()
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .forEach(Main::runJson);
+                .forEach((options) -> runJson(finalManager, options));
     }
 
-    public static void runJson(JsonMigrationOptions options){
+    public static void runJson(ClusterManager manager, JsonMigrationOptions options){
         File jsonDataFile = new File(options.getInput());
         File jsonTemplateFile = new File(options.getTemplate());
 

--- a/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
+++ b/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.migration.sql;
 
+import ai.grakn.engine.GraknEngineServer;
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.migration.base.io.MigrationCLI;
 import ai.grakn.migration.base.io.MigrationLoader;
 
@@ -39,6 +41,8 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  * @author alexandraorth
  */
 public class Main {
+
+    private static final ClusterManager manager = new ClusterManager();
 
     public static void main(String[] args){
         MigrationCLI.init(args, SQLMigrationOptions::new).stream()
@@ -65,7 +69,7 @@ public class Main {
             if(options.isNo()){
                 writeToSout(sqlMigrator.migrate());
             } else {
-                MigrationLoader.load(options.getKeyspace(), options.getBatch(), sqlMigrator);
+                MigrationLoader.load(GraknEngineServer.getClusterManager(), options.getKeyspace(), options.getBatch(), sqlMigrator);
                 printWholeCompletionMessage(options);
             }
 

--- a/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
+++ b/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.migration.sql;
 
-import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.migration.base.io.MigrationCLI;
 import ai.grakn.migration.base.io.MigrationLoader;

--- a/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
+++ b/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/Main.java
@@ -42,16 +42,23 @@ import static ai.grakn.migration.base.io.MigrationCLI.writeToSout;
  */
 public class Main {
 
-    private static final ClusterManager manager = new ClusterManager();
+    public static void main(String[] args) {
+        start(null, args);
+    }
 
-    public static void main(String[] args){
+    public static void start(ClusterManager manager, String[] args){
+        if(manager == null){
+            manager = new ClusterManager();
+        }
+
+        ClusterManager finalManager = manager;
         MigrationCLI.init(args, SQLMigrationOptions::new).stream()
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .forEach(Main::runSQL);
+                .forEach((options) -> runSQL(finalManager, options));
     }
 
-    public static void runSQL(SQLMigrationOptions options) {
+    public static void runSQL(ClusterManager manager, SQLMigrationOptions options) {
         File sqlTemplate = new File(options.getTemplate());
 
         if(!sqlTemplate.exists()){
@@ -69,7 +76,7 @@ public class Main {
             if(options.isNo()){
                 writeToSout(sqlMigrator.migrate());
             } else {
-                MigrationLoader.load(GraknEngineServer.getClusterManager(), options.getKeyspace(), options.getBatch(), sqlMigrator);
+                MigrationLoader.load(manager, options.getKeyspace(), options.getBatch(), sqlMigrator);
                 printWholeCompletionMessage(options);
             }
 

--- a/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
@@ -21,6 +21,8 @@ package ai.grakn.test;
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.GraknGraphFactory;
+import ai.grakn.engine.GraknEngineServer;
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.util.ConfigProperties;
 import org.junit.rules.ExternalResource;
@@ -46,6 +48,10 @@ public class EngineContext extends ExternalResource {
 
     public GraknGraph graphWithNewKeyspace(){
         return factoryWithNewKeyspace().getGraph();
+    }
+
+    public ClusterManager getClusterManager(){
+        return GraknEngineServer.getClusterManager();
     }
 
     public GraknGraphFactory factoryWithNewKeyspace() {

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -159,7 +159,7 @@ public abstract class GraknTestEnv {
     static void hideLogs() {
         Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         logger.setLevel(Level.OFF);
-//        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
+        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
     }
 
     public static boolean usingTinker() {

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -84,8 +84,8 @@ public abstract class GraknTestEnv {
             kafkaUnit.startup();
 
             // start engine
-            ensureHTTPRunning();
             GraknEngineServer.startCluster();
+            ensureHTTPRunning();
             startPostprocessing();
 
             try {Thread.sleep(5000);} catch(InterruptedException ex) { LOG.info("Thread sleep interrupted."); }

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -10,15 +10,14 @@ import ch.qos.logback.classic.Logger;
 import com.auth0.jwt.internal.org.apache.commons.io.FileUtils;
 import com.jayway.restassured.RestAssured;
 import info.batey.kafka.unit.KafkaUnit;
-import jline.internal.Log;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static ai.grakn.engine.GraknEngineServer.startPostprocessing;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static ai.grakn.graql.Graql.var;
 
@@ -33,6 +32,8 @@ import static ai.grakn.graql.Graql.var;
  */
 public abstract class GraknTestEnv {
 
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(GraknTestEnv.class);
+
     private static String CONFIG = System.getProperty("grakn.test-profile");
     private static AtomicBoolean CASSANDRA_RUNNING = new AtomicBoolean(false);
     private static AtomicBoolean ENGINE_RUNNING = new AtomicBoolean(false);
@@ -46,7 +47,7 @@ public abstract class GraknTestEnv {
     public static void ensureCassandraRunning() throws Exception {
         if (CASSANDRA_RUNNING.compareAndSet(false, true) && usingTitan()) {
             startEmbeddedCassandra();
-            System.out.println("CASSANDRA RUNNING.");
+            LOG.info("CASSANDRA RUNNING.");
         }
     }
 
@@ -74,7 +75,7 @@ public abstract class GraknTestEnv {
     	// we end up wanting to use the TitanFactory but without starting Cassandra first.
 
         if(ENGINE_RUNNING.compareAndSet(false, true)) {
-            System.out.println("STARTING ENGINE...");
+            LOG.info("STARTING ENGINE...");
 
             ensureCassandraRunning();
 
@@ -83,27 +84,28 @@ public abstract class GraknTestEnv {
             kafkaUnit.startup();
 
             // start engine
-            ensureHTTPRunning();
             GraknEngineServer.startCluster();
+            ensureHTTPRunning();
+            startPostprocessing();
 
-            try {Thread.sleep(5000);} catch(InterruptedException ex) { Log.info("Thread sleep interrupted."); }
-            
-            System.out.println("ENGINE STARTED.");
+            try {Thread.sleep(5000);} catch(InterruptedException ex) { LOG.info("Thread sleep interrupted."); }
+
+            LOG.info("ENGINE STARTED.");
         }
     }
 
-    static void stopEngine() throws IOException {
+    static void stopEngine() throws Exception {
         if(ENGINE_RUNNING.compareAndSet(true, false)) {
-            System.out.println("STOPPING ENGINE...");
+            LOG.info("STOPPING ENGINE...");
 
-            noThrow(GraknEngineServer::stopCluster, "Problem while shutting down Zookeeper cluster.");
+            GraknEngineServer.stopCluster();
             noThrow(kafkaUnit::shutdown, "Problem while shutting down Kafka Unit.");
             noThrow(GraknTestEnv::clearGraphs, "Problem while clearing graphs.");
             noThrow(GraknTestEnv::stopHTTP, "Problem while shutting down Engine");
 
             FileUtils.deleteDirectory(tempDirectory.toFile());
 
-            System.out.println("ENGINE STOPPED.");
+            LOG.info("ENGINE STOPPED.");
         }
 
         // There is no way to stop the embedded Casssandra, no such API offered.

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -84,8 +84,8 @@ public abstract class GraknTestEnv {
             kafkaUnit.startup();
 
             // start engine
-            GraknEngineServer.startCluster();
             ensureHTTPRunning();
+            GraknEngineServer.startCluster();
             startPostprocessing();
 
             try {Thread.sleep(5000);} catch(InterruptedException ex) { LOG.info("Thread sleep interrupted."); }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/ClusterManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/ClusterManagerTest.java
@@ -39,7 +39,7 @@ public class ClusterManagerTest {
 
     @BeforeClass
     public static void instantiate(){
-        clusterManager = ClusterManager.getInstance();
+        clusterManager = engine.getClusterManager();
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/ClusterManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/ClusterManagerTest.java
@@ -20,39 +20,52 @@ package ai.grakn.test.engine.backgroundtasks;
 
 import ai.grakn.engine.backgroundtasks.distributed.Scheduler;
 import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
+import ai.grakn.test.EngineContext;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.Objects;
+import java.util.function.Predicate;
 
 import static org.junit.Assert.assertNotEquals;
 
 public class ClusterManagerTest {
-    private final ClusterManager clusterManager = ClusterManager.getInstance();
+    private static ClusterManager clusterManager;
 
-//    @ClassRule
-//    public static final EngineContext engine = EngineContext.startServer();
+    @ClassRule
+    public static final EngineContext engine = EngineContext.startServer();
 
-    // There is a strange issue that only shows up when running these tests on Travis; as such this test is being ignored
-    // for now in order to get the code into central now, and fix later.
-    @Ignore
+    @BeforeClass
+    public static void instantiate(){
+        clusterManager = ClusterManager.getInstance();
+    }
+
     @Test
     public void testSchedulerRestartsAfterKilled() throws Exception {
         synchronized (clusterManager.getScheduler()) {
-//            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("c scheduler not null");
+            waitForScheduler(clusterManager, Objects::nonNull);
             Scheduler scheduler1 = clusterManager.getScheduler();
 
             // Kill scheduler- client should create a new one
             scheduler1.close();
-            System.out.println("c closed scheduler");
 
-//            waitForScheduler(clusterManager, Objects::isNull);
-            System.out.println("c scheduler is null");
-
-//            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("c scheduler not null again");
+            waitForScheduler(clusterManager, Objects::nonNull);
 
             Scheduler scheduler2 = clusterManager.getScheduler();
             assertNotEquals(scheduler1, scheduler2);
         }
+    }
+
+    protected void waitForScheduler(ClusterManager clusterManager, Predicate<Scheduler> fn) throws Exception {
+        int runs = 0;
+
+        while (fn.test(clusterManager.getScheduler()) && runs < 50 ) {
+            Thread.sleep(100);
+            runs++;
+        }
+
+        System.out.println("wait done, runs " + runs + " scheduler " + clusterManager.getScheduler());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -67,19 +67,24 @@ import static org.junit.Assert.assertTrue;
  */
 public class SchedulerTest {
     private GraknStateStorage stateStorage = new GraknStateStorage();
-    private SynchronizedStateStorage zkStorage;
-    private final ClusterManager clusterManager = ClusterManager.getInstance();
+    private static ClusterManager clusterManager;
+    private final SynchronizedStateStorage zkStorage = clusterManager.getStorage();
 
     @ClassRule
     public static final EngineContext engine = EngineContext.startServer();
 
+    @BeforeClass
+    public static void setupCluster(){
+        clusterManager = engine.getClusterManager();
+    }
+
     @Before
     public void setup() throws Exception {
         ((Logger) org.slf4j.LoggerFactory.getLogger(KafkaLogger.class)).setLevel(Level.DEBUG);
-        zkStorage = SynchronizedStateStorage.getInstance();
     }
 
     @Test
+    @Ignore
     public void testInstantaneousOneTimeTasks() throws Exception {
         Map<String, TaskState> tasks = createTasks(5);
         sendTasksToNewTasksQueue(tasks);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -21,39 +21,32 @@ package ai.grakn.test.engine.backgroundtasks;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.config.ConfigHelper;
-import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
-import ai.grakn.engine.backgroundtasks.distributed.Scheduler;
+import ai.grakn.engine.backgroundtasks.distributed.KafkaLogger;
 import ai.grakn.engine.backgroundtasks.taskstorage.GraknStateStorage;
 import ai.grakn.test.EngineContext;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import javafx.util.Pair;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.json.JSONObject;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
-import java.util.function.Predicate;
 
 import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.CREATED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.RUNNING;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.SCHEDULED;
-import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
 import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.NEW_TASKS_TOPIC;
-import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.WORK_QUEUE_TOPIC;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Each test needs to be run with a clean Kafka to pass
@@ -64,54 +57,16 @@ public class SchedulerTest {
     @Rule
     public final EngineContext engine = EngineContext.startServer();
 
+    @BeforeClass
+    public static void setup(){
+        ((Logger) org.slf4j.LoggerFactory.getLogger(KafkaLogger.class)).setLevel(Level.DEBUG);
+    }
+
     @Test
     public void testInstantaneousOneTimeTasks() throws Exception {
         Map<String, TaskState> tasks = createTasks(5);
         sendTasksToNewTasksQueue(tasks);
         waitUntilScheduled(tasks.keySet());
-    }
-
-    @Test
-    public void testRecurringTasksStarted() throws Exception {
-        // persist a recurring task in system graph
-        Pair<String, TaskState> task = createTask(0, CREATED, true, 3000);
-        String taskId = task.getKey();
-
-        // force scheduler restart
-        engine.getClusterManager().getScheduler().close();
-
-        // sleep a bit and stop scheduler
-        waitUntilScheduled(taskId);
-
-        // check recurring task in work queue
-        Map<String, String> recurringTasks = getMessagesInWorkQueue();
-        assertTrue(recurringTasks.containsKey(taskId));
-    }
-
-    @Test
-    public void testRecurringTasksThatAreStoppedNotStarted() throws Exception{
-        // persist a recurring task in system graph
-        Pair<String, TaskState> task1 = createTask(0, CREATED, true, 3000);
-        String taskId1 = task1.getKey();
-        TaskState state1 = task1.getValue();
-
-        // persist a recurring task in system graph
-        Pair<String, TaskState> task2 = createTask(1, STOPPED, true, 3000);
-        String taskId2 = task2.getKey();
-        TaskState state2 = task2.getValue();
-
-        System.out.println(taskId1 + "   " + state1);
-        System.out.println(taskId2 + "   " + state2);
-
-        // force scheduler to stop
-        engine.getClusterManager().getScheduler().close();
-
-        waitUntilScheduled(taskId1);
-
-        // check CREATED task in work queue and not stopped
-        Map<String, String> recurringTasks = getMessagesInWorkQueue();
-        assertTrue(recurringTasks.containsKey(taskId1));
-        assertTrue(!recurringTasks.containsKey(taskId2));
     }
 
     private Map<String, TaskState> createTasks(int n) throws Exception {
@@ -156,27 +111,6 @@ public class SchedulerTest {
         producer.close();
     }
 
-    private Map<String, String> getMessagesInWorkQueue() {
-        // Create a consumer in a new group to read all messages
-        Properties properties = Utilities.testConsumer();
-        properties.put("group.id", "workQueue");
-        properties.put("auto.offset.reset", "earliest");
-
-        KafkaConsumer<String, String> consumer = new KafkaConsumer<>(properties);
-        consumer.subscribe(Collections.singletonList(WORK_QUEUE_TOPIC));
-
-        ConsumerRecords<String, String> records = consumer.poll(1000);
-        Map<String, String> recordsInMap = new HashMap<>();
-        for(ConsumerRecord<String, String> record:records) {
-            recordsInMap.put(record.key(), record.value());
-        }
-
-        System.out.println("test received total count: " + records.count());
-
-        consumer.close();
-        return recordsInMap;
-    }
-
     private void waitUntilScheduled(Collection<String> tasks) {
         tasks.forEach(this::waitUntilScheduled);
     }
@@ -205,16 +139,5 @@ public class SchedulerTest {
                 throw new RuntimeException(e);
             }
         }
-    }
-
-    private void waitForScheduler(ClusterManager clusterManager, Predicate<Scheduler> fn) throws Exception {
-        int runs = 0;
-
-        while (!fn.test(clusterManager.getScheduler()) && runs < 50 ) {
-            Thread.sleep(100);
-            runs++;
-        }
-
-        System.out.println("wait done, runs " + Integer.toString(runs) + " scheduler " + clusterManager.getScheduler());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -37,6 +37,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.json.JSONObject;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -84,16 +85,12 @@ public class SchedulerTest {
     }
 
     @Test
-    @Ignore
     public void testInstantaneousOneTimeTasks() throws Exception {
         Map<String, TaskState> tasks = createTasks(5);
         sendTasksToNewTasksQueue(tasks);
         waitUntilScheduled(tasks.keySet());
     }
 
-    // There is a strange issue that only shows up when running these tests on Travis; as such this test is being ignored
-    // for now in order to get the code into central now, and fix later.
-    @Ignore
     @Test
     public void testRecurringTasksStarted() throws Exception {
         // persist a recurring task in system graph
@@ -101,19 +98,7 @@ public class SchedulerTest {
         String taskId = task.getKey();
 
         // force scheduler restart
-        synchronized (clusterManager.getScheduler()) {
-            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("scheduler is not null");
-
-            clusterManager.getScheduler().close();
-            System.out.println("closed scheduler");
-
-            waitForScheduler(clusterManager, Objects::isNull);
-            System.out.println("scheduler now null");
-
-            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("scheduler not null again");
-        }
+        clusterManager.getScheduler().close();
 
         // sleep a bit and stop scheduler
         waitUntilScheduled(taskId);
@@ -123,9 +108,6 @@ public class SchedulerTest {
         assertTrue(recurringTasks.containsKey(taskId));
     }
 
-    // There is a strange issue that only shows up when running these tests on Travis; as such this test is being ignored
-    // for now in order to get the code into central now, and fix later.
-    @Ignore
     @Test
     public void testRecurringTasksThatAreStoppedNotStarted() throws Exception{
         // persist a recurring task in system graph
@@ -142,19 +124,7 @@ public class SchedulerTest {
         System.out.println(taskId2 + "   " + state2);
 
         // force scheduler to stop
-        synchronized (clusterManager.getScheduler()) {
-            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("2 scheduler is not null");
-
-            clusterManager.getScheduler().close();
-            System.out.println("2 closed scheduler");
-
-            waitForScheduler(clusterManager, Objects::isNull);
-            System.out.println("2 scheduler now null");
-
-            waitForScheduler(clusterManager, Objects::nonNull);
-            System.out.println("2 scheduler not null again");
-        }
+        clusterManager.getScheduler().close();
 
         waitUntilScheduled(taskId1);
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -22,13 +22,9 @@ import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.config.ConfigHelper;
 import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
-import ai.grakn.engine.backgroundtasks.distributed.KafkaLogger;
 import ai.grakn.engine.backgroundtasks.distributed.Scheduler;
 import ai.grakn.engine.backgroundtasks.taskstorage.GraknStateStorage;
-import ai.grakn.engine.backgroundtasks.taskstorage.SynchronizedStateStorage;
 import ai.grakn.test.EngineContext;
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import javafx.util.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -36,7 +32,6 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.json.JSONObject;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -67,12 +62,7 @@ public class SchedulerTest {
     private GraknStateStorage stateStorage = new GraknStateStorage();
 
     @Rule
-    public static final EngineContext engine = EngineContext.startServer();
-
-    @Before
-    public void setup() throws Exception {
-        ((Logger) org.slf4j.LoggerFactory.getLogger(KafkaLogger.class)).setLevel(Level.DEBUG);
-    }
+    public final EngineContext engine = EngineContext.startServer();
 
     @Test
     public void testInstantaneousOneTimeTasks() throws Exception {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SynchronizedStateStorageTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SynchronizedStateStorageTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.test.engine.backgroundtasks;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.backgroundtasks.taskstorage.SynchronizedState;
 import ai.grakn.engine.backgroundtasks.taskstorage.SynchronizedStateStorage;
 import ai.grakn.test.EngineContext;
@@ -39,7 +40,7 @@ public class SynchronizedStateStorageTest {
 
     @Before
     public void setUp() throws Exception {
-        stateStorage = SynchronizedStateStorage.getInstance();
+        stateStorage = engine.getClusterManager().getStorage();
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskManagerTest.java
@@ -47,7 +47,7 @@ public class TaskManagerTest {
     @Before
     public void setup() throws Exception {
         assumeFalse(usingTinker());
-        manager = DistributedTaskManager.getInstance();
+        manager = engine.getClusterManager().getTaskManager();
         Thread.sleep(5000);
     }
 
@@ -59,7 +59,7 @@ public class TaskManagerTest {
                 break;
             }
 
-            System.out.println("Checking " + id);
+            System.out.println("Checking " + id + " " + status);
 
             try {
                 Thread.sleep(5000);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
@@ -22,6 +22,7 @@ import ai.grakn.engine.backgroundtasks.StateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.config.ConfigHelper;
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.backgroundtasks.distributed.KafkaLogger;
 import ai.grakn.engine.backgroundtasks.taskstorage.GraknStateStorage;
 import ai.grakn.engine.backgroundtasks.taskstorage.SynchronizedStateStorage;
@@ -69,7 +70,7 @@ public class TaskRunnerTest {
         stateStorage = new GraknStateStorage();
 
         // ZooKeeper client
-        zkStorage = SynchronizedStateStorage.getInstance();
+        zkStorage = engine.getClusterManager().getStorage();
         assumeFalse(usingTinker());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.test.engine.controller;
 
+import ai.grakn.engine.backgroundtasks.distributed.ClusterManager;
 import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.controller.TasksController;
 import ai.grakn.test.EngineContext;
@@ -66,7 +67,7 @@ public class TasksControllerTest {
     @Before
     public void setUp() throws Exception {
         assumeFalse(usingTinker());
-        DistributedTaskManager manager = DistributedTaskManager.getInstance();
+        DistributedTaskManager manager = engine.getClusterManager().getTaskManager();
         singleTask = manager.scheduleTask(new TestTask(), this.getClass().getName(), Instant.now(), 0, new JSONObject());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
@@ -71,7 +71,7 @@ public class LoaderTest {
     public void setup() {
         //TODO fix this
         graph = engine.graphWithNewKeyspace();
-        loader = new Loader(graph.getKeyspace());
+        loader = new Loader(engine.getClusterManager(), graph.getKeyspace());
         loadOntology(graph.getKeyspace());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
@@ -25,6 +25,7 @@ import ai.grakn.concept.EntityType;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.TypeName;
+import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.loader.Loader;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graql.QueryBuilderImplMock;
@@ -272,7 +273,7 @@ public class ScalingTestIT {
         // create the ontology
         simpleOntology(keyspace);
 
-        Loader loader = new Loader(keyspace);
+        Loader loader = new Loader(GraknEngineServer.getClusterManager(), keyspace);
 
         for (int g=1; g<totalSteps+1; g++) {
             LOGGER.info("starting step: " + g);
@@ -409,7 +410,7 @@ public class ScalingTestIT {
 
     private void addNodesToSuperNodes(String keyspace, Set<String> superNodes, int startRange, int endRange) {
         // batch in the nodes
-        Loader loader = new Loader(keyspace);
+        Loader loader = new Loader(GraknEngineServer.getClusterManager(), keyspace);
 
         for (int nodeIndex = startRange; nodeIndex < endRange; nodeIndex++) {
             List<Var> insertQuery = new ArrayList<>();

--- a/grakn-test/src/test/java/ai/grakn/test/migration/MigratorTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/MigratorTestUtils.java
@@ -27,6 +27,7 @@ import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.TypeName;
+import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.migration.base.Migrator;
 import ai.grakn.migration.base.io.MigrationLoader;
@@ -61,7 +62,7 @@ public class MigratorTestUtils {
     }
 
     public static void migrate(GraknGraph graph, Migrator migrator){
-        MigrationLoader.load(graph.getKeyspace(), migrator);
+        MigrationLoader.load(GraknEngineServer.getClusterManager(), graph.getKeyspace(), migrator);
     }
 
     public static void load(GraknGraph graph, File ontology) {

--- a/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
@@ -23,6 +23,7 @@ import ai.grakn.migration.csv.Main;
 import ai.grakn.test.EngineContext;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,6 +33,7 @@ import static ai.grakn.test.migration.MigratorTestUtils.assertPokemonGraphCorrec
 import static ai.grakn.test.migration.MigratorTestUtils.getFile;
 import static ai.grakn.test.migration.MigratorTestUtils.load;
 
+@Ignore
 public class CSVMigratorMainTest {
 
     private GraknGraph graph;

--- a/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
@@ -19,11 +19,9 @@
 package ai.grakn.test.migration.csv;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.migration.csv.Main;
 import ai.grakn.test.EngineContext;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,8 +30,8 @@ import static ai.grakn.test.migration.MigratorTestUtils.assertPetGraphCorrect;
 import static ai.grakn.test.migration.MigratorTestUtils.assertPokemonGraphCorrect;
 import static ai.grakn.test.migration.MigratorTestUtils.getFile;
 import static ai.grakn.test.migration.MigratorTestUtils.load;
+import static ai.grakn.migration.csv.Main.start;
 
-@Ignore
 public class CSVMigratorMainTest {
 
     private GraknGraph graph;
@@ -132,7 +130,7 @@ public class CSVMigratorMainTest {
     }
 
     private void run(String... args){
-        Main.main(args);
+        start(engine.getClusterManager(), args);
     }
 
     private void runAndAssertDataCorrect(String... args){

--- a/grakn-test/src/test/java/ai/grakn/test/migration/json/JsonMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/json/JsonMigratorMainTest.java
@@ -28,6 +28,7 @@ import ai.grakn.migration.json.Main;
 import ai.grakn.test.EngineContext;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -41,6 +42,7 @@ import static ai.grakn.test.migration.MigratorTestUtils.getResource;
 import static ai.grakn.test.migration.MigratorTestUtils.load;
 import static junit.framework.TestCase.assertEquals;
 
+@Ignore
 public class JsonMigratorMainTest {
 
     private final String dataFile = getFile("json", "simple-schema/data.json").getAbsolutePath();

--- a/grakn-test/src/test/java/ai/grakn/test/migration/json/JsonMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/json/JsonMigratorMainTest.java
@@ -24,7 +24,6 @@ import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.TypeName;
-import ai.grakn.migration.json.Main;
 import ai.grakn.test.EngineContext;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -40,9 +39,9 @@ import static ai.grakn.test.migration.MigratorTestUtils.getProperties;
 import static ai.grakn.test.migration.MigratorTestUtils.getProperty;
 import static ai.grakn.test.migration.MigratorTestUtils.getResource;
 import static ai.grakn.test.migration.MigratorTestUtils.load;
+import static ai.grakn.migration.json.Main.start;
 import static junit.framework.TestCase.assertEquals;
 
-@Ignore
 public class JsonMigratorMainTest {
 
     private final String dataFile = getFile("json", "simple-schema/data.json").getAbsolutePath();
@@ -115,7 +114,7 @@ public class JsonMigratorMainTest {
     }
 
     private void run(String... args){
-        Main.main(args);
+        start(engine.getClusterManager(), args);
     }
 
     private void runAndAssertDataCorrect(String... args){

--- a/grakn-test/src/test/java/ai/grakn/test/migration/sql/SQLMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/sql/SQLMigratorMainTest.java
@@ -19,7 +19,6 @@
 package ai.grakn.test.migration.sql;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.migration.sql.Main;
 import ai.grakn.test.EngineContext;
 import org.junit.After;
 import org.junit.Before;
@@ -40,8 +39,8 @@ import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.DRIVER;
 import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.PASS;
 import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.URL;
 import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.USER;
+import static ai.grakn.migration.sql.Main.start;
 
-@Ignore
 public class SQLMigratorMainTest {
 
     private final String templateFile = getFile("sql", "pets/template.gql").getAbsolutePath();
@@ -132,7 +131,7 @@ public class SQLMigratorMainTest {
     }
 
     private void run(String... args){
-        Main.main(args);
+        start(engine.getClusterManager(), args);
     }
 
     private void runAndAssertDataCorrect(String... args){

--- a/grakn-test/src/test/java/ai/grakn/test/migration/sql/SQLMigratorMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/sql/SQLMigratorMainTest.java
@@ -24,6 +24,7 @@ import ai.grakn.test.EngineContext;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -40,6 +41,7 @@ import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.PASS;
 import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.URL;
 import static ai.grakn.test.migration.sql.SQLMigratorTestUtils.USER;
 
+@Ignore
 public class SQLMigratorMainTest {
 
     private final String templateFile = getFile("sql", "pets/template.gql").getAbsolutePath();


### PR DESCRIPTION
Cleanups include:
+ Removing singletons
+ Speed-up in TaskRunner by updating state multithreaded
+ Comments and methods in ClusterManager
+ Remove reflection in TasksController

Right now starting the Cluster before the controllers results in a "Could not contact engine" error-- Starting the cluster (therefore Scheduler) loads the the GraknSystem graph which submits logs to the CommitController. Filipe & I will work on this tomorrow, the GraknSystem graph should not submit commit logs. 