### PR TITLE
Stop refreshing after every query in shell

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
@@ -232,10 +232,6 @@ class GraqlSession {
                     sendQueryError(errorMessage);
                 }
 
-                // Refresh the graph, in case it has been closed by analytics
-                // TODO: Handle this elsewhere (analytics or graph factory?)
-                attemptRefresh();
-
                 sendEnd();
             }
         });


### PR DESCRIPTION
This might be unnecessary and is causing issues with the new transactions.