### PR TITLE
Revert "Add support for stopping tasks between engines (#1262)"

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ZookeeperPaths.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ZookeeperPaths.java
@@ -31,8 +31,6 @@ public interface ZookeeperPaths {
     String SCHEDULER = "/scheduler";
     String FAILOVER = "/failover";
     String TASKS_PATH_PREFIX = "/tasks";
-    String TASKS_STOPPED_PREFIX = "/stopped";
-    String TASKS_STOPPED = "/stopped/%s";
     String TASK_LOCK_SUFFIX = "/lock";
     String PARTITION_PATH = "/partition/%s";
     String ALL_ENGINE_PATH = "/engine";

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskManager.java
@@ -27,16 +27,13 @@ import ai.grakn.engine.tasks.manager.ZookeeperConnection;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.engine.util.EngineID;
 import com.google.common.collect.ImmutableList;
-import com.google.common.base.Charsets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.curator.framework.recipes.cache.PathChildrenCache;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.charset.Charset;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -47,14 +44,10 @@ import static ai.grakn.engine.tasks.config.ConfigHelper.kafkaProducer;
 import static ai.grakn.engine.tasks.config.KafkaTerms.NEW_TASKS_TOPIC;
 import static ai.grakn.engine.tasks.config.KafkaTerms.TASK_RUNNER_GROUP;
 import static ai.grakn.engine.tasks.manager.ExternalStorageRebalancer.rebalanceListener;
-import static ai.grakn.engine.tasks.config.ZookeeperPaths.TASKS_STOPPED;
-import static ai.grakn.engine.tasks.config.ZookeeperPaths.TASKS_STOPPED_PREFIX;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
-import static java.lang.String.format;
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static java.util.stream.Collectors.toSet;
 import static java.util.stream.Stream.generate;
-import static org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_ADDED;
 
 /**
  * {@link TaskManager} implementation that operates using a single Kafka queue and controls the
@@ -73,12 +66,9 @@ public class SingleQueueTaskManager implements TaskManager {
     private final ZookeeperConnection zookeeper;
     private final TaskStateStorage storage;
     private final FailoverElector failover;
-    private final PathChildrenCache stoppedTasks;
 
     private Set<SingleQueueTaskRunner> taskRunners;
     private ExecutorService taskRunnerThreadPool;
-
-    private Charset zkCharset = Charsets.UTF_8;
 
     /**
      * Create a {@link SingleQueueTaskManager}
@@ -92,19 +82,6 @@ public class SingleQueueTaskManager implements TaskManager {
     public SingleQueueTaskManager(EngineID engineId){
         this.zookeeper = new ZookeeperConnection();
         this.storage = chooseStorage(properties, zookeeper);
-
-        stoppedTasks = new PathChildrenCache(zookeeper.connection(), TASKS_STOPPED_PREFIX, true);
-        stoppedTasks.getListenable().addListener((client, event) -> {
-            if (event.getType() == CHILD_ADDED) {
-                TaskId id = TaskId.of(new String(event.getData().getData(), zkCharset));
-                taskRunners.forEach(taskRunner -> taskRunner.stopTask(id));
-            }
-        });
-        try {
-            stoppedTasks.start();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
 
         //TODO check that the number of partitions is at least the capacity
         //TODO Single queue task manager should have its own impl of failover
@@ -169,13 +146,12 @@ public class SingleQueueTaskManager implements TaskManager {
      */
     @Override
     public void stopTask(TaskId id, String requesterName) {
-        byte[] serializedId = id.getValue().getBytes(zkCharset);
-        try {
-            zookeeper.connection().create().creatingParentsIfNeeded().forPath(format(TASKS_STOPPED, id), serializedId);
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new RuntimeException(e);
+        // TODO: Make only one call to storage if possible
+        if (!storage.containsTask(id)) {
+            TaskState task = TaskState.of(id).markStopped();
+            storage.newState(task);
+        } else {
+            taskRunners.forEach(taskRunner -> taskRunner.stopTask(id));
         }
     }
 
@@ -195,15 +171,6 @@ public class SingleQueueTaskManager implements TaskManager {
         Consumer<TaskId, TaskState> consumer = kafkaConsumer(TASK_RUNNER_GROUP);
         consumer.subscribe(ImmutableList.of(NEW_TASKS_TOPIC), rebalanceListener(consumer, zookeeper));
         return consumer;
-    }
-
-    /**
-     * Check in Zookeeper whether the task has been stopped.
-     * @param taskId the task ID to look up in Zookeeper
-     * @return true if the task has been marked stopped
-     */
-    boolean isTaskMarkedStopped(TaskId taskId) {
-        return stoppedTasks.getCurrentData(format(TASKS_STOPPED, taskId)) != null;
     }
 
     /**

--- a/grakn-test/src/test/java/ai/grakn/generator/TaskStates.java
+++ b/grakn-test/src/test/java/ai/grakn/generator/TaskStates.java
@@ -26,6 +26,7 @@ import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.test.engine.tasks.FailingTestTask;
 import ai.grakn.test.engine.tasks.LongExecutionTestTask;
 import ai.grakn.test.engine.tasks.ShortExecutionTestTask;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
 import com.pholser.junit.quickcheck.generator.Generator;
@@ -36,6 +37,7 @@ import mjson.Json;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static ai.grakn.engine.TaskStatus.CREATED;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.PARAMETER;
@@ -46,19 +48,14 @@ public class TaskStates extends Generator<TaskState> {
 
     private boolean newTask = false;
 
-    // TODO: make this generate more classes
-    @SuppressWarnings("unchecked")
-    private Class<? extends BackgroundTask>[] classes = new Class[] {
-            LongExecutionTestTask.class, ShortExecutionTestTask.class, FailingTestTask.class
-    };
-
     public TaskStates() {
         super(TaskState.class);
     }
 
     @Override
     public TaskState generate(SourceOfRandomness random, GenerationStatus status) {
-        Class<? extends BackgroundTask> taskClass = random.choose(classes);
+        // TODO: make this generate more classes
+        Class<? extends BackgroundTask> taskClass = random.choose(ImmutableList.of(LongExecutionTestTask.class, ShortExecutionTestTask.class, FailingTestTask.class));
 
         TaskId taskId;
 
@@ -84,21 +81,10 @@ public class TaskStates extends Generator<TaskState> {
         this.newTask = newTask.value();
     }
 
-    public void configure(WithClass withClass) {
-        this.classes = withClass.value();
-    }
-
     @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
     @Retention(RUNTIME)
     @GeneratorConfiguration
     public @interface NewTask {
         boolean value() default true;
-    }
-
-    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
-    @Retention(RUNTIME)
-    @GeneratorConfiguration
-    public @interface WithClass {
-        Class<? extends BackgroundTask>[] value() default {};
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerIT.java
@@ -19,14 +19,10 @@
 
 package ai.grakn.test.engine;
 
-import ai.grakn.client.TaskClient;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.TaskStateStorage;
 import ai.grakn.generator.TaskStates.NewTask;
-import ai.grakn.generator.TaskStates.WithClass;
 import ai.grakn.test.EngineContext;
-import ai.grakn.test.engine.tasks.EndlessExecutionTestTask;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
@@ -45,28 +41,21 @@ import static ai.grakn.engine.TaskStatus.STOPPED;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.clearTasks;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.completableTasks;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.completedTasks;
-import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForDoneStatus;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForStatus;
-import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.whenTaskStarts;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertThat;
 
 @RunWith(JUnitQuickcheck.class)
 public class GraknEngineServerIT {
-
-    private static final int PORT1 = 4567;
-    private static final int PORT2 = 5678;
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
     @ClassRule
-    public static final EngineContext engine1 = EngineContext.startSingleQueueServer().port(PORT1);
+    public static final EngineContext engine1 = EngineContext.startSingleQueueServer().port(4567);
 
     @ClassRule
-    public static final EngineContext engine2 = EngineContext.startSingleQueueServer().port(PORT2);
+    public static final EngineContext engine2 = EngineContext.startSingleQueueServer().port(5678);
 
     private TaskStateStorage storage;
 
@@ -94,55 +83,5 @@ public class GraknEngineServerIT {
         waitForStatus(storage, allTasks, COMPLETED, STOPPED, FAILED);
 
         assertEquals(completableTasks(allTasks), completedTasks());
-    }
-
-    @Property(trials=10)
-    public void whenEngine1StopsATaskBeforeExecution_TheTaskIsStopped(@NewTask TaskState task) {
-        String uri1 = "localhost:" + PORT1;
-        TaskClient.of(uri1).stopTask(task.getId());
-
-        engine1.getTaskManager().addTask(task);
-
-        waitForDoneStatus(storage, ImmutableList.of(task));
-
-        assertThat(completedTasks(), empty());
-    }
-
-    @Property(trials=10)
-    public void whenEngine2StopsATaskBeforeExecution_TheTaskIsStopped(@NewTask TaskState task) {
-        String uri2 = "localhost:" + PORT2;
-        TaskClient.of(uri2).stopTask(task.getId());
-
-        engine1.getTaskManager().addTask(task);
-
-        waitForDoneStatus(storage, ImmutableList.of(task));
-
-        assertThat(completedTasks(), empty());
-    }
-
-    @Property(trials=10)
-    public void whenEngine1StopsATaskDuringExecution_TheTaskIsStopped(
-            @NewTask @WithClass(EndlessExecutionTestTask.class) TaskState task) {
-        String uri1 = "localhost:" + PORT1;
-        whenTaskStarts(id -> TaskClient.of(uri1).stopTask(task.getId()));
-
-        engine1.getTaskManager().addTask(task);
-
-        waitForDoneStatus(storage, ImmutableList.of(task));
-
-        assertThat(completedTasks(), empty());
-    }
-
-    @Property(trials=10)
-    public void whenEngine2StopsATaskDuringExecution_TheTaskIsStopped(
-            @NewTask @WithClass(EndlessExecutionTestTask.class) TaskState task) {
-        String uri2 = "localhost:" + PORT2;
-        whenTaskStarts(id -> TaskClient.of(uri2).stopTask(task.getId()));
-
-        engine1.getTaskManager().addTask(task);
-
-        waitForDoneStatus(storage, ImmutableList.of(task));
-
-        assertThat(completedTasks(), empty());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/MockBackgroundTask.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/MockBackgroundTask.java
@@ -45,12 +45,6 @@ public abstract class MockBackgroundTask implements BackgroundTask {
 
         if (!wasCancelled) {
             startInner(id);
-        }
-
-        // Cancelled status may have changed
-        wasCancelled = cancelled.get();
-
-        if (!wasCancelled) {
             addCompletedTask(id);
         } else {
             addCancelledTask(id);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
@@ -24,9 +24,7 @@ import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskManager;
 import ai.grakn.engine.util.EngineID;
 import ai.grakn.generator.TaskStates.NewTask;
-import ai.grakn.generator.TaskStates.WithClass;
 import ai.grakn.test.EngineContext;
-import ai.grakn.test.engine.tasks.EndlessExecutionTestTask;
 import com.google.common.collect.ImmutableList;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
@@ -113,8 +111,7 @@ public class SingleQueueTaskManagerTest {
     }
 
     @Property(trials=10)
-    public void whenStoppingATaskDuringExecution_TheTaskIsCancelled(
-            @NewTask @WithClass(EndlessExecutionTestTask.class) TaskState task, String requester) {
+    public void whenStoppingATaskDuringExecution_TheTaskIsCancelled(@NewTask TaskState task, String requester) {
         whenTaskStarts(id -> taskManager.stopTask(id, requester));
 
         taskManager.addTask(task);
@@ -126,8 +123,7 @@ public class SingleQueueTaskManagerTest {
     }
 
     @Property(trials=10)
-    public void whenStoppingATaskDuringExecution_TheTaskIsMarkedAsStopped(
-            @NewTask @WithClass(EndlessExecutionTestTask.class) TaskState task, String requester) {
+    public void whenStoppingATaskDuringExecution_TheTaskIsMarkedAsStopped(@NewTask TaskState task, String requester) {
         whenTaskStarts(id -> taskManager.stopTask(id, requester));
 
         taskManager.addTask(task);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskRunnerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskRunnerTest.java
@@ -25,7 +25,6 @@ import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskManager;
 import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskRunner;
 import ai.grakn.engine.tasks.storage.TaskStateInMemoryStore;
 import ai.grakn.engine.util.EngineID;
-import ai.grakn.test.EngineContext;
 import ai.grakn.test.engine.tasks.EndlessExecutionTestTask;
 import ai.grakn.test.engine.tasks.LongExecutionTestTask;
 import ai.grakn.test.engine.tasks.ShortExecutionTestTask;
@@ -41,17 +40,15 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -74,12 +71,7 @@ import static java.time.Duration.between;
 import static java.time.Duration.ofMillis;
 import static java.time.Instant.now;
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -88,17 +80,10 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doCallRealMethod;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(JUnitQuickcheck.class)
 public class SingleQueueTaskRunnerTest {
-
-    @ClassRule
-    public static final EngineContext zookeeperRunning = EngineContext.startKafkaServer();
 
     private static final EngineID engineID = EngineID.me();
     private SingleQueueTaskRunner taskRunner;
@@ -114,7 +99,7 @@ public class SingleQueueTaskRunnerTest {
         hideLogs();
 
         storage = new TaskStateInMemoryStore();
-
+        
         consumer = new MockGraknConsumer<>(OffsetResetStrategy.EARLIEST);
 
         partition = new TopicPartition("hi", 0);
@@ -129,7 +114,7 @@ public class SingleQueueTaskRunnerTest {
         doAnswer(invocation -> {
             addTask(invocation.getArgument(0));
             return null;
-        }).when(mockedTM).addTask(Mockito.any());
+        }).when(mockedTM).addTask(any());
     }
 
     public void setUpTasks(List<List<TaskState>> tasks) {


### PR DESCRIPTION
This reverts commit b3d0f90464c83938095607a5c01752cac2295db0.

This was causing frequent test failures for people. If re-introduced, it should be re-tested several times to be confident.