### PR TITLE
Introduce low level caching into the core API - WIP - DO NOT MERGE

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
@@ -53,7 +53,7 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
         if(o.getValue() instanceof Comparable){
             //Most vendor ids implement comparable so this should work most of the time.
             //noinspection unchecked
-            return ((Comparable) o).compareTo(getValue());
+            return ((Comparable) o.getValue()).compareTo(getValue());
         } else {
             //When vendor Id's are not comparable we fallback to toString  comparison
             return getValue().toString().compareTo(o.getValue().toString());

--- a/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
@@ -33,13 +33,13 @@ import java.io.Serializable;
  * @author fppt
  */
 public class ConceptId implements Comparable<ConceptId>, Serializable {
-    private String conceptId;
+    private Object conceptId;
 
-    private ConceptId(String conceptId){
+    private ConceptId(Object conceptId){
         this.conceptId = conceptId;
     }
 
-    public String getValue(){
+    public Object getValue(){
         return conceptId;
     }
 
@@ -50,12 +50,19 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
 
     @Override
     public int compareTo(ConceptId o) {
-        return getValue().compareTo(o.getValue());
+        if(o.getValue() instanceof Comparable){
+            //Most vendor ids implement comparable so this should work most of the time.
+            //noinspection unchecked
+            return ((Comparable) o).compareTo(getValue());
+        } else {
+            //When vendor Id's are not comparable we fallback to toString  comparison
+            return getValue().toString().compareTo(o.getValue().toString());
+        }
     }
 
     @Override
     public String toString(){
-        return conceptId;
+        return conceptId.toString();
     }
 
     @Override
@@ -68,7 +75,7 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
      * @param value The string which potentially represents a Concept
      * @return The matching concept ID
      */
-    public static ConceptId of(String value){
+    public static ConceptId of(Object value){
         return new ConceptId(value);
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -568,7 +568,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         InstanceImpl toRolePlayer = (InstanceImpl) to;
 
         String hash = calculateShortcutHash(relation, relationType, fromRole, fromRolePlayer, toRole, toRolePlayer);
-        boolean exists = getTinkerPopGraph().traversal().V(fromRolePlayer.getBaseIdentifier()).
+        boolean exists = getTinkerPopGraph().traversal().V(fromRolePlayer.getId().getValue()).
                     local(outE(Schema.EdgeLabel.SHORTCUT.getLabel()).has(Schema.EdgeProperty.SHORTCUT_HASH.name(), hash)).
                     hasNext();
 
@@ -869,7 +869,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
                 }
             }
 
-            getTinkerPopGraph().traversal().V(otherCasting.getBaseIdentifier()).next().remove();
+            getTinkerPopGraph().traversal().V(otherCasting.getId().getValue()).next().remove();
         }
 
         return relationsToClean;

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -409,7 +409,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     @Override
     public <T extends Concept> T getConcept(ConceptId id) {
-        return getConcept(Schema.ConceptProperty.ID, id.getValue());
+        return getConcept(Schema.ConceptProperty.ID, id.toString());
     }
     private <T extends Type> T getTypeByName(TypeName name){
         return getConcept(Schema.ConceptProperty.NAME, name.getValue());
@@ -506,7 +506,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         CastingImpl casting = elementFactory.buildCasting(addVertex(Schema.BaseType.CASTING), role).setHash(role, rolePlayer);
         if(rolePlayer != null) {
             EdgeImpl castingToRolePlayer = addEdge(casting, rolePlayer, Schema.EdgeLabel.ROLE_PLAYER); // Casting to RolePlayer
-            castingToRolePlayer.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().getValue());
+            castingToRolePlayer.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
         }
         return casting;
     }
@@ -522,7 +522,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
         // Relation To Casting
         EdgeImpl relationToCasting = addEdge(relation, foundCasting, Schema.EdgeLabel.CASTING);
-        relationToCasting.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().getValue());
+        relationToCasting.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
         getConceptLog().putConcept(relation); //The relation is explicitly tracked so we can look them up without committing
 
         putShortcutEdges(relation, relation.type());
@@ -575,15 +575,15 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         if (!exists) {
             EdgeImpl edge = addEdge(fromRolePlayer, toRolePlayer, Schema.EdgeLabel.SHORTCUT);
             edge.setProperty(Schema.EdgeProperty.RELATION_TYPE_NAME, relationType.getName().getValue());
-            edge.setProperty(Schema.EdgeProperty.RELATION_ID, relation.getId().getValue());
+            edge.setProperty(Schema.EdgeProperty.RELATION_ID, relation.getId().toString());
 
             if (fromRolePlayer.getId() != null) {
-                edge.setProperty(Schema.EdgeProperty.FROM_ID, fromRolePlayer.getId().getValue());
+                edge.setProperty(Schema.EdgeProperty.FROM_ID, fromRolePlayer.getId().toString());
             }
             edge.setProperty(Schema.EdgeProperty.FROM_ROLE_NAME, fromRole.getName().getValue());
 
             if (toRolePlayer.getId() != null) {
-                edge.setProperty(Schema.EdgeProperty.TO_ID, toRolePlayer.getId().getValue());
+                edge.setProperty(Schema.EdgeProperty.TO_ID, toRolePlayer.getId().toString());
             }
             edge.setProperty(Schema.EdgeProperty.TO_ROLE_NAME, toRole.getName().getValue());
 
@@ -595,12 +595,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     private String calculateShortcutHash(Relation relation, RelationType relationType, RoleType fromRole, Instance fromRolePlayer, RoleType toRole, Instance toRolePlayer){
         String hash = "";
-        String relationIdValue = relationType.getId().getValue();
-        String fromIdValue = fromRolePlayer.getId().getValue();
-        String fromRoleValue = fromRole.getId().getValue();
-        String toIdValue = toRolePlayer.getId().getValue();
-        String toRoleValue = toRole.getId().getValue();
-        String assertionIdValue = relation.getId().getValue();
+        String relationIdValue = relationType.getId().toString();
+        String fromIdValue = fromRolePlayer.getId().toString();
+        String fromRoleValue = fromRole.getId().toString();
+        String toIdValue = toRolePlayer.getId().toString();
+        String toRoleValue = toRole.getId().toString();
+        String assertionIdValue = relation.getId().toString();
 
         if(relationIdValue != null) hash += relationIdValue;
         if(fromIdValue != null) hash += fromIdValue;
@@ -774,7 +774,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
             JSONObject jsonObject = new JSONObject();
             jsonObject.put(REST.Request.COMMIT_LOG_TYPE, baseType.name());
             jsonObject.put(REST.Request.COMMIT_LOG_INDEX, concept.getValue0());
-            jsonObject.put(REST.Request.COMMIT_LOG_ID, concept.getValue1().getValue());
+            jsonObject.put(REST.Request.COMMIT_LOG_ID, concept.getValue1().toString());
             jsonArray.put(jsonObject);
         });
     }
@@ -819,13 +819,13 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      */
     private void deleteRelations(Set<RelationImpl> relations){
         for (RelationImpl relation : relations) {
-            String relationID = relation.getId().getValue();
+            String relationID = relation.getId().toString();
 
             //Kill Shortcut Edges
             relation.rolePlayers().values().forEach(instance -> {
                 if(instance != null) {
                     List<Edge> edges = getTinkerTraversal().
-                            hasId(instance.getId().getValue()).
+                            hasId(instance.getId().toString()).
                             bothE(Schema.EdgeLabel.SHORTCUT.getLabel()).
                             has(Schema.EdgeProperty.RELATION_ID.name(), relationID).toList();
 
@@ -865,7 +865,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
                 //Perform the transfer
                 if(transferEdge) {
                     EdgeImpl assertionToCasting = addEdge(otherRelation, mainCasting, Schema.EdgeLabel.CASTING);
-                    assertionToCasting.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().getValue());
+                    assertionToCasting.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
                 }
             }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -87,12 +87,12 @@ import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.outE;
  */
 public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph, GraknAdmin, EngineGraknGraph {
     protected final Logger LOG = LoggerFactory.getLogger(AbstractGraknGraph.class);
-    private final ElementFactory elementFactory;
     private final String keyspace;
     private final String engine;
     private final boolean batchLoadingEnabled;
     private final G graph;
 
+    private final ThreadLocal<ElementFactory> localElementFactory = new ThreadLocal<>();
     private final ThreadLocal<ConceptLog> localConceptLog = new ThreadLocal<>();
     private final ThreadLocal<Boolean> localIsOpen = new ThreadLocal<>();
     private final ThreadLocal<String> localClosedReason = new ThreadLocal<>();
@@ -105,7 +105,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         this.keyspace = keyspace;
         this.engine = engine;
         localIsOpen.set(true);
-        elementFactory = new ElementFactory(this);
 
         if(initialiseMetaConcepts()) {
             try {
@@ -162,7 +161,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     @Override
     public <T extends Concept> T buildConcept(Vertex vertex) {
-        return elementFactory.buildConcept(vertex);
+        return getElementFactory().buildConcept(vertex);
     }
 
     public boolean hasCommitted(){
@@ -234,6 +233,10 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     ElementFactory getElementFactory(){
+        ElementFactory elementFactory = localElementFactory.get();
+        if(elementFactory == null){
+            localElementFactory.set(elementFactory = new ElementFactory(this));
+        }
         return elementFactory;
     }
 
@@ -254,7 +257,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
             if(!byPassDuplicates && vertices.hasNext()) {
                 throw new MoreThanOneConceptException(ErrorMessage.TOO_MANY_CONCEPTS.getMessage(key.name(), value));
             }
-            return elementFactory.buildConcept(vertex);
+            return getElementFactory().buildConcept(vertex);
         } else {
             return null;
         }
@@ -264,7 +267,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         Set<ConceptImpl> concepts = new HashSet<>();
         getTinkerTraversal().has(key.name(), value).
             forEachRemaining(v -> {
-                concepts.add(elementFactory.buildConcept(v));
+                concepts.add(getElementFactory().buildConcept(v));
             });
         return concepts;
     }
@@ -315,7 +318,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public EntityType putEntityType(TypeName name) {
         return putType(name, Schema.BaseType.ENTITY_TYPE,
-                v -> elementFactory.buildEntityType(v, getMetaEntityType()));
+                v -> getElementFactory().buildEntityType(v, getMetaEntityType()));
     }
 
     private <V extends Type> V putType(TypeName name, Schema.BaseType baseType, Function<Vertex, V> factory){
@@ -331,12 +334,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public RelationType putRelationType(TypeName name) {
         return putType(name, Schema.BaseType.RELATION_TYPE,
-                v -> elementFactory.buildRelationType(v, getMetaRelationType(), Boolean.FALSE)).asRelationType();
+                v -> getElementFactory().buildRelationType(v, getMetaRelationType(), Boolean.FALSE)).asRelationType();
     }
 
     RelationType putRelationTypeImplicit(TypeName name) {
         return putType(name, Schema.BaseType.RELATION_TYPE,
-                v -> elementFactory.buildRelationType(v, getMetaRelationType(), Boolean.TRUE)).asRelationType();
+                v -> getElementFactory().buildRelationType(v, getMetaRelationType(), Boolean.TRUE)).asRelationType();
     }
 
     @Override
@@ -347,12 +350,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public RoleType putRoleType(TypeName name) {
         return putType(name, Schema.BaseType.ROLE_TYPE,
-                v -> elementFactory.buildRoleType(v, getMetaRoleType(), Boolean.FALSE)).asRoleType();
+                v -> getElementFactory().buildRoleType(v, getMetaRoleType(), Boolean.FALSE)).asRoleType();
     }
 
     RoleType putRoleTypeImplicit(TypeName name) {
         return putType(name, Schema.BaseType.ROLE_TYPE,
-                v -> elementFactory.buildRoleType(v, getMetaRoleType(), Boolean.TRUE)).asRoleType();
+                v -> getElementFactory().buildRoleType(v, getMetaRoleType(), Boolean.TRUE)).asRoleType();
     }
 
     @Override
@@ -364,7 +367,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public <V> ResourceType<V> putResourceType(TypeName name, ResourceType.DataType<V> dataType) {
         return putType(name, Schema.BaseType.RESOURCE_TYPE,
-                v -> elementFactory.buildResourceType(v, getMetaResourceType(), dataType, Boolean.FALSE)).asResourceType();
+                v -> getElementFactory().buildResourceType(v, getMetaResourceType(), dataType, Boolean.FALSE)).asResourceType();
     }
 
     @Override
@@ -376,7 +379,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public <V> ResourceType<V> putResourceTypeUnique(TypeName name, ResourceType.DataType<V> dataType) {
         return putType(name, Schema.BaseType.RESOURCE_TYPE,
-                v -> elementFactory.buildResourceType(v, getMetaResourceType(), dataType, Boolean.TRUE)).asResourceType();
+                v -> getElementFactory().buildResourceType(v, getMetaResourceType(), dataType, Boolean.TRUE)).asResourceType();
     }
 
     @Override
@@ -387,7 +390,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public RuleType putRuleType(TypeName name) {
         return putType(name, Schema.BaseType.RULE_TYPE,
-                v ->  elementFactory.buildRuleType(v, getMetaRuleType()));
+                v ->  getElementFactory().buildRuleType(v, getMetaRuleType()));
     }
 
     //------------------------------------ Lookup
@@ -401,7 +404,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     public <T extends Concept> T getConceptByBaseIdentifier(Object baseIdentifier) {
         GraphTraversal<Vertex, Vertex> traversal = getTinkerPopGraph().traversal().V(baseIdentifier);
         if (traversal.hasNext()) {
-            return elementFactory.buildConcept(traversal.next());
+            return getElementFactory().buildConcept(traversal.next());
         } else {
             return null;
         }
@@ -503,10 +506,10 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     //-----------------------------------------------Casting Functionality----------------------------------------------
     //------------------------------------ Construction
     private CastingImpl addCasting(RoleTypeImpl role, InstanceImpl rolePlayer){
-        CastingImpl casting = elementFactory.buildCasting(addVertex(Schema.BaseType.CASTING), role).setHash(role, rolePlayer);
+        CastingImpl casting = getElementFactory().buildCasting(addVertex(Schema.BaseType.CASTING), role).setHash(role, rolePlayer);
         if(rolePlayer != null) {
             EdgeImpl castingToRolePlayer = addEdge(casting, rolePlayer, Schema.EdgeLabel.ROLE_PLAYER); // Casting to RolePlayer
-            castingToRolePlayer.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
+            castingToRolePlayer.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.toString());
         }
         return casting;
     }
@@ -656,7 +659,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
      */
     @Override
     public void close() {
-        getConceptLog().clearTransaction();
         closeGraph(ErrorMessage.CLOSED_USER.getMessage());
     }
 
@@ -672,6 +674,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     //Standard Close Operation Overridden by Vendor
     public void closeGraph(String closedReason){
+        clearLocalVariables();
         finaliseClose(this::closePermanent, closedReason);
     }
 
@@ -698,6 +701,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @Override
     public void commit() throws GraknValidationException {
         commit(this::submitCommitLogs);
+        clearLocalVariables();
     }
 
     /**
@@ -712,6 +716,11 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
                 resources.forEach(pair -> cache.addJobResource(keyspace, pair.getValue0(), pair.getValue1()));
             }
         });
+    }
+
+    private void clearLocalVariables(){
+        localElementFactory.remove();
+        localConceptLog.remove();
     }
 
     public void commit(BiConsumer<Set<Pair<String, ConceptId>>, Set<Pair<String,ConceptId>>> conceptLogger) throws GraknValidationException {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/CastingImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/CastingImpl.java
@@ -87,7 +87,7 @@ class CastingImpl extends InstanceImpl<CastingImpl, RoleType> {
     public CastingImpl setHash(RoleTypeImpl role, InstanceImpl rolePlayer){
         String hash;
         if(getGraknGraph().isBatchLoadingEnabled()) {
-            hash = "CastingBaseId_" + this.getBaseIdentifier() + UUID.randomUUID().toString();
+            hash = "CastingBaseId_" + getId() + UUID.randomUUID().toString();
         } else {
             hash = generateNewHash(role, rolePlayer);
         }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
@@ -488,14 +488,6 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
 
     /**
      *
-     * @return The unique base identifier of this concept.
-     */
-    public Object getBaseIdentifier() {
-        return vertex.id();
-    }
-
-    /**
-     *
      * @return The base ttpe of this concept which helps us identify the concept
      */
     public String getBaseType(){
@@ -508,7 +500,7 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
      */
     @Override
     public ConceptId getId(){
-        return ConceptId.of(getProperty(Schema.ConceptProperty.ID));
+        return ConceptId.of(vertex.id());
     }
 
     /**
@@ -562,7 +554,7 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
      */
     EdgeImpl putEdge(Concept to, Schema.EdgeLabel type){
         ConceptImpl toConcept = (ConceptImpl) to;
-        GraphTraversal<Vertex, Edge> traversal = graknGraph.getTinkerPopGraph().traversal().V(getBaseIdentifier()).outE(type.getLabel()).as("edge").otherV().hasId(toConcept.getBaseIdentifier()).select("edge");
+        GraphTraversal<Vertex, Edge> traversal = graknGraph.getTinkerPopGraph().traversal().V(getId().getValue()).outE(type.getLabel()).as("edge").otherV().hasId(toConcept.getId().getValue()).select("edge");
         if(!traversal.hasNext()) {
             return addEdge(toConcept, type);
         } else {
@@ -595,8 +587,8 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
      * @param toConcept The target concept
      */
     void deleteEdgeTo(Schema.EdgeLabel type, Concept toConcept){
-        GraphTraversal<Vertex, Edge> traversal = graknGraph.getTinkerPopGraph().traversal().V(getBaseIdentifier()).
-                outE(type.getLabel()).as("edge").otherV().hasId(((ConceptImpl) toConcept).getBaseIdentifier()).select("edge");
+        GraphTraversal<Vertex, Edge> traversal = graknGraph.getTinkerPopGraph().traversal().V(getId().getValue()).
+                outE(type.getLabel()).as("edge").otherV().hasId(toConcept.getId().getValue()).select("edge");
         if(traversal.hasNext()) {
             traversal.next().remove();
         }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
@@ -223,7 +223,7 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
             InstanceImpl<?, ?> instance = casting.getRolePlayer();
             if(instance != null) {
                 for (EdgeImpl edge : instance.getEdgesOfType(Direction.BOTH, Schema.EdgeLabel.SHORTCUT)) {
-                    if(edge.getProperty(Schema.EdgeProperty.RELATION_ID).equals(getId().getValue())){
+                    if(edge.getProperty(Schema.EdgeProperty.RELATION_ID).equals(getId().toString())){
                         edge.delete();
                     }
                 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
@@ -86,13 +86,13 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
     public static String generateNewHash(RelationType relationType, Map<RoleType, Instance> roleMap){
         SortedSet<RoleType> sortedRoleIds = new TreeSet<>(roleMap.keySet());
         StringBuilder hash = new StringBuilder();
-        hash.append("RelationType_").append(relationType.getId().getValue().replace("_", "\\_")).append("_Relation");
+        hash.append("RelationType_").append(relationType.getId().toString().replace("_", "\\_")).append("_Relation");
 
         for(RoleType role: sortedRoleIds){
-            hash.append("_").append(role.getId().getValue().replace("_", "\\_"));
+            hash.append("_").append(role.getId().toString().replace("_", "\\_"));
             Instance instance = roleMap.get(role);
             if(instance != null){
-                hash.append("_").append(instance.getId().getValue().replace("_", "\\_"));
+                hash.append("_").append(instance.getId().toString().replace("_", "\\_"));
             }
         }
         return hash.toString();

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/CastingTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/CastingTest.java
@@ -51,7 +51,7 @@ public class CastingTest extends GraphTestBase{
     @Test
     public void testEquals() throws Exception {
         Graph graph = graknGraph.getTinkerPopGraph();
-        Vertex v = graph.traversal().V(relation.getBaseIdentifier()).out(Schema.EdgeLabel.CASTING.getLabel()).next();
+        Vertex v = graph.traversal().V(relation.getId().getValue()).out(Schema.EdgeLabel.CASTING.getLabel()).next();
         CastingImpl castingCopy = graknGraph.getConcept(ConceptId.of(v.id().toString()));
         assertEquals(casting, castingCopy);
 
@@ -64,7 +64,7 @@ public class CastingTest extends GraphTestBase{
 
     @Test
     public void hashCodeTest() throws Exception {
-        Vertex castingVertex = graknGraph.getTinkerPopGraph().traversal().V(casting.getBaseIdentifier()).next();
+        Vertex castingVertex = graknGraph.getTinkerPopGraph().traversal().V(casting.getId().getValue()).next();
         assertEquals(casting.hashCode(), castingVertex.hashCode());
     }
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptTest.java
@@ -71,28 +71,23 @@ public class ConceptTest extends GraphTestBase{
 
         assertNotNull(type1.getEdgeOutgoingOfType(Schema.EdgeLabel.SUB));
 
-        Vertex vertexType1 = graknGraph.getTinkerPopGraph().traversal().V(type1.getBaseIdentifier()).next();
-        Vertex vertexType3 = graknGraph.getTinkerPopGraph().traversal().V(type3.getBaseIdentifier()).next();
+        Vertex vertexType1 = graknGraph.getTinkerPopGraph().traversal().V(type1.getId().getValue()).next();
+        Vertex vertexType3 = graknGraph.getTinkerPopGraph().traversal().V(type3.getId().getValue()).next();
         vertexType1.addEdge(Schema.EdgeLabel.SUB.getLabel(), vertexType3);
         type1.getEdgeOutgoingOfType(Schema.EdgeLabel.SUB);
     }
 
     @Test
-    public void testGetVertex(){
-        assertNotNull(concept.getBaseIdentifier());
-    }
-
-    @Test
     public void testSetType() {
         concept.setType("test_type");
-        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getBaseIdentifier()).next();
+        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getId().getValue()).next();
         assertEquals("test_type", conceptVertex.property(Schema.ConceptProperty.TYPE.name()).value());
     }
 
     @Test
     public void testGetType() {
         concept.setType("test_type");
-        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getBaseIdentifier()).next();
+        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getId().getValue()).next();
         assertEquals(concept.getType().getValue(), conceptVertex.property(Schema.ConceptProperty.TYPE.name()).value());
     }
 
@@ -106,7 +101,7 @@ public class ConceptTest extends GraphTestBase{
 
         assertEquals(c1, c1_copy);
         assertNotEquals(c1, c2);
-        assertNotEquals(c1.getBaseIdentifier(), concept.getBaseIdentifier());
+        assertNotEquals(c1.getId().getValue(), concept.getId().getValue());
 
         HashSet<Concept> concepts = new HashSet<>();
 
@@ -117,7 +112,7 @@ public class ConceptTest extends GraphTestBase{
 
         concepts.add(c2);
         assertEquals(2, concepts.size());
-        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getBaseIdentifier()).next();
+        Vertex conceptVertex = graknGraph.getTinkerPopGraph().traversal().V(concept.getId().getValue()).next();
         assertNotEquals(concept, conceptVertex);
     }
 
@@ -176,12 +171,12 @@ public class ConceptTest extends GraphTestBase{
         InstanceImpl conceptInstance4 = (InstanceImpl) entityType.addEntity();
         InstanceImpl conceptInstance5 = (InstanceImpl) entityType.addEntity();
         InstanceImpl conceptInstance6 = (InstanceImpl) entityType.addEntity();
-        Vertex conceptInstance1_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance1.getBaseIdentifier()).next();
-        Vertex conceptInstance2_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance2.getBaseIdentifier()).next();
-        Vertex conceptInstance3_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance3.getBaseIdentifier()).next();
-        Vertex conceptInstance4_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance4.getBaseIdentifier()).next();
-        Vertex conceptInstance5_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance5.getBaseIdentifier()).next();
-        Vertex conceptInstance6_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance6.getBaseIdentifier()).next();
+        Vertex conceptInstance1_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance1.getId().getValue()).next();
+        Vertex conceptInstance2_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance2.getId().getValue()).next();
+        Vertex conceptInstance3_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance3.getId().getValue()).next();
+        Vertex conceptInstance4_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance4.getId().getValue()).next();
+        Vertex conceptInstance5_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance5.getId().getValue()).next();
+        Vertex conceptInstance6_Vertex = graknGraph.getTinkerPopGraph().traversal().V(conceptInstance6.getId().getValue()).next();
 
         conceptInstance2_Vertex.addEdge(Schema.EdgeLabel.SHORTCUT.getLabel(), conceptInstance1_Vertex);
         conceptInstance3_Vertex.addEdge(Schema.EdgeLabel.SHORTCUT.getLabel(), conceptInstance1_Vertex);

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
@@ -53,7 +53,7 @@ public class EntityTest extends GraphTestBase{
         Relation relation = relationType.addRelation();
         relation.scope(scope);
         scope.delete();
-        assertNull(graknGraph.getConceptByBaseIdentifier(((ConceptImpl) scope).getBaseIdentifier()));
+        assertNull(graknGraph.getConceptByBaseIdentifier(scope.getId().getValue()));
     }
 
     @Test

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTypeTest.java
@@ -222,7 +222,7 @@ public class EntityTypeTest extends GraphTestBase{
 
         conceptType.playsRole(roleType1).playsRole(roleType2);
         Set<RoleType> foundRoles = new HashSet<>();
-        graknGraph.getTinkerPopGraph().traversal().V(conceptType.getBaseIdentifier()).
+        graknGraph.getTinkerPopGraph().traversal().V(conceptType.getId().getValue()).
                 out(Schema.EdgeLabel.PLAYS_ROLE.getLabel()).forEachRemaining(r -> foundRoles.add(graknGraph.getRoleType(r.value(Schema.ConceptProperty.NAME.name()))));
 
         assertEquals(2, foundRoles.size());

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -98,9 +98,9 @@ public class GraknGraphTest extends GraphTestBase {
 
         CastingImpl casting = graknGraph.getConcept(ConceptId.of(id));
         EdgeImpl edge = casting.addEdge(role, Schema.EdgeLabel.ISA); // Casting to Role
-        edge.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().getValue());
+        edge.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
         edge = casting.addEdge(rolePlayer, Schema.EdgeLabel.ROLE_PLAYER);// Casting to Roleplayer
-        edge.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().getValue());
+        edge.setProperty(Schema.EdgeProperty.ROLE_TYPE, role.getId().toString());
         relation.addEdge(casting, Schema.EdgeLabel.CASTING);// Assertion to Casting
     }
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/PostprocessingTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/PostprocessingTest.java
@@ -104,14 +104,14 @@ public class PostprocessingTest extends GraphTestBase{
         EdgeImpl edge = new EdgeImpl(tinkerEdge, graknGraph);
 
         edge.setProperty(Schema.EdgeProperty.RELATION_TYPE_NAME, relationType.getName().getValue());
-        edge.setProperty(Schema.EdgeProperty.RELATION_ID, relation.getId().getValue());
+        edge.setProperty(Schema.EdgeProperty.RELATION_ID, relation.getId().toString());
 
         if (fromInstance.getId() != null)
-            edge.setProperty(Schema.EdgeProperty.FROM_ID, fromInstance.getId().getValue());
+            edge.setProperty(Schema.EdgeProperty.FROM_ID, fromInstance.getId().toString());
         edge.setProperty(Schema.EdgeProperty.FROM_ROLE_NAME, fromRole.getName().getValue());
 
         if (toInstance.getId() != null)
-            edge.setProperty(Schema.EdgeProperty.TO_ID, toInstance.getId().getValue());
+            edge.setProperty(Schema.EdgeProperty.TO_ID, toInstance.getId().toString());
         edge.setProperty(Schema.EdgeProperty.TO_ROLE_NAME, toRole.getName().getValue());
 
         edge.setProperty(Schema.EdgeProperty.FROM_TYPE_NAME, fromInstance.type().getName().getValue());

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RelationTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RelationTest.java
@@ -142,9 +142,9 @@ public class RelationTest extends GraphTestBase{
             if(edge.getProperty(TO_ROLE_NAME).equals(role2.getName().getValue())) {
                 foundEdge = true;
                 assertEquals(edge.getProperty(RELATION_TYPE_NAME), relationType.getName().getValue());
-                assertEquals(edge.getProperty(RELATION_ID), relation.getId().getValue());
-                assertEquals(edge.getProperty(TO_ID), b.getId().getValue());
-                assertEquals(edge.getProperty(FROM_ID), a.getId().getValue());
+                assertEquals(edge.getProperty(RELATION_ID), relation.getId().toString());
+                assertEquals(edge.getProperty(TO_ID), b.getId().toString());
+                assertEquals(edge.getProperty(FROM_ID), a.getId().toString());
                 assertEquals(edge.getProperty(FROM_TYPE_NAME), a.type().getName().getValue());
                 assertEquals(edge.getProperty(TO_TYPE_NAME), b.type().getName().getValue());
             }
@@ -161,11 +161,11 @@ public class RelationTest extends GraphTestBase{
         relation.scope(scope);
         relationValue.scope(scope);
 
-        Vertex vertex = graknGraph.getTinkerPopGraph().traversal().V(relation.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_SCOPE.getLabel()).next();
-        assertEquals(scope.getBaseIdentifier(), vertex.id());
+        Vertex vertex = graknGraph.getTinkerPopGraph().traversal().V(relation.getId().getValue()).out(Schema.EdgeLabel.HAS_SCOPE.getLabel()).next();
+        assertEquals(scope.getId().getValue(), vertex.id());
 
-        vertex = graknGraph.getTinkerPopGraph().traversal().V(relationValue.getBaseIdentifier()).out(Schema.EdgeLabel.HAS_SCOPE.getLabel()).next();
-        assertEquals(scope.getBaseIdentifier(), vertex.id());
+        vertex = graknGraph.getTinkerPopGraph().traversal().V(relationValue.getId().getValue()).out(Schema.EdgeLabel.HAS_SCOPE.getLabel()).next();
+        assertEquals(scope.getId().getValue(), vertex.id());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class RelationTest extends GraphTestBase{
         relation2.scope(scope2);
 
         relation2.deleteScope(scope2);
-        Vertex assertion2_vertex = graknGraph.getTinkerPopGraph().traversal().V(relation2.getBaseIdentifier()).next();
+        Vertex assertion2_vertex = graknGraph.getTinkerPopGraph().traversal().V(relation2.getId().getValue()).next();
 
         int count = 0;
         Iterator<Edge> edges =  assertion2_vertex.edges(Direction.OUT, Schema.EdgeLabel.HAS_SCOPE.getLabel());
@@ -226,13 +226,13 @@ public class RelationTest extends GraphTestBase{
         assertEquals(2, count);
 
         relation2.deleteScope(scope3);
-        assertTrue(graknGraph.getTinkerPopGraph().traversal().V(scope3.getBaseIdentifier()).hasNext());
+        assertTrue(graknGraph.getTinkerPopGraph().traversal().V(scope3.getId().getValue()).hasNext());
 
         relation.deleteScope(scope1);
-        assertTrue(graknGraph.getTinkerPopGraph().traversal().V(scope1.getBaseIdentifier()).hasNext());
+        assertTrue(graknGraph.getTinkerPopGraph().traversal().V(scope1.getId().getValue()).hasNext());
         relation2.deleteScope(scope1);
         relation.deleteScope(scope3);
-        assertFalse(graknGraph.getTinkerPopGraph().traversal().V(relation.getBaseIdentifier()).next().edges(Direction.OUT, Schema.EdgeLabel.HAS_SCOPE.getLabel()).hasNext());
+        assertFalse(graknGraph.getTinkerPopGraph().traversal().V(relation.getId().getValue()).next().edges(Direction.OUT, Schema.EdgeLabel.HAS_SCOPE.getLabel()).hasNext());
     }
 
     @Test
@@ -243,13 +243,13 @@ public class RelationTest extends GraphTestBase{
         relation.scope(scope2);
 
         relation.scopes().forEach(relation::deleteScope);
-        assertFalse(graknGraph.getTinkerPopGraph().traversal().V(relation.getBaseIdentifier()).next().edges(Direction.OUT, Schema.EdgeLabel.HAS_SCOPE.getLabel()).hasNext());
+        assertFalse(graknGraph.getTinkerPopGraph().traversal().V(relation.getId().getValue()).next().edges(Direction.OUT, Schema.EdgeLabel.HAS_SCOPE.getLabel()).hasNext());
     }
 
     @Test
     public void testDelete() throws ConceptException{
         relation.delete();
-        assertNull(graknGraph.getConceptByBaseIdentifier(relation.getBaseIdentifier()));
+        assertNull(graknGraph.getConceptByBaseIdentifier(relation.getId().getValue()));
     }
 
     @Test
@@ -535,15 +535,15 @@ public class RelationTest extends GraphTestBase{
         assertEdgeCountOfVertex(godfather, Schema.EdgeLabel.ROLE_PLAYER, 2, 0);
 
         //More Specific Checks
-        List<Vertex> assertionsTypes = graknGraph.getTinkerPopGraph().traversal().V(godfather.getBaseIdentifier()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).in(Schema.EdgeLabel.CASTING.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).toList();
+        List<Vertex> assertionsTypes = graknGraph.getTinkerPopGraph().traversal().V(godfather.getId().getValue()).in(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).in(Schema.EdgeLabel.CASTING.getLabel()).out(Schema.EdgeLabel.ISA.getLabel()).toList();
         assertEquals(2, assertionsTypes.size());
 
         List<Object> assertTypeIds = assertionsTypes.stream().map(Vertex::id).collect(Collectors.toList());
 
-        assertTrue(assertTypeIds.contains(cast.getBaseIdentifier()));
-        assertTrue(assertTypeIds.contains(movieHasGenre.getBaseIdentifier()));
+        assertTrue(assertTypeIds.contains(cast.getId().getValue()));
+        assertTrue(assertTypeIds.contains(movieHasGenre.getId().getValue()));
 
-        List<Vertex> collection = graknGraph.getTinkerPopGraph().traversal().V(cast.getBaseIdentifier(), movieHasGenre.getBaseIdentifier()).in(Schema.EdgeLabel.ISA.getLabel()).out(Schema.EdgeLabel.CASTING.getLabel()).out().toList();
+        List<Vertex> collection = graknGraph.getTinkerPopGraph().traversal().V(cast.getId().getValue(), movieHasGenre.getId().getValue()).in(Schema.EdgeLabel.ISA.getLabel()).out(Schema.EdgeLabel.CASTING.getLabel()).out().toList();
         assertEquals(8, collection.size());
 
         HashSet<Object> uniqueCollection = new HashSet<>();
@@ -552,13 +552,13 @@ public class RelationTest extends GraphTestBase{
         }
 
         assertEquals(7, uniqueCollection.size());
-        assertTrue(uniqueCollection.contains(feature.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(actor.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(godfather.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(pacino.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(movieOfGenre.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(movieGenre.getBaseIdentifier()));
-        assertTrue(uniqueCollection.contains(crime.getBaseIdentifier()));
+        assertTrue(uniqueCollection.contains(feature.getId().getValue()));
+        assertTrue(uniqueCollection.contains(actor.getId().getValue()));
+        assertTrue(uniqueCollection.contains(godfather.getId().getValue()));
+        assertTrue(uniqueCollection.contains(pacino.getId().getValue()));
+        assertTrue(uniqueCollection.contains(movieOfGenre.getId().getValue()));
+        assertTrue(uniqueCollection.contains(movieGenre.getId().getValue()));
+        assertTrue(uniqueCollection.contains(crime.getId().getValue()));
 
         assertEquals(Schema.BaseType.ENTITY.name(), pacino.getBaseType());
         for(CastingImpl casting: assertion.getMappingCasting()){
@@ -567,7 +567,7 @@ public class RelationTest extends GraphTestBase{
 
     }
     private void assertEdgeCountOfVertex(Concept concept , Schema.EdgeLabel type, int inCount, int outCount){
-        Vertex v= graknGraph.getTinkerPopGraph().traversal().V(((ConceptImpl) concept).getBaseIdentifier()).next();
+        Vertex v= graknGraph.getTinkerPopGraph().traversal().V(concept.getId().getValue()).next();
         assertEquals(inCount, Iterators.size(v.edges(Direction.IN, type.getLabel())));
         assertEquals(outCount, Iterators.size(v.edges(Direction.OUT, type.getLabel())));
     }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
@@ -91,7 +91,7 @@ public class RuleTest extends GraphTestBase{
     public void testAddHypothesis() throws Exception {
         RuleType conceptType = graknGraph.putRuleType("A Thing");
         Rule rule = conceptType.addRule(lhs, rhs);
-        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(((RuleImpl) rule).getBaseIdentifier()).next();
+        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(rule.getId().getValue()).next();
         Type type1 = graknGraph.putEntityType("A Concept Type 1");
         Type type2 = graknGraph.putEntityType("A Concept Type 2");
         assertFalse(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.HYPOTHESIS.getLabel()).hasNext());
@@ -103,7 +103,7 @@ public class RuleTest extends GraphTestBase{
     public void testAddConclusion() throws Exception {
         RuleType conceptType = graknGraph.putRuleType("A Thing");
         Rule rule = conceptType.addRule(lhs, rhs);
-        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(((RuleImpl) rule).getBaseIdentifier()).next();
+        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(rule.getId().getValue()).next();
         Type type1 = graknGraph.putEntityType("A Concept Type 1");
         Type type2 = graknGraph.putEntityType("A Concept Type 2");
         assertFalse(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.CONCLUSION.getLabel()).hasNext());

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IdFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/IdFragment.java
@@ -40,7 +40,7 @@ class IdFragment extends AbstractFragment {
     @Override
     public void applyTraversal(GraphTraversal<Vertex, Vertex> traversal) {
         // Whenever looking up by ID, we have to confirm this is not a casting
-        traversal.has(Schema.ConceptProperty.ID.name(), id.getValue()).not(__.hasLabel(CASTING.name()));
+        traversal.has(Schema.ConceptProperty.ID.name(), id.toString()).not(__.hasLabel(CASTING.name()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/IdPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/IdPredicate.java
@@ -68,7 +68,7 @@ public class IdPredicate extends Predicate<ConceptId>{
     public boolean isIdPredicate(){ return true;}
 
     @Override
-    public String getPredicateValue() { return predicate.getValue();}
+    public String getPredicateValue() { return predicate.toString();}
 
     @Override
     protected ConceptId extractPredicate(VarAdmin var){ return var.admin().getId().orElse(null);}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/util/StringConverter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/util/StringConverter.java
@@ -95,7 +95,7 @@ public class StringConverter {
      * then it will be returned as-is, otherwise it will be quoted and escaped.
      */
     public static String idToString(ConceptId id) {
-        return escapeNameOrId(id.getValue());
+        return escapeNameOrId(id.toString());
     }
 
     /**

--- a/grakn-migration/export/src/main/java/ai/grakn/migration/export/InstanceMapper.java
+++ b/grakn-migration/export/src/main/java/ai/grakn/migration/export/InstanceMapper.java
@@ -132,7 +132,7 @@ public class InstanceMapper {
      */
     private static  Var roleplayers(Var var, Relation relation){
         for(RoleType role:relation.rolePlayers().keySet()){
-            var = var.rel(name(role.getName()), relation.rolePlayers().get(role).getId().getValue());
+            var = var.rel(name(role.getName()), relation.rolePlayers().get(role).getId().toString());
         }
         return var;
     }
@@ -143,7 +143,7 @@ public class InstanceMapper {
      * @return var patterns representing given instance
      */
     private static  Var base(Instance instance){
-        Var var = var(instance.getId().getValue()).isa(name(instance.type().getName()));
+        Var var = var(instance.getId().toString()).isa(name(instance.type().getName()));
         return hasResources(var, instance);
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/VisualiserControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/VisualiserControllerTest.java
@@ -19,8 +19,8 @@
 package ai.grakn.test.engine.controller;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.test.EngineContext;
 import ai.grakn.concept.TypeName;
+import ai.grakn.test.EngineContext;
 import ai.grakn.util.REST;
 import ai.grakn.util.Schema;
 import com.jayway.restassured.response.Response;
@@ -30,10 +30,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static ai.grakn.graphs.TestGraph.loadFromFile;
 import static ai.grakn.util.REST.Request.GRAQL_CONTENTTYPE;
@@ -43,7 +40,6 @@ import static ai.grakn.util.REST.Request.QUERY_FIELD;
 import static com.jayway.restassured.RestAssured.get;
 import static com.jayway.restassured.RestAssured.with;
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class VisualiserControllerTest {
@@ -124,7 +120,7 @@ public class VisualiserControllerTest {
 
     private void checkHALStructureOfPerson(Json person, String id){
         assertEquals(person.at("_type").asString(), "person");
-        assertEquals(person.at("_id").getValue(),id);
+        assertEquals(person.at("_id").asString(),id);
         assertEquals(person.at("_baseType").asString(), Schema.BaseType.ENTITY.name());
 
         //check we are always attaching the correct keyspace
@@ -140,7 +136,7 @@ public class VisualiserControllerTest {
     private void checkHALStructureOfPersonWithoutEmbedded(Json person, String id){
 
         assertEquals(person.at("_type").asString(), "person");
-        assertEquals(person.at("_id").getValue(),id);
+        assertEquals(person.at("_id").asString(),id);
         assertEquals(person.at("_baseType").asString(), Schema.BaseType.ENTITY.name());
 
         //check we are always attaching the correct keyspace

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ClusteringTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ClusteringTest.java
@@ -216,15 +216,15 @@ public class ClusteringTest {
         assertEquals(7, memberMap.size());
 
         String id;
-        id = graph.getResourceType(resourceType1).putResource(2.8).asInstance().getId().getValue();
+        id = graph.getResourceType(resourceType1).putResource(2.8).asInstance().toString();
         assertEquals(1L, sizeMap.get(id).longValue());
-        id = graph.getResourceType(resourceType2).putResource(-5L).asInstance().getId().getValue();
+        id = graph.getResourceType(resourceType2).putResource(-5L).asInstance().toString();
         assertEquals(1L, sizeMap.get(id).longValue());
-        id = graph.getResourceType(resourceType3).putResource(100L).asInstance().getId().getValue();
+        id = graph.getResourceType(resourceType3).putResource(100L).asInstance().toString();
         assertEquals(1L, sizeMap.get(id).longValue());
-        id = graph.getResourceType(resourceType5).putResource(10L).asInstance().getId().getValue();
+        id = graph.getResourceType(resourceType5).putResource(10L).asInstance().toString();
         assertEquals(1L, sizeMap.get(id).longValue());
-        id = graph.getResourceType(resourceType6).putResource(0.8).asInstance().getId().getValue();
+        id = graph.getResourceType(resourceType6).putResource(0.8).asInstance().toString();
         assertEquals(1L, sizeMap.get(id).longValue());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
@@ -21,7 +21,6 @@ package ai.grakn.test.graql.analytics;
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
-import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.RelationType;
@@ -201,7 +200,7 @@ public class GraqlTest {
 
         Optional<List<Concept>> path = query.execute();
         assert path.isPresent();
-        List<String> result = path.get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+        List<String> result = path.get().stream().map(Object::toString).collect(Collectors.toList());
 
         List<String> expected = Lists.newArrayList(entityId1, relationId12, entityId2);
 
@@ -258,10 +257,10 @@ public class GraqlTest {
         Entity entity3 = entityType1.addEntity();
         Entity entity4 = entityType2.addEntity();
 
-        entityId1 = entity1.getId().getValue();
-        entityId2 = entity2.getId().getValue();
-        entityId3 = entity3.getId().getValue();
-        entityId4 = entity4.getId().getValue();
+        entityId1 = entity1.toString();
+        entityId2 = entity2.toString();
+        entityId3 = entity3.toString();
+        entityId4 = entity4.toString();
 
         RoleType role1 = graph.putRoleType("role1");
         RoleType role2 = graph.putRoleType("role2");
@@ -271,10 +270,10 @@ public class GraqlTest {
 
         relationId12 = relationType.addRelation()
                 .putRolePlayer(role1, entity1)
-                .putRolePlayer(role2, entity2).getId().getValue();
+                .putRolePlayer(role2, entity2).toString();
         relationId24 = relationType.addRelation()
                 .putRolePlayer(role1, entity2)
-                .putRolePlayer(role2, entity4).getId().getValue();
+                .putRolePlayer(role2, entity4).toString();
 
         graph.commit();
         graph = Grakn.factory(Grakn.DEFAULT_URI, graph.getKeyspace()).getGraph();

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
@@ -401,7 +401,7 @@ public class ScalingTestIT {
         EntityType thing = graph.getEntityType("thing");
         Set<String> superNodes = new HashSet<>();
         for (int i = 0; i < NUM_SUPER_NODES; i++) {
-            superNodes.add(thing.addEntity().getId().getValue());
+            superNodes.add(thing.addEntity().toString());
         }
         graph.commit();
         graph.close();

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ShortestPathTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ShortestPathTest.java
@@ -107,63 +107,63 @@ public class ShortestPathTest {
         addOntologyAndEntities();
 
         // directly connected vertices
-        correctPath = Lists.newArrayList(entityId1.getValue(), relationId12.getValue());
+        correctPath = Lists.newArrayList(entityId1.toString(), relationId12.toString());
         result = graph.graql().compute().path().from(entityId1).to(relationId12).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = Graql.compute().withGraph(graph).path().to(entityId1).from(relationId12).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
 
         // entities connected by a relation
-        correctPath = Lists.newArrayList(entityId1.getValue(), relationId12.getValue(), entityId2.getValue());
+        correctPath = Lists.newArrayList(entityId1.toString(), relationId12.toString(), entityId2.toString());
         result = graph.graql().compute().path().from(entityId1).to(entityId2).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = graph.graql().compute().path().to(entityId1).from(entityId2).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
 
         // only one path exists with given subtypes
-        correctPath = Lists.newArrayList(entityId2.getValue(), relationId12.getValue(), entityId1.getValue(), relationId13.getValue(), entityId3.getValue());
+        correctPath = Lists.newArrayList(entityId2.toString(), relationId12.toString(), entityId1.toString(), relationId13.toString(), entityId3.toString());
         result = Graql.compute().withGraph(graph).path().to(entityId3).from(entityId2).in(thing, related).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = graph.graql().compute().path().in(thing, related).to(entityId2).from(entityId3).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
 
-        correctPath = Lists.newArrayList(entityId1.getValue(), relationId12.getValue(), entityId2.getValue());
+        correctPath = Lists.newArrayList(entityId1.toString(), relationId12.toString(), entityId2.toString());
         result = graph.graql().compute().path().in(thing, related).to(entityId2).from(entityId1).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = graph.graql().compute().path().in(thing, related).from(entityId2).to(entityId1).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
@@ -179,31 +179,31 @@ public class ShortestPathTest {
         List<String> result;
         addOntologyAndEntities2();
 
-        correctPath = Lists.newArrayList(entityId2.getValue(), relationId12.getValue(), entityId1.getValue(), relationId13.getValue(), entityId3.getValue());
+        correctPath = Lists.newArrayList(entityId2.toString(), relationId12.toString(), entityId1.toString(), relationId13.toString(), entityId3.toString());
         result = graph.graql().compute().path().from(entityId2).to(entityId3).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = graph.graql().compute().path().to(entityId2).from(entityId3).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
 
-        correctPath = Lists.newArrayList(relationId1A12.getValue(), entityId1.getValue(), relationId13.getValue(), entityId3.getValue());
+        correctPath = Lists.newArrayList(relationId1A12.toString(), entityId1.toString(), relationId13.toString(), entityId3.toString());
         result = graph.graql().compute().path().from(relationId1A12).to(entityId3).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));
         }
         Collections.reverse(correctPath);
         result = graph.graql().compute().path().to(relationId1A12).from(entityId3).execute()
-                .get().stream().map(Concept::getId).map(ConceptId::getValue).collect(Collectors.toList());
+                .get().stream().map(Object::toString).collect(Collectors.toList());
         assertEquals(correctPath.size(), result.size());
         for (int i = 0; i < result.size(); i++) {
             assertEquals(correctPath.get(i), result.get(i));

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
@@ -19,6 +19,7 @@
 package ai.grakn.test.graql.reasoner;
 
 import ai.grakn.GraknGraph;
+import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Type;
 import ai.grakn.concept.TypeName;
@@ -180,20 +181,21 @@ public class AtomicTest {
 
     @Test
     public void testTypeInference(){
-        String typeId = snbGraph.graph().getType(TypeName.of("recommendation")).toString();
+        ConceptId typeId = snbGraph.graph().getType(TypeName.of("recommendation")).getId();
+
         String patternString = "{($x, $y); $x isa person; $y isa product;}";
         ReasonerAtomicQuery query = new ReasonerAtomicQuery(conjunction(patternString, snbGraph.graph()), snbGraph.graph());
         Atom atom = query.getAtom();
-        assertTrue(atom.getTypeId().getValue().equals(typeId));
+        assertTrue(atom.getTypeId().equals(typeId));
     }
 
     @Test
     public void testTypeInference2(){
-        String typeId = cwGraph.graph().getType(TypeName.of("transaction")).toString();
+        ConceptId typeId = cwGraph.graph().getType(TypeName.of("transaction")).getId();
         String patternString = "{($z, $y, $x);$z isa country;$x isa rocket;$y isa person;}";
         ReasonerAtomicQuery query = new ReasonerAtomicQuery(conjunction(patternString, cwGraph.graph()), cwGraph.graph());
         Atom atom = query.getAtom();
-        assertTrue(atom.getTypeId().getValue().equals(typeId));
+        assertTrue(atom.getTypeId().equals(typeId));
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
@@ -22,23 +22,22 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.Type;
 import ai.grakn.concept.TypeName;
+import ai.grakn.graphs.CWGraph;
+import ai.grakn.graphs.SNBGraph;
 import ai.grakn.graql.VarName;
+import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.reasoner.Reasoner;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
-import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.internal.reasoner.atom.binary.Relation;
 import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
-import ai.grakn.graphs.CWGraph;
-import ai.grakn.graphs.SNBGraph;
 import ai.grakn.test.GraphContext;
 import com.google.common.collect.Sets;
-import java.util.stream.Collectors;
 import javafx.util.Pair;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -49,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static ai.grakn.test.GraknTestEnv.usingTinker;
 import static java.util.stream.Collectors.toSet;
@@ -180,7 +180,7 @@ public class AtomicTest {
 
     @Test
     public void testTypeInference(){
-        String typeId = snbGraph.graph().getType(TypeName.of("recommendation")).getId().getValue();
+        String typeId = snbGraph.graph().getType(TypeName.of("recommendation")).toString();
         String patternString = "{($x, $y); $x isa person; $y isa product;}";
         ReasonerAtomicQuery query = new ReasonerAtomicQuery(conjunction(patternString, snbGraph.graph()), snbGraph.graph());
         Atom atom = query.getAtom();
@@ -189,7 +189,7 @@ public class AtomicTest {
 
     @Test
     public void testTypeInference2(){
-        String typeId = cwGraph.graph().getType(TypeName.of("transaction")).getId().getValue();
+        String typeId = cwGraph.graph().getType(TypeName.of("transaction")).toString();
         String patternString = "{($z, $y, $x);$z isa country;$x isa rocket;$y isa person;}";
         ReasonerAtomicQuery query = new ReasonerAtomicQuery(conjunction(patternString, cwGraph.graph()), cwGraph.graph());
         Atom atom = query.getAtom();


### PR DESCRIPTION
- Get conceptID to wrap an object in order to get rid of redundant code.
- Cache the conceptID
- Change equality measures
- Cache concept construction in the element factory
- Cache super types