### PR TITLE
Dashboard small improvements

### DIFF
--- a/grakn-dashboard/src/components/configPage.vue
+++ b/grakn-dashboard/src/components/configPage.vue
@@ -26,7 +26,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
                     <tr>
                         <th>Config Item</th>
                         <th>Value</th>
-                        <tr>
+                    </tr>
                 </thead>
                 <tbody>
                     <tr>
@@ -59,7 +59,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
                     </tr>
                     <tr>
                         <td>Log File</td>
-                        <td>{{response['logging.file']}}</td>
+                        <td>{{response['logging.file.main']}}</td>
                     </tr>
                     <tr>
                         <td>Logging Level</td>
@@ -115,6 +115,17 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 </template>
 
 <style scoped>
+table {
+    border-collapse: separate;
+    border-spacing: 15px;
+}
+th{
+  font-weight: bold;
+}
+td{
+  border-bottom: 1px solid #606060;
+  padding: 5px;
+}
 .container {
     display: flex;
     flex-direction: row;
@@ -124,6 +135,10 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
     position: absolute;
 }
 
+.table-responsive{
+  margin-top: 10px;
+}
+
 .inline-flex-1 {
     display: inline-flex;
     flex: 1;
@@ -131,14 +146,16 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 
 .panel-body {
     display: inline-flex;
+    justify-content: center;
     flex: 3;
     background-color: green;
-    margin-top: 20px;
+    margin-top: 10px;
     margin-bottom: 25px;
-    background-color: rgba(68, 70, 79, 1);
+    background-color: #0f0f0f;
     margin-left: 15px;
     margin-right: 15px;
-    padding: 10px 15px;
+    padding-top: 30px;
+    overflow: scroll;
 }
 </style>
 

--- a/grakn-dashboard/src/components/consolePage.vue
+++ b/grakn-dashboard/src/components/consolePage.vue
@@ -43,7 +43,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
 
 .panel-body {
     display: inline-flex;
-    flex: 3;
+    flex: 4;
     background-color: green;
     margin-top: 20px;
     margin-bottom: 25px;
@@ -51,6 +51,16 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     margin-left: 15px;
     margin-right: 15px;
     padding: 10px 15px;
+    position: relative;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+.panel-body::-webkit-scrollbar {
+    display: none;
+}
+
+pre{
+  width: 100%;
 }
 </style>
 

--- a/grakn-dashboard/src/components/graphPage/graphPage.vue
+++ b/grakn-dashboard/src/components/graphPage/graphPage.vue
@@ -27,7 +27,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 </div>
 </template>
 
-<style>
+<style scoped>
 .graph-panel-body {
     height: 100%;
     width: 100%;
@@ -95,7 +95,6 @@ export default {
         this.state.eventHub.$on('load-ontology', this.onLoadOntology);
         this.state.eventHub.$on('clear-page', this.onClear);
         this.state.eventHub.$on('configure-node', this.configureNode);
-
 
     },
     beforeDestroy() {
@@ -220,10 +219,6 @@ export default {
             }
 
             const eventKeys = param.event.srcEvent;
-
-            if (eventKeys.shiftKey) {
-                visualiser.clearGraph();
-            }
 
             EngineClient.request({
                 url: visualiser.getNode(node).href,

--- a/grakn-dashboard/src/components/graphPage/nodePanel.vue
+++ b/grakn-dashboard/src/components/graphPage/nodePanel.vue
@@ -55,6 +55,8 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
     width: 270px;
     background-color: #0f0f0f;
     padding: 10px;
+    max-height: 95%;
+    overflow: scroll;
 }
 
 .panel-heading {
@@ -72,6 +74,10 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
   cursor: default;
 }
 
+.fa-times{
+  cursor: pointer;
+}
+
 .dd-header {
     margin-top: 10px;
     margin-bottom: 5px;
@@ -79,7 +85,6 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 
 .dd-handle {
     cursor: pointer;
-    /*border: 1px solid #3d404c;*/
     padding: 10px 10px;
     border-radius: 3px;
     margin: 3px 0px;
@@ -87,7 +92,6 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
 
 .node-properties {
     cursor: text;
-    /*border: 1px solid #3d404c;*/
     padding: 10px 10px;
     border-radius: 3px;
 }

--- a/grakn-dashboard/src/components/graqlEditor/favQueriesList.vue
+++ b/grakn-dashboard/src/components/graqlEditor/favQueriesList.vue
@@ -23,26 +23,29 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     <transition name="fade-in">
         <div v-if="showFavourites" class="dropdown-content">
             <div class="panel-heading">
+                <div></div>
                 <h4><i class="page-header-icon fa fa-star-o"></i>Saved queries</h4>
                 <a @click="closeFavQueriesList"><i class="fa fa-times"></i></a>
             </div>
-            <div class="panel-body"  v-if="favouriteQueries.length">
+            <div class="panel-body" v-if="favouriteQueries.length">
                 <div class="dd-item" v-for="(query,index) in favouriteQueries">
-                    <div class="full-query" @click="emitTypeQuery(query.value)">
+                    <div class="full-query">
                         <span class="list-key"> {{query.name}}</span>
                         <span class="tooltiptext"> {{query.value}}</span>
                     </div>
-                    <div class="col-sm-2">
-                        <button class="btn" @click="removeFavQuery(index,query.name)">Delete</button>
+                    <div class="line-buttons">
+                        <button class="btn bold" @click="emitTypeQuery(query.value)">USE</button>
+                        <button class="btn" @click="removeFavQuery(index,query.name)"><i class="fa fa-trash-o"></i></button>
                     </div>
                 </div>
             </div>
             <div class="panel-body" v-else>
-              <div class="dd-item">
-                  <div class="no-saved">
-                      No saved queries.
-                  </div>
-              </div></div>
+                <div class="dd-item">
+                    <div class="no-saved">
+                        No saved queries.
+                    </div>
+                </div>
+            </div>
 
         </div>
     </transition>
@@ -50,19 +53,35 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
 </template>
 
 <style scoped>
-
 .panel-filled {
     background-color: rgba(68, 70, 79, 1);
 }
 
-.no-saved{
-  margin-bottom: 5px;
+.bold {
+    font-weight: bold;
+}
+
+.no-saved {
+    margin-bottom: 15px;
+}
+
+.fa-trash-o {
+    font-size: 95%;
+}
+
+.a {
+    margin-left: auto;
+}
+
+.fa-times{
+  cursor: pointer;
 }
 
 .panel-heading {
     padding: 5px 10px;
     display: flex;
-    justify-content: space-around;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .page-header-icon {
@@ -82,12 +101,17 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     margin: auto;
     margin-top: 5px;
     padding-left: 7px;
-    cursor: pointer;
 }
 
-.list-key{
-  display: inline-flex;
-  flex:1;
+.list-key {
+    display: inline-flex;
+    flex: 1;
+}
+
+.line-buttons {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
 }
 
 .dropdown-content {
@@ -97,6 +121,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     z-index: 2;
     margin-top: 5px;
     background-color: #0f0f0f;
+    padding:10px;
 }
 
 
@@ -112,7 +137,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     border-radius: 3px;
     position: absolute;
     z-index: 5;
-    bottom:100%;
+    bottom: 120%;
     text-align: left;
     word-break: normal;
     overflow: scroll;
@@ -124,7 +149,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
 
 /* Show the tooltip text when you mouse over the tooltip container */
 
-.list-key:hover ~ .tooltiptext {
+.list-key:hover~.tooltiptext {
     visibility: visible;
 }
 
@@ -132,6 +157,8 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     width: 200px;
     display: inline-flex;
     position: relative;
+    border-bottom: 1px solid #606060;
+    padding-bottom: 5px;
 }
 </style>
 
@@ -164,8 +191,8 @@ export default {
                 this.showFavourites = false;
             }
         },
-        refreshList(){
-          this.favouriteQueries = this.objectToArray(FavQueries.getFavQueries());
+        refreshList() {
+            this.favouriteQueries = this.objectToArray(FavQueries.getFavQueries());
         },
         closeFavQueriesList() {
             this.showFavourites = false;

--- a/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
+++ b/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
@@ -35,7 +35,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
             <add-current-query :current-query="currentQuery" v-on:new-query-saved="refreshSavedQueries"></add-current-query>
             <button @click="runQuery" class="btn"><i
                           class="pe-7s-angle-right-circle"></i></button>
-            <button @click="clearGraph" @click.shift="clearGraphAndPage" class="btn"><i class="pe-7s-refresh"></i>
+            <button @click="clearGraph" @click.shift="clearGraphAndPage" class="btn"><i class="pe-7s-close-circle"></i>
                           </button>
             <query-settings></query-settings>
         </div>
@@ -143,6 +143,10 @@ export default {
     created: function() {
         this.loadState();
         this.loadMetaTypeInstances();
+
+        //Global key bindings
+        window.addEventListener('keyup', (e)=>{if(e.keyCode===13) this.runQuery();})
+
     },
     mounted: function() {
         this.$nextTick(function() {
@@ -151,6 +155,7 @@ export default {
                 theme: "dracula",
                 mode: "graql",
                 viewportMargin: Infinity,
+                autofocus: true,
                 extraKeys: {
                     Enter: this.runQuery,
                     "Shift-Delete": this.clearGraph,

--- a/grakn-dashboard/src/components/graqlEditor/querySettings.vue
+++ b/grakn-dashboard/src/components/graqlEditor/querySettings.vue
@@ -57,6 +57,9 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
   display: inline-flex;
   flex:1;
 }
+.fa-times{
+  cursor: pointer;
+}
 
 .grey{
   opacity: 0.5;

--- a/grakn-dashboard/src/components/mainTemplate/mainTemplate.vue
+++ b/grakn-dashboard/src/components/mainTemplate/mainTemplate.vue
@@ -82,6 +82,8 @@ const computeComponentCenterLeft = function(path) {
     return null;
 };
 
+import User from '../../js/User';
+
 
 export default {
     name: 'MainTemplate',
@@ -127,6 +129,13 @@ export default {
               "showMethod": "fadeIn",
               "hideMethod": "fadeOut"
           };
+
+          if (!User.getModalShown()){
+            var modal = document.getElementById('myModal');
+            modal.style.display = "block";
+            User.setModalShown(true);
+          }
+
         });
     },
     watch: {

--- a/grakn-dashboard/src/components/mainTemplate/sidebar.vue
+++ b/grakn-dashboard/src/components/mainTemplate/sidebar.vue
@@ -92,18 +92,12 @@ export default {
     props: ['showSideBar'],
     data: function() {
         return {
-            version: undefined,
             isUserAuth: User.isAuthenticated(),
         }
     },
     created: function() {},
     mounted: function() {
         this.$nextTick(function() {
-            EngineClient.getConfig((r, e) => {
-                this.version = (r == null ? 'error' : r['project.version'])
-            });
-            // if (!User.getModalShown())
-            // $('#signupModal').modal('show');
         })
     },
     methods: {

--- a/grakn-dashboard/src/components/mainTemplate/signupModal.vue
+++ b/grakn-dashboard/src/components/mainTemplate/signupModal.vue
@@ -245,7 +245,6 @@ export default {
 
     mounted: function() {
         this.$nextTick(function() {
-            User.setModalShown(true);
             // Get the modal
             var modal = document.getElementById('myModal');
 


### PR DESCRIPTION
  - config page cleaned up and fixed small bug
  - console page has now a max-width and becomes scrollable horizontally
  - global listener on Enter key, to execute the query in the editor
  - removed double-clik+shift behaviour to clear graph
  - new icon on graql editor delete button
  - nodePanel has a max height and becomes scrollable if content too big
  - new style in saved queries panel
  - autofocus on graqlEditor when the page is loaded, so no need to manually put cursor there
  - show joinCommunity modal first time user opens dashboard