### PR TITLE
LoaderClient & Migration callback fixes

### DIFF
--- a/conf/main/logback.xml
+++ b/conf/main/logback.xml
@@ -77,15 +77,6 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <!--Client side migration should print debug-->
-    <logger name="ai.grakn.migration.base.Migrator" level="DEBUG">
-        <appender-ref ref="MAIN"/>
-    </logger>
-
-    <logger name="ai.grakn.client.LoaderClient" level="DEBUG">
-        <appender-ref ref="MAIN"/>
-    </logger>
-
     <!--Post Processing logs go to separate log file-->
     <logger name="ai.grakn.engine.postprocessing" level="${grakn.log.level:-INFO}" additivity="false">
         <appender-ref ref="POST-PROCESSING"/>

--- a/grakn-client/src/main/java/ai/grakn/client/LoaderClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/LoaderClient.java
@@ -223,13 +223,16 @@ public class LoaderClient {
 
             status
             // Unblock and log errors when task completes
-            .whenComplete((result, error) -> {
+            .handle((result, error) -> {
                 unblock(status);
 
                 // Log any errors
                 if(error != null){
                     LOG.error("Error", error);
-                }})
+                }
+
+                return result;
+            })
             // Execute registered completion function
             .thenAcceptAsync(onCompletionOfTask)
             // Log errors in completion function

--- a/grakn-client/src/main/java/ai/grakn/client/LoaderClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/LoaderClient.java
@@ -221,16 +221,23 @@ public class LoaderClient {
             // Add this status to the set of completable futures
             futures.put(status.hashCode(), status);
 
-            // Function to execute when the task completes
-            status.whenComplete((result, error) -> {
+            status
+            // Unblock and log errors when task completes
+            .whenComplete((result, error) -> {
                 unblock(status);
 
+                // Log any errors
                 if(error != null){
                     LOG.error("Error", error);
-                }
-
-                onCompletionOfTask.accept(result);
+                }})
+            // Execute registered completion function
+            .thenAcceptAsync(onCompletionOfTask)
+            // Log errors in completion function
+            .exceptionally(t -> {
+                LOG.error("error in callback", t);
+                throw new RuntimeException(t);
             });
+
         } catch (Throwable throwable){
             LOG.error("Error", throwable);
             blocker.release();

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.migration.base;
 
-import ai.grakn.engine.TaskStatus;
 import ai.grakn.client.LoaderClient;
 import ai.grakn.exception.GraqlTemplateParsingException;
 import ai.grakn.graql.Graql;
@@ -163,16 +162,11 @@ public class Migrator {
      */
     private Consumer<Json> recordMigrationStates(){
         return (Json json) -> {
-            TaskStatus status = TaskStatus.valueOf(json.at("status").asString());
-            Json configuration = Json.read(json.at("configuration").asString());
-            int batch = configuration.at("batchNumber").asInteger();
-
             numberBatchesCompleted.incrementAndGet();
 
             long timeElapsedSeconds = (System.currentTimeMillis() - startTime)/1000;
             long numberQueriesCompleted = numberBatchesCompleted.get() * batchSize;
 
-            LOG.info(format("Status of batch [%s]: %s", batch, status));
             LOG.info(format("Number queries submitted: %s", numberQueriesSubmitted.get()));
             LOG.info(format("Number batches completed: %s", numberBatchesCompleted.get()));
             LOG.info(format("~Number queries completed: %s", numberQueriesCompleted));

--- a/grakn-test/src/test/java/ai/grakn/client/LoaderClientTest.java
+++ b/grakn-test/src/test/java/ai/grakn/client/LoaderClientTest.java
@@ -23,6 +23,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Entity;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.engine.controller.CommitLogController;
 import ai.grakn.engine.controller.TasksController;
 import ai.grakn.engine.tasks.TaskManager;
 import ai.grakn.engine.tasks.manager.StandaloneTaskManager;
@@ -70,6 +71,7 @@ public class LoaderClientTest {
         configureSpark(spark, PORT);
 
         new TasksController(spark, manager);
+        new CommitLogController(spark, manager);
 
         spark.awaitInitialization();
     }


### PR DESCRIPTION
Addresses Bug #12903 (Client may execute CompletableFuture twice) and Bug #13616 (Migration client-side logs not printing)