### PR TITLE
[Bug fix] Logs always relative to starting directory

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -107,7 +107,8 @@ loader.threads=0
 ############################# Logging Configuration #############################
 # These properties are read directly by logback.xml
 
-# Single directory under which to store log files
+# Single directory under which to store log files. If using a relative path it will be relative
+# to the JVM system variable "grakn.dir"
 log.dirs=../logs/
 # Specify the log verbosity level. This can be one of:
 #

--- a/conf/main/logback.xml
+++ b/conf/main/logback.xml
@@ -46,7 +46,6 @@
     <!--Configure the "main" appender used for all non-post processing Grakn logs. Logs are kept for
         60 days and each file is capped at 50MB, but at most 1GB -->
     <appender name="MAIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <!--grakn.dir is a system variable, log.dirs is taken from the grakn.properties on the classpath-->
         <file>${configuredLogDir}/${graknLogFileName}</file>
         <encoder>
             <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>

--- a/conf/main/logback.xml
+++ b/conf/main/logback.xml
@@ -21,32 +21,47 @@
     <property name="graknLogFileName" value="grakn.log"/>
     <property name="graknPPLogFileName" value="grakn-postprocessing.log"/>
 
+    <!--Configure a properties file (located on the classpath) from which values can be referenced-->
     <property resource="grakn.properties"/>
 
+    <!--Extract the directory of the grakn logs from the properties file. If the path is relative it
+    will be appended to the directory containing grakn (system property grakn.dir). Otherwise the absolute
+    path is used. -->
+    <if condition='property("log.dirs").startsWith("/")'>
+        <then>
+            <property name="configuredLogDir" value="${log.dirs}" />
+        </then>
+        <else>
+            <property name="configuredLogDir" value="${grakn.dir}/${log.dirs}" />
+        </else>
+    </if>
+
+    <!--Configure the standard out appender used to print the Grakn logo-->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%msg%n</pattern>
         </encoder>
     </appender>
 
+    <!--Configure the "main" appender used for all non-post processing Grakn logs. Logs are kept for
+        60 days and each file is capped at 50MB, but at most 1GB -->
     <appender name="MAIN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${log.dirs}/${graknLogFileName}</file>
+        <!--grakn.dir is a system variable, log.dirs is taken from the grakn.properties on the classpath-->
+        <file>${configuredLogDir}/${graknLogFileName}</file>
         <encoder>
             <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-            <!-- rollover at the beginning of each month (add '-dd' to have a daily rollover)-->
-            <!-- improve this by handling only log path without name included-->
             <fileNamePattern>${graknLogFileName}-%d{yyyy-MM}.%i.log</fileNamePattern>
-            <!-- each file should be at most 50MB, keep 60 days worth of history, but at most 1GB -->
             <maxFileSize>50MB</maxFileSize>
             <maxHistory>60</maxHistory>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
     </appender>
 
+    <!--Configure the post processing appender used for logs in the post processing package-->
     <appender name="POST-PROCESSING" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${log.dirs}/${graknPPLogFileName}</file>
+        <file>${configuredLogDir}/${graknPPLogFileName}</file>
         <encoder>
             <pattern>%d{dd-MM-yyyy HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>

--- a/grakn-dist/pom.xml
+++ b/grakn-dist/pom.xml
@@ -44,6 +44,13 @@
             <version>${logback.version}</version>
             <scope>compile</scope>
         </dependency>
+        <!--Jaino used for conditionals in log files-->
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>${janino.version}</version>
+            <scope>compile</scope>
+        </dependency>
 
         <!--Core dependencies-->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <orientdb.version>3.2.3.0</orientdb.version>
         <orientdb-gremlin-core.version>3.2.1</orientdb-gremlin-core.version>
         <logback.version>1.1.7</logback.version>
+        <janino.version>2.7.8</janino.version>
         <slf4j.version>1.7.20</slf4j.version>
         <csv.version>1.4</csv.version>
         <jool.version>3.8.5</jool.version>
@@ -229,6 +230,13 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--Jaino used for conditionals in log files-->
+        <dependency>
+            <groupId>org.codehaus.janino</groupId>
+            <artifactId>janino</artifactId>
+            <version>${janino.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is a bug fix for #15307, where the logs were always being placed relative to the directory where grakn was starting. 

Now, if a relative log dir is specified in the properties file, it will be relative to the system variable grakn.dir. Otherwise the absolute value is used.