### PR TITLE
Stop travis sending emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
 
 notifications:
   slack: grakn:RbxoPzX267spGT4cgmoGLMpT
+  email: false
+  
 install: mvn install -T 2.5C -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script:


### PR DESCRIPTION
Given that we get Slack notifications, this seems redundant.