### PR TITLE
Scheduler initially persists tasks

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/TaskState.java
@@ -20,9 +20,11 @@ package ai.grakn.engine.backgroundtasks;
 
 import ai.grakn.engine.TaskStatus;
 import mjson.Json;
+import org.apache.commons.lang.SerializationUtils;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.UUID;
 
 /**
@@ -214,6 +216,14 @@ public class TaskState implements Serializable {
 
     public Json configuration() {
         return configuration;
+    }
+
+    public static String serialize(TaskState task){
+        return Base64.getMimeEncoder().encodeToString(SerializationUtils.serialize(task));
+    }
+
+    public static TaskState deserialize(String task){
+        return (TaskState) SerializationUtils.deserialize(Base64.getMimeDecoder().decode(task));
     }
 }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/DistributedTaskManager.java
@@ -95,9 +95,7 @@ public final class DistributedTaskManager implements TaskManager {
                 .interval(period)
                 .configuration(configuration);
 
-        stateStorage.newState(taskState);
-
-        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), configuration.toString()));
+        producer.send(new ProducerRecord<>(NEW_TASKS_TOPIC, taskState.getId(), TaskState.serialize(taskState)));
         producer.flush();
 
         return taskState.getId();

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/Scheduler.java
@@ -20,7 +20,6 @@ package ai.grakn.engine.backgroundtasks.distributed;
 
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
-import ai.grakn.engine.util.ConfigProperties;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -51,7 +50,6 @@ import static ai.grakn.engine.backgroundtasks.config.ConfigHelper.kafkaProducer;
 import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.NEW_TASKS_TOPIC;
 import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.SCHEDULERS_GROUP;
 import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.WORK_QUEUE_TOPIC;
-import static ai.grakn.engine.util.ConfigProperties.SCHEDULER_POLLING_FREQ;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -67,7 +65,6 @@ import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
 public class Scheduler implements Runnable, AutoCloseable {
     private static final String STATUS_MESSAGE = "Topic [%s], partition [%s] received [%s] records, next offset is [%s]";
 
-    private final static ConfigProperties properties = ConfigProperties.getInstance();
     private final static Logger LOG = LoggerFactory.getLogger(Scheduler.class);
     private final AtomicBoolean OPENED = new AtomicBoolean(false);
 
@@ -91,7 +88,6 @@ public class Scheduler implements Runnable, AutoCloseable {
             producer = kafkaProducer();
 
             waitToClose = new CountDownLatch(1);
-
             schedulingService = Executors.newScheduledThreadPool(1);
 
             LOG.debug("Scheduler started");
@@ -113,7 +109,13 @@ public class Scheduler implements Runnable, AutoCloseable {
                 printConsumerStatus(records);
 
                 for(ConsumerRecord<String, String> record:records) {
-                    scheduleTask(record.key(), record.value());
+                    TaskState taskState = TaskState.deserialize(record.value());
+
+                    // mark the task as created
+                    storage.newState(taskState);
+
+                    // schedule the task
+                    scheduleTask(taskState);
 
                     //acknowledge that the record was read to the consumer
                     consumer.seek(new TopicPartition(record.topic(), record.partition()), record.offset() + 1);
@@ -121,34 +123,36 @@ public class Scheduler implements Runnable, AutoCloseable {
             }
         }
         catch (WakeupException e) {
-            // do nothing to shutdown
             LOG.debug("Shutting down scheduler consumer");
-        }
-        finally {
-            consumer.commitSync();
-            consumer.close();
-            waitToClose.countDown();
+        } catch (Throwable t){
+            LOG.error("Error in scheduler poll " + getFullStackTrace(t));
+        } finally {
+            noThrow(consumer::commitSync, "Exception syncing commits while closing in Scheduler");
+            noThrow(consumer::close, "Exception while closing consumer in Scheduler");
+            noThrow(waitToClose::countDown, "Exception while counting down close latch in Scheduler");
         }
     }
 
+    /**
+     * Stop the main loop, causing run() to exit.
+     *
+     * noThrow() functions used here so that if an error occurs during execution of a
+     * certain step, the subsequent stops continue to execute.
+     */
     public void close() {
         if(OPENED.compareAndSet(true, false)) {
             running = false;
             noThrow(consumer::wakeup, "Could not wake up scheduler thread.");
 
             // Wait for thread calling run() to wakeup and close consumer.
-            try {
-                waitToClose.await(5*properties.getPropertyAsLong(SCHEDULER_POLLING_FREQ), MILLISECONDS);
-            } catch (Throwable t) {
-                LOG.error("Exception whilst waiting for scheduler run() thread to finish - " + getFullStackTrace(t));
-            }
+            noThrow(waitToClose::await, "Error waiting for TaskRunner consumer to exit");
 
             noThrow(schedulingService::shutdownNow, "Could not shutdown scheduling service.");
 
             noThrow(producer::flush, "Could not flush Kafka producer in scheduler.");
             noThrow(producer::close, "Could not close Kafka producer in scheduler.");
 
-            noThrow(() -> LOG.debug("Scheduler stopped."), "Kafka logging error.");
+            LOG.debug("Scheduler stopped.");
         }
         else {
             LOG.error("Scheduler open() must be called before close()!");
@@ -157,33 +161,21 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     /**
      * Schedule a task to be submitted to the work queue when it is supposed to be run
-     * @param id id of the task to be scheduled
-     * @param configuration configuration of task to be scheduled, will be copied to WORK_QUEUE_TOPIC
-     */
-    private void scheduleTask(String id, String configuration) {
-        TaskState state = storage.getState(id);
-        scheduleTask(id, configuration, state);
-    }
-
-    /**
-     * Schedule a task to be submitted to the work queue when it is supposed to be run
-     * @param id id of the task to be scheduled
-     * @param configuration configuration of task to be scheduled, will be copied to WORK_QUEUE_TOPIC
      * @param state state of the task
      */
-    private void scheduleTask(String id,  String configuration, TaskState state) {
+    private void scheduleTask(TaskState state) {
         long delay = Duration.between(Instant.now(), state.runAt()).toMillis();
 
         markAsScheduled(state);
         if(state.isRecurring()) {
             Runnable submit = () -> {
                 markAsScheduled(state);
-                sendToWorkQueue(id, configuration);
+                sendToWorkQueue(state);
             };
             schedulingService.scheduleAtFixedRate(submit, delay, state.interval(), MILLISECONDS);
         }
         else {
-            Runnable submit = () -> sendToWorkQueue(id, configuration);
+            Runnable submit = () -> sendToWorkQueue(state);
             schedulingService.schedule(submit, delay, MILLISECONDS);
         }
     }
@@ -199,12 +191,11 @@ public class Scheduler implements Runnable, AutoCloseable {
 
     /**
      * Submit a task to the work queue
-     * @param taskId id of the task to be submitted
-     * @param configuration task to be submitted
+     * @param state task to be submitted
      */
-    private void sendToWorkQueue(String taskId, String configuration) {
-        LOG.debug("Sending to work queue " + taskId);
-        producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, taskId, configuration), new KafkaLoggingCallback());
+    private void sendToWorkQueue(TaskState state) {
+        LOG.debug("Sending to work queue " + state.getId());
+        producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, state.getId(), TaskState.serialize(state)), new KafkaLoggingCallback());
         producer.flush();
     }
 
@@ -216,13 +207,7 @@ public class Scheduler implements Runnable, AutoCloseable {
         tasks.stream()
                 .filter(TaskState::isRecurring)
                 .filter(p -> p.status() != STOPPED)
-                .forEach(p -> {
-                    // Not sure what is the right format for "no configuration", but somehow the configuration
-                    // here for a postprocessing task is "null": if we say that the configuration of a task
-                    // is a JSONObject, then an empty configuration ought to be {}
-                    String config = p.configuration() == null ? "{}" : p.configuration().toString();
-                    scheduleTask(p.getId(), config, p);
-                });
+                .forEach(this::scheduleTask);
     }
 
     private void printConsumerStatus(ConsumerRecords<String, String> records){

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/distributed/TaskRunner.java
@@ -23,6 +23,7 @@ import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.engine.util.EngineID;
+import ai.grakn.exception.EngineStorageException;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -53,6 +54,7 @@ import static ai.grakn.engine.backgroundtasks.config.KafkaTerms.WORK_QUEUE_TOPIC
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_STATE;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_WATCH;
 import static ai.grakn.engine.util.ConfigProperties.TASKRUNNER_POLLING_FREQ;
+import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
@@ -115,29 +117,30 @@ public class TaskRunner implements Runnable, AutoCloseable {
         }
         catch (WakeupException e) {
             LOG.debug("TaskRunner exiting, woken up.");
-        }
-        finally {
-            consumer.commitSync();
-            consumer.close();
-            shutdownLatch.countDown();
+        } catch (Throwable t){
+            LOG.error("Error in TaskRunner poll " + getFullStackTrace(t));
+        } finally {
+            noThrow(consumer::commitSync, "Exception syncing commits while closing in TaskRunner");
+            noThrow(consumer::close, "Exception while closing consumer in TaskRunner");
+            noThrow(shutdownLatch::countDown, "Exception while counting down close latch in TaskRunner");
         }
     }
 
     /**
      * Stop the main loop, causing run() to exit.
+     *
+     * noThrow() functions used here so that if an error occurs during execution of a
+     * certain step, the subsequent stops continue to execute.
      */
     public void close() {
         // Stop execution of kafka consumer
-        consumer.wakeup();
+        noThrow(consumer::wakeup, "Could not wake up task runner thread.");
 
-        try {
-            shutdownLatch.await();
-        } catch (InterruptedException e){
-            LOG.error("Error waiting for TaskRunner consumer to exit " + getFullStackTrace(e));
-        }
+        // Wait for the shutdown latch to complete
+        noThrow(shutdownLatch::await, "Error waiting for TaskRunner consumer to exit");
 
         // Interrupt all currently running threads - these will be re-allocated to another Engine.
-        executor.shutdownNow();
+        noThrow(executor::shutdownNow, "Could not shutdown scheduling service.");
 
         LOG.debug("TaskRunner stopped");
     }
@@ -154,24 +157,29 @@ public class TaskRunner implements Runnable, AutoCloseable {
 
             String id = record.key();
 
-            TaskState state = storage.getState(id);
-            if(state.status() != SCHEDULED) {
-                LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: "+ state.status());
-                continue;
-            }
+            // Instead of deserializing TaskState from value, get up-to-date state from the storage
+            try {
+                TaskState state = storage.getState(id);
+                if (state.status() != SCHEDULED) {
+                    LOG.debug("Cant run this task - " + id + " because\n\t\tstatus: " + state.status());
+                    continue;
+                }
 
-            // Mark as RUNNING and update task & runner states.
-            addRunningTask(state.getId());
-            storage.updateState(state
+                // Mark as RUNNING and update task & runner states.
+                addRunningTask(state.getId());
+                storage.updateState(state
                     .status(RUNNING)
                     .statusChangedBy(this.getClass().getName())
                     .engineID(ENGINE_ID));
 
-            // Submit to executor
-            executor.submit(() -> executeTask(state));
+                // Submit to executor
+                executor.submit(() -> executeTask(state));
 
-            // Advance offset
-            seekAndCommit(new TopicPartition(record.topic(), record.partition()), record.offset()+1);
+                // Advance offset
+                seekAndCommit(new TopicPartition(record.topic(), record.partition()), record.offset() + 1);
+            } catch (EngineStorageException e){
+                LOG.error("Cant run this task - " + id + " because state was not found in storage");
+            }
         }
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateGraphStore.java
@@ -38,7 +38,6 @@ import ai.grakn.util.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Optional;
@@ -66,8 +65,6 @@ import static ai.grakn.graql.Graql.name;
 import static ai.grakn.graql.Graql.var;
 import static java.lang.Thread.sleep;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang.SerializationUtils.deserialize;
-import static org.apache.commons.lang.SerializationUtils.serialize;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
@@ -95,7 +92,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
                 .has(RUN_AT, var().value(task.runAt().toEpochMilli()))
                 .has(RECURRING, var().value(task.isRecurring()))
                 .has(RECUR_INTERVAL, var().value(task.interval()))
-                .has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+                .has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         if(task.configuration() != null) {
             state.has(TASK_CONFIGURATION, var().value(task.configuration().toString()));
@@ -122,7 +119,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         Var resources = var(TASK_VAR);
 
         resourcesToDettach.add(SERIALISED_TASK);
-        resources.has(SERIALISED_TASK, var().value(Base64.getMimeEncoder().encodeToString(serialize(task))));
+        resources.has(SERIALISED_TASK, var().value(TaskState.serialize(task)));
 
         // TODO make sure all properties are being update
         if(task.status() != null) {
@@ -200,7 +197,7 @@ public class TaskStateGraphStore implements TaskStateStorage {
         ResourceType<String> serialisedResourceType = graph.getResourceType(SERIALISED_TASK.getValue());
         String serialisedTask = (String) instance.resources(serialisedResourceType).iterator().next().getValue();
 
-        return (TaskState) deserialize(Base64.getMimeDecoder().decode(serialisedTask));
+        return TaskState.deserialize(serialisedTask);
     }
 
     @Override

--- a/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateInMemoryStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/backgroundtasks/taskstatestorage/TaskStateInMemoryStore.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.backgroundtasks.taskstatestorage;
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.TaskStatus;
+import ai.grakn.exception.EngineStorageException;
 
 import java.lang.ref.SoftReference;
 import java.util.HashSet;
@@ -59,7 +60,7 @@ public class TaskStateInMemoryStore implements TaskStateStorage {
     @Override
     public TaskState getState(String id) {
         if(id == null || !storage.containsKey(id)) {
-            return null;
+            throw new EngineStorageException("Could not retrieve id " + id);
         }
 
         return storage.get(id).get();

--- a/grakn-engine/src/main/java/ai/grakn/engine/util/ExceptionWrapper.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/util/ExceptionWrapper.java
@@ -30,12 +30,21 @@ import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
 public class ExceptionWrapper {
     private static final Logger LOG = LoggerFactory.getLogger(ExceptionWrapper.class);
 
-    public static void noThrow(Runnable fn, String errorMessage) {
+    public static void noThrow(RunnableWithExceptions fn, String errorMessage) {
         try {
             fn.run();
         }
         catch (Throwable t) {
             LOG.error(errorMessage + "\nThe exception was: " + getFullStackTrace(t));
         }
+    }
+
+    /**
+     * Function interface that throws exception for use in the noThrow function
+     * @param <E>
+     */
+    @FunctionalInterface
+    public interface RunnableWithExceptions<E extends Exception> {
+        void run() throws E;
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
@@ -35,15 +35,14 @@ import static java.util.stream.Collectors.toSet;
  */
 public class BackgroundTaskTestUtils {
 
-    public static Set<TaskState> createTasks(TaskStateStorage storage, int n, TaskStatus status) {
+    public static Set<TaskState> createTasks(int n, TaskStatus status) {
         return IntStream.range(0, n)
-                .mapToObj(i -> createTask(storage, i, status, false, 0))
+                .mapToObj(i -> createTask(i, status, false, 0))
                 .collect(toSet());
     }
 
-    public static TaskState createTask(TaskStateStorage storage,
-                                int i, TaskStatus status, boolean recurring, int interval) {
-        TaskState state = new TaskState(TestTask.class.getName())
+    public static TaskState createTask(int i, TaskStatus status, boolean recurring, int interval) {
+        return new TaskState(TestTask.class.getName())
                 .status(status)
                 .creator(BackgroundTaskTestUtils.class.getName())
                 .statusChangedBy(BackgroundTaskTestUtils.class.getName())
@@ -51,9 +50,6 @@ public class BackgroundTaskTestUtils {
                 .isRecurring(recurring)
                 .interval(interval)
                 .configuration(Json.object("name", "task" + i));
-
-        storage.newState(state);
-        return state;
     }
     
     public static void waitForStatus(TaskStateStorage storage, Set<TaskState> tasks, TaskStatus status) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerElectorTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/SchedulerElectorTest.java
@@ -48,6 +48,7 @@ public class SchedulerElectorTest {
 
     @AfterClass
     public static void teardown(){
+        elector.stop();
         connection.close();
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskFailoverTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskFailoverTest.java
@@ -40,11 +40,11 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 
-import static ai.grakn.engine.backgroundtasks.TaskStatus.COMPLETED;
-import static ai.grakn.engine.backgroundtasks.TaskStatus.FAILED;
-import static ai.grakn.engine.backgroundtasks.TaskStatus.RUNNING;
-import static ai.grakn.engine.backgroundtasks.TaskStatus.SCHEDULED;
-import static ai.grakn.engine.backgroundtasks.TaskStatus.STOPPED;
+import static ai.grakn.engine.TaskStatus.COMPLETED;
+import static ai.grakn.engine.TaskStatus.FAILED;
+import static ai.grakn.engine.TaskStatus.RUNNING;
+import static ai.grakn.engine.TaskStatus.SCHEDULED;
+import static ai.grakn.engine.TaskStatus.STOPPED;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_STATE;
 import static ai.grakn.engine.backgroundtasks.config.ZookeeperPaths.RUNNERS_WATCH;
 import static ai.grakn.test.engine.backgroundtasks.BackgroundTaskTestUtils.createTask;
@@ -106,7 +106,7 @@ public class TaskFailoverTest {
         registerFakeEngine(fakeEngineID);
 
         // Add some tasks to a fake task runner watch and storage, marked as running
-        Set<TaskState> tasks = createTasks(storage, 5, RUNNING);
+        Set<TaskState> tasks = createTasks(5, RUNNING);
         tasks.forEach(storage::newState);
         registerTasksInZKLikeTaskRunnerWould(fakeEngineID, tasks);
 
@@ -131,11 +131,11 @@ public class TaskFailoverTest {
         registerFakeEngine(fakeEngineID);
 
         // Add a task in each state (SCHEDULED, COMPLETED, STOPPED, FAILED, RUNNING) to fake task runner watch
-        TaskState scheduled = createTask(storage, 0, SCHEDULED, false, 0);
-        TaskState running = createTask(storage, 1, RUNNING, false, 0);
-        TaskState stopped = createTask(storage, 2, STOPPED, false, 0);
-        TaskState failed = createTask(storage, 3, FAILED, false, 0);
-        TaskState completed = createTask(storage, 4, COMPLETED, false, 0);
+        TaskState scheduled = createTask(0, SCHEDULED, false, 0);
+        TaskState running = createTask(1, RUNNING, false, 0);
+        TaskState stopped = createTask(2, STOPPED, false, 0);
+        TaskState failed = createTask(3, FAILED, false, 0);
+        TaskState completed = createTask(4, COMPLETED, false, 0);
 
         Set<TaskState> tasks = Sets.newHashSet(scheduled, running, stopped, failed, completed);
         tasks.forEach(storage::newState);
@@ -169,7 +169,7 @@ public class TaskFailoverTest {
         Json configuration = Json.object("configuration", true);
         Json checkpoint = Json.object("configuration", false);
 
-        TaskState running = createTask(storage, 1, RUNNING, false, 0);
+        TaskState running = createTask(1, RUNNING, false, 0);
         running.configuration(configuration);
         running.checkpoint(checkpoint.toString());
         storage.newState(running);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskRunnerTest.java
@@ -80,7 +80,8 @@ public class TaskRunnerTest {
     public void testSendReceive() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         waitForStatus(storage, tasks, COMPLETED);
 
@@ -91,7 +92,8 @@ public class TaskRunnerTest {
     public void testSendDuplicate() throws Exception {
         TestTask.startedCounter.set(0);
 
-        Set<TaskState> tasks = createTasks(storage, 5, SCHEDULED);
+        Set<TaskState> tasks = createTasks(5, SCHEDULED);
+        tasks.forEach(storage::newState);
         sendTasksToWorkQueue(tasks);
         sendTasksToWorkQueue(tasks);
 
@@ -100,7 +102,7 @@ public class TaskRunnerTest {
     }
 
     private void sendTasksToWorkQueue(Set<TaskState> tasks) {
-        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), t.configuration().toString())));
+        tasks.forEach(t -> producer.send(new ProducerRecord<>(WORK_QUEUE_TOPIC, t.getId(), TaskState.serialize(t))));
         producer.flush();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/GraqlTest.java
@@ -82,7 +82,7 @@ public class GraqlTest {
     private String relationId24;
 
     @ClassRule
-    public static final EngineContext context = EngineContext.startDistributedServer();
+    public static final EngineContext context = EngineContext.startInMemoryServer();
 
     @Before
     public void setUp() {


### PR DESCRIPTION
+ The `Scheduler` stores and marks tasks as `CREATED` 
+ This removes any blocking on REST endpoint
+ Kafka passing around Task ID as key and Serialized `TaskState` as value
+ Cleanup in Engine shutdown methods