### PR TITLE
Grakn Engine failover test framework 

### DIFF
--- a/grakn-test/pom.xml
+++ b/grakn-test/pom.xml
@@ -67,6 +67,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>net.lingala.zip4j</groupId>
+            <artifactId>zip4j</artifactId>
+            <version>1.3.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>${commons-collections.version}</version>

--- a/grakn-test/src/test/java/ai/grakn/test/DistributionContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/DistributionContext.java
@@ -39,6 +39,7 @@ import static ai.grakn.engine.GraknEngineConfig.SERVER_PORT_NUMBER;
 import static ai.grakn.engine.GraknEngineConfig.TASK_MANAGER_IMPLEMENTATION;
 import static ai.grakn.test.GraknTestEnv.hideLogs;
 import static ai.grakn.test.GraknTestEnv.startKafka;
+import static ai.grakn.test.GraknTestEnv.stopKafka;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.file.Files.setPosixFilePermissions;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
@@ -108,6 +109,12 @@ public class DistributionContext extends ExternalResource {
     @Override
     public void after() {
         engineProcess.destroyForcibly();
+
+        try {
+            stopKafka();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not shut down", e);
+        }
     }
 
     private void unzipDistribution() throws ZipException, IOException {

--- a/grakn-test/src/test/java/ai/grakn/test/DistributionContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/DistributionContext.java
@@ -1,0 +1,172 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.test;
+
+import ai.grakn.client.Client;
+import ai.grakn.engine.GraknEngineConfig;
+import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskManager;
+import ai.grakn.util.GraknVersion;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Stream;
+import net.lingala.zip4j.core.ZipFile;
+import net.lingala.zip4j.exception.ZipException;
+import org.junit.rules.ExternalResource;
+
+import static ai.grakn.engine.GraknEngineConfig.SERVER_PORT_NUMBER;
+import static ai.grakn.engine.GraknEngineConfig.TASK_MANAGER_IMPLEMENTATION;
+import static ai.grakn.test.GraknTestEnv.hideLogs;
+import static ai.grakn.test.GraknTestEnv.startKafka;
+import static java.lang.System.currentTimeMillis;
+import static java.nio.file.Files.setPosixFilePermissions;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
+import static java.util.stream.Collectors.joining;
+
+/**
+ * Start a SingleQueueEngine from the packaged distribution.
+ * This context can be used for integration tests.
+ *
+ * @author alexandraorth
+ */
+public class DistributionContext extends ExternalResource {
+
+    private static final FilenameFilter jarFiles = (dir, name) -> name.toLowerCase().endsWith(".jar");
+    private static final String ZIP = "grakn-dist-" + GraknVersion.VERSION + ".zip";
+    private static final String CURRENT_DIRECTORY = System.getProperty("user.dir");
+    private static final String TARGET_DIRECTORY = CURRENT_DIRECTORY + "/../grakn-dist/target/";
+    private static final String DIST_DIRECTORY = TARGET_DIRECTORY + "grakn-dist-" + GraknVersion.VERSION;
+    private static final Set<PosixFilePermission> permissions =  EnumSet.of(
+            OWNER_EXECUTE, OWNER_READ, OWNER_WRITE,
+            GROUP_EXECUTE, GROUP_WRITE, GROUP_READ,
+            OTHERS_EXECUTE, OTHERS_READ, OTHERS_WRITE);
+
+    private Process engineProcess;
+    private int port = 4567;
+
+    private DistributionContext(){}
+
+    public static DistributionContext startSingleQueueEngineProcess(){
+        return new DistributionContext();
+    }
+
+    public DistributionContext port(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public Process process(){
+        return engineProcess;
+    }
+
+    public int port(){
+        return port;
+    }
+
+    @Override
+    public void before() throws Throwable {
+        hideLogs();
+
+        unzipDistribution();
+
+        startKafka();
+
+        engineProcess = newEngineProcess(port);
+
+        waitForEngine(port);
+    }
+
+    @Override
+    public void after() {
+        engineProcess.destroyForcibly();
+    }
+
+    private void unzipDistribution() throws ZipException, IOException {
+        // Unzip the distribution
+        ZipFile zipped = new ZipFile( TARGET_DIRECTORY + ZIP);
+        zipped.extractAll(TARGET_DIRECTORY);
+
+        setPosixFilePermissions(new File(DIST_DIRECTORY + "/bin/grakn-engine.sh").toPath(), permissions);
+    }
+
+    private Process newEngineProcess(Integer port) throws IOException {
+        // Set correct port & task manager
+        Properties properties = GraknEngineConfig.getInstance().getProperties();
+        properties.setProperty(SERVER_PORT_NUMBER, port.toString());
+        properties.setProperty(TASK_MANAGER_IMPLEMENTATION, SingleQueueTaskManager.class.getName());
+
+        // Write new properties to disk
+        File propertiesFile = new File("grakn-engine-" + port + ".properties");
+        propertiesFile.deleteOnExit();
+        try(FileOutputStream os = new FileOutputStream(propertiesFile)) {
+            properties.store(os, null);
+        }
+
+        // Java commands to start Engine process
+        String[] commands = {"java",
+                "-cp", getClassPath(),
+                "-Dgrakn.dir=" + DIST_DIRECTORY + "/bin",
+                "-Dgrakn.conf=" + propertiesFile.getAbsolutePath(),
+                "ai.grakn.engine.GraknEngineServer", "&"};
+
+        // Start process
+        return new ProcessBuilder(commands).inheritIO().start();
+    }
+
+    /**
+     * Get the class path of all the jars in the /lib folder
+     */
+    private String getClassPath(){
+        return Stream.of(new File(DIST_DIRECTORY + "/lib").listFiles(jarFiles))
+                .filter(f -> !f.getName().contains("slf4j-log4j12"))
+                .map(File::getAbsolutePath)
+                .collect(joining(":"));
+    }
+
+    /**
+     * Wait for the engine REST API to be available
+     */
+    private static void waitForEngine(int port) {
+        long endTime = currentTimeMillis() + 60000;
+        while (currentTimeMillis() < endTime) {
+            if (Client.serverIsRunning("localhost:" + port)) {
+                return;
+            }
+
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
@@ -89,7 +89,7 @@ public class GraknEngineFailoverIT {
 
 
     private Set<TaskId> sendTasks(int port, List<TaskState> tasks) {
-        TaskClient engineClient = TaskClient.of("localhost:" + port);
+        TaskClient engineClient = TaskClient.of("localhost", port);
 
         return tasks.stream().map(t -> engineClient.sendTask(
                 t.taskClass(),

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
@@ -1,0 +1,106 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.test.engine;
+
+import ai.grakn.client.TaskClient;
+import ai.grakn.engine.TaskId;
+import ai.grakn.engine.TaskStatus;
+import ai.grakn.engine.tasks.TaskState;
+import ai.grakn.engine.tasks.TaskStateStorage;
+import ai.grakn.engine.tasks.manager.ZookeeperConnection;
+import ai.grakn.engine.tasks.mock.FailingMockTask;
+import ai.grakn.engine.tasks.storage.TaskStateZookeeperStore;
+import ai.grakn.generator.TaskStates.NewTask;
+import ai.grakn.test.DistributionContext;
+import ai.grakn.test.engine.tasks.BackgroundTaskTestUtils;
+import com.google.common.collect.Sets;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import java.util.List;
+import java.util.Set;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import static ai.grakn.engine.TaskStatus.COMPLETED;
+import static ai.grakn.engine.TaskStatus.FAILED;
+import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@RunWith(JUnitQuickcheck.class)
+public class GraknEngineFailoverIT {
+
+    private static ZookeeperConnection connection;
+    private static TaskStateStorage storage;
+
+    @ClassRule
+    public static DistributionContext engine1 = DistributionContext.startSingleQueueEngineProcess().port(4567);
+
+    @BeforeClass
+    public static void getStorage() {
+        connection = new ZookeeperConnection();
+        storage = new TaskStateZookeeperStore(connection);
+    }
+
+    @AfterClass
+    public static void closeStorage() {
+        connection.close();
+    }
+
+    @Property(trials = 10)
+    public void whenSubmittingTasksToEngine_TheyComplete(List<@NewTask TaskState> tasks1) throws Exception {
+        // Create & Send tasks to rest api
+        Set<TaskId> tasks = sendTasks(engine1.port(), tasks1);
+
+        // Wait for those tasks to complete
+        waitForStatus(tasks, COMPLETED, FAILED);
+
+        // Assert the tasks have finished with the correct status depending on type
+        assertTasksCompletedWithCorrectStatus(tasks);
+    }
+
+    private void assertTasksCompletedWithCorrectStatus(Set<TaskId> tasks) {
+        tasks.stream().map(storage::getState).forEach(t -> {
+            if(t.taskClass() == FailingMockTask.class){
+                assertThat(t.status(), equalTo(FAILED));
+            } else {
+                assertThat(t.status(), equalTo(COMPLETED));
+            }
+        });
+    }
+
+
+    private Set<TaskId> sendTasks(int port, List<TaskState> tasks) {
+        TaskClient engineClient = TaskClient.of("localhost:" + port);
+
+        return tasks.stream().map(t -> engineClient.sendTask(
+                t.taskClass(),
+                t.creator(),
+                t.schedule().runAt(),
+                t.schedule().interval().orElse(null),
+                t.configuration())).collect(toSet());
+    }
+
+    private static void waitForStatus(Set<TaskId> taskIds, TaskStatus... status) {
+        Set<TaskStatus> statusSet = Sets.newHashSet(status);
+        taskIds.forEach(t -> BackgroundTaskTestUtils.waitForStatus(storage, t, statusSet));
+    }
+}

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/BackgroundTaskTestUtils.java
@@ -95,11 +95,15 @@ public class BackgroundTaskTestUtils {
     }
 
     private static void waitForStatus(TaskStateStorage storage, TaskState task, Set<TaskStatus> status) {
+        waitForStatus(storage, task.getId(), status);
+    }
+
+    public static void waitForStatus(TaskStateStorage storage, TaskId task, Set<TaskStatus> status) {
         final long initial = new Date().getTime();
 
         while((new Date().getTime())-initial < 60000) {
-            if (storage.containsTask(task.getId())) {
-                TaskStatus currentStatus = storage.getState(task.getId()).status();
+            if (storage.containsTask(task)) {
+                TaskStatus currentStatus = storage.getState(task).status();
                 if (status.contains(currentStatus)) {
                     return;
                 }
@@ -112,7 +116,7 @@ public class BackgroundTaskTestUtils {
             }
         }
 
-        TaskStatus finalStatus = storage.containsTask(task.getId()) ? storage.getState(task.getId()).status() : null;
+        TaskStatus finalStatus = storage.containsTask(task) ? storage.getState(task).status() : null;
 
         fail("Timeout waiting for status of " + task + " to be any of " + status + ", but status is " + finalStatus);
     }


### PR DESCRIPTION
+ Added `DistributionContext` for testing that unzips the `dist` folder and starts engine in a separate process
+ Added `GraknEngineFailoverIT` that tests `DistributionContext` for now and will soon test killing random engines