### PR TITLE
[DO NOT MERGE] Engine API consistency refactor

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/exception/GraknServerException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/GraknServerException.java
@@ -27,9 +27,11 @@ import static ai.grakn.util.ErrorMessage.INVALID_QUERY_USAGE;
 import static ai.grakn.util.ErrorMessage.MISSING_MANDATORY_BODY_REQUEST_PARAMETERS;
 import static ai.grakn.util.ErrorMessage.MISSING_MANDATORY_REQUEST_PARAMETERS;
 import static ai.grakn.util.ErrorMessage.MISSING_REQUEST_BODY;
+import static ai.grakn.util.ErrorMessage.NO_CONCEPT_IN_KEYSPACE;
 import static ai.grakn.util.ErrorMessage.UNAVAILABLE_TASK_CLASS;
 import static ai.grakn.util.ErrorMessage.UNSUPPORTED_CONTENT_TYPE;
 
+import ai.grakn.concept.ConceptId;
 import ai.grakn.graql.Query;
 
 /**
@@ -139,6 +141,13 @@ public class GraknServerException extends GraknBackendException {
      */
     public static GraknServerException couldNotDelete(String keyspace){
         return new GraknServerException(CANNOT_DELETE_KEYSPACE.getMessage(keyspace), 500);
+    }
+
+    /**
+     * Thrown when requested concept is not found in the graph
+     */
+    public static GraknServerException noConceptFound(ConceptId conceptId, String keyspace){
+        return new GraknServerException(NO_CONCEPT_IN_KEYSPACE.getMessage(conceptId, keyspace), 404);
     }
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -173,6 +173,7 @@ public class REST {
             public static final String APPLICATION_JSON = "application/json";
             public static final String APPLICATION_TEXT = "application/text";
             public static final String APPLICATION_HAL ="application/hal+json";
+            public static final String APPLICATION_ALL ="*/*";
         }
 
         /**

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
@@ -25,10 +25,10 @@ import ai.grakn.concept.OntologyConcept;
 import ai.grakn.concept.Label;
 import ai.grakn.engine.factory.EngineGraknGraphFactory;
 import ai.grakn.exception.GraknServerException;
-import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiImplicitParams;
 import io.swagger.annotations.ApiOperation;
+import java.util.Arrays;
 import mjson.Json;
 import org.apache.commons.httpclient.HttpStatus;
 import spark.Request;
@@ -150,7 +150,7 @@ public class ConceptController {
     static void validateRequest(Request request, String... contentTypes){
         String acceptType = getAcceptType(request);
 
-        if(!ImmutableSet.of(contentTypes).contains(acceptType)){
+        if(!Arrays.asList(contentTypes).contains(acceptType)){
             throw GraknServerException.unsupportedContentType(acceptType);
         }
     }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/TasksController.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.controller;
 
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
 import static ai.grakn.engine.tasks.TaskSchedule.recurring;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON;
 import static ai.grakn.util.REST.WebPath.Tasks.GET;
 import static ai.grakn.util.REST.WebPath.Tasks.STOP;
 import static ai.grakn.util.REST.WebPath.Tasks.TASKS;
@@ -137,8 +138,8 @@ public class TasksController {
                 .map(this::serialiseStateSubset)
                 .forEach(result::add);
 
-        response.status(200);
-        response.type(ContentType.APPLICATION_JSON.getMimeType());
+        response.status(HttpStatus.SC_OK);
+        response.type(APPLICATION_JSON);
 
         return result;
     }
@@ -151,7 +152,7 @@ public class TasksController {
         String id = request.params("id");
 
         response.status(200);
-        response.type("application/json");
+        response.type(APPLICATION_JSON);
 
         return serialiseStateFull(manager.storage().getState(TaskId.of(id)));
     }
@@ -162,7 +163,12 @@ public class TasksController {
     @ApiImplicitParam(name = REST.Request.UUID_PARAMETER, value = "ID of task.", required = true, dataType = "string", paramType = "path")
     private Json stopTask(Request request, Response response) {
         String id = request.params(REST.Request.ID_PARAMETER);
+
         manager.stopTask(TaskId.of(id));
+
+        response.status(HttpStatus.SC_OK);
+        response.type(APPLICATION_JSON);
+
         return Json.object();
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
@@ -19,6 +19,8 @@
 package ai.grakn.engine.controller.util;
 
 import ai.grakn.exception.GraknServerException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Optional;
 import java.util.function.Function;
 import spark.Request;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
@@ -19,8 +19,6 @@
 package ai.grakn.engine.controller.util;
 
 import ai.grakn.exception.GraknServerException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.Optional;
 import java.util.function.Function;
 import spark.Request;

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/ConceptControllerTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/ConceptControllerTest.java
@@ -85,15 +85,16 @@ public class ConceptControllerTest {
     }
 
     @Test
-    public void gettingConceptByIdWithNoAcceptType_ResponseStatusIs406(){
+    public void gettingConceptByIdWithNoAcceptType_ResponseContentTypeIsHAL() {
         Concept concept = graphContext.graph().getEntityType("movie");
 
-        Response response = with().queryParam(KEYSPACE, mockGraph.getKeyspace())
+        Response response = with()
+                .queryParam(KEYSPACE, mockGraph.getKeyspace())
                 .queryParam(IDENTIFIER, concept.getId().getValue())
                 .get(REST.WebPath.Concept.CONCEPT + concept.getId());
 
-        assertThat(response.statusCode(), equalTo(406));
-        assertThat(exception(response), containsString(UNSUPPORTED_CONTENT_TYPE.getMessage("*/*")));}
+        assertThat(response.contentType(), equalTo(APPLICATION_HAL));
+    }
 
     @Test
     public void gettingConceptByIdWithHAlAcceptType_ResponseContentTypeIsHAL(){
@@ -154,13 +155,13 @@ public class ConceptControllerTest {
     }
 
     @Test
-    public void gettingNonExistingElementById_ResponseStatusIs500(){
+    public void gettingNonExistingElementById_ResponseStatusIs404(){
         Response response = with().queryParam(KEYSPACE, mockGraph.getKeyspace())
                 .queryParam(IDENTIFIER, "invalid")
                 .accept(APPLICATION_HAL)
                 .get(REST.WebPath.Concept.CONCEPT + "blah");
 
-        assertThat(response.statusCode(), equalTo(500));
+        assertThat(response.statusCode(), equalTo(404));
     }
 
     private Response sendRequest(Concept concept, int numberEmbeddedComponents){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerDELETETest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerDELETETest.java
@@ -33,11 +33,10 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static ai.grakn.test.engine.controller.GraqlControllerGETTest.exception;
-import static ai.grakn.test.engine.controller.GraqlControllerGETTest.originalQuery;
 import static ai.grakn.util.ErrorMessage.MISSING_MANDATORY_REQUEST_PARAMETERS;
 import static ai.grakn.util.ErrorMessage.MISSING_REQUEST_BODY;
 import static ai.grakn.util.REST.Request.KEYSPACE;
-import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_TEXT;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -219,18 +218,10 @@ public class GraqlControllerDELETETest {
     }
 
     @Test
-    public void DELETEGraqlDelete_ResponseContentTypeIsJson(){
+    public void DELETEGraqlDelete_ResponseContentTypeIsText(){
         Response response = sendDELETE("match $x has name \"Harry\"; limit 1; delete $x;");
 
-        assertThat(response.contentType(), equalTo(APPLICATION_JSON));
-    }
-
-    @Test
-    public void DELETEGraqlDelete_ResponseContainsOriginalQuery(){
-        String query = "match $x has name \"Miranda Heart\"; limit 1; delete $x;";
-        Response response = sendDELETE(query);
-
-        assertThat(originalQuery(response), equalTo(query));
+        assertThat(response.contentType(), equalTo(APPLICATION_TEXT));
     }
 
     private Response sendDELETE(String query){

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerGETTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerGETTest.java
@@ -274,14 +274,6 @@ public class GraqlControllerGETTest {
     }
 
     @Test
-    public void GETGraqlMatchWithHALType_ResponseContainsOriginalQuery() {
-        String query = "match $x isa movie;";
-        Response response = sendGET(query, APPLICATION_HAL);
-
-        assertThat(originalQuery(response), equalTo(query));
-    }
-
-    @Test
     public void GETGraqlMatchWithTextType_ResponseContentTypeIsGraql() {
         Response response = sendGET(APPLICATION_TEXT);
 
@@ -294,21 +286,6 @@ public class GraqlControllerGETTest {
 
         assertThat(stringResponse(response).length(), greaterThan(0));
         assertThat(stringResponse(response), stringContainsInOrder(Collections.nCopies(10, "isa movie")));
-    }
-
-    @Test
-    public void GETGraqlMatchWithTextType_ResponseContainsOriginalQuery() {
-        String query = "match $x isa movie;";
-        Response response = sendGET(APPLICATION_TEXT);
-
-        assertThat(originalQuery(response), equalTo(query));
-    }
-
-    @Test
-    public void GETGraqlMatchWithTextTypeAndEmptyResponse_ResponseIsEmptyString() {
-        Response response = sendGET("match $x isa \"runtime\";", APPLICATION_TEXT);
-
-        assertThat(stringResponse(response), isEmptyString());
     }
 
     @Test
@@ -326,14 +303,6 @@ public class GraqlControllerGETTest {
         Json expectedResponse = Json.read(
                 Printers.json().graqlString(graphContext.graph().graql().parse(query).execute()));
         assertThat(jsonResponse(response), equalTo(expectedResponse));
-    }
-
-    @Test
-    public void GETGraqlMatchWithGraqlJsonType_ResponseContainsOriginalQuery() {
-        String query = "match $x isa movie;";
-        Response response = sendGET(APPLICATION_JSON_GRAQL);
-
-        assertThat(originalQuery(response), equalTo(query));
     }
 
     @Test
@@ -393,14 +362,6 @@ public class GraqlControllerGETTest {
         Response response = sendGET(query, APPLICATION_TEXT);
 
         assertThat(response.contentType(), equalTo(APPLICATION_TEXT));
-    }
-
-    @Test
-    public void GETGraqlCompute_ResponseContainsOriginalQuery() {
-        String query = "compute count in movie;";
-        Response response = sendGET(query, APPLICATION_TEXT);
-
-        assertThat(originalQuery(response), equalTo(query));
     }
 
     @Test
@@ -550,14 +511,10 @@ public class GraqlControllerGETTest {
     }
 
     protected static String stringResponse(Response response) {
-        return response.getBody().as(Json.class, jsonMapper).at(RESPONSE).asString();
+        return response.getBody().asString();
     }
 
     protected static Json jsonResponse(Response response) {
-        return response.getBody().as(Json.class, jsonMapper).at(RESPONSE);
-    }
-
-    protected static String originalQuery(Response response) {
-        return response.getBody().as(Json.class, jsonMapper).at(ORIGINAL_QUERY).asString();
+        return response.getBody().as(Json.class, jsonMapper);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerPOSTTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/controller/GraqlControllerPOSTTest.java
@@ -21,6 +21,7 @@ package ai.grakn.test.engine.controller;
 import ai.grakn.GraknGraph;
 import ai.grakn.engine.controller.GraqlController;
 import ai.grakn.engine.factory.EngineGraknGraphFactory;
+import ai.grakn.exception.GraqlSyntaxException;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.test.GraphContext;
 import ai.grakn.test.SparkContext;
@@ -34,15 +35,19 @@ import org.junit.Test;
 
 import static ai.grakn.test.engine.controller.GraqlControllerGETTest.exception;
 import static ai.grakn.test.engine.controller.GraqlControllerGETTest.jsonResponse;
-import static ai.grakn.test.engine.controller.GraqlControllerGETTest.originalQuery;
+import static ai.grakn.test.engine.controller.GraqlControllerGETTest.stringResponse;
 import static ai.grakn.util.ErrorMessage.MISSING_MANDATORY_REQUEST_PARAMETERS;
 import static ai.grakn.util.ErrorMessage.MISSING_REQUEST_BODY;
 import static ai.grakn.util.REST.Request.KEYSPACE;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_HAL;
 import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON_GRAQL;
+import static ai.grakn.util.REST.Response.ContentType.APPLICATION_TEXT;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -207,26 +212,38 @@ public class GraqlControllerPOSTTest {
     }
 
     @Test
-    public void POSTGraqlInsert_ResponseContentTypeIsJson(){
-        Response response = sendPOST("insert $x isa person;");
+    public void POSTGraqlInsertWithJsonType_ResponseContentTypeIsJson(){
+        Response response = sendPOST("insert $x isa person;", APPLICATION_JSON_GRAQL);
 
-        assertThat(response.contentType(), equalTo(APPLICATION_JSON));
+        assertThat(response.contentType(), equalTo(APPLICATION_JSON_GRAQL));
     }
 
     @Test
-    public void POSTGraqlInsert_ResponseContainsOriginalQuery(){
-        String query = "insert $x isa person;";
-        Response response = sendPOST(query);
+    public void POSTGraqlInsertWithJsonType_ResponseIsCorrectJson(){
+        Response response = sendPOST("insert $x isa person;", APPLICATION_JSON_GRAQL);
 
-        assertThat(originalQuery(response), equalTo(query));
+        assertThat(jsonResponse(response).asJsonList().size(), equalTo(1));
     }
 
     @Test
-    public void POSTGraqlInsert_ResponseContainsCorrectNumberOfIds(){
-        String query = "insert $x isa person;";
-        Response response = sendPOST(query);
+    public void POSTGraqlInsertWithTextType_ResponseIsTextType(){
+        Response response = sendPOST("insert $x isa person;", APPLICATION_TEXT);
 
-        assertThat(1, equalTo(jsonResponse(response).asJsonList().size()));
+        assertThat(response.contentType(), equalTo(APPLICATION_TEXT));
+    }
+
+    @Test
+    public void POSTGraqlInsertWithTextType_ResponseIsCorrectText(){
+        Response response = sendPOST("insert $x isa person;", APPLICATION_TEXT);
+
+        assertThat(stringResponse(response), containsString("isa person"));
+    }
+
+    @Test
+    public void POSTGraqlInsertWithHALType_ErrorIsThrown(){
+        Response response = sendPOST("insert $x isa person;", APPLICATION_HAL);
+
+        assertThat(exception(response), containsString("Unsupported query type in HAL formatter"));
     }
 
     @Test
@@ -241,7 +258,12 @@ public class GraqlControllerPOSTTest {
     }
 
     private Response sendPOST(String query){
+        return sendPOST(query, APPLICATION_TEXT);
+    }
+
+    private Response sendPOST(String query, String acceptType){
         return RestAssured.with()
+                .accept(acceptType)
                 .queryParam(KEYSPACE, mockGraph.getKeyspace())
                 .body(query)
                 .post(REST.WebPath.Graph.GRAQL);


### PR DESCRIPTION
+ Graql controller does not always return a JSON object - depends on content type
+ Graql insert endpoint can return either JSON or text, if requested.