### PR TITLE
New Background Task Which Counts The Number of Instances per Type

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
@@ -19,6 +19,7 @@
 package ai.grakn.graph.admin;
 
 import ai.grakn.concept.ConceptId;
+import ai.grakn.concept.TypeName;
 
 import java.util.Map;
 import java.util.Set;
@@ -45,18 +46,40 @@ public interface ConceptCache {
     long getNumJobs(String keyspace);
 
     /**
+     * Removes all jobs from the keyspace
      *
-     * @param keyspace The keyspace of a specific graph.
-     * @return The number of casting jobs pending to be performed on that graph
+     * @param keyspace The keyspace to purge of all jobs
      */
-    long getNumCastingJobs(String keyspace);
+    void clearAllJobs(String keyspace);
 
     /**
      *
-     * @param keyspace The keyspace of a specific graph.
-     * @return The number of resource jobs pending to be performed on that graph
+     * @return The timestamp of the last time a job was added
      */
-    long getNumResourceJobs(String keyspace);
+    long getLastTimeJobAdded();
+
+    //-------------------- Instance Count Jobs
+    /**
+     *
+     * @param keyspace The keyspace of a specific graph.
+     * @return The types and the number of instances that have been removed or added to the type
+     */
+    Map<TypeName, Long> getInstanceCountJobs(String keyspace);
+
+    /**
+     *
+     * @param keyspace The keyspace of the concepts
+     * @param name The name of the type with new or removed instances
+     * @param instances The number of new or removed instances
+     */
+    void addJobInstanceCount(String keyspace, TypeName name, long instances);
+
+    /**
+     *
+     * @param keyspace The keyspace of the concepts
+     * @param name The name of the type with new or removed instances
+     */
+    void deleteJobCasting(String keyspace, TypeName name);
 
     //-------------------- Casting Jobs
     /**
@@ -81,6 +104,20 @@ public interface ConceptCache {
      * @param castingId The casting Id which no longer needs post processing.
      */
     void deleteJobCasting(String keyspace, String castingIndex, ConceptId castingId);
+
+    /**
+     *
+     * @param keyspace The keyspace of a specific graph.
+     * @return The number of casting jobs pending to be performed on that graph
+     */
+    long getNumCastingJobs(String keyspace);
+
+    /**
+     *
+     * @param keyspace The keyspace of the concepts
+     * @param conceptIndex The unique index value has been enforced.
+     */
+    void clearJobSetCastings(String keyspace, String conceptIndex);
 
     //-------------------- Resource Jobs
     /**
@@ -108,28 +145,15 @@ public interface ConceptCache {
 
     /**
      *
+     * @param keyspace The keyspace of a specific graph.
+     * @return The number of resource jobs pending to be performed on that graph
+     */
+    long getNumResourceJobs(String keyspace);
+
+    /**
+     *
      * @param keyspace The keyspace of the concepts
      * @param conceptIndex The unique index value which has been enforced.
      */
     void clearJobSetResources(String keyspace, String conceptIndex);
-
-    /**
-     *
-     * @param keyspace The keyspace of the concepts
-     * @param conceptIndex The unique index value has been enforced.
-     */
-    void clearJobSetCastings(String keyspace, String conceptIndex);
-
-    /**
-     * Removes all jobs from the keyspace
-     *
-     * @param keyspace The keyspace to purge of all jobs
-     */
-    void clearAllJobs(String keyspace);
-
-    /**
-     *
-     * @return The timestamp of the last time a job was added
-     */
-    long getLastTimeJobAdded();
 }

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
@@ -70,9 +70,9 @@ public interface ConceptCache {
      *
      * @param keyspace The keyspace of the concepts
      * @param name The name of the type with new or removed instances
-     * @param instances The number of new or removed instances
+     * @param instanceCount The number of new or removed instances
      */
-    void addJobInstanceCount(String keyspace, TypeName name, long instances);
+    void addJobInstanceCount(String keyspace, TypeName name, long instanceCount);
 
     /**
      *

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
@@ -113,6 +113,7 @@ public interface ConceptCache {
     long getNumCastingJobs(String keyspace);
 
     /**
+     * Deletes the job set only if there are no pending jobs
      *
      * @param keyspace The keyspace of the concepts
      * @param conceptIndex The unique index value has been enforced.
@@ -151,6 +152,7 @@ public interface ConceptCache {
     long getNumResourceJobs(String keyspace);
 
     /**
+     * Deletes the job set only if there are no pending jobs
      *
      * @param keyspace The keyspace of the concepts
      * @param conceptIndex The unique index value which has been enforced.

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
@@ -19,7 +19,7 @@
 package ai.grakn.graph.admin;
 
 import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +64,7 @@ public interface ConceptCache {
      * @param keyspace The keyspace of a specific graph.
      * @return The types and the number of instances that have been removed or added to the type
      */
-    Map<TypeName, Long> getInstanceCountJobs(String keyspace);
+    Map<TypeLabel, Long> getInstanceCountJobs(String keyspace);
 
     /**
      *
@@ -72,14 +72,14 @@ public interface ConceptCache {
      * @param name The name of the type with new or removed instances
      * @param instanceCount The number of new or removed instances
      */
-    void addJobInstanceCount(String keyspace, TypeName name, long instanceCount);
+    void addJobInstanceCount(String keyspace, TypeLabel name, long instanceCount);
 
     /**
      *
      * @param keyspace The keyspace of the concepts
      * @param name The name of the type with new or removed instances
      */
-    void deleteJobInstanceCount(String keyspace, TypeName name);
+    void deleteJobInstanceCount(String keyspace, TypeLabel name);
 
     //-------------------- Casting Jobs
     /**

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/ConceptCache.java
@@ -79,7 +79,7 @@ public interface ConceptCache {
      * @param keyspace The keyspace of the concepts
      * @param name The name of the type with new or removed instances
      */
-    void deleteJobCasting(String keyspace, TypeName name);
+    void deleteJobInstanceCount(String keyspace, TypeName name);
 
     //-------------------- Casting Jobs
     /**

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
@@ -27,7 +27,7 @@ import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -167,7 +167,7 @@ public interface GraknAdmin {
      *
      * @param typeCounts The types and the changes to put on their counts
      */
-    void updateTypeCounts(Map<TypeName, Long> typeCounts);
+    void updateTypeCounts(Map<TypeLabel, Long> typeCounts);
 
     /**
      *

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
@@ -27,11 +27,13 @@ import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
+import ai.grakn.concept.TypeName;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -153,11 +155,20 @@ public interface GraknAdmin {
     boolean fixDuplicateCastings(String index, Set<ConceptId> castingVertexIds);
 
     /**
+     * Merges the provided duplicate resources
      *
      * @param resourceVertexIds The resource vertex ids which need to be merged.
      * @return True if a commit is required.
      */
     boolean fixDuplicateResources(String index, Set<ConceptId> resourceVertexIds);
+
+    /**
+     * Updates the counts of all the types
+     *
+     * @param typeCounts The types and the changes to put on their counts
+     * @return true if an update was performed thus requiring a commit
+     */
+    boolean updateTypeCounts(Map<TypeName, Long> typeCounts);
 
     /**
      *

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
@@ -166,9 +166,8 @@ public interface GraknAdmin {
      * Updates the counts of all the types
      *
      * @param typeCounts The types and the changes to put on their counts
-     * @return true if an update was performed thus requiring a commit
      */
-    boolean updateTypeCounts(Map<TypeName, Long> typeCounts);
+    void updateTypeCounts(Map<TypeName, Long> typeCounts);
 
     /**
      *

--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -82,9 +82,15 @@ public class REST {
         public static final String OFFSET_PARAM = "offset";
         public static final String HAL_CONTENTTYPE = "application/hal+json";
         public static final String GRAQL_CONTENTTYPE = "application/graql";
+
+        //Commit Logs
+        public static final String COMMIT_LOG_FIXING = "concepts-to-fix";
         public static final String COMMIT_LOG_TYPE = "concept-base-type";
         public static final String COMMIT_LOG_ID = "concept-vertex-id";
         public static final String COMMIT_LOG_INDEX = "concept-index";
+        public static final String COMMIT_LOG_COUNTING = "types-with-new-counts";
+        public static final String COMMIT_LOG_TYPE_NAME = "type-name";
+        public static final String COMMIT_LOG_INSTANCE_COUNT = "instance-count";
     }
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -149,7 +149,7 @@ public final class Schema {
 
         //Other Properties
         TYPE(String.class), IS_ABSTRACT(Boolean.class), IS_IMPLICIT(Boolean.class),
-        REGEX(String.class), DATA_TYPE(String.class),
+        REGEX(String.class), DATA_TYPE(String.class), INSTANCE_COUNT(Long.class),
         RULE_LHS(String.class), RULE_RHS(String.class),
 
         //Supported Data Types

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -25,6 +25,7 @@ import ai.grakn.engine.controller.UserController;
 import ai.grakn.engine.controller.VisualiserController;
 import ai.grakn.engine.postprocessing.PostProcessing;
 import ai.grakn.engine.postprocessing.PostProcessingTask;
+import ai.grakn.engine.postprocessing.UpdatingInstanceCountTask;
 import ai.grakn.engine.session.RemoteSession;
 import ai.grakn.engine.tasks.TaskManager;
 import ai.grakn.engine.tasks.TaskSchedule;
@@ -78,7 +79,7 @@ public class GraknEngineServer implements AutoCloseable {
         taskManager = startTaskManager(taskManagerClass);
         this.port = port;
         startHTTP();
-        startPostprocessing();
+        startRecurringBackgroundTasks();
         printStartMessage(prop.getProperty(SERVER_HOST_NAME), prop.getProperty(GraknEngineConfig.SERVER_PORT_NUMBER), prop.getLogFilePath());
     }
 
@@ -159,12 +160,16 @@ public class GraknEngineServer implements AutoCloseable {
         spark.exception(Exception.class,                  (e, req, res) -> handleInternalError(e, res));
     }
 
-    private void startPostprocessing(){
+    private void startRecurringBackgroundTasks(){
         // Submit a recurring post processing task
         Duration interval = Duration.ofMillis(prop.getPropertyAsInt(GraknEngineConfig.TIME_LAPSE));
         String creator = GraknEngineServer.class.getName();
+
         TaskState postprocessing = TaskState.of(PostProcessingTask.class, creator, TaskSchedule.recurring(interval), Json.object());
         taskManager.addTask(postprocessing);
+
+        TaskState updatingInstanceCount = TaskState.of(UpdatingInstanceCountTask.class, creator, TaskSchedule.recurring(interval), Json.object());
+        taskManager.addTask(updatingInstanceCount);
     }
 
     public void stopHTTP() {

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
@@ -233,7 +233,7 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
     }
 
     @Override
-    public void deleteJobCasting(String keyspace, TypeName name) {
+    public void deleteJobInstanceCount(String keyspace, TypeName name) {
         throw new UnsupportedOperationException("Not Yet Implemented");
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
@@ -19,6 +19,7 @@
 package ai.grakn.engine.cache;
 
 import ai.grakn.concept.ConceptId;
+import ai.grakn.concept.TypeName;
 import ai.grakn.engine.tasks.manager.ZookeeperConnection;
 import ai.grakn.exception.EngineStorageException;
 
@@ -217,5 +218,22 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
         if(indices.isPresent()){
             indices.get().forEach(index -> cleanJobSet(jobType, keyspace, index));
         }
+    }
+
+    //-------------------- Instance Count Jobs
+
+    @Override
+    public Map<TypeName, Long> getInstanceCountJobs(String keyspace) {
+        throw new UnsupportedOperationException("Not Yet Implemented");
+    }
+
+    @Override
+    public void addJobInstanceCount(String keyspace, TypeName name, long instances) {
+        throw new UnsupportedOperationException("Not Yet Implemented");
+    }
+
+    @Override
+    public void deleteJobCasting(String keyspace, TypeName name) {
+        throw new UnsupportedOperationException("Not Yet Implemented");
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheDistributed.java
@@ -19,7 +19,7 @@
 package ai.grakn.engine.cache;
 
 import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.tasks.manager.ZookeeperConnection;
 import ai.grakn.exception.EngineStorageException;
 
@@ -81,7 +81,7 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
     private String getPathExactJob(String jobType, String keyspace, String index, ConceptId conceptId){
         return format(ENGINE_CACHE_EXACT_JOB, keyspace, jobType, index, conceptId.getValue());
     }
-    private String getPathTypeInstanceCount(String keyspace, TypeName name){
+    private String getPathTypeInstanceCount(String keyspace, TypeLabel name){
         return format(ENGINE_CACHE_TYPE_INSTANCE_COUNT, keyspace, COUNTING_JOB, name);
     }
 
@@ -230,16 +230,16 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
     //-------------------- Instance Count Jobs
 
     @Override
-    public Map<TypeName, Long> getInstanceCountJobs(String keyspace) {
-        Map<TypeName, Long> results = new HashMap<>();
+    public Map<TypeLabel, Long> getInstanceCountJobs(String keyspace) {
+        Map<TypeLabel, Long> results = new HashMap<>();
         Optional<List<String>> types = getChildrenFromZookeeper(getPathJobRoot(COUNTING_JOB, keyspace));
 
         if(types.isPresent()){
             types.get().forEach(name -> {
-                String pathTypeIntanceCount = getPathTypeInstanceCount(keyspace, TypeName.of(name));
+                String pathTypeIntanceCount = getPathTypeInstanceCount(keyspace, TypeLabel.of(name));
                 Optional<Object> value = getObjectFromZookeeper(pathTypeIntanceCount);
                 if(value.isPresent()){
-                    results.put(TypeName.of(name), (Long) value.get());
+                    results.put(TypeLabel.of(name), (Long) value.get());
                 } else {
                     deleteObjectFromZookeeper(pathTypeIntanceCount); //We have a type saved with no count. Kill it
                 }
@@ -250,7 +250,7 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
     }
 
     @Override
-    public void addJobInstanceCount(String keyspace, TypeName name, long instanceCount) {
+    public void addJobInstanceCount(String keyspace, TypeLabel name, long instanceCount) {
         String path = getPathTypeInstanceCount(keyspace, name);
         Optional<Object> currentValue = getObjectFromZookeeper(path);
         long newValue = instanceCount;
@@ -263,7 +263,7 @@ public class EngineCacheDistributed extends EngineCacheAbstract{
     }
 
     @Override
-    public void deleteJobInstanceCount(String keyspace, TypeName name) {
+    public void deleteJobInstanceCount(String keyspace, TypeLabel name) {
         deleteObjectFromZookeeper(getPathTypeInstanceCount(keyspace, name));
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
@@ -159,7 +159,7 @@ public class EngineCacheStandAlone extends EngineCacheAbstract{
     }
 
     @Override
-    public void deleteJobCasting(String keyspace, TypeName name) {
+    public void deleteJobInstanceCount(String keyspace, TypeName name) {
         getInstanceCountJobs(keyspace).remove(name);
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
@@ -144,6 +144,7 @@ public class EngineCacheStandAlone extends EngineCacheAbstract{
         updateLastTimeJobAdded();
         if(castings.containsKey(keyspace)) castings.remove(keyspace);
         if(resources.containsKey(keyspace)) resources.remove(keyspace);
+        if(instanceCounts.containsKey(keyspace)) instanceCounts.remove(keyspace);
     }
 
     //-------------------- Instance Count Jobs

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author fppt
  */
-//TODO: Maybe we can merge this with distributed engine cache using Kafka for example?
 public class EngineCacheStandAlone extends EngineCacheAbstract{
     //These are maps of keyspaces to indices to vertex ids
     private final Map<String, Map<String, Set<ConceptId>>> castings;
@@ -155,8 +154,8 @@ public class EngineCacheStandAlone extends EngineCacheAbstract{
     }
 
     @Override
-    public void addJobInstanceCount(String keyspace, TypeName name, long instances) {
-        getInstanceCountJobs(keyspace).compute(name, (key, value) -> value == null ? instances : value + instances);
+    public void addJobInstanceCount(String keyspace, TypeName name, long instanceCount) {
+        getInstanceCountJobs(keyspace).compute(name, (key, value) -> value == null ? instanceCount : value + instanceCount);
     }
 
     @Override

--- a/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/cache/EngineCacheStandAlone.java
@@ -19,7 +19,7 @@
 package ai.grakn.engine.cache;
 
 import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -47,7 +47,7 @@ public class EngineCacheStandAlone extends EngineCacheAbstract{
     //These are maps of keyspaces to indices to vertex ids
     private final Map<String, Map<String, Set<ConceptId>>> castings;
     private final Map<String, Map<String, Set<ConceptId>>> resources;
-    private final Map<String, Map<TypeName, Long>> instanceCounts;
+    private final Map<String, Map<TypeLabel, Long>> instanceCounts;
 
     private static EngineCacheStandAlone instance=null;
 
@@ -149,17 +149,17 @@ public class EngineCacheStandAlone extends EngineCacheAbstract{
     //-------------------- Instance Count Jobs
 
     @Override
-    public Map<TypeName, Long> getInstanceCountJobs(String keyspace) {
+    public Map<TypeLabel, Long> getInstanceCountJobs(String keyspace) {
         return instanceCounts.computeIfAbsent(keyspace, (key) -> new ConcurrentHashMap<>());
     }
 
     @Override
-    public void addJobInstanceCount(String keyspace, TypeName name, long instanceCount) {
+    public void addJobInstanceCount(String keyspace, TypeLabel name, long instanceCount) {
         getInstanceCountJobs(keyspace).compute(name, (key, value) -> value == null ? instanceCount : value + instanceCount);
     }
 
     @Override
-    public void deleteJobInstanceCount(String keyspace, TypeName name) {
+    public void deleteJobInstanceCount(String keyspace, TypeLabel name) {
         getInstanceCountJobs(keyspace).remove(name);
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -59,7 +59,7 @@ public class CommitLogController {
     @GET
     @Path("/commit_log")
     @ApiOperation(value = "Delete all the post processing jobs for a specific keyspace")
-    @ApiImplicitParam(name = "keysoace", value = "The key space of an opened graph", required = true, dataType = "string", paramType = "path")
+    @ApiImplicitParam(name = "keyspace", value = "The key space of an opened graph", required = true, dataType = "string", paramType = "path")
     private String deleteConcepts(Request req, Response res){
         String graphName = req.queryParams(REST.Request.KEYSPACE_PARAM);
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -78,7 +78,7 @@ public class CommitLogController {
     @ApiOperation(value = "Submits post processing jobs for a specific keyspace")
     @ApiImplicitParams({
         @ApiImplicitParam(name = "keyspace", value = "The key space of an opened graph", required = true, dataType = "string", paramType = "path"),
-            @ApiImplicitParam(name = "concepts", value = "A Json Array of IDs representing concepts to be post processed", required = true, dataType = "string", paramType = "body")
+            @ApiImplicitParam(name = REST.Request.COMMIT_LOG_FIXING, value = "A Json Array of IDs representing concepts to be post processed", required = true, dataType = "string", paramType = "body")
     })
     private String submitConcepts(Request req, Response res) {
         try {
@@ -89,7 +89,7 @@ public class CommitLogController {
             }
             LOG.info("Commit log received for graph [" + graphName + "]");
 
-            JSONArray jsonArray = (JSONArray) new JSONObject(req.body()).get("concepts");
+            JSONArray jsonArray = (JSONArray) new JSONObject(req.body()).get(REST.Request.COMMIT_LOG_FIXING);
 
             for (Object object : jsonArray) {
                 JSONObject jsonObject = (JSONObject) object;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -19,7 +19,7 @@
 package ai.grakn.engine.controller;
 
 import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.cache.EngineCacheProvider;
 import ai.grakn.graph.admin.ConceptCache;
@@ -114,7 +114,7 @@ public class CommitLogController {
         JSONArray instancesToCount = (JSONArray) new JSONObject(req.body()).get(REST.Request.COMMIT_LOG_COUNTING);
         for (Object object : instancesToCount) {
             JSONObject jsonObject = (JSONObject) object;
-            TypeName name = TypeName.of(jsonObject.getString(REST.Request.COMMIT_LOG_TYPE_NAME));
+            TypeLabel name = TypeLabel.of(jsonObject.getString(REST.Request.COMMIT_LOG_TYPE_NAME));
             Long value = jsonObject.getLong(REST.Request.COMMIT_LOG_INSTANCE_COUNT);
             cache.addJobInstanceCount(graphName, name, value);
         }

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -1,0 +1,29 @@
+package ai.grakn.engine.postprocessing;
+
+import ai.grakn.engine.tasks.BackgroundTask;
+import ai.grakn.engine.tasks.TaskCheckpoint;
+import mjson.Json;
+
+import java.util.function.Consumer;
+
+public class UpdatingInstanceCountTask implements BackgroundTask {
+    @Override
+    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public boolean stop() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public void pause() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public boolean resume(Consumer<TaskCheckpoint> saveCheckpoint, TaskCheckpoint lastCheckpoint) {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+}

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -20,7 +20,7 @@ package ai.grakn.engine.postprocessing;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.GraknTxType;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.cache.EngineCacheProvider;
 import ai.grakn.engine.tasks.BackgroundTask;
@@ -58,7 +58,7 @@ public class UpdatingInstanceCountTask implements BackgroundTask {
     }
 
     private void updateCountsOnKeySpace(String keyspace){
-        Map<TypeName, Long> jobs = new HashMap<>(cache.getInstanceCountJobs(keyspace));
+        Map<TypeLabel, Long> jobs = new HashMap<>(cache.getInstanceCountJobs(keyspace));
         //Clear the cache optimistically because we think we going to update successfully
         jobs.forEach((key, value) -> cache.deleteJobInstanceCount(keyspace, key));
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -1,3 +1,21 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
 package ai.grakn.engine.postprocessing;
 
 import ai.grakn.engine.tasks.BackgroundTask;
@@ -6,6 +24,17 @@ import mjson.Json;
 
 import java.util.function.Consumer;
 
+/**
+ * <p>
+ *     Task that controls when types are updated with their new instance counts
+ * </p>
+ *
+ * <p>
+ *     This task begins only if enough time has passed (configurable) since the last time a job was added.
+ * </p>
+ *
+ * @author fppt
+ */
 public class UpdatingInstanceCountTask implements BackgroundTask {
     @Override
     public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -32,6 +32,7 @@ import mjson.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -57,7 +58,7 @@ public class UpdatingInstanceCountTask implements BackgroundTask {
     }
 
     private void updateCountsOnKeySpace(String keyspace){
-        Map<TypeName, Long> jobs = cache.getInstanceCountJobs(keyspace);
+        Map<TypeName, Long> jobs = new HashMap<>(cache.getInstanceCountJobs(keyspace));
         //Clear the cache optimistically because we think we going to update successfully
         jobs.forEach((key, value) -> cache.deleteJobInstanceCount(keyspace, key));
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ZookeeperPaths.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ZookeeperPaths.java
@@ -44,9 +44,10 @@ public interface ZookeeperPaths {
 
     String ENGINE_CACHE = "/engine/cache/";
     String ENGINE_CACHE_KEYSPACES = ENGINE_CACHE + "keyspaces";
-    //String ENGINE_CACHE_JOBS = ENGINE_CACHE + "%s/%s"; //Format is /keyspace/job_type
 
-    String ENGINE_CACHE_INDICES = ENGINE_CACHE + "%s/%s"; //Used to get all the indices of a job type
-    String ENGINE_CACHE_CONCEPT_IDS = ENGINE_CACHE_INDICES +  "/%s"; //Used to get all the ids of a specific index
+    String ENGINE_CACHE_JOB_TYPE = ENGINE_CACHE + "%s/%s"; //Used to get all the indices of a job type
+    String ENGINE_CACHE_CONCEPT_IDS = ENGINE_CACHE_JOB_TYPE +  "/%s"; //Used to get all the ids of a specific index
     String ENGINE_CACHE_EXACT_JOB = ENGINE_CACHE_CONCEPT_IDS + "/%s";
+
+    String ENGINE_CACHE_TYPE_INSTANCE_COUNT = ENGINE_CACHE_JOB_TYPE + "/%s";
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -1051,7 +1051,12 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     @Override
-    public boolean updateTypeCounts(Map<TypeName, Long> typeCounts){
-        throw new UnsupportedOperationException("Not yet implemented");
+    public void updateTypeCounts(Map<TypeName, Long> typeCounts){
+       typeCounts.entrySet().forEach(entry -> {
+           if(entry.getValue() != 0) {
+               TypeImpl type = getType(entry.getKey());
+               type.setInstanceCount(type.getInstanceCount() + entry.getValue());
+           }
+       });
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -845,15 +845,26 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     private void submitCommitLogs(Set<Pair<String, ConceptId>> castings, Set<Pair<String, ConceptId>> resources){
-        JSONArray jsonArray = new JSONArray();
+        //Concepts In Need of Inspection
+        JSONArray conceptsForInspection = new JSONArray();
+        loadCommitLogConcepts(conceptsForInspection, Schema.BaseType.CASTING, castings);
+        loadCommitLogConcepts(conceptsForInspection, Schema.BaseType.RESOURCE, resources);
 
-        loadCommitLogConcepts(jsonArray, Schema.BaseType.CASTING, castings);
-        loadCommitLogConcepts(jsonArray, Schema.BaseType.RESOURCE, resources);
+        //Types with instance changes
+        JSONArray typesWithInstanceChanges = new JSONArray();
+        getConceptLog().getInstanceCount().entrySet().forEach(entry -> {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put(REST.Request.COMMIT_LOG_TYPE_NAME, entry.getKey().getValue());
+            jsonObject.put(REST.Request.COMMIT_LOG_INSTANCE_COUNT, entry.getValue());
+            typesWithInstanceChanges.put(jsonObject);
+        });
 
+        //Final Commit Log
         JSONObject postObject = new JSONObject();
-        postObject.put("concepts", jsonArray);
-        LOG.debug("Response from engine [" + EngineCommunicator.contactEngine(getCommitLogEndPoint(), REST.HttpConn.POST_METHOD, postObject.toString()) + "]");
+        postObject.put(REST.Request.COMMIT_LOG_FIXING, conceptsForInspection);
+        postObject.put(REST.Request.COMMIT_LOG_COUNTING, typesWithInstanceChanges);
 
+        LOG.debug("Response from engine [" + EngineCommunicator.contactEngine(getCommitLogEndPoint(), REST.HttpConn.POST_METHOD, postObject.toString()) + "]");
     }
     private void loadCommitLogConcepts(JSONArray jsonArray, Schema.BaseType baseType, Set<Pair<String, ConceptId>> concepts){
         concepts.forEach(concept -> {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -1051,7 +1051,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     @Override
-    public void updateTypeCounts(Map<TypeName, Long> typeCounts){
+    public void updateTypeCounts(Map<TypeLabel, Long> typeCounts){
        typeCounts.entrySet().forEach(entry -> {
            if(entry.getValue() != 0) {
                TypeImpl type = getType(entry.getKey());

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -1049,4 +1049,9 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         String newHash = generateNewHash(relationType, allRolePlayers);
         getConceptLog().getModifiedRelations().put(newHash, foundRelation);
     }
+
+    @Override
+    public boolean updateTypeCounts(Map<TypeName, Long> typeCounts){
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
@@ -63,7 +63,7 @@ class ConceptLog {
     private final Map<String, RelationImpl> modifiedRelations = new HashMap<>();
 
     //We Track the number of instances each type has lost or gained
-    private final Map<TypeName, Long> instanceCount = new HashMap<>();
+    private final Map<TypeLabel, Long> instanceCount = new HashMap<>();
 
 
     ConceptLog(AbstractGraknGraph<?> graknGraph) {
@@ -144,7 +144,7 @@ class ConceptLog {
      *
      * @return All the types that have gained or lost instances and by how much
      */
-    Map<TypeName, Long> getInstanceCount(){
+    Map<TypeLabel, Long> getInstanceCount(){
         return instanceCount;
     }
 
@@ -228,15 +228,15 @@ class ConceptLog {
         return (X) typeCache.get(label);
     }
 
-    void addedInstance(TypeName name){
+    void addedInstance(TypeLabel name){
         instanceCount.compute(name, (key, value) -> value == null ? 1 : value + 1);
         cleanupInstanceCount(name);
     }
-    void removedInstance(TypeName name){
+    void removedInstance(TypeLabel name){
         instanceCount.compute(name, (key, value) -> value == null ? -1 : value - 1);
         cleanupInstanceCount(name);
     }
-    private void cleanupInstanceCount(TypeName name){
+    private void cleanupInstanceCount(TypeLabel name){
         if(instanceCount.get(name) == 0) instanceCount.remove(name);
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptLog.java
@@ -62,6 +62,9 @@ class ConceptLog {
     //We Track Relations so that we can look them up before they are completely defined and indexed on commit
     private final Map<String, RelationImpl> modifiedRelations = new HashMap<>();
 
+    //We Track the number of instances each type has lost or gained
+    private final Map<TypeName, Long> instanceCount = new HashMap<>();
+
 
     ConceptLog(AbstractGraknGraph<?> graknGraph) {
         this.graknGraph = graknGraph;
@@ -135,6 +138,14 @@ class ConceptLog {
      */
     Map<String, RelationImpl> getModifiedRelations(){
         return modifiedRelations;
+    }
+
+    /**
+     *
+     * @return All the types that have gained or lost instances and by how much
+     */
+    Map<TypeName, Long> getInstanceCount(){
+        return instanceCount;
     }
 
     /**
@@ -215,5 +226,17 @@ class ConceptLog {
     <X extends Type> X getCachedType(TypeLabel label){
         //noinspection unchecked
         return (X) typeCache.get(label);
+    }
+
+    void addedInstance(TypeName name){
+        instanceCount.compute(name, (key, value) -> value == null ? 1 : value + 1);
+        cleanupInstanceCount(name);
+    }
+    void removedInstance(TypeName name){
+        instanceCount.compute(name, (key, value) -> value == null ? -1 : value - 1);
+        cleanupInstanceCount(name);
+    }
+    private void cleanupInstanceCount(TypeName name){
+        if(instanceCount.get(name) == 0) instanceCount.remove(name);
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
@@ -77,6 +77,7 @@ abstract class InstanceImpl<T extends Instance, V extends Type> extends ConceptI
     public void delete() {
         InstanceImpl<?, ?> parent = this;
         Set<CastingImpl> castings = parent.castings();
+        getGraknGraph().getConceptLog().removedInstance(type().getName());
         deleteNode();
         for(CastingImpl casting: castings){
             Set<Relation> relations = casting.getRelations();

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/InstanceImpl.java
@@ -77,7 +77,7 @@ abstract class InstanceImpl<T extends Instance, V extends Type> extends ConceptI
     public void delete() {
         InstanceImpl<?, ?> parent = this;
         Set<CastingImpl> castings = parent.castings();
-        getGraknGraph().getConceptLog().removedInstance(type().getName());
+        getGraknGraph().getConceptLog().removedInstance(type().getLabel());
         deleteNode();
         for(CastingImpl casting: castings){
             Set<Relation> relations = casting.getRelations();

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -671,13 +671,13 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         }
     }
 
-    public long getInstanceCount(){
+    long getInstanceCount(){
         Long value = getProperty(Schema.ConceptProperty.INSTANCE_COUNT);
         if(value == null) return 0L;
         return value;
     }
 
-    public void setInstanceCount(Long instanceCount){
+    void setInstanceCount(Long instanceCount){
         setProperty(Schema.ConceptProperty.INSTANCE_COUNT, instanceCount);
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -670,4 +670,14 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
             throw new ConceptException(ErrorMessage.CANNOT_BE_KEY_AND_RESOURCE.getMessage(getLabel(), resourceType.getLabel()));
         }
     }
+
+    private Long getInstanceCount(){
+        Long value = getProperty(Schema.ConceptProperty.INSTANCE_COUNT);
+        if(value == null) return 0L;
+        return value;
+    }
+
+    private void setInstanceCount(Long instanceCount){
+        setProperty(Schema.ConceptProperty.INSTANCE_COUNT, instanceCount);
+    }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -150,6 +150,7 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         }
 
         Vertex instanceVertex = getGraknGraph().addVertex(instanceBaseType);
+        getGraknGraph().getConceptLog().addedInstance(getName());
         return producer.apply(instanceVertex, getThis());
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -671,13 +671,13 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         }
     }
 
-    private Long getInstanceCount(){
+    public long getInstanceCount(){
         Long value = getProperty(Schema.ConceptProperty.INSTANCE_COUNT);
         if(value == null) return 0L;
         return value;
     }
 
-    private void setInstanceCount(Long instanceCount){
+    public void setInstanceCount(Long instanceCount){
         setProperty(Schema.ConceptProperty.INSTANCE_COUNT, instanceCount);
     }
 }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TypeImpl.java
@@ -150,7 +150,7 @@ class TypeImpl<T extends Type, V extends Instance> extends ConceptImpl<T> implem
         }
 
         Vertex instanceVertex = getGraknGraph().addVertex(instanceBaseType);
-        getGraknGraph().getConceptLog().addedInstance(getName());
+        getGraknGraph().getConceptLog().addedInstance(getLabel());
         return producer.apply(instanceVertex, getThis());
     }
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptLogTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptLogTest.java
@@ -138,17 +138,17 @@ public class ConceptLogTest extends GraphTestBase{
         Entity e1 = entityType.addEntity();
         Entity e2 = entityType.addEntity();
         relationType.addRelation();
-        assertEquals(2, (long) conceptLog.getInstanceCount().get(entityType.getName()));
-        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
+        assertEquals(2, (long) conceptLog.getInstanceCount().get(entityType.getLabel()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getLabel()));
 
         //Remove an entity
         e1.delete();
-        assertEquals(1, (long) conceptLog.getInstanceCount().get(entityType.getName()));
-        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(entityType.getLabel()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getLabel()));
 
         //Remove another entity
         e2.delete();
-        assertFalse(conceptLog.getInstanceCount().containsKey(entityType.getName()));
-        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
+        assertFalse(conceptLog.getInstanceCount().containsKey(entityType.getLabel()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getLabel()));
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptLogTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptLogTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
 /**
@@ -122,5 +124,31 @@ public class ConceptLogTest extends GraphTestBase{
 
         i1.delete();
         assertThat(graknGraph.getConceptLog().getModifiedConcepts(), is(empty()));
+    }
+
+    @Test
+    public void whenAddingAndRemovingInstancesFromTypes_EnsureLogTracksNumberOfChanges(){
+        EntityType entityType = graknGraph.putEntityType("My Type");
+        RelationType relationType = graknGraph.putRelationType("My Relation Type");
+
+        ConceptLog conceptLog = graknGraph.getConceptLog();
+        assertThat(conceptLog.getInstanceCount().keySet(), empty());
+
+        //Add some instances
+        Entity e1 = entityType.addEntity();
+        Entity e2 = entityType.addEntity();
+        relationType.addRelation();
+        assertEquals(2, (long) conceptLog.getInstanceCount().get(entityType.getName()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
+
+        //Remove an entity
+        e1.delete();
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(entityType.getName()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
+
+        //Remove another entity
+        e2.delete();
+        assertFalse(conceptLog.getInstanceCount().containsKey(entityType.getName()));
+        assertEquals(1, (long) conceptLog.getInstanceCount().get(relationType.getName()));
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
@@ -227,8 +227,9 @@ public class PostProcessingTest extends GraphTestBase{
 
         //Lets Set Some Counts
         types.put(t1.getName(), -5L);
-        types.put(t1.getName(), -2L);
-        types.put(t1.getName(), 3L);
+        types.put(t2.getName(), -2L);
+        types.put(t3.getName(), 3L);
+        graknGraph.admin().updateTypeCounts(types);
 
         assertEquals(0L, t1.getInstanceCount());
         assertEquals(4L, t2.getInstanceCount());

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
@@ -25,13 +25,16 @@ import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
+import ai.grakn.concept.TypeName;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -40,7 +43,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class PostprocessingTest extends GraphTestBase{
+public class PostProcessingTest extends GraphTestBase{
     private RoleType roleType1;
     private RoleType roleType2;
     private RelationType relationType;
@@ -203,5 +206,32 @@ public class PostprocessingTest extends GraphTestBase{
         resourceVertex.property(Schema.ConceptProperty.ID.name(), resourceVertex.id().toString());
 
         return new ResourceImpl<>(graknGraph, resourceVertex);
+    }
+
+    @Test
+    public void whenUpdatingTheCountsOfTypes_TheTypesHaveNewCounts() {
+        Map<TypeName, Long> types = new HashMap<>();
+        //Create Some Types;
+        EntityTypeImpl t1 = (EntityTypeImpl) graknGraph.putEntityType("t1");
+        ResourceTypeImpl t2 = (ResourceTypeImpl)  graknGraph.putResourceType("t2", ResourceType.DataType.STRING);
+        RelationTypeImpl t3 = (RelationTypeImpl) graknGraph.putRelationType("t3");
+
+        //Lets Set Some Counts
+        types.put(t1.getName(), 5L);
+        types.put(t2.getName(), 6L);
+        types.put(t3.getName(), 2L);
+
+        graknGraph.admin().updateTypeCounts(types);
+        types.entrySet().forEach(entry ->
+                assertEquals((long) entry.getValue(), ((TypeImpl) graknGraph.getType(entry.getKey())).getInstanceCount()));
+
+        //Lets Set Some Counts
+        types.put(t1.getName(), -5L);
+        types.put(t1.getName(), -2L);
+        types.put(t1.getName(), 3L);
+
+        assertEquals(0L, t1.getInstanceCount());
+        assertEquals(4L, t2.getInstanceCount());
+        assertEquals(5L, t3.getInstanceCount());
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/PostProcessingTest.java
@@ -25,7 +25,7 @@ import ai.grakn.concept.RelationType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -210,25 +210,25 @@ public class PostProcessingTest extends GraphTestBase{
 
     @Test
     public void whenUpdatingTheCountsOfTypes_TheTypesHaveNewCounts() {
-        Map<TypeName, Long> types = new HashMap<>();
+        Map<TypeLabel, Long> types = new HashMap<>();
         //Create Some Types;
         EntityTypeImpl t1 = (EntityTypeImpl) graknGraph.putEntityType("t1");
         ResourceTypeImpl t2 = (ResourceTypeImpl)  graknGraph.putResourceType("t2", ResourceType.DataType.STRING);
         RelationTypeImpl t3 = (RelationTypeImpl) graknGraph.putRelationType("t3");
 
         //Lets Set Some Counts
-        types.put(t1.getName(), 5L);
-        types.put(t2.getName(), 6L);
-        types.put(t3.getName(), 2L);
+        types.put(t1.getLabel(), 5L);
+        types.put(t2.getLabel(), 6L);
+        types.put(t3.getLabel(), 2L);
 
         graknGraph.admin().updateTypeCounts(types);
         types.entrySet().forEach(entry ->
                 assertEquals((long) entry.getValue(), ((TypeImpl) graknGraph.getType(entry.getKey())).getInstanceCount()));
 
         //Lets Set Some Counts
-        types.put(t1.getName(), -5L);
-        types.put(t2.getName(), -2L);
-        types.put(t3.getName(), 3L);
+        types.put(t1.getLabel(), -5L);
+        types.put(t2.getLabel(), -2L);
+        types.put(t3.getLabel(), 3L);
         graknGraph.admin().updateTypeCounts(types);
 
         assertEquals(0L, t1.getInstanceCount());

--- a/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheDistributedTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheDistributedTest.java
@@ -19,6 +19,7 @@
 package ai.grakn.test.engine.cache;
 
 import ai.grakn.concept.ConceptId;
+import ai.grakn.concept.TypeName;
 import ai.grakn.engine.cache.EngineCacheProvider;
 import ai.grakn.graph.admin.ConceptCache;
 import ai.grakn.test.EngineContext;
@@ -60,7 +61,7 @@ public class EngineCacheDistributedTest {
     }
 
     @Test
-    public void whenDeletingJobsFromCache_EnsureJobsAreNoLongerInCache(){
+    public void whenDeletingFixingJobsFromCache_EnsureJobsAreNoLongerInCache(){
         String keyspace = "my_fake_keyspace";
 
         //Fake Commit Logs
@@ -109,7 +110,7 @@ public class EngineCacheDistributedTest {
     }
 
     @Test
-    public void whenAddingJobsToCacheOfSameKeyspace_EnsureCacheContainsJobs(){
+    public void whenAddingFixingJobsToCacheOfSameKeyspace_EnsureCacheContainsJobs(){
         String keyspace = "my_fake_keyspace";
 
         //Fake Commit Logs
@@ -134,7 +135,7 @@ public class EngineCacheDistributedTest {
     }
 
     @Test
-    public void whenAddingJobsToCacheOfDifferentKeySpaces_EnsureCacheContainsJob(){
+    public void whenAddingFixingJobsToCacheOfDifferentKeySpaces_EnsureCacheContainsJob(){
         String keyspace1 = "key1";
         String keyspace2 = "key2";
 
@@ -155,6 +156,28 @@ public class EngineCacheDistributedTest {
         checkContentsOfCache(cache.getResourceJobs(keyspace1), key1_resourcesFake);
         checkContentsOfCache(cache.getCastingJobs(keyspace2), key2_castingsFake);
         checkContentsOfCache(cache.getResourceJobs(keyspace2), key2_resourcesFake);
+    }
+
+    @Test
+    public void whenAddingAndRemovingInstanceJobsToCache_CacheIsUpdated(){
+        String keyspace1 = "key1";
+
+        //Create fake commit log
+        Map<TypeName, Long> fakeCache = new HashMap<>();
+        fakeCache.put(TypeName.of("A"), 1L);
+        fakeCache.put(TypeName.of("B"), 2L);
+        fakeCache.put(TypeName.of("C"), 3L);
+
+        fakeCache.entrySet().forEach(entry -> cache.addJobInstanceCount(keyspace1, entry.getKey(), entry.getValue()));
+
+        assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
+        assertEquals(fakeCache.values(), cache.getInstanceCountJobs(keyspace1).values());
+
+        fakeCache.remove(TypeName.of("B"));
+        cache.deleteJobInstanceCount(keyspace1, TypeName.of("B"));
+
+        assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
+        assertEquals(fakeCache.values(), cache.getInstanceCountJobs(keyspace1).values());
     }
 
     private Map<String, Set<ConceptId>> createFakeInternalConceptLog(String indexPrefix, int numIndex, int numJobs){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertThat;
 //NOTE: This test is only in grakn-test because it needs a running ZK
 //Ideally this should be moved to the grakn-engine module
 @RunWith(Theories.class)
-public class EngineCacheDistributedTest {
+public class EngineCacheTest {
 
     @DataPoints
     public static Caches[] configValues = Caches.values();
@@ -68,8 +68,6 @@ public class EngineCacheDistributedTest {
     //We do this just so we can start ZK
     @ClassRule
     public static final EngineContext engine = EngineContext.startSingleQueueServer();
-
-
 
     @Theory
     public void whenDeletingFixingJobsFromCache_EnsureJobsAreNoLongerInCache(Caches caches){
@@ -107,13 +105,18 @@ public class EngineCacheDistributedTest {
 
         //Clear Jobs 1
         String deletedIndex3 = "Casting_Index_2";
+        cache.deleteJobCasting(keyspace, deletedIndex3, ConceptId.of(0));
+        cache.deleteJobCasting(keyspace, deletedIndex3, ConceptId.of(1));
+        cache.deleteJobCasting(keyspace, deletedIndex3, ConceptId.of(2));
+        cache.deleteJobCasting(keyspace, deletedIndex3, ConceptId.of(3));
+        cache.deleteJobCasting(keyspace, deletedIndex3, ConceptId.of(4));
         cache.clearJobSetCastings(keyspace, deletedIndex3);
         assertFalse("Index [" + deletedIndex3 + "] was not cleared form the cache", cache.getCastingJobs(keyspace).containsKey(deletedIndex3));
 
         //Clear Jobs 2
         String deletedIndex4 = "Resource_Index_3";
         cache.clearJobSetResources(keyspace, deletedIndex4);
-        assertFalse("Index [" + deletedIndex4 + "] was not cleared form the cache", cache.getResourceJobs(keyspace).containsKey(deletedIndex3));
+        assertTrue("Index [" + deletedIndex4 + "] was cleared form the cache even though it had pending jobs", cache.getResourceJobs(keyspace).containsKey(deletedIndex4));
 
         //Clear all Jobs
         cache.clearAllJobs(keyspace);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
@@ -19,7 +19,7 @@
 package ai.grakn.test.engine.cache;
 
 import ai.grakn.concept.ConceptId;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.cache.EngineCacheProvider;
 import ai.grakn.engine.cache.EngineCacheStandAlone;
 import ai.grakn.graph.admin.ConceptCache;
@@ -181,18 +181,18 @@ public class EngineCacheTest {
         String keyspace1 = "key1";
 
         //Create fake commit log
-        Map<TypeName, Long> fakeCache = new HashMap<>();
-        fakeCache.put(TypeName.of("A"), 1L);
-        fakeCache.put(TypeName.of("B"), 2L);
-        fakeCache.put(TypeName.of("C"), 3L);
+        Map<TypeLabel, Long> fakeCache = new HashMap<>();
+        fakeCache.put(TypeLabel.of("A"), 1L);
+        fakeCache.put(TypeLabel.of("B"), 2L);
+        fakeCache.put(TypeLabel.of("C"), 3L);
 
         fakeCache.entrySet().forEach(entry -> cache.addJobInstanceCount(keyspace1, entry.getKey(), entry.getValue()));
 
         assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
         fakeCache.entrySet().forEach(entry -> assertEquals(entry.getValue(), cache.getInstanceCountJobs(keyspace1).get(entry.getKey())));
 
-        fakeCache.remove(TypeName.of("B"));
-        cache.deleteJobInstanceCount(keyspace1, TypeName.of("B"));
+        fakeCache.remove(TypeLabel.of("B"));
+        cache.deleteJobInstanceCount(keyspace1, TypeLabel.of("B"));
 
         assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
         fakeCache.entrySet().forEach(entry -> assertEquals(entry.getValue(), cache.getInstanceCountJobs(keyspace1).get(entry.getKey())));

--- a/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/cache/EngineCacheTest.java
@@ -48,6 +48,10 @@ import static org.junit.Assert.assertThat;
 @RunWith(Theories.class)
 public class EngineCacheTest {
 
+    //We do this just so we can start ZK
+    @ClassRule
+    public static final EngineContext engine = EngineContext.startSingleQueueServer();
+
     @DataPoints
     public static Caches[] configValues = Caches.values();
 
@@ -64,10 +68,6 @@ public class EngineCacheTest {
         }
         throw new RuntimeException("Invalid cache [" + caches + "]");
     }
-
-    //We do this just so we can start ZK
-    @ClassRule
-    public static final EngineContext engine = EngineContext.startSingleQueueServer();
 
     @Theory
     public void whenDeletingFixingJobsFromCache_EnsureJobsAreNoLongerInCache(Caches caches){
@@ -189,13 +189,13 @@ public class EngineCacheTest {
         fakeCache.entrySet().forEach(entry -> cache.addJobInstanceCount(keyspace1, entry.getKey(), entry.getValue()));
 
         assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
-        assertEquals(fakeCache.values(), cache.getInstanceCountJobs(keyspace1).values());
+        fakeCache.entrySet().forEach(entry -> assertEquals(entry.getValue(), cache.getInstanceCountJobs(keyspace1).get(entry.getKey())));
 
         fakeCache.remove(TypeName.of("B"));
         cache.deleteJobInstanceCount(keyspace1, TypeName.of("B"));
 
         assertEquals(fakeCache.keySet(), cache.getInstanceCountJobs(keyspace1).keySet());
-        assertEquals(fakeCache.values(), cache.getInstanceCountJobs(keyspace1).values());
+        fakeCache.entrySet().forEach(entry -> assertEquals(entry.getValue(), cache.getInstanceCountJobs(keyspace1).get(entry.getKey())));
     }
 
     private Map<String, Set<ConceptId>> createFakeInternalConceptLog(String indexPrefix, int numIndex, int numJobs){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
@@ -93,12 +93,14 @@ public class CommitLogControllerTest {
         test.admin().clear(EngineCacheProvider.getCache());
         assertEquals(0, cache.getCastingJobs(KEYSPACE).size());
         assertEquals(0, cache.getResourceJobs(KEYSPACE).size());
+        assertEquals(0, cache.getInstanceCountJobs(KEYSPACE).size());
     }
 
     @Test
     public void whenControllerReceivesLog_CacheIsUpdated() {
         assertEquals(4, cache.getCastingJobs(KEYSPACE).size());
         assertEquals(2, cache.getResourceJobs(KEYSPACE).size());
+        assertEquals(5, cache.getInstanceCountJobs(KEYSPACE).size());
     }
 
     @Test
@@ -113,14 +115,17 @@ public class CommitLogControllerTest {
 
         assertEquals(2, cache.getCastingJobs(BOB).size());
         assertEquals(1, cache.getResourceJobs(BOB).size());
+        assertEquals(-1, cache.getInstanceCountJobs(BOB).size());
 
         assertEquals(0, cache.getCastingJobs(TIM).size());
         assertEquals(0, cache.getResourceJobs(TIM).size());
+        assertEquals(-1, cache.getInstanceCountJobs(TIM).size());
 
         addSomeData(tim);
 
         assertEquals(2, cache.getCastingJobs(TIM).size());
         assertEquals(1, cache.getResourceJobs(TIM).size());
+        assertEquals(-1, cache.getInstanceCountJobs(TIM).size());
 
         Grakn.session(Grakn.DEFAULT_URI, BOB).open(GraknTxType.WRITE).clear();
         Grakn.session(Grakn.DEFAULT_URI, TIM).open(GraknTxType.WRITE).clear();
@@ -129,6 +134,9 @@ public class CommitLogControllerTest {
         assertEquals(0, cache.getCastingJobs(TIM).size());
         assertEquals(0, cache.getResourceJobs(BOB).size());
         assertEquals(0, cache.getResourceJobs(TIM).size());
+
+        assertEquals(0, cache.getInstanceCountJobs(BOB).size());
+        assertEquals(0, cache.getInstanceCountJobs(BOB).size());
 
         bob.close();
         tim.close();
@@ -150,9 +158,6 @@ public class CommitLogControllerTest {
 
     @Test
     public void whenDeletingViaController_CacheIsCleared() throws InterruptedException {
-        assertEquals(4, cache.getCastingJobs(KEYSPACE).size());
-        assertEquals(2, cache.getResourceJobs(KEYSPACE).size());
-
         delete(REST.WebPath.COMMIT_LOG_URI + "?" + REST.Request.KEYSPACE_PARAM + "=" + KEYSPACE).
                 then().statusCode(200).extract().response().andReturn();
 
@@ -160,6 +165,7 @@ public class CommitLogControllerTest {
 
         assertEquals(0, cache.getCastingJobs(KEYSPACE).size());
         assertEquals(0, cache.getResourceJobs(KEYSPACE).size());
+        assertEquals(0, cache.getInstanceCountJobs(KEYSPACE).size());
     }
 
     private void waitForCache(String keyspace, int value) throws InterruptedException {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
@@ -56,7 +56,7 @@ public class CommitLogControllerTest {
     @Before
     public void setUp() throws Exception {
         String commitLog = "{\n" +
-                "    \"concepts\":[\n" +
+                "    \"" + REST.Request.COMMIT_LOG_FIXING + "\":[\n" +
                 "        {\"" + REST.Request.COMMIT_LOG_INDEX + "\":\"10\", \"" + REST.Request.COMMIT_LOG_ID + "\":\"1\", \"" + REST.Request.COMMIT_LOG_TYPE + "\":\"" + Schema.BaseType.CASTING + "\"}, \n" +
                 "        {\"" + REST.Request.COMMIT_LOG_INDEX + "\":\"20\", \"" + REST.Request.COMMIT_LOG_ID + "\":\"2\", \"" + REST.Request.COMMIT_LOG_TYPE + "\":\"" + Schema.BaseType.CASTING + "\"}, \n" +
                 "        {\"" + REST.Request.COMMIT_LOG_INDEX + "\":\"30\", \"" + REST.Request.COMMIT_LOG_ID + "\":\"3\", \"" + REST.Request.COMMIT_LOG_TYPE + "\":\"" + Schema.BaseType.CASTING + "\"}, \n" +

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
@@ -69,11 +69,11 @@ public class CommitLogControllerTest {
                 "        {\"" + REST.Request.COMMIT_LOG_INDEX + "\":\"100\", \"" + REST.Request.COMMIT_LOG_ID + "\":\"10\", \"" + REST.Request.COMMIT_LOG_TYPE + "\":\"" + Schema.BaseType.RELATION + "\"}\n" +
                 "    ],\n" +
                 "    \"" + REST.Request.COMMIT_LOG_COUNTING + "\":[\n" +
-                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Alpha\", \"" + REST.Request.COMMIT_LOG_COUNTING + "\":\"-3\"}, \n" +
-                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Bravo\", \"" + REST.Request.COMMIT_LOG_COUNTING + "\":\"-2\"}, \n" +
-                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Charlie\", \"" + REST.Request.COMMIT_LOG_COUNTING + "\":\"-1\"}, \n" +
-                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Delta\", \"" + REST.Request.COMMIT_LOG_COUNTING + "\":\"1\"}, \n" +
-                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Foxtrot\", \"" + REST.Request.COMMIT_LOG_COUNTING + "\":\"2\"} \n" +
+                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Alpha\", \"" + REST.Request.COMMIT_LOG_INSTANCE_COUNT + "\":\"-3\"}, \n" +
+                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Bravo\", \"" + REST.Request.COMMIT_LOG_INSTANCE_COUNT + "\":\"-2\"}, \n" +
+                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Charlie\", \"" + REST.Request.COMMIT_LOG_INSTANCE_COUNT + "\":\"-1\"}, \n" +
+                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Delta\", \"" + REST.Request.COMMIT_LOG_INSTANCE_COUNT + "\":\"1\"}, \n" +
+                "        {\"" + REST.Request.COMMIT_LOG_TYPE_NAME + "\":\"Foxtrot\", \"" + REST.Request.COMMIT_LOG_INSTANCE_COUNT + "\":\"2\"} \n" +
                 "    ]\n" +
                 "}";
 
@@ -115,17 +115,17 @@ public class CommitLogControllerTest {
 
         assertEquals(2, cache.getCastingJobs(BOB).size());
         assertEquals(1, cache.getResourceJobs(BOB).size());
-        assertEquals(-1, cache.getInstanceCountJobs(BOB).size());
+        assertEquals(3, cache.getInstanceCountJobs(BOB).size());
 
         assertEquals(0, cache.getCastingJobs(TIM).size());
         assertEquals(0, cache.getResourceJobs(TIM).size());
-        assertEquals(-1, cache.getInstanceCountJobs(TIM).size());
+        assertEquals(0, cache.getInstanceCountJobs(TIM).size());
 
         addSomeData(tim);
 
         assertEquals(2, cache.getCastingJobs(TIM).size());
         assertEquals(1, cache.getResourceJobs(TIM).size());
-        assertEquals(-1, cache.getInstanceCountJobs(TIM).size());
+        assertEquals(3, cache.getInstanceCountJobs(TIM).size());
 
         Grakn.session(Grakn.DEFAULT_URI, BOB).open(GraknTxType.WRITE).clear();
         Grakn.session(Grakn.DEFAULT_URI, TIM).open(GraknTxType.WRITE).clear();

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
@@ -1,0 +1,77 @@
+package ai.grakn.test.engine.postprocessing;
+
+import ai.grakn.Grakn;
+import ai.grakn.GraknGraph;
+import ai.grakn.GraknTxType;
+import ai.grakn.concept.TypeName;
+import ai.grakn.engine.cache.EngineCacheProvider;
+import ai.grakn.engine.postprocessing.UpdatingInstanceCountTask;
+import ai.grakn.engine.tasks.TaskSchedule;
+import ai.grakn.engine.tasks.TaskState;
+import ai.grakn.engine.tasks.manager.StandaloneTaskManager;
+import ai.grakn.engine.util.EngineID;
+import ai.grakn.graph.admin.ConceptCache;
+import ai.grakn.test.EngineContext;
+import ai.grakn.util.Schema;
+import mjson.Json;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static ai.grakn.engine.TaskStatus.COMPLETED;
+import static org.junit.Assert.assertEquals;
+
+public class UpdatingInstanceCountTaskTest {
+    //Different task manager is required so we don't interfere with main engine running
+    private StandaloneTaskManager taskManager = new StandaloneTaskManager(EngineID.of("hello"));
+
+    @ClassRule
+    public static final EngineContext engine = EngineContext.startInMemoryServer();
+
+    @Test
+    public void whenUpdatingInstanceCounts_EnsureTypesInGraphAreUpdated() throws InterruptedException {
+        String keyspace = "mysimplekeyspace";
+        String entityType1 = "e1";
+        String entityType2 = "e2";
+
+        //Create Simple Graph
+        try(GraknGraph graknGraph = Grakn.session(Grakn.DEFAULT_URI, keyspace).open(GraknTxType.WRITE)){
+            graknGraph.putEntityType(entityType1);
+            graknGraph.putEntityType(entityType2);
+            graknGraph.commit();
+        }
+
+        //Create Artificial Caches
+        ConceptCache cache = EngineCacheProvider.getCache();
+        cache.addJobInstanceCount(keyspace, TypeName.of(entityType1), 6);
+        cache.addJobInstanceCount(keyspace, TypeName.of(entityType2), 3);
+
+        //Start up the Job
+        TaskState task = TaskState.of(UpdatingInstanceCountTask.class, getClass().getName(), TaskSchedule.now(), Json.object());
+        taskManager.addTask(task);
+
+        // Wait for supervisor thread to mark task as completed
+        final long initial = new Date().getTime();
+
+        while ((new Date().getTime())-initial < 10000) {
+            if (taskManager.storage().getState(task.getId()).status() == COMPLETED)
+                break;
+            Thread.sleep(100);
+        }
+
+        // Check that task has ran
+        assertEquals(COMPLETED, taskManager.storage().getState(task.getId()).status());
+
+        // Check the results of the task
+        try(GraknGraph graknGraph = Grakn.session(Grakn.DEFAULT_URI, keyspace).open(GraknTxType.WRITE)){
+            Vertex v1 = graknGraph.admin().getTinkerTraversal().has(Schema.ConceptProperty.ID.name(), graknGraph.getEntityType(entityType1).getId().getValue()).next();
+            Vertex v2 = graknGraph.admin().getTinkerTraversal().has(Schema.ConceptProperty.ID.name(), graknGraph.getEntityType(entityType2).getId().getValue()).next();
+
+            assertEquals(6L, (long) v1.value(Schema.ConceptProperty.INSTANCE_COUNT.name()));
+            assertEquals(3L, (long) v2.value(Schema.ConceptProperty.INSTANCE_COUNT.name()));
+        }
+    }
+
+}

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
@@ -3,7 +3,7 @@ package ai.grakn.test.engine.postprocessing;
 import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.GraknTxType;
-import ai.grakn.concept.TypeName;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.cache.EngineCacheProvider;
 import ai.grakn.engine.postprocessing.UpdatingInstanceCountTask;
 import ai.grakn.engine.tasks.TaskSchedule;
@@ -45,8 +45,8 @@ public class UpdatingInstanceCountTaskTest {
 
         //Create Artificial Caches
         ConceptCache cache = EngineCacheProvider.getCache();
-        cache.addJobInstanceCount(keyspace, TypeName.of(entityType1), 6);
-        cache.addJobInstanceCount(keyspace, TypeName.of(entityType2), 3);
+        cache.addJobInstanceCount(keyspace, TypeLabel.of(entityType1), 6);
+        cache.addJobInstanceCount(keyspace, TypeLabel.of(entityType2), 3);
 
         //Start up the Job
         TaskState task = TaskState.of(UpdatingInstanceCountTask.class, getClass().getName(), TaskSchedule.now(), Json.object());


### PR DESCRIPTION
- Track instance change in graph API
- Submit expanded commit logs to engine
- Cache the details needed for the new job
- Background task to persist count's to types

Note: The lack of thread safety here is going to make the counts inaccurate. Might have to synchronise on the ZK mutations. 