### PR TITLE
Graph API Cleanup - Paying off some debt

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/Rule.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Rule.java
@@ -54,22 +54,6 @@ public interface Rule extends Instance{
 
     //------------------------------------- Edge Handling ----------------------------------
     /**
-     * Add a hypothesis of the specified Type to the Rule.
-     *
-     * @param type The Type which this Rule applies to.
-     * @return The Rule itself
-     */
-    Rule addHypothesis(Type type);
-    /**
-     *
-     * Add a conclusion of the specified Type to the Rule.
-     *
-     * @param type The Type which is the conclusion of this Rule.
-     * @return The Rule itself
-     */
-    Rule addConclusion(Type type);
-
-    /**
      * Retrieve a set of Types that constitute a part of the hypothesis of this Rule.
      *
      * @return A collection of Concept Types that constitute a part of the hypothesis of the Rule

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -29,7 +29,7 @@ package ai.grakn.util;
 public enum ErrorMessage {
     //--------------------------------------------- Core Errors -----------------------------------------------
     CANNOT_DELETE("Type [%s] cannot be deleted as it still has incoming edges"),
-    LOOP_DETECTED("Concept [%s] loops when following edges of type [%s]"),
+    SUPER_TYPE_LOOP_DETECTED("By setting the super type of concept [%s] to [%s]. You will be creating a loop. This is prohibited"),
     ID_NOT_UNIQUE("Failed to change the Id of Concept [%s] due to another concept already having an id of " +
             "type [%s] with value [%s]"),
     ID_ALREADY_TAKEN("The id [%s] is already taken by concept [%s]"),

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RuleImpl.java
@@ -84,8 +84,7 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      * @param type The concept type which this rules applies to.
      * @return The Rule itself
      */
-    @Override
-    public Rule addHypothesis(Type type) {
+    Rule addHypothesis(Type type) {
         putEdge(type, Schema.EdgeLabel.HYPOTHESIS);
         return getThis();
     }
@@ -95,8 +94,7 @@ class RuleImpl extends InstanceImpl<Rule, RuleType> implements Rule {
      * @param type The concept type which is the conclusion of this Rule.
      * @return The Rule itself
      */
-    @Override
-    public Rule addConclusion(Type type) {
+    Rule addConclusion(Type type) {
         putEdge(type, Schema.EdgeLabel.CONCLUSION);
         return getThis();
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -237,11 +237,7 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         T superParent = superType();
 
         while(superParent != null && !Schema.MetaSchema.CONCEPT.getName().equals(superParent.getName())){
-            if(superSet.contains(superParent)) {
-                throw new ConceptException(ErrorMessage.LOOP_DETECTED.getMessage(toString(), Schema.EdgeLabel.SUB.getLabel()));
-            } else {
-                superSet.add(superParent);
-            }
+            superSet.add(superParent);
             //noinspection unchecked
             superParent = (T) superParent.superType();
         }
@@ -375,7 +371,7 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
             //Note the check before the actual construction
             if(superTypeLoops()){
                 cachedSuperType.set(oldSuperType); //Reset if the new super type causes a loop
-                throw new ConceptException(ErrorMessage.LOOP_DETECTED.getMessage(getName(), Schema.EdgeLabel.SUB.getLabel()));
+                throw new ConceptException(ErrorMessage.SUPER_TYPE_LOOP_DETECTED.getMessage(getName(), newSuperType.getName()));
             }
 
             //Modify the graph once we have checked no loop occurs

--- a/grakn-graph/src/test/java/ai/grakn/example/PokemonGraphFactoryTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/example/PokemonGraphFactoryTest.java
@@ -46,7 +46,7 @@ public class PokemonGraphFactoryTest {
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void setup() {
+    public void setupPokemonGraph() {
         GraknGraphFactory factory = Grakn.factory(Grakn.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a"));
         PokemonGraphFactory.loadGraph(factory.getGraph());
         factory.getGraph().commitOnClose();

--- a/grakn-graph/src/test/java/ai/grakn/example/PokemonGraphFactoryTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/example/PokemonGraphFactoryTest.java
@@ -22,6 +22,7 @@ import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.GraknGraphFactory;
 import ai.grakn.concept.Entity;
+import ai.grakn.concept.Instance;
 import ai.grakn.concept.Relation;
 import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
@@ -32,71 +33,55 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static junit.framework.TestCase.assertNotNull;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class PokemonGraphFactoryTest {
     private GraknGraph graknGraph;
-    private GraknGraphFactory factory;
 
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void setup() {
-        factory = Grakn.factory(Grakn.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a"));
+        GraknGraphFactory factory = Grakn.factory(Grakn.IN_MEMORY, UUID.randomUUID().toString().replaceAll("-", "a"));
         PokemonGraphFactory.loadGraph(factory.getGraph());
         factory.getGraph().commitOnClose();
         factory.getGraph().close();
         graknGraph = factory.getGraph();
     }
 
-    @Test(expected=InvocationTargetException.class)
-    public void testConstructorIsPrivate() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<PokemonGraphFactory> c = PokemonGraphFactory.class.getDeclaredConstructor();
-        c.setAccessible(true);
-        c.newInstance();
-    }
-
     @Test
-    public void testGraphExists() {
-        assertNotNull(graknGraph);
-    }
-
-    @Test
-    public void testGraphHasPokemon() {
+    public void whenQueryingPokemonByName_ReturnPokemon() {
         Entity bulbasaur = graknGraph.getResourcesByValue("Bulbasaur").iterator().next().ownerInstances().iterator().next().asEntity();
-        assertTrue(bulbasaur.type().equals(graknGraph.getEntityType("pokemon")));
+        assertEquals(bulbasaur.type(), graknGraph.getEntityType("pokemon"));
     }
 
     @Test
-    public void testGraphHasPokemonType() {
+    public void whenQueryingPokemonTypeByName_ReturnPokemonType() {
         Entity poison = graknGraph.getResourcesByValue("poison").iterator().next().ownerInstances().iterator().next().asEntity();
-        assertTrue(poison.type().equals(graknGraph.getEntityType("pokemon-type")));
+        assertEquals(poison.type(), graknGraph.getEntityType("pokemon-type"));
     }
 
     @Test
-    public void testBulbasaurHasResource() {
+    public void whenQueryingResourceOfPokemonForSpecificResourceType_ReturnResource() {
         ResourceType<Long> pokedexNo = graknGraph.getResourceType("pokedex-no");
-        Entity bulbasaur = graknGraph.getResourcesByValue("Bulbasaur").iterator().next().ownerInstances().iterator().next().asEntity();
+        Instance bulbasaur = graknGraph.getResourcesByValue("Bulbasaur").iterator().next().owner();
         Stream<Resource<?>> resources = bulbasaur.resources().stream();
-        assertTrue(resources.anyMatch(r -> r.type().equals(pokedexNo) && r.getValue().equals(1L)));
+        assertTrue("Pokemon [" + bulbasaur + "] does not have the resource type [" + pokedexNo + "]", resources.anyMatch(r -> r.type().equals(pokedexNo) && r.getValue().equals(1L)));
     }
 
     @Test
-    public void testTypeIsSuperEffective() {
+    public void checkThatPokemonTypeIsEffectiveAgainstAnotherPokeminTypeViaRelation() {
         RelationType relationType = graknGraph.getRelationType("super-effective");
         RoleType role = graknGraph.getRoleType("defending-type");
         Entity poison = graknGraph.getResourcesByValue("poison").iterator().next().ownerInstances().iterator().next().asEntity();
         Entity grass = graknGraph.getResourcesByValue("grass").iterator().next().ownerInstances().iterator().next().asEntity();
         Stream<Relation> relations = poison.relations().stream();
-        assertTrue(relations.anyMatch(r -> r.type().equals(relationType)
-                && r.rolePlayers().get(role).equals(grass)));
+        assertTrue(relations.anyMatch(r -> r.type().equals(relationType) && r.rolePlayers().get(role).equals(grass)));
     }
 
 }

--- a/grakn-graph/src/test/java/ai/grakn/factory/FactoryBuilderTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/factory/FactoryBuilderTest.java
@@ -28,8 +28,6 @@ import org.junit.rules.ExpectedException;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -55,21 +53,13 @@ public class FactoryBuilderTest {
         }
     }
 
-    @Test(expected=InvocationTargetException.class)
-    public void testConstructorIsPrivate() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
-        Constructor<FactoryBuilder> c = FactoryBuilder.class.getDeclaredConstructor();
-        c.setAccessible(true);
-        c.newInstance();
+    @Test
+    public void whenBuildingInMemoryFactory_ReturnTinkerFactory(){
+        assertThat(FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_PROPERTIES), instanceOf(TinkerInternalFactory.class));
     }
 
     @Test
-    public void testBuildGraknFactory(){
-        InternalFactory mgf = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_PROPERTIES);
-        assertThat(mgf, instanceOf(TinkerInternalFactory.class));
-    }
-
-    @Test
-    public void testSingleton(){
+    public void whenBuildingFactoriesWithTheSameProperties_ReturnSameGraphs(){
         InternalFactory mgf1 = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_PROPERTIES);
         InternalFactory mgf2 = FactoryBuilder.getFactory(KEYSPACE, ENGINE_URL, TEST_PROPERTIES);
         InternalFactory mgf3 = FactoryBuilder.getFactory("key", ENGINE_URL, TEST_PROPERTIES);

--- a/grakn-graph/src/test/java/ai/grakn/factory/GraknTinkerGraphFactoryTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/factory/GraknTinkerGraphFactoryTest.java
@@ -23,7 +23,6 @@ import ai.grakn.GraknGraph;
 import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.graph.internal.AbstractGraknGraph;
 import ai.grakn.graph.internal.GraknTinkerGraph;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,25 +43,19 @@ public class GraknTinkerGraphFactoryTest {
     public final ExpectedException expectedException = ExpectedException.none();
 
     @Before
-    public void setTinkerGraphFactory(){
+    public void setupTinkerGraphFactory(){
         tinkerGraphFactory = new TinkerInternalFactory("test", Grakn.IN_MEMORY, null);
     }
 
     @Test
-    public void testBuildTinkerGraph() throws Exception {
+    public void whenBuildingGraphUsingTinkerFactory_ReturnGraknTinkerGraph() throws Exception {
         GraknGraph graph = tinkerGraphFactory.getGraph(false);
         assertThat(graph, instanceOf(GraknTinkerGraph.class));
         assertThat(graph, instanceOf(AbstractGraknGraph.class));
-
-        try {
-            graph.close();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     @Test
-    public void testFactorySingleton(){
+    public void whenBuildingGraphFromTheSameFactory_ReturnSingletonGraphs(){
         GraknGraph graph1 = tinkerGraphFactory.getGraph(false);
         GraknGraph graph1_copy = tinkerGraphFactory.getGraph(false);
 
@@ -76,7 +69,6 @@ public class GraknTinkerGraphFactoryTest {
 
         TinkerGraph tinkerGraph1 = ((GraknTinkerGraph) graph1).getTinkerPopGraph();
         TinkerGraph tinkerGraph2 = ((GraknTinkerGraph) graph2).getTinkerPopGraph();
-
         assertEquals(tinkerGraph1, tinkerGraph2);
     }
 
@@ -92,18 +84,15 @@ public class GraknTinkerGraphFactoryTest {
     }
 
     @Test
-    public void testGetTinkerPopGraph(){
-        Graph mg1 = tinkerGraphFactory.getTinkerPopGraph(false);
-        assertThat(mg1, instanceOf(TinkerGraph.class));
+    public void whenRetrievingGraphFromGraknTinkerGraph_ReturnTinkerGraph(){
+        assertThat(tinkerGraphFactory.getTinkerPopGraph(false), instanceOf(TinkerGraph.class));
     }
 
     @Test
-    public void testGetNullKeySpace(){
+    public void whenCreatingFactoryWithNullKeyspace_Throw(){
         expectedException.expect(GraphRuntimeException.class);
         expectedException.expectMessage(NULL_VALUE.getMessage("keyspace"));
-
         tinkerGraphFactory = new TinkerInternalFactory(null, null, null);
-        tinkerGraphFactory.getGraph(false);
     }
 
 }

--- a/grakn-graph/src/test/java/ai/grakn/factory/SystemKeyspaceTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/factory/SystemKeyspaceTest.java
@@ -13,7 +13,9 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class SystemKeyspaceTest {
@@ -21,9 +23,9 @@ public class SystemKeyspaceTest {
 	private final String space1 = "SystemKeyspaceTest.space1".toLowerCase();
 	private final String space2 = "SystemKeyspaceTest.space2";
 	private final String space3 = "SystemKeyspaceTest.space3";
-	
+
     @Test
-    public void testCollectKeyspaces() throws GraknValidationException {
+    public void whenCreatingMultipleGraphs_EnsureKeySpacesAreAddedToSystemGraph() throws GraknValidationException {
     	GraknGraphFactory f1 = Grakn.factory(Grakn.IN_MEMORY, space1);
     	f1.getGraph().close();
     	GraknGraphFactory f2 = Grakn.factory(Grakn.IN_MEMORY, space2);
@@ -36,9 +38,8 @@ public class SystemKeyspaceTest {
     	Collection<String> spaces = graph.getEntityType("keyspace").instances()
     		.stream().map(e -> 
     			e.resources(keyspaceName).iterator().next().getValue().toString()).collect(Collectors.toList());
-    	assertTrue(spaces.contains(space1));
-    	assertTrue(spaces.contains(space2.toLowerCase()));
-    	assertTrue(spaces.contains(space3.toLowerCase()));
+        assertThat(spaces, containsInAnyOrder(space1, space2.toLowerCase(), space3.toLowerCase()));
+
         assertEquals(GraknVersion.VERSION,
                 graph.getResourceType("system-version").instances().iterator().next().getValue().toString());
     	gf2.close();
@@ -46,8 +47,10 @@ public class SystemKeyspaceTest {
     	graph.close();
     }
 
+
+
     @Test
-    public void testUserOntology(){
+    public void ensureUserOntologyIsLoadedIntoSystemGraph(){
         GraknGraph graph = Grakn.factory(Grakn.IN_MEMORY, SystemKeyspace.SYSTEM_GRAPH_NAME).getGraph();
         graph.showImplicitConcepts(true);
 

--- a/grakn-graph/src/test/java/ai/grakn/factory/SystemKeyspaceTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/factory/SystemKeyspaceTest.java
@@ -13,9 +13,7 @@ import org.junit.Test;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class SystemKeyspaceTest {
@@ -38,11 +36,15 @@ public class SystemKeyspaceTest {
     	Collection<String> spaces = graph.getEntityType("keyspace").instances()
     		.stream().map(e -> 
     			e.resources(keyspaceName).iterator().next().getValue().toString()).collect(Collectors.toList());
-        assertThat(spaces, containsInAnyOrder(space1, space2.toLowerCase(), space3.toLowerCase()));
+
+        assertTrue("Keyspace [" + space1 + "] is missing from system graph", spaces.contains(space1));
+        assertTrue("Keyspace [" + space2 + "] is missing from system graph", spaces.contains(space2.toLowerCase()));
+        assertTrue("Keyspace [" + space3 + "] is missing from system graph", spaces.contains(space3.toLowerCase()));
 
         assertEquals(GraknVersion.VERSION,
                 graph.getResourceType("system-version").instances().iterator().next().getValue().toString());
-    	gf2.close();
+
+        gf2.close();
     	gf3.close();
     	graph.close();
     }

--- a/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
@@ -150,9 +150,7 @@ public class GraknGraphs extends AbstractGenerator<GraknGraph> {
             () -> ruleType().addRule(var("x"), var("x")), // TODO: generate more complicated rules
             () -> instance().hasResource(resource()),
             () -> relation().scope(instance()),
-            () -> relation().putRolePlayer(roleType(), instance()),
-            () -> rule().addHypothesis(type()),
-            () -> rule().addConclusion(type())
+            () -> relation().putRolePlayer(roleType(), instance())
     );
 
     private TypeName typeName() {

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EdgeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EdgeTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
 
 public class EdgeTest extends GraphTestBase{
 
@@ -36,7 +35,7 @@ public class EdgeTest extends GraphTestBase{
     private EdgeImpl edge;
 
     @Before
-    public void setUp(){
+    public void createEdge(){
         entityType = graknGraph.putEntityType("My Entity Type");
         entity = entityType.addEntity();
         Edge tinkerEdge = graknGraph.getTinkerTraversal().hasId(entity.getId().getValue()).outE().next();
@@ -44,7 +43,7 @@ public class EdgeTest extends GraphTestBase{
     }
 
     @Test
-    public void testEquals(){
+    public void checkEqualityBetweenEdgesBasedOnID(){
         Entity entity2 = entityType.addEntity();
         Edge tinkerEdge = graknGraph.getTinkerTraversal().hasId(entity2.getId().getValue()).outE().next();
         EdgeImpl edge2 = new EdgeImpl(tinkerEdge, graknGraph);
@@ -54,25 +53,17 @@ public class EdgeTest extends GraphTestBase{
     }
 
     @Test
-    public void testGetSource() throws Exception {
+    public void whenGettingTheSourceOfAnEdge_ReturnTheConceptTheEdgeComesFrom() throws Exception {
         assertEquals(entity, edge.getSource());
     }
 
     @Test
-    public void testGetTarget() throws Exception {
+    public void whenGettingTheTargetOfAnEdge_ReturnTheConceptTheEdgePointsTowards() throws Exception {
         assertEquals(entityType, edge.getTarget());
     }
 
     @Test
-    public void testGetType() throws Exception {
+    public void whenGettingTheLabelOfAnEdge_ReturnExpectedType() throws Exception {
         assertEquals(Schema.EdgeLabel.ISA, edge.getType());
     }
-
-    @Test
-    public void testProperty() throws Exception {
-        edge.setProperty(Schema.EdgeProperty.ROLE_TYPE, "role");
-        assertEquals("role", edge.getProperty(Schema.EdgeProperty.ROLE_TYPE));
-        assertNull(edge.getProperty(Schema.EdgeProperty.FROM_TYPE_NAME));
-    }
-
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
@@ -48,6 +48,13 @@ import static org.junit.Assert.assertTrue;
 public class EntityTest extends GraphTestBase{
 
     @Test
+    public void whenGettingTypeOfEntity_ReturnEntityType(){
+        EntityType entityType = graknGraph.putEntityType("Entiy Type");
+        Entity entity = entityType.addEntity();
+        assertEquals(entityType, entity.type());
+    }
+
+    @Test
     public void testDeleteScope() throws ConceptException {
         EntityType entityType = graknGraph.putEntityType("entity type");
         RelationType relationType = graknGraph.putRelationType("RelationType");

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTest.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graph.internal;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
@@ -37,13 +36,13 @@ import ai.grakn.util.Schema;
 import org.junit.Test;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
 
 public class EntityTest extends GraphTestBase{
 
@@ -55,46 +54,15 @@ public class EntityTest extends GraphTestBase{
     }
 
     @Test
-    public void testDeleteScope() throws ConceptException {
-        EntityType entityType = graknGraph.putEntityType("entity type");
-        RelationType relationType = graknGraph.putRelationType("RelationType");
-        Instance scope = entityType.addEntity();
-        Relation relation = relationType.addRelation();
-        relation.scope(scope);
-        scope.delete();
-        assertNull(graknGraph.getConceptByBaseIdentifier(scope.getId().getRawValue()));
-    }
-
-    @Test
-    public void testGetCastings(){
-        RelationType relationType = graknGraph.putRelationType("rel type");
-        EntityType entityType = graknGraph.putEntityType("entity type");
-        InstanceImpl<?, ?> rolePlayer1 = (InstanceImpl) entityType.addEntity();
-        assertEquals(0, rolePlayer1.getIncomingNeighbours(Schema.EdgeLabel.CASTING).collect(Collectors.toSet()).size());
-
-        RoleTypeImpl role = (RoleTypeImpl) graknGraph.putRoleType("Role");
-        RoleTypeImpl role2 = (RoleTypeImpl) graknGraph.putRoleType("Role 2");
-        Relation relation = relationType.addRelation();
-        Relation relation2 = relationType.addRelation();
-        CastingImpl casting1 = graknGraph.putCasting(role, rolePlayer1, (RelationImpl) relation);
-        CastingImpl casting2 = graknGraph.putCasting(role2, rolePlayer1, (RelationImpl) relation2);
-
-        Set<Concept> castings = rolePlayer1.getIncomingNeighbours(Schema.EdgeLabel.ROLE_PLAYER).collect(Collectors.toSet());
-
-        assertEquals(2, castings.size());
-        assertTrue(castings.contains(casting1));
-        assertTrue(castings.contains(casting2));
-        assertNotEquals(casting1, casting2);
-    }
-
-    @Test
-    public void testDeleteConceptInstanceInRelationship() throws ConceptException{
-        //Build
+    public void whenDeletingInstanceInRelationShip_TheInstanceAndCastingsAreDeleteTheRelationRemains() throws ConceptException{
+        //Ontology
         EntityType type = graknGraph.putEntityType("Concept Type");
         RelationType relationType = graknGraph.putRelationType("relationTypes");
         RoleType role1 = graknGraph.putRoleType("role1");
         RoleType role2 = graknGraph.putRoleType("role2");
         RoleType role3 = graknGraph.putRoleType("role3");
+
+        //Data
         Instance rolePlayer1 = type.addEntity();
         Instance rolePlayer2 = type.addEntity();
         Instance rolePlayer3 = type.addEntity();
@@ -102,146 +70,49 @@ public class EntityTest extends GraphTestBase{
         relationType.hasRole(role1);
         relationType.hasRole(role2);
         relationType.hasRole(role3);
-        relationType.addRelation().
+
+        //Check Structure is in order
+        RelationImpl relation = (RelationImpl) relationType.addRelation().
                 putRolePlayer(role1, rolePlayer1).
                 putRolePlayer(role2, rolePlayer2).
                 putRolePlayer(role3, rolePlayer3);
 
-        assertEquals(20, graknGraph.getTinkerPopGraph().traversal().V().toList().size());
-        assertEquals(34, graknGraph.getTinkerPopGraph().traversal().E().toList().size());
+        CastingImpl casting1 = ((InstanceImpl<?, ?>) rolePlayer1).castings().iterator().next();
+        CastingImpl casting2 = ((InstanceImpl<?, ?>) rolePlayer2).castings().iterator().next();
+        CastingImpl casting3 = ((InstanceImpl<?, ?>) rolePlayer3).castings().iterator().next();
+        Set<CastingImpl> castings = relation.getMappingCasting();
 
+        assertThat(relation.getMappingCasting(), containsInAnyOrder(casting1, casting2, casting3));
+
+        //Delete And Check Again
         ConceptId idOfDeleted = rolePlayer1.getId();
         rolePlayer1.delete();
 
         assertNull(graknGraph.getConcept(idOfDeleted));
-        assertEquals(18, graknGraph.getTinkerPopGraph().traversal().V().toList().size());
-        assertEquals(26, graknGraph.getTinkerPopGraph().traversal().E().toList().size());
+        assertThat(relation.getMappingCasting(), containsInAnyOrder(casting2, casting3));
     }
 
     @Test
-    public void testDeleteConceptInstanceInRelationshipLastRolePlayer() throws ConceptException {
+    public void whenDeletingLastRolePlayerInRelation_TheRelationIsDeleted() throws ConceptException {
         EntityType type = graknGraph.putEntityType("Concept Type");
         RelationType relationType = graknGraph.putRelationType("relationTypes");
         RoleType role1 = graknGraph.putRoleType("role1");
         RoleType role2 = graknGraph.putRoleType("role2");
-        RoleType role3 = graknGraph.putRoleType("role3");
         Instance rolePlayer1 = type.addEntity();
 
-        relationType.hasRole(role1);
-        relationType.hasRole(role2);
-        relationType.hasRole(role3);
-        relationType.addRelation().
+        Relation relation = relationType.addRelation().
                 putRolePlayer(role1, rolePlayer1).
-                putRolePlayer(role2, null).
-                putRolePlayer(role3, null);
+                putRolePlayer(role2, null);
 
-        long value = graknGraph.getTinkerPopGraph().traversal().V().count().next();
-        assertEquals(16, value);
-        value = graknGraph.getTinkerPopGraph().traversal().E().count().next();
-        assertEquals(20, value);
+        assertNotNull(graknGraph.getConcept(relation.getId()));
 
-        ConceptId idOfDeleted = rolePlayer1.getId();
         rolePlayer1.delete();
 
-        assertNull(graknGraph.getConcept(idOfDeleted));
-        assertEquals(13, graknGraph.getTinkerPopGraph().traversal().V().toList().size());
-        assertEquals(15, graknGraph.getTinkerPopGraph().traversal().E().toList().size());
+        assertNull(graknGraph.getConcept(relation.getId()));
     }
 
     @Test
-    public void testRelationsAndPlayedRoleTypes(){
-        EntityType entityType = graknGraph.putEntityType("Concept Type");
-        RelationType castSinging = graknGraph.putRelationType("Acting Cast");
-        RelationType castActing = graknGraph.putRelationType("Singing Cast");
-        RoleType feature = graknGraph.putRoleType("Feature");
-        RoleType musical = graknGraph.putRoleType("Musical");
-        RoleType actor = graknGraph.putRoleType("Actor");
-        RoleType singer = graknGraph.putRoleType("Singer");
-        Instance pacino = entityType.addEntity();
-        Instance godfather = entityType.addEntity();
-        Instance godfather2 = entityType.addEntity();
-        Instance godfather3 = entityType.addEntity();
-        Instance godfather4 = entityType.addEntity();
-
-        castActing.hasRole(actor).hasRole(feature);
-        castSinging.hasRole(singer).hasRole(musical);
-
-        Relation relation1 = castActing.addRelation().putRolePlayer(feature, godfather).putRolePlayer(actor, pacino);
-        Relation relation2 = castActing.addRelation().putRolePlayer(feature, godfather2).putRolePlayer(actor, pacino);
-        Relation relation3 = castActing.addRelation().putRolePlayer(feature, godfather3).putRolePlayer(actor, pacino);
-        Relation relation4 = castActing.addRelation().putRolePlayer(feature, godfather4).putRolePlayer(singer, pacino);
-
-        assertEquals(4, pacino.relations().size());
-        assertEquals(1, godfather.relations().size());
-        assertEquals(1, godfather2.relations().size());
-        assertEquals(1, godfather3.relations().size());
-        assertEquals(1, godfather4.relations().size());
-        assertEquals(3, pacino.relations(actor).size());
-        assertEquals(1, pacino.relations(singer).size());
-        assertEquals(4, pacino.relations(actor, singer).size());
-
-        assertTrue(pacino.relations(actor).contains(relation1));
-        assertTrue(pacino.relations(actor).contains(relation2));
-        assertTrue(pacino.relations(actor).contains(relation3));
-        assertFalse(pacino.relations(actor).contains(relation4));
-        assertTrue(pacino.relations(singer).contains(relation4));
-
-        assertEquals(2, pacino.playsRoles().size());
-        assertEquals(1, godfather.playsRoles().size());
-        assertEquals(1, godfather2.playsRoles().size());
-        assertEquals(1, godfather3.playsRoles().size());
-        assertEquals(1, godfather4.playsRoles().size());
-
-        assertTrue(pacino.playsRoles().contains(actor));
-        assertTrue(pacino.playsRoles().contains(singer));
-    }
-
-    @Test
-    public void testResources(){
-        EntityType randomThing = graknGraph.putEntityType("A Thing");
-        ResourceType<String> resourceType = graknGraph.putResourceType("A Resource Thing", ResourceType.DataType.STRING);
-        ResourceType<String> resourceType2 = graknGraph.putResourceType("A Resource Thing 2", ResourceType.DataType.STRING);
-
-        RelationType hasResource = graknGraph.putRelationType("Has Resource");
-
-        RoleType resourceRole = graknGraph.putRoleType("Resource Role");
-        RoleType actorRole = graknGraph.putRoleType("Actor");
-
-        Entity pacino = randomThing.addEntity();
-        Resource birthplace = resourceType.putResource("a place");
-        Resource age = resourceType.putResource("100");
-        Resource family = resourceType.putResource("people");
-        Resource birthDate = resourceType.putResource("10/10/10");
-        hasResource.hasRole(resourceRole).hasRole(actorRole);
-
-        Resource randomResource = resourceType2.putResource("Random 1");
-        Resource randomResource2 = resourceType2.putResource("Random 2");
-
-        assertEquals(0, birthDate.ownerInstances().size());
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, birthDate);
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, birthplace);
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, age);
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, family);
-
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, randomResource);
-        hasResource.addRelation().putRolePlayer(actorRole, pacino).putRolePlayer(resourceRole, randomResource2);
-
-        assertEquals(1, birthDate.ownerInstances().size());
-        assertEquals(6, pacino.resources().size());
-        assertTrue(pacino.resources().contains(birthDate));
-        assertTrue(pacino.resources().contains(birthplace));
-        assertTrue(pacino.resources().contains(age));
-        assertTrue(pacino.resources().contains(family));
-        assertTrue(pacino.resources().contains(randomResource));
-        assertTrue(pacino.resources().contains(randomResource2));
-
-        assertEquals(2, pacino.resources(resourceType2).size());
-        assertTrue(pacino.resources(resourceType2).contains(randomResource));
-        assertTrue(pacino.resources(resourceType2).contains(randomResource2));
-    }
-
-    @Test
-    public void testHasResource(){
+    public void whenAddingResourceToAnEntity_EnsureTheImplicitStructureIsCreated(){
         TypeName resourceTypeName = TypeName.of("A Resource Thing");
         EntityType entityType = graknGraph.putEntityType("A Thing");
         ResourceType<String> resourceType = graknGraph.putResourceType(resourceTypeName, ResourceType.DataType.STRING);
@@ -266,7 +137,7 @@ public class EntityTest extends GraphTestBase{
     }
 
     @Test
-    public void testHasResourceWithNoSchema(){
+    public void whenAddingResourceToEntityWitoutAllowingItBetweenTypes_Throw(){
         EntityType entityType = graknGraph.putEntityType("A Thing");
         ResourceType<String> resourceType = graknGraph.putResourceType("A Resource Thing", ResourceType.DataType.STRING);
 
@@ -282,32 +153,7 @@ public class EntityTest extends GraphTestBase{
     }
 
     @Test
-    public void testKey(){
-        TypeName resourceTypeName = TypeName.of("A Resource Thing");
-        EntityType entityType = graknGraph.putEntityType("A Thing");
-        ResourceType<String> resourceType = graknGraph.putResourceType(resourceTypeName, ResourceType.DataType.STRING);
-        entityType.key(resourceType);
-
-        Entity entity = entityType.addEntity();
-        Resource resource = resourceType.putResource("A resource thing");
-
-        Relation relation = entity.hasResource(resource);
-        assertEquals(Schema.Resource.HAS_RESOURCE.getName(resourceTypeName), relation.type().getName());
-
-        relation.rolePlayers().entrySet().forEach(entry -> {
-            RoleType roleType = entry.getKey();
-            Instance instance = entry.getValue();
-
-            if(instance.equals(entity)){
-                assertEquals(Schema.Resource.HAS_RESOURCE_OWNER.getName(resourceTypeName), roleType.getName());
-            } else {
-                assertEquals(Schema.Resource.HAS_RESOURCE_VALUE.getName(resourceTypeName), roleType.getName());
-            }
-        });
-    }
-
-    @Test
-    public void testMultipleResources() throws GraknValidationException {
+    public void whenAddingMultipleResourcesToEntity_EnsureDifferentRelationsAreBuilt() throws GraknValidationException {
         String resourceTypeId = "A Resource Thing";
         EntityType entityType = graknGraph.putEntityType("A Thing");
         ResourceType<String> resourceType = graknGraph.putResourceType(resourceTypeId, ResourceType.DataType.STRING);
@@ -326,27 +172,7 @@ public class EntityTest extends GraphTestBase{
     }
 
     @Test
-    public void testMultipleKeys() throws GraknValidationException {
-        String resourceTypeId = "A Resource Thing";
-        EntityType entityType = graknGraph.putEntityType("A Thing");
-        ResourceType<String> resourceType = graknGraph.putResourceType(resourceTypeId, ResourceType.DataType.STRING);
-        entityType.key(resourceType);
-
-        Entity entity = entityType.addEntity();
-        Resource resource1 = resourceType.putResource("A resource thing");
-        Resource resource2 = resourceType.putResource("Another resource thing");
-
-        Relation relation1 = entity.hasResource(resource1);
-        Relation relation2 = entity.hasResource(resource2);
-
-        assertNotEquals(relation1, relation2);
-
-        expectedException.expect(GraknValidationException.class);
-        graknGraph.validateGraph();
-    }
-
-    @Test
-    public void testNoKey() throws GraknValidationException {
+    public void whenMissingKeyOnEntity_Throw() throws GraknValidationException {
         String resourceTypeId = "A Resource Thing";
         EntityType entityType = graknGraph.putEntityType("A Thing");
         ResourceType<String> resourceType = graknGraph.putResourceType(resourceTypeId, ResourceType.DataType.STRING);

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/EntityTypeTest.java
@@ -71,6 +71,18 @@ public class EntityTypeTest extends GraphTestBase{
     }
 
     @Test
+    public void whenDeletingEntityTypeWithSubTypes_Throw() throws ConceptException{
+        EntityType c1 = graknGraph.putEntityType("C1");
+        EntityType c2 = graknGraph.putEntityType("C2");
+        c1.superType(c2);
+
+        expectedException.expect(ConceptException.class);
+        expectedException.expectMessage(ErrorMessage.CANNOT_DELETE.getMessage(c2.getName()));
+
+        c2.delete();
+    }
+
+    @Test
     public void testItemName(){
         Type test = graknGraph.putEntityType("test");
         assertEquals(TypeName.of("test"), test.getName());

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/RuleTest.java
@@ -21,14 +21,10 @@ package ai.grakn.graph.internal;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.RuleType;
-import ai.grakn.concept.Type;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.util.ErrorMessage;
-import ai.grakn.util.Schema;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +33,6 @@ import static ai.grakn.util.Schema.ConceptProperty.RULE_LHS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -70,58 +65,6 @@ public class RuleTest extends GraphTestBase{
         expectedException.expectMessage(NULL_VALUE.getMessage(RULE_LHS));
 
         conceptType.addRule(null, null);
-    }
-
-    @Test
-    public void testAddHypothesis() throws Exception {
-        RuleType conceptType = graknGraph.putRuleType("A Thing");
-        Rule rule = conceptType.addRule(lhs, rhs);
-        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(rule.getId().getRawValue()).next();
-        Type type1 = graknGraph.putEntityType("A Concept Type 1");
-        Type type2 = graknGraph.putEntityType("A Concept Type 2");
-        assertFalse(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.HYPOTHESIS.getLabel()).hasNext());
-        rule.addHypothesis(type1).addHypothesis(type2);
-        assertTrue(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.HYPOTHESIS.getLabel()).hasNext());
-    }
-
-    @Test
-    public void testAddConclusion() throws Exception {
-        RuleType conceptType = graknGraph.putRuleType("A Thing");
-        Rule rule = conceptType.addRule(lhs, rhs);
-        Vertex ruleVertex = graknGraph.getTinkerPopGraph().traversal().V(rule.getId().getRawValue()).next();
-        Type type1 = graknGraph.putEntityType("A Concept Type 1");
-        Type type2 = graknGraph.putEntityType("A Concept Type 2");
-        assertFalse(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.CONCLUSION.getLabel()).hasNext());
-        rule.addConclusion(type1).addConclusion(type2);
-        assertTrue(ruleVertex.edges(Direction.BOTH, Schema.EdgeLabel.CONCLUSION.getLabel()).hasNext());
-    }
-
-    @Test
-    public void testHypothesisTypes(){
-        RuleType ruleType = graknGraph.putRuleType("A Rule Type");
-        Rule rule = ruleType.addRule(lhs, rhs);
-        assertEquals(0, rule.getHypothesisTypes().size());
-
-        Type ct1 = graknGraph.putEntityType("A Concept Type 1");
-        Type ct2 = graknGraph.putEntityType("A Concept Type 2");
-        rule.addHypothesis(ct1).addHypothesis(ct2);
-        assertEquals(2, rule.getHypothesisTypes().size());
-        assertTrue(rule.getHypothesisTypes().contains(ct1));
-        assertTrue(rule.getHypothesisTypes().contains(ct2));
-    }
-
-    @Test
-    public void testConclusionTypes(){
-        RuleType ruleType = graknGraph.putRuleType("A Rule Type");
-        Rule rule = ruleType.addRule(lhs, rhs);
-        assertEquals(0, rule.getConclusionTypes().size());
-
-        Type ct1 = graknGraph.putEntityType("A Concept Type 1");
-        Type ct2 = graknGraph.putEntityType("A Concept Type 2");
-        rule.addConclusion(ct1).addConclusion(ct2);
-        assertEquals(2, rule.getConclusionTypes().size());
-        assertTrue(rule.getConclusionTypes().contains(ct1));
-        assertTrue(rule.getConclusionTypes().contains(ct2));
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
@@ -292,15 +292,13 @@ public class MovieGraph extends TestGraph {
         Pattern lhs = graph.graql().parsePattern("$x id 'expect-lhs'");
         Pattern rhs = graph.graql().parsePattern("$x id 'expect-rhs'");
 
-        Rule expectation = aRuleType.addRule(lhs, rhs)
-                .addConclusion(movie).addHypothesis(person);
+        Rule expectation = aRuleType.addRule(lhs, rhs);
 
         putResource(expectation, name, "expectation-rule");
 
         lhs = graph.graql().parsePattern("$x id 'materialize-lhs'");
         rhs = graph.graql().parsePattern("$x id 'materialize-rhs'");
-        Rule materialize = aRuleType.addRule(lhs, rhs)
-                .addConclusion(person).addConclusion(genre).addHypothesis(hasCast);
+        Rule materialize = aRuleType.addRule(lhs, rhs);
 
         putResource(materialize, name, "materialize-rule");
     }


### PR DESCRIPTION
- Cleaning up a lot of old tests which are no longer even remotely applicable
- Making test names more informative
- Removing API methods which are no longer needed
- Getting rid of redundant tests