### PR TITLE
Various migration fixes

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
@@ -91,14 +91,14 @@ public interface QueryBuilder {
      * @param queryString a string representing several queries
      * @return a list of queries
      */
-     List<Query<?>> parseList(String queryString);
+    <T extends Query<?>> List<T> parseList(String queryString);
 
     /**
      * @param template a string representing a templated graql query
      * @param data data to use in template
      * @return a query, the type will depend on the type of template.
      */
-    <T extends Query<?>> T  parseTemplate(String template, Map<String, Object> data);
+    <T extends Query<?>> List<T> parseTemplate(String template, Map<String, Object> data);
 
     /**
      * Register an aggregate that can be used when parsing a Graql query

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -137,7 +137,7 @@ public class Graql {
      * @param data data to use in template
      * @return a query, the type will depend on the type indicated in the template
      */
-    public static <T extends Query<?>> T parseTemplate(String template, Map<String, Object> data){
+    public static <T extends Query<?>> List<T> parseTemplate(String template, Map<String, Object> data){
         return withoutGraph().parseTemplate(template, data);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParser.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParser.java
@@ -123,22 +123,22 @@ public class QueryParser {
      * @param queryString a string representing several queries
      * @return a list of queries
      */
-    public List<Query<?>> parseList(String queryString) {
-        List<Query<?>> queries = parseQueryFragment(GraqlParser::queryList, QueryVisitor::visitQueryList, queryString);
+    public <T extends Query<?>> List<T> parseList(String queryString) {
+        List<T> queries = parseQueryFragment(GraqlParser::queryList, (q, t) -> (List<T>) q.visitQueryList(t), queryString);
 
         // Merge any match...insert queries together
         // TODO: Find a way to NOT do this horrid thing
-        List<Query<?>> merged = Lists.newArrayList();
+        List<T> merged = Lists.newArrayList();
 
         if (queries.isEmpty()) return queries;
 
-        Query<?> previous = queries.get(0);
+        T previous = queries.get(0);
 
         for (int i = 1; i < queries.size(); i ++) {
-            Query<?> current = queries.get(i);
+            T current = queries.get(i);
 
             if (previous instanceof MatchQuery && current instanceof InsertQuery) {
-                previous = ((MatchQuery) previous).insert(((InsertQuery) current).admin().getVars());
+                previous = (T) ((MatchQuery) previous).insert(((InsertQuery) current).admin().getVars());
             } else {
                 merged.add(previous);
                 previous = current;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
@@ -177,7 +177,7 @@ public class QueryBuilderImpl implements QueryBuilder {
     }
 
     @Override
-    public List<Query<?>> parseList(String queryString) {
+    public <T extends Query<?>> List<T> parseList(String queryString) {
         return queryParser.parseList(queryString);
     }
 
@@ -187,8 +187,8 @@ public class QueryBuilderImpl implements QueryBuilder {
      * @return a resolved graql query
      */
     @Override
-    public <T extends Query<?>> T parseTemplate(String template, Map<String, Object> data){
-        return parse(templateParser.parseTemplate(template, data));
+    public <T extends Query<?>> List<T> parseTemplate(String template, Map<String, Object> data){
+        return parseList(templateParser.parseTemplate(template, data));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/template/TemplateVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/template/TemplateVisitor.java
@@ -156,8 +156,7 @@ public class TemplateVisitor extends GraqlTemplateBaseVisitor {
     // ;
     @Override
     public Object visitMacro(GraqlTemplateParser.MacroContext ctx){
-        String macro = ctx.ID_MACRO().getText().replace("@", "");
-
+        String macro = ctx.ID_MACRO().getText().replace("@", "").toLowerCase();
         List<Object> values = ctx.expr().stream().map(this::visit).collect(toList());
         return macros.get(macro).apply(values);
     }
@@ -413,11 +412,7 @@ public class TemplateVisitor extends GraqlTemplateBaseVisitor {
 
     public String formatVar(Object variable){
         String var = variable instanceof UnescapedString ? ((UnescapedString) variable).get() : variable.toString();
-        if(var.contains(" ")){
-            return var.replaceAll("(\\S)\\s(\\S)", "$1-$2");
-        }
-
-        return var;
+        return var.replaceAll("[^a-zA-Z0-9]", "-");
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
@@ -26,10 +26,10 @@ import java.text.ParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.List;
 import java.util.Map;
 
 import static ai.grakn.graql.Graql.parse;
-import static junit.framework.TestCase.assertEquals;
 
 public class MacroTest {
 
@@ -68,6 +68,15 @@ public class MacroTest {
     @Test
     public void intMacroTest(){
         String template = "insert $x value @int(<value>);";
+        String expected = "insert $x0 value 4;";
+
+        assertParseEquals(template, Collections.singletonMap("value", "4"), expected);
+        assertParseEquals(template, Collections.singletonMap("value", 4), expected);
+    }
+
+    @Test
+    public void whenMacroIsWrongCase_ResolvedToLowerCase(){
+        String template = "insert $x value @InT(<value>);";
         String expected = "insert $x0 value 4;";
 
         assertParseEquals(template, Collections.singletonMap("value", "4"), expected);
@@ -276,8 +285,7 @@ public class MacroTest {
     }
 
     private void assertParseEquals(String template, Map<String, Object> data, String expected){
-        Query<?> result = Graql.parseTemplate(template, data);
-        System.out.println(result);
-        assertEquals(parse(expected), result);
+        List<Query> result = Graql.parseTemplate(template, data);
+        assertEquals(parse(expected), result.get(0));
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import static ai.grakn.graql.Graql.parse;
+import static junit.framework.TestCase.assertEquals;
 
 public class MacroTest {
 

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/AbstractMigrator.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/AbstractMigrator.java
@@ -29,9 +29,10 @@ import mjson.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -116,15 +117,17 @@ public abstract class AbstractMigrator implements Migrator {
      * @param data data used in the template
      * @return an insert query
      */
-    protected Optional<InsertQuery> template(String template, Map<String, Object> data){
+    protected List<InsertQuery> template(String template, Map<String, Object> data){
         try {
-            return Optional.of(queryBuilder.parseTemplate(template, data));
-        } catch (GraqlTemplateParsingException e){
+            return queryBuilder.parseTemplate(template, data);
+
+            //TODO Graql should throw a GraqlParsignException so we do not need to catch IllegalArgumentException
+        } catch (GraqlTemplateParsingException | IllegalArgumentException e){
             LOG.warn("Query was not sent to loader- " + e.getMessage());
             LOG.warn("See the Grakn engine logs for more detail about loading status and any resulting stacktraces");
         }
 
-        return Optional.empty();
+        return Collections.emptyList();
     }
 
     /**

--- a/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/CSVMigrator.java
+++ b/grakn-migration/csv/src/main/java/ai/grakn/migration/csv/CSVMigrator.java
@@ -32,7 +32,6 @@ import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toMap;
@@ -122,10 +121,7 @@ public class CSVMigrator extends AbstractMigrator {
                             .parse(reader);
 
             Iterator<CSVRecord> it = csvParser.iterator();
-            return stream(it)
-                    .map(col -> template(template, parse(col)))
-                    .filter(Optional::isPresent)
-                    .map(Optional::get);
+            return stream(it).flatMap(col -> template(template, parse(col)).stream());
         } catch (IOException e){
             throw new RuntimeException(e);
         }

--- a/grakn-migration/json/src/main/java/ai/grakn/migration/json/JsonMigrator.java
+++ b/grakn-migration/json/src/main/java/ai/grakn/migration/json/JsonMigrator.java
@@ -32,7 +32,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -81,9 +80,7 @@ public class JsonMigrator extends AbstractMigrator {
         return readers.stream()
                 .map(this::asString)
                 .map(this::toJsonMap)
-                .map(data -> template(template, data))
-                .filter(Optional::isPresent)
-                .map(Optional::get);
+                .flatMap(data -> template(template, data).stream());
     }
 
     /**

--- a/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/SQLMigrator.java
+++ b/grakn-migration/sql/src/main/java/ai/grakn/migration/sql/SQLMigrator.java
@@ -29,7 +29,6 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
@@ -62,9 +61,7 @@ public class SQLMigrator extends AbstractMigrator {
     public Stream<InsertQuery> migrate() {
         return records.map(Record::intoMap)
                 .map(this::convertToValidValues)
-                .map(r -> template(template, r))
-                .filter(Optional::isPresent)
-                .map(Optional::get);
+                .flatMap(r -> template(template, r).stream());
     }
 
     /**

--- a/grakn-test/src/test/java/ai/grakn/test/client/LoaderClientTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/client/LoaderClientTest.java
@@ -105,8 +105,10 @@ public class LoaderClientTest {
 
             loader.add(query);
 
-            GraknEngineServer.stopHTTP();
-            GraknEngineServer.startHTTP();
+            if(i%5 == 0) {
+                GraknEngineServer.stopHTTP();
+                GraknEngineServer.startHTTP();
+            }
         }
 
         loader.waitToFinish();
@@ -137,8 +139,10 @@ public class LoaderClientTest {
 
             loader.add(query);
 
-            GraknEngineServer.stopHTTP();
-            GraknEngineServer.startHTTP();
+            if(i%5 == 0) {
+                GraknEngineServer.stopHTTP();
+                GraknEngineServer.startHTTP();
+            }
         }
 
         loader.waitToFinish();

--- a/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/migration/csv/CSVMigratorTest.java
@@ -43,6 +43,7 @@ import static ai.grakn.test.migration.MigratorTestUtils.migrate;
 import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class CSVMigratorTest {
@@ -106,7 +107,6 @@ public class CSVMigratorTest {
         migrate(graph, new CSVMigrator(template, getFile("csv", "pets/data/pets.empty")).setNullString(""));
         graph = factory.getGraph();//Re Open Transaction
 
-//        graph = factory.getGraph();
         Collection<Entity> pets = graph.getEntityType("pet").instances();
         assertEquals(1, pets.size());
 
@@ -118,6 +118,16 @@ public class CSVMigratorTest {
 
         Entity fluffy = name.getResource("Fluffy").ownerInstances().iterator().next().asEntity();
         assertEquals(1, fluffy.resources(death).size());
+    }
+
+    @Test
+    public void parsedLineIsEmpty_MigratorSkipsThatLine(){
+        load(graph, getFile("csv", "pets/schema.gql"));
+
+        // Only insert Puffball
+        String template = "if (<name> != \"Puffball\") do { insert $x isa pet; }";
+        migrate(graph, new CSVMigrator(template, getFile("csv", "pets/data/pets.quotes")));
+        assertEquals(1, graph.getEntityType("pet").instances().size());
     }
 
     @Ignore //Ignored because this feature is not yet supported


### PR DESCRIPTION
+ Migration will skip any line where the template is empty
+ Migration can parse multiple queries in one template, so long as they are all insert
+ Various usability fixes