### PR TITLE
Fix bug where graph is not re-opened when there is an error

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
@@ -117,6 +117,7 @@ class GraqlSession {
     }
 
     private void refreshGraph() {
+        if (graph != null && !graph.isClosed()) graph.close();
         graph = factory.open(GraknTxType.WRITE);
         graph.showImplicitConcepts(showImplicitTypes);
     }
@@ -227,7 +228,7 @@ class GraqlSession {
             } finally {
                 if (errorMessage != null) {
                     if (queries != null && !queries.stream().allMatch(Query::isReadOnly)) {
-                        graph.close();
+                        attemptRefresh();
                     }
                     sendQueryError(errorMessage);
                 }


### PR DESCRIPTION
There are no tests because `GraqlShellIT` is currently ignored.