### PR TITLE
Graql-native explanation

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
@@ -52,6 +52,12 @@ public interface MatchQueryAdmin extends MatchQuery {
     Stream<Map<VarName, Concept>> streamWithVarNames();
 
     /**
+     *
+     * @return
+     */
+    Stream<Answer> streamWithAnswers();
+
+    /**
      * @param graph the graph to use to get types from
      * @return all concept types referred to explicitly in the query
      */

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
@@ -52,8 +52,9 @@ public interface MatchQueryAdmin extends MatchQuery {
     Stream<Map<VarName, Concept>> streamWithVarNames();
 
     /**
-     *
-     * @return
+     * Get a stream of answers. This differs from {@code MatchQuery#execute} because it returns a stream of
+     * {@code Answer} objects containing the original map with {@code VarName} as key.
+     * @return a stream of answers
      */
     Stream<Answer> streamWithAnswers();
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatchQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatchQuery.java
@@ -31,6 +31,7 @@ import ai.grakn.graql.Order;
 import ai.grakn.graql.Printer;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarName;
+import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.MatchQueryAdmin;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.query.Queries;
@@ -85,10 +86,15 @@ abstract class AbstractMatchQuery implements MatchQueryAdmin {
      * @param graph the graph to use to execute the query
      * @return a stream of results
      */
-    public abstract Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph);
+    public abstract Stream<Answer> stream(Optional<GraknGraph> graph);
 
     @Override
     public final Stream<Map<VarName, Concept>> streamWithVarNames() {
+        return stream(Optional.empty()).map(Answer::map);
+    }
+
+    @Override
+    public final Stream<Answer> streamWithAnswers(){
         return stream(Optional.empty());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrder.java
@@ -18,10 +18,9 @@
 
 package ai.grakn.graql.internal.query.match;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 
-import java.util.Map;
+import ai.grakn.graql.admin.Answer;
 import java.util.stream.Stream;
 
 /**
@@ -36,5 +35,5 @@ public interface MatchOrder {
      * Order the stream
      * @param stream the stream to order
      */
-    Stream<Map<VarName, Concept>> orderStream(Stream<Map<VarName, Concept>> stream);
+    Stream<Answer> orderStream(Stream<Answer> stream);
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrderImpl.java
@@ -22,6 +22,7 @@ import ai.grakn.concept.Concept;
 import ai.grakn.graql.Order;
 import ai.grakn.graql.VarName;
 
+import ai.grakn.graql.admin.Answer;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -30,12 +31,12 @@ class MatchOrderImpl implements MatchOrder {
 
     private final VarName var;
 
-    private final Comparator<Map<VarName, Concept>> comparator;
+    private final Comparator<Answer> comparator;
 
     MatchOrderImpl(VarName var, Order order) {
         this.var = var;
 
-        Comparator<Map<VarName, Concept>> comparator = Comparator.comparing(this::getOrderValue);
+        Comparator<Answer> comparator = Comparator.comparing(this::getOrderValue);
 
         this.comparator = (order == Order.desc) ? comparator.reversed() : comparator;
     }
@@ -46,13 +47,13 @@ class MatchOrderImpl implements MatchOrder {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> orderStream(Stream<Map<VarName, Concept>> stream) {
+    public Stream<Answer> orderStream(Stream<Answer> stream) {
         return stream.sorted(comparator);
     }
 
     // All data types are comparable, so this is safe
     @SuppressWarnings("unchecked")
-    private Comparable<? super Comparable> getOrderValue(Map<VarName, Concept> result) {
+    private Comparable<? super Comparable> getOrderValue(Answer result) {
         return (Comparable<? super Comparable>) result.get(var).asResource().getValue();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchOrderImpl.java
@@ -18,13 +18,11 @@
 
 package ai.grakn.graql.internal.query.match;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.graql.Order;
 import ai.grakn.graql.VarName;
 
 import ai.grakn.graql.admin.Answer;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.stream.Stream;
 
 class MatchOrderImpl implements MatchOrder {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryBase.java
@@ -24,12 +24,14 @@ import ai.grakn.concept.Type;
 import ai.grakn.concept.TypeName;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.VarName;
+import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.gremlin.GraqlTraversal;
 import ai.grakn.graql.internal.gremlin.GreedyTraversalPlan;
 import ai.grakn.graql.internal.pattern.property.VarPropertyInternal;
+import ai.grakn.graql.internal.reasoner.query.QueryAnswer;
 import ai.grakn.graql.internal.util.CommonUtil;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.ImmutableSet;
@@ -76,8 +78,10 @@ public class MatchQueryBase extends AbstractMatchQuery {
         this.typeNames = getAllTypeNames();
     }
 
+
+
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> optionalGraph) {
+    public Stream<Answer> stream(Optional<GraknGraph> optionalGraph) {
         GraknGraph graph = optionalGraph.orElseThrow(
                 () -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage())
         );
@@ -101,7 +105,8 @@ public class MatchQueryBase extends AbstractMatchQuery {
         return traversal.toStream()
                 .map(vertices -> makeResults(graph, vertices))
                 .filter(result -> shouldShowResult(graph, result))
-                .sequential();
+                .sequential()
+                .map(QueryAnswer::new);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryDistinct.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryDistinct.java
@@ -19,10 +19,7 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
-import ai.grakn.graql.VarName;
-
-import java.util.Map;
+import ai.grakn.graql.admin.Answer;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -36,7 +33,7 @@ class MatchQueryDistinct extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
         return inner.stream(graph).distinct();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
@@ -19,13 +19,10 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.Type;
-import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.util.ErrorMessage;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryGraph.java
@@ -22,6 +22,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.Type;
 import ai.grakn.graql.VarName;
+import ai.grakn.graql.admin.Answer;
 import ai.grakn.util.ErrorMessage;
 
 import java.util.Map;
@@ -42,7 +43,7 @@ class MatchQueryGraph extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
         if (graph.isPresent()) {
             throw new IllegalStateException(ErrorMessage.MULTIPLE_GRAPH.getMessage());
         }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.reasoner.Reasoner;
+import ai.grakn.graql.internal.reasoner.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.Maps;
@@ -50,7 +51,7 @@ class MatchQueryInfer extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> optionalGraph) {
+    public Stream<Answer> stream(Optional<GraknGraph> optionalGraph) {
         GraknGraph graph = optionalOr(optionalGraph, inner.getGraph()).orElseThrow(
                 () -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage())
         );
@@ -59,13 +60,13 @@ class MatchQueryInfer extends MatchQueryModifier {
 
         Iterator<Conjunction<VarAdmin>> conjIt = getPattern().getDisjunctiveNormalForm().getPatterns().iterator();
         ReasonerQuery conjunctiveQuery = new ReasonerQueryImpl(conjIt.next(), graph);
-        Stream<Map<VarName, Concept>> answerStream = conjunctiveQuery.resolve(materialise, false).map(Answer::map);
+        Stream<Answer> answerStream = conjunctiveQuery.resolve(materialise, true);
         while(conjIt.hasNext()) {
             conjunctiveQuery = new ReasonerQueryImpl(conjIt.next(), graph);
-            Stream<Map<VarName, Concept>> localStream = conjunctiveQuery.resolve(materialise, false).map(Answer::map);
+            Stream<Answer> localStream = conjunctiveQuery.resolve(materialise, true);
             answerStream = Stream.concat(answerStream, localStream);
         }
-        return answerStream.map(result -> Maps.filterKeys(result, getSelectedNames()::contains));
+        return answerStream.map(result -> result.filterVars(getSelectedNames()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryInfer.java
@@ -19,20 +19,15 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
-import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.reasoner.Reasoner;
-import ai.grakn.graql.internal.reasoner.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.util.ErrorMessage;
-import com.google.common.collect.Maps;
 
 import java.util.Iterator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryLimit.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryLimit.java
@@ -22,6 +22,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 
+import ai.grakn.graql.admin.Answer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -39,7 +40,7 @@ class MatchQueryLimit extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
         return inner.stream(graph).limit(limit);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryLimit.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryLimit.java
@@ -19,11 +19,8 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
-import ai.grakn.graql.VarName;
 
 import ai.grakn.graql.admin.Answer;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOffset.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOffset.java
@@ -19,11 +19,8 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
-import ai.grakn.graql.VarName;
 
 import ai.grakn.graql.admin.Answer;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOffset.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOffset.java
@@ -22,6 +22,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 
+import ai.grakn.graql.admin.Answer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -39,7 +40,7 @@ class MatchQueryOffset extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
         return inner.stream(graph).skip(offset);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
@@ -22,6 +22,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 
+import ai.grakn.graql.admin.Answer;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -39,7 +40,7 @@ class MatchQueryOrder extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
         return order.orderStream(inner.stream(graph));
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQueryOrder.java
@@ -19,11 +19,8 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
-import ai.grakn.graql.VarName;
 
 import ai.grakn.graql.admin.Answer;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
@@ -19,15 +19,12 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknGraph;
-import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchQuerySelect.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.internal.query.match;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
+import ai.grakn.graql.admin.Answer;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -58,8 +59,8 @@ class MatchQuerySelect extends MatchQueryModifier {
     }
 
     @Override
-    public Stream<Map<VarName, Concept>> stream(Optional<GraknGraph> graph) {
-        return inner.stream(graph).map(result -> Maps.filterKeys(result, names::contains));
+    public Stream<Answer> stream(Optional<GraknGraph> graph) {
+        return inner.stream(graph).map(result -> result.filterVars(names));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Reasoner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Reasoner.java
@@ -94,31 +94,6 @@ public class Reasoner {
     }
 
     /**
-     * resolve query and provide each answer with a corresponding explicit path
-     * @param query to resolve
-     * @param materialise whether to materialise inferences
-     * @return stream of answers
-     */
-    public static Stream<Answer> resolveWithExplanation(MatchQuery query, boolean materialise) {
-        GraknGraph graph = optionalOr(query.admin().getGraph()).orElseThrow(
-                () -> new IllegalStateException(ErrorMessage.NO_GRAPH.getMessage())
-        );
-
-        if (!Reasoner.hasRules(graph)) return query.admin().streamWithVarNames().map(QueryAnswer::new);
-
-        Iterator<Conjunction<VarAdmin>> conjIt = query.admin().getPattern().getDisjunctiveNormalForm().getPatterns().iterator();
-        ReasonerQuery conjunctiveQuery = new ReasonerQueryImpl(conjIt.next(), graph);
-        Stream<Answer> answerStream = conjunctiveQuery.resolve(materialise, true);
-        while(conjIt.hasNext()) {
-            conjunctiveQuery = new ReasonerQueryImpl(conjIt.next(), graph);
-            Stream<Answer> localStream = conjunctiveQuery.resolve(materialise, true);
-            answerStream = Stream.concat(answerStream, localStream);
-        }
-        Set<VarName> selectVars = query.admin().getSelectedNames();
-        return answerStream.map(result -> result.filterVars(selectVars));
-    }
-
-    /**
      * materialise all possible inferences
      */
     public static void precomputeInferences(GraknGraph graph){

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Reasoner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/Reasoner.java
@@ -22,21 +22,11 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.TypeName;
 import ai.grakn.exception.GraknValidationException;
-import ai.grakn.graql.MatchQuery;
-import ai.grakn.graql.VarName;
-import ai.grakn.graql.admin.Conjunction;
-import ai.grakn.graql.admin.ReasonerQuery;
-import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.reasoner.cache.LazyQueryCache;
 import ai.grakn.graql.admin.Answer;
-import ai.grakn.graql.internal.reasoner.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
-import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
-import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
-import java.util.Iterator;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +36,6 @@ import java.util.stream.Collectors;
 
 import static ai.grakn.graql.Graql.name;
 import static ai.grakn.graql.Graql.var;
-import static ai.grakn.graql.internal.util.CommonUtil.optionalOr;
 
 /**
  *

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ExplanationTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/ExplanationTest.java
@@ -24,10 +24,10 @@ import ai.grakn.graphs.GenealogyGraph;
 import ai.grakn.graphs.GeoGraph;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.MatchQuery;
+import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.VarName;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
-import ai.grakn.graql.internal.reasoner.Reasoner;
 import ai.grakn.graql.internal.reasoner.query.QueryAnswer;
 import ai.grakn.test.GraphContext;
 import com.google.common.collect.ImmutableMap;
@@ -61,6 +61,7 @@ public class ExplanationTest {
     public void testTransitiveExplanation() {
         GraknGraph graph = geoGraph.graph();
         String queryString = "match (geo-entity: $x, entity-location: $y) isa is-located-in;";
+        QueryBuilder iqb = graph.graql().infer(true).materialise(false);
 
         Concept polibuda = getConcept(graph, "name", "Warsaw-Polytechnics");
         Concept warsaw = getConcept(graph, "name", "Warsaw");
@@ -73,9 +74,7 @@ public class ExplanationTest {
         Answer answer3 = new QueryAnswer(ImmutableMap.of(VarName.of("x"), polibuda, VarName.of("y"), poland));
         Answer answer4 = new QueryAnswer(ImmutableMap.of(VarName.of("x"), polibuda, VarName.of("y"), europe));
 
-        MatchQuery query = graph.graql().parse(queryString);
-
-        List<Answer> answers = Reasoner.resolveWithExplanation(query, false).collect(Collectors.toList());
+        List<Answer> answers = iqb.<MatchQuery>parse(queryString).admin().streamWithAnswers().collect(Collectors.toList());
 
         Answer queryAnswer1 = findAnswer(answer1, answers);
         Answer queryAnswer2 = findAnswer(answer2, answers);
@@ -100,6 +99,7 @@ public class ExplanationTest {
     @Test
     public void testExplainingSpecificAnswer(){
         GraknGraph graph = geoGraph.graph();
+        QueryBuilder iqb = graph.graql().infer(true).materialise(false);
         Concept polibuda = getConcept(graph, "name", "Warsaw-Polytechnics");
         Concept europe = getConcept(graph, "name", "Europe");
 
@@ -109,7 +109,7 @@ public class ExplanationTest {
                 "$y id '" + europe.getId() + "';";
 
         MatchQuery query = graph.graql().parse(queryString);
-        List<Answer> answers = Reasoner.resolveWithExplanation(query, false).collect(Collectors.toList());
+        List<Answer> answers = iqb.<MatchQuery>parse(queryString).admin().streamWithAnswers().collect(Collectors.toList());
         assertEquals(answers.size(), 1);
 
         Answer answer = answers.iterator().next();


### PR DESCRIPTION
- removed Reasoner endpoint for explanations
- explanations provided via MatchQueryInfer with all query modifiers applicable