### PR TITLE
Run parallel tests in docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM graknlabs/jenkins-base
+
+ENV WORKSPACE $WORKSPACE
+COPY . /grakn-src/
+WORKDIR /grakn-src/
+RUN mvn install -T 2.0C -DskipTests=True -DskipITs=True -Dmaven.javadoc.skip=true -U

--- a/grakn-test-profiles/pom.xml
+++ b/grakn-test-profiles/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <grakn.test-profile>tinker</grakn.test-profile>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <docker-tests>true</docker-tests>
     </properties>
 
     <build>
@@ -100,6 +101,37 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
+        </profile>
+
+        <profile>
+            <id>docker</id>
+            <properties>
+                <docker-tests>false</docker-tests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <configuration>
+                          <excludes>
+                            <exclude>**/**</exclude>
+                          </excludes>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>2.19.1</version>
+                        <configuration>
+                          <excludes>
+                            <exclude>**/**</exclude>
+                          </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
 
         <profile>

--- a/grakn-test/bin/run_test_in_docker.sh
+++ b/grakn-test/bin/run_test_in_docker.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Requires the test profile as argument, ie. tinker, titan
+
+if [[ -z "$1" ]]; then
+  echo Test profile required. eg. tinker/titan
+  exit 1
+fi  
+
+SCRIPT_DIR=$(dirname $0)
+GRAKN_TEST_PROFILE=$1
+
+# Find all tests in grakn-test
+find "$SCRIPT_DIR"/../../grakn-test/ -name '*Test.java' -o -name '*IT.java' | xargs --no-run-if-empty -n1 basename | sed -e 's/\.java//' > /tmp/grakn_mvn_docker_test_list
+
+# Run parallel at '75% core capacity'
+# Mount volume so tests results are output in surefire-reports
+# Picks a tests from the list above and starts container to run test within grakn-test project
+
+parallel --jobs 75% \
+  --no-run-if-empty \
+  "/usr/bin/docker run -i \
+  -v "$SCRIPT_DIR"/../../grakn-test/target/surefire-reports:/grakn-src/grakn-test/target/surefire-reports/ \
+  -w /grakn-src/ graknlabs/jenkins-with-src-compiled:latest \
+  mvn test -DfailIfNoTests=false \
+  -Dtest={} \
+  -P"${GRAKN_TEST_PROFILE}" \
+  -pl grakn-test" \
+  < /tmp/grakn_mvn_docker_test_list

--- a/grakn-test/build-jenkins-base.sh
+++ b/grakn-test/build-jenkins-base.sh
@@ -1,0 +1,1 @@
+docker build -f ./jenkins-base.dockerfile -t graknlabs/jenkins-base . 

--- a/grakn-test/jenkins-base.dockerfile
+++ b/grakn-test/jenkins-base.dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+RUN locale-gen en_GB.UTF-8
+ENV LANG en_GB.UTF-8
+RUN apt-get update
+RUN apt-get install -y software-properties-common debconf-utils curl
+RUN add-apt-repository ppa:webupd8team/java
+RUN apt-get update
+RUN echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
+RUN echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections
+RUN apt-get install -y lsof maven oracle-java8-installer
+
+RUN curl -sL https://deb.nodesource.com/setup_6.x -o nodesource_setup.sh && \
+    bash nodesource_setup.sh && \
+    apt-get install -u nodejs
+
+COPY .m2 /root/.m2/
+
+RUN rm -rf /var/lib/apt/lists/* && \
+    rm -rf /var/cache/oracle-jdk8-installer
+
+CMD ["bash"]

--- a/grakn-test/pom.xml
+++ b/grakn-test/pom.xml
@@ -31,6 +31,9 @@
     <artifactId>grakn-test</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <jenkins.docker-test.reportsDirectory>${project.basedir}/target/surefire-reports</jenkins.docker-test.reportsDirectory>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -195,4 +198,48 @@
                 </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <skip>${docker-tests}</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>docker-image-with-src-compiled</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <executable>/usr/bin/docker</executable>
+                            <arguments>
+                                <argument>build</argument>
+                                <argument>-t</argument>
+                                <argument>graknlabs/jenkins-with-src-compiled:latest</argument>
+                                <argument>${project.basedir}/../</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>docker-test</id>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <executable>${project.basedir}/bin/run_test_in_docker.sh</executable>
+                            <arguments>
+                                <argument>${grakn.test-profile}</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Activate with: mvn -Pdocker

Requires a jenkins slave with:
- docker-engine installed
- graknlabs/jenkins-base image pre-built (files in grakn-test)
- gnu parallel

'docker' profile:
- disables unit and IT tests in grakn-test module so they are run only
in containers
- builds graknlabs/jenkins-with-src-compiled which has Grakn packaged
and installed into ~/.m2/
- runs test within a separate docker container and outputs results into
grakn-test/target/surefire-reports
- number of parallel containers is 75% of cores