### PR TITLE
Change logs to never hide `ai.grakn`

### DIFF
--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -147,6 +147,10 @@ public abstract class GraknTestEnv {
 
     public static void hideLogs() {
         ((Logger) org.slf4j.LoggerFactory.getLogger(ROOT_LOGGER_NAME)).setLevel(Level.ERROR);
+
+        // Some dependencies are using log4j, so must be managed separately
+        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
+
         ((Logger) org.slf4j.LoggerFactory.getLogger("ai.grakn")).setLevel(Level.INFO);
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
+++ b/grakn-test/src/test/java/ai/grakn/test/GraknTestEnv.java
@@ -6,7 +6,6 @@ import ai.grakn.engine.postprocessing.EngineCache;
 import ai.grakn.engine.util.ConfigProperties;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.factory.SystemKeyspace;
-import ai.grakn.test.engine.tasks.BackgroundTaskTestUtils;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.jayway.restassured.RestAssured;
@@ -19,6 +18,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static ai.grakn.engine.tasks.config.KafkaTerms.NEW_TASKS_TOPIC;
 import static ai.grakn.graql.Graql.var;
+import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 
 /**
  * <p>
@@ -146,10 +146,8 @@ public abstract class GraknTestEnv {
     }
 
     public static void hideLogs() {
-        ((Logger) org.slf4j.LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).setLevel(Level.OFF);
-        ((Logger) org.slf4j.LoggerFactory.getLogger(GraknTestEnv.class)).setLevel(Level.DEBUG);
-        ((Logger) org.slf4j.LoggerFactory.getLogger(BackgroundTaskTestUtils.class)).setLevel(Level.DEBUG);
-        org.apache.log4j.Logger.getRootLogger().setLevel(org.apache.log4j.Level.ERROR);
+        ((Logger) org.slf4j.LoggerFactory.getLogger(ROOT_LOGGER_NAME)).setLevel(Level.ERROR);
+        ((Logger) org.slf4j.LoggerFactory.getLogger("ai.grakn")).setLevel(Level.INFO);
     }
 
     public static boolean usingTinker() {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/StandaloneTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/StandaloneTaskManagerTest.java
@@ -18,16 +18,19 @@
 
 package ai.grakn.test.engine.tasks.manager;
 
-import ai.grakn.engine.TaskStatus;
 import ai.grakn.engine.TaskId;
+import ai.grakn.engine.TaskStatus;
 import ai.grakn.engine.tasks.TaskManager;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.TaskStateStorage;
 import ai.grakn.engine.tasks.manager.StandaloneTaskManager;
 import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.engine.tasks.ShortExecutionTestTask;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -142,6 +145,9 @@ public class StandaloneTaskManagerTest {
 
     @Test
     public void consecutiveStopStart() {
+        // Disable excessive logs for this test
+        ((Logger) LoggerFactory.getLogger(StandaloneTaskManager.class)).setLevel(Level.WARN);
+
         for (int i = 0; i < 100000; i++) {
             testStopSingle();
         }


### PR DESCRIPTION
Now we print all logs from `ai.grakn` as `INFO` and everything else only if it is `ERROR`.

This means we don't see loads of cassandra/titan logs, but we still see real problems from them. Additionally, we see a reasonable amount of output from `ai.grakn`, without overwhelming the longs.