### PR TITLE
Close the main connection to the graph by closing on the factory.

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknGraphFactory.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraphFactory.java
@@ -19,6 +19,8 @@
 package ai.grakn;
 
 
+import ai.grakn.exception.GraphRuntimeException;
+
 /**
  * <p>
  *     Builds a Grakn Graph factory
@@ -58,4 +60,23 @@ public interface GraknGraphFactory {
      * @see GraknComputer
      */
     GraknComputer getGraphComputer();
+
+    /**
+     * Closes the main connection to the graph. This should be done at the end of using the graph.
+     *
+     * @throws GraphRuntimeException when more than 1 transaction is open on the graph
+     */
+    void close() throws GraphRuntimeException;
+
+    /**
+     *
+     * @return The number of transactions open on the graph.
+     */
+    int openGraphTxs();
+
+    /**
+     *
+     * @return The number of batch transactions open on the graph.
+     */
+    int openGraphBatchTxs();
 }

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -67,6 +67,7 @@ public enum ErrorMessage {
     GRAPH_CLOSED("The Graph for keyspace [%s] is closed"),
     GRAPH_PERMANENTLY_CLOSED("The Graph for keyspace [%s] is closed. Use the factory to get a new graph."),
     CANNOT_FIND_VERTEX("Cannot find vertex using id [%s] on graph [%s] on a already constructed concept. This may be due to the vertex being deleted."),
+    TRANSACTIONS_OPEN("Cannot close graph [%s] connecting to keyspace [%s] because there are [%s] open transactions"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-factory/orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
+++ b/grakn-factory/orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
@@ -56,6 +56,11 @@ public class GraknOrientDBGraph extends AbstractGraknGraph<OrientGraph> {
     }
 
     @Override
+    public int numOpenTx() {
+        return 1;
+    }
+
+    @Override
     protected void commitTransaction(){
         getTinkerPopGraph().commit();
     }

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -81,10 +81,6 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
         } catch (TitanException e){
             throw new GraknBackendException(e);
         }
-
-        if(!getTinkerPopGraph().tx().isOpen()){
-            getTinkerPopGraph().tx().open(); //Until we sort out the transaction handling properly commits have to result in transactions being auto opened
-        }
     }
 
     @Override

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -70,11 +70,6 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
     }
 
     @Override
-    public void closeGraph(String reason){
-        finaliseClose(this::closeTitan, reason);
-    }
-
-    @Override
     public void commitTransaction(){
         try {
             super.commitTransaction();
@@ -86,18 +81,5 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
     @Override
     public boolean validVertex(Vertex vertex) {
         return !((TitanVertex) vertex).isRemoved() && super.validVertex(vertex);
-    }
-
-    private void closeTitan(){
-        StandardTitanGraph graph = (StandardTitanGraph) getTinkerPopGraph();
-        synchronized (graph) { //Have to block here because the list of open transactions in Titan is not thread safe.
-            if(graph.tx().isOpen()) {
-                graph.tx().close();
-            }
-
-            if (graph.getOpenTxs() == 0) {
-                closePermanent();
-            }
-        }
     }
 }

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -58,6 +58,11 @@ public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
     }
 
     @Override
+    public int numOpenTx() {
+        return ((StandardTitanGraph)getTinkerPopGraph()).getOpenTxs();
+    }
+
+    @Override
     protected void clearGraph() {
         TitanGraph titanGraph = getTinkerPopGraph();
         titanGraph.close();

--- a/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
+++ b/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
@@ -20,10 +20,8 @@ package ai.grakn.factory;
 
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
-import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.graph.internal.GraknTitanGraph;
-import com.thinkaurelius.titan.graphdb.database.StandardTitanGraph;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -140,27 +138,5 @@ public class GraknTitanGraphTest extends TitanTestBase{
         expectedException.expectMessage(GRAPH_PERMANENTLY_CLOSED.getMessage(graph.getKeyspace()));
 
         graph.getEntityType(entityTypeName);
-    }
-
-    @Test
-    public void testStableTransactions() throws GraknValidationException {
-        GraknTitanGraph graph = new TitanInternalFactory("stabletransactions", Grakn.IN_MEMORY, TEST_PROPERTIES).getGraph(false);
-        assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
-
-        graph.putEntityType("name 1");
-        graph.commit();
-        assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
-
-        graph.putEntityType("name 2");
-        graph.commit();
-        assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
-
-        graph.putEntityType("name 3");
-        graph.commit();
-        assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
-
-        graph.putEntityType("name 4");
-        graph.commit();
-        assertEquals(1, ((StandardTitanGraph) graph.getTinkerPopGraph()).getOpenTxs());
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -205,7 +205,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     @SuppressWarnings("unchecked")
-    boolean initialiseMetaConcepts(){
+    private boolean initialiseMetaConcepts(){
         if(isMetaOntologyNotInitialised()){
             Vertex type = putVertex(Schema.MetaSchema.CONCEPT.getName(), Schema.BaseType.TYPE);
             Vertex entityType = putVertex(Schema.MetaSchema.ENTITY.getName(), Schema.BaseType.ENTITY_TYPE);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -134,17 +134,23 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     /**
+     * @param concept A concept in the graph
+     * @return True if the concept has been modified in the transaction
+     */
+    public abstract boolean isConceptModified(ConceptImpl concept);
+
+    /**
+     *
+     * @return The number of open transactions currently.
+     */
+    public abstract int numOpenTx();
+
+    /**
      * Opens the thread bound transaction
      */
     public void openTransaction(){
         localIsOpen.set(true);
     }
-
-    /**
-     * @param concept A concept in the graph
-     * @return True if the concept has been modified in the transaction
-     */
-    public abstract boolean isConceptModified(ConceptImpl concept);
 
     @Override
     public String getKeyspace(){
@@ -199,7 +205,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     @SuppressWarnings("unchecked")
-    public boolean initialiseMetaConcepts(){
+    boolean initialiseMetaConcepts(){
         if(isMetaOntologyNotInitialised()){
             Vertex type = putVertex(Schema.MetaSchema.CONCEPT.getName(), Schema.BaseType.TYPE);
             Vertex entityType = putVertex(Schema.MetaSchema.ENTITY.getName(), Schema.BaseType.ENTITY_TYPE);
@@ -801,7 +807,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         finaliseClose(this::closePermanent, closedReason);
     }
 
-    public void finaliseClose(Runnable closer, String closedReason){
+    void finaliseClose(Runnable closer, String closedReason){
         if(!isClosed()) {
             closer.run();
             localClosedReason.set(closedReason);
@@ -810,7 +816,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         }
     }
 
-    public void closePermanent(){
+    void closePermanent(){
         try {
             graph.close();
         } catch (Exception e) {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -818,9 +818,9 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     void closePermanent(){
         try {
-            graph.close();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+            graph.tx().close();
+        } catch (UnsupportedOperationException e) {
+            //Ignored for Tinker
         }
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -782,7 +782,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     private void innerClear(){
         clearGraph();
-        finaliseClose(this::closePermanent, ErrorMessage.CLOSED_CLEAR.getMessage());
+        closeGraph(ErrorMessage.CLOSED_CLEAR.getMessage());
     }
 
     //This is overridden by vendors for more efficient clearing approaches
@@ -802,26 +802,15 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         closeGraph(ErrorMessage.GRAPH_PERMANENTLY_CLOSED.getMessage(getKeyspace()));
     }
 
-    //Standard Close Operation Overridden by Vendor
-    public void closeGraph(String closedReason){
-        finaliseClose(this::closePermanent, closedReason);
-    }
-
-    void finaliseClose(Runnable closer, String closedReason){
-        if(!isClosed()) {
-            closer.run();
-            localClosedReason.set(closedReason);
-            localIsOpen.set(false);
-            clearLocalVariables();
-        }
-    }
-
-    void closePermanent(){
+    private void closeGraph(String closedReason){
         try {
             graph.tx().close();
         } catch (UnsupportedOperationException e) {
             //Ignored for Tinker
         }
+        localClosedReason.set(closedReason);
+        localIsOpen.set(false);
+        clearLocalVariables();
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/GraknTinkerGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/GraknTinkerGraph.java
@@ -51,6 +51,11 @@ public class GraknTinkerGraph extends AbstractGraknGraph<TinkerGraph> {
     }
 
     @Override
+    public int numOpenTx() {
+        return 1;
+    }
+
+    @Override
     public <T extends Concept> T getConceptByBaseIdentifier(Object baseIdentifier) {
         try {
             return super.getConceptByBaseIdentifier(Long.valueOf(baseIdentifier.toString()));

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ValidatorTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ValidatorTest.java
@@ -210,8 +210,6 @@ public class ValidatorTest extends GraphTestBase{
 
     @Test
     public void testValidateAfterManualAssertionDelete() throws GraknValidationException {
-        graknGraph.initialiseMetaConcepts();
-
         // ontology
         EntityType person = graknGraph.putEntityType("person");
         EntityType movie = graknGraph.putEntityType("movie");

--- a/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graph/GraphTest.java
@@ -74,7 +74,7 @@ public class GraphTest {
 
     @Test
     public void checkNumberOfOpenTransactionsChangesAsExpected() throws ExecutionException, InterruptedException {
-        GraknGraphFactory factory = Grakn.factory(Grakn.DEFAULT_URI, "MyWonderFullGraph");
+        GraknGraphFactory factory = engine.factoryWithNewKeyspace();
         assertEquals(0, factory.openGraphTxs());
         assertEquals(0, factory.openGraphBatchTxs());
 
@@ -104,7 +104,7 @@ public class GraphTest {
     public void closeGraphWhenOnlyOneTransactionIsOpen(){
         assumeFalse(usingTinker()); //Tinker does not have any connections to close
 
-        GraknGraphFactory factory = Grakn.factory(Grakn.DEFAULT_URI, "MyWonderFullGraph");
+        GraknGraphFactory factory = engine.factoryWithNewKeyspace();
         GraknGraph graph = factory.getGraph();
         factory.close();
 
@@ -118,7 +118,7 @@ public class GraphTest {
     public void attemptToCloseGraphWithOpenTransactionsThenThrowException() throws ExecutionException, InterruptedException {
         assumeFalse(usingTinker()); //Only tinker really supports transactions
 
-        GraknGraphFactory factory = Grakn.factory(Grakn.DEFAULT_URI, "MyWonderFullGraph");
+        GraknGraphFactory factory = engine.factoryWithNewKeyspace();
         GraknGraph graph = factory.getGraph();
         Executors.newSingleThreadExecutor().submit(factory::getGraph).get();
 


### PR DESCRIPTION
- Monitor transactions counts in factory
- Add explicit close to factory which must be used at the end of using the graph
- Get rid of magic auto closing on TItan

@alexandraorth @aelred @duckofyork @mikonapoli @sheldonkhall When this goes in guys you will have to call `factory.close()` or your app will NEVER terminate.