### PR TITLE
Deep clone cache to avoid transactions from affecting central cache.

### DIFF
--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -63,11 +63,13 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -103,6 +105,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     private final ThreadLocal<Boolean> localIsOpen = new ThreadLocal<>();
     private final ThreadLocal<String> localClosedReason = new ThreadLocal<>();
     private final ThreadLocal<Boolean> localShowImplicitStructures = new ThreadLocal<>();
+    private final ThreadLocal<Map<TypeName, Type>> localCloneCache = new ThreadLocal<>();
 
     private boolean committed; //Shared between multiple threads so we know if a refresh must be performed
 
@@ -285,13 +288,101 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         return concepts;
     }
 
-
     ConceptLog getConceptLog() {
         ConceptLog conceptLog = localConceptLog.get();
         if(conceptLog == null){
             localConceptLog.set(conceptLog = new ConceptLog(this));
+            loadOntologyCacheIntoTransactionCache(conceptLog);
         }
         return conceptLog;
+    }
+
+    private Map<TypeName, Type> getCloneCache(){
+        Map<TypeName, Type> cloneCache = localCloneCache.get();
+        if(cloneCache == null){
+            localCloneCache.set(cloneCache = new HashMap<>());
+        }
+        return cloneCache;
+    }
+
+    /**
+     * Given a concept log bound to a specific thread the central ontology cache is read into this concept log.
+     * This method performs this operation whilst making a deep clone of the cached concepts to ensure transactions
+     * do not accidentally break the central ontology cache.
+     *
+     * @param conceptLog The thread bound concept log to read the snapshot into.
+     */
+    private void loadOntologyCacheIntoTransactionCache(ConceptLog conceptLog){
+        ConcurrentMap<TypeName, TypeImpl> cachedOntologySnapshot = getCachedOntology().asMap();
+
+        //Read central cache into conceptLog cloning only base concepts. Sets clones later
+        for (TypeImpl type : cachedOntologySnapshot.values()) {
+            conceptLog.cacheConcept(clone(type));
+        }
+
+        //Iterate through cached clones completing the cloning process.
+        //This part has to be done in a separate iteration otherwise we will infinitely recurse trying to clone everything
+        for (Type type : getCloneCache().values()) {
+            if(type.isRoleType()){
+                ((RoleTypeImpl) type).completeClone(cachedOntologySnapshot.get(type.getName()));
+            } else if(type.isRelationType()){
+                ((RelationTypeImpl) type).completeClone(cachedOntologySnapshot.get(type.getName()));
+            } else {
+                ((TypeImpl) type).completeClone(cachedOntologySnapshot.get(type.getName()));
+            }
+        }
+
+        //Purge clone cache to save memory
+        localCloneCache.remove();
+    }
+
+    /**
+     *
+     * @param type The type to clone
+     * @param <X> The type of the concept
+     * @return The newly deep cloned set
+     */
+    @SuppressWarnings({"unchecked", "ConstantConditions"})
+    <X extends Type> X clone(X type){
+        //Is a cloning even needed?
+        if(getCloneCache().containsKey(type.getName())){
+            return (X) getCloneCache().get(type.getName());
+        }
+
+        //If the clone has not happened then make a new one
+        Type clonedType = null;
+        if(type.isRoleType()) {
+            clonedType = new RoleTypeImpl((RoleTypeImpl) type);
+        } else if(type.isRelationType()) {
+            clonedType = new RelationTypeImpl((RelationTypeImpl) type);
+        } else if(type.isEntityType()) {
+            clonedType = new EntityTypeImpl((EntityTypeImpl) type);
+        } else if(type.isRuleType()) {
+            clonedType = new RuleTypeImpl((RuleTypeImpl) type);
+        } else if(type.isResourceType()) {
+            clonedType = new ResourceTypeImpl((ResourceTypeImpl) type);
+        } else if(type.isType()) {
+            clonedType = new TypeImpl((TypeImpl) type);
+        }
+
+        if(clonedType == null){
+            throw new IllegalArgumentException("Attempting to clone concept [" + type + "] which is not supported");
+        }
+
+        //Update clone cache so we don't clone multiple concepts in the same transaction
+        getCloneCache().put(clonedType.getName(), clonedType);
+
+        return (X) clonedType;
+    }
+
+    /**
+     *
+     * @param types a set of concepts to clone
+     * @param <X> the type of those concepts
+     * @return the set of concepts deep cloned
+     */
+    <X extends Type> Set<X> clone(Set<X> types){
+        return types.stream().map(this::clone).collect(Collectors.toSet());
     }
 
     void checkOntologyMutation(){
@@ -804,7 +895,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
         LOG.trace("Graph committed.");
         getConceptLog().writeToCentralCache(true);
-        getConceptLog().resetTransaction();
+        clearLocalVariables();
 
         //No post processing should ever be done for the system keyspace
         if(!keyspace.equalsIgnoreCase(SystemKeyspace.SYSTEM_GRAPH_NAME) && (!castings.isEmpty() || !resources.isEmpty())) {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
@@ -81,6 +81,12 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
         vertex = v;
     }
 
+    ConceptImpl(ConceptImpl concept){
+        this.graknGraph = concept.getGraknGraph();
+        this.conceptId = concept.getId();
+        this.vertex = concept.getVertex();
+    }
+
     /**
      *
      * @param key The key of the property to mutate

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
@@ -68,20 +68,6 @@ class ConceptLog {
     }
 
     /**
-     * Removes all the concepts from the transaction tracker
-     */
-    /*void resetTransaction(){
-        //Clear all transaction bound caches
-        modifiedConcepts.clear();
-        modifiedCastings.clear();
-        modifiedResources.clear();
-        modifiedRelations.clear();
-        conceptCache.clear();
-        typeCache.clear();
-
-    }*/
-
-    /**
      * A helper method which writes back into the central cache at the end of a transaction.
      *
      * @param committed true if a commit has occurred

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
@@ -65,13 +65,12 @@ class ConceptLog {
 
     ConceptLog(AbstractGraknGraph<?> graknGraph) {
         this.graknGraph = graknGraph;
-        resetTransaction();
     }
 
     /**
      * Removes all the concepts from the transaction tracker
      */
-    void resetTransaction(){
+    /*void resetTransaction(){
         //Clear all transaction bound caches
         modifiedConcepts.clear();
         modifiedCastings.clear();
@@ -80,10 +79,7 @@ class ConceptLog {
         conceptCache.clear();
         typeCache.clear();
 
-        //Reload types back in from grakn graph
-        //TODO: Improve thread safety further. References stored in sets are the same as originals in central cache. This is dangerous.
-        graknGraph.getCachedOntology().asMap().values().forEach(type -> this.cacheConcept(type.clone()));
-    }
+    }*/
 
     /**
      * A helper method which writes back into the central cache at the end of a transaction.

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/EntityTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/EntityTypeImpl.java
@@ -45,6 +45,10 @@ class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements EntityType{
         super(graknGraph, v, type);
     }
 
+    EntityTypeImpl(EntityTypeImpl entityType){
+        super(entityType);
+    }
+
     @Override
     public Entity addEntity() {
         return addInstance(Schema.BaseType.ENTITY, (vertex, type) ->

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
@@ -54,13 +54,11 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
 
     RelationTypeImpl(RelationTypeImpl relationType){
         super(relationType);
-        //relationType.cachedHasRoles.ifPresent(value -> this.cachedHasRoles.set(getGraknGraph().clone(value)));
     }
 
-    void completeClone(RelationTypeImpl relationType){
-        super.completeClone(relationType);
-        relationType.cachedHasRoles.ifPresent(value -> this.cachedHasRoles.set(getGraknGraph().clone(value)));
-
+    void copyCachedConcepts(RelationTypeImpl type){
+        super.copyCachedConcepts(type);
+        type.cachedHasRoles.ifPresent(value -> this.cachedHasRoles.set(getGraknGraph().clone(value)));
     }
 
     @Override

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationTypeImpl.java
@@ -52,6 +52,17 @@ class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements Relat
         super(graknGraph, v, type, isImplicit);
     }
 
+    RelationTypeImpl(RelationTypeImpl relationType){
+        super(relationType);
+        //relationType.cachedHasRoles.ifPresent(value -> this.cachedHasRoles.set(getGraknGraph().clone(value)));
+    }
+
+    void completeClone(RelationTypeImpl relationType){
+        super.completeClone(relationType);
+        relationType.cachedHasRoles.ifPresent(value -> this.cachedHasRoles.set(getGraknGraph().clone(value)));
+
+    }
+
     @Override
     public Relation addRelation() {
         return addInstance(Schema.BaseType.RELATION,

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
@@ -59,6 +59,10 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
         setImmutableProperty(Schema.ConceptProperty.IS_UNIQUE, isUnique, getProperty(Schema.ConceptProperty.IS_UNIQUE), Function.identity());
     }
 
+    ResourceTypeImpl(ResourceTypeImpl resourceType){
+        super(resourceType);
+    }
+
     /**
      * @param regex The regular expression which instances of this resource must conform to.
      * @return The Resource Type itself.

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RoleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RoleTypeImpl.java
@@ -65,6 +65,18 @@ class RoleTypeImpl extends TypeImpl<RoleType, Instance> implements RoleType{
         super(graknGraph, v, type, isImplicit);
     }
 
+    RoleTypeImpl(RoleTypeImpl role){
+        super(role);
+        //role.cachedDirectPlayedByTypes.ifPresent(value -> this.cachedDirectPlayedByTypes.set(getGraknGraph().clone(value)));
+        //role.cachedRelationTypes.ifPresent(value -> this.cachedRelationTypes.set(getGraknGraph().clone(value)));
+    }
+
+    void completeClone(RoleTypeImpl roleType){
+        super.completeClone(roleType);
+        roleType.cachedDirectPlayedByTypes.ifPresent(value -> this.cachedDirectPlayedByTypes.set(getGraknGraph().clone(value)));
+        roleType.cachedRelationTypes.ifPresent(value -> this.cachedRelationTypes.set(getGraknGraph().clone(value)));
+    }
+
     /**
      *
      * @return The Relation Type which this role takes part in.

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RoleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RoleTypeImpl.java
@@ -67,14 +67,12 @@ class RoleTypeImpl extends TypeImpl<RoleType, Instance> implements RoleType{
 
     RoleTypeImpl(RoleTypeImpl role){
         super(role);
-        //role.cachedDirectPlayedByTypes.ifPresent(value -> this.cachedDirectPlayedByTypes.set(getGraknGraph().clone(value)));
-        //role.cachedRelationTypes.ifPresent(value -> this.cachedRelationTypes.set(getGraknGraph().clone(value)));
     }
 
-    void completeClone(RoleTypeImpl roleType){
-        super.completeClone(roleType);
-        roleType.cachedDirectPlayedByTypes.ifPresent(value -> this.cachedDirectPlayedByTypes.set(getGraknGraph().clone(value)));
-        roleType.cachedRelationTypes.ifPresent(value -> this.cachedRelationTypes.set(getGraknGraph().clone(value)));
+    void copyCachedConcepts(RoleTypeImpl type){
+        super.copyCachedConcepts(type);
+        type.cachedDirectPlayedByTypes.ifPresent(value -> this.cachedDirectPlayedByTypes.set(getGraknGraph().clone(value)));
+        type.cachedRelationTypes.ifPresent(value -> this.cachedRelationTypes.set(getGraknGraph().clone(value)));
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
@@ -48,6 +48,10 @@ class RuleTypeImpl extends TypeImpl<RuleType, Rule> implements RuleType {
         super(graknGraph, v, type);
     }
 
+    RuleTypeImpl(RuleTypeImpl rule){
+        super(rule);
+    }
+
     @Override
     public Rule addRule(Pattern lhs, Pattern rhs) {
         if(lhs == null) {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -61,7 +61,7 @@ import java.util.stream.Collectors;
  * @param <T> The leaf interface of the object concept. For example an {@link ai.grakn.concept.EntityType} or {@link RelationType}
  * @param <V> The instance of this type. For example {@link ai.grakn.concept.Entity} or {@link ai.grakn.concept.Relation}
  */
-class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implements Type, Cloneable {
+class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implements Type{
     protected final Logger LOG = LoggerFactory.getLogger(TypeImpl.class);
 
     private TypeName cachedTypeName;
@@ -99,13 +99,9 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         cachedIsImplicit.set(isImplicit);
     }
 
-    @Override
-    public TypeImpl clone() {
-        try {
-            return (TypeImpl) super.clone();
-        } catch (CloneNotSupportedException e) {
-            throw new RuntimeException("Could not clone type [" + cachedTypeName.getValue() + "]", e);
-        }
+    TypeImpl(TypeImpl type) {
+        super(type);
+        this.cachedTypeName = type.getName();
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -99,9 +99,18 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         cachedIsImplicit.set(isImplicit);
     }
 
-    TypeImpl(TypeImpl type) {
+    TypeImpl(TypeImpl<T, V> type) {
         super(type);
         this.cachedTypeName = type.getName();
+        type.cachedIsImplicit.ifPresent(value -> this.cachedIsImplicit.set(value));
+        type.cachedIsAbstract.ifPresent(value -> this.cachedIsAbstract.set(value));
+        //type.cachedSuperType.ifPresent(value -> this.cachedSuperType.set(getGraknGraph().clone(value)));
+        //type.cachedDirectSubTypes.ifPresent(value -> this.cachedDirectSubTypes.set(getGraknGraph().clone(value)));
+    }
+
+    void completeClone(TypeImpl<T, V> type){
+        type.cachedSuperType.ifPresent(value -> this.cachedSuperType.set(getGraknGraph().clone(value)));
+        type.cachedDirectSubTypes.ifPresent(value -> this.cachedDirectSubTypes.set(getGraknGraph().clone(value)));
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -104,11 +104,9 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         this.cachedTypeName = type.getName();
         type.cachedIsImplicit.ifPresent(value -> this.cachedIsImplicit.set(value));
         type.cachedIsAbstract.ifPresent(value -> this.cachedIsAbstract.set(value));
-        //type.cachedSuperType.ifPresent(value -> this.cachedSuperType.set(getGraknGraph().clone(value)));
-        //type.cachedDirectSubTypes.ifPresent(value -> this.cachedDirectSubTypes.set(getGraknGraph().clone(value)));
     }
 
-    void completeClone(TypeImpl<T, V> type){
+    void copyCachedConcepts(TypeImpl<T, V> type){
         type.cachedSuperType.ifPresent(value -> this.cachedSuperType.set(getGraknGraph().clone(value)));
         type.cachedDirectSubTypes.ifPresent(value -> this.cachedDirectSubTypes.set(getGraknGraph().clone(value)));
     }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -30,11 +30,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static ai.grakn.graql.Graql.var;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class GraknGraphTest extends GraphTestBase {
@@ -317,6 +319,38 @@ public class GraknGraphTest extends GraphTestBase {
         graph.open();
 
         graph.putEntityType("A Thing");
+    }
+
+    @Test
+    public void checkThatMainCentralCacheIsNotAffectedByTransactionModifications() throws GraknValidationException, ExecutionException, InterruptedException {
+        //Check Central cache is empty
+        assertTrue(graknGraph.getCachedOntology().asMap().isEmpty());
+
+        RoleType r1 = graknGraph.putRoleType("r1");
+        RoleType r2 = graknGraph.putRoleType("r2");
+        EntityType e1 = graknGraph.putEntityType("e1").playsRole(r1).playsRole(r2);
+        RelationType rel1 = graknGraph.putRelationType("rel1").hasRole(r1).hasRole(r2);
+
+        //Purge the above concepts into the main cache
+        graknGraph.commit();
+
+        //Check cache is in good order
+        assertThat(graknGraph.getCachedOntology().asMap().values(), containsInAnyOrder(r1, r2, e1, rel1,
+                graknGraph.getMetaConcept(), graknGraph.getMetaEntityType(),
+                graknGraph.getMetaRelationType(), graknGraph.getMetaRoleType()));
+
+        ExecutorService pool = Executors.newSingleThreadExecutor();
+        //Mutate Ontology in a separate thread
+        pool.submit(() -> {
+            graknGraph.open();
+            EntityType entityType = graknGraph.getEntityType("e1");
+            RoleType role = graknGraph.getRoleType("r1");
+            entityType.deletePlaysRole(role);
+        }).get();
+
+        //Check the above mutation did not affect central repo
+        TypeImpl foundE1 = graknGraph.getCachedOntology().asMap().get(e1.getName());
+        assertTrue("Main cache was affected by transaction", foundE1.playsRoles().contains(r1));
     }
 
     @Test

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -339,6 +339,8 @@ public class GraknGraphTest extends GraphTestBase {
                 graknGraph.getMetaConcept(), graknGraph.getMetaEntityType(),
                 graknGraph.getMetaRelationType(), graknGraph.getMetaRoleType()));
 
+        assertThat(e1.playsRoles(), containsInAnyOrder(r1, r2));
+
         ExecutorService pool = Executors.newSingleThreadExecutor();
         //Mutate Ontology in a separate thread
         pool.submit(() -> {


### PR DESCRIPTION
The need for this feature is best exhibited by the test attached in this PR.
It's to avoid a transaction from affecting the centrally cached ontology. The only way to do this is to deep clone the cached ontology at the start of a transaction.

Please review this PR very carefully. As with other caching PRs this has the potential to cause a lot of harm.
