### PR TITLE
Prohibit duplicate rules with same patterns

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/RuleType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/RuleType.java
@@ -39,14 +39,14 @@ import java.util.Collection;
 public interface RuleType extends Type {
     //------------------------------------- Modifiers ----------------------------------
     /**
-     * Add a new Rule, given Patterns for the Left Hand Side and Right Hand Side.
+     * Adds a new Rule if it does not exist otherwise returns the existing rule.
      * @see Pattern
      *
      * @param lhs A string representing the left hand side Graql query.
      * @param rhs A string representing the right hand side Graql query.
      * @return a new Rule
      */
-    Rule addRule(Pattern lhs, Pattern rhs);
+    Rule putRule(Pattern lhs, Pattern rhs);
 
     //---- Inherited Methods
     /**

--- a/grakn-core/src/main/java/ai/grakn/exception/ConceptNotUniqueException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/ConceptNotUniqueException.java
@@ -41,4 +41,8 @@ public class ConceptNotUniqueException extends ConceptException {
     public ConceptNotUniqueException(Resource resource, Instance instance){
         super(ErrorMessage.RESOURCE_TYPE_UNIQUE.getMessage(resource.getId(), instance.getId()));
     }
+
+    public ConceptNotUniqueException(String message){
+        super(message);
+    }
 }

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -57,7 +57,7 @@ public enum ErrorMessage {
     GRAPH_PERMANENTLY_CLOSED("The Graph for keyspace [%s] is closed. Use the factory to get a new graph."),
     TRANSACTIONS_OPEN("Cannot close graph [%s] connecting to keyspace [%s] because there are [%s] open transactions"),
     LOCKING_EXCEPTION("Internal locking exception. Please clear the transaction and try again."),
-    DUPLICATE_RULES("Rule [%s] already has patterns with lhs [%s] and rhs [%s]. Creating another rule with the same pattern is prohibited"),
+    DUPLICATE_RULES("Rule [%s] already has patterns with lhs [%s] and rhs [%s]. Creating another rule with the same patterns is prohibited"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -57,7 +57,6 @@ public enum ErrorMessage {
     GRAPH_PERMANENTLY_CLOSED("The Graph for keyspace [%s] is closed. Use the factory to get a new graph."),
     TRANSACTIONS_OPEN("Cannot close graph [%s] connecting to keyspace [%s] because there are [%s] open transactions"),
     LOCKING_EXCEPTION("Internal locking exception. Please clear the transaction and try again."),
-    DUPLICATE_RULES("Rule [%s] already has patterns with lhs [%s] and rhs [%s]. Creating another rule with the same patterns is prohibited"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -57,6 +57,7 @@ public enum ErrorMessage {
     GRAPH_PERMANENTLY_CLOSED("The Graph for keyspace [%s] is closed. Use the factory to get a new graph."),
     TRANSACTIONS_OPEN("Cannot close graph [%s] connecting to keyspace [%s] because there are [%s] open transactions"),
     LOCKING_EXCEPTION("Internal locking exception. Please clear the transaction and try again."),
+    DUPLICATE_RULES("Rule [%s] already has patterns with lhs [%s] and rhs [%s]. Creating another rule with the same pattern is prohibited"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graph.internal;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.exception.InvalidConceptValueException;
@@ -111,11 +110,7 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
     @Override
     public <V> Resource<V> getResource(V value) {
         String index = ResourceImpl.generateResourceIndex(this, value.toString());
-        Concept concept = getGraknGraph().getConcept(Schema.ConceptProperty.INDEX, index);
-        if(concept != null){
-            return concept.asResource();
-        }
-        return null;
+        return getGraknGraph().getConcept(Schema.ConceptProperty.INDEX, index);
     }
 
     /**

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
@@ -51,6 +51,7 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
         super(graknGraph, v, type);
         setImmutableProperty(Schema.ConceptProperty.RULE_LHS, lhs, getLHS(), Pattern::toString);
         setImmutableProperty(Schema.ConceptProperty.RULE_RHS, rhs, getRHS(), Pattern::toString);
+        setUniqueProperty(Schema.ConceptProperty.INDEX, generateRuleIndex(type, lhs, rhs));
     }
 
     /**
@@ -119,5 +120,12 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
         Collection<Type> types = new HashSet<>();
         getOutgoingNeighbours(Schema.EdgeLabel.CONCLUSION).forEach(concept -> types.add(concept.asType()));
         return types;
+    }
+
+    /**
+     * Generate the internal hash in order to perform a faster lookups and ensure rules are unique
+     */
+    public static String generateRuleIndex(RuleType type, Pattern lhs, Pattern rhs){
+        return type.getName().getValue() + "_LHS:" + lhs.hashCode() + "_RHS:" + rhs.hashCode();
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
@@ -126,6 +126,6 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      * Generate the internal hash in order to perform a faster lookups and ensure rules are unique
      */
     public static String generateRuleIndex(RuleType type, Pattern lhs, Pattern rhs){
-        return type.getName().getValue() + "_LHS:" + lhs.hashCode() + "_RHS:" + rhs.hashCode();
+        return "RuleType_" + type.getName().getValue() + "_LHS:" + lhs.hashCode() + "_RHS:" + rhs.hashCode();
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
@@ -20,7 +20,6 @@ package ai.grakn.graph.internal;
 
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
-import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graph.admin.GraknAdmin;
 import ai.grakn.graql.Pattern;
@@ -59,7 +58,7 @@ class RuleTypeImpl extends TypeImpl<RuleType, Rule> implements RuleType {
     }
 
     @Override
-    public Rule addRule(Pattern lhs, Pattern rhs) {
+    public Rule putRule(Pattern lhs, Pattern rhs) {
         if(lhs == null) {
             throw new InvalidConceptValueException(ErrorMessage.NULL_VALUE.getMessage(Schema.ConceptProperty.RULE_LHS.name()));
         }
@@ -68,13 +67,13 @@ class RuleTypeImpl extends TypeImpl<RuleType, Rule> implements RuleType {
             throw new InvalidConceptValueException(ErrorMessage.NULL_VALUE.getMessage(Schema.ConceptProperty.RULE_RHS.name()));
         }
 
-        Rule foundRule = getRule(lhs, rhs);
-        if(foundRule != null){
-            throw new ConceptNotUniqueException(ErrorMessage.DUPLICATE_RULES.getMessage(foundRule, lhs, rhs));
+        Rule newRule = getRule(lhs, rhs);
+        if(newRule == null){
+            newRule = addInstance(Schema.BaseType.RULE, (vertex, type) ->
+                    getGraknGraph().getElementFactory().buildRule(vertex, type, lhs, rhs));
         }
 
-        return addInstance(Schema.BaseType.RULE, (vertex, type) ->
-                getGraknGraph().getElementFactory().buildRule(vertex, type, lhs, rhs));
+        return newRule;
     }
 
     private Rule getRule(Pattern lhs, Pattern rhs) {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleTypeImpl.java
@@ -20,6 +20,7 @@ package ai.grakn.graph.internal;
 
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
+import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graph.admin.GraknAdmin;
 import ai.grakn.graql.Pattern;
@@ -67,7 +68,17 @@ class RuleTypeImpl extends TypeImpl<RuleType, Rule> implements RuleType {
             throw new InvalidConceptValueException(ErrorMessage.NULL_VALUE.getMessage(Schema.ConceptProperty.RULE_RHS.name()));
         }
 
+        Rule foundRule = getRule(lhs, rhs);
+        if(foundRule != null){
+            throw new ConceptNotUniqueException(ErrorMessage.DUPLICATE_RULES.getMessage(foundRule, lhs, rhs));
+        }
+
         return addInstance(Schema.BaseType.RULE, (vertex, type) ->
                 getGraknGraph().getElementFactory().buildRule(vertex, type, lhs, rhs));
+    }
+
+    private Rule getRule(Pattern lhs, Pattern rhs) {
+        String index = RuleImpl.generateRuleIndex(this, lhs, rhs);
+        return getGraknGraph().getConcept(Schema.ConceptProperty.INDEX, index);
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
@@ -147,7 +147,7 @@ public class GraknGraphs extends AbstractGenerator<GraknGraph> {
             () -> resourceType().putResource(gen().make(ResourceValues.class).generate(random, status)),
             // () -> resourceType().setRegex(gen(String.class)), // TODO: Enable this when doesn't throw a NPE
             () -> ruleType().superType(ruleType()),
-            () -> ruleType().addRule(var("x"), var("x")), // TODO: generate more complicated rules
+            () -> ruleType().putRule(var("x"), var("x")), // TODO: generate more complicated rules
             () -> instance().hasResource(resource()),
             () -> relation().scope(instance()),
             () -> relation().putRolePlayer(roleType(), instance())

--- a/grakn-graph/src/test/java/ai/grakn/generator/Rules.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/Rules.java
@@ -33,6 +33,6 @@ public class Rules extends AbstractInstanceGenerator<Rule, RuleType> {
     @Override
     protected Rule newInstance(RuleType type) {
         // TODO: generate more complicated rules
-        return type.addRule(var("x"), var("x"));
+        return type.putRule(var("x"), var("x"));
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
@@ -22,7 +22,6 @@ import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
-import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graql.Pattern;
@@ -52,7 +51,7 @@ public class RuleTest extends GraphTestBase{
     @Test
     public void testType() {
         RuleType conceptType = graknGraph.putRuleType("A Thing");
-        Rule rule = conceptType.addRule(lhs, rhs);
+        Rule rule = conceptType.putRule(lhs, rhs);
         assertNotNull(rule.type());
         assertEquals(conceptType, rule.type());
     }
@@ -60,14 +59,14 @@ public class RuleTest extends GraphTestBase{
     @Test
     public void testRuleValues() throws Exception {
         RuleType conceptType = graknGraph.putRuleType("A Thing");
-        Rule rule = conceptType.addRule(lhs, rhs);
+        Rule rule = conceptType.putRule(lhs, rhs);
         assertEquals(lhs, rule.getLHS());
         assertEquals(rhs, rule.getRHS());
 
         expectedException.expect(InvalidConceptValueException.class);
         expectedException.expectMessage(NULL_VALUE.getMessage(RULE_LHS));
 
-        conceptType.addRule(null, null);
+        conceptType.putRule(null, null);
     }
 
     @Test
@@ -76,7 +75,7 @@ public class RuleTest extends GraphTestBase{
 
         lhs = graknGraph.graql().parsePattern("$x isa Your-Type");
         rhs = graknGraph.graql().parsePattern("$x isa My-Type");
-        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        Rule rule = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
 
         expectedException.expect(GraknValidationException.class);
         expectedException.expectMessage(
@@ -91,7 +90,7 @@ public class RuleTest extends GraphTestBase{
 
         lhs = graknGraph.graql().parsePattern("$x isa My-Type");
         rhs = graknGraph.graql().parsePattern("$x has-role Your-Type");
-        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        Rule rule = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
 
         expectedException.expect(GraknValidationException.class);
         expectedException.expectMessage(
@@ -108,7 +107,7 @@ public class RuleTest extends GraphTestBase{
         lhs = graknGraph.graql().parsePattern("$x isa type1");
         rhs = graknGraph.graql().parsePattern("$x isa type2");
 
-        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        Rule rule = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
         assertTrue("Hypothesis is not empty before commit", rule.getHypothesisTypes().isEmpty());
         assertTrue("Conclusion is not empty before commit", rule.getConclusionTypes().isEmpty());
 
@@ -119,31 +118,27 @@ public class RuleTest extends GraphTestBase{
     }
 
     @Test
-    public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_Throw(){
+    public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_ReturnTheSameRule(){
         graknGraph.putEntityType("type1");
         lhs = graknGraph.graql().parsePattern("$x isa type1");
         rhs = graknGraph.graql().parsePattern("$x isa type1");
 
-        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        Rule rule1 = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
+        Rule rule2 = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
 
-        expectedException.expect(ConceptNotUniqueException.class);
-        expectedException.expectMessage(ErrorMessage.DUPLICATE_RULES.getMessage(rule, lhs, rhs));
-
-        graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        assertEquals(rule1, rule2);
     }
 
     @Ignore //This is ignored because we currently have no way to determine if patterns with different variables name are equivalent
     @Test
-    public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_Throw(){
+    public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_ReturnTheSameRule(){
         graknGraph.putEntityType("type1");
         lhs = graknGraph.graql().parsePattern("$x isa type1");
         rhs = graknGraph.graql().parsePattern("$y isa type1");
 
-        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        Rule rule1 = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
+        Rule rule2 = graknGraph.admin().getMetaRuleInference().putRule(lhs, rhs);
 
-        expectedException.expect(ConceptNotUniqueException.class);
-        expectedException.expectMessage(ErrorMessage.DUPLICATE_RULES.getMessage(rule, lhs, rhs));
-
-        graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+        assertEquals(rule1, rule2);
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
@@ -21,7 +21,6 @@ package ai.grakn.graph.internal;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
-import ai.grakn.concept.Type;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graql.Pattern;

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
@@ -21,11 +21,14 @@ package ai.grakn.graph.internal;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
+import ai.grakn.concept.Type;
+import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.util.ErrorMessage;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static ai.grakn.util.ErrorMessage.NULL_VALUE;
@@ -113,5 +116,34 @@ public class RuleTest extends GraphTestBase{
 
         assertThat(rule.getHypothesisTypes(), containsInAnyOrder(t1));
         assertThat(rule.getConclusionTypes(), containsInAnyOrder(t2));
+    }
+
+    @Test
+    public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_Throw(){
+        graknGraph.putEntityType("type1");
+        lhs = graknGraph.graql().parsePattern("$x isa type1");
+        rhs = graknGraph.graql().parsePattern("$x isa type1");
+
+        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+
+        expectedException.expect(ConceptNotUniqueException.class);
+        expectedException.expectMessage(ErrorMessage.DUPLICATE_RULES.getMessage(rule, lhs, rhs));
+
+        graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+    }
+
+    @Ignore //This is ignored because we currently have no way to determine if patterns with different variables name are equivalent
+    @Test
+    public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_Throw(){
+        graknGraph.putEntityType("type1");
+        lhs = graknGraph.graql().parsePattern("$x isa type1");
+        rhs = graknGraph.graql().parsePattern("$y isa type1");
+
+        Rule rule = graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
+
+        expectedException.expect(ConceptNotUniqueException.class);
+        expectedException.expectMessage(ErrorMessage.DUPLICATE_RULES.getMessage(rule, lhs, rhs));
+
+        graknGraph.admin().getMetaRuleInference().addRule(lhs, rhs);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
@@ -262,7 +262,7 @@ public class InsertQueryExecutor {
                         .orElseThrow(() -> new IllegalStateException(INSERT_RULE_WITHOUT_LHS.getMessage(var)));
                 RhsProperty rhs = var.getProperty(RhsProperty.class)
                         .orElseThrow(() -> new IllegalStateException(INSERT_RULE_WITHOUT_RHS.getMessage(var)));
-                return type.asRuleType().addRule(lhs.getPattern(), rhs.getPattern());
+                return type.asRuleType().putRule(lhs.getPattern(), rhs.getPattern());
             });
         } else if (type.getName().equals(Schema.MetaSchema.CONCEPT.getName())) {
             throw new IllegalStateException(var + " cannot be an instance of meta-type " + type.getName());

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Utility.java
@@ -347,7 +347,7 @@ public class Utility {
         VarAdmin endVar = var().isa(name(relType.getName())).rel(name(fromRoleName), "z").rel(name(toRoleName), "y").admin();
         VarAdmin headVar = var().isa(name(relType.getName())).rel(name(fromRoleName), "x").rel(name(toRoleName), "y").admin();
         Pattern body = Patterns.conjunction(Sets.newHashSet(startVar, endVar));
-        return graph.admin().getMetaRuleInference().addRule(body, headVar);
+        return graph.admin().getMetaRuleInference().putRule(body, headVar);
     }
 
     /**
@@ -362,7 +362,7 @@ public class Utility {
 
         Var body = var().isa(name(relType.getName())).rel("x").rel("y");
         Var head = var().isa(name(relType.getName())).rel("x").rel("x");
-        return graph.admin().getMetaRuleInference().addRule(body, head);
+        return graph.admin().getMetaRuleInference().putRule(body, head);
     }
 
     /**
@@ -388,7 +388,7 @@ public class Utility {
             parentVar = parentVar.rel(name(entry.getKey()), var(varName));
             childVar = childVar.rel(name(entry.getValue()), var(varName));
         }
-        return graph.admin().getMetaRuleInference().addRule(childVar, parentVar);
+        return graph.admin().getMetaRuleInference().putRule(childVar, parentVar);
     }
 
     /**
@@ -415,7 +415,7 @@ public class Utility {
         });
 
         Var headVar = var().isa(name(relation.getName())).rel(name(fromRoleName), "x").rel(name(toRoleName), var(varNames.peek()));
-        return graph.admin().getMetaRuleInference().addRule(Patterns.conjunction(bodyVars), headVar);
+        return graph.admin().getMetaRuleInference().putRule(Patterns.conjunction(bodyVars), headVar);
     }
     
     /**

--- a/grakn-test/src/test/graql/matrix-test.gql
+++ b/grakn-test/src/test/graql/matrix-test.gql
@@ -82,9 +82,3 @@ lhs {
 (Q1-from: $x, Q1-to: $y) isa Q1;},
 rhs {
 (P-from: $x, P-to: $y) isa P;};
-
-isa inference-rule,
-lhs {
-(Q1-from: $x, Q1-to: $y) isa Q1;},
-rhs {
-(P-from: $x, P-to: $y) isa P;};

--- a/grakn-test/src/test/java/ai/grakn/graphs/AbstractGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/AbstractGraph.java
@@ -92,22 +92,22 @@ public class AbstractGraph extends TestGraph {
 
         Pattern R1_LHS = and(graph.graql().parsePatterns("$x isa p;$y isa q;($x, $y) isa rel;"));
         Pattern R1_RHS = and(graph.graql().parsePatterns("$x isa Q;"));
-        inferenceRule.addRule(R1_LHS, R1_RHS);
+        inferenceRule.putRule(R1_LHS, R1_RHS);
 
         Pattern R2_LHS = and(graph.graql().parsePatterns("$x isa r;"));
         Pattern R2_RHS = and(graph.graql().parsePatterns("$x isa p;"));
-        inferenceRule.addRule(R2_LHS, R2_RHS);
+        inferenceRule.putRule(R2_LHS, R2_RHS);
 
         Pattern R3_LHS = and(graph.graql().parsePatterns("$x isa s;"));
         Pattern R3_RHS = and(graph.graql().parsePatterns("$x isa p;"));
-        inferenceRule.addRule(R3_LHS, R3_RHS);
+        inferenceRule.putRule(R3_LHS, R3_RHS);
 
         Pattern R4_LHS = and(graph.graql().parsePatterns("$x isa t;"));
         Pattern R4_RHS = and(graph.graql().parsePatterns("$x isa q;"));
-        inferenceRule.addRule(R4_LHS, R4_RHS);
+        inferenceRule.putRule(R4_LHS, R4_RHS);
 
         Pattern R5_LHS = and(graph.graql().parsePatterns("$x isa u;"));
         Pattern R5_RHS = and(graph.graql().parsePatterns("$x isa r;"));
-        inferenceRule.addRule(R5_LHS, R5_RHS);
+        inferenceRule.putRule(R5_LHS, R5_RHS);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/graphs/CWGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/CWGraph.java
@@ -177,12 +177,12 @@ public class CWGraph extends TestGraph {
                 "(seller: $x, transaction-item: $y, buyer: $z) isa transaction;"));
 
         Pattern R1_RHS = Graql.and(graph.graql().parsePatterns("$x isa criminal;"));
-        inferenceRule.addRule(R1_LHS, R1_RHS);
+        inferenceRule.putRule(R1_LHS, R1_RHS);
 
         //R2: "Missiles are a kind of a weapon"
         Pattern R2_LHS = Graql.and(graph.graql().parsePatterns("$x isa missile;"));
         Pattern R2_RHS = Graql.and(graph.graql().parsePatterns("$x isa weapon;"));
-        inferenceRule.addRule(R2_LHS, R2_RHS);
+        inferenceRule.putRule(R2_LHS, R2_RHS);
 
         //R3: "If a country is an enemy of America then it is hostile"
         Pattern R3_LHS = Graql.and(
@@ -190,12 +190,12 @@ public class CWGraph extends TestGraph {
                 "($x, $y) isa is-enemy-of;" +
                 "$y isa country;$y has name 'America';"));
         Pattern R3_RHS = Graql.and(graph.graql().parsePatterns("$x has alignment 'hostile';"));
-        inferenceRule.addRule(R3_LHS, R3_RHS);
+        inferenceRule.putRule(R3_LHS, R3_RHS);
 
         //R4: "If a rocket is self-propelled and guided, it is a missile"
         Pattern R4_LHS = Graql.and(graph.graql().parsePatterns("$x isa rocket;$x has propulsion 'gsp';"));
         Pattern R4_RHS = Graql.and(graph.graql().parsePatterns("$x isa missile;"));
-        inferenceRule.addRule(R4_LHS, R4_RHS);
+        inferenceRule.putRule(R4_LHS, R4_RHS);
 
         Pattern R5_LHS = Graql.and(
                 graph.graql().parsePatterns("$x isa person;" +
@@ -205,6 +205,6 @@ public class CWGraph extends TestGraph {
                 "($y, $z) isa owns;"));
 
         Pattern R5_RHS = Graql.and(graph.graql().parsePatterns("(seller: $x, buyer: $y, transaction-item: $z) isa transaction;"));
-        inferenceRule.addRule(R5_LHS, R5_RHS);
+        inferenceRule.putRule(R5_LHS, R5_RHS);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/graphs/GeoGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/GeoGraph.java
@@ -194,6 +194,6 @@ public class GeoGraph extends TestGraph {
                 "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                 "(geo-entity: $y, entity-location: $z) isa is-located-in;"));
         Pattern transitivity_RHS = and(graph.graql().parsePatterns("(geo-entity: $x, entity-location: $z) isa is-located-in;"));
-        inferenceRule.addRule(transitivity_LHS, transitivity_RHS);
+        inferenceRule.putRule(transitivity_LHS, transitivity_RHS);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
@@ -292,13 +292,13 @@ public class MovieGraph extends TestGraph {
         Pattern lhs = graph.graql().parsePattern("$x id 'expect-lhs'");
         Pattern rhs = graph.graql().parsePattern("$x id 'expect-rhs'");
 
-        Rule expectation = aRuleType.addRule(lhs, rhs);
+        Rule expectation = aRuleType.putRule(lhs, rhs);
 
         putResource(expectation, name, "expectation-rule");
 
         lhs = graph.graql().parsePattern("$x id 'materialize-lhs'");
         rhs = graph.graql().parsePattern("$x id 'materialize-rhs'");
-        Rule materialize = aRuleType.addRule(lhs, rhs);
+        Rule materialize = aRuleType.putRule(lhs, rhs);
 
         putResource(materialize, name, "materialize-rule");
     }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicTest.java
@@ -361,7 +361,7 @@ public class AtomicTest {
         Atom parentAtom = new ReasonerAtomicQuery(conjunction(parentString, graph), graph).getAtom();
 
         String childPatternString = "(wife: $x, husband: $y) isa marriage";
-        InferenceRule testRule = new InferenceRule(graph.admin().getMetaRuleInference().addRule(
+        InferenceRule testRule = new InferenceRule(graph.admin().getMetaRuleInference().putRule(
                 graph.graql().parsePattern(childPatternString),
                 graph.graql().parsePattern(childPatternString)),
                 graph);
@@ -455,7 +455,7 @@ public class AtomicTest {
         Relation parent = (Relation) new ReasonerAtomicQuery(conjunction(parentString, graph), graph).getAtom();
         PatternAdmin body = graph.graql().parsePattern("($z, $b) isa recommendation").admin();
         PatternAdmin head = graph.graql().parsePattern("($z, $b) isa recommendation").admin();
-        InferenceRule rule = new InferenceRule(graph.admin().getMetaRuleInference().addRule(body, head), graph);
+        InferenceRule rule = new InferenceRule(graph.admin().getMetaRuleInference().putRule(body, head), graph);
 
         rule.unify(parent);
         Set<VarName> vars = rule.getHead().getAtom().getVarNames();

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
@@ -105,7 +105,7 @@ public class ReasonerTest {
         Pattern body = and(graph.graql().parsePatterns("(subject-location: $x, located-subject: $x1) isa resides;"));
         Pattern head = and(graph.graql().parsePatterns("(member-location: $x, container-location: $x1) isa sublocate;"));
 
-        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().addRule(body, head), graph);
+        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().putRule(body, head), graph);
         Rule rule = Utility.createSubPropertyRule(parent, child, roleMap, graph);
         InferenceRule R = new InferenceRule(rule, graph);
 
@@ -127,7 +127,7 @@ public class ReasonerTest {
                 "(member-location: $z, container-location: $y) isa sublocate;"));
         Pattern head = and(graph.graql().parsePatterns("(member-location: $x, container-location: $y) isa sublocate;"));
 
-        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().addRule(body, head), graph);
+        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().putRule(body, head), graph);
         assertTrue(R.getHead().equals(R2.getHead()));
         assertTrue(R.getBody().equals(R2.getBody()));
     }
@@ -141,7 +141,7 @@ public class ReasonerTest {
         Pattern body = and(graph.graql().parsePatterns("($x, $y) isa knows;"));
         Pattern head = and(graph.graql().parsePatterns("($x, $x) isa knows;"));
 
-        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().addRule(body, head), graph);
+        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().putRule(body, head), graph);
         assertTrue(R.getHead().equals(R2.getHead()));
         assertTrue(R.getBody().equals(R2.getBody()));
     }
@@ -165,7 +165,7 @@ public class ReasonerTest {
                 "(member-location: $z, container-location: $y) isa sublocate;"));
         Pattern head = and(graph.graql().parsePatterns("(located-subject: $x, subject-location: $z) isa resides;"));
 
-        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().addRule(body, head), graph);
+        InferenceRule R2 = new InferenceRule(graph.admin().getMetaRuleInference().putRule(body, head), graph);
         assertTrue(R.getHead().equals(R2.getHead()));
         assertTrue(R.getBody().equals(R2.getBody()));
     }
@@ -228,7 +228,7 @@ public class ReasonerTest {
         String queryString = "match $x has firstname $y;";
         Pattern body = and(snbGraph.graph().graql().parsePatterns("$x isa person;$x has name 'Bob';"));
         Pattern head = and(snbGraph.graph().graql().parsePatterns("$x has firstname 'Bob';"));
-        snbGraph.graph().admin().getMetaRuleInference().addRule(body, head);
+        snbGraph.graph().admin().getMetaRuleInference().putRule(body, head);
 
         Reasoner.commitGraph(snbGraph.graph());
         snbGraph.graph(); //Reopen transaction

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
@@ -625,7 +625,7 @@ public class ReasonerTest {
     public void testReasoningWithRuleContainingVarContraction3(){
         Pattern body = snbGraph.graph().graql().parsePattern("$x isa person");
         Pattern head = snbGraph.graph().graql().parsePattern("($x, $x) isa knows");
-        snbGraph.graph().admin().getMetaRuleInference().addRule(body, head);
+        snbGraph.graph().admin().getMetaRuleInference().putRule(body, head);
 
         String queryString = "match ($x, $y) isa knows;$x has name 'Bob';";
         String explicitQuery = "match $y isa person;$y has name 'Bob' or $y has name 'Charlie';";

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
@@ -190,8 +190,6 @@ public class ReasonerTest {
         InferenceRule R1 = new InferenceRule(rule1, graph);
         InferenceRule R2 = new InferenceRule(rule2, graph);
         assertEquals(R1, R2);
-        rule1.delete();
-        rule2.delete();
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ReasonerTest.java
@@ -179,13 +179,13 @@ public class ReasonerTest {
                         "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                         "(geo-entity: $y, entity-location: $z) isa is-located-in;"));
         Pattern R1_RHS = Graql.and(graph.graql().parsePatterns("(geo-entity: $x, entity-location: $z) isa is-located-in;"));
-        Rule rule1 = inferenceRule.addRule(R1_LHS, R1_RHS);
+        Rule rule1 = inferenceRule.putRule(R1_LHS, R1_RHS);
 
         Pattern R2_LHS = Graql.and(graph.graql().parsePatterns(
                         "(geo-entity: $l1, entity-location: $l2) isa is-located-in;" +
                         "(geo-entity: $l2, entity-location: $l3) isa is-located-in;"));
         Pattern R2_RHS = Graql.and(graph.graql().parsePatterns("(geo-entity: $l1, entity-location: $l3) isa is-located-in;"));
-        Rule rule2 = inferenceRule.addRule(R2_LHS, R2_RHS);
+        Rule rule2 = inferenceRule.putRule(R2_LHS, R2_RHS);
 
         InferenceRule R1 = new InferenceRule(rule1, graph);
         InferenceRule R2 = new InferenceRule(rule2, graph);

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/inference/CWInferenceTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/inference/CWInferenceTest.java
@@ -216,7 +216,7 @@ public class CWInferenceTest {
 
         Pattern R6_LHS = and(localGraph.graql().parsePatterns("$x isa region;"));
         Pattern R6_RHS = and(localGraph.graql().parsePatterns("$x isa country;"));
-        inferenceRule.addRule(R6_LHS, R6_RHS);
+        inferenceRule.putRule(R6_LHS, R6_RHS);
         Reasoner.commitGraph(localGraph);
 
         String queryString = "match $x isa criminal;";


### PR DESCRIPTION
Note: This only takes into account patterns with the same variable names. 