### PR TITLE
Set npm registry to http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,5 @@ script:
     - mvn test -Dtest=$TESTS -DfailIfNoTests=false jacoco:report
     - bash <(curl -s https://codecov.io/bash)
 before_install:
+  - npm config set registry http://registry.npmjs.org/
   - npm install -g npm


### PR DESCRIPTION
Work around https issues with fastly causing connection resets.
https://github.com/travis-ci/travis-ci/issues/2389#issuecomment-74163184

In jenkins, I set this in pre-build steps.