### PR TITLE
Fix bug when running tests using only a `GraphContext`

### DIFF
--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -19,6 +19,7 @@
 package ai.grakn.test;
 
 import ai.grakn.GraknGraph;
+import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.backgroundtasks.standalone.StandaloneTaskManager;
 import ai.grakn.engine.controller.CommitLogController;
 import ai.grakn.engine.util.ConfigProperties;
@@ -26,6 +27,7 @@ import ai.grakn.factory.EngineGraknGraphFactory;
 import org.junit.rules.ExternalResource;
 import spark.Spark;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static ai.grakn.engine.util.ConfigProperties.TASK_MANAGER_INSTANCE;
@@ -43,6 +45,7 @@ public class GraphContext extends ExternalResource {
     private Consumer<GraknGraph> preLoad;
     private String[] files;
 
+    private final static AtomicInteger numberActiveContexts = new AtomicInteger(0);
 
     private GraphContext(Consumer<GraknGraph> build, String[] files){
         this.preLoad = build;
@@ -81,7 +84,10 @@ public class GraphContext extends ExternalResource {
 
         //TODO remove when Bug #12029 fixed
         ConfigProperties.getInstance().setConfigProperty(TASK_MANAGER_INSTANCE, StandaloneTaskManager.class.getName());
-        new CommitLogController();
+        if (numberActiveContexts.getAndIncrement() == 0) {
+            new CommitLogController();
+            Spark.awaitInitialization();
+        }
         //TODO finish remove
 
         // create the graph
@@ -91,7 +97,9 @@ public class GraphContext extends ExternalResource {
     @Override
     protected void after() {
         closeGraph();
-        Spark.stop();
+        if (numberActiveContexts.decrementAndGet() == 0) {
+            GraknEngineServer.stopHTTP();
+        }
     }
 
     private void closeGraph(){

--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -24,6 +24,7 @@ import ai.grakn.engine.controller.CommitLogController;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import org.junit.rules.ExternalResource;
+import spark.Spark;
 
 import java.util.function.Consumer;
 
@@ -90,6 +91,7 @@ public class GraphContext extends ExternalResource {
     @Override
     protected void after() {
         closeGraph();
+        Spark.stop();
     }
 
     private void closeGraph(){

--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -20,6 +20,7 @@ package ai.grakn.test;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.backgroundtasks.standalone.StandaloneTaskManager;
+import ai.grakn.engine.controller.CommitLogController;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import org.junit.rules.ExternalResource;
@@ -29,7 +30,6 @@ import java.util.function.Consumer;
 import static ai.grakn.engine.util.ConfigProperties.TASK_MANAGER_INSTANCE;
 import static ai.grakn.graphs.TestGraph.loadFromFile;
 import static ai.grakn.test.GraknTestEnv.ensureCassandraRunning;
-import static ai.grakn.test.GraknTestEnv.ensureHTTPRunning;
 import static ai.grakn.test.GraknTestEnv.randomKeyspace;
 
 /**
@@ -41,6 +41,7 @@ public class GraphContext extends ExternalResource {
     private GraknGraph graph;
     private Consumer<GraknGraph> preLoad;
     private String[] files;
+
 
     private GraphContext(Consumer<GraknGraph> build, String[] files){
         this.preLoad = build;
@@ -79,7 +80,7 @@ public class GraphContext extends ExternalResource {
 
         //TODO remove when Bug #12029 fixed
         ConfigProperties.getInstance().setConfigProperty(TASK_MANAGER_INSTANCE, StandaloneTaskManager.class.getName());
-        ensureHTTPRunning();
+        new CommitLogController();
         //TODO finish remove
 
         // create the graph

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/CountTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/CountTest.java
@@ -24,12 +24,12 @@ import ai.grakn.concept.TypeName;
 import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.internal.analytics.GraknVertexProgram;
-import ai.grakn.test.GraphContext;
+import ai.grakn.test.EngineContext;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -39,8 +39,8 @@ import static org.junit.Assume.assumeFalse;
 
 public class CountTest {
 
-    @Rule
-    public final GraphContext rule = GraphContext.empty();
+    @ClassRule
+    public static final EngineContext rule = EngineContext.startServer();
 
     private GraknGraph graph;
 
@@ -49,7 +49,7 @@ public class CountTest {
         // TODO: Make orientdb support analytics
         assumeFalse(usingOrientDB());
 
-        graph = rule.graph();
+        graph = rule.graphWithNewKeyspace();
 
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(GraknVertexProgram.class);
         logger.setLevel(Level.DEBUG);

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
@@ -39,13 +39,13 @@ import ai.grakn.graql.analytics.MinQuery;
 import ai.grakn.graql.analytics.PathQuery;
 import ai.grakn.graql.analytics.SumQuery;
 import ai.grakn.graql.internal.analytics.GraknVertexProgram;
-import ai.grakn.test.GraphContext;
+import ai.grakn.test.EngineContext;
 import ai.grakn.util.Schema;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.Lists;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -81,15 +81,15 @@ public class GraqlTest {
     private String relationId12;
     private String relationId24;
 
-    @Rule
-    public final GraphContext context = GraphContext.empty();
+    @ClassRule
+    public static final EngineContext context = EngineContext.startServer();
 
     @Before
     public void setUp() {
         // TODO: Make orientdb support analytics
         assumeFalse(usingOrientDB());
 
-        graph = context.graph();
+        graph = context.graphWithNewKeyspace();
         qb = graph.graql();
 
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(GraknVertexProgram.class);

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ShortestPathTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ShortestPathTest.java
@@ -11,12 +11,12 @@ import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.internal.analytics.GraknVertexProgram;
-import ai.grakn.test.GraphContext;
+import ai.grakn.test.EngineContext;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.Lists;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -53,15 +53,15 @@ public class ShortestPathTest {
 
     public GraknGraph graph;
 
-    @Rule
-    public GraphContext rule = GraphContext.empty();
+    @ClassRule
+    public static EngineContext rule = EngineContext.startServer();
 
     @Before
     public void setUp() {
         // TODO: Fix tests in orientdb
         assumeFalse(usingOrientDB());
 
-        graph = rule.graph();
+        graph = rule.graphWithNewKeyspace();
 
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(GraknVertexProgram.class);
         logger.setLevel(Level.DEBUG);

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/StatisticsTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/StatisticsTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.test.graql.analytics;
 
+import ai.grakn.GraknGraph;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
@@ -29,13 +30,13 @@ import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.internal.analytics.GraknVertexProgram;
-import ai.grakn.test.GraphContext;
+import ai.grakn.test.EngineContext;
 import ai.grakn.util.Schema;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.Sets;
 import org.junit.Before;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -73,13 +74,16 @@ public class StatisticsTest {
     private ConceptId entityId3;
     private ConceptId entityId4;
 
-    @Rule
-    public GraphContext context = GraphContext.empty();
+    @ClassRule
+    public static final EngineContext context = EngineContext.startServer();
+    private GraknGraph graph;
 
     @Before
     public void setUp() {
         // TODO: Fix tests in orientdb
         assumeFalse(usingOrientDB());
+
+        graph = context.graphWithNewKeyspace();
 
         Logger logger = (Logger) org.slf4j.LoggerFactory.getLogger(GraknVertexProgram.class);
         logger.setLevel(Level.DEBUG);
@@ -95,53 +99,53 @@ public class StatisticsTest {
 
         //TODO: add more detailed error messages
         // resources-type is not set
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().max().in(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().min().in(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().mean().in(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().sum().in(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().std().in(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().median().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().max().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().min().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().mean().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().sum().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().std().in(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().median().in(thing)::execute);
 
         // if it's not a resource-type
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().max().of(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().min().of(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().mean().of(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().sum().of(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().std().of(thing)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().median().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().max().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().min().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().mean().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().sum().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().std().of(thing)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().median().of(thing)::execute);
 
         // resource-type has no instance
-        assertFalse(context.graph().graql().compute().max().of(resourceType7).execute().isPresent());
-        assertFalse(context.graph().graql().compute().min().of(resourceType7).execute().isPresent());
-        assertFalse(context.graph().graql().compute().sum().of(resourceType7).execute().isPresent());
-        assertFalse(context.graph().graql().compute().std().of(resourceType7).execute().isPresent());
-        assertFalse(context.graph().graql().compute().median().of(resourceType7).execute().isPresent());
-        assertFalse(context.graph().graql().compute().mean().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().max().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().min().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().sum().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().std().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().median().of(resourceType7).execute().isPresent());
+        assertFalse(graph.graql().compute().mean().of(resourceType7).execute().isPresent());
 
         // resources are not connected to any entities
-        assertFalse(context.graph().graql().compute().max().of(resourceType3).execute().isPresent());
-        assertFalse(context.graph().graql().compute().min().of(resourceType3).execute().isPresent());
-        assertFalse(context.graph().graql().compute().sum().of(resourceType3).execute().isPresent());
-        assertFalse(context.graph().graql().compute().std().of(resourceType3).execute().isPresent());
-        assertFalse(context.graph().graql().compute().median().of(resourceType3).execute().isPresent());
-        assertFalse(context.graph().graql().compute().mean().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().max().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().min().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().sum().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().std().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().median().of(resourceType3).execute().isPresent());
+        assertFalse(graph.graql().compute().mean().of(resourceType3).execute().isPresent());
 
         // resource-type has incorrect data type
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().max().of(resourceType4)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().min().of(resourceType4)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().mean().of(resourceType4)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().sum().of(resourceType4)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().std().of(resourceType4)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().median().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().max().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().min().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().mean().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().sum().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().std().of(resourceType4)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().median().of(resourceType4)::execute);
 
         // resource-types have different data types
         Set<TypeName> resourceTypes = Sets.newHashSet(TypeName.of(resourceType1), TypeName.of(resourceType2));
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().max().of(resourceTypes)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().min().of(resourceTypes)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().mean().of(resourceTypes)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().sum().of(resourceTypes)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().std().of(resourceTypes)::execute);
-        assertIllegalStateExceptionThrown(context.graph().graql().compute().median().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().max().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().min().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().mean().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().sum().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().std().of(resourceTypes)::execute);
+        assertIllegalStateExceptionThrown(graph.graql().compute().median().of(resourceTypes)::execute);
     }
 
     private void assertIllegalStateExceptionThrown(Supplier<Optional> method) {
@@ -164,82 +168,82 @@ public class StatisticsTest {
         // resource-type has no instance
         addOntologyAndEntities();
 
-        result = Graql.compute().min().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().min().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().min().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().min().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).min().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).min().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().min().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().min().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().min().of(resourceType2).execute();
+        result = graph.graql().compute().min().of(resourceType2).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().min().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().min().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().min().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().min().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).min().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).min().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
-        result = Graql.compute().max().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().max().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().max().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().max().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).max().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).max().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().max().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().max().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().max().of(resourceType2).in(Collections.emptyList()).execute();
+        result = graph.graql().compute().max().of(resourceType2).in(Collections.emptyList()).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().max().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().max().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().max().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().max().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).max().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).max().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
         // add resources, but resources are not connected to any entities
         addResourcesInstances();
 
-        result = Graql.compute().min().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().min().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().min().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().min().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().min().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().min().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().min().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().min().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
-        result = Graql.compute().max().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().max().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().max().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().max().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().max().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().max().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().max().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().max().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
         // connect entity and resources
         addResourceRelations();
 
-        result = context.graph().graql().compute().min().of(resourceType1).in(Collections.emptySet()).execute();
+        result = graph.graql().compute().min().of(resourceType1).in(Collections.emptySet()).execute();
         assertEquals(1.2, result.get().doubleValue(), delta);
-        result = Graql.compute().min().in(thing).of(resourceType2).withGraph(context.graph()).execute();
+        result = Graql.compute().min().in(thing).of(resourceType2).withGraph(graph).execute();
         assertEquals(-1L, result.get());
-        result = context.graph().graql().compute().min().in(thing).of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().min().in(thing).of(resourceType2, resourceType5).execute();
         assertEquals(-7L, result.get());
-        result = context.graph().graql().compute().min().in(thing, thing, thing).of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().min().in(thing, thing, thing).of(resourceType2, resourceType5).execute();
         assertEquals(-7L, result.get());
 
-        result = Graql.compute().max().in().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().max().in().withGraph(graph).of(resourceType1).execute();
         assertEquals(1.8, result.get().doubleValue(), delta);
-        result = context.graph().graql().compute().max().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().max().of(resourceType1, resourceType6).execute();
         assertEquals(7.5, result.get().doubleValue(), delta);
-        result = context.graph().graql().compute().max().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().max().of(resourceType1, resourceType6).execute();
         assertEquals(7.5, result.get().doubleValue(), delta);
 
         // TODO: fix this test: we need to check the type of the resource owner, not just the type or relation
-        result = context.graph().graql().compute().max().in(anotherThing).of(resourceType2).execute();
+        result = graph.graql().compute().max().in(anotherThing).of(resourceType2).execute();
         assertEquals(4L, result.get());
     }
 
@@ -253,45 +257,45 @@ public class StatisticsTest {
         // resource-type has no instance
         addOntologyAndEntities();
 
-        result = Graql.compute().sum().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().sum().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).sum().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).sum().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().sum().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().sum().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().sum().of(resourceType2).execute();
+        result = graph.graql().compute().sum().of(resourceType2).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().sum().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().sum().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().sum().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().sum().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).sum().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).sum().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
         // add resources, but resources are not connected to any entities
         addResourcesInstances();
 
-        result = Graql.compute().sum().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().sum().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().sum().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().sum().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().sum().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().sum().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
         // connect entity and resources
         addResourceRelations();
 
-        result = Graql.compute().sum().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType1).withGraph(graph).execute();
         assertEquals(4.5, result.get().doubleValue(), delta);
-        result = Graql.compute().sum().of(resourceType2).in(thing).withGraph(context.graph()).execute();
+        result = Graql.compute().sum().of(resourceType2).in(thing).withGraph(graph).execute();
         assertEquals(3L, result.get());
-        result = context.graph().graql().compute().sum().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().sum().of(resourceType1, resourceType6).execute();
         assertEquals(27.0, result.get().doubleValue(), delta);
-        result = context.graph().graql().compute().sum().of(resourceType2, resourceType5).in(thing, anotherThing).execute();
+        result = graph.graql().compute().sum().of(resourceType2, resourceType5).in(thing, anotherThing).execute();
         assertEquals(-18L, result.get());
     }
 
@@ -305,45 +309,45 @@ public class StatisticsTest {
         // resource-type has no instance
         addOntologyAndEntities();
 
-        result = Graql.compute().mean().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().mean().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().mean().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().mean().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).mean().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).mean().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().mean().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().mean().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().mean().of(resourceType2).execute();
+        result = graph.graql().compute().mean().of(resourceType2).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().mean().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().mean().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().mean().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().mean().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).mean().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).mean().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
         // add resources, but resources are not connected to any entities
         addResourcesInstances();
 
-        result = Graql.compute().mean().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().mean().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().mean().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().mean().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().mean().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().mean().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().mean().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().mean().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
         // connect entity and resources
         addResourceRelations();
 
-        result = Graql.compute().withGraph(context.graph()).mean().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).mean().of(resourceType1).execute();
         assertEquals(1.5, result.get(), delta);
-        result = Graql.compute().mean().in(thing).of(resourceType2).withGraph(context.graph()).execute();
+        result = Graql.compute().mean().in(thing).of(resourceType2).withGraph(graph).execute();
         assertEquals(1D, result.get(), delta);
-        result = context.graph().graql().compute().mean().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().mean().of(resourceType1, resourceType6).execute();
         assertEquals(4.5, result.get(), delta);
-        result = context.graph().graql().compute().mean().in(anotherThing).of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().mean().in(anotherThing).of(resourceType2, resourceType5).execute();
         assertEquals(-3D, result.get(), delta);
     }
 
@@ -357,45 +361,45 @@ public class StatisticsTest {
         // resource-type has no instance
         addOntologyAndEntities();
 
-        result = Graql.compute().std().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().std().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().std().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().std().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).std().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).std().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().std().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().std().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().std().of(resourceType2).execute();
+        result = graph.graql().compute().std().of(resourceType2).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().std().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().std().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().std().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().std().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).std().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).std().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
         // add resources, but resources are not connected to any entities
         addResourcesInstances();
 
-        result = Graql.compute().std().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().std().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().std().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().std().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().std().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().std().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().std().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().std().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
         // connect entity and resources
         addResourceRelations();
 
-        result = Graql.compute().std().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().std().of(resourceType1).withGraph(graph).execute();
         assertEquals(Math.sqrt(0.18 / 3), result.get(), delta);
-        result = Graql.compute().std().of(resourceType2).withGraph(context.graph()).in(thing).execute();
+        result = Graql.compute().std().of(resourceType2).withGraph(graph).in(thing).execute();
         assertEquals(Math.sqrt(14.0 / 3), result.get(), delta);
-        result = context.graph().graql().compute().std().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().std().of(resourceType1, resourceType6).execute();
         assertEquals(Math.sqrt(54.18 / 6), result.get(), delta);
-        result = context.graph().graql().compute().std().of(resourceType2, resourceType5).in(thing, anotherThing).execute();
+        result = graph.graql().compute().std().of(resourceType2, resourceType5).in(thing, anotherThing).execute();
         assertEquals(Math.sqrt(110.0 / 6), result.get(), delta);
     }
 
@@ -409,55 +413,55 @@ public class StatisticsTest {
         // resource-type has no instance
         addOntologyAndEntities();
 
-        result = Graql.compute().median().of(resourceType1).in(Collections.emptyList()).withGraph(context.graph()).execute();
+        result = Graql.compute().median().of(resourceType1).in(Collections.emptyList()).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().median().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().median().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().withGraph(context.graph()).median().of(resourceType1).execute();
+        result = Graql.compute().withGraph(graph).median().of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().median().withGraph(context.graph()).of(resourceType1).execute();
+        result = Graql.compute().median().withGraph(graph).of(resourceType1).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().median().of(resourceType2).execute();
+        result = graph.graql().compute().median().of(resourceType2).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().median().of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().median().of(resourceType2, resourceType5).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().median().of(resourceType2).withGraph(context.graph()).execute();
+        result = graph.graql().compute().median().of(resourceType2).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().withGraph(context.graph()).median().of(resourceType2).execute();
+        result = graph.graql().compute().withGraph(graph).median().of(resourceType2).execute();
         assertFalse(result.isPresent());
 
         // add resources, but resources are not connected to any entities
         addResourcesInstances();
 
-        result = Graql.compute().median().of(resourceType1).withGraph(context.graph()).execute();
+        result = Graql.compute().median().of(resourceType1).withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().median().of(resourceType1).in().withGraph(context.graph()).execute();
+        result = Graql.compute().median().of(resourceType1).in().withGraph(graph).execute();
         assertFalse(result.isPresent());
-        result = context.graph().graql().compute().median().of(resourceType2).in(thing, anotherThing).execute();
+        result = graph.graql().compute().median().of(resourceType2).in(thing, anotherThing).execute();
         assertFalse(result.isPresent());
-        result = Graql.compute().median().of(resourceType2).withGraph(context.graph()).in(anotherThing).execute();
+        result = Graql.compute().median().of(resourceType2).withGraph(graph).in(anotherThing).execute();
         assertFalse(result.isPresent());
 
         // connect entity and resources
         addResourceRelations();
 
-        result = context.graph().graql().compute().median().of(resourceType1).in().execute();
+        result = graph.graql().compute().median().of(resourceType1).in().execute();
         assertEquals(1.5D, result.get().doubleValue(), delta);
-        result = Graql.compute().withGraph(context.graph()).median().of(resourceType6).execute();
+        result = Graql.compute().withGraph(graph).median().of(resourceType6).execute();
         assertEquals(7.5D, result.get().doubleValue(), delta);
-        result = context.graph().graql().compute().median().of(resourceType1, resourceType6).execute();
+        result = graph.graql().compute().median().of(resourceType1, resourceType6).execute();
         assertEquals(1.8D, result.get().doubleValue(), delta);
-        result = Graql.compute().withGraph(context.graph()).median().of(resourceType2).execute();
+        result = Graql.compute().withGraph(graph).median().of(resourceType2).execute();
         assertEquals(0L, result.get().longValue());
-        result = Graql.compute().withGraph(context.graph()).median().in(thing).of(resourceType5).execute();
+        result = Graql.compute().withGraph(graph).median().in(thing).of(resourceType5).execute();
         assertEquals(-7L, result.get().longValue());
-        result = context.graph().graql().compute().median().in(thing, anotherThing).of(resourceType2, resourceType5).execute();
+        result = graph.graql().compute().median().in(thing, anotherThing).of(resourceType2, resourceType5).execute();
         assertEquals(-7L, result.get().longValue());
     }
 
     private void addOntologyAndEntities() throws GraknValidationException {
-        EntityType entityType1 = context.graph().putEntityType(thing);
-        EntityType entityType2 = context.graph().putEntityType(anotherThing);
+        EntityType entityType1 = graph.putEntityType(thing);
+        EntityType entityType2 = graph.putEntityType(anotherThing);
 
         Entity entity1 = entityType1.addEntity();
         Entity entity2 = entityType1.addEntity();
@@ -468,11 +472,11 @@ public class StatisticsTest {
         entityId3 = entity3.getId();
         entityId4 = entity4.getId();
 
-        RoleType relation1 = context.graph().putRoleType("relation1");
-        RoleType relation2 = context.graph().putRoleType("relation2");
+        RoleType relation1 = graph.putRoleType("relation1");
+        RoleType relation2 = graph.putRoleType("relation2");
         entityType1.playsRole(relation1).playsRole(relation2);
         entityType2.playsRole(relation1).playsRole(relation2);
-        RelationType related = context.graph().putRelationType("related").hasRole(relation1).hasRole(relation2);
+        RelationType related = graph.putRelationType("related").hasRole(relation1).hasRole(relation2);
 
         related.addRelation()
                 .putRolePlayer(relation1, entity1)
@@ -485,43 +489,43 @@ public class StatisticsTest {
                 .putRolePlayer(relation2, entity4);
 
         List<ResourceType> resourceTypeList = new ArrayList<>();
-        resourceTypeList.add(context.graph().putResourceType(resourceType1, ResourceType.DataType.DOUBLE));
-        resourceTypeList.add(context.graph().putResourceType(resourceType2, ResourceType.DataType.LONG));
-        resourceTypeList.add(context.graph().putResourceType(resourceType3, ResourceType.DataType.LONG));
-        resourceTypeList.add(context.graph().putResourceType(resourceType4, ResourceType.DataType.STRING));
-        resourceTypeList.add(context.graph().putResourceType(resourceType5, ResourceType.DataType.LONG));
-        resourceTypeList.add(context.graph().putResourceType(resourceType6, ResourceType.DataType.DOUBLE));
-        resourceTypeList.add(context.graph().putResourceType(resourceType7, ResourceType.DataType.DOUBLE));
+        resourceTypeList.add(graph.putResourceType(resourceType1, ResourceType.DataType.DOUBLE));
+        resourceTypeList.add(graph.putResourceType(resourceType2, ResourceType.DataType.LONG));
+        resourceTypeList.add(graph.putResourceType(resourceType3, ResourceType.DataType.LONG));
+        resourceTypeList.add(graph.putResourceType(resourceType4, ResourceType.DataType.STRING));
+        resourceTypeList.add(graph.putResourceType(resourceType5, ResourceType.DataType.LONG));
+        resourceTypeList.add(graph.putResourceType(resourceType6, ResourceType.DataType.DOUBLE));
+        resourceTypeList.add(graph.putResourceType(resourceType7, ResourceType.DataType.DOUBLE));
 
-        RoleType resourceOwner1 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType1)));
-        RoleType resourceOwner2 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType2)));
-        RoleType resourceOwner3 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType3)));
-        RoleType resourceOwner4 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType4)));
-        RoleType resourceOwner5 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType5)));
-        RoleType resourceOwner6 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType6)));
-        RoleType resourceOwner7 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType7)));
+        RoleType resourceOwner1 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType1)));
+        RoleType resourceOwner2 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType2)));
+        RoleType resourceOwner3 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType3)));
+        RoleType resourceOwner4 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType4)));
+        RoleType resourceOwner5 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType5)));
+        RoleType resourceOwner6 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType6)));
+        RoleType resourceOwner7 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType7)));
 
-        RoleType resourceValue1 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType1)));
-        RoleType resourceValue2 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType2)));
-        RoleType resourceValue3 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType3)));
-        RoleType resourceValue4 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType4)));
-        RoleType resourceValue5 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType5)));
-        RoleType resourceValue6 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType6)));
-        RoleType resourceValue7 = context.graph().putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType7)));
+        RoleType resourceValue1 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType1)));
+        RoleType resourceValue2 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType2)));
+        RoleType resourceValue3 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType3)));
+        RoleType resourceValue4 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType4)));
+        RoleType resourceValue5 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType5)));
+        RoleType resourceValue6 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType6)));
+        RoleType resourceValue7 = graph.putRoleType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType7)));
 
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType1)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType1)))
                 .hasRole(resourceOwner1).hasRole(resourceValue1);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType2)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType2)))
                 .hasRole(resourceOwner2).hasRole(resourceValue2);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType3)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType3)))
                 .hasRole(resourceOwner3).hasRole(resourceValue3);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType4)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType4)))
                 .hasRole(resourceOwner4).hasRole(resourceValue4);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType5)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType5)))
                 .hasRole(resourceOwner5).hasRole(resourceValue5);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType6)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType6)))
                 .hasRole(resourceOwner6).hasRole(resourceValue6);
-        context.graph().putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType7)))
+        graph.putRelationType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType7)))
                 .hasRole(resourceOwner7).hasRole(resourceValue7);
 
         entityType1.playsRole(resourceOwner1)
@@ -548,105 +552,105 @@ public class StatisticsTest {
                 .playsRole(resourceValue6)
                 .playsRole(resourceValue7));
 
-        context.graph().commit();
+        graph.commit();
     }
 
     private void addResourcesInstances() throws GraknValidationException {
-        context.graph().<Double>getResourceType(resourceType1).putResource(1.2);
-        context.graph().<Double>getResourceType(resourceType1).putResource(1.5);
-        context.graph().<Double>getResourceType(resourceType1).putResource(1.8);
+        graph.<Double>getResourceType(resourceType1).putResource(1.2);
+        graph.<Double>getResourceType(resourceType1).putResource(1.5);
+        graph.<Double>getResourceType(resourceType1).putResource(1.8);
 
-        context.graph().<Long>getResourceType(resourceType2).putResource(4L);
-        context.graph().<Long>getResourceType(resourceType2).putResource(-1L);
-        context.graph().<Long>getResourceType(resourceType2).putResource(0L);
+        graph.<Long>getResourceType(resourceType2).putResource(4L);
+        graph.<Long>getResourceType(resourceType2).putResource(-1L);
+        graph.<Long>getResourceType(resourceType2).putResource(0L);
 
-        context.graph().<Long>getResourceType(resourceType5).putResource(6L);
-        context.graph().<Long>getResourceType(resourceType5).putResource(7L);
-        context.graph().<Long>getResourceType(resourceType5).putResource(8L);
+        graph.<Long>getResourceType(resourceType5).putResource(6L);
+        graph.<Long>getResourceType(resourceType5).putResource(7L);
+        graph.<Long>getResourceType(resourceType5).putResource(8L);
 
-        context.graph().<Double>getResourceType(resourceType6).putResource(7.2);
-        context.graph().<Double>getResourceType(resourceType6).putResource(7.5);
-        context.graph().<Double>getResourceType(resourceType6).putResource(7.8);
+        graph.<Double>getResourceType(resourceType6).putResource(7.2);
+        graph.<Double>getResourceType(resourceType6).putResource(7.5);
+        graph.<Double>getResourceType(resourceType6).putResource(7.8);
 
-        context.graph().<String>getResourceType(resourceType4).putResource("a");
-        context.graph().<String>getResourceType(resourceType4).putResource("b");
-        context.graph().<String>getResourceType(resourceType4).putResource("c");
+        graph.<String>getResourceType(resourceType4).putResource("a");
+        graph.<String>getResourceType(resourceType4).putResource("b");
+        graph.<String>getResourceType(resourceType4).putResource("c");
 
-        context.graph().commit();
+        graph.commit();
     }
 
     private void addResourceRelations() throws GraknValidationException {
-        Entity entity1 = context.graph().getConcept(entityId1);
-        Entity entity2 = context.graph().getConcept(entityId2);
-        Entity entity3 = context.graph().getConcept(entityId3);
-        Entity entity4 = context.graph().getConcept(entityId4);
+        Entity entity1 = graph.getConcept(entityId1);
+        Entity entity2 = graph.getConcept(entityId2);
+        Entity entity3 = graph.getConcept(entityId3);
+        Entity entity4 = graph.getConcept(entityId4);
 
-        RoleType resourceOwner1 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType1)));
-        RoleType resourceOwner2 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType2)));
-        RoleType resourceOwner3 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType3)));
-        RoleType resourceOwner4 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType4)));
-        RoleType resourceOwner5 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType5)));
-        RoleType resourceOwner6 = context.graph().getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType6)));
+        RoleType resourceOwner1 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType1)));
+        RoleType resourceOwner2 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType2)));
+        RoleType resourceOwner3 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType3)));
+        RoleType resourceOwner4 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType4)));
+        RoleType resourceOwner5 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType5)));
+        RoleType resourceOwner6 = graph.getType(Schema.Resource.HAS_RESOURCE_OWNER.getName(TypeName.of(resourceType6)));
 
-        RoleType resourceValue1 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType1)));
-        RoleType resourceValue2 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType2)));
-        RoleType resourceValue3 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType3)));
-        RoleType resourceValue4 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType4)));
-        RoleType resourceValue5 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType5)));
-        RoleType resourceValue6 = context.graph().getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType6)));
+        RoleType resourceValue1 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType1)));
+        RoleType resourceValue2 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType2)));
+        RoleType resourceValue3 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType3)));
+        RoleType resourceValue4 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType4)));
+        RoleType resourceValue5 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType5)));
+        RoleType resourceValue6 = graph.getType(Schema.Resource.HAS_RESOURCE_VALUE.getName(TypeName.of(resourceType6)));
 
-        RelationType relationType1 = context.graph().getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType1)));
+        RelationType relationType1 = graph.getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType1)));
         relationType1.addRelation()
                 .putRolePlayer(resourceOwner1, entity1)
-                .putRolePlayer(resourceValue1, context.graph().<Double>getResourceType(resourceType1).putResource(1.2));
+                .putRolePlayer(resourceValue1, graph.<Double>getResourceType(resourceType1).putResource(1.2));
         relationType1.addRelation()
                 .putRolePlayer(resourceOwner1, entity1)
-                .putRolePlayer(resourceValue1, context.graph().<Double>getResourceType(resourceType1).putResource(1.5));
+                .putRolePlayer(resourceValue1, graph.<Double>getResourceType(resourceType1).putResource(1.5));
         relationType1.addRelation()
                 .putRolePlayer(resourceOwner1, entity3)
-                .putRolePlayer(resourceValue1, context.graph().<Double>getResourceType(resourceType1).putResource(1.8));
+                .putRolePlayer(resourceValue1, graph.<Double>getResourceType(resourceType1).putResource(1.8));
 
-        RelationType relationType2 = context.graph().getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType2)));
+        RelationType relationType2 = graph.getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType2)));
         relationType2.addRelation()
                 .putRolePlayer(resourceOwner2, entity1)
-                .putRolePlayer(resourceValue2, context.graph().<Long>getResourceType(resourceType2).putResource(4L));
+                .putRolePlayer(resourceValue2, graph.<Long>getResourceType(resourceType2).putResource(4L));
         relationType2.addRelation()
                 .putRolePlayer(resourceOwner2, entity1)
-                .putRolePlayer(resourceValue2, context.graph().<Long>getResourceType(resourceType2).putResource(-1L));
+                .putRolePlayer(resourceValue2, graph.<Long>getResourceType(resourceType2).putResource(-1L));
         relationType2.addRelation()
                 .putRolePlayer(resourceOwner2, entity4)
-                .putRolePlayer(resourceValue2, context.graph().<Long>getResourceType(resourceType2).putResource(0L));
+                .putRolePlayer(resourceValue2, graph.<Long>getResourceType(resourceType2).putResource(0L));
 
-        context.graph().<Long>getResourceType(resourceType3).putResource(100L);
+        graph.<Long>getResourceType(resourceType3).putResource(100L);
 
-        RelationType relationType5 = context.graph().getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType5)));
+        RelationType relationType5 = graph.getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType5)));
         relationType5.addRelation()
                 .putRolePlayer(resourceOwner5, entity1)
-                .putRolePlayer(resourceValue5, context.graph().<Long>getResourceType(resourceType5).putResource(-7L));
+                .putRolePlayer(resourceValue5, graph.<Long>getResourceType(resourceType5).putResource(-7L));
         relationType5.addRelation()
                 .putRolePlayer(resourceOwner5, entity2)
-                .putRolePlayer(resourceValue5, context.graph().<Long>getResourceType(resourceType5).putResource(-7L));
+                .putRolePlayer(resourceValue5, graph.<Long>getResourceType(resourceType5).putResource(-7L));
         relationType5.addRelation()
                 .putRolePlayer(resourceOwner5, entity4)
-                .putRolePlayer(resourceValue5, context.graph().<Long>getResourceType(resourceType5).putResource(-7L));
+                .putRolePlayer(resourceValue5, graph.<Long>getResourceType(resourceType5).putResource(-7L));
 
-        RelationType relationType6 = context.graph().getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType6)));
+        RelationType relationType6 = graph.getType(Schema.Resource.HAS_RESOURCE.getName(TypeName.of(resourceType6)));
         relationType6.addRelation()
                 .putRolePlayer(resourceOwner6, entity1)
-                .putRolePlayer(resourceValue6, context.graph().<Double>getResourceType(resourceType6).putResource(7.5));
+                .putRolePlayer(resourceValue6, graph.<Double>getResourceType(resourceType6).putResource(7.5));
         relationType6.addRelation()
                 .putRolePlayer(resourceOwner6, entity2)
-                .putRolePlayer(resourceValue6, context.graph().<Double>getResourceType(resourceType6).putResource(7.5));
+                .putRolePlayer(resourceValue6, graph.<Double>getResourceType(resourceType6).putResource(7.5));
         relationType6.addRelation()
                 .putRolePlayer(resourceOwner6, entity4)
-                .putRolePlayer(resourceValue6, context.graph().<Double>getResourceType(resourceType6).putResource(7.5));
+                .putRolePlayer(resourceValue6, graph.<Double>getResourceType(resourceType6).putResource(7.5));
 
         // some resources in, but not connect them to any instances
-        context.graph().<Double>getResourceType(resourceType1).putResource(2.8);
-        context.graph().<Long>getResourceType(resourceType2).putResource(-5L);
-        context.graph().<Long>getResourceType(resourceType5).putResource(10L);
-        context.graph().<Double>getResourceType(resourceType6).putResource(0.8);
+        graph.<Double>getResourceType(resourceType1).putResource(2.8);
+        graph.<Long>getResourceType(resourceType2).putResource(-5L);
+        graph.<Long>getResourceType(resourceType5).putResource(10L);
+        graph.<Double>getResourceType(resourceType6).putResource(0.8);
 
-        context.graph().commit();
+        graph.commit();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
@@ -18,13 +18,13 @@
 
 package ai.grakn.test.graql.query;
 
-import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graphs.MovieGraph;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.QueryBuilder;
@@ -782,7 +782,7 @@ public class MatchQueryTest {
 
         assertThat(types, allOf(hasItem("movie"), not(hasItem("has-title"))));
 
-        GraknGraph graph2 = Grakn.factory(Grakn.DEFAULT_URI, movieGraph.graph().getKeyspace()).getGraph();
+        GraknGraph graph2 = (GraknGraph) EngineGraknGraphFactory.getInstance().getGraph(movieGraph.graph().getKeyspace());
         Set<String> typesAgain = graph2.graql().match(var("x").sub("concept")).get("x").map(type -> type.asType().getName().getValue()).collect(toSet());
 
         assertEquals(types, typesAgain);

--- a/grakn-test/src/test/java/ai/grakn/test/migration/export/GraphWriterMainTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/export/GraphWriterMainTest.java
@@ -18,26 +18,35 @@
 
 package ai.grakn.test.migration.export;
 
-import ai.grakn.graphs.MovieGraph;
+import ai.grakn.GraknGraph;
+import ai.grakn.example.MovieGraphFactory;
 import ai.grakn.migration.export.Main;
-
-import ai.grakn.test.GraphContext;
+import ai.grakn.test.EngineContext;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 public class GraphWriterMainTest {
 
     @ClassRule
-    public static final GraphContext movieContext = GraphContext.preLoad(MovieGraph.get());
+    public static final EngineContext engineContext = EngineContext.startServer();
+
+    private static GraknGraph graph;
+
+    @BeforeClass
+    public static void loadMovieGraph() {
+        graph =  engineContext.graphWithNewKeyspace();
+        MovieGraphFactory.loadGraph(graph);
+    }
 
     @Test
     public void exportOntologyToSystemOutTest(){
-        runAndAssertDataCorrect("export", "-ontology", "-keyspace", movieContext.graph().getKeyspace());
+        runAndAssertDataCorrect("export", "-ontology", "-keyspace", graph.getKeyspace());
     }
 
     @Test
     public void exportDataToSystemOutTest(){
-        runAndAssertDataCorrect("export", "-data", "-keyspace", movieContext.graph().getKeyspace());
+        runAndAssertDataCorrect("export", "-data", "-keyspace", graph.getKeyspace());
     }
     
     @Test
@@ -52,7 +61,7 @@ public class GraphWriterMainTest {
 
     @Test
     public void exportEngineURLProvidedTest(){
-        runAndAssertDataCorrect("export", "-data", "-uri", "localhost:4567", "-keyspace", movieContext.graph().getKeyspace());
+        runAndAssertDataCorrect("export", "-data", "-uri", "localhost:4567", "-keyspace", graph.getKeyspace());
     }
 
     private void runAndAssertDataCorrect(String... args){


### PR DESCRIPTION
This bug meant that tests that used `GraphContext` implicitly depended on a cluster running with Zookeeper and Kafka.