### PR TITLE
Work around config search bug in titan.

### DIFF
--- a/grakn-dist/src/bin/grakn-engine.sh
+++ b/grakn-dist/src/bin/grakn-engine.sh
@@ -47,6 +47,7 @@ start)
     else
         # engine has not already started
         echo -n "Starting engine"
+        cd "${GRAKN_HOME}"
         if [[ "$FOREGROUND" = true ]]; then
             java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}/bin" -Dgrakn.conf="${GRAKN_CONFIG}" ai.grakn.engine.GraknEngineServer
         else


### PR DESCRIPTION
The bug causes titan to recursively search for a config file from the
PWD. Work around by changing to GRAKN_HOME to narrow search scope.