### PR TITLE
Bumping Cassandra to 2.1.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <csv.version>1.4</csv.version>
         <jool.version>3.8.5</jool.version>
         <cassandra-unit.version>2.1.9.2</cassandra-unit.version>
+        <cassandra-all.version>2.1.17</cassandra-all.version>
         <h2-database.version>1.4.192</h2-database.version>
         <hermit.version>1.3.8.500</hermit.version>
         <owl-api.version>5.0.2</owl-api.version>
@@ -224,7 +225,7 @@
         <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
-            <version>2.1.17</version>
+            <version>${cassandra-all.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -221,6 +221,11 @@
             <version>${logback.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.cassandra</groupId>
+            <artifactId>cassandra-all</artifactId>
+            <version>2.1.17</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
             <version>${cassandra-all.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>it.unimi.dsi</groupId>
+                    <artifactId>fastutil</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Re-opening this to make sure we test against latest 2.1 version.

Countless Cassandra fixes but more practically it fixes the cqlsh bug (https://issues.apache.org/jira/browse/CASSANDRA-11850).