### PR TITLE
Remove configuration from TaskState

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/loader/LoaderTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/loader/LoaderTask.java
@@ -23,12 +23,12 @@ import ai.grakn.GraknTxType;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.graql.QueryBuilder;
-import mjson.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +60,7 @@ public class LoaderTask implements BackgroundTask {
     private final QueryBuilder builder = Graql.withoutGraph().infer(false);
 
     @Override
-    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
+    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
         attemptInsertions(
                 getKeyspace(configuration),
                 getInserts(configuration));
@@ -159,10 +159,10 @@ public class LoaderTask implements BackgroundTask {
      * @param configuration JSONObject containing configuration
      * @return insert queries from the configuration
      */
-    private Collection<InsertQuery> getInserts(Json configuration){
-        if(configuration.has(TASK_LOADER_INSERTS)){
+    private Collection<InsertQuery> getInserts(TaskConfiguration configuration){
+        if(configuration.json().has(TASK_LOADER_INSERTS)){
             List<String> inserts = new ArrayList<>();
-            configuration.at(TASK_LOADER_INSERTS).asJsonList().forEach(i -> inserts.add(i.asString()));
+            configuration.json().at(TASK_LOADER_INSERTS).asJsonList().forEach(i -> inserts.add(i.asString()));
 
             return inserts.stream()
                     .map(builder::<InsertQuery>parse)
@@ -177,9 +177,9 @@ public class LoaderTask implements BackgroundTask {
      * @param configuration JSONObject containing configuration
      * @return keyspace from the configuration
      */
-    private String getKeyspace(Json configuration){
-        if(configuration.has(KEYSPACE)){
-            return configuration.at(KEYSPACE).asString();
+    private String getKeyspace(TaskConfiguration configuration){
+        if(configuration.json().has(KEYSPACE)){
+            return configuration.json().at(KEYSPACE).asString();
         }
 
         //TODO default graph name

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/PostProcessingTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/PostProcessingTask.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.postprocessing;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.storage.LockingBackgroundTask;
 import ai.grakn.util.Schema;
 import mjson.Json;
@@ -75,7 +76,7 @@ public class PostProcessingTask extends LockingBackgroundTask {
      * Run postprocessing only if enough time has passed since the last job was added
      */
     @Override
-    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
+    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
         Instant lastJobAdded = Instant.ofEpochMilli(lastPPTaskCreated.get());
         long timeElapsed = Duration.between(lastJobAdded, now()).toMillis();
 
@@ -108,10 +109,10 @@ public class PostProcessingTask extends LockingBackgroundTask {
     }
 
     @Override
-    public boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration){
-        String keyspace = configuration.at(KEYSPACE).asString();
+    public boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration){
+        String keyspace = configuration.json().at(KEYSPACE).asString();
 
-        Json innerConfig = configuration.at(COMMIT_LOG_FIXING);
+        Json innerConfig = configuration.json().at(COMMIT_LOG_FIXING);
         runPostProcessing(keyspace, innerConfig.at(Schema.BaseType.CASTING.name()).asJsonMap(), postProcessing::performCastingFix);
         runPostProcessing(keyspace, innerConfig.at(Schema.BaseType.RESOURCE.name()).asJsonMap(), postProcessing::performResourceFix);
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ResourceDeduplicationTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/ResourceDeduplicationTask.java
@@ -26,9 +26,9 @@ import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Resource;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.exception.GraknLockingException;
 import ai.grakn.util.Schema;
-import mjson.Json;
 import org.apache.tinkerpop.gremlin.process.computer.KeyValue;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -198,13 +198,13 @@ public class ResourceDeduplicationTask implements BackgroundTask {
     }
     
     @Override
-    public boolean start(Consumer<TaskCheckpoint> saveCheckpoin, Json configuration) {
-        LOG.info("Starting ResourceDeduplicationTask : " + configuration);
+    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
+        LOG.info("Starting ResourceDeduplicationTask : " + configuration.json());
         
-        String keyspace = configuration.at("keyspace", KEYSPACE_DEFAULT).asString();
+        String keyspace = configuration.json().at("keyspace", KEYSPACE_DEFAULT).asString();
         GraknComputer computer = Grakn.session(Grakn.DEFAULT_URI, keyspace).getGraphComputer();
         Job job = new Job().keyspace(keyspace)
-                           .deleteUnattached(configuration.at("deletedUnattached", DELETE_UNATTACHED_DEFAULT ).asBoolean());
+                           .deleteUnattached(configuration.json().at("deletedUnattached", DELETE_UNATTACHED_DEFAULT ).asBoolean());
         this.totalEliminated = computer.compute(job).memory().get(job.getMemoryKey());
         return true;
     }

--- a/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/postprocessing/UpdatingInstanceCountTask.java
@@ -23,6 +23,7 @@ import ai.grakn.GraknTxType;
 import ai.grakn.concept.TypeLabel;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.storage.LockingBackgroundTask;
 import ai.grakn.factory.EngineGraknGraphFactory;
 import ai.grakn.util.ErrorMessage;
@@ -60,9 +61,9 @@ public class UpdatingInstanceCountTask extends LockingBackgroundTask {
     }
 
     @Override
-    protected boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
-        String keyspace = configuration.at(KEYSPACE).asString();
-        Json instancesToCount = configuration.at(COMMIT_LOG_COUNTING);
+    protected boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
+        String keyspace = configuration.json().at(KEYSPACE).asString();
+        Json instancesToCount = configuration.json().at(COMMIT_LOG_COUNTING);
 
         Map<TypeLabel, Long> instanceMap = instancesToCount
                 .asJsonList().stream()

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/BackgroundTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/BackgroundTask.java
@@ -18,8 +18,6 @@
 
 package ai.grakn.engine.tasks;
 
-import mjson.Json;
-
 import java.util.function.Consumer;
 
 /**
@@ -35,7 +33,7 @@ public interface BackgroundTask {
      *
      * @return true if the task successfully completed, or false if it was stopped.
      */
-    boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration);
+    boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration);
 
     /**
      * Called to stop execution of the task, may be called on a running or paused task.

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfiguration.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine.tasks;
+
+import java.io.Serializable;
+import mjson.Json;
+
+/**
+ * Internal checkpoint used to keep track of task execution
+ *
+ * @author alexandraorth
+ */
+public class TaskConfiguration implements Serializable {
+
+    private static final long serialVersionUID = -7301340972479426643L;
+
+    private final Json configuration;
+
+    public static TaskConfiguration of(Json checkpoint){
+        return new TaskConfiguration(checkpoint);
+    }
+
+    private TaskConfiguration(Json configuration){
+        this.configuration = configuration;
+    }
+
+    public Json json(){
+        return configuration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TaskConfiguration that = (TaskConfiguration) o;
+
+        return configuration.toString().equals(that.configuration.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = configuration != null ? configuration.hashCode() : 0;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TaskConfiguration.of(" + configuration + ")";
+    }
+}

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfigurationDeserializer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfigurationDeserializer.java
@@ -19,29 +19,27 @@
 package ai.grakn.engine.tasks;
 
 import ai.grakn.engine.TaskId;
-import org.apache.kafka.common.serialization.Serializer;
+import mjson.Json;
+import org.apache.kafka.common.serialization.Deserializer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
  * <p>
- * Implementation of {@link org.apache.kafka.common.serialization.Serializer} that allows usage of {@link TaskId} as
+ * Implementation of {@link org.apache.kafka.common.serialization.Deserializer} that allows usage of {@link TaskId} as
  * kafka queue keys
  * </p>
  *
  * @author alexandraorth
  */
-public class TaskIdSerializer implements Serializer<TaskId> {
+public class TaskConfigurationDeserializer implements Deserializer<TaskConfiguration> {
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {}
 
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
-
-    }
-
-    @Override
-    public byte[] serialize(String topic, TaskId data) {
-        return data.getValue().getBytes(StandardCharsets.UTF_8);
+    public TaskConfiguration deserialize(String topic, byte[] data) {
+        return TaskConfiguration.of(Json.read(new String(data, StandardCharsets.UTF_8)));
     }
 
     @Override

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfigurationSerializer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskConfigurationSerializer.java
@@ -18,28 +18,30 @@
 
 package ai.grakn.engine.tasks;
 
-
 import ai.grakn.engine.TaskId;
-import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 /**
  * <p>
- * Implementation of {@link org.apache.kafka.common.serialization.Deserializer} that allows usage of {@link TaskId} as
+ * Implementation of {@link org.apache.kafka.common.serialization.Serializer} that allows usage of {@link TaskId} as
  * kafka queue keys
  * </p>
  *
  * @author alexandraorth
  */
-public class TaskIdDeserializer implements Deserializer<TaskId> {
-    @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {}
+public class TaskConfigurationSerializer implements Serializer<TaskConfiguration> {
 
     @Override
-    public TaskId deserialize(String topic, byte[] data) {
-        return TaskId.of(new String(data, StandardCharsets.UTF_8));
+    public void configure(Map<String, ?> configs, boolean isKey) {
+
+    }
+
+    @Override
+    public byte[] serialize(String topic, TaskConfiguration data) {
+        return data.json().toString().getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskManager.java
@@ -43,13 +43,13 @@ public interface TaskManager extends AutoCloseable {
      * Schedule a {@link BackgroundTask} for execution, giving it priority to run after all other tasks
      * @param taskState Task to execute
      */
-    void addLowPriorityTask(TaskState taskState);
+    void addLowPriorityTask(TaskState taskState, TaskConfiguration configuration);
 
     /**
      * Schedule a {@link BackgroundTask} for execution, giving it priority to run before all other tasks
      * @param taskState Task to execute
      */
-    void addHighPriorityTask(TaskState taskState);
+    void addHighPriorityTask(TaskState taskState, TaskConfiguration configuration);
 
     /**
      * Stop a Scheduled, Paused or Running task. Task's .stop() method will be called to perform any cleanup and the

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskState.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/TaskState.java
@@ -21,9 +21,7 @@ package ai.grakn.engine.tasks;
 import ai.grakn.engine.TaskId;
 import ai.grakn.engine.TaskStatus;
 import ai.grakn.engine.util.EngineID;
-import mjson.Json;
 
-import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.time.Instant;
 
@@ -82,27 +80,17 @@ public class TaskState implements Serializable {
      * Used to store a task checkpoint allowing it to resume from the same point of execution as at the time of the checkpoint.
      */
     private TaskCheckpoint taskCheckpoint;
-    /**
-     * Configuration passed to the task on startup, can contain data/location of data for task to process, etc.
-     */
-    private Json configuration;
 
-    public static TaskState of(Class<?> taskClass, String creator, TaskSchedule schedule, Json configuration) {
-        return of(taskClass, creator, schedule, configuration, TaskId.generate());
+    public static TaskState of(Class<?> taskClass, String creator, TaskSchedule schedule) {
+        return new TaskState(taskClass, creator, schedule, TaskId.generate());
     }
 
-    public static TaskState of(
-            Class<?> taskClass, String creator, TaskSchedule schedule, Json configuration, TaskId id) {
-        return new TaskState(taskClass, creator, schedule, configuration, id);
-    }
-
-    private TaskState(Class<?> taskClass, String creator, TaskSchedule schedule, Json configuration, TaskId id) {
+    private TaskState(Class<?> taskClass, String creator, TaskSchedule schedule, TaskId id) {
         this.status = CREATED;
         this.statusChangeTime = now();
         this.taskClassName = taskClass != null ? taskClass.getName() : null;
         this.creator = creator;
         this.schedule = schedule;
-        this.configuration = configuration;
         this.taskId = id.getValue();
     }
 
@@ -117,7 +105,6 @@ public class TaskState implements Serializable {
         this.stackTrace = taskState.stackTrace;
         this.exception = taskState.exception;
         this.taskCheckpoint = taskState.taskCheckpoint;
-        this.configuration = taskState.configuration;
     }
 
     public TaskId getId() {
@@ -137,8 +124,6 @@ public class TaskState implements Serializable {
         this.statusChangeTime = now();
 
         // Clearing out any not relevant information
-        removeConfigUnlessRecurring();
-
         this.taskCheckpoint = null;
 
         return this;
@@ -148,17 +133,12 @@ public class TaskState implements Serializable {
         this.status = SCHEDULED;
         this.statusChangeTime = now();
 
-        removeConfigUnlessRecurring();
-
         return this;
     }
 
     public TaskState markStopped(){
         this.status = STOPPED;
         this.statusChangeTime = now();
-
-        // Clearing out any not relevant information
-        removeConfig();
 
         return this;
     }
@@ -223,20 +203,6 @@ public class TaskState implements Serializable {
 
     public TaskCheckpoint checkpoint() {
         return taskCheckpoint;
-    }
-
-    public @Nullable Json configuration() {
-        return configuration;
-    }
-
-    private void removeConfig(){
-        this.configuration = null;
-    }
-
-    private void removeConfigUnlessRecurring(){
-        if(!schedule.isRecurring()) {
-            removeConfig();
-        }
     }
 
     public TaskState copy() {

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ConfigHelper.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/config/ConfigHelper.java
@@ -18,9 +18,9 @@
 
 package ai.grakn.engine.tasks.config;
 
-import ai.grakn.engine.tasks.TaskIdDeserializer;
-import ai.grakn.engine.tasks.TaskIdSerializer;
-import ai.grakn.engine.TaskId;
+import ai.grakn.engine.tasks.TaskConfiguration;
+import ai.grakn.engine.tasks.TaskConfigurationDeserializer;
+import ai.grakn.engine.tasks.TaskConfigurationSerializer;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.TaskStateDeserializer;
 import ai.grakn.engine.tasks.TaskStateSerializer;
@@ -43,7 +43,7 @@ import java.util.Properties;
  */
 public class ConfigHelper {
 
-    public static Consumer<TaskId, TaskState> kafkaConsumer(String groupId) {
+    public static Consumer<TaskState, TaskConfiguration> kafkaConsumer(String groupId) {
         Properties properties = new Properties();
         properties.putAll(GraknEngineConfig.getInstance().getProperties());
 
@@ -60,13 +60,13 @@ public class ConfigHelper {
         // Max poll records should be set to one: each TaskRunner should only handle one record at a time
         properties.put("max.poll.records", "1");
 
-        return new KafkaConsumer<>(properties, new TaskIdDeserializer(), new TaskStateDeserializer());
+        return new KafkaConsumer<>(properties, new TaskStateDeserializer(), new TaskConfigurationDeserializer());
     }
 
-    public static Producer<TaskId, TaskState> kafkaProducer() {
+    public static Producer<TaskState, TaskConfiguration> kafkaProducer() {
         Properties properties = new Properties();
         properties.putAll(GraknEngineConfig.getInstance().getProperties());
 
-        return new KafkaProducer<>(properties, new TaskIdSerializer(), new TaskStateSerializer());
+        return new KafkaProducer<>(properties, new TaskStateSerializer(), new TaskConfigurationSerializer());
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/StandaloneTaskManager.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/StandaloneTaskManager.java
@@ -27,6 +27,7 @@ import ai.grakn.engine.postprocessing.PostProcessingTask;
 import ai.grakn.engine.postprocessing.UpdatingInstanceCountTask;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.TaskManager;
 import ai.grakn.engine.tasks.TaskSchedule;
 import ai.grakn.engine.tasks.TaskState;
@@ -100,15 +101,15 @@ public class StandaloneTaskManager implements TaskManager {
     }
 
     @Override
-    public void addLowPriorityTask(TaskState taskState){
-        addTask(taskState);
+    public void addLowPriorityTask(TaskState taskState, TaskConfiguration configuration){
+        addTask(taskState, configuration);
     }
 
     //TODO IMPLEMENT HIGH AND LOW PRIORITY IN STANDALONE MODE
     @Override
-    public void addHighPriorityTask(TaskState taskState){
+    public void addHighPriorityTask(TaskState taskState, TaskConfiguration configuration){
         LOG.info("Standalone mode only has a single priority.");
-        addTask(taskState);
+        addTask(taskState, configuration);
     }
 
     public void stopTask(TaskId id) {
@@ -144,7 +145,7 @@ public class StandaloneTaskManager implements TaskManager {
         return storage;
     }
 
-    private void addTask(TaskState taskState){
+    private void addTask(TaskState taskState, TaskConfiguration taskConfiguration){
         storage.newState(taskState);
 
         // Schedule task to run.
@@ -152,7 +153,7 @@ public class StandaloneTaskManager implements TaskManager {
         TaskSchedule schedule = taskState.schedule();
         long delay = Duration.between(now, taskState.schedule().runAt()).toMillis();
 
-        Runnable taskExecution = submitTaskForExecution(taskState);
+        Runnable taskExecution = submitTaskForExecution(taskState, taskConfiguration);
 
         if(schedule.isRecurring()){
             schedulingService.scheduleAtFixedRate(taskExecution, delay, schedule.interval().get().toMillis(), MILLISECONDS);
@@ -161,7 +162,7 @@ public class StandaloneTaskManager implements TaskManager {
         }
     }
 
-    private Runnable executeTask(TaskState task) {
+    private Runnable executeTask(TaskState task, TaskConfiguration configuration) {
         return () -> {
             try {
                 task.markRunning(engineID);
@@ -171,7 +172,7 @@ public class StandaloneTaskManager implements TaskManager {
                 BackgroundTask runningTask = task.taskClass().newInstance();
                 runningTasks.put(task.getId(), runningTask);
 
-                boolean completed = runningTask.start(saveCheckpoint(task), task.configuration());
+                boolean completed = runningTask.start(saveCheckpoint(task), configuration);
 
                 if (completed) {
                     task.markCompleted();
@@ -189,10 +190,10 @@ public class StandaloneTaskManager implements TaskManager {
         };
     }
 
-    private Runnable submitTaskForExecution(TaskState taskState) {
+    private Runnable submitTaskForExecution(TaskState taskState, TaskConfiguration configuration) {
         return () -> {
             if (shouldRunTask(storage.getState(taskState.getId()))) {
-                executorService.submit(executeTask(taskState));
+                executorService.submit(executeTask(taskState, configuration));
             }
         };
     }

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskRunner.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/manager/singlequeue/SingleQueueTaskRunner.java
@@ -23,10 +23,10 @@ import ai.grakn.engine.TaskId;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.ExternalOffsetStorage;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.TaskStateStorage;
 import ai.grakn.engine.util.EngineID;
-import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -55,7 +55,7 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
 
     private final static Logger LOG = LoggerFactory.getLogger(SingleQueueTaskRunner.class);
 
-    private final Consumer<TaskId, TaskState> consumer;
+    private final Consumer<TaskState, TaskConfiguration> consumer;
     private final SingleQueueTaskManager manager;
     private final TaskStateStorage storage;
     private final ExternalOffsetStorage offsetStorage;
@@ -80,10 +80,10 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
      * @param manager a place to control the lifecycle of tasks
      * @param offsetStorage a place to externally store kafka offsets
      */
-    public SingleQueueTaskRunner(SingleQueueTaskManager manager, EngineID engineID, ExternalOffsetStorage offsetStorage, int timeUntilBackoff, Supplier<Consumer<TaskId, TaskState>> consumerSupplier){
+    public SingleQueueTaskRunner(SingleQueueTaskManager manager, EngineID engineID, ExternalOffsetStorage offsetStorage, int timeUntilBackoff, Consumer<TaskState, TaskConfiguration> consumer){
         this.manager = manager;
         this.storage = manager.storage();
-        this.consumer = consumerSupplier.get();
+        this.consumer = consumer;
         this.engineID = engineID;
         this.offsetStorage = offsetStorage;
         this.MAX_TIME_SINCE_HANDLED_BEFORE_BACKOFF = timeUntilBackoff;
@@ -161,29 +161,30 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
     /**
      * Read and handle some records from the given consumer
      */
-    private void readRecords(Consumer<TaskId, TaskState> theConsumer) {
+    private void readRecords(Consumer<TaskState, TaskConfiguration> theConsumer) {
         // This TaskRunner should only ever receive one record from each consumer
-        ConsumerRecords<TaskId, TaskState> records = theConsumer.poll(0);
+        ConsumerRecords<TaskState, TaskConfiguration> records = theConsumer.poll(0);
         debugConsumerStatus(theConsumer, records);
 
-        for (ConsumerRecord<TaskId, TaskState> record : records) {
-            TaskState task = record.value();
-            boolean handled = handleTask(task, record.topic());
+        for (ConsumerRecord< TaskState, TaskConfiguration> record : records) {
+            TaskState task = record.key();
+            TaskConfiguration configuration = record.value();
 
+            boolean handled = handleTask(task, configuration, record.topic());
             if (handled) {
                 timeTaskLastHandled = now();
             }
 
             offsetStorage.saveOffset(theConsumer, new TopicPartition(record.topic(), record.partition()));
 
-            LOG.trace("{} acknowledged", record.key().getValue());
+            LOG.trace("{} acknowledged", task.getId());
         }
     }
 
     /**
      * Returns whether the task was succesfully handled, or was just re-submitted.
      */
-    private boolean handleTask(TaskState taskFromkafka, String priority) {
+    private boolean handleTask(TaskState taskFromkafka, TaskConfiguration configuration, String priority) {
         LOG.debug("{}\treceived", taskFromkafka);
 
         TaskState latestState = getLatestState(taskFromkafka);
@@ -192,14 +193,14 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
             stopTask(latestState);
             return true;
         } else if(shouldDelayTask(latestState)){
-            resubmitTask(latestState, priority);
+            resubmitTask(latestState, configuration, priority);
             return false;
         } else {
             // Need updated state to reflect task state changes in the execute method
-            TaskState updatedState = executeTask(latestState);
+            TaskState updatedState = executeTask(latestState, configuration);
 
             if(taskShouldRecur(updatedState)){
-                resubmitTask(updatedState, priority);
+                resubmitTask(updatedState, configuration, priority);
             }
 
             return true;
@@ -214,7 +215,7 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
      *
      * @param task the task to execute from the kafka queue
      */
-    private TaskState executeTask(TaskState task){
+    private TaskState executeTask(TaskState task, TaskConfiguration configuration){
         try {
             runningTaskId = task.getId();
             runningTask = task.taskClass().newInstance();
@@ -234,7 +235,7 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
 
                 LOG.debug("{}\tmarked as running", task);
 
-                completed = runningTask.start(saveCheckpoint(task), task.configuration());
+                completed = runningTask.start(saveCheckpoint(task), configuration);
             }
 
             if (completed) {
@@ -267,11 +268,11 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
      * to be executed
      * @param task Task to be delayed
      */
-    private void resubmitTask(TaskState task, String priority){
+    private void resubmitTask(TaskState task, TaskConfiguration configuration, String priority){
         if(priority.equals(HIGH_PRIORITY_TASKS_TOPIC)){
-            manager.addHighPriorityTask(task);
+            manager.addHighPriorityTask(task, configuration);
         } else {
-            manager.addLowPriorityTask(task);
+            manager.addLowPriorityTask(task, configuration);
         }
         LOG.debug("{}\tresubmitted with {}", task, priority);
     }
@@ -343,7 +344,7 @@ public class SingleQueueTaskRunner implements Runnable, AutoCloseable {
      * Log debug information about the given set of {@param records} polled from Kafka
      * @param records Polled-for records to return information about
      */
-    private void debugConsumerStatus(Consumer<TaskId, TaskState> theConsumer, ConsumerRecords<TaskId, TaskState> records ){
+    private void debugConsumerStatus(Consumer<TaskState, TaskConfiguration> theConsumer, ConsumerRecords<TaskState, TaskConfiguration> records ){
         for (TopicPartition partition : theConsumer.assignment()) {
             LOG.trace("Partition {}{} has offset {} after receiving {} records",
                     partition.topic(), partition.partition(), theConsumer.position(partition), records.records(partition).size());

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/mock/MockBackgroundTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/mock/MockBackgroundTask.java
@@ -21,10 +21,10 @@ package ai.grakn.engine.tasks.mock;
 import ai.grakn.engine.TaskId;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.manager.singlequeue.SingleQueueTaskManager;
 import com.google.common.collect.ConcurrentHashMultiset;
 import com.google.common.collect.ImmutableMultiset;
-import mjson.Json;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -100,11 +100,11 @@ public abstract class MockBackgroundTask implements BackgroundTask {
     private TaskId id;
 
     @Override
-    public final boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
-        id = TaskId.of(configuration.at("id").asString());
+    public final boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
+        id = TaskId.of(configuration.json().at("id").asString());
         onTaskStart(id);
 
-        saveCheckpoint.accept(TaskCheckpoint.of(configuration));
+        saveCheckpoint.accept(TaskCheckpoint.of(configuration.json()));
 
         boolean wasCancelled = cancelled.get();
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/LockingBackgroundTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/LockingBackgroundTask.java
@@ -22,7 +22,6 @@ import ai.grakn.engine.lock.LockProvider;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
 import ai.grakn.engine.tasks.TaskConfiguration;
-import mjson.Json;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/LockingBackgroundTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/LockingBackgroundTask.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.tasks.storage;
 import ai.grakn.engine.lock.LockProvider;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import mjson.Json;
 
 import java.util.concurrent.locks.Lock;
@@ -40,7 +41,7 @@ import java.util.function.Consumer;
 public abstract class LockingBackgroundTask implements BackgroundTask {
 
     @Override
-    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration) {
+    public boolean start(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration) {
         Lock engineLock = LockProvider.getLock(getLockingKey());
 
         // Try to get lock.
@@ -64,5 +65,5 @@ public abstract class LockingBackgroundTask implements BackgroundTask {
      *
      * @return The actual job to run once the job is acquired
      */
-    protected abstract boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, Json configuration);
+    protected abstract boolean runLockingBackgroundTask(Consumer<TaskCheckpoint> saveCheckpoint, TaskConfiguration configuration);
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
@@ -104,10 +104,6 @@ public class TaskStateGraphStore implements TaskStateStorage {
             state = state.has(RECUR_INTERVAL, var().val(interval.getSeconds()));
         }
 
-        if(task.configuration() != null) {
-            state = state.has(TASK_CONFIGURATION, var().val(task.configuration().toString()));
-        }
-
         if(task.engineID() != null){
             state = state.has(ENGINE_ID, var().val(task.engineID().value()));
         }
@@ -160,10 +156,6 @@ public class TaskStateGraphStore implements TaskStateStorage {
         if(task.checkpoint() != null) {
             resourcesToDettach.add(TASK_CHECKPOINT);
             resources = resources.has(TASK_CHECKPOINT, var().val(task.checkpoint()));
-        }
-        if(task.configuration() != null) {
-            resourcesToDettach.add(TASK_CONFIGURATION);            
-            resources = resources.has(TASK_CONFIGURATION, var().val(task.configuration().toString()));
         }
 
         Var finalResources = resources;

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
@@ -66,7 +66,6 @@ import static ai.grakn.engine.util.SystemOntologyElements.STATUS;
 import static ai.grakn.engine.util.SystemOntologyElements.STATUS_CHANGE_TIME;
 import static ai.grakn.engine.util.SystemOntologyElements.TASK_CHECKPOINT;
 import static ai.grakn.engine.util.SystemOntologyElements.TASK_CLASS_NAME;
-import static ai.grakn.engine.util.SystemOntologyElements.TASK_CONFIGURATION;
 import static ai.grakn.engine.util.SystemOntologyElements.TASK_EXCEPTION;
 import static ai.grakn.engine.util.SystemOntologyElements.TASK_ID;
 import static ai.grakn.graql.Graql.var;

--- a/grakn-engine/src/main/java/ai/grakn/engine/util/SystemOntologyElements.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/util/SystemOntologyElements.java
@@ -32,7 +32,6 @@ public interface SystemOntologyElements {
     TypeLabel SCHEDULED_TASK = TypeLabel.of("scheduled-task");
     TypeLabel STATUS = TypeLabel.of("status");
     TypeLabel STATUS_CHANGE_TIME = TypeLabel.of("status-change-time");
-    TypeLabel STATUS_CHANGE_BY = TypeLabel.of("status-change-by");
     TypeLabel TASK_CLASS_NAME = TypeLabel.of("task-class-name");
     TypeLabel CREATED_BY = TypeLabel.of("created-by");
     TypeLabel ENGINE_ID = TypeLabel.of("engine-id");
@@ -42,6 +41,5 @@ public interface SystemOntologyElements {
     TypeLabel STACK_TRACE = TypeLabel.of("stack-trace");
     TypeLabel TASK_EXCEPTION = TypeLabel.of("task-exception");
     TypeLabel TASK_CHECKPOINT = TypeLabel.of("task-checkpoint");
-    TypeLabel TASK_CONFIGURATION = TypeLabel.of("task-configuration");
     TypeLabel SERIALISED_TASK = TypeLabel.of("task-serialized");
 }

--- a/grakn-test/src/test/java/ai/grakn/client/TaskClientTest.java
+++ b/grakn-test/src/test/java/ai/grakn/client/TaskClientTest.java
@@ -107,10 +107,9 @@ public class TaskClientTest {
         verify(manager).addLowPriorityTask(argThat(argument ->
                 argument.getId().equals(identifier)
                 && argument.taskClass().equals(taskClass)
-                && argument.configuration().equals(configuration)
                 && argument.schedule().runAt().equals(runAt)
                 && argument.schedule().interval().get().equals(interval)
-                && argument.creator().equals(creator)));
+                && argument.creator().equals(creator)), argThat(argument -> argument.json().toString().equals(configuration.toString())));
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/generator/TaskStates.java
+++ b/grakn-test/src/test/java/ai/grakn/generator/TaskStates.java
@@ -59,8 +59,6 @@ public class TaskStates extends Generator<TaskState> {
     public TaskState generate(SourceOfRandomness random, GenerationStatus status) {
         Class<? extends BackgroundTask> taskClass = random.choose(classes);
 
-        TaskId taskId = TaskId.generate();
-
         // TODO: Make this generate random task statuses
 
         String creator = gen().type(String.class).generate(random, status);
@@ -70,10 +68,7 @@ public class TaskStates extends Generator<TaskState> {
         // A bit in the past, because Instant is not monotonic
         TaskSchedule schedule = TaskSchedule.at(Instant.now().minusSeconds(60));
 
-        Json configuration = Json.object();
-        TaskState taskState = TaskState.of(taskClass, creator, schedule, configuration, taskId);
-        configuration.set("id", taskState.getId().getValue());
-        return taskState;
+        return TaskState.of(taskClass, creator, schedule);
     }
 
     public void configure(WithClass withClass) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineFailoverIT.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import static ai.grakn.engine.TaskStatus.COMPLETED;
 import static ai.grakn.engine.TaskStatus.FAILED;
 import static ai.grakn.engine.TaskStatus.STOPPED;
+import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.configuration;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -153,7 +154,7 @@ public class GraknEngineFailoverIT {
                 t.creator(),
                 t.schedule().runAt(),
                 t.schedule().interval().orElse(null),
-                t.configuration())).collect(toSet());
+                configuration(t).json())).collect(toSet());
     }
 
     private static void waitForStatus(Set<TaskId> taskIds, TaskStatus... status) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineServerIT.java
@@ -46,6 +46,7 @@ import static ai.grakn.engine.tasks.mock.MockBackgroundTask.clearTasks;
 import static ai.grakn.engine.tasks.mock.MockBackgroundTask.whenTaskStarts;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.completableTasks;
 import static ai.grakn.engine.tasks.mock.MockBackgroundTask.completedTasks;
+import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.configuration;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForDoneStatus;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForStatus;
 import static org.hamcrest.Matchers.empty;
@@ -89,8 +90,8 @@ public class GraknEngineServerIT {
         List<TaskState> allTasks = Lists.newArrayList(tasks1);
         allTasks.addAll(tasks2);
 
-        tasks1.forEach(engine1.getTaskManager()::addLowPriorityTask);
-        tasks2.forEach(engine2.getTaskManager()::addLowPriorityTask);
+        tasks1.forEach((taskState) -> engine1.getTaskManager().addLowPriorityTask(taskState, configuration(taskState)));
+        tasks2.forEach((taskState) -> engine2.getTaskManager().addLowPriorityTask(taskState, configuration(taskState)));
 
         waitForStatus(storage, allTasks, COMPLETED, STOPPED, FAILED);
 
@@ -102,7 +103,7 @@ public class GraknEngineServerIT {
     public void whenEngine1StopsATaskBeforeExecution_TheTaskIsStopped(TaskState task) {
         assertTrue(TaskClient.of("localhost", PORT1).stopTask(task.getId()));
 
-        engine1.getTaskManager().addLowPriorityTask(task);
+        engine1.getTaskManager().addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(storage, ImmutableList.of(task));
 
@@ -114,7 +115,7 @@ public class GraknEngineServerIT {
     public void whenEngine2StopsATaskBeforeExecution_TheTaskIsStopped(TaskState task) {
         assertTrue(TaskClient.of("localhost", PORT2).stopTask(task.getId()));
 
-        engine1.getTaskManager().addLowPriorityTask(task);
+        engine1.getTaskManager().addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(storage, ImmutableList.of(task));
 
@@ -126,7 +127,7 @@ public class GraknEngineServerIT {
             @WithClass(EndlessExecutionMockTask.class) TaskState task) {
         whenTaskStarts(id -> TaskClient.of("localhost", PORT1).stopTask(task.getId()));
 
-        engine1.getTaskManager().addLowPriorityTask(task);
+        engine1.getTaskManager().addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(storage, ImmutableList.of(task));
 
@@ -138,7 +139,7 @@ public class GraknEngineServerIT {
             @WithClass(EndlessExecutionMockTask.class) TaskState task) {
         whenTaskStarts(id -> TaskClient.of("localhost", PORT2).stopTask(task.getId()));
 
-        engine1.getTaskManager().addLowPriorityTask(task);
+        engine1.getTaskManager().addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(storage, ImmutableList.of(task));
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/CommitLogControllerTest.java
@@ -122,9 +122,8 @@ public class CommitLogControllerTest {
         sendFakeCommitLog();
 
         verify(manager, times(1)).addLowPriorityTask(
-                argThat(argument ->
-                                argument.taskClass().equals(PostProcessingTask.class) &&
-                                argument.configuration().at(COMMIT_LOG_FIXING).equals(commitLog.at(COMMIT_LOG_FIXING)))
+                argThat(argument -> argument.taskClass().equals(PostProcessingTask.class)),
+                argThat(argument -> argument.json().at(COMMIT_LOG_FIXING).equals(commitLog.at(COMMIT_LOG_FIXING)))
         );
     }
 
@@ -138,21 +137,26 @@ public class CommitLogControllerTest {
 
         addSomeData(bob);
 
-        verify(manager, times(1)).addLowPriorityTask(argThat(argument ->
-                        argument.taskClass().equals(PostProcessingTask.class) &&
-                        argument.configuration().at(KEYSPACE).asString().equals(BOB) &&
-                        argument.configuration().at(COMMIT_LOG_FIXING).at(Schema.BaseType.CASTING.name()).asJsonMap().size() == 2 &&
-                        argument.configuration().at(COMMIT_LOG_FIXING).at(Schema.BaseType.RESOURCE.name()).asJsonMap().size() == 1));
+        verify(manager, times(1)).addLowPriorityTask(
+                argThat(argument ->
+                        argument.taskClass().equals(PostProcessingTask.class)),
+                argThat(argument ->
+                        argument.json().at(KEYSPACE).asString().equals(BOB) &&
+                        argument.json().at(COMMIT_LOG_FIXING).at(Schema.BaseType.CASTING.name()).asJsonMap().size() == 2 &&
+                        argument.json().at(COMMIT_LOG_FIXING).at(Schema.BaseType.RESOURCE.name()).asJsonMap().size() == 1));
 
-        verify(manager, never()).addLowPriorityTask(argThat(arg -> arg.configuration().at(KEYSPACE).asString().equals(TIM)));
+        verify(manager, never()).addLowPriorityTask(
+                any(), argThat(arg -> arg.json().at(KEYSPACE).asString().equals(TIM)));
 
         addSomeData(tim);
 
-        verify(manager, times(1)).addLowPriorityTask(argThat(argument ->
-                        argument.taskClass().equals(PostProcessingTask.class) &&
-                        argument.configuration().at(KEYSPACE).asString().equals(TIM) &&
-                        argument.configuration().at(COMMIT_LOG_FIXING).at(Schema.BaseType.CASTING.name()).asJsonMap().size() == 2 &&
-                        argument.configuration().at(COMMIT_LOG_FIXING).at(Schema.BaseType.RESOURCE.name()).asJsonMap().size() == 1));
+        verify(manager, times(1)).addLowPriorityTask(
+                argThat(argument ->
+                        argument.taskClass().equals(PostProcessingTask.class)),
+                argThat(argument ->
+                        argument.json().at(KEYSPACE).asString().equals(TIM) &&
+                        argument.json().at(COMMIT_LOG_FIXING).at(Schema.BaseType.CASTING.name()).asJsonMap().size() == 2 &&
+                        argument.json().at(COMMIT_LOG_FIXING).at(Schema.BaseType.RESOURCE.name()).asJsonMap().size() == 1));
 
         bob.close();
         tim.close();
@@ -173,8 +177,9 @@ public class CommitLogControllerTest {
 
         verify(manager, atLeastOnce()).addHighPriorityTask(
                 argThat(argument ->
-                                argument.taskClass().equals(UpdatingInstanceCountTask.class) &&
-                                argument.configuration().at(COMMIT_LOG_COUNTING).asJsonList().size() == 5)
+                                argument.taskClass().equals(UpdatingInstanceCountTask.class)),
+                argThat(argument ->
+                                argument.json().at(COMMIT_LOG_COUNTING).asJsonList().size() == 5)
         );
     }
 
@@ -190,15 +195,19 @@ public class CommitLogControllerTest {
         addSomeData(tim);
 
         try {
-            verify(manager, atLeastOnce()).addHighPriorityTask(argThat(argument ->
-                            argument.taskClass().equals(UpdatingInstanceCountTask.class) &&
-                            argument.configuration().at(KEYSPACE).asString().equals(BOB) &&
-                            argument.configuration().at(COMMIT_LOG_COUNTING).asJsonList().size() == 3));
+            verify(manager, atLeastOnce()).addHighPriorityTask(
+                    argThat(argument ->
+                            argument.taskClass().equals(UpdatingInstanceCountTask.class)),
+                    argThat(argument ->
+                            argument.json().at(KEYSPACE).asString().equals(BOB) &&
+                            argument.json().at(COMMIT_LOG_COUNTING).asJsonList().size() == 3));
 
-            verify(manager, atLeastOnce()).addHighPriorityTask(argThat(argument ->
-                            argument.taskClass().equals(UpdatingInstanceCountTask.class) &&
-                            argument.configuration().at(KEYSPACE).asString().equals(TIM) &&
-                            argument.configuration().at(COMMIT_LOG_COUNTING).asJsonList().size() == 3));
+            verify(manager, atLeastOnce()).addHighPriorityTask(
+                    argThat(argument ->
+                            argument.taskClass().equals(UpdatingInstanceCountTask.class)),
+                    argThat(argument ->
+                            argument.json().at(KEYSPACE).asString().equals(TIM) &&
+                            argument.json().at(COMMIT_LOG_COUNTING).asJsonList().size() == 3));
         } finally {
             Grakn.session(Grakn.DEFAULT_URI, BOB).open(GraknTxType.WRITE).clear();
             Grakn.session(Grakn.DEFAULT_URI, TIM).open(GraknTxType.WRITE).clear();
@@ -217,8 +226,8 @@ public class CommitLogControllerTest {
         resourceType.putResource("c");
         graph1.commit();
 
-        verify(manager, never()).addLowPriorityTask(any());
-        verify(manager, never()).addHighPriorityTask(any());
+        verify(manager, never()).addLowPriorityTask(any(), any());
+        verify(manager, never()).addHighPriorityTask(any(), any());
     }
 
     private void sendFakeCommitLog() {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/TasksControllerTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -114,7 +115,7 @@ public class TasksControllerTest {
         send();
 
         verify(manager, atLeastOnce()).addLowPriorityTask(
-                argThat(argument -> argument.taskClass().equals(ShortExecutionMockTask.class)));
+                argThat(argument -> argument.taskClass().equals(ShortExecutionMockTask.class)), any());
     }
 
     @Test
@@ -136,7 +137,7 @@ public class TasksControllerTest {
         Instant runAt = now();
         send(Json.object().toString(), defaultParams());
 
-        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().runAt().equals(runAt)));
+        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().runAt().equals(runAt)), any());
     }
 
     @Test
@@ -151,8 +152,8 @@ public class TasksControllerTest {
                 )
         );
 
-        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().interval().isPresent()));
-        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().isRecurring()));
+        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().interval().isPresent()), any());
+        verify(manager).addLowPriorityTask(argThat(argument -> argument.schedule().isRecurring()), any());
     }
 
     @Test
@@ -259,7 +260,6 @@ public class TasksControllerTest {
         assertThat(json.at(TASK_CREATOR_PARAMETER).asString(), equalTo(task.creator()));
         assertThat(json.at(TASK_RUN_AT_PARAMETER).asLong(), equalTo(task.schedule().runAt().toEpochMilli()));
         assertThat(json.at(TASK_STATUS_PARAMETER).asString(), equalTo(task.status().name()));
-        assertThat(json.at("configuration"), equalTo(task.configuration()));
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTaskTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTaskTest.java
@@ -24,6 +24,7 @@ import ai.grakn.engine.lock.NonReentrantLock;
 import ai.grakn.engine.postprocessing.PostProcessing;
 import ai.grakn.engine.postprocessing.PostProcessingTask;
 import ai.grakn.engine.tasks.TaskCheckpoint;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.util.REST;
 import ai.grakn.util.Schema;
 import com.google.common.collect.Sets;
@@ -54,7 +55,7 @@ public class PostProcessingTaskTest {
     private String mockResourceIndex;
     private Set<ConceptId> mockCastingSet;
     private Set<ConceptId> mockResourceSet;
-    private Json mockJson;
+    private TaskConfiguration mockConfiguration;
     private Consumer<TaskCheckpoint> mockConsumer;
     private PostProcessing mockPostProcessing;
 
@@ -77,12 +78,13 @@ public class PostProcessingTaskTest {
         mockResourceIndex = UUID.randomUUID().toString();
         mockCastingSet = Sets.newHashSet();
         mockResourceSet = Sets.newHashSet();
-        mockJson = Json.object(
-                KEYSPACE, TEST_KEYSPACE,
-                REST.Request.COMMIT_LOG_FIXING, Json.object(
-                    Schema.BaseType.CASTING.name(), Json.object(mockCastingIndex, mockCastingSet),
-                    Schema.BaseType.RESOURCE.name(), Json.object(mockResourceIndex, mockResourceSet)
-                )
+        mockConfiguration = TaskConfiguration.of(
+                Json.object(
+                        KEYSPACE, TEST_KEYSPACE,
+                    REST.Request.COMMIT_LOG_FIXING, Json.object(
+                        Schema.BaseType.CASTING.name(), Json.object(mockCastingIndex, mockCastingSet),
+                        Schema.BaseType.RESOURCE.name(), Json.object(mockResourceIndex, mockResourceSet)
+                    ))
         );
 
         Mockito.reset(mockPostProcessing);
@@ -92,7 +94,7 @@ public class PostProcessingTaskTest {
     public void whenPPTaskStartCalledAndNotEnoughTimeElapsed_PostProcessingRunNotCalled(){
         PostProcessingTask task = new PostProcessingTask(mockPostProcessing, Long.MAX_VALUE);
 
-        task.start(mockConsumer, mockJson);
+        task.start(mockConsumer, mockConfiguration);
 
         verify(mockPostProcessing, never())
                 .performCastingFix(TEST_KEYSPACE, mockCastingIndex, mockCastingSet);
@@ -102,7 +104,7 @@ public class PostProcessingTaskTest {
     public void whenPPTaskCalledWithCastingsToPP_PostProcessingPerformCastingsFixCalled(){
         PostProcessingTask task = new PostProcessingTask(mockPostProcessing, 0);
 
-        task.start(mockConsumer, mockJson);
+        task.start(mockConsumer, mockConfiguration);
 
         verify(mockPostProcessing, times(1))
                 .performCastingFix(TEST_KEYSPACE, mockCastingIndex, mockCastingSet);
@@ -112,7 +114,7 @@ public class PostProcessingTaskTest {
     public void whenPPTaskCalledWithResourcesToPP_PostProcessingPerformResourcesFixCalled(){
         PostProcessingTask task = new PostProcessingTask(mockPostProcessing, 0);
 
-        task.start(mockConsumer, mockJson);
+        task.start(mockConsumer, mockConfiguration);
 
         verify(mockPostProcessing, times(1))
                 .performResourceFix(TEST_KEYSPACE, mockResourceIndex, mockResourceSet);
@@ -122,14 +124,14 @@ public class PostProcessingTaskTest {
     public void whenPPTaskStartCalledAndNotEnoughTimeElapsed_PostProcessingStartReturnsTrue(){
         PostProcessingTask task = new PostProcessingTask(mockPostProcessing, Long.MAX_VALUE);
 
-        assertTrue("Task " + task + " ran when it should not have", task.start(mockConsumer, mockJson));
+        assertTrue("Task " + task + " ran when it should not have", task.start(mockConsumer, mockConfiguration));
     }
 
     @Test
     public void whenPPTaskStartCalledAndPostProcessingRuns_PostProcessingStartReturnsFalse(){
         PostProcessingTask task = new PostProcessingTask(mockPostProcessing, 0);
 
-        assertFalse("Task " + task + " did not run when it should have", task.start(mockConsumer, mockJson));
+        assertFalse("Task " + task + " did not run when it should have", task.start(mockConsumer, mockConfiguration));
     }
 
     @Test
@@ -148,10 +150,10 @@ public class PostProcessingTaskTest {
         PostProcessingTask task2 = new PostProcessingTask(mockPostProcessing, 0);
 
         Thread pp1 = new Thread(() -> {
-            task1.start(mockConsumer, mockJson);
+            task1.start(mockConsumer, mockConfiguration);
         });
         Thread pp2 = new Thread(() -> {
-            task2.start(mockConsumer, mockJson);
+            task2.start(mockConsumer, mockConfiguration);
         });
 
         pp1.start();

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestIT.java
@@ -26,6 +26,7 @@ import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.engine.postprocessing.PostProcessingTask;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.exception.ConceptNotUniqueException;
 import ai.grakn.exception.GraknValidationException;
 import ai.grakn.graph.internal.AbstractGraknGraph;
@@ -145,7 +146,7 @@ public class PostProcessingTestIT {
         //TODO: Find a better way of doing this
         jsonLogs.forEach(log -> {
             PostProcessingTask ppTask = new PostProcessingTask();
-            ppTask.runLockingBackgroundTask(null, log);
+            ppTask.runLockingBackgroundTask(null, TaskConfiguration.of(log));
         });
 
         //Check current broken state of graph

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/ResourceDeduplicationMapReduceTestIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/ResourceDeduplicationMapReduceTestIT.java
@@ -11,6 +11,7 @@ import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.RoleType;
 import ai.grakn.engine.postprocessing.ResourceDeduplicationTask;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.test.EngineContext;
 import ai.grakn.util.Schema;
 import mjson.Json;
@@ -150,8 +151,8 @@ public class ResourceDeduplicationMapReduceTestIT {
     //@Ignore
     public void testNoResources() {
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(0), task.totalElimintated());
     }
     
@@ -173,8 +174,8 @@ public class ResourceDeduplicationMapReduceTestIT {
             graph.commit();
         });
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(0), task.totalElimintated());        
     }
     
@@ -211,8 +212,8 @@ public class ResourceDeduplicationMapReduceTestIT {
             Assert.assertFalse(checkUnique(graph, doubleIndex));
         });
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));        
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(9), task.totalElimintated());
         transact(graph -> {
             Assert.assertTrue(checkUnique(graph, stringIndex));
@@ -237,8 +238,8 @@ public class ResourceDeduplicationMapReduceTestIT {
             Assert.assertFalse(checkUnique(graph, resourceIndex));
         });        
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));        
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(1), task.totalElimintated());
         transact(graph -> {
             Assert.assertTrue(checkUnique(graph, resourceIndex));
@@ -262,8 +263,8 @@ public class ResourceDeduplicationMapReduceTestIT {
             Assert.assertFalse(checkUnique(graph, resourceIndex));
         });        
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));        
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(3), task.totalElimintated());
         transact(graph -> {
             Assert.assertTrue(checkUnique(graph, resourceIndex));
@@ -290,9 +291,9 @@ public class ResourceDeduplicationMapReduceTestIT {
              Assert.assertFalse(checkUnique(graph, resourceIndex));
          });        
          ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-         task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                     Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));        
-         Assert.assertEquals(new Long(1), task.totalElimintated());
+         task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                 TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
+        Assert.assertEquals(new Long(1), task.totalElimintated());
          transact(graph -> {
              Assert.assertTrue(checkUnique(graph, resourceIndex));
              Resource<String> res = graph.admin().getConcept(Schema.ConceptProperty.INDEX, resourceIndex);
@@ -337,8 +338,8 @@ public class ResourceDeduplicationMapReduceTestIT {
            return new String[] { indexOf(graph, sres), indexOf(graph, fres) };
         });
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
-        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace()));        
+        task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); },
+                TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace())));
         Assert.assertEquals(new Long(7), task.totalElimintated());
         transact(graph -> {
             for (String key : resourceKeys)
@@ -382,8 +383,8 @@ public class ResourceDeduplicationMapReduceTestIT {
         });
         ResourceDeduplicationTask task = new ResourceDeduplicationTask(); 
         task.start(checkpoint -> { throw new RuntimeException("No checkpoint expected."); }, 
-                    Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace(),
-                            ResourceDeduplicationTask.DELETE_UNATTACHED_CONFIG, true));        
+                    TaskConfiguration.of(Json.object(ResourceDeduplicationTask.KEYSPACE_CONFIG, keyspace(),
+                            ResourceDeduplicationTask.DELETE_UNATTACHED_CONFIG, true)));
         Assert.assertEquals(new Long(3), task.totalElimintated());        
         transact(graph -> {
             for (String key : resourceKeys)

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/UpdatingInstanceCountTaskTest.java
@@ -4,6 +4,7 @@ import ai.grakn.Grakn;
 import ai.grakn.GraknGraph;
 import ai.grakn.GraknTxType;
 import ai.grakn.engine.postprocessing.UpdatingInstanceCountTask;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.TaskSchedule;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.test.EngineContext;
@@ -51,8 +52,8 @@ public class UpdatingInstanceCountTaskTest {
         );
 
         //Start up the Job
-        TaskState task = TaskState.of(UpdatingInstanceCountTask.class, getClass().getName(), TaskSchedule.now(), configuration);
-        engine.getTaskManager().addLowPriorityTask(task);
+        TaskState task = TaskState.of(UpdatingInstanceCountTask.class, getClass().getName(), TaskSchedule.now());
+        engine.getTaskManager().addLowPriorityTask(task, TaskConfiguration.of(configuration));
 
         // Wait for task to complete
         waitForDoneStatus(engine.getTaskManager().storage(), singleton(task));

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/BackgroundTaskTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/BackgroundTaskTestUtils.java
@@ -21,6 +21,7 @@ package ai.grakn.test.engine.tasks;
 import ai.grakn.engine.TaskStatus;
 import ai.grakn.engine.tasks.BackgroundTask;
 import ai.grakn.engine.TaskId;
+import ai.grakn.engine.tasks.TaskConfiguration;
 import ai.grakn.engine.tasks.TaskSchedule;
 import ai.grakn.engine.tasks.TaskState;
 import ai.grakn.engine.tasks.TaskStateStorage;
@@ -33,13 +34,13 @@ import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
 import java.time.Duration;
 import java.time.Instant;
-import mjson.Json;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import mjson.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +64,10 @@ public class BackgroundTaskTestUtils {
         return generate(() -> createTask(ShortExecutionMockTask.class).markRunning(engineID)).limit(n).collect(toSet());
     }
 
+    public static TaskConfiguration configuration(TaskState taskState){
+        return TaskConfiguration.of(Json.object("id", taskState.getId().getValue()));
+    }
+
     public static TaskState createTask() {
         return createTask(ShortExecutionMockTask.class);
     }
@@ -72,13 +77,7 @@ public class BackgroundTaskTestUtils {
     }
 
     public static TaskState createTask(Class<? extends BackgroundTask> clazz, TaskSchedule schedule) {
-        return createTask(clazz, schedule, Json.object());
-    }
-
-    public static TaskState createTask(Class<? extends BackgroundTask> clazz, TaskSchedule schedule, Json configuration) {
-        TaskState taskState = TaskState.of(clazz, BackgroundTaskTestUtils.class.getName(), schedule, configuration);
-        configuration.set("id", taskState.getId().getValue());
-        return taskState;
+        return TaskState.of(clazz, BackgroundTaskTestUtils.class.getName(), schedule);
     }
 
     public static void waitForDoneStatus(TaskStateStorage storage, Collection<TaskState> tasks) {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/StandaloneTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/StandaloneTaskManagerTest.java
@@ -49,6 +49,7 @@ import static ai.grakn.engine.TaskStatus.STOPPED;
 import static ai.grakn.engine.tasks.TaskSchedule.at;
 import static ai.grakn.engine.tasks.TaskSchedule.recurring;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.completableTasks;
+import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.configuration;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.createTask;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.failingTasks;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForDoneStatus;
@@ -75,7 +76,7 @@ public class StandaloneTaskManagerTest {
     @Test
     public void testRunSingle() {
         TaskState task = createTask();
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         // Wait for task to be executed.
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
@@ -86,7 +87,7 @@ public class StandaloneTaskManagerTest {
     @Property(trials=10)
     public void afterRunning_AllNonFailingTasksAreRecordedAsCompleted(List<TaskState> tasks) {
         // Schedule tasks
-        tasks.forEach(taskManager::addLowPriorityTask);
+        tasks.forEach((taskState) -> taskManager.addLowPriorityTask(taskState, configuration(taskState)));
 
         waitForDoneStatus(taskManager.storage(), tasks);
 
@@ -98,7 +99,7 @@ public class StandaloneTaskManagerTest {
     @Property(trials=10)
     public void afterRunning_AllFailingTasksAreRecordedAsFailed(List<TaskState> tasks) {
         // Schedule tasks
-        tasks.forEach(taskManager::addLowPriorityTask);
+        tasks.forEach((taskState) -> taskManager.addLowPriorityTask(taskState, configuration(taskState)));
 
         waitForDoneStatus(taskManager.storage(), tasks);
 
@@ -110,7 +111,7 @@ public class StandaloneTaskManagerTest {
     @Test
     public void testRunRecurring() throws Exception {
         TaskState task = createTask(ShortExecutionMockTask.class, recurring(Duration.ofMillis(100)));
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         Thread.sleep(2000);
 
@@ -123,7 +124,7 @@ public class StandaloneTaskManagerTest {
     @Test
     public void testStopSingle() {
         TaskState task = createTask(ShortExecutionMockTask.class, at(now().plusSeconds(1000)));
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         TaskStatus status = taskManager.storage().getState(task.getId()).status();
         assertTrue(status == CREATED || status == RUNNING);

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/manager/singlequeue/SingleQueueTaskManagerTest.java
@@ -56,6 +56,7 @@ import static ai.grakn.engine.tasks.mock.MockBackgroundTask.completedTasks;
 import static ai.grakn.engine.tasks.mock.MockBackgroundTask.whenTaskFinishes;
 import static ai.grakn.engine.tasks.mock.MockBackgroundTask.whenTaskStarts;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.completableTasks;
+import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.configuration;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.createTask;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForDoneStatus;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForStatus;
@@ -97,7 +98,7 @@ public class SingleQueueTaskManagerTest {
 
     @Property(trials=10)
     public void afterSubmitting_AllTasksAreCompleted(List<TaskState> tasks){
-        tasks.forEach(taskManager::addLowPriorityTask);
+        tasks.forEach((taskState) -> taskManager.addLowPriorityTask(taskState, configuration(taskState)));
         waitForStatus(taskManager.storage(), tasks, COMPLETED, FAILED);
 
         assertEquals(completableTasks(tasks), completedTasks());
@@ -108,7 +109,7 @@ public class SingleQueueTaskManagerTest {
     public void whenStoppingATaskBeforeItsExecuted_TheTaskIsNotExecuted(TaskState task) {
         taskManager.stopTask(task.getId());
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -120,7 +121,7 @@ public class SingleQueueTaskManagerTest {
     public void whenStoppingATaskBeforeItsExecuted_TheTaskIsMarkedAsStopped(TaskState task) {
         taskManager.stopTask(task.getId());
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -132,7 +133,7 @@ public class SingleQueueTaskManagerTest {
             @WithClass(EndlessExecutionMockTask.class) TaskState task) {
         whenTaskStarts(id -> taskManager.stopTask(id));
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -145,7 +146,7 @@ public class SingleQueueTaskManagerTest {
             @WithClass(EndlessExecutionMockTask.class) TaskState task) {
         whenTaskStarts(id -> taskManager.stopTask(id));
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -156,7 +157,7 @@ public class SingleQueueTaskManagerTest {
     public void whenStoppingATaskAfterExecution_TheTaskIsNotCancelled(TaskState task) {
         whenTaskFinishes(id -> taskManager.stopTask(id));
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -167,7 +168,7 @@ public class SingleQueueTaskManagerTest {
     public void whenStoppingATaskAfterExecution_TheTaskIsMarkedAsCompleted(TaskState task) {
         whenTaskFinishes(id -> taskManager.stopTask(id));
 
-        taskManager.addLowPriorityTask(task);
+        taskManager.addLowPriorityTask(task, configuration(task));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(task));
 
@@ -180,8 +181,8 @@ public class SingleQueueTaskManagerTest {
 
         TaskState highPriorityTask = createTask(ShortExecutionMockTask.class, now());
 
-        manyTasks.forEach(taskManager::addLowPriorityTask);
-        taskManager.addHighPriorityTask(highPriorityTask);
+        manyTasks.forEach((taskState) -> taskManager.addLowPriorityTask(taskState, configuration(taskState)));
+        taskManager.addHighPriorityTask(highPriorityTask, configuration(highPriorityTask));
 
         waitForDoneStatus(taskManager.storage(), ImmutableList.of(highPriorityTask));
         waitForDoneStatus(taskManager.storage(), manyTasks);
@@ -214,8 +215,8 @@ public class SingleQueueTaskManagerTest {
             }
         });
 
-        manyTasks.forEach(taskManager::addLowPriorityTask);
-        taskManager.addHighPriorityTask(recurringTask);
+        manyTasks.forEach((taskState) -> taskManager.addLowPriorityTask(taskState, configuration(taskState)));
+        taskManager.addHighPriorityTask(recurringTask, configuration(recurringTask));
 
         Thread.sleep(sleepDur.toMillis());
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateGraphStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateGraphStoreTest.java
@@ -26,7 +26,6 @@ import ai.grakn.engine.tasks.storage.TaskStateGraphStore;
 import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.EngineContext;
 import ai.grakn.engine.tasks.mock.ShortExecutionMockTask;
-import mjson.Json;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -45,7 +44,6 @@ import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TaskStateGraphStoreTest {
@@ -64,9 +62,8 @@ public class TaskStateGraphStoreTest {
     public void testTaskStateStoreRetrieve() {
         ShortExecutionMockTask task = new ShortExecutionMockTask();
         Instant runAt = Instant.now();
-        Json configuration = Json.object("test key", "test value");
 
-        TaskId id = stateStorage.newState(task(at(runAt), configuration));
+        TaskId id = stateStorage.newState(task(at(runAt)));
         assertNotNull(id);
 
         TaskState state = stateStorage.getState(id);
@@ -77,15 +74,13 @@ public class TaskStateGraphStoreTest {
         assertEquals(runAt, state.schedule().runAt());
         assertFalse(state.schedule().isRecurring());
         assertEquals(Optional.empty(), state.schedule().interval());
-        assertEquals(configuration.toString(), state.configuration().toString());
     }
 
     @Test
     public void testUpdateTaskState() {
         Instant runAt = Instant.now();
-        Json configuration = Json.object("test key", "test value");
 
-        TaskId id = stateStorage.newState(task(at(runAt), configuration));
+        TaskId id = stateStorage.newState(task(at(runAt)));
         assertNotNull(id);
 
         // Get current values
@@ -124,7 +119,7 @@ public class TaskStateGraphStoreTest {
 
     @Test
     public void testGetTaskStateByCreator() {
-        TaskId id = stateStorage.newState(task(TaskSchedule.now(), Json.object(), "other"));
+        TaskId id = stateStorage.newState(task(TaskSchedule.now(), "other"));
         assertNotNull(id);
 
         Set<TaskState> res = stateStorage.getTasks(null, null, "other", null, 0, 0);
@@ -191,14 +186,14 @@ public class TaskStateGraphStoreTest {
     }
 
     public TaskState task(){
-        return task(TaskSchedule.now(), Json.object(), getClass().getName());
+        return task(TaskSchedule.now(), getClass().getName());
     }
 
-    public TaskState task(TaskSchedule schedule, Json configuration){
-        return task(schedule, configuration, getClass().getName());
+    public TaskState task(TaskSchedule schedule){
+        return task(schedule, getClass().getName());
     }
 
-    public TaskState task(TaskSchedule schedule, Json configuration, String creator){
-        return TaskState.of(ShortExecutionMockTask.class, creator, schedule, configuration);
+    public TaskState task(TaskSchedule schedule, String creator){
+        return TaskState.of(ShortExecutionMockTask.class, creator, schedule);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateInMemoryStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateInMemoryStoreTest.java
@@ -38,7 +38,6 @@ import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class TaskStateInMemoryStoreTest {
@@ -159,6 +158,6 @@ public class TaskStateInMemoryStoreTest {
     }
 
     public TaskState task(){
-        return TaskState.of(ShortExecutionMockTask.class, this.getClass().getName(), TaskSchedule.now(), null);
+        return TaskState.of(ShortExecutionMockTask.class, this.getClass().getName(), TaskSchedule.now());
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateZookeeperStoreTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/tasks/storage/TaskStateZookeeperStoreTest.java
@@ -251,7 +251,7 @@ public class TaskStateZookeeperStoreTest {
     }
 
     public TaskState task(String creator){
-        return TaskState.of(ShortExecutionMockTask.class, creator, TaskSchedule.now(), null);
+        return TaskState.of(ShortExecutionMockTask.class, creator, TaskSchedule.now());
     }
 
     /**


### PR DESCRIPTION
+ TaskState is stored in Zookeeper - we need to keep this small
+ Without failover there is never a need to recover configuration