### PR TITLE
Add `@CheckReturnValue` annotation to several classes

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/Grakn.java
+++ b/grakn-core/src/main/java/ai/grakn/Grakn.java
@@ -18,6 +18,7 @@
 
 package ai.grakn;
 
+import javax.annotation.CheckReturnValue;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Locale;
@@ -124,6 +125,7 @@ public class Grakn {
      * If one doesn't exist, it will be created for you.
      * @return A session instance that can produce concurrent connection to the specified knowledge graph.
      */
+    @CheckReturnValue
     public static GraknSession session(String location, String keyspace) {
         String finalKeyspace = keyspace.toLowerCase(Locale.getDefault());
         String key = location + finalKeyspace;

--- a/grakn-core/src/main/java/ai/grakn/GraknComputer.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknComputer.java
@@ -23,6 +23,8 @@ import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * <p>
  *     Graph Computer Used For Analytics Algorithms
@@ -53,6 +55,7 @@ public interface GraknComputer {
      * @return          the result of the computation
      * @see ComputerResult
      */
+    @CheckReturnValue
     ComputerResult compute(VertexProgram program, MapReduce... mapReduce);
 
     /**
@@ -62,6 +65,7 @@ public interface GraknComputer {
      * @return          the result of the computation
      * @see ComputerResult
      */
+    @CheckReturnValue
     ComputerResult compute(MapReduce mapReduce);
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/GraknGraph.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknGraph.java
@@ -35,6 +35,7 @@ import ai.grakn.exception.GraphRuntimeException;
 import ai.grakn.graph.admin.GraknAdmin;
 import ai.grakn.graql.QueryBuilder;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -198,6 +199,7 @@ public interface GraknGraph extends AutoCloseable{
      * @throws GraphRuntimeException if the graph is closed
      * @throws ClassCastException if the concept is not an instance of {@link T}
      */
+    @CheckReturnValue
     <T extends Concept> T getConcept(ConceptId id);
 
     /**
@@ -209,6 +211,7 @@ public interface GraknGraph extends AutoCloseable{
      * @throws GraphRuntimeException if the graph is closed
      * @throws ClassCastException if the type is not an instance of {@link T}
      */
+    @CheckReturnValue
     <T extends Type> T getType(TypeLabel label);
 
     /**
@@ -220,6 +223,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     <V> Collection<Resource<V>> getResourcesByValue(V value);
 
     /**
@@ -230,6 +234,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     EntityType getEntityType(String label);
 
     /**
@@ -240,6 +245,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     RelationType getRelationType(String label);
 
     /**
@@ -251,6 +257,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     <V> ResourceType<V> getResourceType(String label);
 
     /**
@@ -261,6 +268,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     RoleType getRoleType(String label);
 
     /**
@@ -271,6 +279,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @throws GraphRuntimeException if the graph is closed
      */
+    @CheckReturnValue
     RuleType getRuleType(String label);
 
     //------------------------------------- Utilities ----------------------------------
@@ -281,6 +290,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @return The admin interface which allows you to access more low level details of the graph.
      */
+    @CheckReturnValue
     GraknAdmin admin();
 
     /**
@@ -288,6 +298,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @return true if the current transaction is read only
      */
+    @CheckReturnValue
     boolean isReadOnly();
 
     // TODO: what does this do when the graph is closed?
@@ -303,6 +314,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @return true if implicit concepts are exposed.
      */
+    @CheckReturnValue
     boolean implicitConceptsVisible();
 
     /**
@@ -318,6 +330,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @return The name of the keyspace where the graph is persisted
      */
+    @CheckReturnValue
     String getKeyspace();
 
     /**
@@ -325,6 +338,7 @@ public interface GraknGraph extends AutoCloseable{
      *
      * @return True if the graph has been closed
      */
+    @CheckReturnValue
     boolean isClosed();
 
     // TODO: what does this do when the graph is closed?
@@ -334,6 +348,7 @@ public interface GraknGraph extends AutoCloseable{
      * @return returns a query builder to allow for the creation of graql queries
      * @see QueryBuilder
      */
+    @CheckReturnValue
     QueryBuilder graql();
 
     // TODO: what does this do when the graph is closed?

--- a/grakn-core/src/main/java/ai/grakn/GraknSession.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknSession.java
@@ -21,6 +21,8 @@ package ai.grakn;
 
 import ai.grakn.exception.GraphRuntimeException;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * <p>
  *     Builds a Grakn Graph Session
@@ -46,6 +48,7 @@ public interface GraknSession extends AutoCloseable {
      * @return A new Grakn graph transaction
      * @see GraknGraph
      */
+    @CheckReturnValue
     GraknGraph open(GraknTxType transactionType);
 
     /**
@@ -54,6 +57,7 @@ public interface GraknSession extends AutoCloseable {
      * @return A new or existing Grakn graph computer
      * @see GraknComputer
      */
+    @CheckReturnValue
     GraknComputer getGraphComputer();
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/concept/Concept.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Concept.java
@@ -21,6 +21,8 @@ package ai.grakn.concept;
 import ai.grakn.exception.ConceptException;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import javax.annotation.CheckReturnValue;
+
 
 /**
  * <p>
@@ -45,6 +47,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A value the concept's unique id.
      */
+    @CheckReturnValue
     ConceptId getId();
 
     //------------------------------------- Other ---------------------------------
@@ -54,6 +57,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Type if the concept is a Type
      */
+    @CheckReturnValue
     Type asType();
 
     /**
@@ -61,6 +65,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return An Instance if the concept is an Instance
      */
+    @CheckReturnValue
     Instance asInstance();
 
     /**
@@ -68,6 +73,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Entity Type if the concept is an Entity Type
      */
+    @CheckReturnValue
     EntityType asEntityType();
 
     /**
@@ -75,6 +81,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Role Type if the concept is a Role Type
      */
+    @CheckReturnValue
     RoleType asRoleType();
 
     /**
@@ -82,6 +89,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Relation Type if the concept is a Relation Type
      */
+    @CheckReturnValue
     RelationType asRelationType();
 
     /**
@@ -89,6 +97,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Resource Type if the concept is a Resource Type
      */
+    @CheckReturnValue
     <D> ResourceType<D> asResourceType();
 
     /**
@@ -96,12 +105,14 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Rule Type if the concept is a Rule Type
      */
+    @CheckReturnValue
     RuleType asRuleType();
 
     /**
      * Return as an Entity, if the Concept is an Entity Instance.
      * @return An Entity if the concept is an Instance
      */
+    @CheckReturnValue
     Entity asEntity();
 
     /**
@@ -109,6 +120,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Relation if the concept is a Relation
      */
+    @CheckReturnValue
     Relation asRelation();
 
     /**
@@ -116,6 +128,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Resource if the concept is a Resource
      */
+    @CheckReturnValue
     <D> Resource<D> asResource();
 
     /**
@@ -123,6 +136,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return A Rule if the concept is a Rule
      */
+    @CheckReturnValue
     Rule asRule();
 
     /**
@@ -130,6 +144,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Type
      */
+    @CheckReturnValue
     boolean isType();
 
     /**
@@ -137,6 +152,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is an Instance
      */
+    @CheckReturnValue
     boolean isInstance();
 
     /**
@@ -144,6 +160,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is an Entity Type
      */
+    @CheckReturnValue
     boolean isEntityType();
 
     /**
@@ -151,6 +168,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Role Type
      */
+    @CheckReturnValue
     boolean isRoleType();
 
     /**
@@ -158,6 +176,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Relation Type
      */
+    @CheckReturnValue
     boolean isRelationType();
 
     /**
@@ -165,6 +184,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Resource Type
      */
+    @CheckReturnValue
     boolean isResourceType();
 
     /**
@@ -172,6 +192,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Rule Type
      */
+    @CheckReturnValue
     boolean isRuleType();
 
     /**
@@ -179,6 +200,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Entity
      */
+    @CheckReturnValue
     boolean isEntity();
 
     /**
@@ -186,6 +208,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Relation
      */
+    @CheckReturnValue
     boolean isRelation();
 
     /**
@@ -193,6 +216,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Resource
      */
+    @CheckReturnValue
     boolean isResource();
 
     /**
@@ -200,6 +224,7 @@ public interface Concept extends Comparable<Concept>{
      *
      * @return true if the concept is a Rule
      */
+    @CheckReturnValue
     boolean isRule();
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/ConceptId.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.concept;
 
+import javax.annotation.CheckReturnValue;
 import java.io.Serializable;
 
 /**
@@ -46,6 +47,7 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
      *
      * @return Used for indexing purposes and for graql traversals
      */
+    @CheckReturnValue
     public String getValue(){
         return conceptId.toString();
     }
@@ -54,6 +56,7 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
      *
      * @return the raw vertex id. This is used for traversing across vertices directly.
      */
+    @CheckReturnValue
     public Object getRawValue(){
         return conceptId;
     }
@@ -95,6 +98,7 @@ public class ConceptId implements Comparable<ConceptId>, Serializable {
      * @param value The string which potentially represents a Concept
      * @return The matching concept ID
      */
+    @CheckReturnValue
     public static ConceptId of(Object value){
         return new ConceptId(value);
     }

--- a/grakn-core/src/main/java/ai/grakn/concept/Entity.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Entity.java
@@ -39,6 +39,7 @@ public interface Entity extends Instance{
      * @return The EntityType of this Entity
      * @see EntityType
      */
+    @Override
     EntityType type();
 
     /**
@@ -47,5 +48,6 @@ public interface Entity extends Instance{
      * @param resource The resource to which a relationship is created
      * @return The instance itself
      */
+    @Override
     Entity resource(Resource resource);
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/EntityType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/EntityType.java
@@ -44,6 +44,7 @@ public interface EntityType extends Type{
      *
      * @return The EntityType itself
      */
+    @Override
     EntityType setAbstract(Boolean isAbstract);
 
     /**
@@ -74,6 +75,7 @@ public interface EntityType extends Type{
      * @param roleType The Role Type which the instances of this EntityType are allowed to play.
      * @return The EntityType itself
      */
+    @Override
     EntityType plays(RoleType roleType);
 
     /**
@@ -82,6 +84,7 @@ public interface EntityType extends Type{
      * @param roleType The Role Type which the instances of this EntityType should no longer be allowed to play.
      * @return The EntityType itself
      */
+    @Override
     EntityType deletePlays(RoleType roleType);
 
     /**
@@ -100,6 +103,7 @@ public interface EntityType extends Type{
      * @param scope The category of this Type
      * @return The Type itself.
      */
+    @Override
     EntityType scope(Instance scope);
 
     /**
@@ -108,6 +112,7 @@ public interface EntityType extends Type{
      * @param scope The Instances that is currently scoping this Type.
      * @return The Type itself
      */
+    @Override
     EntityType deleteScope(Instance scope);
 
     /**
@@ -116,6 +121,7 @@ public interface EntityType extends Type{
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     EntityType key(ResourceType resourceType);
 
     /**
@@ -124,6 +130,7 @@ public interface EntityType extends Type{
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     EntityType resource(ResourceType resourceType);
 
     //------------------------------------- Accessors ----------------------------------
@@ -132,6 +139,7 @@ public interface EntityType extends Type{
      *
      * @return The supertype of this EntityType
      */
+    @Override
     EntityType superType();
 
     /**
@@ -139,6 +147,7 @@ public interface EntityType extends Type{
      *
      * @return All the sub classes of this EntityType
      */
+    @Override
     Collection<EntityType> subTypes();
 
     /**
@@ -148,11 +157,13 @@ public interface EntityType extends Type{
      *
      * @return All the instances of this EntityType.
      */
+    @Override
     Collection<Entity> instances();
 
     /**
      *
      * @return a deep copy of this concept.
      */
+    @Override
     EntityType copy();
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/Instance.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Instance.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.concept;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -46,6 +47,7 @@ public interface Instance extends Concept{
      *
      * @return A Type which is the type of this concept. This concept is an instance of that type.
      */
+    @CheckReturnValue
     Type type();
 
     /**
@@ -57,6 +59,7 @@ public interface Instance extends Concept{
      * @param roleTypes An optional parameter which allows you to specify the role of the relations you wish to retrieve.
      * @return A set of Relations which the concept instance takes part in, optionally constrained by the Role Type.
      */
+    @CheckReturnValue
     Collection<Relation> relations(RoleType... roleTypes);
 
     /**
@@ -65,6 +68,7 @@ public interface Instance extends Concept{
      *
      * @return A set of all the Role Types which this instance plays.
      */
+    @CheckReturnValue
     Collection<RoleType> plays();
 
     /**
@@ -82,5 +86,6 @@ public interface Instance extends Concept{
      * @param resourceTypes Resource Types of the resources attached to this entity
      * @return A collection of resources attached to this Instance.
      */
+    @CheckReturnValue
     Collection<Resource<?>> resources(ResourceType ... resourceTypes);
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/Relation.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Relation.java
@@ -21,6 +21,7 @@ package ai.grakn.concept;
 
 import ai.grakn.exception.ConceptNotUniqueException;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +48,7 @@ public interface Relation extends Instance {
      * @param resource The resource to which a relationship is created
      * @return The instance itself
      */
+    @Override
     Relation resource(Resource resource);
 
     //------------------------------------- Accessors ----------------------------------
@@ -57,6 +59,7 @@ public interface Relation extends Instance {
      *
      * @return The associated Relation Type for this Relation.
      */
+    @Override
     RelationType type();
 
     /**
@@ -65,6 +68,7 @@ public interface Relation extends Instance {
      *
      * @return A list of all the role types and the instances playing them in this relation.
      */
+    @CheckReturnValue
     Map<RoleType, Set<Instance>> allRolePlayers();
 
     /**
@@ -73,6 +77,7 @@ public interface Relation extends Instance {
      *                  If blank, returns all role players.
      * @return a list of every {@link Instance} involved in the {@link Relation}.
      */
+    @CheckReturnValue
     Collection<Instance> rolePlayers(RoleType... roleTypes);
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/concept/RelationType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/RelationType.java
@@ -20,6 +20,7 @@ package ai.grakn.concept;
 
 import ai.grakn.exception.ConceptException;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -69,6 +70,7 @@ public interface RelationType extends Type {
      * @param scope The category of this Type
      * @return The Type itself.
      */
+    @Override
     RelationType scope(Instance scope);
 
     /**
@@ -77,6 +79,7 @@ public interface RelationType extends Type {
      * @param scope The Instances that is currently scoping this Type.
      * @return The Type itself
      */
+    @Override
     RelationType deleteScope(Instance scope);
 
     /**
@@ -85,6 +88,7 @@ public interface RelationType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RelationType key(ResourceType resourceType);
 
     /**
@@ -93,6 +97,7 @@ public interface RelationType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RelationType resource(ResourceType resourceType);
 
     //------------------------------------- Accessors ----------------------------------
@@ -102,6 +107,7 @@ public interface RelationType extends Type {
      *
      * @return A list of the RoleTypes which make up this RelationType.
      */
+    @CheckReturnValue
     Collection<RoleType> relates();
 
     //------------------------------------- Edge Handling ----------------------------------
@@ -133,12 +139,14 @@ public interface RelationType extends Type {
      * @param isAbstract  Specifies if the concept is to be abstract (true) or not (false).
      * @return The RelationType itself.
      */
+    @Override
     RelationType setAbstract(Boolean isAbstract);
 
     /**
      * Returns the direct supertype of this RelationType.
      * @return The direct supertype of this RelationType
      */
+    @Override
     RelationType superType();
 
     /**
@@ -146,6 +154,7 @@ public interface RelationType extends Type {
      *
      * @return All the sub types of this RelationType
      */
+    @Override
     Collection<RelationType> subTypes();
 
     /**
@@ -154,6 +163,7 @@ public interface RelationType extends Type {
      * @param roleType The RoleType which the instances of this Type are allowed to play.
      * @return  The RelationType itself.
      */
+    @Override
     RelationType plays(RoleType roleType);
 
     /**
@@ -162,6 +172,7 @@ public interface RelationType extends Type {
      * @param roleType The RoleType which the instances of this Type should no longer be allowed to play.
      * @return The RelationType itself.
      */
+    @Override
     RelationType deletePlays(RoleType roleType);
 
     /**
@@ -170,11 +181,13 @@ public interface RelationType extends Type {
      *
      * @return All the Relation instances of this relation type
      */
+    @Override
     Collection<Relation> instances();
 
     /**
      *
      * @return a deep copy of this concept.
      */
+    @Override
     RelationType copy();
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/Resource.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Resource.java
@@ -20,6 +20,7 @@ package ai.grakn.concept;
 
 
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -45,6 +46,7 @@ public interface Resource<D> extends Instance{
      *
      * @return The Resource itself
      */
+    @CheckReturnValue
     D getValue();
 
     /**
@@ -52,6 +54,7 @@ public interface Resource<D> extends Instance{
      *
      * @return The ResourceType of which this resource is an Instance.
      */
+    @Override
     ResourceType<D> type();
 
     /**
@@ -59,6 +62,7 @@ public interface Resource<D> extends Instance{
      *
      * @return The data type of this Resource's type.
      */
+    @CheckReturnValue
     ResourceType.DataType<D> dataType();
 
     /**
@@ -66,6 +70,7 @@ public interface Resource<D> extends Instance{
      *
      * @return The list of all Instances that possess this Resource.
      */
+    @CheckReturnValue
     Collection<Instance> ownerInstances();
 
     /**
@@ -73,6 +78,7 @@ public interface Resource<D> extends Instance{
      *
      * @return The Instance which is connected to a unique Resource.
      */
+    @CheckReturnValue
     Instance owner();
 
     /**
@@ -81,6 +87,7 @@ public interface Resource<D> extends Instance{
      * @param resource The resource to which a relationship is created
      * @return The instance itself
      */
+    @Override
     Resource resource(Resource resource);
 
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/ResourceType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/ResourceType.java
@@ -24,6 +24,7 @@ import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import com.google.common.collect.ImmutableMap;
 
+import javax.annotation.CheckReturnValue;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -57,6 +58,7 @@ public interface ResourceType<D> extends Type {
      *
      * @return The ResourceType itself.
      */
+    @Override
     ResourceType<D> setAbstract(Boolean isAbstract);
 
     /**
@@ -81,6 +83,7 @@ public interface ResourceType<D> extends Type {
      * @param roleType The Role Type which the instances of this ResourceType are allowed to play.
      * @return The ResourceType itself.
      */
+    @Override
     ResourceType<D> plays(RoleType roleType);
 
     /**
@@ -89,6 +92,7 @@ public interface ResourceType<D> extends Type {
      * @param roleType The Role Type which the instances of this ResourceType should no longer be allowed to play.
      * @return The ResourceType itself.
      */
+    @Override
     ResourceType<D> deletePlays(RoleType roleType);
 
     /**
@@ -113,6 +117,7 @@ public interface ResourceType<D> extends Type {
      * @param scope The category of this Type
      * @return The Type itself.
      */
+    @Override
     ResourceType<D> scope(Instance scope);
 
     /**
@@ -121,6 +126,7 @@ public interface ResourceType<D> extends Type {
      * @param scope The Instances that is currently scoping this Type.
      * @return The Type itself
      */
+    @Override
     ResourceType<D> deleteScope(Instance scope);
 
     /**
@@ -129,6 +135,7 @@ public interface ResourceType<D> extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     ResourceType<D> key(ResourceType resourceType);
 
     /**
@@ -137,6 +144,7 @@ public interface ResourceType<D> extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     ResourceType<D> resource(ResourceType resourceType);
 
     //------------------------------------- Accessors ---------------------------------
@@ -145,6 +153,7 @@ public interface ResourceType<D> extends Type {
      *
      * @return The supertype of this ResourceType,
      */
+    @Override
     ResourceType<D> superType();
 
     /**
@@ -155,6 +164,7 @@ public interface ResourceType<D> extends Type {
      * @param value A value which a Resource in the graph may be holding
      * @return The Resource with the provided value and type or null if no such Resource exists.
      */
+    @CheckReturnValue
     <V> Resource<V> getResource(V value);
 
     /**
@@ -162,6 +172,7 @@ public interface ResourceType<D> extends Type {
      *
      * @return The subtypes of this ResourceType
      */
+    @Override
     Collection<ResourceType<D>> subTypes();
 
     /**
@@ -169,6 +180,7 @@ public interface ResourceType<D> extends Type {
      *
      * @return The resource instances of this ResourceType
      */
+    @Override
     Collection<Resource<D>> instances();
 
     /**
@@ -176,6 +188,7 @@ public interface ResourceType<D> extends Type {
      *
      * @return The data type to which instances of this resource must conform.
      */
+    @CheckReturnValue
     DataType<D> getDataType();
 
     /**
@@ -186,12 +199,14 @@ public interface ResourceType<D> extends Type {
      *
      * @return The regular expression to which instances of this ResourceType must conform.
      */
+    @CheckReturnValue
     String getRegex();
 
     /**
      *
      * @return a deep copy of this concept.
      */
+    @Override
     ResourceType<D> copy();
 
     /**
@@ -282,10 +297,12 @@ public interface ResourceType<D> extends Type {
             }
         }
 
+        @CheckReturnValue
         public String getName(){
             return dataType;
         }
 
+        @CheckReturnValue
         public Schema.ConceptProperty getConceptProperty(){
             return conceptProperty;
         }
@@ -301,6 +318,7 @@ public interface ResourceType<D> extends Type {
          * @param value The value to be converted
          * @return The String representation of the value
          */
+        @CheckReturnValue
         public Object getPersistenceValue(D value){
             return persistenceValueSupplier.apply(value);
         }
@@ -311,6 +329,7 @@ public interface ResourceType<D> extends Type {
          * @param object The object to be converted into the value
          * @return The value of the string
          */
+        @CheckReturnValue
         public D getValue(Object object){
             return valueSupplier.apply(object);
         }

--- a/grakn-core/src/main/java/ai/grakn/concept/RoleType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/RoleType.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.concept;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -45,6 +46,7 @@ public interface RoleType extends Type {
      *
      * @return The RoleType itself
      */
+    @Override
     RoleType setAbstract(Boolean isAbstract);
 
     /**
@@ -69,6 +71,7 @@ public interface RoleType extends Type {
      * @param roleType The RoleType which the instances of this Type are allowed to play.
      * @return The RoleType itself
      */
+    @Override
     RoleType plays(RoleType roleType);
 
     /**
@@ -77,6 +80,7 @@ public interface RoleType extends Type {
      * @param roleType The RoleType which the instances of this Type should no longer be allowed to play.
      * @return The RoleType itself
      */
+    @Override
     RoleType deletePlays(RoleType roleType);
 
 
@@ -86,6 +90,7 @@ public interface RoleType extends Type {
      * @param scope The category of this Type
      * @return The Type itself.
      */
+    @Override
     RoleType scope(Instance scope);
 
     /**
@@ -94,6 +99,7 @@ public interface RoleType extends Type {
      * @param scope The Instances that is currently scoping this Type.
      * @return The Type itself
      */
+    @Override
     RoleType deleteScope(Instance scope);
 
     /**
@@ -102,6 +108,7 @@ public interface RoleType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RoleType key(ResourceType resourceType);
 
     /**
@@ -110,6 +117,7 @@ public interface RoleType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RoleType resource(ResourceType resourceType);
 
     //------------------------------------- Accessors ----------------------------------
@@ -118,6 +126,7 @@ public interface RoleType extends Type {
      *
      * @return The supertype of this RoleType
      */
+    @Override
     RoleType superType();
 
     /**
@@ -125,6 +134,7 @@ public interface RoleType extends Type {
      *
      * @return The sub types of this RoleType
      */
+    @Override
     Collection<RoleType> subTypes();
 
     /**
@@ -133,6 +143,7 @@ public interface RoleType extends Type {
      *
      * @return The RelationTypes which this role takes part in.
      */
+    @CheckReturnValue
     Collection<RelationType> relationTypes();
 
     /**
@@ -141,12 +152,14 @@ public interface RoleType extends Type {
      *
      * @return A list of all the Types which can play this role.
      */
+    @CheckReturnValue
     Collection<Type> playedByTypes();
 
     /**
      *
      * @return a deep copy of this concept.
      */
+    @Override
     RoleType copy();
 }
 

--- a/grakn-core/src/main/java/ai/grakn/concept/Rule.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Rule.java
@@ -20,6 +20,7 @@ package ai.grakn.concept;
 
 import ai.grakn.graql.Pattern;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -44,6 +45,7 @@ public interface Rule extends Instance{
      * @param resource The resource to which a relationship is created
      * @return The instance itself
      */
+    @Override
     Rule resource(Resource resource);
 
     //------------------------------------- Accessors ----------------------------------
@@ -52,6 +54,7 @@ public interface Rule extends Instance{
      *
      * @return A string representing the left hand side Graql query.
      */
+    @CheckReturnValue
     Pattern getLHS();
 
     /**
@@ -59,6 +62,7 @@ public interface Rule extends Instance{
      *
      * @return A string representing the right hand side Graql query.
      */
+    @CheckReturnValue
     Pattern getRHS();
 
     //------------------------------------- Edge Handling ----------------------------------
@@ -67,6 +71,7 @@ public interface Rule extends Instance{
      *
      * @return A collection of Concept Types that constitute a part of the hypothesis of the Rule
      */
+    @CheckReturnValue
     Collection<Type> getHypothesisTypes();
 
     /**
@@ -74,6 +79,7 @@ public interface Rule extends Instance{
      *
      * @return A collection of Concept Types that constitute a part of the conclusion of the Rule
      */
+    @CheckReturnValue
     Collection<Type> getConclusionTypes();
 
     //---- Inherited Methods
@@ -81,5 +87,6 @@ public interface Rule extends Instance{
      *
      * @return The type of this Graql
      */
+    @Override
     RuleType type();
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/RuleType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/RuleType.java
@@ -54,6 +54,7 @@ public interface RuleType extends Type {
      * @param scope The category of this Type
      * @return The Type itself.
      */
+    @Override
     RuleType scope(Instance scope);
 
     /**
@@ -62,6 +63,7 @@ public interface RuleType extends Type {
      * @param scope The Instances that is currently scoping this Type.
      * @return The Type itself
      */
+    @Override
     RuleType deleteScope(Instance scope);
 
     /**
@@ -70,6 +72,7 @@ public interface RuleType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RuleType key(ResourceType resourceType);
 
     /**
@@ -78,6 +81,7 @@ public interface RuleType extends Type {
      * @param resourceType The resource type which instances of this type should be allowed to play.
      * @return The Type itself.
      */
+    @Override
     RuleType resource(ResourceType resourceType);
 
     //---- Inherited Methods
@@ -87,12 +91,14 @@ public interface RuleType extends Type {
      *                    If the concept type is abstract it is not allowed to have any instances.
      * @return The Rule Type itself
      */
+    @Override
     RuleType setAbstract(Boolean isAbstract);
 
     /**
      *
      * @return The super type of this Rule Type
      */
+    @Override
     RuleType superType();
 
     /**
@@ -114,6 +120,7 @@ public interface RuleType extends Type {
      *
      * @return All the sub types of this rule type
      */
+    @Override
     Collection<RuleType> subTypes();
 
     /**
@@ -121,6 +128,7 @@ public interface RuleType extends Type {
      * @param roleType The Role Type which the instances of this Type are allowed to play.
      * @return The Rule Type itself
      */
+    @Override
     RuleType plays(RoleType roleType);
 
     /**
@@ -128,17 +136,20 @@ public interface RuleType extends Type {
      * @param roleType The Role Type which the instances of this Type should no longer be allowed to play.
      * @return The Rule Type itself
      */
+    @Override
     RuleType deletePlays(RoleType roleType);
 
     /**
      *
      * @return All the rule instances of this Rule Type.
      */
+    @Override
     Collection<Rule> instances();
 
     /**
      *
      * @return a deep copy of this concept.
      */
+    @Override
     RuleType copy();
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/Type.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Type.java
@@ -20,6 +20,7 @@ package ai.grakn.concept;
 
 import ai.grakn.exception.ConceptException;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -105,6 +106,7 @@ public interface Type extends Concept {
      *
      * @return The unique id of this type
      */
+    @CheckReturnValue
     Integer getTypeId();
 
     /**
@@ -112,6 +114,7 @@ public interface Type extends Concept {
      *
      * @return The unique label of this type
      */
+    @CheckReturnValue
     TypeLabel getLabel();
 
     /**
@@ -124,18 +127,21 @@ public interface Type extends Concept {
      *
      * @return The resource types which this type is linked with.
      */
+    @CheckReturnValue
     Collection<ResourceType> resources();
 
     /**
      *
      * @return The resource types which this type is linked with as a key.
      */
+    @CheckReturnValue
     Collection<ResourceType> keys();
 
     /**
      *
      * @return The direct super of this Type
      */
+    @CheckReturnValue
     Type superType();
 
     /**
@@ -145,6 +151,7 @@ public interface Type extends Concept {
      *
      * @return All the indirect sub-types of this Type
      */
+    @CheckReturnValue
     Collection<? extends Type> subTypes();
 
     /**
@@ -154,6 +161,7 @@ public interface Type extends Concept {
      *
      * @return All the indirect instances of this type.
      */
+    @CheckReturnValue
     Collection<? extends Instance> instances();
 
     /**
@@ -163,6 +171,7 @@ public interface Type extends Concept {
      *
      * @return returns true if the type is set to be abstract.
      */
+    @CheckReturnValue
     Boolean isAbstract();
 
     /**
@@ -172,6 +181,7 @@ public interface Type extends Concept {
      *
      * @return returns true if the type was created implicitly through {@link #resource}
      */
+    @CheckReturnValue
     Boolean isImplicit();
 
     /**
@@ -180,6 +190,7 @@ public interface Type extends Concept {
      *
      * @return A collection of Rules for which this Type serves as a hypothesis
      */
+    @CheckReturnValue
     Collection<Rule> getRulesOfHypothesis();
 
     /**
@@ -188,6 +199,7 @@ public interface Type extends Concept {
      *
      * @return A collection of Rules for which this Type serves as a conclusion
      */
+    @CheckReturnValue
     Collection<Rule> getRulesOfConclusion();
 
     /**
@@ -195,6 +207,7 @@ public interface Type extends Concept {
      *
      * @return A list of the Instances that scope this Type.
      */
+    @CheckReturnValue
     Collection<Instance> scopes();
 
     //------------------------------------- Other ----------------------------------
@@ -209,5 +222,6 @@ public interface Type extends Concept {
      *
      * @return a deep copy of this concept.
      */
+    @CheckReturnValue
     Type copy();
 }

--- a/grakn-core/src/main/java/ai/grakn/concept/TypeLabel.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/TypeLabel.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.concept;
 
+import javax.annotation.CheckReturnValue;
 import java.io.Serializable;
 import java.util.function.Function;
 
@@ -41,6 +42,7 @@ public class TypeLabel implements Comparable<TypeLabel>, Serializable {
         this.label = label;
     }
 
+    @CheckReturnValue
     public String getValue(){
         return label;
     }
@@ -50,6 +52,7 @@ public class TypeLabel implements Comparable<TypeLabel>, Serializable {
      * @param mapper a function to apply to the underlying type label
      * @return the new type label
      */
+    @CheckReturnValue
     public TypeLabel map(Function<String, String> mapper) {
         return TypeLabel.of(mapper.apply(label));
     }
@@ -84,6 +87,7 @@ public class TypeLabel implements Comparable<TypeLabel>, Serializable {
      * @param value The string which potentially represents a Type
      * @return The matching Type Label
      */
+    @CheckReturnValue
     public static TypeLabel of(String value){
         return new TypeLabel(value);
     }

--- a/grakn-core/src/main/java/ai/grakn/engine/TaskId.java
+++ b/grakn-core/src/main/java/ai/grakn/engine/TaskId.java
@@ -19,6 +19,7 @@
 
 package ai.grakn.engine;
 
+import javax.annotation.CheckReturnValue;
 import java.util.UUID;
 
 /**
@@ -29,10 +30,12 @@ import java.util.UUID;
 public final class TaskId {
     private final String value;
 
+    @CheckReturnValue
     public static TaskId of(String value) {
         return new TaskId(value);
     }
 
+    @CheckReturnValue
     public static TaskId generate() {
         return new TaskId(UUID.randomUUID().toString());
     }
@@ -44,6 +47,7 @@ public final class TaskId {
     /**
      * Get the string value of the task ID
      */
+    @CheckReturnValue
     public String getValue() {
         return value;
     }

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
@@ -33,6 +33,7 @@ import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -50,6 +51,7 @@ public interface GraknAdmin {
      * @param <T> The type of the concept being built
      * @return A concept built using the provided vertex
      */
+    @CheckReturnValue
     <T extends Concept> T buildConcept(Vertex vertex);
 
     /**
@@ -57,6 +59,7 @@ public interface GraknAdmin {
      *
      * @return A read-only Tinkerpop traversal for manually traversing the graph
      */
+    @CheckReturnValue
     GraphTraversal<Vertex, Vertex> getTinkerTraversal();
 
     /**
@@ -64,6 +67,7 @@ public interface GraknAdmin {
      *
      * @return true if batch loading is enabled
      */
+    @CheckReturnValue
     boolean isBatchLoadingEnabled();
 
     //------------------------------------- Meta Types ----------------------------------
@@ -72,6 +76,7 @@ public interface GraknAdmin {
      *
      * @return The meta type -> type.
      */
+    @CheckReturnValue
     Type getMetaConcept();
 
     /**
@@ -79,6 +84,7 @@ public interface GraknAdmin {
      *
      * @return The meta relation type -> relation-type.
      */
+    @CheckReturnValue
     RelationType getMetaRelationType();
 
     /**
@@ -86,6 +92,7 @@ public interface GraknAdmin {
      *
      * @return The meta role type -> role-type.
      */
+    @CheckReturnValue
     RoleType getMetaRoleType();
 
     /**
@@ -93,6 +100,7 @@ public interface GraknAdmin {
      *
      * @return The meta resource type -> resource-type.
      */
+    @CheckReturnValue
     ResourceType getMetaResourceType();
 
     /**
@@ -100,6 +108,7 @@ public interface GraknAdmin {
      *
      * @return The meta entity type -> entity-type.
      */
+    @CheckReturnValue
     EntityType getMetaEntityType();
 
     /**
@@ -107,6 +116,7 @@ public interface GraknAdmin {
      *
      * @return The meta rule type -> rule-type.
      */
+    @CheckReturnValue
     RuleType getMetaRuleType();
 
     /**
@@ -114,6 +124,7 @@ public interface GraknAdmin {
      *
      * @return The meta rule -> inference-rule.
      */
+    @CheckReturnValue
     RuleType getMetaRuleInference();
 
     /**
@@ -121,6 +132,7 @@ public interface GraknAdmin {
      *
      * @return The meta rule -> constraint-rule.
      */
+    @CheckReturnValue
     RuleType getMetaRuleConstraint();
 
     //------------------------------------- Admin Specific Operations ----------------------------------
@@ -132,6 +144,7 @@ public interface GraknAdmin {
      * @param label The label to be converted to the id
      * @return The matching type id or -1 if no such type exists
      */
+    @CheckReturnValue
     Integer convertToId(TypeLabel label);
 
     /**
@@ -170,6 +183,7 @@ public interface GraknAdmin {
      * @param value The value of the concept
      * @return A concept with the matching key and value
      */
+    @CheckReturnValue
     <T extends Concept> T  getConcept(Schema.ConceptProperty key, Object value);
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql;
 
+import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;
 
 /**
@@ -33,6 +34,7 @@ public interface Aggregate<T, S> {
      * @param stream a stream of query results
      * @return the result of the aggregate operation
      */
+    @CheckReturnValue
     S apply(Stream<? extends T> stream);
 
     /**
@@ -40,5 +42,6 @@ public interface Aggregate<T, S> {
      * @param name the name of the aggregate
      * @return a new named aggregate
      */
+    @CheckReturnValue
     NamedAggregate<T, S> as(String name);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/AskQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/AskQuery.java
@@ -21,6 +21,8 @@ package ai.grakn.graql;
 import ai.grakn.graql.admin.AskQueryAdmin;
 import ai.grakn.GraknGraph;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A query that will return whether a match query can be found in the graph.
  * <p>
@@ -40,5 +42,6 @@ public interface AskQuery extends Query<Boolean> {
     /**
      * @return admin instance for inspecting and manipulating this query
      */
+    @CheckReturnValue
     AskQueryAdmin admin();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/ComputeQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/ComputeQuery.java
@@ -21,6 +21,7 @@ package ai.grakn.graql;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.TypeLabel;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -43,12 +44,14 @@ public interface ComputeQuery<T> extends Query<T> {
      * @param subTypelabels an array of types to include in the subgraph
      * @return a ComputeQuery with the subTypelabels set
      */
+    @CheckReturnValue
     ComputeQuery<T> in(String... subTypelabels);
 
     /**
      * @param subTypeLabels a collection of types to include in the subgraph
      * @return a ComputeQuery with the subTypeLabels set
      */
+    @CheckReturnValue
     ComputeQuery<T> in(Collection<TypeLabel> subTypeLabels);
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/graql/ComputeQueryBuilder.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/ComputeQueryBuilder.java
@@ -30,6 +30,7 @@ import ai.grakn.graql.analytics.PathQuery;
 import ai.grakn.graql.analytics.StdQuery;
 import ai.grakn.graql.analytics.SumQuery;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Map;
 
 /**
@@ -43,55 +44,66 @@ public interface ComputeQueryBuilder {
      * @param graph the graph to execute the compute query on
      * @return a compute query builder with the graph set
      */
+    @CheckReturnValue
     ComputeQueryBuilder withGraph(GraknGraph graph);
 
     /**
      * @return a count query that will count the number of instances
      */
+    @CheckReturnValue
     CountQuery count();
 
     /**
      * @return a min query that will find the min value of the given resource types
      */
+    @CheckReturnValue
     MinQuery min();
 
     /**
      * @return a max query that will find the max value of the given resource types
      */
+    @CheckReturnValue
     MaxQuery max();
 
     /**
      * @return a sum query that will compute the sum of values of the given resource types
      */
+    @CheckReturnValue
     SumQuery sum();
 
     /**
      * @return a mean query that will compute the mean of values of the given resource types
      */
+    @CheckReturnValue
     MeanQuery mean();
 
     /**
      * @return a std query that will compute the standard deviation of values of the given resource types
      */
+    @CheckReturnValue
     StdQuery std();
 
     /**
      * @return a median query that will compute the median of values of the given resource types
      */
+    @CheckReturnValue
     MedianQuery median();
 
     /**
      * @return a path query that will find the shortest path between two instances
      */
+    @CheckReturnValue
     PathQuery path();
 
     /**
      * @return a cluster query that will find the clusters in the graph
      */
+    @CheckReturnValue
     ClusterQuery<Map<String, Long>> cluster();
 
     /**
      * @return a degree query that will compute the degree of instances
      */
+    @CheckReturnValue
     DegreeQuery degree();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/DeleteQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/DeleteQuery.java
@@ -21,6 +21,8 @@ package ai.grakn.graql;
 import ai.grakn.GraknGraph;
 import ai.grakn.graql.admin.DeleteQueryAdmin;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A query for deleting concepts from a match query.
  * <p>
@@ -39,10 +41,12 @@ public interface DeleteQuery extends Query<Void> {
      * @param graph the graph to execute the query on
      * @return a new DeleteQuery with the graph set
      */
+    @Override
     DeleteQuery withGraph(GraknGraph graph);
 
     /**
      * @return admin instance for inspecting and manipulating this query
      */
+    @CheckReturnValue
     DeleteQueryAdmin admin();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
@@ -22,6 +22,7 @@ import ai.grakn.GraknGraph;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.InsertQueryAdmin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 
 /**
@@ -42,11 +43,13 @@ public interface InsertQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param graph the graph to execute the query on
      * @return a new InsertQuery with the graph set
      */
+    @Override
     InsertQuery withGraph(GraknGraph graph);
 
     /**
      * @return admin instance for inspecting and manipulating this query
      */
+    @CheckReturnValue
     InsertQueryAdmin admin();
 
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/MatchQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/MatchQuery.java
@@ -23,6 +23,7 @@ import ai.grakn.concept.Concept;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.MatchQueryAdmin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -44,53 +45,62 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param names an array of variable names to select
      * @return a new MatchQuery that selects the given variables
      */
+    @CheckReturnValue
     MatchQuery select(String... names);
 
     /**
      * @param names a set of variable names to select
      * @return a new MatchQuery that selects the given variables
      */
+    @CheckReturnValue
     MatchQuery select(Set<VarName> names);
 
     /**
      * @param name a variable name to get
      * @return a stream of concepts
      */
+    @CheckReturnValue
     Stream<Concept> get(String name);
 
     /**
      * @return an ask query that will return true if any matches are found
      */
+    @CheckReturnValue
     AskQuery ask();
 
     /**
      * @param vars an array of variables to insert for each result of this match query
      * @return an insert query that will insert the given variables for each result of this match query
      */
+    @CheckReturnValue
     InsertQuery insert(Var... vars);
 
     /**
      * @param vars a collection of variables to insert for each result of this match query
      * @return an insert query that will insert the given variables for each result of this match query
      */
+    @CheckReturnValue
     InsertQuery insert(Collection<? extends Var> vars);
 
     /**
      * @param names an array of variable names to delete for each result of this match query
      * @return a delete query that will delete the given variable names for each result of this match query
      */
+    @CheckReturnValue
     DeleteQuery delete(String... names);
 
     /**
      * @param deleters an array of variables stating what properties to delete for each result of this match query
      * @return a delete query that will delete the given properties for each result of this match query
      */
+    @CheckReturnValue
     DeleteQuery delete(Var... deleters);
 
     /**
      * @param deleters a collection of variables stating what properties to delete for each result of this match query
      * @return a delete query that will delete the given properties for each result of this match query
      */
+    @CheckReturnValue
     DeleteQuery delete(Collection<? extends Var> deleters);
 
     /**
@@ -98,6 +108,7 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param varName the variable name to order the results by
      * @return a new MatchQuery with the given ordering
      */
+    @CheckReturnValue
     MatchQuery orderBy(String varName);
 
     /**
@@ -105,6 +116,7 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param varName the variable name to order the results by
      * @return a new MatchQuery with the given ordering
      */
+    @CheckReturnValue
     MatchQuery orderBy(VarName varName);
 
     /**
@@ -113,6 +125,7 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param order the ordering to use
      * @return a new MatchQuery with the given ordering
      */
+    @CheckReturnValue
     MatchQuery orderBy(String varName, Order order);
 
     /**
@@ -121,30 +134,35 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param order the ordering to use
      * @return a new MatchQuery with the given ordering
      */
+    @CheckReturnValue
     MatchQuery orderBy(VarName varName, Order order);
 
     /**
      * @param graph the graph to execute the query on
      * @return a new MatchQuery with the graph set
      */
+    @Override
     MatchQuery withGraph(GraknGraph graph);
 
     /**
      * @param limit the maximum number of results the query should return
      * @return a new MatchQuery with the limit set
      */
+    @CheckReturnValue
     MatchQuery limit(long limit);
 
     /**
      * @param offset the number of results to skip
      * @return a new MatchQuery with the offset set
      */
+    @CheckReturnValue
     MatchQuery offset(long offset);
 
     /**
      * remove any duplicate results from the query
      * @return a new MatchQuery without duplicate results
      */
+    @CheckReturnValue
     MatchQuery distinct();
 
     /**
@@ -153,10 +171,12 @@ public interface MatchQuery extends Query<List<Answer>>, Streamable<Answer> {
      * @param <S> the type of the aggregate result
      * @return a query that will yield the aggregate result
      */
+    @CheckReturnValue
     <S> AggregateQuery<S> aggregate(Aggregate<? super Answer, S> aggregate);
 
     /**
      * @return admin instance for inspecting and manipulating this query
      */
+    @CheckReturnValue
     MatchQueryAdmin admin();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.graql;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * An aggregate operation with an associated name. Used when combining aggregates using the 'select' aggregate.
  * @param <T> the type of the query to perform the aggregate operation on
@@ -30,11 +32,13 @@ public interface NamedAggregate<T, S> {
      * Get the aggregate this named aggregate represents.
      * @return the aggregate this named aggregate represents
      */
+    @CheckReturnValue
     Aggregate<T, S> getAggregate();
 
     /**
      * Get the name of this aggregate.
      * @return the name of this aggregate
      */
+    @CheckReturnValue
     String getName();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Pattern.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Pattern.java
@@ -20,6 +20,8 @@ package ai.grakn.graql;
 
 import ai.grakn.graql.admin.PatternAdmin;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A pattern describing a subgraph.
  * <p>
@@ -38,6 +40,7 @@ public interface Pattern {
     /**
      * @return an Admin class that allows inspecting or manipulating this pattern
      */
+    @CheckReturnValue
     PatternAdmin admin();
 
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Printer.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Printer.java
@@ -21,6 +21,7 @@ package ai.grakn.graql;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.admin.Answer;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +44,7 @@ public interface Printer<T> {
      * @param object the object to convert to a string
      * @return the object as a string
      */
+    @CheckReturnValue
     default String graqlString(Object object) {
         T builder = graqlString(false, object);
         return build(builder);
@@ -54,6 +56,7 @@ public interface Printer<T> {
      * @param object the object to convert into a builder
      * @return the object as a builder
      */
+    @CheckReturnValue
     default T graqlString(boolean inner, Object object) {
         if (object instanceof Concept) {
             return graqlString(inner, (Concept) object);
@@ -79,6 +82,7 @@ public interface Printer<T> {
      * @param builder the builder to convert into a string
      * @return the builder as a string
      */
+    @CheckReturnValue
     String build(T builder);
 
     /**
@@ -87,6 +91,7 @@ public interface Printer<T> {
      * @param concept the concept to convert into a builder
      * @return the concept as a builder
      */
+    @CheckReturnValue
     T graqlString(boolean inner, Concept concept);
 
     /**
@@ -95,6 +100,7 @@ public interface Printer<T> {
      * @param bool the boolean to convert into a builder
      * @return the boolean as a builder
      */
+    @CheckReturnValue
     T graqlString(boolean inner, boolean bool);
 
     /**
@@ -103,6 +109,7 @@ public interface Printer<T> {
      * @param optional the optional to convert into a builder
      * @return the optional as a builder
      */
+    @CheckReturnValue
     T graqlString(boolean inner, Optional<?> optional);
 
     /**
@@ -111,6 +118,7 @@ public interface Printer<T> {
      * @param collection the collection to convert into a builder
      * @return the collection as a builder
      */
+    @CheckReturnValue
     T graqlString(boolean inner, Collection<?> collection);
 
     /**
@@ -119,6 +127,7 @@ public interface Printer<T> {
      * @param map the map to convert into a builder
      * @return the map as a builder
      */
+    @CheckReturnValue
     T graqlString(boolean inner, Map<?, ?> map);
 
     /**
@@ -127,6 +136,7 @@ public interface Printer<T> {
      * @param answer the answer to convert into a builder
      * @return the map as a builder
      */
+    @CheckReturnValue
     default T graqlString(boolean inner, Answer answer) {
         return graqlString(inner, answer.map());
     }
@@ -137,5 +147,6 @@ public interface Printer<T> {
      * @param object the object to convert into a builder
      * @return the object as a builder
      */
+    @CheckReturnValue
     T graqlStringDefault(boolean inner, Object object);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Query.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Query.java
@@ -20,6 +20,7 @@ package ai.grakn.graql;
 
 import ai.grakn.GraknGraph;
 
+import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;
 
 /**
@@ -35,6 +36,7 @@ public interface Query<T> {
      * @param graph the graph to execute the query on
      * @return a new query with the graph set
      */
+    @CheckReturnValue
     Query<T> withGraph(GraknGraph graph);
 
     /**
@@ -46,10 +48,12 @@ public interface Query<T> {
     /**
      * Execute the query and return a human-readable stream of results
      */
+    @CheckReturnValue
     Stream<String> resultsString(Printer printer);
 
     /**
      * Whether this query will modify the graph
      */
+    @CheckReturnValue
     boolean isReadOnly();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
@@ -20,6 +20,7 @@ package ai.grakn.graql;
 
 import ai.grakn.graql.macro.Macro;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -36,53 +37,62 @@ public interface QueryBuilder {
      * @param patterns an array of patterns to match in the graph
      * @return a match query that will find matches of the given patterns
      */
+    @CheckReturnValue
     MatchQuery match(Pattern... patterns);
 
     /**
      * @param patterns a collection of patterns to match in the graph
      * @return a match query that will find matches of the given patterns
      */
+    @CheckReturnValue
     MatchQuery match(Collection<? extends Pattern> patterns);
 
     /**
      * @param vars an array of variables to insert into the graph
      * @return an insert query that will insert the given variables into the graph
      */
+    @CheckReturnValue
     InsertQuery insert(Var... vars);
 
     /**
      * @param vars a collection of variables to insert into the graph
      * @return an insert query that will insert the given variables into the graph
      */
+    @CheckReturnValue
     InsertQuery insert(Collection<? extends Var> vars);
 
     /**
      * @return a compute query builder for building analytics query
      */
+    @CheckReturnValue
     ComputeQueryBuilder compute();
 
     /**
      * @param patternsString a string representing a list of patterns
      * @return a list of patterns
      */
+    @CheckReturnValue
     List<Pattern> parsePatterns(String patternsString);
 
     /**
      * @param patternString a string representing a pattern
      * @return a pattern
      */
+    @CheckReturnValue
     Pattern parsePattern(String patternString);
 
     /**
      * @param queryString a string representing a query
      * @return a query, the type will depend on the type of query.
      */
+    @CheckReturnValue
     <T extends Query<?>> T parse(String queryString);
 
     /**
      * @param queryString a string representing several queries
      * @return a list of queries
      */
+    @CheckReturnValue
     <T extends Query<?>> List<T> parseList(String queryString);
 
     /**
@@ -90,6 +100,7 @@ public interface QueryBuilder {
      * @param data data to use in template
      * @return a query, the type will depend on the type of template.
      */
+    @CheckReturnValue
     <T extends Query<?>> List<T> parseTemplate(String template, Map<String, Object> data);
 
     /**
@@ -108,10 +119,12 @@ public interface QueryBuilder {
     /**
      * Enable or disable inference
      */
+    @CheckReturnValue
     QueryBuilder infer(boolean infer);
 
     /**
      * Enable or disable materialisation
      */
+    @CheckReturnValue
     QueryBuilder materialise(boolean materialise);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Streamable.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Streamable.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
@@ -31,6 +32,7 @@ import java.util.stream.Stream;
 public interface Streamable<T> extends Iterable<T> {
 
     @Override
+    @CheckReturnValue
     default Iterator<T> iterator() {
         return stream().iterator();
     }
@@ -38,11 +40,13 @@ public interface Streamable<T> extends Iterable<T> {
     /**
      * @return a stream of elements
      */
+    @CheckReturnValue
     Stream<T> stream();
 
     /**
      * @return a parallel stream of elements
      */
+    @CheckReturnValue
     default Stream<T> parallelStream() {
         return stream().parallel();
     }

--- a/grakn-core/src/main/java/ai/grakn/graql/ValuePredicate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/ValuePredicate.java
@@ -20,6 +20,8 @@ package ai.grakn.graql;
 
 import ai.grakn.graql.admin.ValuePredicateAdmin;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * a atom on a value in a query.
  * <p>
@@ -34,6 +36,7 @@ public interface ValuePredicate {
     /**
      * @return an Admin class allowing inspection of this atom
      */
+    @CheckReturnValue
     ValuePredicateAdmin admin();
 
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Var.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Var.java
@@ -320,5 +320,6 @@ public interface Var extends Pattern {
     /**
      * @return an Admin class to allow inspection of this Var
      */
+    @CheckReturnValue
     VarAdmin admin();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/VarName.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/VarName.java
@@ -20,6 +20,7 @@ package ai.grakn.graql;
 
 import org.apache.commons.lang.StringUtils;
 
+import javax.annotation.CheckReturnValue;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -31,10 +32,12 @@ import java.util.function.Function;
 public final class VarName {
     private final String value;
 
+    @CheckReturnValue
     public static VarName of(String value) {
         return new VarName(value);
     }
 
+    @CheckReturnValue
     public static VarName anon() {
         return new VarName(UUID.randomUUID().toString());
     }
@@ -46,6 +49,7 @@ public final class VarName {
     /**
      * Get the string name of the variable (without prefixed "$")
      */
+    @CheckReturnValue
     public String getValue() {
         return value;
     }
@@ -55,6 +59,7 @@ public final class VarName {
      * @param mapper a function to apply to the underlying variable name
      * @return the new variable name
      */
+    @CheckReturnValue
     public VarName map(Function<String, String> mapper) {
         return VarName.of(mapper.apply(value));
     }
@@ -62,10 +67,12 @@ public final class VarName {
     /**
      * Get a shorter representation of the variable (with prefixed "$")
      */
+    @CheckReturnValue
     public String shortName() {
         return "$" + StringUtils.left(value, 3);
     }
 
+    @CheckReturnValue
     public String toString() {
         return "$" + value;
     }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Answer.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Answer.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.admin;
 import ai.grakn.concept.Concept;
 import ai.grakn.graql.VarName;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -37,34 +38,45 @@ import java.util.function.BiConsumer;
  */
 public interface Answer {
 
+    @CheckReturnValue
     Answer copy();
 
+    @CheckReturnValue
     Set<VarName> keySet();
 
+    @CheckReturnValue
     Collection<Concept> values();
 
+    @CheckReturnValue
     Set<Concept> concepts();
 
+    @CheckReturnValue
     Set<Map.Entry<VarName, Concept>> entrySet();
 
+    @CheckReturnValue
     Concept get(String var);
 
+    @CheckReturnValue
     Concept get(VarName var);
 
     Concept put(VarName var, Concept con);
 
     Concept remove(VarName var);
 
+    @CheckReturnValue
     Map<VarName, Concept> map();
 
     void putAll(Answer a);
 
     void putAll(Map<VarName, Concept> m2);
 
+    @CheckReturnValue
     boolean containsKey(VarName var);
 
+    @CheckReturnValue
     boolean isEmpty();
 
+    @CheckReturnValue
     int size();
 
     void forEach(BiConsumer<? super VarName, ? super Concept> consumer);
@@ -76,6 +88,7 @@ public interface Answer {
      * @param a2 answer to be merged with
      * @return merged answer
      */
+    @CheckReturnValue
     Answer merge(Answer a2);
 
 
@@ -87,6 +100,7 @@ public interface Answer {
      * @param explanation flag for providing explanation
      * @return merged answer
      */
+    @CheckReturnValue
     Answer merge(Answer a2, boolean explanation);
 
     /**
@@ -97,10 +111,13 @@ public interface Answer {
      */
     Answer explain(AnswerExplanation exp);
 
+    @CheckReturnValue
     Answer filterVars(Set<VarName> vars);
 
+    @CheckReturnValue
     Answer unify(Unifier unifier);
 
+    @CheckReturnValue
     AnswerExplanation getExplanation();
 
     /**
@@ -112,15 +129,18 @@ public interface Answer {
     /**
      * @return set of answers corresponding to the explicit path
      */
+    @CheckReturnValue
     Set<Answer> getExplicitPath();
 
     /**
      * @return set of all answers taking part in the derivation of this answer
      */
+    @CheckReturnValue
     Set<Answer> getAnswers();
 
     /**
      * @return all explanations taking part in the derivation of this answer
      */
+    @CheckReturnValue
     Set<AnswerExplanation> getExplanations();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 /**
@@ -31,11 +32,13 @@ import java.util.Set;
  */
 public interface AnswerExplanation {
 
+    @CheckReturnValue
     AnswerExplanation copy();
 
     /**
      * @return query associated with this explanation
      */
+    @CheckReturnValue
     ReasonerQuery getQuery();
 
     /**
@@ -53,35 +56,41 @@ public interface AnswerExplanation {
     /**
      * @return answers this explanation is dependent on
      */
+    @CheckReturnValue
     Set<Answer> getAnswers();
 
     /**
      * @param a2 explanation to be merged with
      * @return merged explanation
      */
+    @CheckReturnValue
     AnswerExplanation merge(AnswerExplanation a2);
 
     /**
      *
      * @return true if this explanation explains the answer on the basis of database lookup
      */
+    @CheckReturnValue
     boolean isLookupExplanation();
 
     /**
      *
      * @return true if this explanation explains the answer on the basis of rule application
      */
+    @CheckReturnValue
     boolean isRuleExplanation();
 
     /**
      *
      * @return true if this explanation explains an intermediate answer being a product of a join operation
      */
+    @CheckReturnValue
     boolean isJoinExplanation();
 
     /**
      *
      * @return true if this is an empty explanation (explanation wasn't recorded)
      */
+    @CheckReturnValue
     boolean isEmpty();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/AskQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/AskQueryAdmin.java
@@ -21,6 +21,8 @@ package ai.grakn.graql.admin;
 import ai.grakn.graql.AskQuery;
 import ai.grakn.graql.MatchQuery;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * Admin class for inspecting and manipulating an AskQuery
  *
@@ -30,5 +32,6 @@ public interface AskQueryAdmin extends AskQuery {
     /**
      * @return the match query used to create this ask query
      */
+    @CheckReturnValue
     MatchQuery getMatchQuery();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Atomic.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Atomic.java
@@ -19,6 +19,8 @@
 package ai.grakn.graql.admin;
 
 import ai.grakn.graql.VarName;
+
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 /**
@@ -32,59 +34,73 @@ import java.util.Set;
  */
 public interface Atomic {
 
+    @CheckReturnValue
     Atomic copy();
 
+    @CheckReturnValue
     default boolean isAtom(){ return false;}
+
+    @CheckReturnValue
     default boolean isPredicate(){ return false;}
 
     /**
      * @return true if atom alpha-equivalent
      */
+    @CheckReturnValue
     boolean isEquivalent(Object obj);
 
     /**
      * @return equivalence hash code
      */
+    @CheckReturnValue
     int equivalenceHashCode();
 
     /**
      * @return true if the variable name is user defined
      */
+    @CheckReturnValue
     default boolean isUserDefinedName(){ return false;}
 
     /**
      * @return true if the atom can be resolved by a rule (atom exists in one of the rule's head)
      */
+    @CheckReturnValue
     default boolean isRuleResolvable(){ return false;}
     /**
      * @return true if the atom can form an atomic query
      */
+    @CheckReturnValue
     default boolean isSelectable(){ return false;}
 
     /**
      * @return true if atom is recursive
      */
+    @CheckReturnValue
     default boolean isRecursive(){ return false;}
 
     /**
      * @param name variable name
      * @return true if atom contains an occurrence of the variable name
      */
+    @CheckReturnValue
     default boolean containsVar(VarName name){ return false;}
 
     /**
      * @return the corresponding base pattern
      * */
+    @CheckReturnValue
     PatternAdmin getPattern();
 
     /**
      * @return the base pattern combined with possible predicate patterns
      */
+    @CheckReturnValue
     PatternAdmin getCombinedPattern();
 
     /**
      * @return the query the atom is contained in
      */
+    @CheckReturnValue
     ReasonerQuery getParentQuery();
 
     /**
@@ -92,6 +108,7 @@ public interface Atomic {
      */
     void setParentQuery(ReasonerQuery q);
 
+    @CheckReturnValue
     Unifier getUnifier(Atomic parentAtom);
 
     /**
@@ -101,10 +118,12 @@ public interface Atomic {
      */
     void unify(Unifier unifier);
 
+    @CheckReturnValue
     VarName getVarName();
 
     /**
      * @return all addressable variable names in the atom
      */
+    @CheckReturnValue
     Set<VarName> getVarNames();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Conjunction.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Conjunction.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 /**
@@ -31,6 +32,7 @@ public interface Conjunction<T extends PatternAdmin> extends PatternAdmin {
     /**
      * @return the patterns within this conjunction
      */
+    @CheckReturnValue
     Set<T> getPatterns();
 
     @Override

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/DeleteQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/DeleteQueryAdmin.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.admin;
 import ai.grakn.graql.DeleteQuery;
 import ai.grakn.graql.MatchQuery;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 
 /**
@@ -32,10 +33,12 @@ public interface DeleteQueryAdmin extends DeleteQuery {
     /**
      * @return the variables to delete
      */
+    @CheckReturnValue
     Collection<VarAdmin> getDeleters();
 
     /**
      * @return the match query this delete query is operating on
      */
+    @CheckReturnValue
     MatchQuery getMatchQuery();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Disjunction.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Disjunction.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 /**
@@ -31,6 +32,7 @@ public interface Disjunction<T extends PatternAdmin> extends PatternAdmin {
     /**
      * @return the patterns within this disjunction
      */
+    @CheckReturnValue
     Set<T> getPatterns();
 
     @Override

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/InsertQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/InsertQueryAdmin.java
@@ -23,6 +23,7 @@ import ai.grakn.concept.Type;
 import ai.grakn.graql.InsertQuery;
 import ai.grakn.graql.MatchQuery;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
@@ -37,20 +38,24 @@ public interface InsertQueryAdmin extends InsertQuery {
     /**
      * @return the match query that this insert query is using, if it was provided one
      */
+    @CheckReturnValue
     Optional<? extends MatchQuery> getMatchQuery();
 
     /**
      * @return all concept types referred to explicitly in the query
      */
+    @CheckReturnValue
     Set<Type> getTypes();
 
     /**
      * @return the variables to insert in the insert query
      */
+    @CheckReturnValue
     Collection<VarAdmin> getVars();
 
     /**
      * @return the graph set on this query, if it was provided one
      */
+    @CheckReturnValue
     Optional<GraknGraph> getGraph();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchQueryAdmin.java
@@ -23,6 +23,7 @@ import ai.grakn.concept.Type;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.VarName;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 import java.util.Set;
 
@@ -37,25 +38,30 @@ public interface MatchQueryAdmin extends MatchQuery {
      * @param graph the graph to use to get types from
      * @return all concept types referred to explicitly in the query
      */
+    @CheckReturnValue
     Set<Type> getTypes(GraknGraph graph);
 
     /**
      * @return all concept types referred to explicitly in the query
      */
+    @CheckReturnValue
     Set<Type> getTypes();
 
     /**
      * @return the pattern to match in the graph
      */
+    @CheckReturnValue
     Conjunction<PatternAdmin> getPattern();
 
     /**
      * @return the graph the query operates on, if one was provided
      */
+    @CheckReturnValue
     Optional<GraknGraph> getGraph();
 
     /**
      * @return all selected variable names in the query
      */
+    @CheckReturnValue
     Set<VarName> getSelectedNames();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.admin;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.VarName;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
 import static java.util.stream.Collectors.toSet;
@@ -41,16 +42,19 @@ public interface PatternAdmin extends Pattern {
      *
      * @return the pattern group in disjunctive normal form
      */
+    @CheckReturnValue
     Disjunction<Conjunction<VarAdmin>> getDisjunctiveNormalForm();
 
     /**
      * Get all common, user-defined variable names in the pattern.
      */
+    @CheckReturnValue
     Set<VarName> commonVarNames();
 
     /**
      * @return true if this Pattern.Admin is a Conjunction
      */
+    @CheckReturnValue
     default boolean isDisjunction() {
         return false;
     }
@@ -58,6 +62,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return true if this Pattern.Admin is a Disjunction
      */
+    @CheckReturnValue
     default boolean isConjunction() {
         return false;
     }
@@ -65,6 +70,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return true if this Pattern.Admin is a Var.Admin
      */
+    @CheckReturnValue
     default boolean isVar() {
         return false;
     }
@@ -72,6 +78,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return this Pattern.Admin as a Disjunction, if it is one.
      */
+    @CheckReturnValue
     default Disjunction<?> asDisjunction() {
         throw new UnsupportedOperationException();
     }
@@ -79,6 +86,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return this Pattern.Admin as a Conjunction, if it is one.
      */
+    @CheckReturnValue
     default Conjunction<?> asConjunction() {
         throw new UnsupportedOperationException();
     }
@@ -86,6 +94,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return this Pattern.Admin as a Var.Admin, if it is one.
      */
+    @CheckReturnValue
     default VarAdmin asVar() {
         throw new UnsupportedOperationException();
     }
@@ -93,6 +102,7 @@ public interface PatternAdmin extends Pattern {
     /**
      * @return all variables referenced in the pattern
      */
+    @CheckReturnValue
     default Set<VarAdmin> getVars() {
         return getDisjunctiveNormalForm().getPatterns().stream()
                 .flatMap(conj -> conj.getPatterns().stream())

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
@@ -22,6 +22,8 @@ import ai.grakn.GraknGraph;
 import ai.grakn.concept.Type;
 import ai.grakn.graql.MatchQuery;
 import ai.grakn.graql.VarName;
+
+import javax.annotation.CheckReturnValue;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -37,37 +39,43 @@ import java.util.stream.Stream;
  */
 public interface ReasonerQuery{
 
-
+    @CheckReturnValue
     ReasonerQuery copy();
 
     /**
      * @return GraknGraph associated with this reasoner query
      */
+    @CheckReturnValue
     GraknGraph graph();
 
     /**
      * @return conjunctive pattern corresponding to this reasoner query
      */
+    @CheckReturnValue
     Conjunction<PatternAdmin> getPattern();
 
     /**
      * @return set of variable names present in this reasoner query
      */
+    @CheckReturnValue
     Set<VarName> getVarNames();
 
     /**
      * @return atom set constituting this reasoner query
      */
+    @CheckReturnValue
     Set<Atomic> getAtoms();
 
     /**
      * @return corresponding MatchQuery
      */
+    @CheckReturnValue
     MatchQuery getMatchQuery();
 
     /**
      * @return true if any of the atoms constituting the query can be resolved through a rule
      */
+    @CheckReturnValue
     boolean isRuleResolvable();
 
     /**
@@ -87,6 +95,7 @@ public interface ReasonerQuery{
      * @param parent query to unify wth
      * @return unifier such that this and parent are equal
      */
+    @CheckReturnValue
     Unifier getUnifier(ReasonerQuery parent);
 
     /**
@@ -95,10 +104,12 @@ public interface ReasonerQuery{
      * @param explanation whether to provide explanation
      * @return stream of answers
      */
+    @CheckReturnValue
     Stream<Answer> resolve(boolean materialise, boolean explanation);
 
     /**
      * @return map of variable name - corresponding type pairs
      */
+    @CheckReturnValue
     Map<VarName, Type> getVarTypeMap();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/RelationPlayer.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/RelationPlayer.java
@@ -30,11 +30,13 @@ public interface RelationPlayer {
     /**
      * @return the role type, if specified
      */
+    @CheckReturnValue
     Optional<VarAdmin> getRoleType();
 
     /**
      * @return the role player
      */
+    @CheckReturnValue
     VarAdmin getRolePlayer();
 
     // TODO: If `VarAdmin#setVarName` is removed, this may no longer be necessary

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Unifier.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Unifier.java
@@ -19,6 +19,8 @@
 package ai.grakn.graql.admin;
 
 import ai.grakn.graql.VarName;
+
+import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +46,7 @@ public interface Unifier{
      * @param key specific variable
      * @return corresponding term
      */
+    @CheckReturnValue
     VarName get(VarName key);
 
     /**
@@ -58,59 +61,72 @@ public interface Unifier{
     /**
      * @return true if the set of mappings is empty
      */
+    @CheckReturnValue
     boolean isEmpty();
 
+    @CheckReturnValue
     Map<VarName, VarName> map();
 
     /**
      * @return variables present in this unifier
      */
+    @CheckReturnValue
     Set<VarName> keySet();
 
     /**
      * @return terms present in this unifier
      */
+    @CheckReturnValue
     Collection<VarName> values();
 
     /**
      *
      * @return set of mappings constituting this unifier
      */
+    @CheckReturnValue
     Set<Map.Entry<VarName, VarName>> getMappings();
 
     /**
      * @param key variable to be inspected for presence
      * @return true if specified key is part of a mapping
      */
+    @CheckReturnValue
     boolean containsKey(VarName key);
 
     /**
      * @param value term to be checked for presence
      * @return true if specified value is part of a mapping
      */
+    @CheckReturnValue
     boolean containsValue(VarName value);
 
     /**
      * @param u unifier to compare with
      * @return true if this unifier contains all mappings of u
      */
+    @CheckReturnValue
     boolean containsAll(Unifier u);
 
     /**
      * @param d unifier to be merged with this unifier
-     * @return merged unifier
+     * @return this
      */
     Unifier merge(Unifier d);
 
+    /**
+     * @return this
+     */
     Unifier removeTrivialMappings();
 
     /**
-     * @return unifier with inverted mappings
+     * @return new unifier with inverted mappings
      */
+    @CheckReturnValue
     Unifier invert();
 
     /**
      * @return number of mappings that consittute this unifier
      */
+    @CheckReturnValue
     int size();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/UniqueVarProperty.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/UniqueVarProperty.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A unique property of a {@link ai.grakn.graql.Var}.
  *
@@ -28,6 +30,7 @@ package ai.grakn.graql.admin;
  */
 public interface UniqueVarProperty extends VarProperty {
 
+    @CheckReturnValue
     default boolean isUnique() {
         return true;
     }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/ValuePredicateAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/ValuePredicateAdmin.java
@@ -23,6 +23,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Optional;
 
 /**
@@ -40,6 +41,7 @@ public interface ValuePredicateAdmin extends ValuePredicate {
     /**
      * @return whether this predicate is specific (e.g. "eq" is specific, "regex" is not)
      */
+    @CheckReturnValue
     default boolean isSpecific() {
         return false;
     }
@@ -48,11 +50,13 @@ public interface ValuePredicateAdmin extends ValuePredicate {
      * @param predicate to be compared in terms of compatibility
      * @return true if compatible
      */
+    @CheckReturnValue
     boolean isCompatibleWith(ValuePredicateAdmin predicate);
 
     /**
      * @return the value comparing against, if this is an "equality" predicate, otherwise nothing
      */
+    @CheckReturnValue
     default Optional<Object> equalsValue() {
         return Optional.empty();
     }
@@ -60,12 +64,14 @@ public interface ValuePredicateAdmin extends ValuePredicate {
     /**
      * @return the gremlin predicate object this ValuePredicate wraps
      */
+    @CheckReturnValue
     Optional<P<Object>> getPredicate();
 
     /**
      * Get the inner variable that this predicate refers to, if one is present
      * @return the inner variable that this predicate refers to, if one is present
      */
+    @CheckReturnValue
     Optional<VarAdmin> getInnerVar();
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/VarAdmin.java
@@ -49,6 +49,7 @@ public interface VarAdmin extends PatternAdmin, Var {
     /**
      * @return the variable name of this variable
      */
+    @CheckReturnValue
     VarName getVarName();
 
     /**
@@ -60,11 +61,13 @@ public interface VarAdmin extends PatternAdmin, Var {
     /**
      * @return whether the user specified a name for this variable
      */
+    @CheckReturnValue
     boolean isUserDefinedName();
 
     /**
      * Get a stream of all properties on this variable
      */
+    @CheckReturnValue
     Stream<VarProperty> getProperties();
 
     /**
@@ -72,6 +75,7 @@ public interface VarAdmin extends PatternAdmin, Var {
      * @param type the class of {@link VarProperty} to return
      * @param <T> the type of {@link VarProperty} to return
      */
+    @CheckReturnValue
     <T extends VarProperty> Stream<T> getProperties(Class<T> type);
 
     /**
@@ -79,6 +83,7 @@ public interface VarAdmin extends PatternAdmin, Var {
      * @param type the class of {@link VarProperty} to return
      * @param <T> the type of {@link VarProperty} to return
      */
+    @CheckReturnValue
     <T extends UniqueVarProperty> Optional<T> getProperty(Class<T> type);
 
     /**
@@ -87,6 +92,7 @@ public interface VarAdmin extends PatternAdmin, Var {
      * @param <T> the type of the {@link VarProperty}
      * @return whether this {@link Var} has a {@link VarProperty} of the given type
      */
+    @CheckReturnValue
     <T extends VarProperty> boolean hasProperty(Class<T> type);
 
     // TODO: If `VarAdmin#setVarName` is removed, this may no longer be necessary
@@ -102,32 +108,37 @@ public interface VarAdmin extends PatternAdmin, Var {
     /**
      * @return the ID this variable represents, if it represents something with a specific ID
      */
+    @CheckReturnValue
     Optional<ConceptId> getId();
 
     /**
      * @return the name this variable represents, if it represents something with a specific name
      */
+    @CheckReturnValue
     Optional<TypeLabel> getTypeLabel();
 
     /**
      * @return all variables that this variable references
      */
-
+    @CheckReturnValue
     Collection<VarAdmin> getInnerVars();
 
     /**
      * Get all inner variables, including implicit variables such as in a has property
      */
+    @CheckReturnValue
     Collection<VarAdmin> getImplicitInnerVars();
 
     /**
      * @return all type names that this variable refers to
      */
+    @CheckReturnValue
     Set<TypeLabel> getTypeLabels();
 
     /**
      * @return the name of this variable, as it would be referenced in a native Graql query (e.g. '$x', 'movie')
      */
+    @CheckReturnValue
     String getPrintableName();
 
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/VarProperty.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/VarProperty.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -37,6 +38,7 @@ public interface VarProperty {
     /**
      * Get the Graql string representation of this property
      */
+    @CheckReturnValue
     default String graqlString() {
         StringBuilder builder = new StringBuilder();
         buildString(builder);
@@ -46,22 +48,26 @@ public interface VarProperty {
     /**
      * Get a stream of {@link VarAdmin} that must be types.
      */
+    @CheckReturnValue
     Stream<VarAdmin> getTypes();
 
     /**
      * Get a stream of any inner {@link VarAdmin} within this `VarProperty`.
      */
+    @CheckReturnValue
     Stream<VarAdmin> getInnerVars();
 
     /**
      * Get a stream of any inner {@link VarAdmin} within this `VarProperty`, including any that may have been
      * implicitly created (such as with "has").
      */
+    @CheckReturnValue
     Stream<VarAdmin> getImplicitInnerVars();
 
     /**
      * True if there is at most one of these properties for each {@link VarAdmin}
      */
+    @CheckReturnValue
     default boolean isUnique() {
         return false;
     }
@@ -73,5 +79,6 @@ public interface VarProperty {
      * @param parent reasoner query this atom should belong to
      * @return created atom
      */
+    @CheckReturnValue
     Atomic mapToAtom(VarAdmin var, Set<VarAdmin> vars, ReasonerQuery parent);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/macro/Macro.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/macro/Macro.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.macro;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 
 /**
@@ -34,11 +35,13 @@ public interface Macro<T> {
      * @param values Values on which to operate the macro
      * @return result of the function
      */
+    @CheckReturnValue
     T apply(List<Object> values);
 
     /**
      * The name of the macro
      * @return the name of the macro
      */
+    @CheckReturnValue
     String name();
 }

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.util;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * Enum containing error messages.
  *
@@ -226,6 +228,7 @@ public enum ErrorMessage {
         this.message = message;
     }
 
+    @CheckReturnValue
     public String getMessage(Object... args) {
         return String.format(message, args);
     }

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -31,6 +31,8 @@ import ai.grakn.concept.RuleType;
 import ai.grakn.concept.Type;
 import ai.grakn.concept.TypeLabel;
 
+import javax.annotation.CheckReturnValue;
+
 /**
  * A type enum which restricts the types of links/concepts which can be created
  *
@@ -64,10 +66,12 @@ public final class Schema {
             label = l;
         }
 
+        @CheckReturnValue
         public String getLabel() {
             return label;
         }
 
+        @CheckReturnValue
         public static EdgeLabel getEdgeLabel(String label) {
             for (EdgeLabel edgeLabel : EdgeLabel.values()) {
                 if (edgeLabel.getLabel().equals(label)) {
@@ -100,14 +104,17 @@ public final class Schema {
             this.id = id;
         }
 
+        @CheckReturnValue
         public TypeLabel getLabel() {
             return label;
         }
 
+        @CheckReturnValue
         public int getId(){
             return id;
         }
 
+        @CheckReturnValue
         public static boolean isMetaLabel(TypeLabel label) {
             for (MetaSchema metaSchema : MetaSchema.values()) {
                 if (metaSchema.getLabel().equals(label)) return true;
@@ -141,6 +148,7 @@ public final class Schema {
             this.classType = classType;
         }
 
+        @CheckReturnValue
         public Class getClassType(){
             return classType;
         }
@@ -170,6 +178,7 @@ public final class Schema {
             this.dataType = dataType;
         }
 
+        @CheckReturnValue
         public Class getDataType() {
             return dataType;
         }
@@ -189,6 +198,7 @@ public final class Schema {
             this.dataType = dataType;
         }
 
+        @CheckReturnValue
         public Class getDataType() {
             return dataType;
         }
@@ -234,10 +244,12 @@ public final class Schema {
             this.label = label;
         }
 
+        @CheckReturnValue
         public TypeLabel getLabel(TypeLabel resourceType) {
             return resourceType.map(resource -> String.format(label, resource));
         }
 
+        @CheckReturnValue
         public TypeLabel getLabel(String resourceType) {
             return TypeLabel.of(String.format(label, resourceType));
         }
@@ -257,6 +269,7 @@ public final class Schema {
             this.label = label;
         }
 
+        @CheckReturnValue
         public TypeLabel getLabel() {
             return TypeLabel.of(label);
         }
@@ -268,6 +281,7 @@ public final class Schema {
      * @param value The value of the resource
      * @return A unique id for the resource
      */
+    @CheckReturnValue
     public static String generateResourceIndex(TypeLabel typeLabel, String value){
         return Schema.BaseType.RESOURCE.name() + "-" + typeLabel + "-" + value;
     }

--- a/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/tasks/storage/TaskStateGraphStore.java
@@ -258,10 +258,10 @@ public class TaskStateGraphStore implements TaskStateStorage {
             MatchQuery q = graph.graql().match(finalMatchVar);
 
             if (limit > 0) {
-                q.limit(limit);
+                q = q.limit(limit);
             }
             if (offset > 0) {
-                q.offset(offset);
+                q = q.offset(offset);
             }
 
             return q.execute().stream()

--- a/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
+++ b/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/GraknTitanGraphTest.java
@@ -118,6 +118,7 @@ public class GraknTitanGraphTest extends TitanTestBase{
         graph.clear();
         expectedException.expect(GraphRuntimeException.class);
         expectedException.expectMessage(CLOSED_CLEAR.getMessage());
+        //noinspection ResultOfMethodCallIgnored
         graph.getEntityType("thing");
     }
 
@@ -135,6 +136,7 @@ public class GraknTitanGraphTest extends TitanTestBase{
         expectedException.expect(GraphRuntimeException.class);
         expectedException.expectMessage(GRAPH_CLOSED_ON_ACTION.getMessage("closed", graph.getKeyspace()));
 
+        //noinspection ResultOfMethodCallIgnored
         graph.getEntityType(entityTypeLabel);
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -1017,6 +1017,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         //This allows us to find relations far more quickly.
         String newIndex = otherRelation.getIndex().replaceAll(other.getId().getValue(), main.getId().getValue());
         RelationImpl foundRelation = getTxCache().getModifiedRelations().get(newIndex);
+        // TODO: Probable bug, the result should be assigned to `foundRelation`
         if(foundRelation == null) getConcept(Schema.ConceptProperty.INDEX, newIndex);
 
         if (foundRelation != null) {//If it exists delete the other one

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/ConceptTest.java
@@ -106,6 +106,7 @@ public class ConceptTest extends GraphTestBase{
         expectedException.expect(RuntimeException.class);
         expectedException.expectMessage(INVALID_OBJECT_TYPE.getMessage(thing, Type.class));
 
+        //noinspection ResultOfMethodCallIgnored
         thing.asType();
     }
 }

--- a/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/internal/GraknGraphTest.java
@@ -132,6 +132,7 @@ public class GraknGraphTest extends GraphTestBase {
     @Test
     public void whenClosingReadOnlyGraph_EnsureTypesAreCached(){
         assertCacheOnlyContainsMetaTypes();
+        //noinspection ResultOfMethodCallIgnored
         graknGraph.getMetaConcept().subTypes(); //This loads some types into transaction cache
         graknGraph.abort();
         assertCacheOnlyContainsMetaTypes(); //Ensure central cache is empty
@@ -363,6 +364,7 @@ public class GraknGraphTest extends GraphTestBase {
         failAtOpeningGraph(session, GraknTxType.BATCH, keyspace);
         graph.close();
 
+        //noinspection ResultOfMethodCallIgnored
         session.open(GraknTxType.BATCH);
         failAtOpeningGraph(session, GraknTxType.WRITE, keyspace);
         failAtOpeningGraph(session, GraknTxType.READ, keyspace);
@@ -370,6 +372,7 @@ public class GraknGraphTest extends GraphTestBase {
     private void failAtOpeningGraph(GraknSession session, GraknTxType txType, String keyspace){
         Exception exception = null;
         try{
+            //noinspection ResultOfMethodCallIgnored
             session.open(txType);
         } catch (GraphRuntimeException e){
             exception = e;

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/ConceptPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/ConceptPropertyTest.java
@@ -159,6 +159,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAType_TheConceptCannotBeConvertedToAType(Concept concept) {
         assumeFalse(concept.isType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asType();
     }
 
@@ -166,6 +167,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAnEntityType_TheConceptCannotBeConvertedToAnEntityType(Concept concept) {
         assumeFalse(concept.isEntityType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asEntityType();
     }
 
@@ -173,6 +175,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotARelationType_TheConceptCannotBeConvertedToARelationType(Concept concept) {
         assumeFalse(concept.isRelationType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asRelationType();
     }
 
@@ -180,6 +183,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotARoleType_TheConceptCannotBeConvertedToARoleType(Concept concept) {
         assumeFalse(concept.isRoleType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asRoleType();
     }
 
@@ -187,6 +191,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAResourceType_TheConceptCannotBeConvertedToAResourceType(Concept concept) {
         assumeFalse(concept.isResourceType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asResourceType();
     }
 
@@ -194,6 +199,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotARuleType_TheConceptCannotBeConvertedToARuleType(Concept concept) {
         assumeFalse(concept.isRuleType());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asRuleType();
     }
 
@@ -201,6 +207,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAnInstance_TheConceptCannotBeConvertedToAnInstance(Concept concept) {
         assumeFalse(concept.isInstance());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asInstance();
     }
 
@@ -208,6 +215,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAnEntity_TheConceptCannotBeConvertedToAnEntity(Concept concept) {
         assumeFalse(concept.isEntity());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asEntity();
     }
 
@@ -215,6 +223,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotARelation_TheConceptCannotBeConvertedToARelation(Concept concept) {
         assumeFalse(concept.isRelation());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asRelation();
     }
 
@@ -222,6 +231,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotAResource_TheConceptCannotBeConvertedToAResource(Concept concept) {
         assumeFalse(concept.isResource());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asResource();
     }
 
@@ -229,6 +239,7 @@ public class ConceptPropertyTest {
     public void whenConceptIsNotARule_TheConceptCannotBeConvertedToARule(Concept concept) {
         assumeFalse(concept.isRule());
         exception.expect(InvalidConceptTypeException.class);
+        //noinspection ResultOfMethodCallIgnored
         concept.asRule();
     }
 

--- a/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPropertyTest.java
+++ b/grakn-graph/src/test/java/ai/grakn/graph/property/GraknGraphPropertyTest.java
@@ -203,6 +203,7 @@ public class GraknGraphPropertyTest {
         String supported = ResourceType.DataType.SUPPORTED_TYPES.keySet().stream().collect(Collectors.joining(","));
         exception.expect(InvalidConceptValueException.class);
         exception.expectMessage(ErrorMessage.INVALID_DATATYPE.getMessage(value.getClass().getName(), supported));
+        //noinspection ResultOfMethodCallIgnored
         graph.getResourcesByValue(value);
     }
 
@@ -322,6 +323,7 @@ public class GraknGraphPropertyTest {
         // TODO: Test for a better error message
         exception.expect(GraphRuntimeException.class);
 
+        //noinspection ResultOfMethodCallIgnored
         resource.superType();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/Autocomplete.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Autocomplete.java
@@ -24,6 +24,7 @@ import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.Token;
 
+import javax.annotation.CheckReturnValue;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -49,6 +50,7 @@ public class Autocomplete {
      * @param cursorPosition the cursor position in the query
      * @return an autocomplete object containing potential candidates and cursor position to autocomplete from
      */
+    @CheckReturnValue
     public static Autocomplete create(Set<String> types, String query, int cursorPosition) {
         return new Autocomplete(types, query, cursorPosition);
     }
@@ -56,6 +58,7 @@ public class Autocomplete {
     /**
      * @return all candidate autocomplete words
      */
+    @CheckReturnValue
     public Set<String> getCandidates() {
         return candidates;
     }
@@ -63,6 +66,7 @@ public class Autocomplete {
     /**
      * @return the cursor position that autocompletions should start from
      */
+    @CheckReturnValue
     public int getCursorPosition() {
         return cursorPosition;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -30,6 +30,7 @@ import ai.grakn.graql.internal.util.AdminConverter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import javax.annotation.CheckReturnValue;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -54,6 +55,7 @@ public class Graql {
     /**
      * @return a query builder without a specified graph
      */
+    @CheckReturnValue
     public static QueryBuilder withoutGraph() {
         return new QueryBuilderImpl();
     }
@@ -62,6 +64,7 @@ public class Graql {
      * @param patterns an array of patterns to match in the graph
      * @return a match query that will find matches of the given patterns
      */
+    @CheckReturnValue
     public static MatchQuery match(Pattern... patterns) {
         return withoutGraph().match(patterns);
     }
@@ -70,6 +73,7 @@ public class Graql {
      * @param patterns a collection of patterns to match in the graph
      * @return a match query that will find matches of the given patterns
      */
+    @CheckReturnValue
     public static MatchQuery match(Collection<? extends Pattern> patterns) {
         return withoutGraph().match(patterns);
     }
@@ -78,6 +82,7 @@ public class Graql {
      * @param vars an array of variables to insert into the graph
      * @return an insert query that will insert the given variables into the graph
      */
+    @CheckReturnValue
     public static InsertQuery insert(Var... vars) {
         return withoutGraph().insert(vars);
     }
@@ -86,6 +91,7 @@ public class Graql {
      * @param vars a collection of variables to insert into the graph
      * @return an insert query that will insert the given variables into the graph
      */
+    @CheckReturnValue
     public static InsertQuery insert(Collection<? extends Var> vars) {
         return withoutGraph().insert(vars);
     }
@@ -93,6 +99,7 @@ public class Graql {
     /**
      * @return a compute query builder without a specified graph
      */
+    @CheckReturnValue
     public static ComputeQueryBuilder compute() {
         return withoutGraph().compute();
     }
@@ -101,6 +108,7 @@ public class Graql {
      * @param patternsString a string representing a list of patterns
      * @return a list of patterns
      */
+    @CheckReturnValue
     public static List<Pattern> parsePatterns(String patternsString) {
         return withoutGraph().parsePatterns(patternsString);
     }
@@ -109,6 +117,7 @@ public class Graql {
      * @param queryString a string representing a query
      * @return a query, the type will depend on the type of query.
      */
+    @CheckReturnValue
     public static <T extends Query<?>> T parse(String queryString) {
         return withoutGraph().parse(queryString);
     }
@@ -117,6 +126,7 @@ public class Graql {
      * @param queryString a string representing several queries
      * @return a list of queries
      */
+    @CheckReturnValue
     public static List<Query<?>> parseList(String queryString) {
         return withoutGraph().parseList(queryString);
     }
@@ -128,6 +138,7 @@ public class Graql {
      * @param data data to use in template
      * @return a query, the type will depend on the type indicated in the template
      */
+    @CheckReturnValue
     public static <T extends Query<?>> List<T> parseTemplate(String template, Map<String, Object> data){
         return withoutGraph().parseTemplate(template, data);
     }
@@ -138,6 +149,7 @@ public class Graql {
      * @param name the name of the variable
      * @return a new query variable
      */
+    @CheckReturnValue
     public static Var var(String name) {
         return var(VarName.of(name));
     }
@@ -146,6 +158,7 @@ public class Graql {
      * @param name the name of the variable
      * @return a new query variable
      */
+    @CheckReturnValue
     public static Var var(VarName name) {
         return Patterns.var(Objects.requireNonNull(name));
     }
@@ -153,6 +166,7 @@ public class Graql {
     /**
      * @return a new, anonymous query variable
      */
+    @CheckReturnValue
     public static Var var() {
         return Patterns.var();
     }
@@ -161,6 +175,7 @@ public class Graql {
      * @param label the label of a concept
      * @return a query variable that identifies a concept by label
      */
+    @CheckReturnValue
     public static Var label(TypeLabel label) {
         return var().label(label);
     }
@@ -169,6 +184,7 @@ public class Graql {
      * @param label the label of a concept
      * @return a query variable that identifies a concept by label
      */
+    @CheckReturnValue
     public static Var label(String label) {
         return var().label(label);
     }
@@ -177,6 +193,7 @@ public class Graql {
      * @param patterns an array of patterns to match
      * @return a pattern that will match only when all contained patterns match
      */
+    @CheckReturnValue
     public static Pattern and(Pattern... patterns) {
         return and(Arrays.asList(patterns));
     }
@@ -185,6 +202,7 @@ public class Graql {
      * @param patterns a collection of patterns to match
      * @return a pattern that will match only when all contained patterns match
      */
+    @CheckReturnValue
     public static Pattern and(Collection<? extends Pattern> patterns) {
         Collection<PatternAdmin> patternAdmins = AdminConverter.getPatternAdmins(patterns);
         return Patterns.conjunction(Sets.newHashSet(patternAdmins));
@@ -194,6 +212,7 @@ public class Graql {
      * @param patterns an array of patterns to match
      * @return a pattern that will match when any contained pattern matches
      */
+    @CheckReturnValue
     public static Pattern or(Pattern... patterns) {
         return or(Arrays.asList(patterns));
     }
@@ -202,6 +221,7 @@ public class Graql {
      * @param patterns a collection of patterns to match
      * @return a pattern that will match when any contained pattern matches
      */
+    @CheckReturnValue
     public static Pattern or(Collection<? extends Pattern> patterns) {
         Collection<PatternAdmin> patternAdmins = AdminConverter.getPatternAdmins(patterns);
         return Patterns.disjunction(Sets.newHashSet(patternAdmins));
@@ -213,6 +233,7 @@ public class Graql {
     /**
      * Create an aggregate that will count the results of a query.
      */
+    @CheckReturnValue
     public static Aggregate<Object, Long> count() {
         return Aggregates.count();
     }
@@ -220,6 +241,7 @@ public class Graql {
     /**
      * Create an aggregate that will sum the values of a variable.
      */
+    @CheckReturnValue
     public static Aggregate<Answer, Number> sum(String name) {
         return Aggregates.sum(VarName.of(name));
     }
@@ -228,6 +250,7 @@ public class Graql {
      * Create an aggregate that will find the maximum of a variable's values.
      * @param name the variable to find the maximum of
      */
+    @CheckReturnValue
     public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> max(String name) {
         return Aggregates.max(VarName.of(name));
     }
@@ -236,6 +259,7 @@ public class Graql {
      * Create an aggregate that will find the minimum of a variable's values.
      * @param name the variable to find the maximum of
      */
+    @CheckReturnValue
     public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> min(String name) {
         return Aggregates.min(VarName.of(name));
     }
@@ -244,6 +268,7 @@ public class Graql {
      * Create an aggregate that will find the mean of a variable's values.
      * @param name the variable to find the mean of
      */
+    @CheckReturnValue
     public static Aggregate<Answer, Optional<Double>> mean(String name) {
         return Aggregates.mean(VarName.of(name));
     }
@@ -252,6 +277,7 @@ public class Graql {
      * Create an aggregate that will find the median of a variable's values.
      * @param name the variable to find the median of
      */
+    @CheckReturnValue
     public static Aggregate<Answer, Optional<Number>> median(String name) {
         return Aggregates.median(VarName.of(name));
     }
@@ -260,6 +286,7 @@ public class Graql {
      * Create an aggregate that will find the unbiased sample standard deviation of a variable's values.
      * @param name the variable to find the standard deviation of
      */
+    @CheckReturnValue
     public static Aggregate<Answer, Optional<Double>> std(String name) {
         return Aggregates.std(VarName.of(name));
     }
@@ -268,6 +295,7 @@ public class Graql {
      * Create an aggregate that will group a query by a variable name.
      * @param varName the variable name to group results by
      */
+    @CheckReturnValue
     public static Aggregate<Answer, Map<Concept, List<Answer>>> group(String varName) {
         return group(varName, Aggregates.list());
     }
@@ -278,6 +306,7 @@ public class Graql {
      * @param aggregate the aggregate to apply to each group
      * @param <T> the type the aggregate returns
      */
+    @CheckReturnValue
     public static <T> Aggregate<Answer, Map<Concept, T>> group(
             String varName, Aggregate<? super Answer, T> aggregate) {
         return Aggregates.group(VarName.of(varName), aggregate);
@@ -289,6 +318,7 @@ public class Graql {
      * @param <S> the type that the query returns
      * @param <T> the type that each aggregate returns
      */
+    @CheckReturnValue
     @SafeVarargs
     public static <S, T> Aggregate<S, Map<String, T>> select(NamedAggregate<? super S, ? extends T>... aggregates) {
         return select(ImmutableSet.copyOf(aggregates));
@@ -300,6 +330,7 @@ public class Graql {
      * @param <S> the type that the query returns
      * @param <T> the type that each aggregate returns
      */
+    @CheckReturnValue
     public static <S, T> Aggregate<S, Map<String, T>> select(Set<NamedAggregate<? super S, ? extends T>> aggregates) {
         return Aggregates.select(ImmutableSet.copyOf(aggregates));
     }
@@ -311,6 +342,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value equals the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate eq(Object value) {
         Objects.requireNonNull(value);
         return Predicates.eq(value);
@@ -320,6 +352,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value equals the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate eq(Var var) {
         Objects.requireNonNull(var);
         return Predicates.eq(var.admin());
@@ -329,6 +362,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value does not equal the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate neq(Object value) {
         Objects.requireNonNull(value);
         return Predicates.neq(value);
@@ -338,6 +372,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value does not equal the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate neq(Var var) {
         Objects.requireNonNull(var);
         return Predicates.neq(var.admin());
@@ -347,6 +382,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value is strictly greater than the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate gt(Comparable value) {
         Objects.requireNonNull(value);
         return Predicates.gt(value);
@@ -356,6 +392,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value is strictly greater than the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate gt(Var var) {
         Objects.requireNonNull(var);
         return Predicates.gt(var.admin());
@@ -365,6 +402,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value is greater or equal to the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate gte(Comparable value) {
         Objects.requireNonNull(value);
         return Predicates.gte(value);
@@ -374,6 +412,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value is greater or equal to the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate gte(Var var) {
         Objects.requireNonNull(var);
         return Predicates.gte(var.admin());
@@ -383,6 +422,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value is strictly less than the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate lt(Comparable value) {
         Objects.requireNonNull(value);
         return Predicates.lt(value);
@@ -392,6 +432,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value is strictly less than the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate lt(Var var) {
         Objects.requireNonNull(var);
         return Predicates.lt(var.admin());
@@ -401,6 +442,7 @@ public class Graql {
      * @param value the value
      * @return a predicate that is true when a value is less or equal to the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate lte(Comparable value) {
         Objects.requireNonNull(value);
         return Predicates.lte(value);
@@ -410,6 +452,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that is true when a value is less or equal to the specified value
      */
+    @CheckReturnValue
     public static ValuePredicate lte(Var var) {
         Objects.requireNonNull(var);
         return Predicates.lte(var.admin());
@@ -419,6 +462,7 @@ public class Graql {
      * @param pattern a regex pattern
      * @return a predicate that returns true when a value matches the given regular expression
      */
+    @CheckReturnValue
     public static ValuePredicate regex(String pattern) {
         Objects.requireNonNull(pattern);
         return Predicates.regex(pattern);
@@ -428,6 +472,7 @@ public class Graql {
      * @param substring a substring to match
      * @return a predicate that returns true when a value contains the given substring
      */
+    @CheckReturnValue
     public static ValuePredicate contains(String substring) {
         Objects.requireNonNull(substring);
         return Predicates.contains(substring);
@@ -437,6 +482,7 @@ public class Graql {
      * @param var the variable representing a resource
      * @return a predicate that returns true when a value contains the given substring
      */
+    @CheckReturnValue
     public static ValuePredicate contains(Var var) {
         Objects.requireNonNull(var);
         return Predicates.contains(var.admin());

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/ConjunctionQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/ConjunctionQueryTest.java
@@ -59,6 +59,7 @@ public class ConjunctionQueryTest {
     private VarName x = VarName.of("x");
     private VarName y = VarName.of("y");
 
+    @SuppressWarnings("ResultOfMethodCallIgnored") // Mockito confuses IntelliJ
     @Before
     public void setUp() {
         graph = mock(GraknGraph.class);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -575,6 +575,7 @@ public class QueryParserTest {
                 containsString("\nmatch $x isa "),
                 containsString("\n             ^")
         ));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x isa ");
     }
 
@@ -582,6 +583,7 @@ public class QueryParserTest {
     public void whenParseIncorrectSyntax_ErrorMessageShouldRetainWhitespace() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(not(containsString("match$xisa")));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x isa ");
     }
 
@@ -592,6 +594,7 @@ public class QueryParserTest {
                 containsString("\nmatch $x is"),
                 containsString("\n         ^")
         ));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x is");
     }
 
@@ -718,6 +721,7 @@ public class QueryParserTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testMultipleQueriesThrowsIllegalArgumentException() {
+        //noinspection ResultOfMethodCallIgnored
         parse("insert $x isa movie; insert $y isa movie");
     }
 
@@ -725,6 +729,7 @@ public class QueryParserTest {
     public void testMissingColon() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("':'");
+        //noinspection ResultOfMethodCallIgnored
         parse("match (actor $x, $y) isa has-cast;");
     }
 
@@ -732,6 +737,7 @@ public class QueryParserTest {
     public void testMissingComma() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("','");
+        //noinspection ResultOfMethodCallIgnored
         parse("match ($x $y) isa has-cast;");
     }
 
@@ -739,6 +745,7 @@ public class QueryParserTest {
     public void testLimitMistake() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("limit1");
+        //noinspection ResultOfMethodCallIgnored
         parse("match ($x, $y); limit1;");
     }
 
@@ -746,6 +753,7 @@ public class QueryParserTest {
     public void whenParsingAggregateWithWrongArgumentNumber_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(ErrorMessage.AGGREGATE_ARGUMENT_NUM.getMessage("count", 0, 1));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x isa name; aggregate count $x;");
     }
 
@@ -753,6 +761,7 @@ public class QueryParserTest {
     public void whenParsingAggregateWithWrongVariableArgumentNumber_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(ErrorMessage.AGGREGATE_ARGUMENT_NUM.getMessage("group", "1-2", 0));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x isa name; aggregate group;");
     }
 
@@ -760,6 +769,7 @@ public class QueryParserTest {
     public void whenParsingAggregateWithWrongName_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(ErrorMessage.UNKNOWN_AGGREGATE.getMessage("hello"));
+        //noinspection ResultOfMethodCallIgnored
         parse("match $x isa name; aggregate hello $x;");
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/template/MacroTest.java
@@ -68,6 +68,7 @@ public class MacroTest {
     @Test(expected = IllegalArgumentException.class)
     public void noescpMacroBreaksWithWrongNumberArguments(){
         String template = "@noescp(<value>, <otherValue>)";
+        //noinspection ResultOfMethodCallIgnored
         Graql.parseTemplate(template, new HashMap<>());
     }
 
@@ -236,6 +237,7 @@ public class MacroTest {
 
         exception.expect(IllegalArgumentException.class);
 
+        //noinspection ResultOfMethodCallIgnored
         Graql.parseTemplate(template, Collections.singletonMap("date", "10/09/1993"));
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/template/TemplateParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/template/TemplateParserTest.java
@@ -681,6 +681,7 @@ public class TemplateParserTest {
     public void testGraqlParsingException(){
         exception.expect(IllegalArgumentException.class);
         String template = "<<<<<<<";
+        //noinspection ResultOfMethodCallIgnored
         Graql.parseTemplate(template, new HashMap<>());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerTest.java
@@ -30,7 +30,6 @@ import ai.grakn.test.engine.controller.TasksControllerTest.JsonMapper;
 import ai.grakn.util.REST;
 import com.jayway.restassured.RestAssured;
 import com.jayway.restassured.response.Response;
-import java.util.Collections;
 import mjson.Json;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -38,9 +37,10 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
-
 import org.junit.runners.MethodSorters;
 import spark.Service;
+
+import java.util.Collections;
 
 import static ai.grakn.engine.GraknEngineServer.configureSpark;
 import static ai.grakn.graql.internal.hal.HALBuilder.renderHALArrayData;
@@ -53,10 +53,10 @@ import static ai.grakn.util.REST.Request.Graql.LIMIT_EMBEDDED;
 import static ai.grakn.util.REST.Request.Graql.MATERIALISE;
 import static ai.grakn.util.REST.Request.Graql.QUERY;
 import static ai.grakn.util.REST.Request.KEYSPACE;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_HAL;
 import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON;
 import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON_GRAQL;
 import static ai.grakn.util.REST.Response.ContentType.APPLICATION_TEXT;
-import static ai.grakn.util.REST.Response.ContentType.APPLICATION_HAL;
 import static ai.grakn.util.REST.Response.EXCEPTION;
 import static ai.grakn.util.REST.Response.Graql.ORIGINAL_QUERY;
 import static ai.grakn.util.REST.Response.Graql.RESPONSE;
@@ -73,7 +73,6 @@ import static org.junit.Assume.assumeTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.booleanThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doAnswer;
@@ -139,6 +138,7 @@ public class GraqlControllerTest {
         String query = "match $x isa person;";
         sendGET(query, APPLICATION_TEXT);
 
+        //noinspection ResultOfMethodCallIgnored
         verify(mockGraph.graql().materialise(anyBoolean()).infer(anyBoolean()))
                 .parse(argThat(argument -> argument.equals(query)));
     }
@@ -217,14 +217,16 @@ public class GraqlControllerTest {
     public void GETGraqlMatchWithReasonerTrue_ReasonerIsOnWhenExecuting(){
         sendGET("match $x isa person;", APPLICATION_TEXT, true, true, 0);
 
-        verify(mockQueryBuilder).infer(booleanThat(arg -> arg));
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockQueryBuilder).infer(true);
     }
 
     @Test
     public void GETGraqlMatchWithReasonerFalse_ReasonerIsOffWhenExecuting(){
         sendGET("match $x isa person;", APPLICATION_TEXT, false, true, 0);
 
-        verify(mockQueryBuilder).infer(booleanThat(arg -> !arg));
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockQueryBuilder).infer(false);
     }
 
     @Test
@@ -242,14 +244,16 @@ public class GraqlControllerTest {
     public void GETGraqlMatchWithMaterialiseFalse_MaterialiseIsOffWhenExecuting(){
         sendGET("match $x isa person;", APPLICATION_TEXT, false, false, 0);
 
-        verify(mockQueryBuilder).materialise(booleanThat(arg -> !arg));
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockQueryBuilder).materialise(false);
     }
 
     @Test
     public void GETGraqlMatchWithMaterialiseTrue_MaterialiseIsOnWhenExecuting(){
         sendGET("match $x isa person;", APPLICATION_TEXT, false, true, 0);
 
-        verify(mockQueryBuilder).materialise(booleanThat(arg -> arg));
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockQueryBuilder).materialise(true);
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestUtils.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/postprocessing/PostProcessingTestUtils.java
@@ -52,6 +52,8 @@ public class PostProcessingTestUtils {
         resourceVertex.property(Schema.ConceptProperty.ID.name(), resourceVertex.id().toString());
 
         resourceVertex.addEdge(Schema.EdgeLabel.ISA.getLabel(), vertexResourceTypeShard);
+        // This is done to push the concept into the cache
+        //noinspection ResultOfMethodCallIgnored
         graknGraph.admin().buildConcept(resourceVertex);
         return Sets.newHashSet(originalResource, resourceVertex);
     }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/CountTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/CountTest.java
@@ -68,9 +68,9 @@ public class CountTest {
         String nameAnotherThing = "another";
         EntityType thing = graph.putEntityType(nameThing);
         EntityType anotherThing = graph.putEntityType(nameAnotherThing);
-        thing.addEntity().getId();
-        thing.addEntity().getId();
-        anotherThing.addEntity().getId();
+        thing.addEntity();
+        thing.addEntity();
+        anotherThing.addEntity();
         graph.commit();
         graph = factory.open(GraknTxType.WRITE);
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/analytics/DegreeTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/analytics/DegreeTest.java
@@ -210,7 +210,7 @@ public class DegreeTest {
         graph.putEntityType("person").plays(owner);
         EntityType animal = graph.putEntityType("animal").plays(pet);
         EntityType dog = graph.putEntityType("dog").superType(animal);
-        dog.addEntity().getId();
+        dog.addEntity();
         graph.commit();
 
         try (GraknGraph graph = factory.open(GraknTxType.READ)) {

--- a/grakn-test/src/test/java/ai/grakn/test/graql/graql/MatchQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/graql/MatchQueryTest.java
@@ -61,6 +61,7 @@ public class MatchQueryTest {
     public void whenQueryIsLimitedToANegativeNumber_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(NON_POSITIVE_LIMIT.getMessage(Long.MIN_VALUE));
+        //noinspection ResultOfMethodCallIgnored
         graph.graql().match(var()).limit(Long.MIN_VALUE);
     }
 
@@ -68,6 +69,7 @@ public class MatchQueryTest {
     public void whenQueryIsLimitedToZero_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(NON_POSITIVE_LIMIT.getMessage(0L));
+        //noinspection ResultOfMethodCallIgnored
         graph.graql().match(var()).limit(0L);
     }
 
@@ -75,6 +77,7 @@ public class MatchQueryTest {
     public void whenQueryIsOffsetByANegativeNumber_Throw() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(NEGATIVE_OFFSET.getMessage(Long.MIN_VALUE));
+        //noinspection ResultOfMethodCallIgnored
         graph.graql().match(var()).offset(Long.MIN_VALUE);
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/graql/VariableAndPatternTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/graql/VariableAndPatternTest.java
@@ -59,8 +59,9 @@ public class VariableAndPatternTest {
     public void setUp() {
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    public void testVarName() {
+    public void testValidVarNames() {
         var("123");
         var("___");
         var("---");
@@ -173,14 +174,16 @@ public class VariableAndPatternTest {
     }
 
     @Test(expected = Exception.class)
-    public void testConjunctionNull() {
+    public void whenConjunctionPassedNull_Throw() {
         Set<Var> varSet = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
         and(varSet);
     }
 
     @Test(expected = Exception.class)
-    public void testConjunctionContainsNull() {
+    public void whenConjunctionPassedVarAndNull_Throw() {
         Var var = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
         and(var(), var);
     }
 
@@ -228,14 +231,16 @@ public class VariableAndPatternTest {
     }
 
     @Test(expected = Exception.class)
-    public void testDisjunctionNull() {
+    public void whenDisjunctionPassedNull_Throw() {
         Set<Var> varSet = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
         or(varSet);
     }
 
     @Test(expected = Exception.class)
-    public void testDisjunctionContainsNull() {
+    public void whenDisjunctionPassedVarAndNull_Throw() {
         Var var = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
         or(var(), var);
     }
 
@@ -263,8 +268,9 @@ public class VariableAndPatternTest {
     }
 
     @Test(expected = Exception.class)
-    public void testNegationNull() {
+    public void whenNegationPassedNull_Throw() {
         Var var = null;
+        //noinspection ConstantConditions,ResultOfMethodCallIgnored
         neq(var);
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryModifierTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryModifierTest.java
@@ -169,6 +169,7 @@ public class MatchQueryModifierTest {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(VarName.of("y")));
 
+        //noinspection ResultOfMethodCallIgnored
         query.select("y");
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/PatternTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/PatternTest.java
@@ -68,16 +68,19 @@ public class PatternTest {
 
     @Test(expected = UnsupportedOperationException.class)
     public void testConjunctionAsVar() {
+        //noinspection ResultOfMethodCallIgnored
         Graql.and(var("x").isa("movie"), var("x").isa("person")).admin().asVar();
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testDisjunctionAsConjunction() {
+        //noinspection ResultOfMethodCallIgnored
         Graql.or(var("x").isa("movie"), var("x").isa("person")).admin().asConjunction();
     }
 
     @Test(expected = UnsupportedOperationException.class)
     public void testVarAsDisjunction() {
+        //noinspection ResultOfMethodCallIgnored
         var("x").isa("movie").admin().asDisjunction();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryBuilderTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryBuilderTest.java
@@ -107,6 +107,7 @@ public class QueryBuilderTest {
         MatchQuery query = match(var("x").isa("movie"));
         exception.expect(IllegalStateException.class);
         exception.expectMessage("graph");
+        //noinspection ResultOfMethodCallIgnored
         query.iterator();
     }
 
@@ -136,6 +137,7 @@ public class QueryBuilderTest {
     public void testValidationWhenGraphProvided() {
         MatchQuery query = match(var("x").isa("not-a-thing"));
         exception.expect(IllegalStateException.class);
+        //noinspection ResultOfMethodCallIgnored
         query.withGraph(movieGraph.graph()).stream();
     }
 
@@ -143,6 +145,7 @@ public class QueryBuilderTest {
     public void testErrorWhenSpecifyGraphTwice() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("graph");
+        //noinspection ResultOfMethodCallIgnored
         movieGraph.graph().graql().match(var("x").isa("movie")).withGraph(movieGraph.graph()).stream();
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/QueryErrorTest.java
@@ -63,6 +63,7 @@ public class QueryErrorTest {
     public void testErrorNonExistentConceptType() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("film");
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("x").isa("film")).stream();
     }
 
@@ -70,6 +71,7 @@ public class QueryErrorTest {
     public void testErrorNotARole() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(containsString("role"), containsString("person"), containsString("isa person")));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("x").isa("movie"), var().rel("person", "y").rel("x")).stream();
     }
 
@@ -85,6 +87,7 @@ public class QueryErrorTest {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(
                 containsString("relation"), containsString("movie"), containsString("separate"), containsString(";")));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var().isa("movie").rel("x").rel("y")).stream();
     }
 
@@ -92,6 +95,7 @@ public class QueryErrorTest {
     public void testErrorInvalidNonExistentRole() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage(ErrorMessage.NOT_A_ROLE_TYPE.getMessage("character-in-production", "character-in-production"));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var().isa("has-cast").rel("character-in-production", "x")).stream();
     }
 
@@ -101,6 +105,7 @@ public class QueryErrorTest {
         exception.expectMessage(allOf(
                 containsString("abc"), containsString("isa"), containsString("person"), containsString("has-cast")
         ));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("abc").isa("person").isa("has-cast"));
     }
 
@@ -109,6 +114,7 @@ public class QueryErrorTest {
         // 'has genre' is not allowed because genre is an entity type
         exception.expect(IllegalStateException.class);
         exception.expectMessage(allOf(containsString("genre"), containsString("resource")));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("x").isa("movie").has("genre", "Drama")).stream();
     }
 
@@ -116,6 +122,7 @@ public class QueryErrorTest {
     public void testExceptionWhenNoSelectVariablesProvided() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage("select");
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("x").isa("movie")).select();
     }
 
@@ -123,12 +130,14 @@ public class QueryErrorTest {
     public void testExceptionWhenNoPatternsProvided() {
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
+        //noinspection ResultOfMethodCallIgnored
         qb.match();
     }
 
     @Test
     public void testExceptionWhenNullValue() {
         exception.expect(NullPointerException.class);
+        //noinspection ResultOfMethodCallIgnored
         var("x").val(null);
     }
 
@@ -156,6 +165,7 @@ public class QueryErrorTest {
                 containsString("actor"),
                 containsString("role")
         ));
+        //noinspection ResultOfMethodCallIgnored
         qb.match(var("x").isa("actor")).stream();
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/reasoner/AtomicQueryTest.java
@@ -34,10 +34,10 @@ import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.admin.VarAdmin;
 import ai.grakn.graql.internal.pattern.Patterns;
+import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.binary.TypeAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
-import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.query.QueryAnswers;
 import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
@@ -47,7 +47,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -60,9 +59,8 @@ import static ai.grakn.graql.internal.reasoner.query.QueryAnswerStream.permuteFu
 import static ai.grakn.graql.internal.reasoner.query.QueryAnswerStream.subFilter;
 import static ai.grakn.test.GraknTestEnv.usingTinker;
 import static java.util.stream.Collectors.toSet;
-
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
@@ -158,7 +156,7 @@ public class AtomicQueryTest {
         ReasonerAtomicQuery atomicQuery = ReasonerQueries.atomic(pattern, graph);
 
         assertFalse(qb.<MatchQuery>parse(explicitQuery).ask().execute());
-        answers.stream().flatMap(atomicQuery::materialise).collect(Collectors.toList());
+        answers.stream().forEach(atomicQuery::materialise);
         assertTrue(qb.<MatchQuery>parse(explicitQuery).ask().execute());
     }
 


### PR DESCRIPTION
This will highlight bugs such as:
```
graph.insert(var("x").isa("movie"));
```
(notice the user has forgotten to execute the query)