### PR TITLE
Performance improvements in `GreedyTraversalPlan`

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/ConjunctionQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/ConjunctionQuery.java
@@ -74,14 +74,14 @@ class ConjunctionQuery {
 
         // Get all variable names mentioned in non-starting fragments
         Set<VarName> names = fragmentSets.stream()
-                .flatMap(EquivalentFragmentSet::getFragments)
+                .flatMap(EquivalentFragmentSet::streamFragments)
                 .filter(fragment -> !fragment.isStartingFragment())
-                .flatMap(Fragment::getVariableNames)
+                .flatMap(fragment -> fragment.getVariableNames().stream())
                 .collect(toImmutableSet());
 
         // Get all dependencies fragments have on certain variables existing
         Set<VarName> dependencies = fragmentSets.stream()
-                .flatMap(EquivalentFragmentSet::getFragments)
+                .flatMap(EquivalentFragmentSet::streamFragments)
                 .flatMap(fragment -> fragment.getDependencies().stream())
                 .collect(toImmutableSet());
 
@@ -89,7 +89,7 @@ class ConjunctionQuery {
 
         // Filter out any non-essential starting fragments (because other fragments refer to their starting variable)
         this.equivalentFragmentSets = fragmentSets.stream()
-                .filter(set -> set.getFragments().anyMatch(
+                .filter(set -> set.streamFragments().anyMatch(
                         fragment -> !fragment.isStartingFragment() || !validNames.contains(fragment.getStart())
                 ))
                 .collect(toImmutableSet());
@@ -111,7 +111,7 @@ class ConjunctionQuery {
     private static Stream<List<Fragment>> cartesianProduct(List<EquivalentFragmentSet> fragmentSets) {
         // Get fragments in each set
         List<Set<Fragment>> fragments = fragmentSets.stream()
-                .map(set -> set.getFragments().collect(toSet()))
+                .map(EquivalentFragmentSet::fragments)
                 .collect(toList());
         return Sets.cartesianProduct(fragments).stream();
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/EquivalentFragmentSet.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/EquivalentFragmentSet.java
@@ -18,9 +18,10 @@
 
 package ai.grakn.graql.internal.gremlin;
 
-import com.google.common.collect.ImmutableSet;
 import ai.grakn.graql.internal.gremlin.fragment.Fragment;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 /**
@@ -52,9 +53,16 @@ public class EquivalentFragmentSet {
     }
 
     /**
+     * @return a set of fragments that this EquivalentFragmentSet contains
+     */
+    Set<Fragment> fragments() {
+        return fragments;
+    }
+
+    /**
      * @return a stream of fragments that this EquivalentFragmentSet contains
      */
-    Stream<Fragment> getFragments() {
+    Stream<Fragment> streamFragments() {
         return fragments.stream();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
@@ -28,6 +28,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -174,7 +175,7 @@ public class GraqlTraversal {
         return listCost;
     }
 
-    static double fragmentCost(Fragment fragment, double previousCost, Set<VarName> names) {
+    static double fragmentCost(Fragment fragment, double previousCost, Collection<VarName> names) {
         if (names.contains(fragment.getStart())) {
             return fragment.fragmentCost(previousCost);
         } else {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GraqlTraversal.java
@@ -153,21 +153,25 @@ public class GraqlTraversal {
         double totalCost = 0;
 
         for (List<Fragment> list : fragments) {
-            Set<VarName> names = new HashSet<>();
-
-            double cost = 1;
-            double listCost = 0;
-
-            for (Fragment fragment : list) {
-                cost = fragmentCost(fragment, cost, names);
-                fragment.getVariableNames().forEach(names::add);
-                listCost += cost;
-            }
-
-            totalCost += listCost;
+            totalCost += fragmentListCost(list);
         }
 
         return totalCost;
+    }
+
+    static double fragmentListCost(List<Fragment> fragments) {
+        Set<VarName> names = new HashSet<>();
+
+        double cost = 1;
+        double listCost = 0;
+
+        for (Fragment fragment : fragments) {
+            cost = fragmentCost(fragment, cost, names);
+            names.addAll(fragment.getVariableNames());
+            listCost += cost;
+        }
+
+        return listCost;
     }
 
     static double fragmentCost(Fragment fragment, double previousCost, Set<VarName> names) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -41,11 +41,11 @@ import static ai.grakn.graql.internal.util.CommonUtil.toImmutableSet;
  */
 public class GreedyTraversalPlan {
 
-    private static final long MAX_TRAVERSAL_ATTEMPTS = 15_000;
+    private static final long MAX_TRAVERSAL_ATTEMPTS = 2_000_000;
 
     // The degree to prune plans - 0.0 means never prune plans, 1.0 means always prune everything except the fastest
     // estimated plan (this is equivalent to a naive greedy algorithm that does not look ahead).
-    private static final double PRUNE_FACTOR = 0.1;
+    private static final double PRUNE_FACTOR = 0.6;
 
     /**
      * Create a traversal plan using the default maxTraersalAttempts.
@@ -113,13 +113,7 @@ public class GreedyTraversalPlan {
             List<Plan> allPlans = Lists.newArrayListWithCapacity((int) numTraversalAttempts);
             extendPlan(plan, allPlans, fragmentSets, depth);
 
-            System.out.println("All plans:");
-            allPlans.forEach(System.out::println);
-
             Plan newPlan = Collections.min(allPlans);
-
-            System.out.println("Chose:");
-            System.out.println(newPlan);
 
             // Only retain one new fragment
             // TODO: Find a more elegant way to do this?

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -111,7 +111,7 @@ public class GreedyTraversalPlan {
         Plan plan = Plan.base();
 
         while (!fragmentSets.isEmpty()) {
-            List<Plan> allPlans = Lists.newArrayListWithCapacity((int) numTraversalAttempts);
+            List<Plan> allPlans = Lists.newArrayList();
             extendPlan(plan, allPlans, fragmentSets, depth);
 
             Plan newPlan = Collections.min(allPlans);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -33,7 +33,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static ai.grakn.graql.internal.util.CommonUtil.toImmutableSet;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Class for generating greedy traversal plans
@@ -129,7 +128,7 @@ public class GreedyTraversalPlan {
             });
         }
 
-        return plan.fragments().collect(toList());
+        return plan.fragments();
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -42,11 +42,11 @@ import static java.util.stream.Collectors.toList;
  */
 public class GreedyTraversalPlan {
 
-    private static final long MAX_TRAVERSAL_ATTEMPTS = 2_000_000;
+    private static final long MAX_TRAVERSAL_ATTEMPTS = 15_000;
 
     // The degree to prune plans - 0.0 means never prune plans, 1.0 means always prune everything except the fastest
     // estimated plan (this is equivalent to a naive greedy algorithm that does not look ahead).
-    private static final double PRUNE_FACTOR = 0.6;
+    private static final double PRUNE_FACTOR = 0.1;
 
     /**
      * Create a traversal plan using the default maxTraersalAttempts.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static ai.grakn.graql.internal.util.CommonUtil.toImmutableSet;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Class for generating greedy traversal plans
@@ -117,7 +118,7 @@ public class GreedyTraversalPlan {
 
             // Only retain one new fragment
             // TODO: Find a more elegant way to do this?
-            while (newPlan.fragments().size() > plan.fragments().size() + 1) {
+            while (newPlan.size() > plan.size() + 1) {
                 newPlan.pop();
             }
 
@@ -128,7 +129,7 @@ public class GreedyTraversalPlan {
             });
         }
 
-        return plan.fragments();
+        return plan.fragments().collect(toList());
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.internal.gremlin;
 
 import ai.grakn.graql.VarName;
 import ai.grakn.graql.internal.gremlin.fragment.Fragment;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import java.util.List;
@@ -111,6 +112,6 @@ class Plan implements Comparable<Plan> {
 
     @Override
     public String toString() {
-        return "Plan(" + fragments + ")";
+        return "Plan(" + GraqlTraversal.create(ImmutableSet.of(fragments)) + ")";
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -93,7 +93,7 @@ class Plan implements Comparable<Plan> {
     }
 
     public double cost() {
-        return elements.peek().cost;
+        return elements.peek().totalCost;
     }
 
     public Stream<Fragment> fragments() {
@@ -136,7 +136,7 @@ class Plan implements Comparable<Plan> {
             this.fragment = fragment;
             this.names = names;
             this.cost = cost;
-            this.totalCost = cost;
+            this.totalCost = totalCost;
         }
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -122,11 +122,29 @@ class Plan implements Comparable<Plan> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Plan plan = (Plan) o;
+
+        if (!elements.equals(plan.elements)) return false;
+        return fragmentSets.equals(plan.fragmentSets);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = elements.hashCode();
+        result = 31 * result + fragmentSets.hashCode();
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "Plan(" + GraqlTraversal.create(ImmutableSet.of(fragments().collect(toList()))) + ")";
     }
 
-    private class PlanElement {
+    private static class PlanElement {
         private final Fragment fragment;
         private final Set<VarName> names;
         private final double cost;
@@ -137,6 +155,32 @@ class Plan implements Comparable<Plan> {
             this.names = names;
             this.cost = cost;
             this.totalCost = totalCost;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            PlanElement that = (PlanElement) o;
+
+            if (Double.compare(that.cost, cost) != 0) return false;
+            if (Double.compare(that.totalCost, totalCost) != 0) return false;
+            if (!fragment.equals(that.fragment)) return false;
+            return names.equals(that.names);
+        }
+
+        @Override
+        public int hashCode() {
+            int result;
+            long temp;
+            result = fragment.hashCode();
+            result = 31 * result + names.hashCode();
+            temp = Double.doubleToLongBits(cost);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            temp = Double.doubleToLongBits(totalCost);
+            result = 31 * result + (int) (temp ^ (temp >>> 32));
+            return result;
         }
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -75,7 +75,7 @@ class Plan implements Comparable<Plan> {
 
         double newCost = fragmentCost(newFragment, cost, names);
         double newTotalCost = totalCost + newCost;
-        Set<VarName> newNames = Sets.union(names, newFragment.getVariableNames());
+        Set<VarName> newNames = Sets.union(newFragment.getVariableNames(), names);
 
         elements.push(new PlanElement(newFragment, newNames, newCost, newTotalCost));
         return true;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/Plan.java
@@ -62,12 +62,17 @@ class Plan implements Comparable<Plan> {
         }
 
         fragments.push(newFragment);
+
+        // TODO: Calculate cost incrementally
+        cost = -1;
+
         return true;
     }
 
     Fragment pop() {
         Fragment fragment = fragments.pop();
         fragmentSets.remove(fragment.getEquivalentFragmentSet());
+        cost = -1;
         return fragment;
     }
 
@@ -102,5 +107,10 @@ class Plan implements Comparable<Plan> {
         }
 
         return false;
+    }
+
+    @Override
+    public String toString() {
+        return "Plan(" + fragments + ")";
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/AbstractFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/AbstractFragment.java
@@ -24,9 +24,6 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
-
-import static ai.grakn.graql.internal.util.CommonUtil.optionalToStream;
 
 abstract class AbstractFragment implements Fragment{
 
@@ -45,16 +42,19 @@ abstract class AbstractFragment implements Fragment{
 
     private final VarName start;
     private final Optional<VarName> end;
+    private final ImmutableSet<VarName> varNames;
     private EquivalentFragmentSet equivalentFragmentSet = null;
 
     AbstractFragment(VarName start) {
         this.start = start;
         this.end = Optional.empty();
+        this.varNames = ImmutableSet.of(start);
     }
 
     AbstractFragment(VarName start, VarName end) {
         this.start = start;
         this.end = Optional.of(end);
+        this.varNames = ImmutableSet.of(start, end);
     }
 
     @Override
@@ -87,8 +87,8 @@ abstract class AbstractFragment implements Fragment{
     }
 
     @Override
-    public Stream<VarName> getVariableNames() {
-        return Stream.concat(Stream.of(start), optionalToStream(end));
+    public Set<VarName> getVariableNames() {
+        return varNames;
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragment.java
@@ -25,7 +25,6 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * represents a graph traversal, with one start point and optionally an end point
@@ -89,7 +88,7 @@ public interface Fragment {
     /**
      * Get all variable names in the fragment - the start and end (if present)
      */
-    Stream<VarName> getVariableNames();
+    Set<VarName> getVariableNames();
 
     /**
      * A starting fragment is a fragment that can start a traversal.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
@@ -63,65 +63,65 @@ public class Fragments {
         return new OutHasRoleFragment(start, end);
     }
 
-    public static InIsaFragment inIsa(VarName start, VarName end) {
+    public static Fragment inIsa(VarName start, VarName end) {
         return new InIsaFragment(start, end, false);
     }
 
-    public static OutIsaFragment outIsa(VarName start, VarName end) {
+    public static Fragment outIsa(VarName start, VarName end) {
         return new OutIsaFragment(start, end, false);
     }
 
     // This method is a special case that allows getting the instances of role-types (castings)
-    public static InIsaFragment inIsaCastings(VarName start, VarName end) {
+    public static Fragment inIsaCastings(VarName start, VarName end) {
         return new InIsaFragment(start, end, true);
     }
 
     // This method is a special case that allows getting the instances of role-types (castings)
-    public static OutIsaFragment outIsaCastings(VarName start, VarName end) {
+    public static Fragment outIsaCastings(VarName start, VarName end) {
         return new OutIsaFragment(start, end, true);
     }
 
-    public static InHasScopeFragment inHasScope(VarName start, VarName end) {
+    public static Fragment inHasScope(VarName start, VarName end) {
         return new InHasScopeFragment(start, end);
     }
 
-    public static OutHasScopeFragment outHasScope(VarName start, VarName end) {
+    public static Fragment outHasScope(VarName start, VarName end) {
         return new OutHasScopeFragment(start, end);
     }
 
-    public static DataTypeFragment dataType(VarName start, ResourceType.DataType dataType) {
+    public static Fragment dataType(VarName start, ResourceType.DataType dataType) {
         return new DataTypeFragment(start, dataType);
     }
 
-    public static InPlaysRoleFragment inPlaysRole(VarName start, VarName end, boolean required) {
+    public static Fragment inPlaysRole(VarName start, VarName end, boolean required) {
         return new InPlaysRoleFragment(start, end, required);
     }
 
-    public static OutPlaysRoleFragment outPlaysRole(VarName start, VarName end, boolean required) {
+    public static Fragment outPlaysRole(VarName start, VarName end, boolean required) {
         return new OutPlaysRoleFragment(start, end, required);
     }
 
-    public static InCastingFragment inCasting(VarName start, VarName end) {
+    public static Fragment inCasting(VarName start, VarName end) {
         return new InCastingFragment(start, end);
     }
 
-    public static OutCastingFragment outCasting(VarName start, VarName end) {
+    public static Fragment outCasting(VarName start, VarName end) {
         return new OutCastingFragment(start, end);
     }
 
-    public static InRolePlayerFragment inRolePlayer(VarName start, VarName end) {
+    public static Fragment inRolePlayer(VarName start, VarName end) {
         return new InRolePlayerFragment(start, end);
     }
 
-    public static OutRolePlayerFragment outRolePlayer(VarName start, VarName end) {
+    public static Fragment outRolePlayer(VarName start, VarName end) {
         return new OutRolePlayerFragment(start, end);
     }
 
-    public static DistinctCastingFragment distinctCasting(VarName start, VarName otherCastingName) {
+    public static Fragment distinctCasting(VarName start, VarName otherCastingName) {
         return new DistinctCastingFragment(start, otherCastingName);
     }
 
-    public static IdFragment id(VarName start, ConceptId id) {
+    public static Fragment id(VarName start, ConceptId id) {
         return new IdFragment(start, id);
     }
 
@@ -129,23 +129,23 @@ public class Fragments {
         return new NameFragment(start, name);
     }
 
-    public static ValueFragment value(VarName start, ValuePredicateAdmin predicate) {
+    public static Fragment value(VarName start, ValuePredicateAdmin predicate) {
         return new ValueFragment(start, predicate);
     }
 
-    public static IsAbstractFragment isAbstract(VarName start) {
+    public static Fragment isAbstract(VarName start) {
         return new IsAbstractFragment(start);
     }
 
-    public static RegexFragment regex(VarName start, String regex) {
+    public static Fragment regex(VarName start, String regex) {
         return new RegexFragment(start, regex);
     }
 
-    public static ValueFlagFragment value(VarName start) {
+    public static Fragment value(VarName start) {
         return new ValueFlagFragment(start);
     }
 
-    public static NotCastingFragment notCasting(VarName start) {
+    public static Fragment notCasting(VarName start) {
         return new NotCastingFragment(start);
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
@@ -29,7 +29,6 @@ import java.util.Optional;
 
 import static ai.grakn.graql.internal.gremlin.fragment.Fragments.outIsa;
 import static ai.grakn.graql.internal.gremlin.fragment.Fragments.shortcut;
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 public class PlanTest {
@@ -52,7 +51,7 @@ public class PlanTest {
         plan.tryPush(outIsa);
         plan.tryPush(shortcut);
 
-        List<Fragment> fragments = plan.fragments().collect(toList());
+        List<Fragment> fragments = plan.fragments();
 
         double traversalComplexity = GraqlTraversal.create(ImmutableSet.of(fragments)).getComplexity();
         double planCost = plan.cost();

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
@@ -19,10 +19,8 @@
 
 package ai.grakn.graql.internal.gremlin;
 
-import ai.grakn.concept.TypeName;
 import ai.grakn.graql.VarName;
 import ai.grakn.graql.internal.gremlin.fragment.Fragment;
-import ai.grakn.graql.internal.gremlin.fragment.Fragments;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
@@ -43,15 +41,9 @@ public class PlanTest {
         VarName y = VarName.of("y");
         VarName z = VarName.of("z");
 
-        Plan plan = Plan.base()
-                .append(outIsa(y, a))
-                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
-
-        Plan plan2 = Plan.base()
-                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), x, y))
-                .append(outIsa(y, a))
-                .append(Fragments.name(a, TypeName.of("person")))
-                .append(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
+        Plan plan = Plan.base();
+        plan.tryPush(outIsa(y, a));
+        plan.tryPush(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
 
         List<Fragment> fragments = plan.fragments();
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
@@ -41,9 +41,15 @@ public class PlanTest {
         VarName y = VarName.of("y");
         VarName z = VarName.of("z");
 
+        Fragment outIsa = outIsa(y, a);
+        outIsa.setEquivalentFragmentSet(EquivalentFragmentSet.create());
+
+        Fragment shortcut = shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z);
+        shortcut.setEquivalentFragmentSet(EquivalentFragmentSet.create());
+
         Plan plan = Plan.base();
-        plan.tryPush(outIsa(y, a));
-        plan.tryPush(shortcut(Optional.empty(), Optional.empty(), Optional.empty(), y, z));
+        plan.tryPush(outIsa);
+        plan.tryPush(shortcut);
 
         List<Fragment> fragments = plan.fragments();
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/PlanTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 
 import static ai.grakn.graql.internal.gremlin.fragment.Fragments.outIsa;
 import static ai.grakn.graql.internal.gremlin.fragment.Fragments.shortcut;
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
 
 public class PlanTest {
@@ -51,7 +52,7 @@ public class PlanTest {
         plan.tryPush(outIsa);
         plan.tryPush(shortcut);
 
-        List<Fragment> fragments = plan.fragments();
+        List<Fragment> fragments = plan.fragments().collect(toList());
 
         double traversalComplexity = GraqlTraversal.create(ImmutableSet.of(fragments)).getComplexity();
         double planCost = plan.cost();


### PR DESCRIPTION
- Reduced the number of object allocations in `GreedyTraversalPlan` by making `Plan` a mutable stack-like class that allows you to `push` and `pop` `Fragment`s.
- Added branch pruning. If a branch in the decision tree is estimated to be more than ten times slower than the fastest branch, it is skipped.