### PR TITLE
Add task to StateStorage in Scheduler 

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/exception/EngineStorageException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/EngineStorageException.java
@@ -1,0 +1,33 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.exception;
+
+import ai.grakn.util.ErrorMessage;
+
+/**
+ * An exception which encapsulates a error storing to or reading from
+ * an engine StateStorage implementation
+ *
+ * @author alexandraorth
+ */
+public class EngineStorageException extends RuntimeException {
+    public EngineStorageException(String e) {
+        super(ErrorMessage.STATE_STORAGE_ERROR.getMessage() + e);
+    }
+}

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -174,6 +174,7 @@ public enum ErrorMessage {
     ERROR_IN_DISTRIBUTED_TRANSACTION("Error while sending transaction to host: [%s]. Code: [%s] Message:[%s] \n Transaction string: [%s] "),
     ERROR_COMMUNICATING_TO_HOST("Exception thrown while trying to communicate with host [%s]"),
     LOADER_WAIT_TIMEOUT("Exception thrown due to timeout being exceeded while waiting for loading to complete"),
+    STATE_STORAGE_ERROR("Exception thrown while retrieving state of a task from storage."),
 
     //--------------------------------------------- Reasoner Errors -----------------------------------------------
     GRAPH_MISSING("Provided query does not have an associated graph"),

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
@@ -19,9 +19,11 @@
 package ai.grakn.engine.backgroundtasks;
 
 import mjson.Json;
+import org.apache.commons.lang.SerializationUtils;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -213,6 +215,14 @@ public class TaskState implements Serializable {
 
     public Json configuration() {
         return configuration;
+    }
+
+    public static String serialize(TaskState task){
+        return Base64.getMimeEncoder().encodeToString(SerializationUtils.serialize(task));
+    }
+
+    public static TaskState deserialize(String task){
+        return (TaskState) SerializationUtils.deserialize(Base64.getMimeDecoder().decode(task));
     }
 }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.engine.backgroundtasks;
 
+import ai.grakn.exception.EngineStorageException;
 import javafx.util.Pair;
 
 import java.util.Set;
@@ -40,7 +41,7 @@ public interface TaskStateStorage {
      * @return String form of the task id, which can be use later to update or retrieve the task state. Null if task could
      * not be created of mandatory fields were omitted.
      */
-    String newState(TaskState state);
+    String newState(TaskState state) throws EngineStorageException;
 
     /**
      * Used to update task state. With the exception of @id any other fields may individually be null, however all parameters
@@ -57,7 +58,7 @@ public interface TaskStateStorage {
      * @param id String id of task.
      * @return TaskState object or null if no TaskState with this id could be found.
      */
-    TaskState getState(String id);
+    TaskState getState(String id) throws EngineStorageException;
 
     /**
      * Return a Set of Pairs of tasks that match any of the criteria. The first value of the Pair is the task id, whilst

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
@@ -100,9 +100,7 @@ public final class DistributedTaskManager implements TaskManager {
                 .interval(period)
                 .configuration(configuration);
 
-        stateStorage.newState(taskState);
-
-        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), configuration.toString()));
+        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), TaskState.serialize(taskState)));
         producer.flush();
 
         return taskState.getId();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -157,6 +157,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
 
             String id = record.key();
 
+            // Instead of deserializing TaskState from value, get up-to-date state from the storage
             TaskState state = storage.getState(id);
             if(state.status() != SCHEDULED) {
                 LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: "+ state.status());

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
@@ -38,7 +38,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.util.Schema;
 import javafx.util.Pair;
 
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -67,8 +66,6 @@ import static ai.grakn.engine.util.SystemOntologyElements.SERIALISED_TASK;
 import static ai.grakn.graql.Graql.name;
 import static ai.grakn.graql.Graql.var;
 import static java.lang.Thread.sleep;
-import static org.apache.commons.lang.SerializationUtils.deserialize;
-import static org.apache.commons.lang.SerializationUtils.serialize;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
@@ -96,7 +93,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
                 .has(RUN_AT, var().value(task.runAt().toEpochMilli()))
                 .has(RECURRING, var().value(task.isRecurring()))
                 .has(RECUR_INTERVAL, var().value(task.interval()))
-                .has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+                .has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         if(task.configuration() != null) {
             state.has(TASK_CONFIGURATION, var().value(task.configuration().toString()));
@@ -123,7 +120,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         Var resources = var(TASK_VAR);
 
         resourcesToDettach.add(SERIALISED_TASK);
-        resources.has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+        resources.has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         // TODO make sure all properties are being update
         if(task.status() != null) {
@@ -201,7 +198,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         ResourceType<String> serialisedResourceType = graph.getResourceType(SERIALISED_TASK.getValue());
         String serialisedTask = (String) instance.resources(serialisedResourceType).iterator().next().getValue();
 
-        return (TaskState) deserialize(Base64.getMimeDecoder().decode(serialisedTask));
+        return TaskState.deserialize(serialisedTask);
     }
 
     @Override

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
@@ -64,8 +64,12 @@ public class BackgroundTaskTestUtils {
         final long initial = new Date().getTime();
 
         while((new Date().getTime())-initial < 60000) {
-            TaskStatus currentStatus = storage.getState(task.getId()).status();
-            if(currentStatus == status) { return; }
+            try {
+                TaskStatus currentStatus = storage.getState(task.getId()).status();
+                if (currentStatus == status) {
+                    return;
+                }
+            } catch (Exception ignored){}
         }
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
@@ -35,15 +35,14 @@ import static java.util.stream.Collectors.toSet;
  */
 public class BackgroundTaskTestUtils {
 
-    public static Set<TaskState> createTasks(TaskStateStorage storage, int n, TaskStatus status) {
+    public static Set<TaskState> createTasks(int n, TaskStatus status) {
         return IntStream.range(0, n)
-                .mapToObj(i -> createTask(storage, i, status, false, 0))
+                .mapToObj(i -> createTask(i, status, false, 0))
                 .collect(toSet());
     }
 
-    public static TaskState createTask(TaskStateStorage storage,
-                                int i, TaskStatus status, boolean recurring, int interval) {
-        TaskState state = new TaskState(TestTask.class.getName())
+    public static TaskState createTask(int i, TaskStatus status, boolean recurring, int interval) {
+        return new TaskState(TestTask.class.getName())
                 .status(status)
                 .creator(BackgroundTaskTestUtils.class.getName())
                 .statusChangedBy(BackgroundTaskTestUtils.class.getName())
@@ -51,9 +50,6 @@ public class BackgroundTaskTestUtils {
                 .isRecurring(recurring)
                 .interval(interval)
                 .configuration(Json.object("name", "task" + i));
-
-        storage.newState(state);
-        return state;
     }
     
     public static void waitForStatus(TaskStateStorage storage, Set<TaskState> tasks, TaskStatus status) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/DistributedTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/DistributedTaskManagerTest.java
@@ -50,19 +50,17 @@ public class DistributedTaskManagerTest {
 
     private void waitToFinish(String id) {
         while (true) {
-            TaskStatus status = manager.storage().getState(id).status();
-            if (status == COMPLETED || status == FAILED) {
-                System.out.println(id + " ------> " + status);
-                break;
-            }
-
-            System.out.println("Checking " + id + " " + status);
-
             try {
+                TaskStatus status = manager.storage().getState(id).status();
+                if (status == COMPLETED || status == FAILED) {
+                    System.out.println(id + " ------> " + status);
+                    break;
+                }
+
+                System.out.println("Checking " + id + " " + status);
+
                 Thread.sleep(5000);
-            } catch(Exception e) {
-                e.printStackTrace();
-            }
+            } catch (Exception ignored){}
         }
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -78,7 +78,7 @@ public class SchedulerTest {
 
     @Test
     public void immediateNonRecurringScheduled() {
-        Set<TaskState> tasks = createTasks(storage, 5, CREATED);
+        Set<TaskState> tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
         waitForStatus(storage, tasks, SCHEDULED);
 
@@ -91,7 +91,7 @@ public class SchedulerTest {
     @Test
     public void schedulerPicksUpFromLastOffset() throws InterruptedException {
         // Schedule 5 tasks
-        Set<TaskState> tasks = createTasks(storage, 5, CREATED);
+        Set<TaskState> tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
         waitForStatus(storage, tasks, SCHEDULED);
 
@@ -102,7 +102,7 @@ public class SchedulerTest {
         producer = ConfigHelper.kafkaProducer();
 
         // Schedule 5 more tasks
-        tasks = createTasks(storage, 5, CREATED);
+        tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
 
         // Restart the scheduler
@@ -121,7 +121,7 @@ public class SchedulerTest {
     }
 
     private void sendTasksToNewTasksQueue(Set<TaskState> tasks) {
-        tasks.forEach(t -> producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, t.getId(), t.configuration().toString())));
+        tasks.forEach(t -> producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, t.getId(), TaskState.serialize(t))));
         producer.flush();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
@@ -83,7 +83,8 @@ public class TaskRunnerTest {
     public void testSendReceive() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         waitForStatus(storage, tasks, COMPLETED);
 
@@ -94,7 +95,8 @@ public class TaskRunnerTest {
     public void testSendDuplicate() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         sendTasksToWorkQueue(tasks);
 
@@ -103,7 +105,7 @@ public class TaskRunnerTest {
     }
 
     private void sendTasksToWorkQueue(Set<TaskState> tasks) {
-        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), t.configuration().toString())));
+        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), TaskState.serialize(t))));
         producer.flush();
     }
 }


### PR DESCRIPTION
+ Persist tasks in `StateStorage` for the first time in the `Scheduler`
+ This means that there is nothing blocking before tasks are sent to Kafka
+ Move `TaskState` serialization code into `TaskState` class