### PR TITLE
Saved queries are now scoped

### DIFF
--- a/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
+++ b/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
@@ -192,6 +192,7 @@ export default {
                 this.state.eventHub.$off('keyspace-changed', this.loadMetaTypeInstances);
                 this.state.eventHub.$off('inject-query', this.injectQuery);
                 this.state.eventHub.$off('append-query', this.appendQuery);
+                this.state.eventHub.$off('keyspace-changed',this.refreshSavedQueries);
             }
 
             switch (this.$route.fullPath) {
@@ -210,6 +211,7 @@ export default {
             this.state.eventHub.$on('keyspace-changed', this.loadMetaTypeInstances);
             this.state.eventHub.$on('inject-query', this.injectQuery);
             this.state.eventHub.$on('append-query', this.appendQuery);
+            this.state.eventHub.$on('keyspace-changed',this.refreshSavedQueries);
 
         },
         startBuilder(nameFunction){

--- a/grakn-dashboard/src/js/FavQueries.js
+++ b/grakn-dashboard/src/js/FavQueries.js
@@ -1,17 +1,29 @@
+import User from './User';
+
 // Default constant values
 const QUERIES_LS_KEY = 'fav_queries';
+
 
 export default {
   getFavQueries() {
     const queries = localStorage.getItem(QUERIES_LS_KEY);
+    const currentKeyspace = User.getCurrentKeySpace();
+
     if (queries === null) {
-      localStorage.setItem(QUERIES_LS_KEY, '{}');
+      localStorage.setItem(QUERIES_LS_KEY, JSON.stringify({ [currentKeyspace]: {} }));
       return {};
     }
-    return JSON.parse(queries);
+
+    const queriesObject = JSON.parse(queries);
+    // If there is not object associated to the current keyspace we return empty object
+    if (!(currentKeyspace in queriesObject)) {
+      return {};
+    }
+    return queriesObject[currentKeyspace];
   },
   addFavQuery(queryName, queryValue) {
     const queries = this.getFavQueries();
+
     queries[queryName] = queryValue;
     this.setFavQueries(queries);
   },
@@ -20,7 +32,9 @@ export default {
     delete queries[queryName];
     this.setFavQueries(queries);
   },
-  setFavQueries(queriesObject) {
-    localStorage.setItem(QUERIES_LS_KEY, JSON.stringify(queriesObject));
+  setFavQueries(queriesParam) {
+    const queries = JSON.parse(localStorage.getItem(QUERIES_LS_KEY));
+    Object.assign(queries, { [User.getCurrentKeySpace()]: queriesParam });
+    localStorage.setItem(QUERIES_LS_KEY, JSON.stringify(queries));
   },
 };

--- a/grakn-dashboard/src/js/User.js
+++ b/grakn-dashboard/src/js/User.js
@@ -1,4 +1,4 @@
-import EngineClient from '../js/EngineClient';
+import EngineClient from './EngineClient';
 
 
 // Default constant values


### PR DESCRIPTION
Saved queries in dashboard are now associated to a specific keyspace,
and they will not be accessible when a different keyspace is selected.