### PR TITLE
Fixing engine random failure in TasksFailoverTest

### DIFF
--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -5,6 +5,7 @@ import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
+import ai.grakn.test.engine.backgroundtasks.BackgroundTaskTestUtils;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.auth0.jwt.internal.org.apache.commons.io.FileUtils;
@@ -141,6 +142,7 @@ public abstract class GraknTestEnv {
     public static void hideLogs() {
         ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.OFF);
         ((Logger) org.slf4j.LoggerFactory.getLogger(GraknTestEnv.class)).setLevel(Level.DEBUG);
+        ((Logger) org.slf4j.LoggerFactory.getLogger(BackgroundTaskTestUtils.class)).setLevel(Level.DEBUG);
         org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/BackgroundTaskTestUtils.java
@@ -21,7 +21,10 @@ package ai.grakn.test.engine.backgroundtasks;
 import ai.grakn.engine.backgroundtasks.TaskState;
 import ai.grakn.engine.backgroundtasks.TaskStateStorage;
 import ai.grakn.engine.TaskStatus;
+import ai.grakn.engine.backgroundtasks.distributed.TaskFailover;
 import mjson.Json;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.Set;
@@ -34,6 +37,7 @@ import static java.util.stream.Collectors.toSet;
  * Class holding useful methods for use throughout background task tests
  */
 public class BackgroundTaskTestUtils {
+    private final static Logger LOG = LoggerFactory.getLogger(TaskFailover.class);
 
     public static Set<TaskState> createTasks(int n, TaskStatus status) {
         return IntStream.range(0, n)
@@ -59,7 +63,7 @@ public class BackgroundTaskTestUtils {
     public static void waitForStatus(TaskStateStorage storage, TaskState task, TaskStatus status) {
         final long initial = new Date().getTime();
 
-        while((new Date().getTime())-initial < 60000) {
+        while((new Date().getTime())-initial < 15000) {
             try {
                 TaskStatus currentStatus = storage.getState(task.getId()).status();
                 if (currentStatus == status) {
@@ -67,5 +71,7 @@ public class BackgroundTaskTestUtils {
                 }
             } catch (Exception ignored){}
         }
+
+        LOG.debug("Timed out waiting for status of {}", task.getId());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskFailoverTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/backgroundtasks/TaskFailoverTest.java
@@ -34,8 +34,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
@@ -51,7 +55,9 @@ import static ai.grakn.test.engine.backgroundtasks.BackgroundTaskTestUtils.creat
 import static ai.grakn.test.engine.backgroundtasks.BackgroundTaskTestUtils.createTasks;
 import static ai.grakn.test.engine.backgroundtasks.BackgroundTaskTestUtils.waitForStatus;
 import static java.util.Collections.singleton;
+import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TaskFailoverTest {
 
@@ -193,12 +199,14 @@ public class TaskFailoverTest {
                     .creatingParentContainersIfNeeded()
                     .withMode(CreateMode.EPHEMERAL).forPath(RUNNERS_WATCH + "/" + id);
         }
+        assertNotNull(connection.connection().checkExists().forPath(RUNNERS_WATCH + "/" + id));
 
         if (connection.connection().checkExists().forPath(RUNNERS_STATE + "/" + id) == null) {
             connection.connection().create()
                     .creatingParentContainersIfNeeded()
                     .forPath(RUNNERS_STATE + "/" + id);
         }
+        assertNotNull(connection.connection().checkExists().forPath(RUNNERS_STATE + "/" + id));
     }
 
     private void registerTasksInZKLikeTaskRunnerWould(String id, Set<TaskState> tasks) throws Exception{
@@ -210,5 +218,6 @@ public class TaskFailoverTest {
 
     private void killFakeEngine(String id) throws Exception {
         connection.connection().delete().forPath(RUNNERS_WATCH + "/" + id);
+        assertNull(connection.connection().checkExists().forPath(RUNNERS_WATCH + "/" + id));
     }
 }


### PR DESCRIPTION
This should be retested a bunch of times to try and recreate the travis failure. 