### PR TITLE
Zookeeper TaskStorage is now default

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskStateStorage.java
@@ -19,7 +19,6 @@
 package ai.grakn.engine.backgroundtasks;
 
 import ai.grakn.exception.EngineStorageException;
-import javafx.util.Pair;
 
 import java.util.Set;
 
@@ -70,9 +69,9 @@ public interface TaskStateStorage {
      * @param createdBy String containing created by. See TaskState.
      * @param limit Limit the returned result set to @limit amount of entries.
      * @param offset Use in conjunction with @limit for pagination.
-     * @return Set<Pair<String, TaskState>> of task IDs and corresponding TaskState *copies*.
+     * @return Set<TaskState> of TaskStates corresponding to search
      */
-    Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus,
+    Set<TaskState> getTasks(TaskStatus taskStatus,
                                           String taskClassName,
                                           String createdBy,
                                           int limit,

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
@@ -24,7 +24,7 @@ import ai.grakn.engine.backgroundtasks.TaskManager;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.config.ConfigHelper;
-import ai.grakn.engine.backgroundtasks.taskstatestorage.TaskStateGraphStore;
+import ai.grakn.engine.backgroundtasks.taskstatestorage.TaskStateZookeeperStore;
 import mjson.Json;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -59,8 +59,8 @@ public final class DistributedTaskManager implements TaskManager {
     private Thread taskRunnerThread;
 
     public DistributedTaskManager() {
-        stateStorage = new TaskStateGraphStore();
         connection = new ZookeeperConnection();
+        stateStorage = new TaskStateZookeeperStore(connection);
 
         // run the TaskRunner in a thread
         taskRunner = new TaskRunner(stateStorage, connection);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
@@ -21,7 +21,6 @@ package ai.grakn.engine.backgroundtasks.distributed;
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.util.ConfigProperties;
-import javafx.util.Pair;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -213,16 +212,16 @@ public class Scheduler implements Runnable, AutoCloseable {
      * Get all recurring tasks from the graph and schedule them
      */
     private void restartRecurringTasks() {
-        Set<Pair<String, TaskState>> tasks = storage.getTasks(null, null, null, 0, 0);
+        Set<TaskState> tasks = storage.getTasks(null, null, null, 0, 0);
         tasks.stream()
-                .filter(p -> p.getValue().isRecurring())
-                .filter(p -> p.getValue().status() != STOPPED)
+                .filter(TaskState::isRecurring)
+                .filter(p -> p.status() != STOPPED)
                 .forEach(p -> {
                     // Not sure what is the right format for "no configuration", but somehow the configuration
                     // here for a postprocessing task is "null": if we say that the configuration of a task
                     // is a JSONObject, then an empty configuration ought to be {}
-                    String config = p.getValue().configuration() == null ? "{}" : p.getValue().configuration().toString();
-                    scheduleTask(p.getKey(), config, p.getValue());
+                    String config = p.configuration() == null ? "{}" : p.configuration().toString();
+                    scheduleTask(p.getId(), config, p);
                 });
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -54,7 +54,6 @@ import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_STAT
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_WATCH;
 import static ai.grakn.engine.util.ConfigProperties.TASKRUNNER_POLLING_FREQ;
 import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
@@ -108,8 +107,6 @@ public class TaskRunner implements Runnable, AutoCloseable {
     public void run()  {
         try {
             while (true) {
-                LOG.debug("TaskRunner polling, size of new tasks " + consumer.endOffsets(consumer.partitionsFor(WORK_QUEUE_TOPIC).stream().map(i -> new TopicPartition(WORK_QUEUE_TOPIC, i.partition())).collect(toSet())));
-
                 // Poll for new tasks only when we know we have space to accept them.
                 if (getRunningTasksCount() < EXECUTOR_SIZE) {
                     processRecords(consumer.poll(POLLING_FREQUENCY));

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
@@ -35,15 +35,12 @@ import ai.grakn.graph.EngineGraknGraph;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.Var;
 import ai.grakn.util.Schema;
-import javafx.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -68,6 +65,7 @@ import static ai.grakn.engine.util.SystemOntologyElements.SERIALISED_TASK;
 import static ai.grakn.graql.Graql.name;
 import static ai.grakn.graql.Graql.var;
 import static java.lang.Thread.sleep;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang.SerializationUtils.deserialize;
 import static org.apache.commons.lang.SerializationUtils.serialize;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
@@ -206,12 +204,12 @@ public class TaskStateGraphStore implements TaskStateStorage {
     }
 
     @Override
-    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy,
+    public Set<TaskState> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy,
                                                  int limit, int offset) {
         return getTasks(taskStatus, taskClassName, createdBy, limit, offset, false);
     }
 
-    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy,
+    public Set<TaskState> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy,
                                                  int limit, int offset, Boolean recurring) {
         Var matchVar = var(TASK_VAR).isa(name(SCHEDULED_TASK));
 
@@ -228,7 +226,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
             matchVar.has(RECURRING, var().value(recurring));
         }
 
-        Optional<Set<Pair<String, TaskState>>> result = attemptCommitToSystemGraph((graph) -> {
+        Optional<Set<TaskState>> result = attemptCommitToSystemGraph((graph) -> {
             MatchQuery q = graph.graql().match(matchVar);
 
             if (limit > 0) {
@@ -238,19 +236,11 @@ public class TaskStateGraphStore implements TaskStateStorage {
                 q.offset(offset);
             }
 
-            List<Map<String, Concept>> res = q.execute();
-
-            // Create Set of pairs with IDs &
-            Set<Pair<String, TaskState>> out = new HashSet<>();
-            for (Map<String, Concept> m : res) {
-                Concept c = m.values().stream().findFirst().orElse(null);
-                if (c != null) {
-                    TaskState state = instanceToState(graph, c.asInstance());
-                    out.add(new Pair<>(state.getId(), state));
-                }
-            }
-
-            return out;
+            return q.execute().stream()
+                    .map(map -> map.values().stream().findFirst())
+                    .map(Optional::get)
+                    .map(c -> instanceToState(graph, c.asInstance()))
+                    .collect(toSet());
         }, false);
 
         return result.isPresent() ? result.get() : new HashSet<>();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateInMemoryStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateInMemoryStore.java
@@ -21,7 +21,6 @@ package ai.grakn.engine.backgroundtasks.taskstatestorage;
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
-import javafx.util.Pair;
 
 import java.lang.ref.SoftReference;
 import java.util.HashSet;
@@ -57,6 +56,7 @@ public class TaskStateInMemoryStore implements TaskStateStorage {
         return true;
     }
 
+    @Override
     public TaskState getState(String id) {
         if(id == null || !storage.containsKey(id)) {
             return null;
@@ -65,8 +65,9 @@ public class TaskStateInMemoryStore implements TaskStateStorage {
         return storage.get(id).get();
     }
 
-    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit, int offset) {
-        Set<Pair<String, TaskState>> res = new HashSet<>();
+    @Override
+    public Set<TaskState> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit, int offset) {
+        Set<TaskState> res = new HashSet<>();
 
         int count = 0;
         for(Map.Entry<String, SoftReference<TaskState>> x: storage.entrySet()) {
@@ -95,7 +96,7 @@ public class TaskStateInMemoryStore implements TaskStateStorage {
             }
             count++;
 
-            res.add(new Pair<>(x.getKey(), state));
+            res.add(state);
         }
 
         return res;

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateZookeeperStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateZookeeperStore.java
@@ -110,11 +110,21 @@ public class TaskStateZookeeperStore implements TaskStateStorage {
 
             Stream<TaskState> stream = zookeeperConnection.getChildren()
                     .forPath(TASKS_PATH_PREFIX).stream()
-                    .map(this::getState)
-                    .filter(t -> taskStatus != null && t.status().equals(taskStatus))
-                    .filter(t -> taskClassName != null && t.taskClassName().equals(taskClassName))
-                    .filter(t -> createdBy != null && t.creator().equals(createdBy))
-                    .skip(offset);
+                    .map(this::getState);
+
+            if (taskStatus != null) {
+                stream = stream.filter(t -> t.status().equals(taskStatus));
+            }
+
+            if (taskClassName != null) {
+                stream = stream.filter(t -> t.taskClassName().equals(taskClassName));
+            }
+
+            if (createdBy != null) {
+                stream = stream.filter(t -> t.creator().equals(createdBy));
+            }
+
+            stream = stream.skip(offset);
 
             if(limit > 0){
                 stream = stream.limit(limit);

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateZookeeperStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateZookeeperStore.java
@@ -22,16 +22,18 @@ import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStatus;
 import ai.grakn.engine.backgroundtasks.distributed.ZookeeperConnection;
-import javafx.util.Pair;
+import ai.grakn.exception.EngineStorageException;
 import org.apache.curator.framework.CuratorFramework;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.TASKS_PATH_PREFIX;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.TASK_STATE_SUFFIX;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang.SerializationUtils.deserialize;
 import static org.apache.commons.lang.SerializationUtils.serialize;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
@@ -52,7 +54,7 @@ public class TaskStateZookeeperStore implements TaskStateStorage {
     private final Logger LOG = LoggerFactory.getLogger(TaskStateZookeeperStore.class);
     private final CuratorFramework zookeeperConnection;
 
-    public TaskStateZookeeperStore(ZookeeperConnection connection) throws Exception {
+    public TaskStateZookeeperStore(ZookeeperConnection connection) {
         zookeeperConnection = connection.connection();
     }
 
@@ -64,9 +66,7 @@ public class TaskStateZookeeperStore implements TaskStateStorage {
                     .forPath(format(ZK_TASK_PATH, task.getId()), serialize(task));
 
         } catch (Exception exception){
-            LOG.error("Could not write task state to Zookeeper");
-            //TODO do not throw runtime exception
-            throw new RuntimeException("Could not write state to storage " + getFullStackTrace(exception));
+            throw new EngineStorageException("Could not write state to storage " + getFullStackTrace(exception));
         }
 
         return task.getId();
@@ -93,13 +93,36 @@ public class TaskStateZookeeperStore implements TaskStateStorage {
             return (TaskState) deserialize(b);
         }
         catch (Exception e) {
-            //TODO do not throw runtime exception
-            throw new RuntimeException("Could not get state from storage " + getFullStackTrace(e));
+            throw new EngineStorageException("Could not get state from storage " + getFullStackTrace(e));
         }
     }
 
+    /**
+     * This implementation will fetch all of the tasks from zookeeper and then
+     * filer them out.
+     *
+     * ZK stores tasks by ID, so at the moment there is no more efficient way to search
+     * within the storage itself.
+     */
     @Override
-    public Set<Pair<String, TaskState>> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit, int offset){
-        throw new UnsupportedOperationException("Task retrieval not supported");
+    public Set<TaskState> getTasks(TaskStatus taskStatus, String taskClassName, String createdBy, int limit, int offset){
+        try {
+
+            Stream<TaskState> stream = zookeeperConnection.getChildren()
+                    .forPath(TASKS_PATH_PREFIX).stream()
+                    .map(this::getState)
+                    .filter(t -> taskStatus != null && t.status().equals(taskStatus))
+                    .filter(t -> taskClassName != null && t.taskClassName().equals(taskClassName))
+                    .filter(t -> createdBy != null && t.creator().equals(createdBy))
+                    .skip(offset);
+
+            if(limit > 0){
+                stream = stream.limit(limit);
+            }
+
+            return stream.collect(toSet());
+        } catch (Exception e){
+            throw new EngineStorageException("Could not get state from storage " + getFullStackTrace(e));
+        }
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
@@ -27,7 +27,6 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
-import javafx.util.Pair;
 import mjson.Json;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -114,8 +113,8 @@ public class TasksController {
         }
 
         JSONArray result = new JSONArray();
-        for (Pair<String, TaskState> pair : manager.storage().getTasks(status, className, creator, limit, offset)) {
-            result.put(serialiseStateSubset(pair.getKey(), pair.getValue()));
+        for (TaskState state : manager.storage().getTasks(status, className, creator, limit, offset)) {
+            result.put(serialiseStateSubset(state));
         }
 
         response.type("application/json");
@@ -129,7 +128,7 @@ public class TasksController {
     private String getTask(Request request, Response response) {
         try {
             String id = request.params(ID_PARAMETER);
-            JSONObject result = serialiseStateFull(id, manager.storage().getState(id));
+            JSONObject result = serialiseStateFull(manager.storage().getState(id));
             response.type("application/json");
 
             return result.toString();
@@ -210,8 +209,8 @@ public class TasksController {
     }
 
 
-    private JSONObject serialiseStateSubset(String id, TaskState state) {
-        return new JSONObject().put("id", id)
+    private JSONObject serialiseStateSubset(TaskState state) {
+        return new JSONObject().put("id", state.getId())
                 .put("status", state.status())
                 .put("creator", state.creator())
                 .put("className", state.taskClassName())
@@ -219,8 +218,8 @@ public class TasksController {
                 .put("recurring", state.isRecurring());
     }
 
-    private JSONObject serialiseStateFull(String id, TaskState state) {
-        return serialiseStateSubset(id, state)
+    private JSONObject serialiseStateFull(TaskState state) {
+        return serialiseStateSubset(state)
                        .put("interval", state.interval())
                        .put("exception", state.exception())
                        .put("stackTrace", state.stackTrace())

--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/Loader.java
@@ -25,7 +25,6 @@ import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.exception.EngineStorageException;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.util.ErrorMessage;
-import javafx.util.Pair;
 import mjson.Json;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -239,9 +238,7 @@ public class Loader {
      * @return IDs of tasks in this keyspace
      */
     private Collection<String> getTasks(){
-        return manager.storage().getTasks(null, LoaderTask.class.getName(), keyspace, 100000, 0).stream()
-                .map(Pair::getKey)
-                .collect(toSet());
+        return getTasks(null);
     }
 
     /**
@@ -251,7 +248,7 @@ public class Loader {
      */
     private Collection<String> getTasks(TaskStatus status){
         return manager.storage().getTasks(status, LoaderTask.class.getName(), keyspace, 100000, 0).stream()
-                .map(Pair::getKey)
+                .map(TaskState::getId)
                 .collect(toSet());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateGraphStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateGraphStoreTest.java
@@ -22,7 +22,6 @@ import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.taskstatestorage.TaskStateGraphStore;
 import ai.grakn.test.EngineContext;
-import javafx.util.Pair;
 import mjson.Json;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,6 +32,7 @@ import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static ai.grakn.engine.backgroundtasks.TaskStatus.CREATED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.SCHEDULED;
@@ -110,11 +110,12 @@ public class TaskStateGraphStoreTest {
     @Test
     public void testGetTaskStateByStatus() {
         String id = stateStorage.newState(task());
+        stateStorage.newState(task().status(SCHEDULED));
         assertNotNull(id);
 
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(CREATED, null, null, 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(CREATED, null, null, 0, 0);
         assertTrue(res.parallelStream()
-                .map(Pair::getKey)
+                .map(TaskState::getId)
                 .filter(x -> x.equals(id))
                 .collect(Collectors.toList())
                 .size() == 1);
@@ -123,11 +124,12 @@ public class TaskStateGraphStoreTest {
     @Test
     public void testGetTaskStateByCreator() {
         String id = stateStorage.newState(task());
+        stateStorage.newState(task().creator("other"));
         assertNotNull(id);
 
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, null, this.getClass().getName(), 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(null, null, this.getClass().getName(), 0, 0);
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
+                .map(TaskState::getId)
                         .filter(x -> x.equals(id))
                         .collect(Collectors.toList())
                         .size() == 1);
@@ -138,9 +140,9 @@ public class TaskStateGraphStoreTest {
         String id = stateStorage.newState(task());
         assertNotNull(id);
 
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, TestTask.class.getName(), null, 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(null, TestTask.class.getName(), null, 0, 0);
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
+                .map(TaskState::getId)
                         .filter(x -> x.equals(id))
                         .collect(Collectors.toList())
                         .size() == 1);
@@ -148,15 +150,15 @@ public class TaskStateGraphStoreTest {
 
     @Test
     public void testGetAllTaskStates() {
-        String id = stateStorage.newState(task());
-        assertNotNull(id);
+        int sizeBeforeAdding = stateStorage.getTasks(null, null, null, 0, 0).size();
 
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, null, null, 0, 0);
-        assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
-                        .filter(x -> x.equals(id))
-                        .collect(Collectors.toList())
-                        .size() == 1);
+        int numberTasks = 10;
+        IntStream.range(0, numberTasks)
+                .mapToObj(i -> task())
+                .forEach(stateStorage::newState);
+
+        Set<TaskState> res = stateStorage.getTasks(null, null, null, 0, 0);
+        assertEquals(sizeBeforeAdding + numberTasks, res.size());
     }
 
     @Test
@@ -165,8 +167,8 @@ public class TaskStateGraphStoreTest {
             stateStorage.newState(task());
         }
 
-        Set<Pair<String, TaskState>> setA = stateStorage.getTasks(null, null, null, 5, 0);
-        Set<Pair<String, TaskState>> setB = stateStorage.getTasks(null, null, null, 5, 5);
+        Set<TaskState> setA = stateStorage.getTasks(null, null, null, 5, 0);
+        Set<TaskState> setB = stateStorage.getTasks(null, null, null, 5, 5);
 
         setA.forEach(x -> assertFalse(setB.contains(x)));
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateInMemoryStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateInMemoryStoreTest.java
@@ -21,7 +21,6 @@ package ai.grakn.test.engine.backgroundtasks;
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.taskstatestorage.TaskStateInMemoryStore;
-import javafx.util.Pair;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +33,6 @@ import static java.time.Instant.now;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -88,10 +86,10 @@ public class TaskStateInMemoryStoreTest {
     @Test
     public void testGetTasksByStatus() {
         String id = stateStorage.newState(task());
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(CREATED, null, null, 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(CREATED, null, null, 0, 0);
 
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
+                        .map(TaskState::getId)
                         .filter(x -> x.equals(id))
                         .collect(Collectors.toList())
                         .size() == 1);
@@ -100,10 +98,10 @@ public class TaskStateInMemoryStoreTest {
     @Test
     public void testGetTasksByCreator() {
         String id = stateStorage.newState(task());
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, null, this.getClass().getName(), 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(null, null, this.getClass().getName(), 0, 0);
 
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
+                .map(TaskState::getId)
                         .filter(x -> x.equals(id))
                         .collect(Collectors.toList())
                         .size() == 1);
@@ -112,25 +110,25 @@ public class TaskStateInMemoryStoreTest {
     @Test
     public void testGetTasksByClassName() {
         String id = stateStorage.newState(task());
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, TestTask.class.getName(), null, 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(null, TestTask.class.getName(), null, 0, 0);
 
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
-                        .filter(x -> x.equals(id))
-                        .collect(Collectors.toList())
-                        .size() == 1);
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
     }
 
     @Test
     public void testGetAllTasks() {
         String id = stateStorage.newState(task());
-        Set<Pair<String, TaskState>> res = stateStorage.getTasks(null, null, null, 0, 0);
+        Set<TaskState> res = stateStorage.getTasks(null, null, null, 0, 0);
 
         assertTrue(res.parallelStream()
-                        .map(Pair::getKey)
-                        .filter(x -> x.equals(id))
-                        .collect(Collectors.toList())
-                        .size() == 1);
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
     }
 
     @Test
@@ -139,8 +137,8 @@ public class TaskStateInMemoryStoreTest {
             stateStorage.newState(task());
         }
 
-        Set<Pair<String, TaskState>> setA = stateStorage.getTasks(null, null, null, 10, 0);
-        Set<Pair<String, TaskState>> setB = stateStorage.getTasks(null, null, null, 10, 10);
+        Set<TaskState> setA = stateStorage.getTasks(null, null, null, 10, 0);
+        Set<TaskState> setB = stateStorage.getTasks(null, null, null, 10, 10);
 
         setA.forEach(x -> assertFalse(setB.contains(x)));
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateZookeeperStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskStateZookeeperStoreTest.java
@@ -28,13 +28,17 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static ai.grakn.engine.backgroundtasks.TaskStatus.CREATED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.SCHEDULED;
 import static java.time.Instant.now;
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TaskStateZookeeperStoreTest {
     private static ZookeeperConnection connection;
@@ -103,6 +107,69 @@ public class TaskStateZookeeperStoreTest {
         assertEquals(CREATED, state.status());
         assertEquals(engineID, state.engineID());
         assertEquals(checkpoint, state.checkpoint());
+    }
+
+
+    @Test
+    public void testGetTasksByStatus() {
+        String id = stateStorage.newState(task());
+        stateStorage.newState(task().status(SCHEDULED));
+        Set<TaskState> res = stateStorage.getTasks(CREATED, null, null, 0, 0);
+
+        assertTrue(res.parallelStream()
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
+    }
+
+    @Test
+    public void testGetTasksByCreator() {
+        String id = stateStorage.newState(task());
+        stateStorage.newState(task().creator("another"));
+        Set<TaskState> res = stateStorage.getTasks(null, null, this.getClass().getName(), 0, 0);
+
+        assertTrue(res.parallelStream()
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
+    }
+
+    @Test
+    public void testGetTasksByClassName() {
+        String id = stateStorage.newState(task());
+        Set<TaskState> res = stateStorage.getTasks(null, TestTask.class.getName(), null, 0, 0);
+
+        assertTrue(res.parallelStream()
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
+    }
+
+    @Test
+    public void testGetAllTasks() {
+        String id = stateStorage.newState(task());
+        Set<TaskState> res = stateStorage.getTasks(null, null, null, 0, 0);
+
+        assertTrue(res.parallelStream()
+                .map(TaskState::getId)
+                .filter(x -> x.equals(id))
+                .collect(Collectors.toList())
+                .size() == 1);
+    }
+
+    @Test
+    public void testTaskPagination() {
+        for (int i = 0; i < 20; i++) {
+            stateStorage.newState(task());
+        }
+
+        Set<TaskState> setA = stateStorage.getTasks(null, null, null, 10, 0);
+        Set<TaskState> setB = stateStorage.getTasks(null, null, null, 10, 10);
+
+        setA.forEach(x -> assertFalse(setB.contains(x)));
     }
 
     public TaskState task(){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.test.engine.controller;
 
+import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.distributed.DistributedTaskManager;
 import ai.grakn.engine.controller.TasksController;
 import ai.grakn.test.EngineContext;
@@ -40,9 +41,9 @@ import org.junit.Test;
 import java.time.Instant;
 import java.util.Date;
 
+import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.CREATED;
 import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
-import static ai.grakn.test.GraknTestEnv.usingTinker;
 import static ai.grakn.util.REST.WebPath.TASKS_SCHEDULE_URI;
 import static com.jayway.restassured.RestAssured.get;
 import static com.jayway.restassured.RestAssured.given;
@@ -51,7 +52,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 
 public class TasksControllerTest {
     private String singleTask;
@@ -66,14 +66,18 @@ public class TasksControllerTest {
 
     @Before
     public void setUp() throws Exception {
-        assumeFalse(usingTinker());
         DistributedTaskManager manager = (DistributedTaskManager) engine.getTaskManager();
-        singleTask = manager.scheduleTask(new TestTask(), this.getClass().getName(), Instant.now(), 0, Json.object());
+        singleTask = manager.storage().newState(
+                new TaskState(TestTask.class.getName())
+                        .creator(this.getClass().getName())
+                        .runAt(Instant.now())
+                        .status(COMPLETED)
+                        .configuration(Json.object()));
     }
 
     @Test
     public void testTasksByStatus() throws Exception{
-        Response response = given().queryParam("status", CREATED.toString())
+        Response response = given().queryParam("status", COMPLETED.toString())
                                    .queryParam("limit", 10)
                                    .get("/tasks/all");
 
@@ -84,18 +88,15 @@ public class TasksControllerTest {
         JSONArray array = new JSONArray(response.body().asString());
         array.forEach(x -> {
             JSONObject o = (JSONObject)x;
-            assertEquals(CREATED.toString(), o.get("status"));
+            assertEquals(COMPLETED.toString(), o.get("status"));
         });
     }
 
     @Test
     public void testTasksByClassName() {
-        System.out.println("testTasksByClassName");
         Response response = given().queryParam("className", TestTask.class.getName())
                                    .queryParam("limit", 10)
                                    .get("/tasks/all");
-
-        System.out.println(response.body().toString());
 
         response.then().statusCode(200)
                 .and().contentType(ContentType.JSON)
@@ -128,8 +129,6 @@ public class TasksControllerTest {
     @Test
     public void testGetAllTasks() {
         Response response = given().queryParam("limit", 10).get("/tasks/all");
-
-        System.out.println(response.body().asString());
 
         response.then().statusCode(200)
                 .and().contentType(ContentType.JSON)

--- a/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
@@ -191,9 +191,8 @@ public class LoaderTest {
         when(fakeTaskManager.storage()).thenReturn(fakeStorage);
         when(fakeStorage.getState(fakeTaskId)).thenReturn(fakeTaskState);
         when(fakeStorage.getState(fakeTaskId).status()).thenAnswer(answer);
-        Set<Pair<String,TaskState>> fakeTasks = new HashSet<>();
-        Pair<String, TaskState> fakePair =  new Pair<String,TaskState>(fakeTaskId, null);
-        fakeTasks.add(fakePair);
+        Set<TaskState> fakeTasks = new HashSet<>();
+        fakeTasks.add(null);
         when(fakeStorage.getTasks(null, LoaderTask.class.getName(), graph.getKeyspace(), 100000, 0)).thenReturn(fakeTasks);
         return fakeTaskManager;
     }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/loader/LoaderTest.java
@@ -184,7 +184,8 @@ public class LoaderTest {
     }
 
     private TaskManager getFakeTaskManager(Answer answer) {
-        String fakeTaskId = "task001";
+        TaskState fakeTask = new TaskState(LoaderTask.class.getName());
+        String fakeTaskId = fakeTask.getId();
         StandaloneTaskManager fakeTaskManager = mock(StandaloneTaskManager.class);
         TaskStateGraphStore fakeStorage = mock(TaskStateGraphStore.class);
         TaskState fakeTaskState = mock(TaskState.class);
@@ -192,7 +193,7 @@ public class LoaderTest {
         when(fakeStorage.getState(fakeTaskId)).thenReturn(fakeTaskState);
         when(fakeStorage.getState(fakeTaskId).status()).thenAnswer(answer);
         Set<TaskState> fakeTasks = new HashSet<>();
-        fakeTasks.add(null);
+        fakeTasks.add(fakeTask);
         when(fakeStorage.getTasks(null, LoaderTask.class.getName(), graph.getKeyspace(), 100000, 0)).thenReturn(fakeTasks);
         return fakeTaskManager;
     }


### PR DESCRIPTION
+ To speed up task processing `TaskStateZookeeperStore` is now the default for distributed engine
+ Required implementing `getTasks` function in `TaskStateZookeeperStore`
+ Simplified the `StateStorage` interface to return `Set<TaskState>` instead of `Set<Pair<String, TaskState>>`