### PR TITLE
Cleanup graph properties

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -58,7 +58,6 @@ graph.sharding-threshold=10000
 # batch loading. Shorter cache timeouts are better for memory usage and in some cases
 # may help avoid GC issues.
 graph.ontology-cache-timeout-ms=600000
-graph.batch.ontology-cache-timeout-ms=600000
 
 ############################# Server Configuration #############################
 

--- a/conf/test/orientdb/grakn.properties
+++ b/conf/test/orientdb/grakn.properties
@@ -31,7 +31,6 @@ graph.default-keyspace=grakntest
 
 # Graph ontology caching
 graph.ontology-cache-timeout-ms=600000
-graph.batch.ontology-cache-timeout-ms=600000
 
 # Post processing delay
 tasks.postprocessing.delay=60000

--- a/conf/test/tinker/grakn.properties
+++ b/conf/test/tinker/grakn.properties
@@ -56,7 +56,6 @@ graph.sharding-threshold=100000
 
 # Graph ontology caching
 graph.ontology-cache-timeout-ms=600000
-graph.batch.ontology-cache-timeout-ms=600000
 
 storage.cassandra.frame-size-mb = 200
 

--- a/conf/test/titan/grakn.properties
+++ b/conf/test/titan/grakn.properties
@@ -53,7 +53,6 @@ graph.sharding-threshold=100000
 
 # Graph ontology caching
 graph.ontology-cache-timeout-ms=600000
-graph.batch.ontology-cache-timeout-ms=600000
 
 # Titan Caching
 cache.db-cache = true

--- a/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graph/admin/GraknAdmin.java
@@ -69,7 +69,7 @@ public interface GraknAdmin {
      * @return true if batch loading is enabled
      */
     @CheckReturnValue
-    boolean isBatchLoadingEnabled();
+    boolean isBatchGraph();
 
     //------------------------------------- Meta Types ----------------------------------
     /**

--- a/grakn-factory/orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
+++ b/grakn-factory/orientdb-factory/src/main/java/ai/grakn/factory/OrientDBInternalFactory.java
@@ -61,8 +61,8 @@ public class OrientDBInternalFactory extends AbstractInternalFactory<GraknOrient
     }
 
     @Override
-    GraknOrientDBGraph buildGraknGraphFromTinker(OrientGraph graph, boolean batchLoading) {
-        return new GraknOrientDBGraph(graph, super.keyspace, super.engineUrl, batchLoading, super.properties);
+    GraknOrientDBGraph buildGraknGraphFromTinker(OrientGraph graph) {
+        return new GraknOrientDBGraph(graph, super.keyspace, super.engineUrl, super.properties);
     }
 
     @Override

--- a/grakn-factory/orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
+++ b/grakn-factory/orientdb-factory/src/main/java/ai/grakn/graph/internal/GraknOrientDBGraph.java
@@ -42,8 +42,8 @@ import java.util.Properties;
  * @author fppt
  */
 public class GraknOrientDBGraph extends AbstractGraknGraph<OrientGraph> {
-    public GraknOrientDBGraph(OrientGraph graph, String name, String engineUrl, boolean batchLoading, Properties properties){
-        super(graph, name, engineUrl, batchLoading, properties);
+    public GraknOrientDBGraph(OrientGraph graph, String name, String engineUrl, Properties properties){
+        super(graph, name, engineUrl, properties);
     }
 
     /**

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/factory/TitanHadoopInternalFactory.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/factory/TitanHadoopInternalFactory.java
@@ -62,7 +62,7 @@ public class TitanHadoopInternalFactory extends AbstractInternalFactory<Abstract
     }
 
     @Override
-    AbstractGraknGraph<HadoopGraph> buildGraknGraphFromTinker(HadoopGraph graph, boolean batchLoading) {
+    AbstractGraknGraph<HadoopGraph> buildGraknGraphFromTinker(HadoopGraph graph) {
         throw new UnsupportedOperationException(ErrorMessage.CANNOT_PRODUCE_GRAPH.getMessage(HadoopGraph.class.getName()));
     }
 

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/factory/TitanInternalFactory.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/factory/TitanInternalFactory.java
@@ -75,8 +75,8 @@ final public class TitanInternalFactory extends AbstractInternalFactory<GraknTit
     }
 
     @Override
-    GraknTitanGraph buildGraknGraphFromTinker(TitanGraph graph, boolean batchLoading) {
-        return new GraknTitanGraph(graph, super.keyspace, super.engineUrl, batchLoading, super.properties);
+    GraknTitanGraph buildGraknGraphFromTinker(TitanGraph graph) {
+        return new GraknTitanGraph(graph, super.keyspace, super.engineUrl, super.properties);
     }
 
     @Override

--- a/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
+++ b/grakn-factory/titan-factory/src/main/java/ai/grakn/graph/internal/GraknTitanGraph.java
@@ -51,8 +51,8 @@ import java.util.function.Supplier;
  * @author fppt
  */
 public class GraknTitanGraph extends AbstractGraknGraph<TitanGraph> {
-    public GraknTitanGraph(TitanGraph graph, String name, String engineUrl, boolean batchLoading, Properties properties){
-        super(graph, name, engineUrl, batchLoading, properties);
+    public GraknTitanGraph(TitanGraph graph, String name, String engineUrl, Properties properties){
+        super(graph, name, engineUrl, properties);
     }
 
     /**

--- a/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/TitanInternalFactoryTest.java
+++ b/grakn-factory/titan-factory/src/test/java/ai/grakn/factory/TitanInternalFactoryTest.java
@@ -107,8 +107,8 @@ public class TitanInternalFactoryTest extends TitanTestBase{
         assertEquals(mg1, mg3);
         assertEquals(tinkerGraphMg1, mg3.getTinkerPopGraph());
 
-        assertTrue(mg1.isBatchLoadingEnabled());
-        assertFalse(mg2.isBatchLoadingEnabled());
+        assertTrue(mg1.isBatchGraph());
+        assertFalse(mg2.isBatchGraph());
 
         assertNotEquals(mg1, mg2);
         assertNotEquals(tinkerGraphMg1, tinkerGraphMg2);

--- a/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/AbstractInternalFactory.java
@@ -80,7 +80,7 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
         return FactoryBuilder.getGraknGraphFactory(this.getClass().getName(), SystemKeyspace.SYSTEM_GRAPH_NAME, engineUrl, properties);
     }
 
-    abstract M buildGraknGraphFromTinker(G graph, boolean batchLoading);
+    abstract M buildGraknGraphFromTinker(G graph);
 
     abstract G buildTinkerPopGraph(boolean batchLoading);
 
@@ -107,7 +107,7 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
         boolean batchLoading = GraknTxType.BATCH.equals(txType);
 
         if(graknGraph == null){
-            graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading), batchLoading);
+            graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading));
             if (!SystemKeyspace.SYSTEM_GRAPH_NAME.equalsIgnoreCase(this.keyspace)) {
                 systemKeyspace.keyspaceOpened(this.keyspace);
             }
@@ -117,7 +117,7 @@ abstract class AbstractInternalFactory<M extends AbstractGraknGraph<G>, G extend
             }
 
             if(graknGraph.isSessionClosed()){
-                graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading), batchLoading);
+                graknGraph = buildGraknGraphFromTinker(getTinkerPopGraph(batchLoading));
             }
         }
 

--- a/grakn-graph/src/main/java/ai/grakn/factory/GraknSessionImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/GraknSessionImpl.java
@@ -158,7 +158,6 @@ public class GraknSessionImpl implements GraknSession {
         Properties inMemoryProperties = new Properties();
         inMemoryProperties.put(AbstractGraknGraph.SHARDING_THRESHOLD, 100_000);
         inMemoryProperties.put(AbstractGraknGraph.NORMAL_CACHE_TIMEOUT_MS, 30_000);
-        inMemoryProperties.put(AbstractGraknGraph.BATCH_CACHE_TIMEOUT_MS, 120_000);
 
         return FactoryBuilder.getGraknGraphFactory(TinkerInternalFactory.class.getName(), keyspace, Grakn.IN_MEMORY, inMemoryProperties);
     }

--- a/grakn-graph/src/main/java/ai/grakn/factory/TinkerInternalFactory.java
+++ b/grakn-graph/src/main/java/ai/grakn/factory/TinkerInternalFactory.java
@@ -48,8 +48,8 @@ public class TinkerInternalFactory extends AbstractInternalFactory<GraknTinkerGr
     }
 
     @Override
-    GraknTinkerGraph buildGraknGraphFromTinker(TinkerGraph graph, boolean batchLoading) {
-        return new GraknTinkerGraph(graph, super.keyspace, super.engineUrl, batchLoading, properties);
+    GraknTinkerGraph buildGraknGraphFromTinker(TinkerGraph graph) {
+        return new GraknTinkerGraph(graph, super.keyspace, super.engineUrl, properties);
     }
 
     @Override

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -99,7 +99,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     private final String keyspace;
     private final String engine;
     private final Properties properties;
-    private final boolean batchLoadingEnabled;
     private final G graph;
     private final ElementFactory elementFactory;
     private final GraphCache graphCache;
@@ -107,7 +106,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     //----------------------------- Transaction Specific
     private final ThreadLocal<TxCache> localConceptLog = new ThreadLocal<>();
 
-    public AbstractGraknGraph(G graph, String keyspace, String engine, boolean batchLoadingEnabled, Properties properties) {
+    public AbstractGraknGraph(G graph, String keyspace, String engine, Properties properties) {
         this.graph = graph;
         this.keyspace = keyspace;
         this.engine = engine;
@@ -124,8 +123,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         if(initialiseMetaConcepts()) close(true, false);
         getTxCache().showImplicitTypes(false);
 
-        //Set batch loading because ontology has been loaded
-        this.batchLoadingEnabled = batchLoadingEnabled;
     }
 
     @Override
@@ -220,7 +217,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     @Override
     public boolean isReadOnly(){
-        return getTxCache().isTxReadOnly();
+        return GraknTxType.READ.equals(getTxCache().txType());
     }
 
     @Override
@@ -239,8 +236,8 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     }
 
     @Override
-    public boolean isBatchLoadingEnabled(){
-        return batchLoadingEnabled;
+    public boolean isBatchGraph(){
+        return GraknTxType.BATCH.equals(getTxCache().txType());
     }
 
     @SuppressWarnings("unchecked")
@@ -345,7 +342,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
 
     void checkOntologyMutation(){
         checkMutation();
-        if(isBatchLoadingEnabled()){
+        if(isBatchGraph()){
             throw new GraphRuntimeException(ErrorMessage.SCHEMA_LOCKED.getMessage());
         }
     }

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/AbstractGraknGraph.java
@@ -94,7 +94,6 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
     //----------------------------- Config Paths
     public static final String SHARDING_THRESHOLD = "graph.sharding-threshold";
     public static final String NORMAL_CACHE_TIMEOUT_MS = "graph.ontology-cache-timeout-ms";
-    public static final String BATCH_CACHE_TIMEOUT_MS = "graph.batch.ontology-cache-timeout-ms";
 
     //----------------------------- Graph Shared Variable
     private final String keyspace;
@@ -116,7 +115,7 @@ public abstract class AbstractGraknGraph<G extends Graph> implements GraknGraph,
         elementFactory = new ElementFactory(this);
 
         //Initialise Graph Caches
-        graphCache = new GraphCache(properties, batchLoadingEnabled);
+        graphCache = new GraphCache(properties);
 
         //Initialise Graph
         getTxCache().openTx(GraknTxType.WRITE);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/CastingImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/CastingImpl.java
@@ -74,7 +74,7 @@ class CastingImpl extends InstanceImpl<CastingImpl, RoleType> {
      */
     CastingImpl setHash(RoleTypeImpl role, InstanceImpl rolePlayer){
         String hash;
-        if(getGraknGraph().isBatchLoadingEnabled()) {
+        if(getGraknGraph().isBatchGraph()) {
             hash = "CastingBaseId_" + this.getId().getValue() + UUID.randomUUID().toString();
         } else {
             hash = generateNewHash(role, rolePlayer);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/ConceptImpl.java
@@ -125,7 +125,7 @@ abstract class ConceptImpl<T extends Concept> implements Concept {
      * @return The concept itself casted to the correct interface itself
      */
     T setUniqueProperty(Schema.ConceptProperty key, String id){
-        if(graknGraph.isBatchLoadingEnabled() || updateAllowed(key, id)) {
+        if(graknGraph.isBatchGraph() || updateAllowed(key, id)) {
             return setProperty(key, id);
         } else {
             throw new ConceptNotUniqueException(this, key, id);

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/GraknTinkerGraph.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/GraknTinkerGraph.java
@@ -41,8 +41,8 @@ import java.util.Properties;
 public class GraknTinkerGraph extends AbstractGraknGraph<TinkerGraph> {
     private final TinkerGraph rootGraph;
 
-    public GraknTinkerGraph(TinkerGraph tinkerGraph, String name, String engineUrl, boolean batchLoading, Properties properties){
-        super(tinkerGraph, name, engineUrl, batchLoading, properties);
+    public GraknTinkerGraph(TinkerGraph tinkerGraph, String name, String engineUrl, Properties properties){
+        super(tinkerGraph, name, engineUrl, properties);
         rootGraph = tinkerGraph;
     }
 

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/GraphCache.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/GraphCache.java
@@ -30,9 +30,6 @@ import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import static ai.grakn.graph.internal.AbstractGraknGraph.BATCH_CACHE_TIMEOUT_MS;
-import static ai.grakn.graph.internal.AbstractGraknGraph.NORMAL_CACHE_TIMEOUT_MS;
-
 /**
  * <p>
  *     Tracks Graph Specific Variables
@@ -57,11 +54,10 @@ class GraphCache {
     private final Cache<TypeLabel, Type> cachedTypes;
     private final Map<TypeLabel, TypeId> cachedLabels;
 
-    GraphCache(Properties properties, boolean batchLoadingEnabled){
+    GraphCache(Properties properties){
         cachedLabels = new ConcurrentHashMap<>();
 
-        int cacheTimeout = Integer.parseInt(
-                properties.get(batchLoadingEnabled ? BATCH_CACHE_TIMEOUT_MS : NORMAL_CACHE_TIMEOUT_MS).toString());
+        int cacheTimeout = Integer.parseInt(properties.get(AbstractGraknGraph.NORMAL_CACHE_TIMEOUT_MS).toString());
         cachedTypes = CacheBuilder.newBuilder()
                 .maximumSize(1000)
                 .expireAfterAccess(cacheTimeout, TimeUnit.MILLISECONDS)

--- a/grakn-graph/src/main/java/ai/grakn/graph/internal/TxCache.java
+++ b/grakn-graph/src/main/java/ai/grakn/graph/internal/TxCache.java
@@ -80,7 +80,7 @@ class TxCache {
     //Transaction Specific Meta Data
     private boolean isTxOpen = false;
     private boolean showImplicitTypes = false;
-    private boolean txReadOnly = false;
+    private GraknTxType txType;
     private String closedReason = null;
 
     TxCache(GraphCache graphCache) {
@@ -378,7 +378,7 @@ class TxCache {
     }
     void openTx(GraknTxType txType){
         isTxOpen = true;
-        txReadOnly = GraknTxType.READ.equals(txType);
+        this.txType = txType;
         closedReason = null;
     }
     boolean isTxOpen(){
@@ -392,8 +392,8 @@ class TxCache {
         return showImplicitTypes;
     }
 
-    boolean isTxReadOnly(){
-        return txReadOnly;
+    GraknTxType txType(){
+        return txType;
     }
 
     String getClosedReason(){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/SystemControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/SystemControllerTest.java
@@ -80,7 +80,7 @@ public class SystemControllerTest {
     @Test
     public void testGraknClientBatch() {
         GraknGraph batch = Grakn.session(Grakn.DEFAULT_URI, "grakntestagain").open(GraknTxType.BATCH);
-        assertTrue(((AbstractGraknGraph) batch).isBatchLoadingEnabled());
+        assertTrue(((AbstractGraknGraph) batch).isBatchGraph());
     }
 
     @Test
@@ -88,12 +88,12 @@ public class SystemControllerTest {
         AbstractGraknGraph graph = (AbstractGraknGraph) Grakn.session(Grakn.DEFAULT_URI, "grakntest").open(GraknTxType.WRITE);
         AbstractGraknGraph graph2 = (AbstractGraknGraph) Grakn.session(Grakn.DEFAULT_URI, "grakntest2").open(GraknTxType.WRITE);
         assertNotEquals(0, graph.getTinkerPopGraph().traversal().V().toList().size());
-        assertFalse(graph.isBatchLoadingEnabled());
+        assertFalse(graph.isBatchGraph());
         assertNotEquals(graph, graph2);
         graph.close();
 
         AbstractGraknGraph batch = (AbstractGraknGraph) Grakn.session(Grakn.DEFAULT_URI, "grakntest").open(GraknTxType.BATCH);
-        assertTrue(batch.isBatchLoadingEnabled());
+        assertTrue(batch.isBatchGraph());
         assertNotEquals(graph, batch);
 
         graph.close();

--- a/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknSessionTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/factory/EngineGraknSessionTest.java
@@ -35,8 +35,8 @@ public class EngineGraknSessionTest {
         graph1.close();
         GraknGraph graph2 = EngineGraknGraphFactory.getInstance().getGraph(keyspace, GraknTxType.BATCH);
 
-        assertFalse(graph1.admin().isBatchLoadingEnabled());
-        assertTrue(graph2.admin().isBatchLoadingEnabled());
+        assertFalse(graph1.admin().isBatchGraph());
+        assertTrue(graph2.admin().isBatchGraph());
 
         graph1.close();
         graph2.close();


### PR DESCRIPTION
- Compress cache timeout configs into one
- Remove explicit and redundant batch loading flag from grakn graph constructore