### PR TITLE
BUG - migrator hangs on timeout exception

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStatus.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStatus.java
@@ -40,7 +40,7 @@ public enum TaskStatus {
      * The task has been stopped on request.
      */
     STOPPED,
-    currentStatus, /**
+    /**
      * The task has failed to execute.
      */
     FAILED

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStatus.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStatus.java
@@ -40,7 +40,7 @@ public enum TaskStatus {
      * The task has been stopped on request.
      */
     STOPPED,
-    /**
+    currentStatus, /**
      * The task has failed to execute.
      */
     FAILED

--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
@@ -24,7 +24,6 @@ import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.util.ErrorMessage;
-import com.google.common.collect.Lists;
 import javafx.util.Pair;
 import org.json.JSONObject;
 import org.slf4j.Logger;

--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
@@ -24,15 +24,19 @@ import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.util.ErrorMessage;
+import com.google.common.collect.Lists;
 import javafx.util.Pair;
 import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 
@@ -157,6 +161,22 @@ public class Loader {
         return false;
     }
 
+    private Map<TaskStatus,Integer> countTasks(Collection<String> tasks) {
+        Map<TaskStatus, Integer> taskCounter = getTaskCounter();
+
+        tasks.stream().map(manager::getState).forEach(state -> {
+            taskCounter.computeIfPresent(state, (key, value) -> ++value);
+        });
+
+        return taskCounter;
+    }
+
+    private Map<TaskStatus,Integer> getTaskCounter() {
+        Map<TaskStatus,Integer> taskCounter = new HashMap<>();
+        Arrays.asList(TaskStatus.values()).forEach(key -> taskCounter.put(key,0));
+        return taskCounter;
+    }
+
     /**
      * Wait for all tasks to finish.
      * @param timeout amount of time (in ms) to wait.
@@ -164,12 +184,24 @@ public class Loader {
     public void waitToFinish(int timeout){
         flush();
 
-        final long initial = new Date().getTime();
         Collection<String> currentTasks = getTasks();
-        while ((new Date().getTime())-initial < timeout) {
+        Map<TaskStatus,Integer> currentTaskCounter = countTasks(currentTasks);
+        Map<TaskStatus, Integer> previousTaskCounter;
+        long timestamp = 0L;
+        while (true) {
             if(allTasksFinished(currentTasks)) {
                 printLoaderState();
                 return;
+            }
+
+            previousTaskCounter = currentTaskCounter;
+            currentTaskCounter = countTasks(currentTasks);
+            if (currentTaskCounter.equals(previousTaskCounter) && timestamp==0L) {
+                timestamp = new Date().getTime();
+            } else if (!currentTaskCounter.equals(previousTaskCounter)) {
+                timestamp = 0L;
+            } else if (new Date().getTime() - timestamp > timeout) {
+                break;
             }
 
             try {

--- a/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
+++ b/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/Main.java
@@ -90,13 +90,13 @@ public class Main {
             }
         } catch (Throwable throwable) {
             die(throwable);
-        }
-
-        if (newClusterManager) {
-            try {
-                manager.stop();
-            } catch (Exception e) {
-                e.printStackTrace();
+        } finally {
+            if (newClusterManager) {
+                try {
+                    manager.stop();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
             }
         }
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
@@ -40,14 +40,19 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.UUID;
 
+import static ai.grakn.graql.Graql.match;
 import static ai.grakn.graql.Graql.var;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class LoaderTest {
 
@@ -95,7 +100,7 @@ public class LoaderTest {
     @Test(expected=RuntimeException.class)
     public void loadAndDontWaitForLongEnoughTest(){
         try {
-            loadAndTime(1);
+            loadAndTime(1000);
         } catch (RuntimeException e) {
             assertTrue(e.getMessage().equals(ErrorMessage.LOADER_WAIT_TIMEOUT.getMessage()));
             throw e;

--- a/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
@@ -110,7 +110,7 @@ public class LoaderTest {
     public void whenLoadingNormalDataThenDontTimeout(){
         // test the the total duration is longer than the timeout
         // however, the individual tasks will be completing faster than the timeout
-        int timeout = 10000;
+        int timeout = 100;
         long startTime = System.currentTimeMillis();
         loadAndTime(timeout);
         long endTime = System.currentTimeMillis();


### PR DESCRIPTION
- fixed a problem where migrator would hang when an exception is thrown
- the timeout logic was incorrect for migrator - now it only times out when the task status has not changed for a given amount of time