### PR TITLE
Configurable task manager

### DIFF
--- a/conf/main/grakn-engine.properties
+++ b/conf/main/grakn-engine.properties
@@ -16,6 +16,8 @@
 # along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 #
 
+#In-Memory or Distributed task manager
+taskmanager.distributed=false
 
 # Logging
 logging.file.main=../logs/grakn.log

--- a/conf/test/orientdb/grakn-engine.properties
+++ b/conf/test/orientdb/grakn-engine.properties
@@ -16,6 +16,9 @@
 # along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 #
 
+#In-Memory or Distributed task manager
+taskmanager.distributed=false
+
 # Logging
 logging.file.main=../logs/grakn.log
 logging.file.postprocessing=../logs/grakn-postprocessing.log

--- a/conf/test/tinker/grakn-engine.properties
+++ b/conf/test/tinker/grakn-engine.properties
@@ -16,6 +16,9 @@
 # along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 #
 
+#In-Memory or Distributed task manager
+taskmanager.distributed=false
+
 # Logging
 logging.file.main=../logs/grakn.log
 logging.file.postprocessing=../logs/grakn-postprocessing.log

--- a/conf/test/titan/grakn-engine.properties
+++ b/conf/test/titan/grakn-engine.properties
@@ -16,6 +16,8 @@
 # along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 #
 
+#In-Memory or Distributed task manager
+taskmanager.distributed=false
 
 # Logging
 logging.file.main=../logs/grakn.log

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -60,6 +60,8 @@ import static spark.Spark.staticFiles;
 import static spark.Spark.webSocket;
 import static spark.Spark.webSocketIdleTimeoutMillis;
 
+import static ai.grakn.engine.util.ConfigProperties.DISTRIBUTED_TASK_MANAGER;
+
 /**
  * Main class in charge to start a web server and all the REST controllers.
  *
@@ -80,11 +82,13 @@ public class GraknEngineServer {
     private static TaskManager taskManager;
 
     public static void main(String[] args) {
-        start(true);
+        boolean distributed = prop.getPropertyAsBool(DISTRIBUTED_TASK_MANAGER);
+
+        start(distributed);
     }
 
-    public static void start(boolean inMemory){
-        startTaskManager(inMemory);
+    public static void start(boolean taskManagerIsDistributed){
+        startTaskManager(taskManagerIsDistributed);
         startHTTP();
         startPostprocessing();
         printStartMessage(prop.getProperty(ConfigProperties.SERVER_HOST_NAME), prop.getProperty(ConfigProperties.SERVER_PORT_NUMBER), prop.getLogFilePath());
@@ -101,11 +105,11 @@ public class GraknEngineServer {
     /**
      * Check in with the properties file to decide which type of task manager should be started
      */
-    private static void startTaskManager(boolean inMemory) {
-        if(inMemory){
-            taskManager = new StandaloneTaskManager();
-        } else {
+    private static void startTaskManager(boolean taskManagerIsDistributed) {
+        if(taskManagerIsDistributed){
             taskManager = new DistributedTaskManager();
+        } else {
+            taskManager = new StandaloneTaskManager();
         }
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ZookeeperConnection.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/ZookeeperConnection.java
@@ -47,12 +47,12 @@ public class ZookeeperConnection {
         try {
             zookeeperConnection.start();
             if(!zookeeperConnection.blockUntilConnected(30, TimeUnit.SECONDS)){
-                throw new RuntimeException("Could not instantiate zookeeper");
+                throw new RuntimeException("Could not connect to zookeeper");
             }
 
             createZKPaths();
         } catch (Exception exception) {
-            throw new RuntimeException("Could not instantiate zookeeper");
+            throw new RuntimeException("Could not connect to zookeeper");
         }
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/util/ConfigProperties.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/util/ConfigProperties.java
@@ -37,8 +37,6 @@ import java.util.Properties;
 public class ConfigProperties {
 
     //Test Configs
-    public static final String TEST_CONFIG_FILE = "../conf/test/tinker/grakn-engine.properties";
-
     public static final String DEFAULT_CONFIG_FILE = "../conf/main/grakn-engine.properties";
     public static final String DEFAULT_LOG_CONFIG_FILE = "../conf/main/logback.xml";
 
@@ -84,6 +82,10 @@ public class ConfigProperties {
 
     public static final String LOG_FILE_CONFIG_SYSTEM_PROPERTY = "logback.configurationFile";
 
+
+    // Engine Config
+    public static final String DISTRIBUTED_TASK_MANAGER = "taskmanager.distributed";
+
     public static final String KAFKA_BOOTSTRAP_SERVERS = "tasks.kafka.bootstrap-servers";
     public static final String KAFKA_SESSION_TIMEOUT = "tasks.kafka.consumer.session-timeout";
     public static final String KAFKA_RETRIES = "tasks.kafka.producer.retries";
@@ -99,7 +101,6 @@ public class ConfigProperties {
 
     public static final String SCHEDULER_POLLING_FREQ = "tasks.scheduler.polling-frequency";
     public static final String TASKRUNNER_POLLING_FREQ = "tasks.runner.polling-frequency";
-    public static final String TASK_MANAGER_INSTANCE = "tasks.task-manager";
 
     private Logger LOG;
 

--- a/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
@@ -76,7 +76,7 @@ public class EngineContext extends ExternalResource {
     }
 
     @Override
-    protected void before() throws Throwable {
+    public void before() throws Throwable {
         hideLogs();
 
         if(startKafka){
@@ -93,7 +93,7 @@ public class EngineContext extends ExternalResource {
     }
 
     @Override
-    protected void after() {
+    public void after() {
         try {
             if(startDistributedEngine | startInMemoryEngine){
                 stopEngine();

--- a/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
@@ -84,11 +84,11 @@ public class EngineContext extends ExternalResource {
         }
 
         if (startDistributedEngine){
-            startEngine(false);
+            startEngine(true);
         }
 
         if (startInMemoryEngine){
-            startEngine(true);
+            startEngine(false);
         }
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -51,7 +51,7 @@ public abstract class GraknTestEnv {
     /**
      * To run engine we must ensure Cassandra, the Grakn HTTP endpoint, Kafka & Zookeeper are running
      */
-    static void startEngine(boolean inMemory) throws Exception {
+    static void startEngine(boolean useDistributedEngine) throws Exception {
     	// To ensure consistency b/w test profiles and configuration files, when not using Titan
     	// for a unit tests in an IDE, add the following option:
     	// -Dgrakn.conf=../conf/test/tinker/grakn-engine.properties
@@ -69,7 +69,7 @@ public abstract class GraknTestEnv {
 
             // start engine
             RestAssured.baseURI = "http://" + properties.getProperty("server.host") + ":" + properties.getProperty("server.port");
-            GraknEngineServer.start(inMemory);
+            GraknEngineServer.start(useDistributedEngine);
 
             LOG.info("ENGINE STARTED.");
         }

--- a/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraphContext.java
@@ -20,9 +20,7 @@ package ai.grakn.test;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.GraknEngineServer;
-import ai.grakn.engine.backgroundtasks.standalone.StandaloneTaskManager;
 import ai.grakn.engine.controller.CommitLogController;
-import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import org.junit.rules.ExternalResource;
 import spark.Spark;
@@ -30,7 +28,6 @@ import spark.Spark;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static ai.grakn.engine.util.ConfigProperties.TASK_MANAGER_INSTANCE;
 import static ai.grakn.graphs.TestGraph.loadFromFile;
 import static ai.grakn.test.GraknTestEnv.ensureCassandraRunning;
 import static ai.grakn.test.GraknTestEnv.hideLogs;
@@ -86,7 +83,6 @@ public class GraphContext extends ExternalResource {
         ensureCassandraRunning();
 
         //TODO remove when Bug #12029 fixed
-        ConfigProperties.getInstance().setConfigProperty(TASK_MANAGER_INSTANCE, StandaloneTaskManager.class.getName());
         if (numberActiveContexts.getAndIncrement() == 0) {
             new CommitLogController();
             Spark.awaitInitialization();

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
@@ -69,6 +69,7 @@ public class GraknEngineServerTest {
         GraknEngineServer.main(new String[]{});
         assertTrue(GraknEngineServer.getTaskManager() instanceof StandaloneTaskManager);
         GraknEngineServer.stop();
+        GraknEngineServer.stopHTTP();
     }
 
     @Test


### PR DESCRIPTION
Allows you to configure the type of task manager you would like to use from the properties file.

Usage in `grakn-engine.properties`:
`taskmanager.distributed=false`
`taskmanager.distributed=true`