### PR TITLE
Do not submit commit logs when creating graph from engine factory

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -20,6 +20,7 @@ package ai.grakn;
 
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graph.BaseGraknGraph;
+import ai.grakn.graph.GraknAdmin;
 
 /**
  * <p>

--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -18,223 +18,23 @@
 
 package ai.grakn;
 
-import ai.grakn.concept.Concept;
-import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.EntityType;
-import ai.grakn.concept.Instance;
-import ai.grakn.concept.Relation;
-import ai.grakn.concept.RelationType;
-import ai.grakn.concept.Resource;
-import ai.grakn.concept.ResourceType;
-import ai.grakn.concept.RoleType;
-import ai.grakn.concept.RuleType;
-import ai.grakn.concept.Type;
-import ai.grakn.concept.TypeName;
 import ai.grakn.exception.GraknValidationException;
-import ai.grakn.graql.QueryBuilder;
-
-import java.util.Collection;
-import java.util.Map;
+import ai.grakn.graph.BaseGraknGraph;
 
 /**
- * A GraknGraph instance which connects to a specific graph keyspace.
- * Through this object, transactions are automatically opened, which enable the graph to be queried and mutated.
+ * <p>
+ *     A Grakn Graph
+ * </p>
+ *
+ * <p>
+ *     This is produced by {@link Grakn#factory(String, String)} and allows the user to construct and perform
+ *     basic look ups to a Grakn Graph. This also allows the execution of Graql queries.
+ * </p>
+ *
+ * @author fppt
+ *
  */
-
-public interface GraknGraph extends AutoCloseable{
-    //------------------------------------- Concept Construction ----------------------------------
-
-    /**
-     * Create a new Entity Type, or return a pre-existing Entity Type, with the specified name.
-     *
-     * @param name A unique name for the Entity Type
-     * @return A new or existing Entity Type with the provided name
-     */
-    EntityType putEntityType(String name);
-
-    /**
-     * Create a new Entity Type, or return a pre-existing Entity Type, with the specified name.
-     *
-     * @param name A unique name for the Entity Type
-     * @return A new or existing Entity Type with the provided name
-     */
-    EntityType putEntityType(TypeName name);
-
-    /**
-     * Create a Resource Type, or return a pre-existing Resource Type, with the specified name.
-     *
-     * @param name A unique name for the Resource Type
-     * @param dataType The data type of the resource type.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing Resource Type with the provided name.
-     */
-    <V> ResourceType<V> putResourceType(String name, ResourceType.DataType<V> dataType);
-
-    /**
-     * Create a Resource Type, or return a pre-existing Resource Type, with the specified name.
-     *
-     * @param name A unique name for the Resource Type
-     * @param dataType The data type of the resource type.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing Resource Type with the provided name.
-     */
-    <V> ResourceType<V> putResourceType(TypeName name, ResourceType.DataType<V> dataType);
-
-    /**
-     * Create a unique Resource Type, or return a pre-existing Resource Type, with the specified name.
-     * The Resource Type is guaranteed to be unique, in that its instances can be connected to one entity.
-     *
-     * @param name A unique name for the Resource Type
-     * @param dataType The data type of the resource type.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing Resource Type with the provided name.
-     */
-    <V> ResourceType <V> putResourceTypeUnique(String name, ResourceType.DataType<V> dataType);
-    /**
-     * Create a unique Resource Type, or return a pre-existing Resource Type, with the specified name.
-     * The Resource Type is guaranteed to be unique, in that its instances can be connected to one entity.
-     *
-     * @param name A unique name for the Resource Type
-     * @param dataType The data type of the resource type.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing Resource Type with the provided name.
-     */
-    <V> ResourceType <V> putResourceTypeUnique(TypeName name, ResourceType.DataType<V> dataType);
-
-    /**
-     * Create a Rule Type, or return a pre-existing Rule Type, with the specified name.
-     *
-     * @param name A unique name for the Rule Type
-     * @return new or existing Rule Type with the provided Id.
-     */
-    RuleType putRuleType(String name);
-
-    /**
-     * Create a Rule Type, or return a pre-existing Rule Type, with the specified name.
-     *
-     * @param name A unique name for the Rule Type
-     * @return new or existing Rule Type with the provided Id.
-     */
-    RuleType putRuleType(TypeName name);
-
-    /**
-     * Create a Relation Type, or return a pre-existing Relation Type, with the specified name.
-     *
-     * @param name A unique name for the Relation Type
-     * @return A new or existing Relation Type with the provided Id.
-     */
-    RelationType putRelationType(String name);
-
-    /**
-     * Create a Relation Type, or return a pre-existing Relation Type, with the specified name.
-     *
-     * @param name A unique name for the Relation Type
-     * @return A new or existing Relation Type with the provided Id.
-     */
-    RelationType putRelationType(TypeName name);
-
-    /**
-     * Create a Role Type, or return a pre-existing Role Type, with the specified name.
-     *
-     * @param name A unique name for the Role Type
-     * @return new or existing Role Type with the provided Id.
-     */
-    RoleType putRoleType(String name);
-
-    /**
-     * Create a Role Type, or return a pre-existing Role Type, with the specified name.
-     *
-     * @param name A unique name for the Role Type
-     * @return new or existing Role Type with the provided Id.
-     */
-    RoleType putRoleType(TypeName name);
-
-    //------------------------------------- Concept Lookup ----------------------------------
-    /**
-     * Get the Concept with identifier provided, if it exists.
-     *
-     * @param id A unique identifier for the Concept in the graph.
-     * @return The Concept with the provided id or null if no such Concept exists.
-     */
-    <T extends Concept> T getConcept(ConceptId id);
-
-    /**
-     * Get the Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Type in the graph.
-     * @return The Type with the provided name or null if no such Type exists.
-     */
-    <T extends Type> T getType(TypeName name);
-
-    /**
-     * Get the Resources holding the value provided, if they exist.
-     *
-     * @param value A value which a Resource in the graph may be holding.
-     * @param <V> The data type of the value. Supported types include: String, Long, Double, and Boolean.
-     * @return The Resources holding the provided value or an empty collection if no such Resource exists.
-     */
-    <V> Collection<Resource<V>> getResourcesByValue(V value);
-
-    /**
-     * Get the Entity Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Entity Type in the graph.
-     * @return The Entity Type  with the provided name or null if no such Entity Type exists.
-     */
-    EntityType getEntityType(String name);
-
-    /**
-     * Get the Relation Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Relation Type in the graph.
-     * @return The Relation Type with the provided name or null if no such Relation Type exists.
-     */
-    RelationType getRelationType(String name);
-
-    /**
-     * Get the Resource Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Resource Type in the graph.
-     * @param <V> The data type of the value. Supported types include: String, Long, Double, and Boolean.
-     * @return The Resource Type with the provided name or null if no such Resource Type exists.
-     */
-    <V> ResourceType<V> getResourceType(String name);
-
-    /**
-     * Get the Role Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Role Type in the graph.
-     * @return The Role Type  with the provided name or null if no such Role Type exists.
-     */
-    RoleType getRoleType(String name);
-
-    /**
-     * Get the Rule Type with the name provided, if it exists.
-     *
-     * @param name A unique name which identifies the Rule Type in the graph.
-     * @return The Rule Type with the provided name or null if no such Rule Type exists.
-     */
-    RuleType getRuleType(String name);
-
-    /**
-     * Get a collection of Relations that match the specified Relation Type and role map, if it exists.
-     * Caller specifies a Relation Type and a role map, which lists the Instances or Resources in the relationship, and the roles each play.
-     *
-     * @param relationType The Relation Type which we wish to find a Relation instance of.
-     * @param roleMap A role map specifying the rolePlayers (Instances or Resources) in the relationship and the roles (Role Types) they play.
-     * @return A collection of Relations which meet the above requirements or an empty collection is no relationship exists fulfilling the above requirements.
-     */
-    Relation getRelation(RelationType relationType, Map<RoleType, Instance> roleMap);
-
-    //------------------------------------- Utilities ----------------------------------
+public interface GraknGraph extends BaseGraknGraph {
 
     /**
      * Returns access to the low-level details of the graph via GraknAdmin
@@ -245,67 +45,10 @@ public interface GraknGraph extends AutoCloseable{
     GraknAdmin admin();
 
     /**
-     * Utility function to specify whether implicit and system-generated types should be returned.
-     * @param flag Specifies if implicit and system-generated types should be returned.
-     */
-    void showImplicitConcepts(boolean flag);
-
-    /**
-     * Utility function to specify whether implicit concepts should be exposed.
-     *
-     * @return true if implicit concepts are exposed.
-     */
-    boolean implicitConceptsVisible();
-
-    /**
-     * Closes and clears the current graph.
-     */
-    void clear();
-
-    /**
-     * Utility function to get the name of the keyspace where the graph is persisted.
-     *
-     * @return The name of the keyspace where the graph is persisted
-     */
-    String getKeyspace();
-
-    /**
-     * Utility function to determine whether the graph has been closed.
-     *
-     * @return True if the graph has been closed
-     */
-    boolean isClosed();
-
-    /**
-     * Returns a QueryBuilder
-     *
-     * @return returns a query builder to allow for the creation of graql queries
-     * @see QueryBuilder
-     */
-    QueryBuilder graql();
-
-    /**
-     * Validates and attempts to commit the graph.
+     * Validates and attempts to commit the graph. Also submits commit logs for post processing
      * An exception is thrown if validation fails or if the graph cannot be persisted due to an underlying database issue.
      *
      * @throws GraknValidationException is thrown when a structural validation fails.
      */
     void commit() throws GraknValidationException;
-
-    /**
-     * Resets the current transaction without committing.
-     *
-     */
-    void rollback();
-
-    /**
-     * Closes the current transaction. If no transactions remain open the graph connection is closed permanently and
-     * the {@link GraknGraphFactory} must be used to get a new connection.
-     */
-    void close();
-
-    /**
-     * Opens the graph. This must be called before a new thread can use the graph.
-     */
-    void open();
 }

--- a/grakn-core/src/main/java/ai/grakn/graph/BaseGraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/BaseGraknGraph.java
@@ -1,0 +1,300 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graph;
+
+import ai.grakn.GraknGraphFactory;
+import ai.grakn.concept.Concept;
+import ai.grakn.concept.ConceptId;
+import ai.grakn.concept.EntityType;
+import ai.grakn.concept.Instance;
+import ai.grakn.concept.Relation;
+import ai.grakn.concept.RelationType;
+import ai.grakn.concept.Resource;
+import ai.grakn.concept.ResourceType;
+import ai.grakn.concept.RoleType;
+import ai.grakn.concept.RuleType;
+import ai.grakn.concept.Type;
+import ai.grakn.concept.TypeName;
+import ai.grakn.graql.QueryBuilder;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * <p>
+ *     The Base Graph Interface
+ * </p>
+ *
+ * <p>
+ *     Provides common method for interacting with a Grakn Graph.
+ * </p>
+ *
+ * @author fppt
+ *
+ */
+public interface BaseGraknGraph extends AutoCloseable {
+    //------------------------------------- Concept Construction ----------------------------------
+    /**
+     * Create a new Entity Type, or return a pre-existing Entity Type, with the specified name.
+     *
+     * @param name A unique name for the Entity Type
+     * @return A new or existing Entity Type with the provided name
+     */
+    EntityType putEntityType(String name);
+
+    /**
+     * Create a new Entity Type, or return a pre-existing Entity Type, with the specified name.
+     *
+     * @param name A unique name for the Entity Type
+     * @return A new or existing Entity Type with the provided name
+     */
+    EntityType putEntityType(TypeName name);
+
+    /**
+     * Create a Resource Type, or return a pre-existing Resource Type, with the specified name.
+     *
+     * @param name A unique name for the Resource Type
+     * @param dataType The data type of the resource type.
+     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
+     *           This should match the parameter type
+     * @return A new or existing Resource Type with the provided name.
+     */
+    <V> ResourceType<V> putResourceType(String name, ResourceType.DataType<V> dataType);
+
+    /**
+     * Create a Resource Type, or return a pre-existing Resource Type, with the specified name.
+     *
+     * @param name A unique name for the Resource Type
+     * @param dataType The data type of the resource type.
+     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
+     *           This should match the parameter type
+     * @return A new or existing Resource Type with the provided name.
+     */
+    <V> ResourceType<V> putResourceType(TypeName name, ResourceType.DataType<V> dataType);
+
+    /**
+     * Create a unique Resource Type, or return a pre-existing Resource Type, with the specified name.
+     * The Resource Type is guaranteed to be unique, in that its instances can be connected to one entity.
+     *
+     * @param name A unique name for the Resource Type
+     * @param dataType The data type of the resource type.
+     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
+     *           This should match the parameter type
+     * @return A new or existing Resource Type with the provided name.
+     */
+    <V> ResourceType <V> putResourceTypeUnique(String name, ResourceType.DataType<V> dataType);
+    /**
+     * Create a unique Resource Type, or return a pre-existing Resource Type, with the specified name.
+     * The Resource Type is guaranteed to be unique, in that its instances can be connected to one entity.
+     *
+     * @param name A unique name for the Resource Type
+     * @param dataType The data type of the resource type.
+     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
+     *           This should match the parameter type
+     * @return A new or existing Resource Type with the provided name.
+     */
+    <V> ResourceType <V> putResourceTypeUnique(TypeName name, ResourceType.DataType<V> dataType);
+
+    /**
+     * Create a Rule Type, or return a pre-existing Rule Type, with the specified name.
+     *
+     * @param name A unique name for the Rule Type
+     * @return new or existing Rule Type with the provided Id.
+     */
+    RuleType putRuleType(String name);
+
+    /**
+     * Create a Rule Type, or return a pre-existing Rule Type, with the specified name.
+     *
+     * @param name A unique name for the Rule Type
+     * @return new or existing Rule Type with the provided Id.
+     */
+    RuleType putRuleType(TypeName name);
+
+    /**
+     * Create a Relation Type, or return a pre-existing Relation Type, with the specified name.
+     *
+     * @param name A unique name for the Relation Type
+     * @return A new or existing Relation Type with the provided Id.
+     */
+    RelationType putRelationType(String name);
+
+    /**
+     * Create a Relation Type, or return a pre-existing Relation Type, with the specified name.
+     *
+     * @param name A unique name for the Relation Type
+     * @return A new or existing Relation Type with the provided Id.
+     */
+    RelationType putRelationType(TypeName name);
+
+    /**
+     * Create a Role Type, or return a pre-existing Role Type, with the specified name.
+     *
+     * @param name A unique name for the Role Type
+     * @return new or existing Role Type with the provided Id.
+     */
+    RoleType putRoleType(String name);
+
+    /**
+     * Create a Role Type, or return a pre-existing Role Type, with the specified name.
+     *
+     * @param name A unique name for the Role Type
+     * @return new or existing Role Type with the provided Id.
+     */
+    RoleType putRoleType(TypeName name);
+
+    //------------------------------------- Concept Lookup ----------------------------------
+    /**
+     * Get the Concept with identifier provided, if it exists.
+     *
+     * @param id A unique identifier for the Concept in the graph.
+     * @return The Concept with the provided id or null if no such Concept exists.
+     */
+    <T extends Concept> T getConcept(ConceptId id);
+
+    /**
+     * Get the Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Type in the graph.
+     * @return The Type with the provided name or null if no such Type exists.
+     */
+    <T extends Type> T getType(TypeName name);
+
+    /**
+     * Get the Resources holding the value provided, if they exist.
+     *
+     * @param value A value which a Resource in the graph may be holding.
+     * @param <V> The data type of the value. Supported types include: String, Long, Double, and Boolean.
+     * @return The Resources holding the provided value or an empty collection if no such Resource exists.
+     */
+    <V> Collection<Resource<V>> getResourcesByValue(V value);
+
+    /**
+     * Get the Entity Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Entity Type in the graph.
+     * @return The Entity Type  with the provided name or null if no such Entity Type exists.
+     */
+    EntityType getEntityType(String name);
+
+    /**
+     * Get the Relation Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Relation Type in the graph.
+     * @return The Relation Type with the provided name or null if no such Relation Type exists.
+     */
+    RelationType getRelationType(String name);
+
+    /**
+     * Get the Resource Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Resource Type in the graph.
+     * @param <V> The data type of the value. Supported types include: String, Long, Double, and Boolean.
+     * @return The Resource Type with the provided name or null if no such Resource Type exists.
+     */
+    <V> ResourceType<V> getResourceType(String name);
+
+    /**
+     * Get the Role Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Role Type in the graph.
+     * @return The Role Type  with the provided name or null if no such Role Type exists.
+     */
+    RoleType getRoleType(String name);
+
+    /**
+     * Get the Rule Type with the name provided, if it exists.
+     *
+     * @param name A unique name which identifies the Rule Type in the graph.
+     * @return The Rule Type with the provided name or null if no such Rule Type exists.
+     */
+    RuleType getRuleType(String name);
+
+    /**
+     * Get a collection of Relations that match the specified Relation Type and role map, if it exists.
+     * Caller specifies a Relation Type and a role map, which lists the Instances or Resources in the relationship, and the roles each play.
+     *
+     * @param relationType The Relation Type which we wish to find a Relation instance of.
+     * @param roleMap A role map specifying the rolePlayers (Instances or Resources) in the relationship and the roles (Role Types) they play.
+     * @return A collection of Relations which meet the above requirements or an empty collection is no relationship exists fulfilling the above requirements.
+     */
+    Relation getRelation(RelationType relationType, Map<RoleType, Instance> roleMap);
+
+    //------------------------------------- Utilities ----------------------------------
+    /**
+     * Utility function to specify whether implicit and system-generated types should be returned.
+     * @param flag Specifies if implicit and system-generated types should be returned.
+     */
+    void showImplicitConcepts(boolean flag);
+
+    /**
+     * Utility function to specify whether implicit concepts should be exposed.
+     *
+     * @return true if implicit concepts are exposed.
+     */
+    boolean implicitConceptsVisible();
+
+    /**
+     * Closes and clears the current graph.
+     */
+    void clear();
+
+    /**
+     * Utility function to get the name of the keyspace where the graph is persisted.
+     *
+     * @return The name of the keyspace where the graph is persisted
+     */
+    String getKeyspace();
+
+    /**
+     * Utility function to determine whether the graph has been closed.
+     *
+     * @return True if the graph has been closed
+     */
+    boolean isClosed();
+
+    /**
+     * Returns a QueryBuilder
+     *
+     * @return returns a query builder to allow for the creation of graql queries
+     * @see QueryBuilder
+     */
+    QueryBuilder graql();
+
+    /**
+     * Resets the current transaction without committing.
+     *
+     */
+    void rollback();
+
+    /**
+     * Closes the current transaction. If no transactions remain open the graph connection is closed permanently and
+     * the {@link GraknGraphFactory} must be used to get a new connection.
+     */
+    void close();
+
+    /**
+     * Opens the graph. This must be called before a new thread can use the graph.
+     */
+    void open();
+}

--- a/grakn-core/src/main/java/ai/grakn/graph/BaseGraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/BaseGraknGraph.java
@@ -42,7 +42,8 @@ import java.util.Map;
  * </p>
  *
  * <p>
- *     Provides common method for interacting with a Grakn Graph.
+ *     Provides common methods for interacting with a Grakn Graph.
+ *     These methods are shared by {@link ai.grakn.GraknGraph} and {@link EngineGraknGraph}
  * </p>
  *
  * @author fppt
@@ -241,6 +242,14 @@ public interface BaseGraknGraph extends AutoCloseable {
     Relation getRelation(RelationType relationType, Map<RoleType, Instance> roleMap);
 
     //------------------------------------- Utilities ----------------------------------
+    /**
+     * Returns access to the low-level details of the graph via GraknAdmin
+     * @see GraknAdmin
+     *
+     * @return The admin interface which allows you to access more low level details of the graph.
+     */
+    GraknAdmin admin();
+
     /**
      * Utility function to specify whether implicit and system-generated types should be returned.
      * @param flag Specifies if implicit and system-generated types should be returned.

--- a/grakn-core/src/main/java/ai/grakn/graph/EngineGraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/EngineGraknGraph.java
@@ -16,31 +16,46 @@
  * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package ai.grakn;
+package ai.grakn.graph;
+
 
 import ai.grakn.exception.GraknValidationException;
-import ai.grakn.graph.BaseGraknGraph;
+
+import java.util.Set;
 
 /**
  * <p>
- *     A Grakn Graph
+ *     The Engine Specific Graph Interface
  * </p>
  *
  * <p>
- *     This is produced by {@link Grakn#factory(String, String)} and allows the user to construct and perform
- *     basic look ups to a Grakn Graph. This also allows the execution of Graql queries.
+ *     Provides common methods for advanced inteaction with the graph.
+ *     This is used internally by Engine
  * </p>
  *
  * @author fppt
  *
  */
-public interface GraknGraph extends BaseGraknGraph {
+public interface EngineGraknGraph extends BaseGraknGraph {
 
     /**
-     * Validates and attempts to commit the graph. Also submits commit logs for post processing
-     * An exception is thrown if validation fails or if the graph cannot be persisted due to an underlying database issue.
+     * Commits the transaction without submitting any commit logs
      *
      * @throws GraknValidationException is thrown when a structural validation fails.
      */
-    void commit() throws GraknValidationException;
+    void commitTx() throws GraknValidationException;
+
+    /**
+     * Merges duplicate castings if one is found.
+     * @param castingId The id of the casting to check for duplicates
+     * @return true if some castings were merged
+     */
+    boolean fixDuplicateCasting(Object castingId);
+
+    /**
+     *
+     * @param resourceIds The resourceIDs which possible contain duplicates.
+     * @return True if a commit is required.
+     */
+    boolean fixDuplicateResources(Set<Object> resourceIds);
 }

--- a/grakn-core/src/main/java/ai/grakn/graph/EngineGraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/EngineGraknGraph.java
@@ -39,7 +39,7 @@ import java.util.Set;
 public interface EngineGraknGraph extends BaseGraknGraph {
 
     /**
-     * Commits the transaction without submitting any commit logs
+     * Commits the transaction without submitting any commit logs through the REST API
      *
      * @throws GraknValidationException is thrown when a structural validation fails.
      */

--- a/grakn-core/src/main/java/ai/grakn/graph/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/GraknAdmin.java
@@ -16,7 +16,7 @@
  * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package ai.grakn;
+package ai.grakn.graph;
 
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.EntityType;

--- a/grakn-core/src/main/java/ai/grakn/graph/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/GraknAdmin.java
@@ -45,6 +45,13 @@ public interface GraknAdmin {
      */
     GraphTraversal<Vertex, Vertex> getTinkerTraversal();
 
+    /**
+     * A flag to check if batch loading is enabled and consistency checks are switched off
+     *
+     * @return true if batch loading is enabled
+     */
+    boolean isBatchLoadingEnabled();
+
     //------------------------------------- Meta Types ----------------------------------
     /**
      * Get the root of all Types.

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/GraknStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/GraknStateStorage.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.engine.backgroundtasks.taskstorage;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Entity;
@@ -33,6 +32,7 @@ import ai.grakn.engine.backgroundtasks.distributed.KafkaLogger;
 import ai.grakn.exception.GraknBackendException;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.Var;
@@ -189,7 +189,7 @@ public class GraknStateStorage implements StateStorage {
         return result.get();
     }
 
-    private TaskState instanceToState(GraknGraph graph, Instance instance){
+    private TaskState instanceToState(EngineGraknGraph graph, Instance instance){
         Resource<?> name = instance.resources(graph.getType(TASK_CLASS_NAME)).stream().findFirst().orElse(null);
         if (name == null) {
             LOG.error("Could not get 'task-class-name' for " + instance.getId());
@@ -310,17 +310,17 @@ public class GraknStateStorage implements StateStorage {
             return state;
         }
 
-    private <T> Optional<T> attemptCommitToSystemGraph(Function<GraknGraph, T> function, boolean commit){
+    private <T> Optional<T> attemptCommitToSystemGraph(Function<EngineGraknGraph, T> function, boolean commit){
         double sleepFor = 100;
         for (int i = 0; i < retries; i++) {
 
             LOG.debug("Attempting "  + (commit ? "commit" : "query") + " on system graph @ t"+Thread.currentThread().getId());
             long time = System.currentTimeMillis();
 
-            try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+            try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
                 T result = function.apply(graph);
                 if (commit) {
-                    graph.commit();
+                    graph.commitTx();
                 }
 
                 return Optional.of(result);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/GraknStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstorage/GraknStateStorage.java
@@ -30,7 +30,7 @@ import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.distributed.KafkaLogger;
 import ai.grakn.exception.GraknBackendException;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.InsertQuery;
@@ -317,7 +317,7 @@ public class GraknStateStorage implements StateStorage {
             LOG.debug("Attempting "  + (commit ? "commit" : "query") + " on system graph @ t"+Thread.currentThread().getId());
             long time = System.currentTimeMillis();
 
-            try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+            try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
                 T result = function.apply(graph);
                 if (commit) {
                     graph.commitTx();

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraphFactoryController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraphFactoryController.java
@@ -25,7 +25,7 @@ import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknEngineServerException;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.util.ErrorMessage;
@@ -94,7 +94,7 @@ public class GraphFactoryController {
     @Path("/keyspaces")
     @ApiOperation(value = "Get all the key spaces that have been opened")
     private String getKeySpaces(Request request, Response response) {
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             ResourceType<String> keyspaceName = graph.getType(SystemKeyspace.KEYSPACE_RESOURCE);
             Json result = Json.array();
             if (graph.getType(SystemKeyspace.KEYSPACE_ENTITY) == null) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraphFactoryController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraphFactoryController.java
@@ -19,7 +19,6 @@
 package ai.grakn.engine.controller;
 
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Resource;
@@ -28,6 +27,7 @@ import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknEngineServerException;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.REST;
 import io.swagger.annotations.ApiImplicitParam;
@@ -94,7 +94,7 @@ public class GraphFactoryController {
     @Path("/keyspaces")
     @ApiOperation(value = "Get all the key spaces that have been opened")
     private String getKeySpaces(Request request, Response response) {
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             ResourceType<String> keyspaceName = graph.getType(SystemKeyspace.KEYSPACE_RESOURCE);
             Json result = Json.array();
             if (graph.getType(SystemKeyspace.KEYSPACE_ENTITY) == null) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
@@ -58,7 +58,7 @@ import java.util.stream.Collectors;
 import static ai.grakn.engine.controller.Utilities.getAcceptType;
 import static ai.grakn.engine.controller.Utilities.getKeyspace;
 import static ai.grakn.engine.util.ConfigProperties.HAL_DEGREE_PROPERTY;
-import static ai.grakn.factory.GraphFactory.getInstance;
+import static ai.grakn.factory.EngineGraknGraphFactory.getInstance;
 import static ai.grakn.graql.internal.hal.HALConceptRepresentationBuilder.renderHALArrayData;
 import static ai.grakn.graql.internal.hal.HALConceptRepresentationBuilder.renderHALConceptData;
 import static ai.grakn.graql.internal.hal.HALConceptRepresentationBuilder.renderHALConceptOntology;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/VisualiserController.java
@@ -24,6 +24,7 @@ import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Type;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.GraknEngineServerException;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.MatchQuery;
@@ -106,7 +107,7 @@ public class VisualiserController {
     private String conceptById(Request req, Response res) {
         String keyspace = getKeyspace(req);
 
-        try (GraknGraph graph = getInstance().getGraph(keyspace)) {
+        try (EngineGraknGraph graph = getInstance().getGraph(keyspace)) {
             Concept concept = graph.getConcept(ConceptId.of(req.params(ID_PARAMETER)));
 
             if(concept==null) {
@@ -131,7 +132,7 @@ public class VisualiserController {
     private String conceptByIdOntology(Request req, Response res) {
         String keyspace = getKeyspace(req);
 
-        try (GraknGraph graph = getInstance().getGraph(keyspace)) {
+        try (EngineGraknGraph graph = getInstance().getGraph(keyspace)) {
             Concept concept = graph.getConcept(ConceptId.of(req.params(ID_PARAMETER)));
             return renderHALConceptOntology(concept, keyspace);
         } catch (Exception e) {
@@ -149,7 +150,7 @@ public class VisualiserController {
     private String ontology(Request req, Response res) {
         String keyspace = getKeyspace(req);
 
-        try (GraknGraph graph = getInstance().getGraph(keyspace)) {
+        try (EngineGraknGraph graph = getInstance().getGraph(keyspace)) {
             JSONObject responseObj = new JSONObject();
             responseObj.put(ROLES_JSON_FIELD, instances(graph.admin().getMetaRoleType()));
             responseObj.put(ENTITIES_JSON_FIELD, instances(graph.admin().getMetaEntityType()));
@@ -176,7 +177,7 @@ public class VisualiserController {
         boolean useReasoner = parseBoolean(req.queryParams("reasoner"));
         boolean materialise = parseBoolean(req.queryParams("materialise"));
 
-        try (GraknGraph graph = getInstance().getGraph(keyspace)) {
+        try (EngineGraknGraph graph = getInstance().getGraph(keyspace)) {
             QueryBuilder qb = graph.graql().infer(useReasoner).materialise(materialise);
             Query parsedQuery = qb.parse(req.queryParams(QUERY_FIELD));
             if (parsedQuery instanceof MatchQuery || parsedQuery instanceof AggregateQuery || parsedQuery instanceof ComputeQuery) {
@@ -205,7 +206,7 @@ public class VisualiserController {
             @ApiImplicitParam(name = "query", value = "Compute query to execute", required = true, dataType = "string", paramType = "query")
     })
     private String compute(Request req, Response res) {
-        try (GraknGraph graph = getInstance().getGraph(getKeyspace(req))) {
+        try (EngineGraknGraph graph = getInstance().getGraph(getKeyspace(req))) {
 
             ComputeQuery computeQuery = graph.graql().parse(req.queryParams(QUERY_FIELD));
             JSONObject response = new JSONObject();
@@ -240,8 +241,9 @@ public class VisualiserController {
     @ApiOperation(value = "Pre materialise all the rules on the graph.")
     @ApiImplicitParam(name = "keyspace", value = "Name of graph to use", dataType = "string", paramType = "query")
     private String preMaterialiseAll(Request req, Response res) {
-        try (GraknGraph graph = getInstance().getGraph(getKeyspace(req))) {
-            Reasoner.precomputeInferences(graph);
+        try (EngineGraknGraph graph = getInstance().getGraph(getKeyspace(req))) {
+            //TODO: Fix ugly casting here
+            Reasoner.precomputeInferences((GraknGraph) graph);
             return "Done.";
         } catch (Exception e) {
             throw new GraknEngineServerException(500, e);

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ConceptFixer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ConceptFixer.java
@@ -19,7 +19,7 @@
 package ai.grakn.engine.postprocessing;
 
 import ai.grakn.engine.util.ConfigProperties;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.util.ErrorMessage;
 import org.slf4j.Logger;
@@ -35,7 +35,7 @@ class ConceptFixer {
         boolean notDone = true;
         int retry = 0;
         while (notDone) {
-            try (AbstractGraknGraph graph = (AbstractGraknGraph) GraphFactory.getInstance().getGraph(keyspace)) {
+            try (AbstractGraknGraph graph = (AbstractGraknGraph) EngineGraknGraphFactory.getInstance().getGraph(keyspace)) {
                 if (graph.fixDuplicateCasting(castingId)) {
                     graph.commit(false);
                 }
@@ -58,7 +58,7 @@ class ConceptFixer {
         int retry = 0;
 
         while (notDone) {
-            try(AbstractGraknGraph graph = (AbstractGraknGraph) GraphFactory.getInstance().getGraph(keyspace))  {
+            try(AbstractGraknGraph graph = (AbstractGraknGraph) EngineGraknGraphFactory.getInstance().getGraph(keyspace))  {
                 if (graph.fixDuplicateResources(resourceIds)) {
                     graph.commit(false);
                 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/user/Password.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/user/Password.java
@@ -18,8 +18,8 @@
 
 package ai.grakn.engine.user;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.graph.EngineGraknGraph;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -56,7 +56,7 @@ public class Password {
      *
      * @return a 16 bytes random salt
      */
-    public static byte[] getNextSalt(GraknGraph graph) {
+    static byte[] getNextSalt(EngineGraknGraph graph) {
         ResourceType<String> saltResourceType = graph.getResourceType(UsersHandler.USER_SALT);
 
         String saltString;
@@ -112,7 +112,7 @@ public class Password {
         return true;
     }
 
-    public static String getString(byte [] bytes){
+    static String getString(byte[] bytes){
         return new String(Base64.getEncoder().encode(bytes), StandardCharsets.UTF_8);
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
@@ -18,11 +18,11 @@
 
 package ai.grakn.engine.user;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.TypeName;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.AskQuery;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.graql.MatchQuery;
@@ -55,7 +55,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean addUser(Json userJson) {
         final Var user = var().isa(USER_ENTITY);
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
 
             userJson.asJsonMap().forEach( (property, value) -> {
                 if(property.equals(UsersHandler.USER_PASSWORD)){//Hash the password with a salt
@@ -71,7 +71,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
 
             InsertQuery query = graph.graql().insert(user);
             query.execute();
-            graph.commit();
+            graph.commitTx();
             LOG.debug("Created user " + userJson);
             return true;
         } catch (Throwable t) {
@@ -87,7 +87,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean userExists(String username) {
         Var lookup = var().isa(USER_ENTITY).has(USER_NAME, username);
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             AskQuery query = graph.graql().match(lookup).ask();
             return query.execute();
         }
@@ -106,7 +106,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     public Json getUser(String username) {
         Var lookup = var("entity").isa(USER_ENTITY).has(USER_NAME, username);
         Var resource = var("property");
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup.has(resource));
             List<Map<String, Concept>> L = query.execute();
             if (L.isEmpty()) {
@@ -135,7 +135,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
      */
     @Override
     public boolean validateUser(String username, String passwordClient) {
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             List<Map<String, Concept>> results = graph.graql().match(
                     var("salt").isa(USER_SALT),
                     var("stored-password").isa(USER_PASSWORD),
@@ -168,7 +168,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public Json allUsers(int offset, int limit) {
         Var lookup = var("entity").isa(USER_ENTITY);
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup.has(USER_NAME, var("username"))).limit(limit).offset(offset);
             List<Map<String, Concept>> L = query.execute();
             Json all = Json.array();
@@ -193,7 +193,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean removeUser(String username) {
         Var lookup = var("entity").isa(USER_ENTITY).has(USER_NAME, username);
-        try (GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup);
             List<Map<String, Concept>> results = query.execute();
             boolean exists = !results.isEmpty();
@@ -205,7 +205,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
             });
 
             if(exists){
-                graph.commit();
+                graph.commitTx();
             }
 
             return exists;

--- a/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
@@ -20,7 +20,7 @@ package ai.grakn.engine.user;
 
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.TypeName;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.AskQuery;
@@ -55,7 +55,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean addUser(Json userJson) {
         final Var user = var().isa(USER_ENTITY);
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
 
             userJson.asJsonMap().forEach( (property, value) -> {
                 if(property.equals(UsersHandler.USER_PASSWORD)){//Hash the password with a salt
@@ -87,7 +87,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean userExists(String username) {
         Var lookup = var().isa(USER_ENTITY).has(USER_NAME, username);
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             AskQuery query = graph.graql().match(lookup).ask();
             return query.execute();
         }
@@ -106,7 +106,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     public Json getUser(String username) {
         Var lookup = var("entity").isa(USER_ENTITY).has(USER_NAME, username);
         Var resource = var("property");
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup.has(resource));
             List<Map<String, Concept>> L = query.execute();
             if (L.isEmpty()) {
@@ -135,7 +135,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
      */
     @Override
     public boolean validateUser(String username, String passwordClient) {
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             List<Map<String, Concept>> results = graph.graql().match(
                     var("salt").isa(USER_SALT),
                     var("stored-password").isa(USER_PASSWORD),
@@ -168,7 +168,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public Json allUsers(int offset, int limit) {
         Var lookup = var("entity").isa(USER_ENTITY);
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup.has(USER_NAME, var("username"))).limit(limit).offset(offset);
             List<Map<String, Concept>> L = query.execute();
             Json all = Json.array();
@@ -193,7 +193,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
     @Override
     public boolean removeUser(String username) {
         Var lookup = var("entity").isa(USER_ENTITY).has(USER_NAME, username);
-        try (EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
+        try (EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             MatchQuery query = graph.graql().match(lookup);
             List<Map<String, Concept>> results = query.execute();
             boolean exists = !results.isEmpty();

--- a/grakn-engine/src/main/java/ai/grakn/factory/EngineGraknGraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/EngineGraknGraphFactory.java
@@ -27,19 +27,19 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-public class GraphFactory {
+public class EngineGraknGraphFactory {
     private final Properties properties;
-    private static GraphFactory instance = null;
+    private static EngineGraknGraphFactory instance = null;
 
 
-    public static synchronized GraphFactory getInstance() {
+    public static synchronized EngineGraknGraphFactory getInstance() {
         if (instance == null) {
-            instance = new GraphFactory();
+            instance = new EngineGraknGraphFactory();
         }
         return instance;
     }
 
-    private GraphFactory() {
+    private EngineGraknGraphFactory() {
         properties = new Properties();
         String pathToConfig = ConfigProperties.getInstance().getPath(ConfigProperties.GRAPH_CONFIG_PROPERTY);
 

--- a/grakn-engine/src/main/java/ai/grakn/factory/EngineGraknGraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/EngineGraknGraphFactory.java
@@ -51,12 +51,20 @@ public class EngineGraknGraphFactory {
     }
 
     public synchronized EngineGraknGraph getGraph(String keyspace) {
-        //TODO: Get rid of ugly casting
-        return (EngineGraknGraph) FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(false);
+        return getGraph(keyspace, false);
+    }
+
+    public synchronized EngineGraknGraph getGraphBatchLoading(String keyspace) {
+        return getGraph(keyspace, true);
     }
 
     public synchronized void refreshConnections(){
         FactoryBuilder.refresh();
+    }
+
+    private EngineGraknGraph getGraph(String keyspace, boolean batchLoading){
+        //TODO: Get rid of ugly casting
+        return (EngineGraknGraph) FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(batchLoading);
     }
 }
 

--- a/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
@@ -19,8 +19,8 @@
 package ai.grakn.factory;
 
 import ai.grakn.Grakn;
-import ai.grakn.GraknGraph;
 import ai.grakn.engine.util.ConfigProperties;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.util.ErrorMessage;
 
 import java.io.FileInputStream;
@@ -50,8 +50,9 @@ public class GraphFactory {
         }
     }
 
-    public synchronized GraknGraph getGraph(String keyspace) {
-        return FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(false);
+    public synchronized EngineGraknGraph getGraph(String keyspace) {
+        //TODO: Get rid of ugly casting
+        return (EngineGraknGraph) FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(false);
     }
 
     public synchronized void refreshConnections(){

--- a/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/factory/GraphFactory.java
@@ -54,7 +54,7 @@ public class GraphFactory {
         return FactoryBuilder.getFactory(keyspace, Grakn.DEFAULT_URI, properties).getGraph(false);
     }
 
-    public synchronized void refershConnections(){
+    public synchronized void refreshConnections(){
         FactoryBuilder.refresh();
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/factory/InternalFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/InternalFactory.java
@@ -50,4 +50,6 @@ interface InternalFactory<M extends GraknGraph, T extends Graph> {
      * @return An instance of a tinker graph
      */
     T getTinkerPopGraph(boolean batchLoading);
+
+
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -19,6 +19,7 @@
 package ai.grakn.graph.internal;
 
 import ai.grakn.Grakn;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graph.GraknAdmin;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
@@ -82,7 +83,7 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
  *
  * @param <G> A vendor specific implementation of a Tinkerpop {@link Graph}.
  */
-public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph, GraknAdmin {
+public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph, GraknAdmin, EngineGraknGraph {
     protected final Logger LOG = LoggerFactory.getLogger(AbstractGraknGraph.class);
     private final ElementFactory elementFactory;
     private final String keyspace;
@@ -692,6 +693,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     public void commit() throws GraknValidationException {
         commit(true);
     }
+
+    @Override
+    public void commitTx() throws GraknValidationException{
+        commit(false);
+    }
+
     public void commit(boolean submitLogs) throws GraknValidationException {
         validateGraph();
 
@@ -707,7 +714,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         }
 
         LOG.debug("Graph is valid. Committing graph . . . ");
-        commitTx();
+        commitTransaction();
         LOG.debug("Graph committed.");
         getConceptLog().clearTransaction();
 
@@ -715,7 +722,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
             submitCommitLogs(modifiedConcepts);
         }
     }
-    protected void commitTx(){
+    protected void commitTransaction(){
         try {
             getTinkerPopGraph().tx().commit();
         } catch (UnsupportedOperationException e){
@@ -771,6 +778,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      * @param castingId The id of the casting to check for duplicates
      * @return true if some castings were merged
      */
+    @Override
     public boolean fixDuplicateCasting(Object castingId){
         //Get the Casting
         ConceptImpl concept = getConceptByBaseIdentifier(castingId);
@@ -882,6 +890,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      * @param resourceIds The resourceIDs which possible contain duplicates.
      * @return True if a commit is required.
      */
+    @Override
     public boolean fixDuplicateResources(Set<Object> resourceIds){
         boolean commitRequired = false;
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -19,7 +19,7 @@
 package ai.grakn.graph.internal;
 
 import ai.grakn.Grakn;
-import ai.grakn.GraknAdmin;
+import ai.grakn.graph.GraknAdmin;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -161,6 +161,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         return committed;
     }
 
+    @Override
     public boolean isBatchLoadingEnabled(){
         return batchLoadingEnabled;
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -711,7 +711,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         LOG.debug("Graph committed.");
         getConceptLog().clearTransaction();
 
-        if(getKeyspace().equals(SystemKeyspace.SYSTEM_GRAPH_NAME) && submitLogs && modifiedConcepts.size() > 0) {
+        if(!getKeyspace().equals(SystemKeyspace.SYSTEM_GRAPH_NAME) && submitLogs && modifiedConcepts.size() > 0) {
             submitCommitLogs(modifiedConcepts);
         }
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -38,6 +38,7 @@ import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.exception.MoreThanOneConceptException;
+import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.internal.query.QueryBuilderImpl;
 import ai.grakn.util.EngineCommunicator;
@@ -710,7 +711,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         LOG.debug("Graph committed.");
         getConceptLog().clearTransaction();
 
-        if(submitLogs && modifiedConcepts.size() > 0) {
+        if(getKeyspace().equals(SystemKeyspace.SYSTEM_GRAPH_NAME) && submitLogs && modifiedConcepts.size() > 0) {
             submitCommitLogs(modifiedConcepts);
         }
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -718,7 +718,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         LOG.debug("Graph committed.");
         getConceptLog().clearTransaction();
 
-        if(!getKeyspace().equals(SystemKeyspace.SYSTEM_GRAPH_NAME) && submitLogs && modifiedConcepts.size() > 0) {
+        if(!getKeyspace().equalsIgnoreCase(SystemKeyspace.SYSTEM_GRAPH_NAME) && submitLogs && modifiedConcepts.size() > 0) {
             submitCommitLogs(modifiedConcepts);
         }
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
@@ -18,7 +18,7 @@
 
 package ai.grakn.graph.internal;
 
-import ai.grakn.GraknAdmin;
+import ai.grakn.graph.GraknAdmin;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
 import ai.grakn.graql.Pattern;

--- a/grakn-orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
+++ b/grakn-orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
@@ -33,7 +33,7 @@ public class GraknOrientDBGraph extends AbstractGraknGraph<OrientGraph> {
 
 
     @Override
-    protected void commitTx(){
+    protected void commitTransaction(){
         getTinkerPopGraph().commit();
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -133,7 +133,7 @@ public abstract class GraknTestEnv {
         // Drop the system keyspaces too
         systemGraph.clear();
 
-        graphFactory.refershConnections();
+        graphFactory.refreshConnections();
     }
 
     static void startEmbeddedCassandra() {

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -2,7 +2,7 @@ package ai.grakn.test;
 
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.util.ConfigProperties;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ch.qos.logback.classic.Level;
@@ -119,21 +119,21 @@ public abstract class GraknTestEnv {
 
     static void clearGraphs() {
         // Drop all keyspaces
-        GraphFactory graphFactory = GraphFactory.getInstance();
+        EngineGraknGraphFactory engineGraknGraphFactory = EngineGraknGraphFactory.getInstance();
 
-        EngineGraknGraph systemGraph = graphFactory.getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph systemGraph = engineGraknGraphFactory.getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         systemGraph.graql().match(var("x").isa("keyspace-name"))
                 .execute()
                 .forEach(x -> x.values().forEach(y -> {
                     String name = y.asResource().getValue().toString();
-                    EngineGraknGraph graph = graphFactory.getGraph(name);
+                    EngineGraknGraph graph = engineGraknGraphFactory.getGraph(name);
                     graph.clear();
                 }));
 
         // Drop the system keyspaces too
         systemGraph.clear();
 
-        graphFactory.refreshConnections();
+        engineGraknGraphFactory.refreshConnections();
     }
 
     static void startEmbeddedCassandra() {

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -1,10 +1,10 @@
 package ai.grakn.test;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.auth0.jwt.internal.org.apache.commons.io.FileUtils;
@@ -121,12 +121,12 @@ public abstract class GraknTestEnv {
         // Drop all keyspaces
         GraphFactory graphFactory = GraphFactory.getInstance();
 
-        GraknGraph systemGraph = graphFactory.getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph systemGraph = graphFactory.getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         systemGraph.graql().match(var("x").isa("keyspace-name"))
                 .execute()
                 .forEach(x -> x.values().forEach(y -> {
                     String name = y.asResource().getValue().toString();
-                    GraknGraph graph = graphFactory.getGraph(name);
+                    EngineGraknGraph graph = graphFactory.getGraph(name);
                     graph.clear();
                 }));
 

--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -27,10 +27,10 @@ import org.junit.rules.ExternalResource;
 import java.util.function.Consumer;
 
 import static ai.grakn.engine.util.ConfigProperties.TASK_MANAGER_INSTANCE;
+import static ai.grakn.graphs.TestGraph.loadFromFile;
 import static ai.grakn.test.GraknTestEnv.ensureCassandraRunning;
 import static ai.grakn.test.GraknTestEnv.ensureHTTPRunning;
 import static ai.grakn.test.GraknTestEnv.randomKeyspace;
-import static ai.grakn.graphs.TestGraph.loadFromFile;
 
 /**
  *
@@ -100,7 +100,8 @@ public class GraphContext extends ExternalResource {
     }
 
     private void loadGraph() {
-        graph = GraphFactory.getInstance().getGraph(randomKeyspace());
+        //TODO: get rid of another ugly cast
+        graph = (GraknGraph) GraphFactory.getInstance().getGraph(randomKeyspace());
 
         // if data should be pre-loaded, load
         if(preLoad != null){

--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -21,7 +21,7 @@ package ai.grakn.test;
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.backgroundtasks.standalone.StandaloneTaskManager;
 import ai.grakn.engine.util.ConfigProperties;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import org.junit.rules.ExternalResource;
 
 import java.util.function.Consumer;
@@ -101,7 +101,7 @@ public class GraphContext extends ExternalResource {
 
     private void loadGraph() {
         //TODO: get rid of another ugly cast
-        graph = (GraknGraph) GraphFactory.getInstance().getGraph(randomKeyspace());
+        graph = (GraknGraph) EngineGraknGraphFactory.getInstance().getGraph(randomKeyspace());
 
         // if data should be pre-loaded, load
         if(preLoad != null){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineRunningTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineRunningTest.java
@@ -20,7 +20,7 @@ package ai.grakn.test.engine;
 
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.backgroundtasks.distributed.TaskRunner;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
@@ -51,7 +51,7 @@ public class GraknEngineRunningTest {
         assertTrue(running);
 
         // Check that we've loaded the ontology
-        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         assertEquals(1, graph.graql().match(var("x").name("scheduled-task")).execute().size());
     }
     

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineRunningTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineRunningTest.java
@@ -18,11 +18,11 @@
 
 package ai.grakn.test.engine;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.backgroundtasks.distributed.TaskRunner;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
@@ -51,7 +51,7 @@ public class GraknEngineRunningTest {
         assertTrue(running);
 
         // Check that we've loaded the ontology
-        GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         assertEquals(1, graph.graql().match(var("x").name("scheduled-task")).execute().size());
     }
     

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
@@ -20,21 +20,25 @@ package ai.grakn.test.engine.controller;
 
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
+import ai.grakn.concept.Concept;
 import ai.grakn.concept.Entity;
+import ai.grakn.concept.EntityType;
 import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.concept.RoleType;
 import ai.grakn.engine.postprocessing.Cache;
+import ai.grakn.exception.GraknValidationException;
+import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.test.EngineContext;
-import com.jayway.restassured.http.ContentType;
-import ai.grakn.concept.Concept;
-import ai.grakn.concept.EntityType;
-import ai.grakn.concept.RoleType;
-import ai.grakn.exception.GraknValidationException;
 import ai.grakn.util.REST;
 import ai.grakn.util.Schema;
-import org.junit.*;
+import com.jayway.restassured.http.ContentType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 import java.util.UUID;
 
@@ -158,5 +162,17 @@ public class CommitLogControllerTest {
                 flag = false;
             }
         }
+    }
+
+    @Test
+    public void testSystemKeyspaceNotSubmittingLogs() throws GraknValidationException {
+        GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, SystemKeyspace.SYSTEM_GRAPH_NAME).getGraph();
+        ResourceType<String> resourceType = graph1.putResourceType("New Resource Type", ResourceType.DataType.STRING);
+        resourceType.putResource("a");
+        resourceType.putResource("b");
+        resourceType.putResource("c");
+        graph1.commit();
+
+        assertEquals(0, cache.getResourceJobs(SystemKeyspace.SYSTEM_GRAPH_NAME).size());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/ImportControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/ImportControllerTest.java
@@ -19,7 +19,7 @@
 package ai.grakn.test.engine.controller;
 
 import ai.grakn.concept.Entity;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import ai.grakn.util.REST;
@@ -82,7 +82,7 @@ public class ImportControllerTest {
 
         waitToFinish();
 
-        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
 
         Collection<Entity> nameTags = graph.getEntityType("name_tag").instances();
         assertEquals(nameTags.size(), 10);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/ImportControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/ImportControllerTest.java
@@ -18,12 +18,12 @@
 
 package ai.grakn.test.engine.controller;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.Entity;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
-import com.jayway.restassured.response.Response;
 import ai.grakn.util.REST;
+import com.jayway.restassured.response.Response;
 import mjson.Json;
 import org.apache.commons.io.IOUtils;
 import org.junit.ClassRule;
@@ -35,8 +35,8 @@ import java.util.Collection;
 import java.util.Date;
 
 import static ai.grakn.test.engine.loader.LoaderTest.loadOntology;
-import static com.jayway.restassured.RestAssured.given;
 import static ai.grakn.util.REST.Request.KEYSPACE_PARAM;
+import static com.jayway.restassured.RestAssured.given;
 import static com.jayway.restassured.RestAssured.post;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -82,7 +82,7 @@ public class ImportControllerTest {
 
         waitToFinish();
 
-        GraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
 
         Collection<Entity> nameTags = graph.getEntityType("name_tag").instances();
         assertEquals(nameTags.size(), 10);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksLoadingControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksLoadingControllerTest.java
@@ -18,10 +18,10 @@
 
 package ai.grakn.test.engine.controller;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.concept.Entity;
 import ai.grakn.engine.loader.LoaderTask;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.graql.Pattern;
@@ -45,9 +45,8 @@ import static ai.grakn.util.REST.Request.TASK_CREATOR_PARAMETER;
 import static ai.grakn.util.REST.Request.TASK_LOADER_INSERTS;
 import static ai.grakn.util.REST.Request.TASK_RUN_AT_PARAMETER;
 import static ai.grakn.util.REST.Request.TASK_STATUS_PARAMETER;
-import static ai.grakn.util.REST.WebPath.TASKS_URI;
 import static ai.grakn.util.REST.WebPath.TASKS_SCHEDULE_URI;
-
+import static ai.grakn.util.REST.WebPath.TASKS_URI;
 import static com.jayway.restassured.RestAssured.given;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -78,7 +77,7 @@ public class TasksLoadingControllerTest {
 
         waitToFinish(taskID);
 
-        GraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
         Collection<Entity> nameTags = graph.getEntityType("name_tag").instances();
 
         assertEquals(NUMBER_TO_TEST, nameTags.size());

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksLoadingControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksLoadingControllerTest.java
@@ -20,7 +20,7 @@ package ai.grakn.test.engine.controller;
 
 import ai.grakn.concept.Entity;
 import ai.grakn.engine.loader.LoaderTask;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.InsertQuery;
@@ -77,7 +77,7 @@ public class TasksLoadingControllerTest {
 
         waitToFinish(taskID);
 
-        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
         Collection<Entity> nameTags = graph.getEntityType("name_tag").instances();
 
         assertEquals(NUMBER_TO_TEST, nameTags.size());

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
@@ -27,7 +27,7 @@ public class EngineGraknGraphFactoryTest {
     }
 
     @Test
-    public void testBatchLoading(){
+    public void testBatchLoadingGraphsInitialisedCorrectly(){
         String keyspace = "mykeyspace";
         EngineGraknGraph graph1 = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
         EngineGraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraphBatchLoading(keyspace);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
@@ -9,6 +9,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class EngineGraknGraphFactoryTest {
     @ClassRule
@@ -22,5 +24,15 @@ public class EngineGraknGraphFactoryTest {
         EngineGraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
 
         assertEquals(graph1, graph2);
+    }
+
+    @Test
+    public void testBatchLoading(){
+        String keyspace = "mykeyspace";
+        EngineGraknGraph graph1 = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraphBatchLoading(keyspace);
+
+        assertFalse(graph1.admin().isBatchLoadingEnabled());
+        assertTrue(graph2.admin().isBatchLoadingEnabled());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknGraphFactoryTest.java
@@ -2,7 +2,7 @@ package ai.grakn.test.engine.factory;
 
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
@@ -10,7 +10,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class GraphFactoryTest {
+public class EngineGraknGraphFactoryTest {
     @ClassRule
     public static final EngineContext engine = EngineContext.startServer();
 
@@ -19,7 +19,7 @@ public class GraphFactoryTest {
         String keyspace = "mykeyspace";
 
         GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
-        EngineGraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraph(keyspace);
 
         assertEquals(graph1, graph2);
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
@@ -3,6 +3,7 @@ package ai.grakn.test.engine.factory;
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -18,7 +19,7 @@ public class GraphFactoryTest {
         String keyspace = "mykeyspace";
 
         GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
-        GraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
+        EngineGraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
 
         assertEquals(graph1, graph2);
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
@@ -2,9 +2,7 @@ package ai.grakn.test.engine.factory;
 
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.ResourceType;
 import ai.grakn.factory.GraphFactory;
-import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -23,11 +21,5 @@ public class GraphFactoryTest {
         GraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
 
         assertEquals(graph1, graph2);
-    }
-
-    @Test
-    public void testSystemKeyspaceNotSubmittingLogs(){
-        GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, SystemKeyspace.SYSTEM_GRAPH_NAME).getGraph();
-        ResourceType<String> resourceType = graph1.putResourceType("New Resource Type", ResourceType.DataType.STRING);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
@@ -2,7 +2,9 @@ package ai.grakn.test.engine.factory;
 
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
+import ai.grakn.concept.ResourceType;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -21,5 +23,11 @@ public class GraphFactoryTest {
         GraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
 
         assertEquals(graph1, graph2);
+    }
+
+    @Test
+    public void testSystemKeyspaceNotSubmittingLogs(){
+        GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, SystemKeyspace.SYSTEM_GRAPH_NAME).getGraph();
+        ResourceType<String> resourceType = graph1.putResourceType("New Resource Type", ResourceType.DataType.STRING);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/GraphFactoryTest.java
@@ -1,0 +1,25 @@
+package ai.grakn.test.engine.factory;
+
+import ai.grakn.Grakn;
+import ai.grakn.GraknGraph;
+import ai.grakn.factory.GraphFactory;
+import ai.grakn.test.EngineContext;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GraphFactoryTest {
+    @ClassRule
+    public static final EngineContext engine = EngineContext.startServer();
+
+    @Test
+    public void testDifferentFactoriesReturnTheSameGraph(){
+        String keyspace = "mykeyspace";
+
+        GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, keyspace).getGraph();
+        GraknGraph graph2 = GraphFactory.getInstance().getGraph(keyspace);
+
+        assertEquals(graph1, graph2);
+    }
+}

--- a/grakn-test/src/test/java/ai/grakn/test/engine/user/UserHandlerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/user/UserHandlerTest.java
@@ -18,11 +18,11 @@
 
 package ai.grakn.test.engine.user;
 
-import ai.grakn.GraknGraph;
 import ai.grakn.engine.user.Password;
 import ai.grakn.engine.user.UsersHandler;
 import ai.grakn.factory.GraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import mjson.Json;
 import org.junit.After;
@@ -77,7 +77,7 @@ public class UserHandlerTest {
 
     @Test
     public void testUserInGraph(){
-        GraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         assertNotNull(graph.getResourceType(UsersHandler.USER_NAME).getResource(userName));
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/user/UserHandlerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/user/UserHandlerTest.java
@@ -20,7 +20,7 @@ package ai.grakn.test.engine.user;
 
 import ai.grakn.engine.user.Password;
 import ai.grakn.engine.user.UsersHandler;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
@@ -77,7 +77,7 @@ public class UserHandlerTest {
 
     @Test
     public void testUserInGraph(){
-        EngineGraknGraph graph = GraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
+        EngineGraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME);
         assertNotNull(graph.getResourceType(UsersHandler.USER_NAME).getResource(userName));
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
@@ -7,6 +7,7 @@ import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.RoleType;
 import ai.grakn.factory.GraphFactory;
+import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -115,7 +116,7 @@ public class GraphTest {
     public void testSameGraphs(){
         String key = "mykeyspace";
         GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, key).getGraph();
-        GraknGraph graph2 = GraphFactory.getInstance().getGraph(key);
+        EngineGraknGraph graph2 = GraphFactory.getInstance().getGraph(key);
         assertEquals(graph1, graph2);
         graph1.close();
         graph2.close();

--- a/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
@@ -6,7 +6,7 @@ import ai.grakn.GraknGraphFactory;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.RoleType;
-import ai.grakn.factory.GraphFactory;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.test.EngineContext;
 import org.junit.ClassRule;
@@ -116,7 +116,7 @@ public class GraphTest {
     public void testSameGraphs(){
         String key = "mykeyspace";
         GraknGraph graph1 = Grakn.factory(Grakn.DEFAULT_URI, key).getGraph();
-        EngineGraknGraph graph2 = GraphFactory.getInstance().getGraph(key);
+        EngineGraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraph(key);
         assertEquals(graph1, graph2);
         graph1.close();
         graph2.close();

--- a/grakn-titan-factory/src/main/java/ai/grakn/factory/TitanInternalFactory.java
+++ b/grakn-titan-factory/src/main/java/ai/grakn/factory/TitanInternalFactory.java
@@ -175,6 +175,7 @@ class TitanInternalFactory extends AbstractInternalFactory<GraknTitanGraph, Tita
         Arrays.stream(Schema.EdgeProperty.values()).forEach(property ->
                 makePropertyKey(management, property.name(), property.getDataType()));
     }
+
     private static void makePropertyKey(TitanManagement management, String propertyKey, Class type){
         if (management.getPropertyKey(propertyKey) == null) {
             management.makePropertyKey(propertyKey).dataType(type).make();

--- a/grakn-titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -68,9 +68,9 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
     }
 
     @Override
-    public void commitTx(){
+    public void commitTransaction(){
         try {
-            super.commitTx();
+            super.commitTransaction();
         } catch (TitanException e){
             throw new GraknBackendException(e);
         }


### PR DESCRIPTION
- Create `EngineGraknGraph` which does not submit commit logs
- Create `BaseGraknGraph` to store methods shared between `EngineGraknGraph` and `BaseGraknGraph`
- Get `GraphFactory` in engine to return a `EngineGraknGraph`