### PR TITLE
Engine- Store created task in Scheduler

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
@@ -19,9 +19,11 @@
 package ai.grakn.engine.backgroundtasks;
 
 import mjson.Json;
+import org.apache.commons.lang.SerializationUtils;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -213,6 +215,14 @@ public class TaskState implements Serializable {
 
     public Json configuration() {
         return configuration;
+    }
+
+    public static String serialize(TaskState task){
+        return Base64.getMimeEncoder().encodeToString(SerializationUtils.serialize(task));
+    }
+
+    public static TaskState deserialize(String task){
+        return (TaskState) SerializationUtils.deserialize(Base64.getMimeDecoder().decode(task));
     }
 }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
@@ -100,9 +100,7 @@ public final class DistributedTaskManager implements TaskManager {
                 .interval(period)
                 .configuration(configuration);
 
-        stateStorage.newState(taskState);
-
-        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), configuration.toString()));
+        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), TaskState.serialize(taskState)));
         producer.flush();
 
         return taskState.getId();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
@@ -113,7 +113,13 @@ public class Scheduler implements Runnable, AutoCloseable {
                 printConsumerStatus(records);
 
                 for(ConsumerRecord<String, String> record:records) {
-                    scheduleTask(record.key(), record.value());
+                    TaskState taskState = TaskState.deserialize(record.value());
+
+                    // mark the task as created
+                    storage.newState(taskState);
+
+                    // schedule the task
+                    scheduleTask(taskState);
 
                     //acknowledge that the record was read to the consumer
                     consumer.seek(new TopicPartition(record.topic(), record.partition()), record.offset() + 1);
@@ -157,33 +163,21 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     /**
      * Schedule a task to be submitted to the work queue when it is supposed to be run
-     * @param id id of the task to be scheduled
-     * @param configuration configuration of task to be scheduled, will be copied to WORK_QUEUE_TOPIC
-     */
-    private void scheduleTask(String id, String configuration) {
-        TaskState state = storage.getState(id);
-        scheduleTask(id, configuration, state);
-    }
-
-    /**
-     * Schedule a task to be submitted to the work queue when it is supposed to be run
-     * @param id id of the task to be scheduled
-     * @param configuration configuration of task to be scheduled, will be copied to WORK_QUEUE_TOPIC
      * @param state state of the task
      */
-    private void scheduleTask(String id,  String configuration, TaskState state) {
+    private void scheduleTask(TaskState state) {
         long delay = Duration.between(Instant.now(), state.runAt()).toMillis();
 
         markAsScheduled(state);
         if(state.isRecurring()) {
             Runnable submit = () -> {
                 markAsScheduled(state);
-                sendToWorkQueue(id, configuration);
+                sendToWorkQueue(state);
             };
             schedulingService.scheduleAtFixedRate(submit, delay, state.interval(), MILLISECONDS);
         }
         else {
-            Runnable submit = () -> sendToWorkQueue(id, configuration);
+            Runnable submit = () -> sendToWorkQueue(state);
             schedulingService.schedule(submit, delay, MILLISECONDS);
         }
     }
@@ -199,12 +193,11 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     /**
      * Submit a task to the work queue
-     * @param taskId id of the task to be submitted
-     * @param configuration task to be submitted
+     * @param state task to be submitted
      */
-    private void sendToWorkQueue(String taskId, String configuration) {
-        LOG.debug("Sending to work queue " + taskId);
-        producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, taskId, configuration), new KafkaLoggingCallback());
+    private void sendToWorkQueue(TaskState state) {
+        LOG.debug("Sending to work queue " + state.getId());
+        producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, state.getId(), TaskState.serialize(state)), new KafkaLoggingCallback());
         producer.flush();
     }
 
@@ -216,13 +209,7 @@ public class Scheduler implements Runnable, AutoCloseable {
         tasks.stream()
                 .filter(TaskState::isRecurring)
                 .filter(p -> p.status() != STOPPED)
-                .forEach(p -> {
-                    // Not sure what is the right format for "no configuration", but somehow the configuration
-                    // here for a postprocessing task is "null": if we say that the configuration of a task
-                    // is a JSONObject, then an empty configuration ought to be {}
-                    String config = p.configuration() == null ? "{}" : p.configuration().toString();
-                    scheduleTask(p.getId(), config, p);
-                });
+                .forEach(this::scheduleTask);
     }
 
     private void printConsumerStatus(ConsumerRecords<String, String> records){

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -154,6 +154,7 @@ public class TaskRunner implements Runnable, AutoCloseable {
 
             String id = record.key();
 
+            // Instead of deserializing TaskState from value, get up-to-date state from the storage
             TaskState state = storage.getState(id);
             if(state.status() != SCHEDULED) {
                 LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: "+ state.status());

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -23,6 +23,7 @@ import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.engine.util.EngineID;
+import ai.grakn.exception.EngineStorageException;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -155,17 +156,21 @@ public class TaskRunner implements Runnable, AutoCloseable {
             String id = record.key();
 
             // Instead of deserializing TaskState from value, get up-to-date state from the storage
-            TaskState state = storage.getState(id);
-            if(state.status() != SCHEDULED) {
-                LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: "+ state.status());
-                continue;
+            try {
+                TaskState state = storage.getState(id);
+                if (state.status() != SCHEDULED) {
+                    LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: " + state.status());
+                    continue;
+                }
+
+                // Submit to executor
+                executor.submit(() -> executeTask(state));
+
+                // Advance offset
+                seekAndCommit(new TopicPartition(record.topic(), record.partition()), record.offset() + 1);
+            } catch (EngineStorageException e){
+                LOG.error("Cant run this task - " + id + " because state was not found in storage");
             }
-
-            // Submit to executor
-            executor.submit(() -> executeTask(state));
-
-            // Advance offset
-            seekAndCommit(new TopicPartition(record.topic(), record.partition()), record.offset()+1);
         }
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
@@ -38,7 +38,6 @@ import ai.grakn.util.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
@@ -66,8 +65,6 @@ import static ai.grakn.graql.Graql.name;
 import static ai.grakn.graql.Graql.var;
 import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang.SerializationUtils.deserialize;
-import static org.apache.commons.lang.SerializationUtils.serialize;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
@@ -95,7 +92,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
                 .has(RUN_AT, var().value(task.runAt().toEpochMilli()))
                 .has(RECURRING, var().value(task.isRecurring()))
                 .has(RECUR_INTERVAL, var().value(task.interval()))
-                .has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+                .has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         if(task.configuration() != null) {
             state.has(TASK_CONFIGURATION, var().value(task.configuration().toString()));
@@ -122,7 +119,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         Var resources = var(TASK_VAR);
 
         resourcesToDettach.add(SERIALISED_TASK);
-        resources.has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+        resources.has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         // TODO make sure all properties are being update
         if(task.status() != null) {
@@ -200,7 +197,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         ResourceType<String> serialisedResourceType = graph.getResourceType(SERIALISED_TASK.getValue());
         String serialisedTask = (String) instance.resources(serialisedResourceType).iterator().next().getValue();
 
-        return (TaskState) deserialize(Base64.getMimeDecoder().decode(serialisedTask));
+        return TaskState.deserialize(serialisedTask);
     }
 
     @Override

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
@@ -35,15 +35,14 @@ import static java.util.stream.Collectors.toSet;
  */
 public class BackgroundTaskTestUtils {
 
-    public static Set<TaskState> createTasks(TaskStateStorage storage, int n, TaskStatus status) {
+    public static Set<TaskState> createTasks(int n, TaskStatus status) {
         return IntStream.range(0, n)
-                .mapToObj(i -> createTask(storage, i, status, false, 0))
+                .mapToObj(i -> createTask(i, status, false, 0))
                 .collect(toSet());
     }
 
-    public static TaskState createTask(TaskStateStorage storage,
-                                int i, TaskStatus status, boolean recurring, int interval) {
-        TaskState state = new TaskState(TestTask.class.getName())
+    public static TaskState createTask(int i, TaskStatus status, boolean recurring, int interval) {
+        return new TaskState(TestTask.class.getName())
                 .status(status)
                 .creator(BackgroundTaskTestUtils.class.getName())
                 .statusChangedBy(BackgroundTaskTestUtils.class.getName())
@@ -51,9 +50,6 @@ public class BackgroundTaskTestUtils {
                 .isRecurring(recurring)
                 .interval(interval)
                 .configuration(Json.object("name", "task" + i));
-
-        storage.newState(state);
-        return state;
     }
     
     public static void waitForStatus(TaskStateStorage storage, Set<TaskState> tasks, TaskStatus status) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -85,7 +85,7 @@ public class SchedulerTest {
 
     @Test
     public void immediateNonRecurringScheduled() {
-        Set<TaskState> tasks = createTasks(storage, 5, CREATED);
+        Set<TaskState> tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
         waitForStatus(storage, tasks, SCHEDULED);
 
@@ -98,7 +98,7 @@ public class SchedulerTest {
     @Test
     public void schedulerPicksUpFromLastOffset() throws InterruptedException {
         // Schedule 5 tasks
-        Set<TaskState> tasks = createTasks(storage, 5, CREATED);
+        Set<TaskState> tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
         waitForStatus(storage, tasks, SCHEDULED);
 
@@ -108,7 +108,7 @@ public class SchedulerTest {
         producer = ConfigHelper.kafkaProducer();
 
         // Schedule 5 more tasks
-        tasks = createTasks(storage, 5, CREATED);
+        tasks = createTasks(5, CREATED);
         sendTasksToNewTasksQueue(tasks);
 
         // Restart the scheduler
@@ -159,7 +159,7 @@ public class SchedulerTest {
     }
 
     private void sendTasksToNewTasksQueue(Set<TaskState> tasks) {
-        tasks.forEach(t -> producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, t.getId(), t.configuration().toString())));
+        tasks.forEach(t -> producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, t.getId(), TaskState.serialize(t))));
         producer.flush();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerTest.java
@@ -129,7 +129,8 @@ public class SchedulerTest {
         stopScheduler();
 
         // persist a recurring task
-        TaskState recurring = createTask(storage, 1, CREATED, true, 10000);
+        TaskState recurring = createTask(1, CREATED, true, 10000);
+        storage.newState(recurring);
 
         // check the task actually exists and is recurring
         TaskState recurringPersisted = storage.getState(recurring.getId());

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
@@ -83,7 +83,8 @@ public class TaskRunnerTest {
     public void testSendReceive() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         waitForStatus(storage, tasks, COMPLETED);
 
@@ -94,7 +95,8 @@ public class TaskRunnerTest {
     public void testSendDuplicate() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         sendTasksToWorkQueue(tasks);
 
@@ -103,7 +105,7 @@ public class TaskRunnerTest {
     }
 
     private void sendTasksToWorkQueue(Set<TaskState> tasks) {
-        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), t.configuration().toString())));
+        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), TaskState.serialize(t))));
         producer.flush();
     }
 }


### PR DESCRIPTION
+ Scheduler will mark tasks as created- no blocking when submitting tasks to `DistributedTaskManager`
+ Kafka passes around ID as key as serialized `TaskState` as value
+ Moved code to serialize `TaskState` object into that class