### PR TITLE
Update counts using BATCH graph

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -83,6 +83,9 @@ public class UpdatingInstanceCountTask extends LockingBackgroundTask {
 
         while(notDone) {
             notDone = false;
+
+            //TODO Using the BATCH transaction type for synchronicity with LoaderTask - had to disable ontology
+            //TODO mutation check in AbstractGraknGraph to do so
             try (GraknGraph graknGraph = EngineGraknGraphFactory.getInstance().getGraph(keyspace, GraknTxType.BATCH)) {
                 graknGraph.admin().updateTypeShards(jobs);
                 graknGraph.admin().commitNoLogs();

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -83,7 +83,7 @@ public class UpdatingInstanceCountTask extends LockingBackgroundTask {
 
         while(notDone) {
             notDone = false;
-            try (GraknGraph graknGraph = EngineGraknGraphFactory.getInstance().getGraph(keyspace, GraknTxType.WRITE)) {
+            try (GraknGraph graknGraph = EngineGraknGraphFactory.getInstance().getGraph(keyspace, GraknTxType.BATCH)) {
                 graknGraph.admin().updateTypeShards(jobs);
                 graknGraph.admin().commitNoLogs();
             } catch (Throwable e) {

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -398,6 +398,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     void checkOntologyMutation(){
         checkMutation();
+        //TODO This is disabled so that sharding/counts can be updated using the BATCH graph
         //if(isBatchLoadingEnabled()){
         //    throw new GraphRuntimeException(ErrorMessage.SCHEMA_LOCKED.getMessage());
         //}

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -398,9 +398,9 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     void checkOntologyMutation(){
         checkMutation();
-        if(isBatchLoadingEnabled()){
-            throw new GraphRuntimeException(ErrorMessage.SCHEMA_LOCKED.getMessage());
-        }
+        //if(isBatchLoadingEnabled()){
+        //    throw new GraphRuntimeException(ErrorMessage.SCHEMA_LOCKED.getMessage());
+        //}
     }
 
     void checkMutation(){


### PR DESCRIPTION
When different types of graphs are used the writes are not aware of one another until the session is closed and refreshed (which is expensive and does not occur often). This means that the `LoaderTask` using a `BATCH` graph will never be aware of the counts written in `UpdateInstanceCountTask` using a normal graph. 

This PR is a temporary solution because we force both tasks to use the same type of graph. 