### PR TITLE
Bug #13405: Ensure that all regexes are applied.

### DIFF
--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
@@ -20,6 +20,7 @@ package ai.grakn.graph.internal;
 
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.ResourceType;
+import ai.grakn.concept.TypeLabel;
 import ai.grakn.exception.InvalidConceptValueException;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
@@ -68,6 +69,16 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
     }
 
     /**
+     * This method is overridden so that we can check that the regex of the new super type (if it has a regex)
+     * can be applied to all the existing instances.
+     */
+    @Override
+    public ResourceType<D> superType(ResourceType<D> superType){
+        checkInstancesMatchRegex(superType.getLabel(), superType.getRegex());
+        return super.superType(superType);
+    }
+
+    /**
      * @param regex The regular expression which instances of this resource must conform to.
      * @return The Resource Type itself.
      */
@@ -77,6 +88,19 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
             throw new UnsupportedOperationException(ErrorMessage.REGEX_NOT_STRING.getMessage(getLabel()));
         }
 
+        checkInstancesMatchRegex(getLabel(), regex);
+
+        return setProperty(Schema.ConceptProperty.REGEX, regex);
+    }
+
+    /**
+     * Checks that existing instances match the provided regex.
+     *
+     * @throws InvalidConceptValueException when an instance does not match the provided regex
+     * @param label The label of the resource type which either contains or will contain this regex
+     * @param regex The regex to check against
+     */
+    private void checkInstancesMatchRegex(TypeLabel label, String regex){
         if(regex != null) {
             Pattern pattern = Pattern.compile(regex);
             Matcher matcher;
@@ -84,12 +108,10 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
                 String value = (String) resource.getValue();
                 matcher = pattern.matcher(value);
                 if(!matcher.matches()){
-                    throw new InvalidConceptValueException(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage(regex, resource.getId(), value, getLabel()));
+                    throw new InvalidConceptValueException(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage(regex, resource.getId(), value, label));
                 }
             }
         }
-
-        return setProperty(Schema.ConceptProperty.REGEX, regex);
     }
 
     @SuppressWarnings("unchecked")

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ResourceTypeImpl.java
@@ -74,7 +74,7 @@ class ResourceTypeImpl<D> extends TypeImpl<ResourceType<D>, Resource<D>> impleme
      */
     @Override
     public ResourceType<D> superType(ResourceType<D> superType){
-        checkInstancesMatchRegex(superType.getLabel(), superType.getRegex());
+        ((ResourceTypeImpl<D>) superType).superTypeSet().forEach(st -> checkInstancesMatchRegex(st.getLabel(), st.getRegex()));
         return super.superType(superType);
     }
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
@@ -113,4 +113,28 @@ public class ResourceTypeTest extends GraphTestBase{
         expectedException.expectMessage(CoreMatchers.allOf(containsString("[b]"), containsString("a"), containsString(t1.getLabel().getValue())));
         t2.putResource("a");
     }
+
+    @Test
+    public void whenSettingTheSuperTypeOfAStringResourceType_EnsureAllRegexesAreAppliedToResources(){
+        ResourceType<String> t1 = graknGraph.putResourceType("t1", ResourceType.DataType.STRING).setRegex("[b]");
+        ResourceType<String> t2 = graknGraph.putResourceType("t2", ResourceType.DataType.STRING).setRegex("[abc]");
+
+        //Future Invalid
+        Resource<String> resource = t2.putResource("a");
+
+        expectedException.expect(InvalidConceptValueException.class);
+        expectedException.expectMessage(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[b]", resource.getId(), resource.getValue(), t1.getLabel()));
+        t2.superType(t1);
+    }
+
+    @Test
+    public void whenSettingRegexOfSuperType_EnsureAllRegexesAreApplied(){
+        ResourceType<String> t1 = graknGraph.putResourceType("t1", ResourceType.DataType.STRING);
+        ResourceType<String> t2 = graknGraph.putResourceType("t2", ResourceType.DataType.STRING).setRegex("[abc]").superType(t1);
+        Resource<String> resource = t2.putResource("a");
+
+        expectedException.expect(InvalidConceptValueException.class);
+        expectedException.expectMessage(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[b]", resource.getId(), resource.getValue(), t1.getLabel()));
+        t1.setRegex("[b]");
+    }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
@@ -30,8 +30,6 @@ import java.util.regex.PatternSyntaxException;
 
 import static junit.framework.TestCase.assertNull;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 public class ResourceTypeTest extends GraphTestBase{
@@ -44,26 +42,26 @@ public class ResourceTypeTest extends GraphTestBase{
     }
 
     @Test
-    public void testDataType() throws Exception {
+    public void whenCreatingResourceTypeOfTypeString_DataTypeIsString() throws Exception {
         assertEquals(ResourceType.DataType.STRING, resourceType.getDataType());
     }
 
     @Test
-    public void testRegexValid(){
+    public void whenCreatingStringResourceTypeWithValidRegex_EnsureNoErrorsThrown(){
         assertNull(resourceType.getRegex());
         resourceType.setRegex("[abc]");
         assertEquals(resourceType.getRegex(), "[abc]");
     }
 
     @Test
-    public void testRegexInvalid(){
+    public void whenCreatingStringResourceTypeWithInvalidRegex_Throw(){
         assertNull(resourceType.getRegex());
         expectedException.expect(PatternSyntaxException.class);
         resourceType.setRegex("[");
     }
 
     @Test
-    public void testRegexSetOnNonString(){
+    public void whenSettingRegexOnNonStringResourceType_Throw(){
         ResourceType<Long> thing = graknGraph.putResourceType("Random ID", ResourceType.DataType.LONG);
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage(ErrorMessage.REGEX_NOT_STRING.getMessage(thing.getLabel()));
@@ -71,7 +69,7 @@ public class ResourceTypeTest extends GraphTestBase{
     }
 
     @Test
-    public void testRegexInstance(){
+    public void whenAddingResourceWhichDoesNotMatchRegex_Throw(){
         resourceType.setRegex("[abc]");
         resourceType.putResource("a");
         expectedException.expect(InvalidConceptValueException.class);
@@ -80,20 +78,11 @@ public class ResourceTypeTest extends GraphTestBase{
     }
 
     @Test
-    public void testRegexInstanceChangeRegexWithInstances(){
+    public void whenSettingRegexOnResourceTypeWithReourceNotMatchingRegex_Throw(){
         Resource<String> thing = resourceType.putResource("1");
         expectedException.expect(InvalidConceptValueException.class);
         expectedException.expectMessage(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[abc]", thing.getId(), thing.getValue(), resourceType.getLabel()));
         resourceType.setRegex("[abc]");
-    }
-
-    @Test
-    public void checkSuper() throws Exception{
-        ResourceType<String> superConcept = graknGraph.putResourceType("super", ResourceType.DataType.STRING);
-        ResourceType<String> resourceType = graknGraph.putResourceType("resourceType", ResourceType.DataType.STRING);
-        resourceType.superType(superConcept);
-        assertThat(resourceType.superType(), instanceOf(ResourceType.class));
-        assertEquals(superConcept, resourceType.superType());
     }
 
     @Test

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
@@ -78,7 +78,7 @@ public class ResourceTypeTest extends GraphTestBase{
     }
 
     @Test
-    public void whenSettingRegexOnResourceTypeWithReourceNotMatchingRegex_Throw(){
+    public void whenSettingRegexOnResourceTypeWithResourceNotMatchingRegex_Throw(){
         Resource<String> thing = resourceType.putResource("1");
         expectedException.expect(InvalidConceptValueException.class);
         expectedException.expectMessage(ErrorMessage.REGEX_INSTANCE_FAILURE.getMessage("[abc]", thing.getId(), thing.getValue(), resourceType.getLabel()));

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ResourceTypeTest.java
@@ -99,4 +99,18 @@ public class ResourceTypeTest extends GraphTestBase{
         assertEquals(c2, t2.getResource("2"));
         assertNull(t2.getResource("1"));
     }
+
+    @Test
+    public void whenCreatingMultipleResourceTypesWithDifferentRegexes_EnsureAllRegexesAreChecked(){
+        ResourceType<String> t1 = graknGraph.putResourceType("t1", ResourceType.DataType.STRING).setRegex("[b]");
+        ResourceType<String> t2 = graknGraph.putResourceType("t2", ResourceType.DataType.STRING).setRegex("[abc]").superType(t1);
+
+        //Valid Resource
+        t2.putResource("b");
+
+        //Invalid Resource
+        expectedException.expect(InvalidConceptValueException.class);
+        expectedException.expectMessage(CoreMatchers.allOf(containsString("[b]"), containsString("a"), containsString(t1.getLabel().getValue())));
+        t2.putResource("a");
+    }
 }


### PR DESCRIPTION
When having multiple resource types with different regexes ensure they are all applied to the instances of those resource types. 