### PR TITLE
Fixed concurrent start problem

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineConfig.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineConfig.java
@@ -118,6 +118,9 @@ public class GraknEngineConfig {
      * If it is not set, it sets it to the default one.
      */
     private static void setConfigFilePath() {
+        if (configFilePath != null && !configFilePath.isEmpty()) {
+            return;
+        }
        configFilePath = (GraknSystemProperty.CONFIGURATION_FILE.value() != null) ? GraknSystemProperty.CONFIGURATION_FILE.value() : GraknEngineConfig.DEFAULT_CONFIG_FILE;
         if (!Paths.get(configFilePath).isAbsolute()) {
             configFilePath = getProjectPath() + configFilePath;

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -50,6 +50,8 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
 import mjson.Json;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
@@ -76,6 +78,7 @@ import spark.Service;
 
 public class GraknEngineServer implements AutoCloseable {
 
+    private static final String LOAD_SYSTEM_ONTOLOGY_LOCK_NAME = "load-system-ontology";
     private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
     private static final Set<String> unauthenticatedEndPoints = new HashSet<>(Arrays.asList(
             REST.WebPath.NEW_SESSION_URI,
@@ -100,12 +103,12 @@ public class GraknEngineServer implements AutoCloseable {
         String redisUrl = prop.tryProperty(REDIS_SERVER_URL).orElse("localhost");
         this.jedisPool = instantiateRedis(prop, redisUrl, redisPort);
         this.redisCountStorage = RedisCountStorage.create(jedisPool);
-        this.factory = EngineGraknGraphFactory.create(prop.getProperties());
-        this.metricRegistry = new MetricRegistry();
         String taskManagerClassName = prop.getProperty(GraknEngineConfig.TASK_MANAGER_IMPLEMENTATION);
         this.inMemoryQueue = !taskManagerClassName.contains("RedisTaskManager");
         this.lockProvider = this.inMemoryQueue ? new ProcessWideLockProvider()
                 : instantiateRedissonLockProvider(redisPort, redisUrl);
+        this.factory = EngineGraknGraphFactory.create(prop.getProperties());
+        this.metricRegistry = new MetricRegistry();
         this.taskManager = startTaskManager(inMemoryQueue, redisCountStorage, jedisPool, lockProvider);
     }
 
@@ -121,9 +124,28 @@ public class GraknEngineServer implements AutoCloseable {
     }
 
     public void start() {
+        lockAndInitializeSystemOntology();
         startHTTP();
         printStartMessage(prop.getProperty(GraknEngineConfig.SERVER_HOST_NAME),
                 prop.getProperty(GraknEngineConfig.SERVER_PORT_NUMBER));
+    }
+
+    private void lockAndInitializeSystemOntology() {
+        try {
+            Lock lock = lockProvider.getLock(LOAD_SYSTEM_ONTOLOGY_LOCK_NAME);
+            if (lock.tryLock(60, TimeUnit.SECONDS)) {
+                try {
+                    LOG.info("{} is initializing the system ontology", this.engineId);
+                    factory.systemKeyspace().loadSystemOntology();
+                } finally {
+                    lock.unlock();
+                }
+            } else {
+                LOG.info("{} found system ontology lock already acquired by other engine", this.engineId);
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("{} was interrupted while initializing system ontology", this.engineId);
+        }
     }
 
     @Override
@@ -328,8 +350,8 @@ public class GraknEngineServer implements AutoCloseable {
         LOG.info("Connecting redisCountStorage client to {}:{}", redisUrl, redisPort);
         Config redissonConfig = new Config();
         redissonConfig.useSingleServer()
-                .setConnectionPoolSize(5)
-                .setAddress(String.format("%s:%s", redisUrl, redisPort));
+                .setAddress(String.format("%s:%d", redisUrl, redisPort))
+                .setConnectionPoolSize(5);
         return new RedissonLockProvider(Redisson.create(redissonConfig));
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/SystemKeyspace.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/SystemKeyspace.java
@@ -77,9 +77,15 @@ public class SystemKeyspace {
     private final EngineGraknGraphFactory factory;
 
     public SystemKeyspace(EngineGraknGraphFactory factory){
+        this(factory, true);
+    }
+
+    public SystemKeyspace(EngineGraknGraphFactory factory, boolean loadSystemOntology){
         this.factory = factory;
         this.openSpaces = new ConcurrentHashMap<>();
-        loadSystemOntology();
+        if (loadSystemOntology) {
+            loadSystemOntology();
+        }
     }
 
     /**
@@ -150,7 +156,7 @@ public class SystemKeyspace {
      * only consists of types, the inserts are idempotent and it is safe to load it
      * multiple times.
      */
-    void loadSystemOntology() {
+    public void loadSystemOntology() {
         try (GraknGraph graph = factory.getGraph(SYSTEM_GRAPH_NAME, GraknTxType.WRITE)) {
             if (graph.getOntologyConcept(KEYSPACE_ENTITY) != null) {
                 checkVersion(graph);

--- a/grakn-engine/src/main/java/ai/grakn/engine/factory/EngineGraknGraphFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/factory/EngineGraknGraphFactory.java
@@ -47,15 +47,19 @@ public class EngineGraknGraphFactory {
     private final String engineURI;
     private final SystemKeyspace systemKeyspace;
 
-    public static EngineGraknGraphFactory create(Properties properties) {
-        return new EngineGraknGraphFactory(properties);
+    public static EngineGraknGraphFactory createAndLoadSystemOntology(Properties properties) {
+        return new EngineGraknGraphFactory(properties, true);
     }
 
-    private EngineGraknGraphFactory(Properties properties) {
+    public static EngineGraknGraphFactory create(Properties properties) {
+        return new EngineGraknGraphFactory(properties, false);
+    }
+
+    private EngineGraknGraphFactory(Properties properties, boolean loadOntology) {
         this.properties = new Properties();
         this.properties.putAll(properties);
         this.engineURI = properties.getProperty(GraknEngineConfig.SERVER_HOST_NAME) + ":" + properties.getProperty(GraknEngineConfig.SERVER_PORT_NUMBER);
-        this.systemKeyspace = new SystemKeyspace(this);
+        this.systemKeyspace = new SystemKeyspace(this, loadOntology);
     }
 
     public synchronized void refreshConnections(){
@@ -66,7 +70,6 @@ public class EngineGraknGraphFactory {
         if(!keyspace.equals(SystemKeyspace.SYSTEM_GRAPH_NAME)) {
             systemKeyspace.ensureKeyspaceInitialised(keyspace);
         }
-
         return FactoryBuilder.getFactory(keyspace, engineURI, properties).open(type);
     }
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/AuthControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/AuthControllerTest.java
@@ -31,7 +31,7 @@ public class AuthControllerTest  {
 
     private UsersHandler usersHandler = UsersHandler.create(
             EngineTestHelper.config().getProperty(GraknEngineConfig.ADMIN_PASSWORD_PROPERTY), 
-                                                  EngineGraknGraphFactory.create(EngineTestHelper.config().getProperties()));
+                                                  EngineGraknGraphFactory.createAndLoadSystemOntology(EngineTestHelper.config().getProperties()));
 
     @Test
     public void newSessionWithNonExistingUser() {

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerTest.java
@@ -64,7 +64,7 @@ public class GraqlControllerTest {
 
     @ClassRule
     public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        EngineGraknGraphFactory factory = EngineGraknGraphFactory.create(GraknEngineConfig.create().getProperties());
+        EngineGraknGraphFactory factory = EngineGraknGraphFactory.createAndLoadSystemOntology(GraknEngineConfig.create().getProperties());
         new GraqlController(factory, spark, new MetricRegistry());
     });
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/session/EngineGraknSessionTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/session/EngineGraknSessionTest.java
@@ -15,7 +15,7 @@ import static org.junit.Assert.assertTrue;
 public class EngineGraknSessionTest {
     
     static { EngineTestHelper.engineWithGraphs(); }
-    static EngineGraknGraphFactory graknFactory = EngineGraknGraphFactory.create(EngineTestHelper.config().getProperties());
+    static EngineGraknGraphFactory graknFactory = EngineGraknGraphFactory.createAndLoadSystemOntology(EngineTestHelper.config().getProperties());
     
     String factoryUri = "localhost:" + EngineTestHelper.config().getProperty(GraknEngineConfig.SERVER_PORT_NUMBER);
     

--- a/grakn-engine/src/test/java/ai/grakn/engine/tasks/manager/redisqueue/RedisTaskManagerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/tasks/manager/redisqueue/RedisTaskManagerTest.java
@@ -91,7 +91,7 @@ public class RedisTaskManagerTest {
         poolConfig.setMaxTotal(MAX_TOTAL);
         jedisPool = new JedisPool(poolConfig, "localhost", 9899);
         assertFalse(jedisPool.isClosed());
-        engineGraknGraphFactory = EngineGraknGraphFactory.create(CONFIG.getProperties());
+        engineGraknGraphFactory = EngineGraknGraphFactory.createAndLoadSystemOntology(CONFIG.getProperties());
         int nThreads = 2;
         executor = Executors.newFixedThreadPool(nThreads);
         taskManager = new RedisTaskManager(engineID, CONFIG, jedisPool, nThreads, engineGraknGraphFactory, LOCK_PROVIDER, metricRegistry);

--- a/grakn-engine/src/test/java/ai/grakn/test/engine/user/SuperUserTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/test/engine/user/SuperUserTest.java
@@ -45,7 +45,7 @@ public class SuperUserTest {
     @BeforeClass
     public static void beforeClass() {
         // TODO: Doing it here because it has to happen after Cassandra starts. Consider refactoring
-        graknFactory = EngineGraknGraphFactory.create(EngineTestHelper.config().getProperties());
+        graknFactory = EngineGraknGraphFactory.createAndLoadSystemOntology(EngineTestHelper.config().getProperties());
     }
 
     @Test

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
@@ -49,8 +49,8 @@ import org.junit.runner.RunWith;
 @RunWith(JUnitQuickcheck.class)
 public class GraknEngineStartIT {
 
-    private static final int[] PORTS = {7000, 7001, 7003};
-    public static final int REDIS_PORT = 6999;
+    private static final int[] PORTS = {50120, 50121, 50122};
+    public static final int REDIS_PORT = 50123;
 
     @BeforeClass
     public static void setUpClass() {

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
@@ -27,7 +27,9 @@ import static ai.grakn.engine.GraknEngineConfig.SERVER_PORT_NUMBER;
 import static ai.grakn.engine.GraknEngineConfig.TASK_MANAGER_IMPLEMENTATION;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
+import ai.grakn.test.GraknTestSetup;
 import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForStatus;
+import ai.grakn.util.EmbeddedCassandra;
 import ai.grakn.util.EmbeddedRedis;
 import com.google.common.base.StandardSystemProperty;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
@@ -53,6 +55,7 @@ public class GraknEngineStartIT {
     @BeforeClass
     public static void setUpClass() {
         EmbeddedRedis.start(REDIS_PORT);
+        GraknTestSetup.startCassandraIfNeeded();
         GraknSystemProperty.CURRENT_DIRECTORY.set(StandardSystemProperty.USER_DIR.value());
     }
 

--- a/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
+++ b/grakn-test/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
@@ -1,0 +1,90 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ *
+ */
+
+package ai.grakn.test.engine;
+
+import ai.grakn.GraknSystemProperty;
+import ai.grakn.engine.GraknEngineConfig;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SERVER_PORT;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SERVER_URL;
+import static ai.grakn.engine.GraknEngineConfig.SERVER_PORT_NUMBER;
+import static ai.grakn.engine.GraknEngineConfig.TASK_MANAGER_IMPLEMENTATION;
+import ai.grakn.engine.GraknEngineServer;
+import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
+import static ai.grakn.test.engine.tasks.BackgroundTaskTestUtils.waitForStatus;
+import ai.grakn.util.EmbeddedRedis;
+import com.google.common.base.StandardSystemProperty;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitQuickcheck.class)
+public class GraknEngineStartIT {
+
+    private static final int[] PORTS = {7000, 7001, 7003};
+    public static final int REDIS_PORT = 6999;
+
+    @BeforeClass
+    public static void setUpClass() {
+        EmbeddedRedis.start(REDIS_PORT);
+        GraknSystemProperty.CURRENT_DIRECTORY.set(StandardSystemProperty.USER_DIR.value());
+    }
+
+    @AfterClass
+    public static void tearDownClass() {
+        EmbeddedRedis.stop();
+    }
+
+    @Test
+    public void whenStartingMultipleEngines_InitializationSucceeds() throws InterruptedException {
+        HashSet<CompletableFuture<Void>> cfs = new HashSet<>();
+        for(int port : PORTS) {
+            cfs
+                    .add(CompletableFuture.supplyAsync(() -> {
+                        GraknEngineConfig graknEngineConfig = GraknEngineConfig.create();
+                        Properties properties = graknEngineConfig.getProperties();
+                        properties.setProperty(SERVER_PORT_NUMBER, String.valueOf(port));
+                        properties.setProperty(REDIS_SERVER_PORT, String.valueOf(REDIS_PORT));
+                        properties.setProperty(TASK_MANAGER_IMPLEMENTATION, RedisTaskManager.class.getName());
+                        GraknEngineServer engine = new GraknEngineServer(graknEngineConfig);
+                        engine.start();
+                        return engine;
+                    })
+                    .thenAccept(GraknEngineServer::close)
+                    .handle((result, exception) -> {
+                        if (exception != null) {
+                            exception.printStackTrace();
+                            fail("Could not initialize engine successfully");
+                        }
+                        return null;
+                    }));
+        }
+        CompletableFuture.allOf(cfs.toArray(new CompletableFuture[cfs.size()])).join();
+    }
+}


### PR DESCRIPTION
Previously when starting multiple engines, one of them would start creating the system ontology and the others would fail.
Now they try to acquire a distributed lock if running on Redis or local lock if using the Standalone Queue.