### PR TITLE
Improve Graql traversal planner

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
@@ -175,8 +175,7 @@ public class GraqlTraversal {
             return fragment.fragmentCost(previousCost);
         } else {
             // Restart traversal, meaning we are navigating from all vertices
-            // The constant '1' cost is to discourage constant restarting, even when indexed
-            return fragment.fragmentCost(NUM_VERTICES_ESTIMATE) * previousCost + 1;
+            return fragment.fragmentCost(NUM_VERTICES_ESTIMATE) * previousCost;
         }
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -42,7 +42,7 @@ import static java.util.Comparator.naturalOrder;
  */
 public class GreedyTraversalPlan {
 
-    private static final long MAX_TRAVERSAL_ATTEMPTS = 1_000;
+    private static final long MAX_TRAVERSAL_ATTEMPTS = 10_000;
 
     /**
      * Create a traversal plan using the default maxTraersalAttempts.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -36,7 +36,7 @@ import static ai.grakn.graql.internal.util.CommonUtil.toImmutableSet;
  * A traversal plan for executing a Graql query, comprised of a list of fragments and a cost
  */
 class Plan implements Comparable<Plan> {
-    private double cost;
+    private final double cost;
     private final Fragment fragment;
     private final Plan innerPlan;
     private final Set<VarName> names;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/ValueFragment.java
@@ -53,7 +53,8 @@ class ValueFragment extends AbstractFragment {
         if (predicate.isSpecific()) {
             return NUM_RESOURCES_PER_VALUE;
         } else {
-            return previousCost;
+            // Assume approximately half of values will satisfy a filter
+            return previousCost / 2.0;
         }
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
@@ -38,7 +38,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static ai.grakn.graql.Graql.and;
 import static ai.grakn.graql.Graql.eq;
+import static ai.grakn.graql.Graql.gt;
 import static ai.grakn.graql.Graql.or;
 import static ai.grakn.graql.Graql.var;
 import static ai.grakn.graql.internal.gremlin.fragment.Fragments.distinctCasting;
@@ -65,6 +67,9 @@ import static org.junit.Assert.assertTrue;
 
 public class GraqlTraversalTest {
 
+    private static final VarName a = VarName.of("a");
+    private static final VarName b = VarName.of("b");
+    private static final VarName c = VarName.of("c");
     private static final VarName x = VarName.of("x");
     private static final VarName y = VarName.of("y");
     private static final VarName z = VarName.of("z");
@@ -209,6 +214,16 @@ public class GraqlTraversalTest {
         assertNearlyOptimal(var()
                 .rel(var(x).isa(var(y).id(ConceptId.of("movie"))))
                 .rel(var(z).value("Titanic").isa(var("a").id(ConceptId.of("title")))));
+    }
+
+    @Test
+    public void makeSureTypeIsCheckedBeforeFollowingAShortcut() {
+        assertNearlyOptimal(and(
+                var(x).id(ConceptId.of("xid")),
+                var().rel(var(x)).rel(var(y)),
+                var(y).isa(var(b).name("person")),
+                var().rel(var(y)).rel(var(z))
+        ));
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
@@ -121,6 +121,14 @@ public class GraqlTraversalTest {
     }
 
     @Test
+    public void valueFilteringIsBetterThanANonFilteringOperation() {
+        GraqlTraversal valueFilterFirst = traversal(value(x, gt(1).admin()), makeShortcut(x, y), outIsa(y, z));
+        GraqlTraversal shortcutFirst = traversal(outIsa(y, z), makeShortcut(y, x), value(x, gt(1).admin()));
+
+        assertFaster(valueFilterFirst, shortcutFirst);
+    }
+
+    @Test
     public void testCheckDistinctCastingEarlyFaster() {
         VarName c1 = VarName.of("c1");
         VarName c2 = VarName.of("c2");

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
@@ -1,0 +1,63 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ *
+ */
+
+package ai.grakn.graql.internal.gremlin;
+
+import ai.grakn.concept.TypeName;
+import ai.grakn.graql.VarName;
+import ai.grakn.graql.internal.gremlin.fragment.Fragment;
+import ai.grakn.graql.internal.gremlin.fragment.Fragments;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static ai.grakn.graql.internal.gremlin.fragment.Fragments.outIsa;
+import static ai.grakn.graql.internal.gremlin.fragment.Fragments.shortcut;
+import static org.junit.Assert.assertEquals;
+
+public class PlanTest {
+
+
+    @Test
+    public void planComplexityShouldAlwaysEqualCostFromGraqlTraversal() {
+        VarName a = VarName.of("a");
+        VarName x = VarName.of("x");
+        VarName y = VarName.of("y");
+        VarName z = VarName.of("z");
+
+        Plan plan = Plan.base()
+                .append(outIsa(y, a))
+                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
+
+        Plan plan2 = Plan.base()
+                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), x, y))
+                .append(outIsa(y, a))
+                .append(Fragments.name(a, TypeName.of("person")))
+                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
+
+        List<Fragment> fragments = plan.fragments();
+
+        double traversalComplexity = GraqlTraversal.create(ImmutableSet.of(fragments)).getComplexity();
+        double planCost = plan.cost();
+
+        assertEquals(traversalComplexity, planCost, 10.0);
+    }
+}


### PR DESCRIPTION
- Remove some cargo culty code where I was adding constant "1"s in some places.
- Fix cost calculation during query planning to reflect the actual complexity value.
- Increase number of traversal plans we check from 1,000 to 10,000

To expand on the last point: we've previously found (by profiling) that calculating the traversal plan has no significant performance cost. The traversal plan time complexity is proportional to this constant, so increasing it ten-fold should not cause any noticeable performance problems.