### PR TITLE
Remove unused abort query behaviour

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -129,7 +129,6 @@ public class REST {
         public static final String ACTION_QUERY = "query";
         public static final String ACTION_END = "end";
         public static final String ACTION_ERROR = "error";
-        public static final String ACTION_QUERY_ABORT = "queryAbort";
         public static final String ACTION_COMMIT = "commit";
         public static final String ACTION_ROLLBACK = "rollback";
         public static final String ACTION_CLEAN = "clean";


### PR DESCRIPTION
This used to be used on the client-side with Ctrl-C, but it never worked reliably. If we still need it, it should be re-worked from the ground up.