### PR TITLE
Limit double click results in dashboard

### DIFF
--- a/grakn-dashboard/src/components/graphPage/contextMenu.vue
+++ b/grakn-dashboard/src/components/graphPage/contextMenu.vue
@@ -29,6 +29,13 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
         <div v-bind:class="[selectedNodes.length!==2 ? 'dd-item' : 'dd-item active']" @click="emitExploreRelations">
             <span class="list-key">Explore relations</span>
         </div>
+        <div class="dd-header">Align nodes</div>
+        <div class="dd-item active" @click="alignHorizontally">
+            <span class="list-key">Horizontally</span>
+        </div>
+        <div class="dd-item active" @click="alignVertically">
+            <span class="list-key">Vertically</span>
+        </div>
     </div>
 </div>
 </template>
@@ -122,7 +129,63 @@ export default {
         emitExploreRelations() {
             if (this.selectedNodes.length === 2)
                 this.$emit('type-query', QueryBuilder.exploreRelationsBuilder(this.selectedNodes));
-        }
+        },
+        alignHorizontally() {
+            this.$emit('close-context');
+            let previousNode = this.selectedNodes[0];
+            visualiser.nodes.update({
+                id: previousNode,
+                x: visualiser.rect.startX,
+                y: visualiser.rect.startY
+            });
+            for (let i = 1; i < this.selectedNodes.length; i++) {
+                const nodeId = this.selectedNodes[i];
+                visualiser.nodes.update({
+                    id: nodeId,
+                    x: this.computeXHorizontal(nodeId, previousNode),
+                    y: visualiser.rect.startY
+                });
+                previousNode = nodeId;
+            }
+        },
+        alignVertically() {
+            this.$emit('close-context');
+            let previousNode = this.selectedNodes[0];
+            visualiser.nodes.update({
+                id: previousNode,
+                x: visualiser.rect.startX,
+                y: visualiser.rect.startY
+            });
+            for (let i = 1; i < this.selectedNodes.length; i++) {
+                const nodeId = this.selectedNodes[i];
+                visualiser.nodes.update({
+                    id: nodeId,
+                    x: visualiser.rect.startX,
+                    y: this.computeYVertical(nodeId, previousNode),
+                });
+                previousNode = nodeId;
+            }
+        },
+        computeXHorizontal(nodeId, previousNode) {
+            const nodeSize = this.computeNodeWidth(nodeId);
+            const rightBorderX = visualiser.network.getBoundingBox(previousNode).right;
+            return rightBorderX + 1 + (nodeSize / 2);
+        },
+        computeNodeWidth(nodeId) {
+            const left = visualiser.network.getBoundingBox(nodeId).left;
+            const right = visualiser.network.getBoundingBox(nodeId).right;
+            return (left < 0) ? Math.abs(left) + right : right - left;
+        },
+        computeNodeHeight(nodeId) {
+            const top = visualiser.network.getBoundingBox(nodeId).top;
+            const bottom = visualiser.network.getBoundingBox(nodeId).bottom;
+            return (top < 0) ? Math.abs(top) + bottom : bottom - top;
+        },
+        computeYVertical(nodeId, previousNode) {
+            const nodeSize = this.computeNodeHeight(nodeId);
+            const bottomBorderY = visualiser.network.getBoundingBox(previousNode).bottom;
+            return bottomBorderY + 1 + (nodeSize / 2);
+        },
     }
 }
 </script>

--- a/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
+++ b/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
@@ -235,11 +235,11 @@ export default {
             //set the panel class to be an error class
         },
         runQuery(ev) {
-            let query = this.codeMirror.getValue();
+            let query = this.codeMirror.getValue().trim();
             this.showMessagePanel = false;
 
             // Empty query.
-            if (query == undefined || query.trim().length === 0)
+            if (query == undefined || query.length === 0)
                 return;
 
             // Add trailing semi-colon

--- a/grakn-dashboard/src/components/graqlEditor/querySettings.vue
+++ b/grakn-dashboard/src/components/graqlEditor/querySettings.vue
@@ -30,10 +30,14 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
                    <div class="left"><input type="checkbox" v-model="useReasoner"></div><div class="right"> Activate inference</div>
                 </div>
                 <div class="dd-item">
-                  <div class="left"><input type="checkbox" v-model="materialiseReasoner" :disabled="!useReasoner"></div><div v-bind:class="[useReasoner ? 'right' : 'right grey']" :disabled="!useReasoner">Materialise inference</div>
+                  <div class="left"><input type="checkbox" v-model="materialiseReasoner" :disabled="!useReasoner"></div><div :class="{'grey':!useReasoner}" :disabled="!useReasoner" class="right">Materialise inference</div>
                 </div>
                 <div class="dd-item">
                   <button @click="materialiseAll()" class="btn materialise">Materialise All</button>
+                </div>
+                <div class="divide"></div>
+                <div class="dd-item">
+                  <div class="left">Query Limit:</div><div class="right"><input v-model="queryLimit" type="text" class="form-control" maxlength="3" size="4"></div>
                 </div>
             </div>
         </div>
@@ -49,6 +53,13 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     justify-content: space-between;
     margin-bottom: 10px;
 }
+
+.divide{
+  border-bottom: 1px solid #606060;
+  min-height: 5px;
+  margin-bottom: 5px;
+}
+
 .left{
   display: inline-flex;
   margin-right: 5px;
@@ -120,6 +131,7 @@ export default {
           useReasoner: User.getReasonerStatus(),
           materialiseReasoner: User.getMaterialiseStatus(),
           showSettings:false,
+          queryLimit: User.getQueryLimit(),
         }
     },
     created() {},
@@ -135,6 +147,10 @@ export default {
         },
         materialiseReasoner: function(newVal, oldVal) {
             User.setMaterialiseStatus(newVal);
+        },
+        queryLimit: function(newVal, oldVal) {
+            User.setQueryLimit(newVal);
+            if(newVal.length>0) this.queryLimit=User.getQueryLimit();
         }
     },
     methods: {

--- a/grakn-dashboard/src/js/EngineClient.js
+++ b/grakn-dashboard/src/js/EngineClient.js
@@ -121,8 +121,9 @@ export default {
              * Send graql query to Engine, returns an array of HAL objects.
              */
   graqlHAL(query) {
+      // In match queries we are also attaching a limit for the embedded objects of the resulting nodes, this is not the query limit.
     return this.request({
-      url: `/graph/match?keyspace=${User.getCurrentKeySpace()}&query=${encodeURIComponent(query)}&reasoner=${User.getReasonerStatus()}&materialise=${User.getMaterialiseStatus()}`,
+      url: `/graph/match?keyspace=${User.getCurrentKeySpace()}&query=${encodeURIComponent(query)}&reasoner=${User.getReasonerStatus()}&materialise=${User.getMaterialiseStatus()}&limit=${User.getQueryLimit()}`,
     });
   },
             /**

--- a/grakn-dashboard/src/js/HAL/HALParser.js
+++ b/grakn-dashboard/src/js/HAL/HALParser.js
@@ -42,6 +42,14 @@ export default class HALParser {
     this.newResource = () => {};
     this.newRelationship = () => {};
     this.nodeAlreadyInGraph = () => {};
+
+    this.metaTypesSet = {
+      ENTITY_TYPE: true,
+      RESOURCE_TYPE: true,
+      ROLE_TYPE: true,
+      RELATION_TYPE: true,
+      RULE_TYPE: true,
+    };
   }
 
     /**
@@ -97,7 +105,7 @@ export default class HALParser {
             // Add assertions from _embedded
       if (API.KEY_EMBEDDED in objResponse) {
         _.map(Object.keys(objResponse[API.KEY_EMBEDDED]), (key) => {
-          if ((key !== 'isa') || showIsa === true) {
+          if ((key !== 'isa') || showIsa === true || objResponse._baseType in this.metaTypesSet) {
             this.parseEmbedded(objResponse[API.KEY_EMBEDDED][key], objResponse, key, hashSet);
           }
         });

--- a/grakn-dashboard/src/js/User.js
+++ b/grakn-dashboard/src/js/User.js
@@ -5,6 +5,8 @@ import EngineClient from './EngineClient';
 const DEFAULT_USE_REASONER = false;
 const DEFAULT_MATERIALISE = false;
 const DEFAULT_KEYSPACE = 'grakn';
+const DEFAULT_QUERY_LIMIT = '30';
+
 
 export default {
 
@@ -80,6 +82,21 @@ export default {
       return false;
     }
     return (modalShown === 'true');
+  },
+
+  // ------------ Limit number of results ---------------- //
+  getQueryLimit() {
+    const queryLimit = localStorage.getItem('query_limit');
+    if (queryLimit == null) {
+      this.setQueryLimit(DEFAULT_QUERY_LIMIT);
+      return DEFAULT_QUERY_LIMIT;
+    }
+    return queryLimit;
+  },
+  setQueryLimit(value) {
+    let parsedValue = parseInt(value, 10) || 0;
+    if (parsedValue < 0) parsedValue = 0;
+    localStorage.setItem('query_limit', parsedValue);
   },
 
 };

--- a/grakn-dashboard/src/js/visualiser/Visualiser.js
+++ b/grakn-dashboard/src/js/visualiser/Visualiser.js
@@ -81,7 +81,7 @@ export default class Visualiser {
       },
     };
 
-    // Additional properties to show in node label by type.
+        // Additional properties to show in node label by type.
     this.displayProperties = {};
     this.alreadyFittedToWindow = false;
 
@@ -109,7 +109,7 @@ export default class Visualiser {
             },
             this.networkConfig);
 
-    for(const eventName in this.callbacks) {
+    for (const eventName in this.callbacks) {
       this.network.on(eventName, this.callbacks[eventName]);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/hal/HALConceptData.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/hal/HALConceptData.java
@@ -36,6 +36,7 @@ import com.theoryinpractise.halbuilder.standard.StandardRepresentationFactory;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static ai.grakn.graql.internal.hal.HALConceptRepresentationBuilder.generateConceptState;
 
@@ -70,20 +71,36 @@ class HALConceptData {
     private final boolean embedType;
     private final Set<TypeName> typesInQuery;
 
-    HALConceptData(Concept concept, int separationDegree, boolean embedTypeParam, Set<TypeName> typesInQuery, String keyspace) {
+    private final int offset;
+    private final int limit;
+
+    HALConceptData(Concept concept, int separationDegree, boolean embedTypeParam, Set<TypeName> typesInQuery, String keyspace, int offset, int limit) {
 
         embedType = embedTypeParam;
         this.typesInQuery = typesInQuery;
-        this.keyspace = "?keyspace=" + keyspace;
+        this.offset = offset;
+        this.limit = limit;
+        this.keyspace = keyspace;
         //building HAL concepts using: https://github.com/HalBuilder/halbuilder-core
         resourceLinkPrefix = REST.WebPath.CONCEPT_BY_ID_URI;
         resourceLinkOntologyPrefix = REST.WebPath.CONCEPT_BY_ID_ONTOLOGY_URI;
 
         factory = new StandardRepresentationFactory();
-        halResource = factory.newRepresentation(resourceLinkPrefix + concept.getId() + this.keyspace);
+
+        //If we will include embedded nodes and limit is >=0 we increase the offset to prepare URI for next request
+        int uriOffset = (separationDegree > 0 && limit >= 0) ? (offset + limit) : offset;
+
+        halResource = factory.newRepresentation(resourceLinkPrefix + concept.getId() + getURIParams(uriOffset));
 
         handleConcept(halResource, concept, separationDegree);
 
+    }
+
+    private String getURIParams(int offset) {
+        // If limit -1, we don't append the limit parameter to the URI string
+        String limitParam = (this.limit >= 0) ? "&limit=" + this.limit : "";
+
+        return "?keyspace=" + this.keyspace + "&offset=" + offset + limitParam;
     }
 
 
@@ -119,10 +136,11 @@ class HALConceptData {
         if (concept.isEntity()) {
             generateEntityEmbedded(halResource, concept.asEntity(), separationDegree);
         }
+
         if (concept.isRelation()) {
             generateRelationEmbedded(halResource, concept.asRelation(), separationDegree);
             //Only when double clicking on a specific relation we want to fetch also the other relations the current one plays a role into.
-            embedRelationsPlaysRole(halResource,concept.asRelation());
+            embedRelationsPlaysRole(halResource, concept.asRelation());
         }
         if (concept.isResource()) {
             generateOwnerInstances(halResource, concept.asResource(), separationDegree);
@@ -135,7 +153,7 @@ class HALConceptData {
     }
 
     private void generateRuleRHS(Representation halResource, Rule rule) {
-        Representation RHS = factory.newRepresentation(resourceLinkPrefix + "RHS-" + rule.getId() + this.keyspace)
+        Representation RHS = factory.newRepresentation(resourceLinkPrefix + "RHS-" + rule.getId() + getURIParams(0))
                 .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE)
                 .withLink(ONTOLOGY_LINK, resourceLinkOntologyPrefix)
                 .withProperty(ID_PROPERTY, "RHS-" + rule.getId().getValue())
@@ -146,7 +164,7 @@ class HALConceptData {
     }
 
     private void generateRuleLHS(Representation halResource, Rule rule) {
-        Representation LHS = factory.newRepresentation(resourceLinkPrefix + "LHS-" + rule.getId() + this.keyspace)
+        Representation LHS = factory.newRepresentation(resourceLinkPrefix + "LHS-" + rule.getId() + getURIParams(0))
                 .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE)
                 .withLink(ONTOLOGY_LINK, resourceLinkOntologyPrefix)
                 .withProperty(ID_PROPERTY, "LHS-" + rule.getId().getValue())
@@ -159,7 +177,7 @@ class HALConceptData {
     private void generateOwnerInstances(Representation halResource, Resource<?> conceptResource, int separationDegree) {
         final TypeName roleType = conceptResource.type().getName();
         conceptResource.ownerInstances().forEach(instance -> {
-            Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + this.keyspace)
+            Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + getURIParams(0))
                     .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
             handleConcept(instanceResource, instance, separationDegree - 1);
             halResource.withRepresentation(roleType.getValue(), instanceResource);
@@ -167,7 +185,7 @@ class HALConceptData {
     }
 
     private void embedSuperType(Representation halResource, Type type) {
-        Representation HALType = factory.newRepresentation(resourceLinkPrefix + type.superType().getId() + this.keyspace)
+        Representation HALType = factory.newRepresentation(resourceLinkPrefix + type.superType().getId() + getURIParams(0))
                 .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE);
         generateStateAndLinks(HALType, type.superType());
         halResource.withRepresentation(SUB_EDGE, HALType);
@@ -176,7 +194,7 @@ class HALConceptData {
     private void embedType(Representation halResource, Instance instance) {
 
         // temp fix until a new behaviour is defined
-        Representation HALType = factory.newRepresentation(resourceLinkPrefix + instance.type().getId() + this.keyspace)
+        Representation HALType = factory.newRepresentation(resourceLinkPrefix + instance.type().getId() + getURIParams(0))
                 .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE);
 
         generateStateAndLinks(HALType, instance.type());
@@ -185,9 +203,9 @@ class HALConceptData {
 
     private void generateStateAndLinks(Representation resource, Concept concept) {
 
-        resource.withLink(ONTOLOGY_LINK, resourceLinkOntologyPrefix + concept.getId() + this.keyspace);
+        resource.withLink(ONTOLOGY_LINK, resourceLinkOntologyPrefix + concept.getId() + getURIParams(0));
 
-       generateConceptState(resource,concept);
+        generateConceptState(resource, concept);
 
         //Resources and links
         if (concept.isInstance()) {
@@ -199,7 +217,7 @@ class HALConceptData {
 
     private void generateResources(Representation resource, Collection<Resource<?>> resourcesCollection) {
         resourcesCollection.forEach(currentResource -> {
-            Representation embeddedResource = factory.newRepresentation(resourceLinkPrefix + currentResource.getId() + this.keyspace)
+            Representation embeddedResource = factory.newRepresentation(resourceLinkPrefix + currentResource.getId() + getURIParams(0))
                     .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE);
             generateStateAndLinks(embeddedResource, currentResource);
             resource.withRepresentation(currentResource.type().getName().getValue(), embeddedResource);
@@ -211,7 +229,9 @@ class HALConceptData {
 
     private void generateEntityEmbedded(Representation halResource, Entity entity, int separationDegree) {
 
-        entity.relations().forEach(rel -> {
+        Stream<Relation> relationStream = entity.relations().stream().skip(offset);
+        if (limit >= 0) relationStream = relationStream.limit(limit);
+        relationStream.forEach(rel -> {
 
             //find the role played by the current instance in the current relation and use the role type as key in the embedded
             TypeName rolePlayedByCurrentConcept = null;
@@ -229,12 +249,11 @@ class HALConceptData {
             if (!isResource) {
                 attachRelation(halResource, rel, rolePlayedByCurrentConcept, separationDegree);
             }
-
         });
     }
 
     private void attachRelation(Representation halResource, Concept rel, TypeName role, int separationDegree) {
-        Representation relationResource = factory.newRepresentation(resourceLinkPrefix + rel.getId() + this.keyspace)
+        Representation relationResource = factory.newRepresentation(resourceLinkPrefix + rel.getId() + getURIParams(0))
                 .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
         handleConcept(relationResource, rel, separationDegree - 1);
         halResource.withRepresentation(role.getValue(), relationResource);
@@ -245,7 +264,7 @@ class HALConceptData {
 
         rel.rolePlayers().forEach((roleType, instance) -> {
             if (instance != null) {
-                Representation roleResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + this.keyspace)
+                Representation roleResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + getURIParams(0))
                         .withProperty(DIRECTION_PROPERTY, OUTBOUND_EDGE);
                 handleConcept(roleResource, instance, separationDegree - 1);
                 halResource.withRepresentation(roleType.getName().getValue(), roleResource);
@@ -253,37 +272,34 @@ class HALConceptData {
         });
     }
 
-    private void embedRelationsPlaysRole(Representation halResource,Relation rel){
+    private void embedRelationsPlaysRole(Representation halResource, Relation rel) {
         rel.playsRoles().forEach(roleTypeRel -> {
             rel.relations(roleTypeRel).forEach(relation -> {
-                Representation relationRepresentation = factory.newRepresentation(resourceLinkPrefix+relation.getId()+this.keyspace)
-                        .withProperty(DIRECTION_PROPERTY,INBOUND_EDGE);
-                handleConcept(relationRepresentation,relation,0);
-                halResource.withRepresentation(roleTypeRel.getName().getValue(),relationRepresentation);
+                Representation relationRepresentation = factory.newRepresentation(resourceLinkPrefix + relation.getId() + getURIParams(0))
+                        .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
+                handleConcept(relationRepresentation, relation, 0);
+                halResource.withRepresentation(roleTypeRel.getName().getValue(), relationRepresentation);
             });
         });
     }
 
     private void generateTypeEmbedded(Representation halResource, Type type, int separationDegree) {
         if (!type.getName().equals(Schema.MetaSchema.CONCEPT.getName())) {
-            type.instances().forEach(instance -> {
-
-                if (instance.isType() && instance.asType().isImplicit()) return;
-
-                Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + this.keyspace)
+            Stream<? extends Instance> instancesStream = type.instances().stream().filter(instance -> (!instance.isType() || !instance.asType().isImplicit())).skip(offset);
+            if (limit >= 0) instancesStream = instancesStream.limit(limit);
+            instancesStream.forEach(instance -> {
+                Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + getURIParams(0))
                         .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
                 handleConcept(instanceResource, instance, separationDegree - 1);
                 halResource.withRepresentation(ISA_EDGE, instanceResource);
             });
         }
-        type.subTypes().forEach(instance -> {
-            // let's not put the current type in its own embedded
-            if (!instance.getName().equals(type.getName())) {
-                Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + this.keyspace)
-                        .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
-                handleConcept(instanceResource, instance, separationDegree - 1);
-                halResource.withRepresentation(SUB_EDGE, instanceResource);
-            }
+        // We only limit the number of instances and not subtypes.
+        type.subTypes().stream().filter(instance -> (!instance.getName().equals(type.getName()))).forEach(instance -> {
+            Representation instanceResource = factory.newRepresentation(resourceLinkPrefix + instance.getId() + getURIParams(0))
+                    .withProperty(DIRECTION_PROPERTY, INBOUND_EDGE);
+            handleConcept(instanceResource, instance, separationDegree - 1);
+            halResource.withRepresentation(SUB_EDGE, instanceResource);
         });
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/hal/HALConceptRepresentationBuilder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/hal/HALConceptRepresentationBuilder.java
@@ -69,7 +69,7 @@ public class HALConceptRepresentationBuilder {
     private final static String NAME_PROPERTY = "_name";
 
 
-    public static Json renderHALArrayData(MatchQuery matchQuery, Collection<Map<VarName, Concept>> graqlResultsList, String keyspace) {
+    public static Json renderHALArrayData(MatchQuery matchQuery, Collection<Map<VarName, Concept>> graqlResultsList, String keyspace, int offset, int limit) {
 
         //Stores connections between variables in Graql result [varName:List<VarAdmin> (only VarAdmins that contain a relation)]
         Map<VarName, Collection<VarAdmin>> linkedNodes =  computeLinkedNodesFromQuery(matchQuery);
@@ -81,18 +81,18 @@ public class HALConceptRepresentationBuilder {
         Set<TypeName> typesAskedInQuery = matchQuery.admin().getTypes().stream().map(x -> x.asType().getName()).collect(Collectors.toSet());
 
 
-        return buildHALRepresentations(graqlResultsList, linkedNodes, typesAskedInQuery, roleTypes, keyspace);
+        return buildHALRepresentations(graqlResultsList, linkedNodes, typesAskedInQuery, roleTypes, keyspace, offset, limit);
     }
 
-    public static String renderHALConceptData(Concept concept, int separationDegree, String keyspace) {
-        return new HALConceptData(concept, separationDegree, false, new HashSet<>(), keyspace).render();
+    public static String renderHALConceptData(Concept concept, int separationDegree, String keyspace, int offset, int limit) {
+        return new HALConceptData(concept, separationDegree, false, new HashSet<>(), keyspace, offset,limit).render();
     }
 
     public static String renderHALConceptOntology(Concept concept, String keyspace) {
         return new HALConceptOntology(concept, keyspace).render();
     }
 
-    private static Json buildHALRepresentations(Collection<Map<VarName, Concept>> graqlResultsList, Map<VarName, Collection<VarAdmin>> linkedNodes, Set<TypeName> typesAskedInQuery, Map<String,Map<VarName, String>> roleTypes, String keyspace) {
+    private static Json buildHALRepresentations(Collection<Map<VarName, Concept>> graqlResultsList, Map<VarName, Collection<VarAdmin>> linkedNodes, Set<TypeName> typesAskedInQuery, Map<String,Map<VarName, String>> roleTypes, String keyspace, int offset, int limit) {
         final Json lines = Json.array();
         graqlResultsList.forEach(resultLine -> resultLine.entrySet().forEach(current -> {
 
@@ -100,7 +100,7 @@ public class HALConceptRepresentationBuilder {
 
             LOG.trace("Building HAL resource for concept with id {}", current.getValue().getId().getValue());
             Representation currentHal = new HALConceptData(current.getValue(), MATCH_QUERY_FIXED_DEGREE, true,
-                    typesAskedInQuery, keyspace).getRepresentation();
+                    typesAskedInQuery, keyspace, offset, limit).getRepresentation();
             attachGeneratedRelations(currentHal, current, linkedNodes, resultLine, roleTypes, keyspace);
             lines.add(Json.read(currentHal.toString(RepresentationFactory.HAL_JSON)));
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/HALPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/HALPrinter.java
@@ -29,7 +29,7 @@ class HALPrinter extends JsonPrinter {
     @Override
     public Json graqlString(boolean inner, Concept concept) {
         //Todo: remove hardcoded keyspace and think about proper solution (maybe expose the getKeyspace on the concept itself)
-        String json = HALConceptRepresentationBuilder.renderHALConceptData(concept, 1,"grakn");
+        String json = HALConceptRepresentationBuilder.renderHALConceptData(concept, 1,"grakn",0,100);
         return Json.read(json);
     }
 


### PR DESCRIPTION
  - added new query limit param in dashboard
  - when double clicking on a node it will limit the connected concepts returned
  - align node vertically functionality added to context menu
  - align node horizontally functionality added to context menu