### PR TITLE
Use shortcut edges in Graql even in the presence of sub-types

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
@@ -51,14 +51,14 @@ public class Fragments {
 
     public static Fragment inShortcut(
             Var rolePlayer, Var edge, Var relation,
-            Optional<Set<TypeLabel>> roleTypes, Optional<TypeLabel> relationType) {
-        return new InShortcutFragment(rolePlayer, edge, relation, roleTypes, relationType);
+            Optional<Set<TypeLabel>> roleTypes, Optional<Set<TypeLabel>> relationTypes) {
+        return new InShortcutFragment(rolePlayer, edge, relation, roleTypes, relationTypes);
     }
 
     public static Fragment outShortcut(
             Var relation, Var edge, Var rolePlayer,
-            Optional<Set<TypeLabel>> roleTypes, Optional<TypeLabel> relationType) {
-        return new OutShortcutFragment(relation, edge, rolePlayer, roleTypes, relationType);
+            Optional<Set<TypeLabel>> roleTypes, Optional<Set<TypeLabel>> relationTypes) {
+        return new OutShortcutFragment(relation, edge, rolePlayer, roleTypes, relationTypes);
     }
 
     public static Fragment inSub(Var start, Var end) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
@@ -24,17 +24,21 @@ import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.TypeLabel;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.ValuePredicateAdmin;
+import ai.grakn.graql.internal.util.StringConverter;
 import ai.grakn.util.Schema;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Optional;
+import java.util.Set;
 
-import static ai.grakn.graql.internal.util.StringConverter.typeLabelToString;
 import static ai.grakn.util.Schema.ConceptProperty.INSTANCE_TYPE_ID;
 import static ai.grakn.util.Schema.EdgeLabel.SUB;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Factory for creating instances of {@link Fragment}.
@@ -47,14 +51,14 @@ public class Fragments {
 
     public static Fragment inShortcut(
             Var rolePlayer, Var edge, Var relation,
-            Optional<TypeLabel> roleType, Optional<TypeLabel> relationType) {
-        return new InShortcutFragment(rolePlayer, edge, relation, roleType, relationType);
+            Optional<Set<TypeLabel>> roleTypes, Optional<TypeLabel> relationType) {
+        return new InShortcutFragment(rolePlayer, edge, relation, roleTypes, relationType);
     }
 
     public static Fragment outShortcut(
             Var relation, Var edge, Var rolePlayer,
-            Optional<TypeLabel> roleType, Optional<TypeLabel> relationType) {
-        return new OutShortcutFragment(relation, edge, rolePlayer, roleType, relationType);
+            Optional<Set<TypeLabel>> roleTypes, Optional<TypeLabel> relationType) {
+        return new OutShortcutFragment(relation, edge, rolePlayer, roleTypes, relationType);
     }
 
     public static Fragment inSub(Var start, Var end) {
@@ -174,12 +178,17 @@ public class Fragments {
         return traversal.union(__.not(__.has(INSTANCE_TYPE_ID.name())), __.repeat(__.in(SUB.getLabel())).emit()).unfold();
     }
 
-    static String displayOptionalTypeLabel(Optional<TypeLabel> typeLabel) {
-        return typeLabel.map(label -> " " + typeLabelToString(label)).orElse("");
+    static String displayOptionalTypeLabels(Optional<Set<TypeLabel>> typeLabels) {
+        return typeLabels.map(labels ->
+            " " + labels.stream().map(StringConverter::typeLabelToString).collect(joining(","))
+        ).orElse("");
     }
 
-    static void applyTypeLabelToTraversal(
-            GraphTraversal<Vertex, Edge> traversal, Schema.EdgeProperty property, Optional<TypeLabel> typeLabel, GraknGraph graph) {
-        typeLabel.ifPresent(label -> traversal.has(property.name(), graph.admin().convertToId(label).getValue()));
+    static void applyTypeLabelsToTraversal(
+            GraphTraversal<Vertex, Edge> traversal, Schema.EdgeProperty property, Optional<Set<TypeLabel>> typeLabels, GraknGraph graph) {
+        typeLabels.ifPresent(labels -> {
+            Set<Integer> typeIds = labels.stream().map(label -> graph.admin().convertToId(label).getValue()).collect(toSet());
+            traversal.has(property.name(), P.within(typeIds));
+        });
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InShortcutFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InShortcutFragment.java
@@ -22,7 +22,6 @@ package ai.grakn.graql.internal.gremlin.fragment;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.TypeLabel;
 import ai.grakn.graql.Var;
-import com.google.common.collect.ImmutableSet;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -48,28 +47,28 @@ class InShortcutFragment extends AbstractFragment {
 
     private final Var edge;
     private final Optional<Set<TypeLabel>> roleTypes;
-    private final Optional<TypeLabel> relationType;
+    private final Optional<Set<TypeLabel>> relationTypes;
 
     InShortcutFragment(
             Var rolePlayer, Var edge, Var relation, Optional<Set<TypeLabel>> roleTypes,
-            Optional<TypeLabel> relationType) {
+            Optional<Set<TypeLabel>> relationTypes) {
         super(rolePlayer, relation, edge);
         this.edge = edge;
         this.roleTypes = roleTypes;
-        this.relationType = relationType;
+        this.relationTypes = relationTypes;
     }
 
     @Override
     public void applyTraversal(GraphTraversal<Vertex, Vertex> traversal, GraknGraph graph) {
         GraphTraversal<Vertex, Edge> edgeTraversal = traversal.inE(SHORTCUT.getLabel()).as(edge.getValue());
         applyTypeLabelsToTraversal(edgeTraversal, ROLE_TYPE_ID, roleTypes, graph);
-        applyTypeLabelsToTraversal(edgeTraversal, RELATION_TYPE_ID, relationType.map(ImmutableSet::of), graph);
+        applyTypeLabelsToTraversal(edgeTraversal, RELATION_TYPE_ID, relationTypes, graph);
         edgeTraversal.outV();
     }
 
     @Override
     public String getName() {
-        String rel = displayOptionalTypeLabels(relationType.map(ImmutableSet::of));
+        String rel = displayOptionalTypeLabels(relationTypes);
         String role = displayOptionalTypeLabels(roleTypes);
         return "<-[shortcut:" + edge.shortName() + rel + role + "]-";
     }
@@ -89,7 +88,7 @@ class InShortcutFragment extends AbstractFragment {
 
         if (!edge.equals(that.edge)) return false;
         if (!roleTypes.equals(that.roleTypes)) return false;
-        return relationType.equals(that.relationType);
+        return relationTypes.equals(that.relationTypes);
     }
 
     @Override
@@ -97,7 +96,7 @@ class InShortcutFragment extends AbstractFragment {
         int result = super.hashCode();
         result = 31 * result + edge.hashCode();
         result = 31 * result + roleTypes.hashCode();
-        result = 31 * result + relationType.hashCode();
+        result = 31 * result + relationTypes.hashCode();
         return result;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutShortcutFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/OutShortcutFragment.java
@@ -22,7 +22,6 @@ package ai.grakn.graql.internal.gremlin.fragment;
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.TypeLabel;
 import ai.grakn.graql.Var;
-import com.google.common.collect.ImmutableSet;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
@@ -48,28 +47,28 @@ class OutShortcutFragment extends AbstractFragment {
 
     private final Var edge;
     private final Optional<Set<TypeLabel>> roleTypes;
-    private final Optional<TypeLabel> relationType;
+    private final Optional<Set<TypeLabel>> relationTypes;
 
     OutShortcutFragment(
             Var relation, Var edge, Var rolePlayer, Optional<Set<TypeLabel>> roleTypes,
-            Optional<TypeLabel> relationType) {
+            Optional<Set<TypeLabel>> relationTypes) {
             super(relation, rolePlayer, edge);
             this.edge = edge;
             this.roleTypes = roleTypes;
-            this.relationType = relationType;
+            this.relationTypes = relationTypes;
     }
 
     @Override
     public void applyTraversal(GraphTraversal<Vertex, Vertex> traversal, GraknGraph graph) {
         GraphTraversal<Vertex, Edge> edgeTraversal = traversal.outE(SHORTCUT.getLabel()).as(edge.getValue());
         applyTypeLabelsToTraversal(edgeTraversal, ROLE_TYPE_ID, roleTypes, graph);
-        applyTypeLabelsToTraversal(edgeTraversal, RELATION_TYPE_ID, relationType.map(ImmutableSet::of), graph);
+        applyTypeLabelsToTraversal(edgeTraversal, RELATION_TYPE_ID, relationTypes, graph);
         edgeTraversal.inV();
     }
 
     @Override
     public String getName() {
-        String rel = displayOptionalTypeLabels(relationType.map(ImmutableSet::of));
+        String rel = displayOptionalTypeLabels(relationTypes);
         String role = displayOptionalTypeLabels(roleTypes);
         return "-[shortcut:" + edge.shortName() + rel + role + "]->";
     }
@@ -90,7 +89,7 @@ class OutShortcutFragment extends AbstractFragment {
 
         if (!edge.equals(that.edge)) return false;
         if (!roleTypes.equals(that.roleTypes)) return false;
-        return relationType.equals(that.relationType);
+        return relationTypes.equals(that.relationTypes);
     }
 
     @Override
@@ -98,7 +97,7 @@ class OutShortcutFragment extends AbstractFragment {
         int result = super.hashCode();
         result = 31 * result + edge.hashCode();
         result = 31 * result + roleTypes.hashCode();
-        result = 31 * result + relationType.hashCode();
+        result = 31 * result + relationTypes.hashCode();
         return result;
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
@@ -20,6 +20,7 @@ package ai.grakn.graql.internal.gremlin;
 
 import ai.grakn.GraknGraph;
 import ai.grakn.concept.ConceptId;
+import ai.grakn.concept.Type;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarPattern;
@@ -67,7 +68,9 @@ import static org.hamcrest.CoreMatchers.anyOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GraqlTraversalTest {
 
@@ -92,6 +95,15 @@ public class GraqlTraversalTest {
     @BeforeClass
     public static void setUp() {
         graph = mock(GraknGraph.class);
+
+        // We have to mock out the `subTypes` call because the shortcut edge optimisation checks it
+        when(graph.getType(any())).thenAnswer(invocation -> {
+            Type type = mock(Type.class);
+            //noinspection unchecked
+            when(type.subTypes()).thenReturn((Collection) ImmutableSet.of(type));
+            when(type.getLabel()).thenReturn(invocation.getArgument(0));
+            return type;
+        });
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
+++ b/grakn-test/src/test/java/ai/grakn/graphs/MovieGraph.java
@@ -41,9 +41,10 @@ public class MovieGraph extends TestGraph {
     private static ResourceType<Long> tmdbVoteCount, runtime;
     private static ResourceType<Double> tmdbVoteAverage;
     private static ResourceType<LocalDateTime> releaseDate;
-    private static RelationType hasCast, directedBy, hasGenre, hasCluster;
+    private static RelationType hasCast, authoredBy, directedBy, hasGenre, hasCluster;
     private static RoleType productionBeingDirected, director, productionWithCast, actor, characterBeingPlayed;
     private static RoleType genreOfProduction, productionWithGenre, clusterOfProduction, productionWithCluster;
+    private static RoleType work, author;
     private static RuleType aRuleType;
 
     private static Instance godfather, theMuppets, heat, apocalypseNow, hocusPocus, spy, chineseCoffee;
@@ -60,9 +61,13 @@ public class MovieGraph extends TestGraph {
 
     @Override
     public void buildOntology(GraknGraph graph) {
-        productionBeingDirected = graph.putRoleType("production-being-directed");
-        director = graph.putRoleType("director");
-        directedBy = graph.putRelationType("directed-by")
+        work = graph.putRoleType("work");
+        author = graph.putRoleType("author");
+        authoredBy = graph.putRelationType("authored-by").relates(work).relates(author);
+
+        productionBeingDirected = graph.putRoleType("production-being-directed").superType(work);
+        director = graph.putRoleType("director").superType(author);
+        directedBy = graph.putRelationType("directed-by").superType(authoredBy)
                 .relates(productionBeingDirected).relates(director);
 
         productionWithCast = graph.putRoleType("production-with-cast");

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/DeleteQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/DeleteQueryTest.java
@@ -229,23 +229,31 @@ public class DeleteQueryTest {
 
     @Test
     public void testDeleteResource() {
-        MatchQuery godfather = qb.match(var().has("title", "Godfather"));
-        ConceptId id = qb.match(
-                var("x").has("title", "Godfather"),
-                var("a").rel("x").rel("y").isa(Schema.ImplicitType.HAS.getLabel("tmdb-vote-count").getValue())
-        ).get("a").findFirst().get().getId();
-        MatchQuery relation = qb.match(var().id(id));
-        MatchQuery voteCount = qb.match(var().val(1000L).isa("tmdb-vote-count"));
+        boolean implicitConcepts = movieGraph.graph().implicitConceptsVisible();
 
-        assertTrue(exists(godfather));
-        assertTrue(exists(relation));
-        assertTrue(exists(voteCount));
+        try {
+            movieGraph.graph().showImplicitConcepts(true);
 
-        qb.match(var("x").val(1000L).isa("tmdb-vote-count")).delete("x").execute();
+            MatchQuery godfather = qb.match(var().has("title", "Godfather"));
+            ConceptId id = qb.match(
+                    var("x").has("title", "Godfather"),
+                    var("a").rel("x").rel("y").isa(Schema.ImplicitType.HAS.getLabel("tmdb-vote-count").getValue())
+            ).get("a").findFirst().get().getId();
+            MatchQuery relation = qb.match(var().id(id));
+            MatchQuery voteCount = qb.match(var().val(1000L).isa("tmdb-vote-count"));
 
-        assertTrue(exists(godfather));
-        assertFalse(exists(relation)); //Relation is implicit it was deleted
-        assertFalse(exists(voteCount));
+            assertTrue(exists(godfather));
+            assertTrue(exists(relation));
+            assertTrue(exists(voteCount));
+
+            qb.match(var("x").val(1000L).isa("tmdb-vote-count")).delete("x").execute();
+
+            assertTrue(exists(godfather));
+            assertFalse(exists(relation)); //Relation is implicit it was deleted
+            assertFalse(exists(voteCount));
+        } finally {
+            movieGraph.graph().showImplicitConcepts(implicitConcepts);
+        }
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
@@ -538,8 +538,8 @@ public class MatchQueryTest {
     @Test
     public void whenQueryingForSuperRolesAndRelations_TheResultsAreTheSame() {
         assertEquals(
-                qb.match(var("x").rel("work", "y").rel("author", "z").isa("authored-by")).execute(),
-                qb.match(var("x").rel("production-being-directed", "y").rel("director", "z").isa("directed-by")).execute()
+                Sets.newHashSet(qb.match(var("x").rel("work", "y").rel("author", "z").isa("authored-by"))),
+                Sets.newHashSet(qb.match(var("x").rel("production-being-directed", "y").rel("director", "z").isa("directed-by")))
         );
     }
 
@@ -547,16 +547,16 @@ public class MatchQueryTest {
     public void whenQueryingForSuperRolesAndRelationsWithOneRolePlayer_TheResultsAreTheSame() {
         // This is a special case which can cause comparisons between shortcut edges and castings
         assertEquals(
-                qb.match(var("x").rel("y").rel("author", "z").isa("authored-by")).execute(),
-                qb.match(var("x").rel("y").rel("director", "z").isa("directed-by")).execute()
+                Sets.newHashSet(qb.match(var("x").rel("y").rel("author", "z").isa("authored-by"))),
+                Sets.newHashSet(qb.match(var("x").rel("y").rel("director", "z").isa("directed-by")))
         );
     }
 
     @Test
     public void whenQueryingForSuperRelationTypes_TheResultsAreTheSame() {
         assertEquals(
-                qb.match(var("x").rel("y").rel("z").isa("authored-by")).execute(),
-                qb.match(var("x").rel("y").rel("z").isa("directed-by")).execute()
+                Sets.newHashSet(qb.match(var("x").rel("y").rel("z").isa("authored-by"))),
+                Sets.newHashSet(qb.match(var("x").rel("y").rel("z").isa("directed-by")))
         );
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/graql/query/MatchQueryTest.java
@@ -85,6 +85,7 @@ import static ai.grakn.test.matcher.GraknMatchers.isShard;
 import static ai.grakn.test.matcher.GraknMatchers.resource;
 import static ai.grakn.test.matcher.GraknMatchers.results;
 import static ai.grakn.test.matcher.GraknMatchers.rule;
+import static ai.grakn.test.matcher.GraknMatchers.type;
 import static ai.grakn.test.matcher.GraknMatchers.variable;
 import static ai.grakn.test.matcher.MovieMatchers.aRuleType;
 import static ai.grakn.test.matcher.MovieMatchers.action;
@@ -211,6 +212,15 @@ public class MatchQueryTest {
         assertThat(query, variable("x", containsInAnyOrder(
                 marlonBrando, alPacino, missPiggy, kermitTheFrog, martinSheen, robertDeNiro, judeLaw, mirandaHeart,
                 betteMidler, sarahJessicaParker
+        )));
+    }
+
+    @Test
+    public void whenQueryingForRole_ResultContainsAllValidRoles() {
+        MatchQuery query = qb.match(var().rel(var(x), var().has("name", "Michael Corleone"))).distinct();
+
+        assertThat(query, variable("x", containsInAnyOrder(
+                type("concept"), type("role"), type("character-being-played")
         )));
     }
 
@@ -523,6 +533,31 @@ public class MatchQueryTest {
         ).select("x");
 
         assertThat(query, variable("x", (Matcher) hasItem(kermitTheFrog)));
+    }
+
+    @Test
+    public void whenQueryingForSuperRolesAndRelations_TheResultsAreTheSame() {
+        assertEquals(
+                qb.match(var("x").rel("work", "y").rel("author", "z").isa("authored-by")).execute(),
+                qb.match(var("x").rel("production-being-directed", "y").rel("director", "z").isa("directed-by")).execute()
+        );
+    }
+
+    @Test
+    public void whenQueryingForSuperRolesAndRelationsWithOneRolePlayer_TheResultsAreTheSame() {
+        // This is a special case which can cause comparisons between shortcut edges and castings
+        assertEquals(
+                qb.match(var("x").rel("y").rel("author", "z").isa("authored-by")).execute(),
+                qb.match(var("x").rel("y").rel("director", "z").isa("directed-by")).execute()
+        );
+    }
+
+    @Test
+    public void whenQueryingForSuperRelationTypes_TheResultsAreTheSame() {
+        assertEquals(
+                qb.match(var("x").rel("y").rel("z").isa("authored-by")).execute(),
+                qb.match(var("x").rel("y").rel("z").isa("directed-by")).execute()
+        );
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/matcher/GraknMatchers.java
+++ b/grakn-test/src/test/java/ai/grakn/test/matcher/GraknMatchers.java
@@ -210,7 +210,7 @@ public class GraknMatchers {
     /**
      * Create a matcher to test that the concept has the given type name.
      */
-    static Matcher<MatchableConcept> type(String type) {
+    public static Matcher<MatchableConcept> type(String type) {
         return type(TypeLabel.of(type));
     }
 


### PR DESCRIPTION
e.g.
`match (spouse: $x, spouse: $y);` will now use shortcut edges, even if `spouse` has sub-types.

`match ($x, $y) isa parenthood;` will use shortcut edges, even if `parenthood` has sub-types.