### PR TITLE
Make sure producer is closed after task runners

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskManager.java
@@ -109,13 +109,13 @@ public class SingleQueueTaskManager implements TaskManager {
     public void close() {
         LOG.debug("Closing SingleQueueTaskManager");
 
-        // close kafka producer
-        noThrow(producer::close, "Error shutting down producer in TaskManager");
-
         // Close all the task runners
         for(SingleQueueTaskRunner taskRunner:taskRunners) {
             noThrow(taskRunner::close, "Error shutting down TaskRunner");
         }
+
+        // close kafka producer
+        noThrow(producer::close, "Error shutting down producer in TaskManager");
 
         // close the thread pool and wait for shutdown
         noThrow(taskRunnerThreadPool::shutdown, "Error closing task runner thread pool");


### PR DESCRIPTION
This is to avoid issues when the task runner attempts to resubmit a task to a closed producer.