### PR TITLE
Test tools module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <description>A distributed semantic graph database.</description>
     <url>https://grakn.ai/pages/platform/index.html</url>
     <modules>
+        <module>test-tools</module>
         <module>grakn-graph</module>
         <module>grakn-graql</module>
         <module>grakn-graql-shell</module>
@@ -223,6 +224,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>ai.grakn</groupId>
+            <artifactId>test-tools</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.cassandra</groupId>
             <artifactId>cassandra-all</artifactId>
             <version>${cassandra-all.version}</version>
@@ -356,7 +362,14 @@
                 <configuration>
                     <systemProperties>
                         <logback.configurationFile>${main.basedir}/conf/test/logback-test.xml</logback.configurationFile>
+                        <grakn.test.timerecord.file>test-timings.csv</grakn.test.timerecord.file>
                     </systemProperties>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>ai.grakn.test.listener.TimingListener</value>
+                        </property>
+                    </properties>                    
                 </configuration>
             </plugin>
             <plugin>

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -34,7 +34,6 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Grakn - A Distributed Semantic Database
+  ~ Copyright (C) 2016  Grakn Labs Limited
+  ~
+  ~ Grakn is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Grakn is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>ai.grakn</groupId>
+    <version>0.13.0-SNAPSHOT</version>
+    <artifactId>test-tools</artifactId>
+
+    <properties>
+        <junit.version>4.12</junit.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+        </plugins>
+    </build>
+
+</project>

--- a/test-tools/pom.xml
+++ b/test-tools/pom.xml
@@ -39,6 +39,31 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.7.6.201602180812</version>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>**/antlr/**</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>            
         </plugins>
     </build>
 

--- a/test-tools/src/main/java/ai/grakn/test/listener/TimingListener.java
+++ b/test-tools/src/main/java/ai/grakn/test/listener/TimingListener.java
@@ -32,14 +32,15 @@ import org.junit.runner.notification.RunListener;
  * <p>
  * A junit listener around each executed test that collects the time it takes to run the test and
  * logs into a file. The file name where time is logged can be specified in a
- * <code>grakn.test.timerecord.file</code> system property. 
+ * <code>grakn.test.timerecord.file</code> system property. The listener will be effectively inactive
+ * unless the system property <code>grakn.test.timing</code> is set to true.
  * </p>
  * 
  * @author borislav
  *
  */
 public class TimingListener extends RunListener {
-    
+    private boolean ignore = !Boolean.getBoolean("grakn.test.timing");
     private long startTime = 0;
     private String test = "";
     
@@ -61,14 +62,17 @@ public class TimingListener extends RunListener {
     }
     
     public void testStarted(Description description) throws Exception {
-        if (!description.isTest()) {
+        if (ignore || !description.isTest()) {
             return;
         }
         startTime = System.currentTimeMillis();
         test = description.getClassName() + "." + description.getMethodName();
     }
 
-    public void testFinished(Description description) throws Exception {        
+    public void testFinished(Description description) throws Exception {
+        if (ignore) {
+            return; 
+        }
         String finishedTest = description.getClassName() + "." + description.getMethodName();
         if (!test.equals(finishedTest)) {
             throw new RuntimeException("Test started " + test + " different from test finished " + finishedTest);

--- a/test-tools/src/main/java/ai/grakn/test/listener/TimingListener.java
+++ b/test-tools/src/main/java/ai/grakn/test/listener/TimingListener.java
@@ -1,0 +1,78 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+package ai.grakn.test.listener;
+
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.CREATE;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunListener;
+
+/**
+ * <p>
+ * A junit listener around each executed test that collects the time it takes to run the test and
+ * logs into a file. The file name where time is logged can be specified in a
+ * <code>grakn.test.timerecord.file</code> system property. 
+ * </p>
+ * 
+ * @author borislav
+ *
+ */
+public class TimingListener extends RunListener {
+    
+    private long startTime = 0;
+    private String test = "";
+    
+    private void writeTime(Description description, long time) {
+        String timeLogFile = System.getProperty("grakn.test.timerecord.file");
+        if (timeLogFile == null) {
+            timeLogFile = "grakn-test-timings.log";
+        }
+        try {
+            String line = description.getTestClass().getPackage().getName() + "," + 
+                          description.getTestClass().getSimpleName() + "," + 
+                          description.getMethodName() + "," + time;                          
+            Files.write(Paths.get(timeLogFile), Collections.singleton(line), APPEND, CREATE);
+        } catch (IOException e) {
+            System.err.println("Failed to write test time to file " + timeLogFile);
+            System.err.println("Please fix configuration or disable test time measurement altogether.");
+            e.printStackTrace();
+        }
+    }
+    
+    public void testStarted(Description description) throws Exception {
+        if (!description.isTest()) {
+            return;
+        }
+        startTime = System.currentTimeMillis();
+        test = description.getClassName() + "." + description.getMethodName();
+    }
+
+    public void testFinished(Description description) throws Exception {        
+        String finishedTest = description.getClassName() + "." + description.getMethodName();
+        if (!test.equals(finishedTest)) {
+            throw new RuntimeException("Test started " + test + " different from test finished " + finishedTest);
+        }
+        writeTime(description, (System.currentTimeMillis() - startTime));
+    }
+}


### PR DESCRIPTION
A new, for now super small module holding a junit TimingListener to measure how long each successful test takes. The listener is configured in the pom already but because it creates CSV files in each folder in which there are unit tests run, it is disable by default. To enable it, the testing JVM needs the `grakn.test.timing` system property set to true. This can be done on the command line as follows:

```
mvn test -DargLine="-Dgrakn.test.timing=true"
```