### PR TITLE
Get rid of putResoureceTypeUnique

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -116,44 +116,6 @@ public interface GraknGraph extends AutoCloseable{
     <V> ResourceType<V> putResourceType(TypeName name, ResourceType.DataType<V> dataType);
 
     /**
-     * Create a unique {@link ResourceType} with super-type {@code resource}, or return a pre-existing
-     * unique {@link ResourceType}, with the specified name and data type.
-     * The {@link ResourceType} is guaranteed to be unique, in that its instances can be connected to one entity.
-     *
-     * @param name A unique name for the {@link ResourceType}
-     * @param dataType The data type of the {@link ResourceType}.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing {@link ResourceType} with the provided name.
-     *
-     * @throws GraphRuntimeException if the graph is closed
-     * @throws ConceptNotUniqueException if the {@param name} is already in use by an existing non-{@link ResourceType}.
-     * @throws ConceptException if the {@param name} is already in use by an existing {@link ResourceType} which is
-     *                          not unique or has a different datatype.
-     */
-    <V> ResourceType <V> putResourceTypeUnique(String name, ResourceType.DataType<V> dataType);
-
-    /**
-     * Create a unique {@link ResourceType} with super-type {@code resource}, or return a pre-existing
-     * unique {@link ResourceType}, with the specified name and data type.
-     * The {@link ResourceType} is guaranteed to be unique, in that its instances can be connected to one entity.
-     *
-     * @param name A unique name for the {@link ResourceType}
-     * @param dataType The data type of the {@link ResourceType}.
-     *             Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
-     * @param <V> The data type of the resource type. Supported types include: String, Long, Double, Boolean.
-     *           This should match the parameter type
-     * @return A new or existing {@link ResourceType} with the provided name.
-     *
-     * @throws GraphRuntimeException if the graph is closed
-     * @throws ConceptNotUniqueException if the {@param name} is already in use by an existing non-{@link ResourceType}.
-     * @throws ConceptException if the {@param name} is already in use by an existing {@link ResourceType} which is
-     *                          not unique or has a different datatype.
-     */
-    <V> ResourceType <V> putResourceTypeUnique(TypeName name, ResourceType.DataType<V> dataType);
-
-    /**
      * Create a {@link RuleType} with super-type {@code rule}, or return a pre-existing {@link RuleType}, with the
      * specified name.
      *

--- a/grakn-core/src/main/java/ai/grakn/concept/ResourceType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/ResourceType.java
@@ -189,13 +189,6 @@ public interface ResourceType<D> extends Type {
     String getRegex();
 
     /**
-     * Returns whether the ResourceType is unique.
-     *
-     * @return True if the ResourceType is unique and its instances are limited to one connection to an entity
-     */
-    Boolean isUnique();
-
-    /**
      *
      * @return a deep copy of this concept.
      */

--- a/grakn-core/src/main/java/ai/grakn/exception/ConceptNotUniqueException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/ConceptNotUniqueException.java
@@ -19,8 +19,6 @@
 package ai.grakn.exception;
 
 import ai.grakn.concept.Concept;
-import ai.grakn.concept.Instance;
-import ai.grakn.concept.Resource;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 
@@ -36,10 +34,6 @@ public class ConceptNotUniqueException extends ConceptException {
 
     public ConceptNotUniqueException(Concept concept, String id){
         super(ErrorMessage.ID_ALREADY_TAKEN.getMessage(id, concept.toString()));
-    }
-
-    public ConceptNotUniqueException(Resource resource, Instance instance){
-        super(ErrorMessage.RESOURCE_TYPE_UNIQUE.getMessage(resource.getId(), instance.getId()));
     }
 
     public ConceptNotUniqueException(String message){

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -47,7 +47,6 @@ public enum ErrorMessage {
     IMMUTABLE_VALUE("The value [%s] of concept [%s] cannot be changed to [%s] due to the property [%s] being immutable"),
     NULL_VALUE("The value of [%s] cannot be set to [null]"),
     META_TYPE_IMMUTABLE("The meta type [%s] is immutable"),
-    RESOURCE_TYPE_UNIQUE("The resource [%s] is unique and is already attached to [%s]."),
     SCHEMA_LOCKED("Schema cannot be modified when using a batch loading graph"),
     HAS_INVALID("The type [%s] is not allowed to have a %s of type [%s]"),
     INVALID_SYSTEM_KEYSPACE("The system keyspace appears to be corrupted: [%s]."),

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -149,7 +149,7 @@ public final class Schema {
 
         //Other Properties
         TYPE(String.class), IS_ABSTRACT(Boolean.class), IS_IMPLICIT(Boolean.class),
-        REGEX(String.class), DATA_TYPE(String.class), IS_UNIQUE(Boolean.class),
+        REGEX(String.class), DATA_TYPE(String.class),
         RULE_LHS(String.class), RULE_RHS(String.class),
 
         //Supported Data Types

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -475,33 +475,15 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     @SuppressWarnings("unchecked")
     @Override
     public <V> ResourceType<V> putResourceType(TypeName name, ResourceType.DataType<V> dataType) {
-        return putResourceType(name, dataType, Boolean.FALSE);
-    }
-
-    @Override
-    public <V> ResourceType <V> putResourceTypeUnique(String name, ResourceType.DataType<V> dataType){
-        return putResourceTypeUnique(TypeName.of(name), dataType);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <V> ResourceType<V> putResourceTypeUnique(TypeName name, ResourceType.DataType<V> dataType) {
-        return putResourceType(name, dataType, Boolean.TRUE);
-    }
-
-    private <V> ResourceType <V> putResourceType(TypeName name, ResourceType.DataType<V> dataType, Boolean isUnique){
-
         @SuppressWarnings("unchecked")
         ResourceType<V> resourceType = putType(name, Schema.BaseType.RESOURCE_TYPE,
-                v -> getElementFactory().buildResourceType(v, getMetaResourceType(), dataType, isUnique)).asResourceType();
+                v -> getElementFactory().buildResourceType(v, getMetaResourceType(), dataType)).asResourceType();
 
         //These checks is needed here because caching will return a type by name without checking the datatype
         if(Schema.MetaSchema.isMetaName(name)) {
             throw new ConceptException(ErrorMessage.META_TYPE_IMMUTABLE.getMessage(name));
         } else if(!dataType.equals(resourceType.getDataType())){
             throw new InvalidConceptValueException(ErrorMessage.IMMUTABLE_VALUE.getMessage(resourceType.getDataType(), resourceType, dataType, Schema.ConceptProperty.DATA_TYPE.name()));
-        } else if(resourceType.isUnique() ^ isUnique){
-            throw new InvalidConceptValueException(ErrorMessage.IMMUTABLE_VALUE.getMessage(resourceType.isUnique(), resourceType, isUnique, Schema.ConceptProperty.IS_UNIQUE.name()));
         }
 
         return resourceType;

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ElementFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ElementFactory.java
@@ -84,8 +84,8 @@ final class ElementFactory {
     }
 
     // ---------------------------------------- Building Resource Types  -----------------------------------------------
-    <V> ResourceTypeImpl<V> buildResourceType(Vertex vertex, ResourceType<V> type, ResourceType.DataType<V> dataType, Boolean isUnique){
-        return getOrBuildConcept(vertex, (v) -> new ResourceTypeImpl<>(graknGraph, v, type, dataType, isUnique));
+    <V> ResourceTypeImpl<V> buildResourceType(Vertex vertex, ResourceType<V> type, ResourceType.DataType<V> dataType){
+        return getOrBuildConcept(vertex, (v) -> new ResourceTypeImpl<>(graknGraph, v, type, dataType));
     }
 
     // ------------------------------------------ Building Resources

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/RelationImpl.java
@@ -21,12 +21,9 @@ package ai.grakn.graph.internal;
 import ai.grakn.concept.Instance;
 import ai.grakn.concept.Relation;
 import ai.grakn.concept.RelationType;
-import ai.grakn.concept.Resource;
 import ai.grakn.concept.RoleType;
-import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Arrays;
@@ -142,25 +139,6 @@ class RelationImpl extends InstanceImpl<Relation, RelationType> implements Relat
     public Relation addRolePlayer(RoleType roleType, Instance instance) {
         if(roleType == null){
             throw new IllegalArgumentException(ErrorMessage.ROLE_IS_NULL.getMessage(instance));
-        }
-
-        //Check if it is a unique resource
-        if(instance != null && instance.isResource()){
-            Resource<Object> resource = instance.asResource();
-            if(resource.type().isUnique()) {
-
-                GraphTraversal traversal = getGraknGraph().getTinkerTraversal().
-                        hasId(resource.getId().getValue()).
-                        in(Schema.EdgeLabel.SHORTCUT.getLabel());
-
-                if(traversal.hasNext()) {
-                    RelationImpl relation = getGraknGraph().getElementFactory().buildConcept((Vertex) traversal.next());
-                    Collection<Instance> rolePlayers = relation.rolePlayers();
-                    rolePlayers.remove(resource);
-
-                    if(!rolePlayers.isEmpty()) throw new ConceptNotUniqueException(resource, rolePlayers.iterator().next());
-                }
-            }
         }
 
         //Do the actual put of the role and role player

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
@@ -25,7 +25,6 @@ import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,10 +51,9 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
         super(graknGraph, v);
     }
 
-    ResourceTypeImpl(AbstractGraknGraph graknGraph, Vertex v, ResourceType<D> type, DataType<D> dataType, Boolean isUnique) {
+    ResourceTypeImpl(AbstractGraknGraph graknGraph, Vertex v, ResourceType<D> type, DataType<D> dataType) {
         super(graknGraph, v, type);
         setImmutableProperty(Schema.ConceptProperty.DATA_TYPE, dataType, getDataType(), DataType::getName);
-        setImmutableProperty(Schema.ConceptProperty.IS_UNIQUE, isUnique, getProperty(Schema.ConceptProperty.IS_UNIQUE), Function.identity());
     }
 
     private ResourceTypeImpl(ResourceTypeImpl resourceType){
@@ -131,12 +129,4 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
         return getProperty(Schema.ConceptProperty.REGEX);
     }
 
-    /**
-     *
-     * @return True if the resource type is unique and its instances are limited to one connection to an entity
-     */
-    @Override
-    public Boolean isUnique() {
-        return getPropertyBoolean(Schema.ConceptProperty.IS_UNIQUE);
-    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/GraknGraphs.java
@@ -162,14 +162,6 @@ public class GraknGraphs extends AbstractGenerator<GraknGraph> implements Minima
             },
             () -> {
                 TypeName typeName = typeName();
-                ResourceType.DataType dataType = gen(ResourceType.DataType.class);
-                ResourceType superType = resourceType();
-                ResourceType resourceType = graph.putResourceTypeUnique(typeName, dataType).superType(superType);
-                summaryAssign(resourceType, "graph", "putResourceTypeUnique", typeName, dataType);
-                summary(resourceType, "superType", superType);
-            },
-            () -> {
-                TypeName typeName = typeName();
                 RoleType superType = roleType();
                 RoleType roleType = graph.putRoleType(typeName).superType(superType);
                 summaryAssign(roleType, "graph", "putRoleType", typeName);

--- a/grakn-graph/src/test/java/ai/grakn/generator/PutTypeFunctions.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/PutTypeFunctions.java
@@ -38,7 +38,6 @@ public class PutTypeFunctions extends AbstractGenerator<BiFunction> {
         return random.choose(ImmutableList.of(
                 GraknGraph::putEntityType,
                 (graph, name) -> graph.putResourceType(name, gen(ResourceType.DataType.class)),
-                (graph, name) -> graph.putResourceTypeUnique(name, gen(ResourceType.DataType.class)),
                 GraknGraph::putRuleType,
                 GraknGraph::putRelationType,
                 GraknGraph::putRoleType

--- a/grakn-graph/src/test/java/ai/grakn/generator/ResourceTypes.java
+++ b/grakn-graph/src/test/java/ai/grakn/generator/ResourceTypes.java
@@ -21,20 +21,8 @@ package ai.grakn.generator;
 
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.TypeName;
-import com.pholser.junit.quickcheck.generator.GeneratorConfiguration;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 public class ResourceTypes extends AbstractTypeGenerator<ResourceType> {
-
-    private Unique unique;
 
     public ResourceTypes() {
         super(ResourceType.class);
@@ -44,34 +32,12 @@ public class ResourceTypes extends AbstractTypeGenerator<ResourceType> {
     protected ResourceType newType(TypeName name) {
         ResourceType.DataType<?> dataType = gen(ResourceType.DataType.class);
 
-        boolean shouldBeUnique = unique != null ? unique.value() : random.nextBoolean();
-
-        if (shouldBeUnique) {
-            return graph().putResourceTypeUnique(name, dataType);
-        } else {
-            return graph().putResourceType(name, dataType);
-        }
+        return graph().putResourceType(name, dataType);
     }
 
     @Override
     protected ResourceType metaType() {
         return graph().admin().getMetaResourceType();
-    }
-
-    @Override
-    protected boolean filter(ResourceType type) {
-        return unique == null || type.isUnique().equals(unique.value());
-    }
-
-    public void configure(Unique unique) {
-        this.unique = unique;
-    }
-
-    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
-    @Retention(RUNTIME)
-    @GeneratorConfiguration
-    public @interface Unique {
-        boolean value() default true;
     }
 
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTest.java
@@ -18,21 +18,17 @@
 
 package ai.grakn.graph.internal;
 
-import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Instance;
-import ai.grakn.concept.Relation;
 import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
-import ai.grakn.exception.ConceptNotUniqueException;
 import org.junit.Test;
 
 import java.time.LocalDateTime;
 
 import static ai.grakn.util.ErrorMessage.INVALID_DATATYPE;
-import static ai.grakn.util.ErrorMessage.RESOURCE_TYPE_UNIQUE;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -145,38 +141,6 @@ public class ResourceTest extends GraphTestBase{
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage(INVALID_DATATYPE.getMessage("1", String.class.getName()));
         stringResourceType.putResource(1L);
-    }
-
-    @Test
-    public void testUniqueResource(){
-        //Create Ontology
-        RoleType primaryKeyRole = graknGraph.putRoleType("Primary Key Role");
-        RoleType entityRole = graknGraph.putRoleType("Entity Role");
-        RelationType hasPrimaryKey = graknGraph.putRelationType("Has Parimary Key").hasRole(primaryKeyRole).hasRole(entityRole);
-
-
-        //Create Resources
-        ResourceType<String> primaryKeyType = graknGraph.putResourceTypeUnique("My Primary Key", ResourceType.DataType.STRING).playsRole(primaryKeyRole);
-        Resource pimaryKey1 = primaryKeyType.putResource("A Primary Key 1");
-        Resource pimaryKey2 = primaryKeyType.putResource("A Primary Key 2");
-
-        //Create Entities
-        EntityType entityType = graknGraph.putEntityType("My Entity Type").playsRole(entityRole);
-        Entity entity1 = entityType.addEntity();
-        Entity entity2 = entityType.addEntity();
-        Entity entity3 = entityType.addEntity();
-
-        //Link Entities to resources
-        assertNull(pimaryKey1.owner());
-        hasPrimaryKey.addRelation().addRolePlayer(primaryKeyRole, pimaryKey1).addRolePlayer(entityRole, entity1);
-        assertEquals(entity1, pimaryKey1.owner());
-
-        Relation relation = hasPrimaryKey.addRelation().addRolePlayer(primaryKeyRole, pimaryKey2).addRolePlayer(entityRole, entity2);
-
-        expectedException.expect(ConceptNotUniqueException.class);
-        expectedException.expectMessage(RESOURCE_TYPE_UNIQUE.getMessage(pimaryKey1.getId(), entity1.getId()));
-
-        hasPrimaryKey.addRelation().addRolePlayer(primaryKeyRole, pimaryKey1).addRolePlayer(entityRole, entity3);
     }
 
     @Test

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
@@ -33,8 +33,6 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class ResourceTypeTest extends GraphTestBase{
     private ResourceType<String> resourceType;
@@ -87,15 +85,6 @@ public class ResourceTypeTest extends GraphTestBase{
         expectedException.expect(InvalidConceptValueException.class);
         expectedException.expectMessage(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[abc]", thing.getId(), thing.getValue(), resourceType.getName()));
         resourceType.setRegex("[abc]");
-    }
-
-    @Test
-    public void testGetUniqueResourceType(){
-        ResourceType unique = graknGraph.putResourceTypeUnique("Random ID", ResourceType.DataType.LONG);
-        ResourceType notUnique = graknGraph.putResourceType("Random ID 2", ResourceType.DataType.LONG);
-
-        assertTrue(unique.isUnique());
-        assertFalse(notUnique.isUnique());
     }
 
     @Test

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPropertyTest.java
@@ -316,12 +316,6 @@ public class GraknGraphPropertyTest {
     }
 
     @Property
-    public void whenCallingIsUniqueOnMetaResourceType_ResultIsFalse(@Open GraknGraph graph) {
-        ResourceType resource = graph.admin().getMetaResourceType();
-        assertFalse(resource.isUnique());
-    }
-
-    @Property
     public void whenCreateInstanceOfMetaResourceType_Throw(
             @Open GraknGraph graph, @From(ResourceValues.class) Object value) {
         ResourceType resource = graph.admin().getMetaResourceType();

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPutPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPutPropertyTest.java
@@ -29,11 +29,9 @@ import ai.grakn.concept.Type;
 import ai.grakn.concept.TypeName;
 import ai.grakn.exception.ConceptException;
 import ai.grakn.exception.ConceptNotUniqueException;
-import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.generator.FromGraphGenerator.FromGraph;
 import ai.grakn.generator.GraknGraphs.Open;
 import ai.grakn.generator.PutTypeFunctions;
-import ai.grakn.generator.ResourceTypes.Unique;
 import ai.grakn.generator.TypeNames.Unused;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
@@ -55,7 +53,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeThat;
 
@@ -125,13 +122,12 @@ public class GraknGraphPutPropertyTest {
         ResourceType<?> resourceType = graph.putResourceType(typeName, dataType);
 
         assertEquals("The data-type should be as specified", dataType, resourceType.getDataType());
-        assertFalse("The resource type should not be unique", resourceType.isUnique());
         assertNull("The resource type should have no regex constraint", resourceType.getRegex());
     }
 
     @Property
     public void whenCallingPutResourceTypeWithThePropertiesOfAnExistingNonUniqueResourceType_ItReturnsThatType(
-            @Open GraknGraph graph, @FromGraph @Unique(false) ResourceType<?> resourceType) {
+            @Open GraknGraph graph, @FromGraph  ResourceType<?> resourceType) {
         assumeFalse(resourceType.equals(graph.admin().getMetaResourceType()));
 
         TypeName typeName = resourceType.getName();
@@ -155,7 +151,7 @@ public class GraknGraphPutPropertyTest {
 
     @Property
     public void whenCallingPutResourceTypeWithAnExistingNonUniqueResourceTypeNameButADifferentDataType_Throw(
-            @Open GraknGraph graph, @FromGraph @Unique(false) ResourceType<?> resourceType,
+            @Open GraknGraph graph, @FromGraph ResourceType<?> resourceType,
             ResourceType.DataType<?> dataType) {
         assumeThat(dataType, not(is(resourceType.getDataType())));
         TypeName typeName = resourceType.getName();
@@ -168,90 +164,6 @@ public class GraknGraphPutPropertyTest {
         }
 
         graph.putResourceType(typeName, dataType);
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeWithAnExistingUniqueResourceTypeName_Throw(
-            @Open GraknGraph graph, @FromGraph @Unique ResourceType<?> resourceType) {
-        TypeName typeName = resourceType.getName();
-        ResourceType.DataType<?> dataType = resourceType.getDataType();
-
-        exception.expect(ConceptException.class);
-        if(isMetaName(typeName)) {
-            exception.expectMessage(ErrorMessage.META_TYPE_IMMUTABLE.getMessage(typeName));
-        } else {
-            exception.expectMessage(ErrorMessage.IMMUTABLE_VALUE.getMessage(true, resourceType, false, Schema.ConceptProperty.IS_UNIQUE.name()));
-        }
-
-        graph.putResourceType(typeName, dataType);
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUnique_CreateATypeWithSuperTypeResource(
-            @Open GraknGraph graph, @Unused TypeName typeName, ResourceType.DataType<?> dataType) {
-        ResourceType<?> resourceType = graph.putResourceTypeUnique(typeName, dataType);
-        assertEquals(graph.admin().getMetaResourceType(), resourceType.superType());
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUnique_CreateATypeWithDefaultProperties(
-            @Open GraknGraph graph, @Unused TypeName typeName, ResourceType.DataType<?> dataType) {
-        ResourceType<?> resourceType = graph.putResourceTypeUnique(typeName, dataType);
-
-        assertEquals("The data-type should be as specified", dataType, resourceType.getDataType());
-        assertTrue("The resource type should be unique", resourceType.isUnique());
-        assertNull("The resource type should have no regex constraint", resourceType.getRegex());
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUniqueWithThePropertiesOfAnExistingUniqueResourceType_ItReturnsThatType(
-            @Open GraknGraph graph, @FromGraph @Unique ResourceType<?> resourceType) {
-        TypeName typeName = resourceType.getName();
-        ResourceType.DataType<?> dataType = resourceType.getDataType();
-
-        ResourceType<?> newType = graph.putResourceTypeUnique(typeName, dataType);
-
-        assertEquals(resourceType, newType);
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUniqueWithAnExistingNonResourceTypeName_Throw(
-            @Open GraknGraph graph, @FromGraph Type type, ResourceType.DataType<?> dataType) {
-        assumeFalse(type.isResourceType());
-
-        exception.expect(ConceptNotUniqueException.class);
-        exception.expectMessage(ErrorMessage.ID_ALREADY_TAKEN.getMessage(type.getName(), type));
-
-        graph.putResourceTypeUnique(type.getName(), dataType);
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUniqueWithAnExistingUniqueResourceTypeNameButADifferentDataType_Throw(
-            @Open GraknGraph graph, @FromGraph @Unique ResourceType<?> resourceType,
-            ResourceType.DataType<?> dataType) {
-        assumeThat(dataType, not(is(resourceType.getDataType())));
-        TypeName typeName = resourceType.getName();
-
-        exception.expect(InvalidConceptValueException.class);
-        exception.expectMessage(ErrorMessage.IMMUTABLE_VALUE.getMessage(resourceType.getDataType().getName(), resourceType, dataType.getName(), Schema.ConceptProperty.DATA_TYPE.name()));
-
-        graph.putResourceTypeUnique(typeName, dataType);
-    }
-
-    @Property
-    public void whenCallingPutResourceTypeUniqueWithAnExistingNonUniqueResourceTypeName_Throw(
-            @Open GraknGraph graph, @FromGraph @Unique(false) ResourceType<?> resourceType) {
-        TypeName typeName = resourceType.getName();
-        ResourceType.DataType<?> dataType = resourceType.getDataType();
-
-        exception.expect(ConceptException.class);
-        if(isMetaName(typeName)) {
-            exception.expectMessage(ErrorMessage.META_TYPE_IMMUTABLE.getMessage(typeName));
-        } else {
-            exception.expectMessage(ErrorMessage.IMMUTABLE_VALUE.getMessage(false, resourceType, true, Schema.ConceptProperty.IS_UNIQUE.name()));
-        }
-
-        graph.putResourceTypeUnique(typeName, dataType);
     }
 
     @Property

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPutPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPutPropertyTest.java
@@ -126,7 +126,7 @@ public class GraknGraphPutPropertyTest {
     }
 
     @Property
-    public void whenCallingPutResourceTypeWithThePropertiesOfAnExistingNonUniqueResourceType_ItReturnsThatType(
+    public void whenCallingPutResourceTypeWithThePropertiesOfAnExistingResourceType_ItReturnsThatType(
             @Open GraknGraph graph, @FromGraph  ResourceType<?> resourceType) {
         assumeFalse(resourceType.equals(graph.admin().getMetaResourceType()));
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
@@ -35,52 +35,13 @@ import java.util.Set;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.google.common.collect.Sets.union;
 import static org.apache.commons.lang.ArrayUtils.addAll;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeFalse;
 
 @RunWith(JUnitQuickcheck.class)
 public class RelationPropertyTest {
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
-
-    @Property
-    public void whenAddingARolePlayer_ItIsAddedToTheCollectionOfRolePlayers(
-            Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
-
-        assumeFalse(rolePlayer.isResource() && rolePlayer.asResource().type().isUnique());
-
-        relation.addRolePlayer(roleType, rolePlayer);
-
-        assertThat(relation.rolePlayers(), hasItem(rolePlayer));
-    }
-
-    @Property
-    public void whenAddingARolePlayerPlayingARole_TheRolePlayerIsAddedToTheCollectionOfRolePlayersForThatRole(
-            Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
-
-        assumeFalse(rolePlayer.isResource() && rolePlayer.asResource().type().isUnique());
-
-        relation.addRolePlayer(roleType, rolePlayer);
-
-        assertThat(relation.rolePlayers(roleType), hasItem(rolePlayer));
-    }
-
-    @Property
-    public void whenAddingARolePlayer_NoRolePlayersAreRemoved(
-            Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
-
-        assumeFalse(rolePlayer.isResource() && rolePlayer.asResource().type().isUnique());
-
-        Instance[] rolePlayers = relation.rolePlayers(roleType).toArray(new Instance[0]);
-
-        relation.addRolePlayer(roleType, rolePlayer);
-
-        assertThat(relation.rolePlayers(roleType), hasItems(rolePlayers));
-    }
 
     @Property
     public void whenCallingRolePlayers_TheResultIsASet(Relation relation, @FromGraph RoleType[] roles) {

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
@@ -39,7 +39,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assume.assumeFalse;
 
 @RunWith(JUnitQuickcheck.class)
 public class RelationPropertyTest {
@@ -51,8 +50,6 @@ public class RelationPropertyTest {
     public void whenAddingARolePlayer_ItIsAddedToTheCollectionOfRolePlayers(
         Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
 
-        assumeFalse(rolePlayer.isResource());
-
         relation.addRolePlayer(roleType, rolePlayer);
 
         assertThat(relation.rolePlayers(), hasItem(rolePlayer));
@@ -62,8 +59,6 @@ public class RelationPropertyTest {
     public void whenAddingARolePlayerPlayingARole_TheRolePlayerIsAddedToTheCollectionOfRolePlayersForThatRole(
         Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
 
-        assumeFalse(rolePlayer.isResource());
-
         relation.addRolePlayer(roleType, rolePlayer);
 
         assertThat(relation.rolePlayers(roleType), hasItem(rolePlayer));
@@ -72,8 +67,6 @@ public class RelationPropertyTest {
     @Property
     public void whenAddingARolePlayer_NoRolePlayersAreRemoved(
         Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
-
-        assumeFalse(rolePlayer.isResource());
 
         Instance[] rolePlayers = relation.rolePlayers(roleType).toArray(new Instance[0]);
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/RelationPropertyTest.java
@@ -35,13 +35,52 @@ import java.util.Set;
 import static com.google.common.collect.Sets.newHashSet;
 import static com.google.common.collect.Sets.union;
 import static org.apache.commons.lang.ArrayUtils.addAll;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
 
 @RunWith(JUnitQuickcheck.class)
 public class RelationPropertyTest {
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
+
+    @Property
+    public void whenAddingARolePlayer_ItIsAddedToTheCollectionOfRolePlayers(
+        Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
+
+        assumeFalse(rolePlayer.isResource());
+
+        relation.addRolePlayer(roleType, rolePlayer);
+
+        assertThat(relation.rolePlayers(), hasItem(rolePlayer));
+    }
+
+    @Property
+    public void whenAddingARolePlayerPlayingARole_TheRolePlayerIsAddedToTheCollectionOfRolePlayersForThatRole(
+        Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
+
+        assumeFalse(rolePlayer.isResource());
+
+        relation.addRolePlayer(roleType, rolePlayer);
+
+        assertThat(relation.rolePlayers(roleType), hasItem(rolePlayer));
+    }
+
+    @Property
+    public void whenAddingARolePlayer_NoRolePlayersAreRemoved(
+        Relation relation, @FromGraph RoleType roleType, @FromGraph Instance rolePlayer) {
+
+        assumeFalse(rolePlayer.isResource());
+
+        Instance[] rolePlayers = relation.rolePlayers(roleType).toArray(new Instance[0]);
+
+        relation.addRolePlayer(roleType, rolePlayer);
+
+        assertThat(relation.rolePlayers(roleType), hasItems(rolePlayers));
+    }
 
     @Property
     public void whenCallingRolePlayers_TheResultIsASet(Relation relation, @FromGraph RoleType[] roles) {


### PR DESCRIPTION
This method is completely unused outside of tests and since we have changed our definition of key/uniques/resources etc . . . 

This method no longer fits the requirement. 