### PR TITLE
Fix post processing race conditions

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -45,6 +45,7 @@ redis.port=6379
 
 #Background tasks Config
 backgroundTasks.time-lapse=300000
+tasks.postprocessing.delay=60000
 
 ####################################
 # Grakn Graph Config               #

--- a/conf/test/orientdb/grakn.properties
+++ b/conf/test/orientdb/grakn.properties
@@ -34,6 +34,9 @@ graphdatabase.default-keyspace=grakntest
 graph.ontology-cache-timeout-ms=600000
 graph.batch.ontology-cache-timeout-ms=600000
 
+# Post processing delay
+tasks.postprocessing.delay=60000
+
 #Spark Config
 server.port=4567
 server.host=0.0.0.0

--- a/conf/test/tinker/grakn.properties
+++ b/conf/test/tinker/grakn.properties
@@ -46,6 +46,9 @@ redis.port=6379
 #Background tasks Config
 backgroundTasks.time-lapse=300000
 
+# Post processing delay
+tasks.postprocessing.delay=60000
+
 ####################################
 # Grakn Graph Config               #
 ####################################

--- a/conf/test/titan/grakn.properties
+++ b/conf/test/titan/grakn.properties
@@ -46,6 +46,9 @@ redis.port=6379
 #Background tasks Config
 backgroundTasks.time-lapse=300000
 
+# Post processing delay
+tasks.postprocessing.delay=60000
+
 ####################################
 # Grakn Graph Config               #
 ####################################

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineConfig.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineConfig.java
@@ -71,6 +71,9 @@ public class GraknEngineConfig {
     public static final String TASK_MANAGER_IMPLEMENTATION = "taskmanager.implementation";
     public static final String USE_ZOOKEEPER_STORAGE = "taskmanager.storage.zk";
 
+    // Delay for the post processing task in milliseconds
+    public static final String POST_PROCESSING_TASK_DELAY = "tasks.postprocessing.delay";
+
     public static final String ZK_SERVERS = "tasks.zookeeper.servers";
     public static final String ZK_NAMESPACE = "tasks.zookeeper.namespace";
     public static final String ZK_SESSION_TIMEOUT = "tasks.zookeeper.session_timeout_ms";

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -29,6 +29,8 @@ import ai.grakn.util.REST;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import mjson.Json;
 import spark.Request;
 import spark.Response;
@@ -90,7 +92,7 @@ public class CommitLogController {
 
         // TODO Make interval configurable
         TaskState postProcessingTask = TaskState.of(
-                PostProcessingTask.class, this.getClass().getName(), TaskSchedule.now());
+                PostProcessingTask.class, this.getClass().getName(), TaskSchedule.at(Instant.now().plus(1, ChronoUnit.MINUTES)));
 
         //Instances to count
         Json countingConfiguration = Json.object();

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -30,7 +30,6 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import mjson.Json;
 import spark.Request;
 import spark.Response;
@@ -42,6 +41,7 @@ import javax.ws.rs.Path;
 import java.util.Optional;
 
 import static ai.grakn.engine.GraknEngineConfig.DEFAULT_KEYSPACE_PROPERTY;
+import static ai.grakn.engine.GraknEngineConfig.POST_PROCESSING_TASK_DELAY;
 import static ai.grakn.util.REST.Request.COMMIT_LOG_COUNTING;
 import static ai.grakn.util.REST.Request.COMMIT_LOG_FIXING;
 import static ai.grakn.util.REST.Request.KEYSPACE;
@@ -54,6 +54,8 @@ import static ai.grakn.util.REST.Request.KEYSPACE_PARAM;
  */
 //TODO Implement delete
 public class CommitLogController {
+
+    private final int PP_TASK_DELAY_MS = GraknEngineConfig.getInstance().getPropertyAsInt(POST_PROCESSING_TASK_DELAY);
     private final TaskManager manager;
 
     public CommitLogController(Service spark, TaskManager manager){
@@ -90,9 +92,8 @@ public class CommitLogController {
         postProcessingConfiguration.set(KEYSPACE, keyspace);
         postProcessingConfiguration.set(COMMIT_LOG_FIXING, Json.read(req.body()).at(COMMIT_LOG_FIXING));
 
-        // TODO Make interval configurable
         TaskState postProcessingTask = TaskState.of(
-                PostProcessingTask.class, this.getClass().getName(), TaskSchedule.at(Instant.now().plus(1, ChronoUnit.MINUTES)));
+                PostProcessingTask.class, this.getClass().getName(), TaskSchedule.at(Instant.now().plusMillis(PP_TASK_DELAY_MS)));
 
         //Instances to count
         Json countingConfiguration = Json.object();


### PR DESCRIPTION
+ Delay post processing task start - This is needed becuase we must ensure that post processing runs only after the index has been set. The index is modifiable so long as duplicates are being created.
+ Make PP task aquire an index-based lock - Eliminate race conditions cause by post processing the same index at the same time.