### PR TITLE
Engine failover relies on current ZK state

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/ZookeeperConnection.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/ZookeeperConnection.java
@@ -21,11 +21,9 @@ package ai.grakn.engine.tasks.manager;
 
 import ai.grakn.engine.tasks.config.ZookeeperPaths;
 import ai.grakn.engine.GraknEngineConfig;
-import ai.grakn.exception.EngineStorageException;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.imps.CuratorFrameworkState;
-import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 
 import java.util.concurrent.TimeUnit;
@@ -34,7 +32,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.FAILOVER;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.SCHEDULER;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.TASKS_PATH_PREFIX;
-import static ai.grakn.engine.tasks.config.ZookeeperPaths.TASK_LOCK_SUFFIX;
 import static ai.grakn.engine.GraknEngineConfig.ZK_BACKOFF_BASE_SLEEP_TIME;
 import static ai.grakn.engine.GraknEngineConfig.ZK_BACKOFF_MAX_RETRIES;
 import static ai.grakn.engine.GraknEngineConfig.ZK_CONNECTION_TIMEOUT;

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/ZookeeperConnection.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/ZookeeperConnection.java
@@ -82,26 +82,6 @@ public class ZookeeperConnection {
         return zookeeperConnection;
     }
 
-    public InterProcessMutex mutex(String id){
-        return new InterProcessMutex(zookeeperConnection, TASKS_PATH_PREFIX + id + TASK_LOCK_SUFFIX);
-    }
-
-    public void acquire(InterProcessMutex mutex){
-        try {
-            mutex.acquire();
-        } catch (Exception e) {
-            throw new EngineStorageException("Error acquiring mutex from zookeeper.");
-        }
-    }
-
-    public void release(InterProcessMutex mutex){
-        try {
-            mutex.release();
-        } catch (Exception e) {
-            throw new EngineStorageException("Error releasing mutex from zookeeper.");
-        }
-    }
-
     private void createZKPaths() throws Exception {
         if(zookeeperConnection.checkExists().forPath(SCHEDULER) == null) {
             zookeeperConnection.create().creatingParentContainersIfNeeded().forPath(SCHEDULER);

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/SchedulerElector.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/SchedulerElector.java
@@ -27,6 +27,7 @@ import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
 import org.apache.curator.framework.state.ConnectionState;
 
+import static ai.grakn.engine.tasks.config.ConfigHelper.kafkaProducer;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.SCHEDULER;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 
@@ -127,6 +128,6 @@ public class SchedulerElector extends LeaderSelectorListenerAdapter {
     }
 
     private void registerFailover(CuratorFramework client) throws Exception {
-        failover = new TaskFailover(client, storage);
+        failover = new TaskFailover(client, storage, kafkaProducer());
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/TaskFailover.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/TaskFailover.java
@@ -33,7 +33,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -41,11 +40,8 @@ import java.util.concurrent.CountDownLatch;
 import static ai.grakn.engine.TaskStatus.RUNNING;
 import static ai.grakn.engine.tasks.config.KafkaTerms.WORK_QUEUE_TOPIC;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.ALL_ENGINE_WATCH_PATH;
-import static ai.grakn.engine.tasks.config.ZookeeperPaths.SINGLE_ENGINE_PATH;
-import static ai.grakn.engine.tasks.config.ZookeeperPaths.TASKS_PATH_PREFIX;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
  * <p>

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/TaskFailover.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/multiqueue/TaskFailover.java
@@ -39,7 +39,6 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 import static ai.grakn.engine.TaskStatus.RUNNING;
-import static ai.grakn.engine.tasks.config.ConfigHelper.kafkaProducer;
 import static ai.grakn.engine.tasks.config.KafkaTerms.WORK_QUEUE_TOPIC;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.ALL_ENGINE_WATCH_PATH;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.SINGLE_ENGINE_PATH;

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/FailoverElector.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/FailoverElector.java
@@ -30,6 +30,7 @@ import org.apache.curator.framework.state.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static ai.grakn.engine.tasks.config.ConfigHelper.kafkaProducer;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.FAILOVER;
 import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 
@@ -94,7 +95,7 @@ public class FailoverElector extends LeaderSelectorListenerAdapter {
     public void takeLeadership(CuratorFramework client) throws Exception {
         LOG.debug("Leadership taken by: " + identifier);
 
-        failover = new TaskFailover(client, storage);
+        failover = new TaskFailover(client, storage, kafkaProducer());
         failover.await();
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/FailoverElector.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/FailoverElector.java
@@ -22,11 +22,10 @@ import ai.grakn.engine.tasks.TaskStateStorage;
 import ai.grakn.engine.tasks.manager.ZookeeperConnection;
 import ai.grakn.engine.tasks.manager.multiqueue.TaskFailover;
 import ai.grakn.engine.util.EngineID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.recipes.leader.CancelLeadershipException;
 import org.apache.curator.framework.recipes.leader.LeaderSelector;
 import org.apache.curator.framework.recipes.leader.LeaderSelectorListenerAdapter;
-import org.apache.curator.framework.state.ConnectionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +45,7 @@ public class FailoverElector extends LeaderSelectorListenerAdapter {
     private final LeaderSelector leaderSelector;
     private final EngineID identifier;
     private final TaskStateStorage storage;
+    private final AtomicBoolean requeue = new AtomicBoolean(true);
     private TaskFailover failover;
 
     /**
@@ -57,18 +57,23 @@ public class FailoverElector extends LeaderSelectorListenerAdapter {
 
         leaderSelector = new LeaderSelector(zookeeper.connection(), FAILOVER, this);
         leaderSelector.setId(identifier.value());
-        leaderSelector.autoRequeue();
 
         // the selection for this instance doesn't start until the leader selector is started
         // leader selection is done in the background so this call to leaderSelector.start() returns immediately
         leaderSelector.start();
-        awaitLeader();
+
+        // Add yourself to the queue if you are not the leader
+        EngineID leader = awaitLeader();
+        if(!leader.equals(identifier)){
+            leaderSelector.requeue();
+        }
     }
 
     /**
      *
      */
     public void renounce(){
+        requeue.set(false);
         noThrow(leaderSelector::interruptLeadership, "Error interrupting leadership");
         noThrow(leaderSelector::close, "Error closing leadership elector");
     }
@@ -76,12 +81,21 @@ public class FailoverElector extends LeaderSelectorListenerAdapter {
     /**
      * Return the identifier of the current leader. Block until there is a leader.
      */
-    public String awaitLeader(){
+    public EngineID awaitLeader(){
         try {
             while (!leaderSelector.getLeader().isLeader()) {
                 Thread.sleep(1000);
             }
-            return leaderSelector.getLeader().getId();
+
+            // TODO Write a test for this block
+            // If you are the leader, wait for failover to have started up
+            if(leaderSelector.getLeader().getId().equals(identifier.value())){
+                while(failover != null && !failover.isAlive()){
+                    Thread.sleep(1000);
+                }
+            }
+
+            return EngineID.of(leaderSelector.getLeader().getId());
         } catch (Exception e){
             throw new RuntimeException("There were errors electing a leader", e);
         }
@@ -95,31 +109,15 @@ public class FailoverElector extends LeaderSelectorListenerAdapter {
     public void takeLeadership(CuratorFramework client) throws Exception {
         LOG.debug("Leadership taken by: " + identifier);
 
-        failover = new TaskFailover(client, storage, kafkaProducer());
-        failover.await();
-    }
+        try {
+            failover = new TaskFailover(client, storage, kafkaProducer());
+            failover.await();
+        } finally {
+            failover.close();
+        }
 
-    /**
-     * Called when this instance of {@link FailoverElector} is leader and the state has changes in any way.
-     * If leadership is suspended or lost the {@link TaskFailover} should be closed.
-     */
-    @Override
-    public void stateChanged(CuratorFramework client, ConnectionState newState)
-    {
-        switch (newState) {
-            case LOST:
-                noThrow(failover::close, "Error closing task failover");
-                throw new CancelLeadershipException();
-            case CONNECTED:
-                break;
-            case SUSPENDED:
-                LOG.debug("Leadership suspended");
-                break;
-            case RECONNECTED:
-                LOG.debug("Leadership regained");
-                break;
-            default:
-                break;
+        if(requeue.get()){
+            leaderSelector.requeue();
         }
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
+++ b/grakn-test/src/test/java/ai/grakn/test/EngineContext.java
@@ -25,8 +25,10 @@ import ai.grakn.engine.tasks.TaskManager;
 import ai.grakn.engine.tasks.manager.StandaloneTaskManager;
 import ai.grakn.engine.tasks.manager.multiqueue.MultiQueueTaskManager;
 import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskManager;
+import ai.grakn.engine.tasks.mock.MockBackgroundTask;
 import org.junit.rules.ExternalResource;
 
+import static ai.grakn.engine.util.ExceptionWrapper.noThrow;
 import static ai.grakn.test.GraknTestEnv.randomKeyspace;
 import static ai.grakn.test.GraknTestEnv.startEngine;
 import static ai.grakn.test.GraknTestEnv.startKafka;
@@ -112,15 +114,15 @@ public class EngineContext extends ExternalResource {
 
     @Override
     public void after() {
-        clearTasks();
+        noThrow(MockBackgroundTask::clearTasks, "Error clearing tasks");
 
         try {
             if(startMultiQueueEngine | startSingleQueueEngine | startStandaloneEngine){
-                stopEngine(server);
+                noThrow(() -> stopEngine(server), "Error closing engine");
             }
 
             if(startKafka){
-                stopKafka();
+                noThrow(GraknTestEnv::stopKafka, "Error stopping kafka");
             }
         } catch (Exception e){
             throw new RuntimeException("Could not shut down ", e);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTaskTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTaskTest.java
@@ -41,7 +41,7 @@ public class PostProcessingTaskTest {
     private StandaloneTaskManager taskManager = new StandaloneTaskManager(EngineID.of("hello"));
 
     @ClassRule
-    public static final EngineContext engine = EngineContext.startMultiQueueServer();
+    public static final EngineContext engine = EngineContext.startSingleQueueServer();
 
     @Test
     public void testStart() throws Exception {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTest.java
@@ -52,7 +52,7 @@ public class PostProcessingTest {
     private GraknGraph graph;
 
     @ClassRule
-    public static final EngineContext engine = EngineContext.startMultiQueueServer();
+    public static final EngineContext engine = EngineContext.startSingleQueueServer();
 
     @BeforeClass
     public static void onlyRunOnTinker(){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestIT.java
@@ -58,7 +58,7 @@ public class PostProcessingTestIT {
     private GraknGraph graph;
 
     @ClassRule
-    public static final EngineContext engine = EngineContext.startMultiQueueServer();
+    public static final EngineContext engine = EngineContext.startSingleQueueServer();
 
     @Before
     public void setUp() throws Exception {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/multiqueue/TaskFailoverTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/multiqueue/TaskFailoverTest.java
@@ -28,6 +28,7 @@ import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.EngineContext;
 import ai.grakn.engine.tasks.mock.ShortExecutionMockTask;
 import com.google.common.collect.Sets;
+import java.util.concurrent.CountDownLatch;
 import java.util.stream.Collectors;
 import mjson.Json;
 import org.apache.kafka.clients.producer.Producer;
@@ -113,7 +114,7 @@ public class TaskFailoverTest {
         Set<TaskId> taskIds = tasks.stream().map(TaskState::getId).collect(Collectors.toSet());
 
         // Verify tasks was sent to the queue
-        verify(producer, timeout(5000).times(1))
+        verify(producer, timeout(5000).times(5))
                 .send(argThat(argument -> taskIds.contains(argument.key())));
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/multiqueue/TaskFailoverTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/multiqueue/TaskFailoverTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.test.engine.tasks.manager.multiqueue;
 
+import ai.grakn.engine.TaskId;
 import ai.grakn.engine.tasks.TaskSchedule;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.manager.ZookeeperConnection;
@@ -27,7 +28,9 @@ import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.EngineContext;
 import ai.grakn.engine.tasks.mock.ShortExecutionMockTask;
 import com.google.common.collect.Sets;
+import java.util.stream.Collectors;
 import mjson.Json;
+import org.apache.kafka.clients.producer.Producer;
 import org.apache.zookeeper.CreateMode;
 import org.junit.After;
 import org.junit.Before;
@@ -41,6 +44,7 @@ import java.util.UUID;
 
 import static ai.grakn.engine.TaskStatus.COMPLETED;
 import static ai.grakn.engine.TaskStatus.FAILED;
+import static ai.grakn.engine.TaskStatus.RUNNING;
 import static ai.grakn.engine.TaskStatus.SCHEDULED;
 import static ai.grakn.engine.TaskStatus.STOPPED;
 import static ai.grakn.engine.tasks.config.ZookeeperPaths.SINGLE_ENGINE_WATCH_PATH;
@@ -53,12 +57,17 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
 
 @Ignore
 public class TaskFailoverTest {
 
     private static ZookeeperConnection connection;
     private static TaskFailover taskFailover;
+    private static Producer<TaskId, TaskState> producer;
     private static TaskStateInMemoryStore storage;
 
     @Rule
@@ -70,7 +79,8 @@ public class TaskFailoverTest {
 
         connection = new ZookeeperConnection();
 
-        taskFailover = new TaskFailover(connection.connection(), storage);
+        producer = mock(Producer.class);
+        taskFailover = new TaskFailover(connection.connection(), storage, producer);
     }
 
     @After
@@ -80,7 +90,7 @@ public class TaskFailoverTest {
     }
 
     @Test
-    public void runningTasksWhenEngineFail_AreAddedToWorkQueue() throws Exception {
+    public void whenAnEngineWithRUNNINGTasksFails_ThatTaskAddedToWorkQueue() throws Exception {
         EngineID fakeEngineID = EngineID.of(UUID.randomUUID().toString());
         registerFakeEngine(fakeEngineID);
 
@@ -92,51 +102,58 @@ public class TaskFailoverTest {
         killFakeEngine(fakeEngineID);
 
         // Wait for those tasks to show up in the work queue
-        waitForStatus(storage, tasks, SCHEDULED);
+        waitForStatus(storage, tasks, RUNNING);
 
-        // Check they are all scheduled in storage
+        // Check they are all running in storage
         assertTrue(tasks.stream().map(TaskState::getId)
                 .map(storage::getState)
                 .map(TaskState::status)
-                .allMatch(t -> t.equals(SCHEDULED)));
+                .allMatch(t -> t.equals(RUNNING)));
+
+        Set<TaskId> taskIds = tasks.stream().map(TaskState::getId).collect(Collectors.toSet());
+
+        // Verify tasks was sent to the queue
+        verify(producer, timeout(5000).times(1))
+                .send(argThat(argument -> taskIds.contains(argument.key())));
     }
 
     @Test
-    public void nonRUNNINGTasksOnTaskRunnerPathNotAddedToWorkQueue() throws Exception {
+    public void whenAnEngineWithNonRUNNINGTasksFails_ThoseTasksNotAddedToWorkQueue() throws Exception {
         // When a task has been added to the task runner watch, but is not marked
         // as running at the time of failure, it should not be added to the work queue
         EngineID fakeEngineID = EngineID.of(UUID.randomUUID().toString());
         registerFakeEngine(fakeEngineID);
 
         // Add a task in each state (SCHEDULED, COMPLETED, STOPPED, FAILED, RUNNING) to fake task runner watch
-        TaskState scheduled = createTask().markScheduled();
         TaskState running = createTask().markRunning(fakeEngineID);
         TaskState stopped = createTask().markStopped();
         TaskState failed = createTask().markFailed(new IOException());
         TaskState completed = createTask().markCompleted();
 
-        Set<TaskState> tasks = Sets.newHashSet(scheduled, running, stopped, failed, completed);
+        Set<TaskState> tasks = Sets.newHashSet(running, stopped, failed, completed);
         tasks.forEach(storage::newState);
 
         // Mock killing that engine
         killFakeEngine(fakeEngineID);
 
         // Make sure only the running task ends up in the work queue
-        waitForStatus(storage, Sets.newHashSet(running, scheduled), SCHEDULED);
+        waitForStatus(storage, Sets.newHashSet(running), RUNNING);
 
-        // the task that was in the middle of running should be marked as scheduled
-        assertEquals(SCHEDULED, storage.getState(running.getId()).status());
-
-        // the task that was scheduled should still be marked as scheduled and in the work queue
-        assertEquals(SCHEDULED, storage.getState(scheduled.getId()).status());
+        // the task that was in the middle of running should be marked as running
+        assertEquals(RUNNING, storage.getState(running.getId()).status());
 
         // the three other tasks should keep their state in the storage
         assertEquals(COMPLETED, storage.getState(completed.getId()).status());
         assertEquals(STOPPED, storage.getState(stopped.getId()).status());
         assertEquals(FAILED, storage.getState(failed.getId()).status());
+
+        // Verify a task was sent to the queue only once
+        verify(producer, timeout(5000).times(1))
+                .send(argThat(argument -> argument.key().equals(running.getId())));
     }
 
     @Test
+    @Ignore
     public void failoverTasksRestartedFromCorrectCheckpoints() throws Exception {
         // On failover, tasks should be restarted from where they left off execution
         EngineID fakeEngineID = EngineID.of(UUID.randomUUID().toString());

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
@@ -66,7 +66,7 @@ public class SingleQueueTaskManagerTest {
     public static final EngineContext kafkaServer = EngineContext.startKafkaServer();
 
     @BeforeClass
-    public static void setup(){
+    public static void setup() throws Exception{
         taskManager = new SingleQueueTaskManager(EngineID.me());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/ScalingTestIT.java
@@ -79,7 +79,7 @@ import static org.junit.Assert.assertEquals;
 public class ScalingTestIT {
 
     @ClassRule
-    public static final EngineContext context = EngineContext.startMultiQueueServer();
+    public static final EngineContext context = EngineContext.startSingleQueueServer();
 
     private static final String[] HOST_NAME =
             {Grakn.DEFAULT_URI};

--- a/grakn-test/src/test/resources/logback.xml
+++ b/grakn-test/src/test/resources/logback.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Grakn - A Distributed Semantic Database
+  ~ Copyright (C) 2016  Grakn Labs Limited
+  ~
+  ~ Grakn is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Grakn is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+  ~
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="ai.grakn" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="ai.grakn.engine.GraknEngineServer" level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+</configuration>

--- a/grakn-test/src/test/resources/logback.xml
+++ b/grakn-test/src/test/resources/logback.xml
@@ -14,9 +14,7 @@
   ~
   ~ You should have received a copy of the GNU General Public License
   ~ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
-  ~
   -->
-
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>


### PR DESCRIPTION
+ Engine Failover was previously missing tasks if it was down while other engines died. Now, when an Engine dies we get all running tasks from storage, and if they are running on a machine that is no longer up, resubmit them. 
+ SQTM will register itself for failover