### PR TITLE
Make `Var` class totally immutable

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/Var.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Var.java
@@ -23,6 +23,8 @@ import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.TypeName;
 import ai.grakn.graql.admin.VarAdmin;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A wildcard variable to refers to a concept in a query.
  * <p>
@@ -43,36 +45,42 @@ public interface Var extends Pattern {
      * @param id a ConceptId that this variable's ID must match
      * @return this
      */
+    @CheckReturnValue
     Var id(ConceptId id);
 
     /**
      * @param name a string that this variable's name must match
      * @return this
      */
+    @CheckReturnValue
     Var name(String name);
 
     /**
      * @param name a type name that this variable's name must match
      * @return this
      */
+    @CheckReturnValue
     Var name(TypeName name);
 
     /**
      * @param value a value that this variable's value must exactly match
      * @return this
      */
+    @CheckReturnValue
     Var value(Object value);
 
     /**
      * @param predicate a atom this variable's value must match
      * @return this
      */
+    @CheckReturnValue
     Var value(ValuePredicate predicate);
 
     /**
      * @param var a variable representing a resource
      * @return this
      */
+    @CheckReturnValue
     Var has(Var var);
 
     /**
@@ -82,6 +90,7 @@ public interface Var extends Pattern {
      * @param value a value of a resource
      * @return this
      */
+    @CheckReturnValue
     Var has(String type, Object value);
 
     /**
@@ -91,6 +100,7 @@ public interface Var extends Pattern {
      * @param predicate a atom on the value of a resource
      * @return this
      */
+    @CheckReturnValue
     Var has(String type, ValuePredicate predicate);
 
     /**
@@ -100,6 +110,7 @@ public interface Var extends Pattern {
      * @param var a variable representing a resource
      * @return this
      */
+    @CheckReturnValue
     Var has(String type, Var var);
 
     /**
@@ -109,84 +120,98 @@ public interface Var extends Pattern {
      * @param var a variable representing a resource
      * @return this
      */
+    @CheckReturnValue
     Var has(TypeName type, Var var);
 
     /**
      * @param type a concept type id that the variable must be of this type
      * @return this
      */
+    @CheckReturnValue
     Var isa(String type);
 
     /**
      * @param type a concept type that this variable must be an instance of
      * @return this
      */
+    @CheckReturnValue
     Var isa(Var type);
 
     /**
      * @param type a concept type id that this variable must be a kind of
      * @return this
      */
+    @CheckReturnValue
     Var sub(String type);
 
     /**
      * @param type a concept type that this variable must be a kind of
      * @return this
      */
+    @CheckReturnValue
     Var sub(Var type);
 
     /**
      * @param type a role type id that this relation type variable must have
      * @return this
      */
+    @CheckReturnValue
     Var hasRole(String type);
 
     /**
      * @param type a role type that this relation type variable must have
      * @return this
      */
+    @CheckReturnValue
     Var hasRole(Var type);
 
     /**
      * @param type a role type id that this concept type variable must play
      * @return this
      */
+    @CheckReturnValue
     Var playsRole(String type);
 
     /**
      * @param type a role type that this concept type variable must play
      * @return this
      */
+    @CheckReturnValue
     Var playsRole(Var type);
 
     /**
      * @param type a scope that this variable must have
      * @return this
      */
+    @CheckReturnValue
     Var hasScope(Var type);
 
     /**
      * @param type a resource type that this type variable can be related to
      * @return this
      */
+    @CheckReturnValue
     Var hasResource(String type);
 
     /**
      * @param type a resource type that this type variable can be related to
      * @return this
      */
+    @CheckReturnValue
     Var hasResource(Var type);
 
     /**
      * @param type a resource type that this type variable can be one-to-one related to
      * @return this
      */
+    @CheckReturnValue
     Var hasKey(String type);
 
     /**
      * @param type a resource type that this type variable can be one-to-one related to
      * @return this
      */
+    @CheckReturnValue
     Var hasKey(Var type);
 
     /**
@@ -195,6 +220,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(String roleplayer);
 
     /**
@@ -203,6 +229,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(Var roleplayer);
 
     /**
@@ -212,6 +239,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(String roletype, String roleplayer);
 
     /**
@@ -221,6 +249,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(Var roletype, String roleplayer);
 
     /**
@@ -230,6 +259,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(String roletype, Var roleplayer);
 
     /**
@@ -239,6 +269,7 @@ public interface Var extends Pattern {
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
+    @CheckReturnValue
     Var rel(Var roletype, Var roleplayer);
 
     /**
@@ -247,6 +278,7 @@ public interface Var extends Pattern {
      * @param roleType the role type the variable must play
      * @return this
      */
+    @CheckReturnValue
     Var plays(String roleType);
 
     /**
@@ -255,18 +287,21 @@ public interface Var extends Pattern {
      * @param roleType the role type the variable must play
      * @return this
      */
+    @CheckReturnValue
     Var plays(Var roleType);
 
     /**
      * set this concept type variable as abstract, meaning it cannot have direct instances
      * @return this
      */
+    @CheckReturnValue
     Var isAbstract();
 
     /**
      * @param datatype the datatype to set for this resource type variable
      * @return this
      */
+    @CheckReturnValue
     Var datatype(ResourceType.DataType<?> datatype);
 
     /**
@@ -274,18 +309,21 @@ public interface Var extends Pattern {
      * @param regex the regex to set for this resource type variable
      * @return this
      */
+    @CheckReturnValue
     Var regex(String regex);
 
     /**
      * @param lhs the left-hand side of this rule
      * @return this
      */
+    @CheckReturnValue
     Var lhs(Pattern lhs);
 
     /**
      * @param rhs the right-hand side of this rule
      * @return this
      */
+    @CheckReturnValue
     Var rhs(Pattern rhs);
 
     /**
@@ -293,6 +331,7 @@ public interface Var extends Pattern {
      * @param varName the variable name that this variable should not be equal to
      * @return this
      */
+    @CheckReturnValue
     Var neq(String varName);
 
     /**
@@ -300,6 +339,7 @@ public interface Var extends Pattern {
      * @param var the variable that this variable should not be equal to
      * @return this
      */
+    @CheckReturnValue
     Var neq(Var var);
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
@@ -92,10 +92,4 @@ public interface PatternAdmin extends Pattern {
                 .flatMap(conj -> conj.getPatterns().stream())
                 .collect(toSet());
     }
-
-    /**
-     * Create a deep copy of this pattern
-     * @return a copy of this pattern
-     */
-    PatternAdmin cloneMe();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/RelationPlayer.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/RelationPlayer.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 
 /**
@@ -35,4 +36,11 @@ public interface RelationPlayer {
      * @return the role player
      */
     VarAdmin getRolePlayer();
+
+    // TODO: If `VarAdmin#setVarName` is removed, this may no longer be necessary
+    /**
+     * Set the role player, returning a new {@link RelationPlayer} with that role player set
+     */
+    @CheckReturnValue
+    RelationPlayer setRolePlayer(VarAdmin rolePlayer);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.VarName;
 import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 /**
@@ -86,6 +87,16 @@ public interface VarAdmin extends PatternAdmin, Var {
      * @return whether this {@link Var} has a {@link VarProperty} of the given type
      */
     <T extends VarProperty> boolean hasProperty(Class<T> type);
+
+    // TODO: If `VarAdmin#setVarName` is removed, this may no longer be necessary
+    /**
+     * Return this {@link Var} with instances of the given {@link VarProperty} modified.
+     * @param type the type of the {@link VarProperty}
+     * @param <T> the type of the {@link VarProperty}
+     * @return whether this {@link Var} has a {@link VarProperty} of the given type
+     */
+    @CheckReturnValue
+    <T extends VarProperty> VarAdmin mapProperty(Class<T> type, UnaryOperator<T> mapper);
 
     /**
      * @return the ID this variable represents, if it represents something with a specific ID

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
@@ -23,6 +23,7 @@ import ai.grakn.concept.TypeName;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarName;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -51,7 +52,8 @@ public interface VarAdmin extends PatternAdmin, Var {
     /**
      * @param name the new variable name of this variable
      */
-    void setVarName(VarName name);
+    @CheckReturnValue
+    VarAdmin setVarName(VarName name);
 
     /**
      * @return whether the user specified a name for this variable

--- a/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/user/SystemKeyspaceUsers.java
@@ -55,7 +55,7 @@ public class SystemKeyspaceUsers extends UsersHandler {
      */
     @Override
     public boolean addUser(Json userJson) {
-        final Var user = var().isa(USER_ENTITY);
+        final Var[] user = {var().isa(USER_ENTITY)};
         try (GraknGraph graph = EngineGraknGraphFactory.getInstance().getGraph(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
 
             userJson.asJsonMap().forEach( (property, value) -> {
@@ -63,14 +63,14 @@ public class SystemKeyspaceUsers extends UsersHandler {
                     byte[] salt = Password.getNextSalt(graph);
                     byte[] hashedPassword = Password.hash(value.getValue().toString().toCharArray(), salt);
 
-                    user.has(UsersHandler.USER_PASSWORD, Password.getString(hashedPassword));
-                    user.has(UsersHandler.USER_SALT, Password.getString(salt));
+                    user[0] = user[0].has(UsersHandler.USER_PASSWORD, Password.getString(hashedPassword));
+                    user[0] = user[0].has(UsersHandler.USER_SALT, Password.getString(salt));
                 } else {
-                    user.has(property, value.getValue());
+                    user[0] = user[0].has(property, value.getValue());
                 }
             });
 
-            InsertQuery query = graph.graql().insert(user);
+            InsertQuery query = graph.graql().insert(user[0]);
             query.execute();
             graph.admin().commit(EngineCache.getInstance());
             LOG.debug("Created user " + userJson);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/ConjunctionImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/ConjunctionImpl.java
@@ -39,10 +39,6 @@ class ConjunctionImpl<T extends PatternAdmin> implements Conjunction<T> {
         this.patterns = patterns;
     }
 
-    private ConjunctionImpl(Conjunction<T> conjunction) {
-        this.patterns = conjunction.getPatterns().stream().map(Patterns::copyOf).collect(toSet());
-    }
-
     @Override
     public Set<T> getPatterns() {
         return patterns;
@@ -76,11 +72,6 @@ class ConjunctionImpl<T extends PatternAdmin> implements Conjunction<T> {
     @Override
     public Conjunction<?> asConjunction() {
         return this;
-    }
-
-    @Override
-    public PatternAdmin cloneMe() {
-        return new ConjunctionImpl<>(this);
     }
 
     private static <U extends PatternAdmin> Conjunction<U> fromConjunctions(List<Conjunction<U>> conjunctions) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/DisjunctionImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/DisjunctionImpl.java
@@ -36,10 +36,6 @@ class DisjunctionImpl<T extends PatternAdmin> implements Disjunction<T> {
         this.patterns = patterns;
     }
 
-    private DisjunctionImpl(Disjunction<T> disjunction) {
-        this.patterns = disjunction.getPatterns().stream().map(Patterns::copyOf).collect(toSet());
-    }
-
     @Override
     public Set<T> getPatterns() {
         return patterns;
@@ -63,11 +59,6 @@ class DisjunctionImpl<T extends PatternAdmin> implements Disjunction<T> {
     @Override
     public Disjunction<?> asDisjunction() {
         return this;
-    }
-
-    @Override
-    public PatternAdmin cloneMe() {
-        return new DisjunctionImpl<>(this);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
@@ -18,11 +18,12 @@
 
 package ai.grakn.graql.internal.pattern;
 
+import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarAdmin;
-import ai.grakn.graql.VarName;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.Set;
@@ -47,11 +48,11 @@ public class Patterns {
     }
 
     public static VarAdmin var() {
-        return new VarImpl();
+        return VarImpl.anon(ImmutableSet.of());
     }
 
     public static VarAdmin var(VarName name) {
-        return new VarImpl(name);
+        return VarImpl.named(name, ImmutableSet.of());
     }
 
     // These clone methods will always return the right type
@@ -61,7 +62,7 @@ public class Patterns {
     }
 
     public static VarAdmin mergeVars(Collection<VarAdmin> vars) {
-        return new VarImpl(vars);
+        return VarImpl.merge(vars);
     }
 
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
@@ -23,7 +23,6 @@ import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarAdmin;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.Set;
@@ -48,11 +47,11 @@ public class Patterns {
     }
 
     public static VarAdmin var() {
-        return VarImpl.anon(ImmutableSet.of());
+        return VarImpl.anon();
     }
 
     public static VarAdmin var(VarName name) {
-        return VarImpl.named(name, ImmutableSet.of());
+        return VarImpl.named(name);
     }
 
     public static VarAdmin mergeVars(Collection<VarAdmin> vars) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/Patterns.java
@@ -55,12 +55,6 @@ public class Patterns {
         return VarImpl.named(name, ImmutableSet.of());
     }
 
-    // These clone methods will always return the right type
-    @SuppressWarnings("unchecked")
-    public static <T extends PatternAdmin> T copyOf(T pattern) {
-        return (T) pattern.cloneMe();
-    }
-
     public static VarAdmin mergeVars(Collection<VarAdmin> vars) {
         return VarImpl.merge(vars);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/RelationPlayerImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/RelationPlayerImpl.java
@@ -27,26 +27,34 @@ import java.util.Optional;
  * A pair of role type and role player (where the role type may not be present)
  */
 class RelationPlayerImpl implements RelationPlayer {
-    private int hashCode = 0;
+    private final int hashCode;
     private final Optional<VarAdmin> roleType;
     private final VarAdmin rolePlayer;
-
-    /**
-     * A casting without a role type specified
-     * @param rolePlayer the role player of the casting
-     */
-    RelationPlayerImpl(VarAdmin rolePlayer) {
-        this.roleType = Optional.empty();
-        this.rolePlayer = rolePlayer;
-    }
 
     /**
      * @param roletype the role type of the casting
      * @param rolePlayer the role player of the casting
      */
-    RelationPlayerImpl(VarAdmin roletype, VarAdmin rolePlayer) {
-        this.roleType = Optional.of(roletype);
+    private RelationPlayerImpl(Optional<VarAdmin> roletype, VarAdmin rolePlayer) {
+        this.roleType = roletype;
         this.rolePlayer = rolePlayer;
+        hashCode = 31 * roleType.hashCode() + rolePlayer.hashCode();
+    }
+
+    /**
+     * A casting without a role type specified
+     * @param rolePlayer the role player of the casting
+     */
+    static RelationPlayerImpl of(VarAdmin rolePlayer) {
+        return new RelationPlayerImpl(Optional.empty(), rolePlayer);
+    }
+
+    /**
+     * @param roleType the role type of the casting
+     * @param rolePlayer the role player of the casting
+     */
+    static RelationPlayerImpl of(VarAdmin roleType, VarAdmin rolePlayer) {
+        return new RelationPlayerImpl(Optional.of(roleType), rolePlayer);
     }
 
     @Override
@@ -57,6 +65,11 @@ class RelationPlayerImpl implements RelationPlayer {
     @Override
     public VarAdmin getRolePlayer() {
         return rolePlayer;
+    }
+
+    @Override
+    public RelationPlayer setRolePlayer(VarAdmin rolePlayer) {
+        return new RelationPlayerImpl(roleType, rolePlayer);
     }
 
     @Override
@@ -77,10 +90,6 @@ class RelationPlayerImpl implements RelationPlayer {
 
     @Override
     public int hashCode() {
-        if (hashCode == 0) {
-            hashCode = roleType.hashCode();
-            hashCode = 31 * hashCode + rolePlayer.hashCode();
-        }
         return hashCode;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -121,9 +121,32 @@ class VarImpl implements VarAdmin {
         var.getProperties().forEach(this::addProperty);
     }
 
+    /**
+     * Create a variable by adding a property to an existing variable
+     * @param var a variable to clone
+     */
+    private VarImpl(VarAdmin var, VarProperty property) {
+        this.name = var.getVarName();
+        this.userDefinedName = var.isUserDefinedName();
+        var.getProperties().forEach(this::addProperty);
+        addProperty(property);
+    }
+
+    /**
+     * Create a variable by replacing a property on an existing variable
+     * @param var a variable to clone
+     */
+    private VarImpl(VarAdmin var, VarProperty oldProperty, VarProperty newProperty) {
+        this.name = var.getVarName();
+        this.userDefinedName = var.isUserDefinedName();
+        var.getProperties().forEach(this::addProperty);
+        properties.remove(oldProperty);
+        addProperty(property);
+    }
+
     @Override
     public Var id(ConceptId id) {
-        return addProperty(new IdProperty(id));
+        return addPropertyImmutable(new IdProperty(id));
     }
 
     @Override
@@ -133,7 +156,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var name(TypeName name) {
-        return addProperty(new NameProperty(name));
+        return addPropertyImmutable(new NameProperty(name));
     }
 
     @Override
@@ -143,12 +166,12 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var value(ValuePredicate predicate) {
-        return addProperty(new ValueProperty(predicate.admin()));
+        return addPropertyImmutable(new ValueProperty(predicate.admin()));
     }
 
     @Override
     public Var has(Var var) {
-        return addProperty(new HasResourceProperty(var.admin()));
+        return addPropertyImmutable(new HasResourceProperty(var.admin()));
     }
 
     @Override
@@ -168,7 +191,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var has(TypeName type, Var var) {
-        return addProperty(new HasResourceProperty(type, var.admin()));
+        return addPropertyImmutable(new HasResourceProperty(type, var.admin()));
     }
 
     @Override
@@ -188,7 +211,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var sub(Var type) {
-        return addProperty(new SubProperty(type.admin()));
+        return addPropertyImmutable(new SubProperty(type.admin()));
     }
 
     @Override
@@ -198,7 +221,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var hasRole(Var type) {
-        return addProperty(new HasRoleProperty(type.admin()));
+        return addPropertyImmutable(new HasRoleProperty(type.admin()));
     }
 
     @Override
@@ -208,12 +231,12 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var playsRole(Var type) {
-        return addProperty(new PlaysRoleProperty(type.admin(), false));
+        return addPropertyImmutable(new PlaysRoleProperty(type.admin(), false));
     }
 
     @Override
     public Var hasScope(Var type) {
-        return addProperty(new HasScopeProperty(type.admin()));
+        return addPropertyImmutable(new HasScopeProperty(type.admin()));
     }
 
     @Override
@@ -223,7 +246,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var hasResource(Var type) {
-        return addProperty(new HasResourceTypeProperty(type.admin(), false));
+        return addPropertyImmutable(new HasResourceTypeProperty(type.admin(), false));
     }
 
     @Override
@@ -233,7 +256,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var hasKey(Var type) {
-        return addProperty(new HasResourceTypeProperty(type.admin(), true));
+        return addPropertyImmutable(new HasResourceTypeProperty(type.admin(), true));
     }
 
     @Override
@@ -273,32 +296,32 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var plays(Var roleType) {
-        return addProperty(new PlaysProperty(roleType.admin()));
+        return addPropertyImmutable(new PlaysProperty(roleType.admin()));
     }
 
     @Override
     public Var isAbstract() {
-        return addProperty(new IsAbstractProperty());
+        return addPropertyImmutable(new IsAbstractProperty());
     }
 
     @Override
     public Var datatype(ResourceType.DataType<?> datatype) {
-        return addProperty(new DataTypeProperty(requireNonNull(datatype)));
+        return addPropertyImmutable(new DataTypeProperty(requireNonNull(datatype)));
     }
 
     @Override
     public Var regex(String regex) {
-        return addProperty(new RegexProperty(regex));
+        return addPropertyImmutable(new RegexProperty(regex));
     }
 
     @Override
     public Var lhs(Pattern lhs) {
-        return addProperty(new LhsProperty(lhs));
+        return addPropertyImmutable(new LhsProperty(lhs));
     }
 
     @Override
     public Var rhs(Pattern rhs) {
-        return addProperty(new RhsProperty(rhs));
+        return addPropertyImmutable(new RhsProperty(rhs));
     }
 
     @Override
@@ -308,7 +331,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var neq(Var var) {
-        return addProperty(new NeqProperty(var.admin()));
+        return addPropertyImmutable(new NeqProperty(var.admin()));
     }
 
     @Override
@@ -474,6 +497,13 @@ class VarImpl implements VarAdmin {
         }
         properties.add(property);
         return this;
+    }
+
+    private Var addPropertyImmutable(VarProperty property) {
+        if (property.isUnique()) {
+            testUniqueProperty((UniqueVarProperty) property);
+        }
+        return new VarImpl(this, property);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -89,16 +89,16 @@ class VarImpl implements VarAdmin {
     /**
      * Create a variable with a random variable name
      */
-    static VarImpl anon(ImmutableSet<VarProperty> properties) {
-        return new VarImpl(VarName.anon(), false, properties);
+    static VarImpl anon() {
+        return new VarImpl(VarName.anon(), false, ImmutableSet.of());
     }
 
     /**
      * Create a variable with a specified name
      * @param name the name of the variable
      */
-    static VarImpl named(VarName name, ImmutableSet<VarProperty> properties) {
-        return new VarImpl(name, true, properties);
+    static VarImpl named(VarName name) {
+        return new VarImpl(name, true, ImmutableSet.of());
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -201,7 +201,7 @@ class VarImpl implements VarAdmin {
 
     @Override
     public Var isa(Var type) {
-        return addProperty(new IsaProperty(type.admin()));
+        return addPropertyImmutable(new IsaProperty(type.admin()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -337,9 +337,10 @@ class VarImpl implements VarAdmin {
     }
 
     @Override
-    public void setVarName(VarName name) {
+    public VarAdmin setVarName(VarName name) {
         if (!userDefinedName) throw new RuntimeException(ErrorMessage.SET_GENERATED_VARIABLE_NAME.getMessage(name));
         this.name = name;
+        return this;
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -141,7 +141,7 @@ class VarImpl implements VarAdmin {
         this.userDefinedName = var.isUserDefinedName();
         var.getProperties().forEach(this::addProperty);
         properties.remove(oldProperty);
-        addProperty(property);
+        addProperty(newProperty);
     }
 
     @Override
@@ -477,11 +477,13 @@ class VarImpl implements VarAdmin {
         ImmutableMultiset<RelationPlayer> relationPlayers =
                 Stream.concat(oldCastings, Stream.of(relationPlayer)).collect(CommonUtil.toImmutableMultiset());
 
-        relationProperty.ifPresent(properties::remove);
+        RelationProperty newProperty = new RelationProperty(relationPlayers);
 
-        properties.add(new RelationProperty(relationPlayers));
-
-        return this;
+        return relationProperty.map(oldProperty ->
+                new VarImpl(this, oldProperty, newProperty)
+        ).orElseGet(() ->
+                new VarImpl(this, newProperty)
+        );
     }
 
     private static boolean invalidInnerVariable(VarAdmin var) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -29,6 +29,7 @@ import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
 import ai.grakn.graql.admin.PatternAdmin;
+import ai.grakn.graql.admin.RelationPlayer;
 import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.admin.VarProperty;
@@ -442,14 +443,14 @@ class VarImpl implements VarAdmin {
         return builder.toString();
     }
 
-    private Var addCasting(ai.grakn.graql.admin.RelationPlayer relationPlayer) {
+    private Var addCasting(RelationPlayer relationPlayer) {
         Optional<RelationProperty> relationProperty = getProperty(RelationProperty.class);
 
-        Stream<ai.grakn.graql.admin.RelationPlayer> oldCastings = relationProperty
+        Stream<RelationPlayer> oldCastings = relationProperty
                 .map(RelationProperty::getRelationPlayers)
                 .orElse(Stream.empty());
 
-        ImmutableMultiset<ai.grakn.graql.admin.RelationPlayer> relationPlayers =
+        ImmutableMultiset<RelationPlayer> relationPlayers =
                 Stream.concat(oldCastings, Stream.of(relationPlayer)).collect(CommonUtil.toImmutableMultiset());
 
         relationProperty.ifPresent(properties::remove);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/VarImpl.java
@@ -28,7 +28,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
-import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.RelationPlayer;
 import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarAdmin;
@@ -505,11 +504,6 @@ class VarImpl implements VarAdmin {
         // a disjunction containing only one option
         Conjunction<VarAdmin> conjunction = Patterns.conjunction(Collections.singleton(this));
         return Patterns.disjunction(Collections.singleton(conjunction));
-    }
-
-    @Override
-    public PatternAdmin cloneMe() {
-        return new VarImpl(name, userDefinedName, properties);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
@@ -41,6 +41,7 @@ import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import com.google.common.collect.Sets;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -71,14 +72,19 @@ public class HasResourceProperty extends AbstractVarProperty implements NamedPro
     private final Optional<TypeName> resourceType;
     private final VarAdmin resource;
 
-    public HasResourceProperty(VarAdmin resource) {
-        this.resourceType = Optional.empty();
-        this.resource = resource.isa(name(Schema.MetaSchema.RESOURCE.getName())).admin();
+    private HasResourceProperty(Optional<TypeName> resourceType, VarAdmin resource) {
+        this.resourceType = resourceType;
+        this.resource = resource;
     }
 
-    public HasResourceProperty(TypeName resourceType, VarAdmin resource) {
-        this.resourceType = Optional.of(resourceType);
-        this.resource = resource.isa(name(resourceType)).admin();
+    public static HasResourceProperty of(VarAdmin resource) {
+        resource = resource.isa(name(Schema.MetaSchema.RESOURCE.getName())).admin();
+        return new HasResourceProperty(Optional.empty(), resource);
+    }
+
+    public static HasResourceProperty of(TypeName resourceType, VarAdmin resource) {
+        resource = resource.isa(name(resourceType)).admin();
+        return new HasResourceProperty(Optional.of(resourceType), resource);
     }
 
     public Optional<TypeName> getType() {
@@ -87,6 +93,12 @@ public class HasResourceProperty extends AbstractVarProperty implements NamedPro
 
     public VarAdmin getResource() {
         return resource;
+    }
+
+    // TODO: If `VarAdmin#setVarName` is removed, this may no longer be necessary
+    @CheckReturnValue
+    public HasResourceProperty setResource(VarAdmin resource) {
+        return new HasResourceProperty(resourceType, resource);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
@@ -291,12 +291,13 @@ public class RelationProperty extends AbstractVarProperty implements UniqueVarPr
                 .count() > 0;
         Var relVar = (var.isUserDefinedName() || isReified)? Graql.var(var.getVarName()) : Graql.var();
         Set<RelationPlayer> relationPlayers = this.getRelationPlayers().collect(toSet());
-        relationPlayers.forEach(rp -> {
+
+        for (RelationPlayer rp : relationPlayers) {
             VarAdmin role = rp.getRoleType().orElse(null);
             VarAdmin rolePlayer = rp.getRolePlayer();
-            if (role != null) relVar.rel(role, rolePlayer);
-            else relVar.rel(rolePlayer);
-        });
+            if (role != null) relVar = relVar.rel(role, rolePlayer);
+            else relVar = relVar.rel(rolePlayer);
+        }
 
         //id part
         IsaProperty isaProp = var.getProperty(IsaProperty.class).orElse(null);
@@ -306,7 +307,7 @@ public class RelationProperty extends AbstractVarProperty implements UniqueVarPr
             VarAdmin isaVar = isaProp.getType();
             TypeName typeName = isaVar.getTypeName().orElse(null);
             VarName typeVariable = typeName == null ? isaVar.getVarName() : VarName.of("rel-" + UUID.randomUUID().toString());
-            relVar.isa(Graql.var(typeVariable));
+            relVar = relVar.isa(Graql.var(typeVariable));
             if (typeName != null) {
                 GraknGraph graph = parent.graph();
                 VarAdmin idVar = Graql.var(typeVariable).id(graph.getType(typeName).getId()).admin();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
@@ -346,15 +346,15 @@ public class Utility {
         if (parentArity != childArity || parentArity != roleMappings.size()) {
             throw new IllegalArgumentException(ErrorMessage.RULE_CREATION_ARITY_ERROR.getMessage());
         }
-        final Var[] parentVar = {var().isa(name(parent.getName()))};
-        final Var[] childVar = {var().isa(name(child.getName()))};
+        Var parentVar = var().isa(name(parent.getName()));
+        Var childVar = var().isa(name(child.getName()));
 
-        roleMappings.forEach( (parentRoleName, childRoleName) -> {
+        for (Map.Entry<TypeName, TypeName> entry : roleMappings.entrySet()) {
             VarName varName = VarName.anon();
-            parentVar[0] = parentVar[0].rel(name(parentRoleName), var(varName));
-            childVar[0] = childVar[0].rel(name(childRoleName), var(varName));
-        });
-        return graph.admin().getMetaRuleInference().addRule(childVar[0], parentVar[0]);
+            parentVar = parentVar.rel(name(entry.getKey()), var(varName));
+            childVar = childVar.rel(name(entry.getValue()), var(varName));
+        }
+        return graph.admin().getMetaRuleInference().addRule(childVar, parentVar);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
@@ -41,15 +41,15 @@ import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import javafx.util.Pair;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
@@ -346,15 +346,15 @@ public class Utility {
         if (parentArity != childArity || parentArity != roleMappings.size()) {
             throw new IllegalArgumentException(ErrorMessage.RULE_CREATION_ARITY_ERROR.getMessage());
         }
-        Var parentVar = var().isa(name(parent.getName()));
-        Var childVar = var().isa(name(child.getName()));
+        final Var[] parentVar = {var().isa(name(parent.getName()))};
+        final Var[] childVar = {var().isa(name(child.getName()))};
 
         roleMappings.forEach( (parentRoleName, childRoleName) -> {
             VarName varName = VarName.anon();
-            parentVar.rel(name(parentRoleName), var(varName));
-            childVar.rel(name(childRoleName), var(varName));
+            parentVar[0] = parentVar[0].rel(name(parentRoleName), var(varName));
+            childVar[0] = childVar[0].rel(name(childRoleName), var(varName));
         });
-        return graph.admin().getMetaRuleInference().addRule(childVar, parentVar);
+        return graph.admin().getMetaRuleInference().addRule(childVar[0], parentVar[0]);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomBase.java
@@ -100,7 +100,7 @@ public abstract class AtomBase implements Atomic {
 
     private void setVarName(VarName var){
         varName = var;
-        atomPattern.asVar().setVarName(var);
+        atomPattern = atomPattern.asVar().setVarName(var);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomBase.java
@@ -24,7 +24,6 @@ import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarAdmin;
-import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.Sets;
 
@@ -57,7 +56,7 @@ public abstract class AtomBase implements Atomic {
     }
 
     protected AtomBase(AtomBase a) {
-        this.atomPattern = Patterns.copyOf(a.atomPattern.asVar());
+        this.atomPattern = a.atomPattern;
         this.varName = atomPattern.asVar().getVarName();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Relation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Relation.java
@@ -142,13 +142,13 @@ public class Relation extends TypeAtom {
         Var var;
         if (!varName.getValue().isEmpty()) var = Graql.var(varName);
         else var = Graql.var();
-        rolePlayerMappings.forEach(mapping -> {
+        for (Pair<VarName, Var> mapping : rolePlayerMappings) {
             VarName rp = mapping.getKey();
             Var role = mapping.getValue();
-            if (role == null) var.rel(Graql.var(rp));
-            else var.rel(role, Graql.var(rp));
-        });
-        var.isa(Graql.var(typeVariable));
+            if (role == null) var = var.rel(Graql.var(rp));
+            else var = var.rel(role, Graql.var(rp));
+        }
+        var = var.isa(Graql.var(typeVariable));
         return var.admin().asVar();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Resource.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Resource.java
@@ -89,7 +89,7 @@ public class Resource extends MultiPredicateBinary{
     @Override
     protected void setValueVariable(VarName var) {
         super.setValueVariable(var);
-        atomPattern.asVar().getProperties(HasResourceProperty.class).forEach(prop -> prop.getResource().setVarName(var));
+        atomPattern = atomPattern.asVar().mapProperty(HasResourceProperty.class, prop -> prop.setResource(prop.getResource().setVarName(var)));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/TypeAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/TypeAtom.java
@@ -56,7 +56,7 @@ public class TypeAtom extends Binary{
     @Override
     protected void setValueVariable(VarName var) {
         super.setValueVariable(var);
-        atomPattern.asVar().getProperties(IsaProperty.class).forEach(prop -> prop.getType().setVarName(var));
+        atomPattern = atomPattern.asVar().mapProperty(IsaProperty.class, prop -> new IsaProperty(prop.getType().setVarName(var)));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
@@ -131,7 +131,7 @@ public class InferenceRule {
 
             //resolve captures
             Set<VarName> varIntersection = Sets.intersection(body.getVarNames(), parentAtom.getVarNames());
-            varIntersection.removeAll(rewriteUnifiers.keySet());
+            varIntersection = Sets.difference(varIntersection, rewriteUnifiers.keySet());
             varIntersection.forEach(var -> body.unify(var, VarName.anon()));
         }
     }

--- a/grakn-migration/export/src/main/java/ai/grakn/migration/export/TypeMapper.java
+++ b/grakn-migration/export/src/main/java/ai/grakn/migration/export/TypeMapper.java
@@ -78,7 +78,7 @@ public class TypeMapper {
 
         Type superType = type.superType();
         if (type.superType() != null) {
-            var.sub(name(superType.getName()));
+            var = var.sub(name(superType.getName()));
         }
 
         var = playsRoles(var, type);

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/PatternImplTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/PatternImplTest.java
@@ -31,8 +31,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
 
 @SuppressWarnings("unchecked")
 public class PatternImplTest {
@@ -105,63 +103,6 @@ public class PatternImplTest {
         );
 
         assertHasDNF(dnf, cnf);
-    }
-
-    @Test
-    public void testCloneVar() {
-        VarAdmin var1 = Graql.var("x").isa("person").admin();
-        VarAdmin var2 = Patterns.copyOf(var1);
-
-        assertEquals(var1, var2);
-        assertNotSame(var1, var2);
-    }
-
-    @Test
-    public void testCloneDisjunction() {
-        VarAdmin inner = Graql.var("abc").admin();
-
-        Disjunction dis1 = disjunction(x, x, y, conjunction(z, x, inner));
-        Disjunction dis2 = Patterns.copyOf(dis1);
-
-        assertEquals(dis1, dis2);
-        assertNotSame(dis1, dis2);
-
-        // Mutate original
-        inner.isa("person");
-
-        assertNotEquals(dis1, dis2);
-    }
-
-    @Test
-    public void testCloneConjunction() {
-        VarAdmin inner = Graql.var("abc").admin();
-
-        Conjunction con1 = conjunction(x, x, conjunction(y, y), disjunction(z, inner));
-        Conjunction con2 = Patterns.copyOf(con1);
-
-        assertEquals(con1, con2);
-        assertNotSame(con1, con2);
-
-        // Mutate original
-        inner.isa("person");
-
-        assertNotEquals(con1, con2);
-    }
-
-    @Test
-    public void testClonePattern() {
-        VarAdmin inner = Graql.var("abc").admin();
-
-        PatternAdmin con1 = conjunction(x, x, inner, conjunction(y, y), disjunction(z));
-        PatternAdmin con2 = Patterns.copyOf(con1);
-
-        assertEquals(con1, con2);
-        assertNotSame(con1, con2);
-
-        // Mutate original
-        inner.isa("person");
-
-        assertNotEquals(con1, con2);
     }
 
     private <T extends PatternAdmin> Conjunction<T> conjunction(T... patterns) {

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
@@ -56,9 +56,6 @@ import static ai.grakn.test.GraknTestEnv.usingTinker;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeTrue;
 
 public class AtomicQueryTest {
@@ -102,23 +99,6 @@ public class AtomicQueryTest {
         ReasonerAtomicQuery copy = new ReasonerAtomicQuery(atomicQuery);
         assertEquals(atomicQuery, copy);
         assertEquals(atomicQuery.hashCode(), copy.hashCode());
-    }
-
-    @Test
-    public void testCopyConstructor2(){
-        GraknGraph graph = snbGraph.graph();
-        String patternString = "{(recommended-item: $x, recommended-customer: $y) isa recommendation;}";
-        Conjunction<VarAdmin> pattern = conjunction(patternString, graph);
-        ReasonerAtomicQuery atomicQuery = new ReasonerAtomicQuery(pattern, graph);
-        MatchQuery q1 = atomicQuery.getMatchQuery();
-
-        ReasonerAtomicQuery copy = new ReasonerAtomicQuery(atomicQuery);
-        MatchQuery q2 = copy.getMatchQuery();
-
-        atomicQuery.unify(VarName.of("y"), VarName.of("z"));
-
-        assertThat(q1.toString(), not(is(q2.toString())));
-        assertEquals(new ReasonerAtomicQuery(conjunction(patternString, graph), snbGraph.graph()).getAtom().getRoleVarTypeMap(), copy.getAtom().getRoleVarTypeMap());
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
@@ -34,18 +34,18 @@ import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.binary.TypeAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
-import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.graql.internal.reasoner.query.QueryAnswers;
+import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.test.GraphContext;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -56,6 +56,9 @@ import static ai.grakn.test.GraknTestEnv.usingTinker;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeTrue;
 
 public class AtomicQueryTest {
@@ -99,6 +102,23 @@ public class AtomicQueryTest {
         ReasonerAtomicQuery copy = new ReasonerAtomicQuery(atomicQuery);
         assertEquals(atomicQuery, copy);
         assertEquals(atomicQuery.hashCode(), copy.hashCode());
+    }
+
+    @Test
+    public void testCopyConstructor2(){
+        GraknGraph graph = snbGraph.graph();
+        String patternString = "{(recommended-item: $x, recommended-customer: $y) isa recommendation;}";
+        Conjunction<VarAdmin> pattern = conjunction(patternString, graph);
+        ReasonerAtomicQuery atomicQuery = new ReasonerAtomicQuery(pattern, graph);
+        MatchQuery q1 = atomicQuery.getMatchQuery();
+
+        ReasonerAtomicQuery copy = new ReasonerAtomicQuery(atomicQuery);
+        MatchQuery q2 = copy.getMatchQuery();
+
+        atomicQuery.unify(VarName.of("y"), VarName.of("z"));
+
+        assertThat(q1.toString(), not(is(q2.toString())));
+        assertEquals(new ReasonerAtomicQuery(conjunction(patternString, graph), snbGraph.graph()).getAtom().getRoleVarTypeMap(), copy.getAtom().getRoleVarTypeMap());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <quickcheck.version>0.7</quickcheck.version>
         <httpclient.version>4.5.3</httpclient.version>
+        <findbugs.version>3.0.1</findbugs.version>
         <main.basedir>${project.parent.basedir}</main.basedir>
     </properties>
 
@@ -177,6 +178,12 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+            <version>${findbugs.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This is for a variety of reasons:
- Easier to reason about behaviour when sharing variables or queries
- `MatchQuery` and `Pattern` classes are already immutable
- We don't have to clone queries anymore
- Prevents bug when performing clones/sharing Graql objects