### PR TITLE
skip tests if skipTests is true

### DIFF
--- a/grakn-dist/pom.xml
+++ b/grakn-dist/pom.xml
@@ -185,7 +185,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <skip>${grakn.skip-bash-tests}</skip>
+                    <skip>${skipTests}</skip>
                 </configuration>
             </plugin>
             <plugin>
@@ -200,7 +200,7 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <skip>${grakn.skip-bash-tests}</skip>
+                            <skip>${skipTests}</skip>
                             <workingDirectory>${main.basedir}/grakn-dist/src/test/bash</workingDirectory>
                             <executable>${main.basedir}/grakn-dist/src/test/bash/bash-startup-test.sh</executable>
                         </configuration>

--- a/grakn-test-profiles/pom.xml
+++ b/grakn-test-profiles/pom.xml
@@ -67,7 +67,6 @@
             </activation>
             <properties>
                 <grakn.test-profile>tinker</grakn.test-profile>
-                <grakn.skip-bash-tests>true</grakn.skip-bash-tests>
             </properties>
         </profile>
 
@@ -75,7 +74,6 @@
             <id>titan</id>
             <properties>
                 <grakn.test-profile>titan</grakn.test-profile>
-                <grakn.skip-bash-tests>false</grakn.skip-bash-tests>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
This will properly skip bash tests in all profiles if skipTests is true.