### PR TITLE
Bug #16266: Fix another randomly failing property test

### DIFF
--- a/grakn-test-tools/src/main/java/ai/grakn/generator/AbstractThingGenerator.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/generator/AbstractThingGenerator.java
@@ -19,12 +19,25 @@
 
 package ai.grakn.generator;
 
+import ai.grakn.concept.Label;
+import ai.grakn.concept.Resource;
+import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
 import ai.grakn.generator.AbstractOntologyConceptGenerator.NonMeta;
+import com.pholser.junit.quickcheck.generator.GeneratorConfiguration;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Stream;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -36,7 +49,7 @@ import static java.util.stream.Collectors.toSet;
  * @author Felix Chapman
  */
 public abstract class AbstractThingGenerator<T extends Thing, S extends Type> extends FromGraphGenerator<T> {
-
+    private boolean withResource = false;
     private final Class<? extends AbstractTypeGenerator<S>> generatorClass;
 
     AbstractThingGenerator(Class<T> type, Class<? extends AbstractTypeGenerator<S>> generatorClass) {
@@ -46,19 +59,79 @@ public abstract class AbstractThingGenerator<T extends Thing, S extends Type> ex
 
     @Override
     protected final T generateFromGraph() {
+        T thing;
         S type = genFromGraph(generatorClass).makeExcludeAbstractTypes().excludeMeta().generate(random, status);
 
         //noinspection unchecked
         Collection<T> instances = (Collection<T> ) type.instances().collect(toSet());
         if (instances.isEmpty()) {
-            return newInstance(type);
+            thing = newInstance(type);
         } else {
-            return random.choose(instances);
+            thing = random.choose(instances);
         }
+
+        if(withResource){
+            //Getting the resource type we need
+            Set<ResourceType> availableResourceTypes = Stream.concat(type.resources(), type.keys()).
+                    filter(rt -> !rt.isAbstract()).
+                    filter(rt -> !rt.equals(type)).
+                    collect(toSet());
+
+            ResourceType resourceType;
+            if(availableResourceTypes.isEmpty()){
+                ResourceType.DataType<?> dataType = gen(ResourceType.DataType.class);
+                Label label = genFromGraph(Labels.class).mustBeUnused().generate(random, status);
+                resourceType = graph().putResourceType(label, dataType);
+                //resourceType = genFromGraph(ResourceTypes.class).makeExcludeAbstractTypes().excludeMeta().generate(random, status);
+                System.out.println("Creating new resource type: " + resourceType.getLabel());
+                type.resource(resourceType);
+            } else {
+                resourceType = random.choose(availableResourceTypes);
+                System.out.println("Using old resource type: " + resourceType.getLabel());
+            }
+
+            //Getting the resource we need
+            //noinspection unchecked
+            Set<Resource> availableResources = (Set<Resource>) resourceType.instances().collect(toSet());
+
+            Resource resource;
+            if(availableResources.isEmpty()){
+                System.out.println("Creating new resource from type: " + resourceType.getLabel());
+                resource = newResource(resourceType);
+            } else {
+                System.out.println("Choosing old resource from type: " + resourceType.getLabel());
+                resource = random.choose(availableResources);
+            }
+
+            System.out.println("Give resource of type [" + resource.type().getLabel() + "] to a thing of type [" + thing.type().getLabel() + "]");
+            thing.resource(resource);
+        }
+
+        return thing;
+    }
+
+    protected Resource newResource(ResourceType type) {
+        ResourceType.DataType<?> dataType = type.getDataType();
+        Object value = gen().make(ResourceValues.class).dataType(dataType).generate(random, status);
+        return type.putResource(value);
     }
 
     public final void configure(NonMeta nonMeta) {
     }
 
+    public final void configure(WithResource withResource) {
+        this.withResource = true;
+    }
+
     protected abstract T newInstance(S type);
+
+    /**
+     * Specify if the generated {@link Thing} should be connected to a {@link ai.grakn.concept.Resource}
+     */
+    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
+    @Retention(RUNTIME)
+    @GeneratorConfiguration
+    public @interface WithResource {
+
+    }
 }

--- a/grakn-test-tools/src/main/java/ai/grakn/generator/ResourceTypes.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/generator/ResourceTypes.java
@@ -19,8 +19,8 @@
 
 package ai.grakn.generator;
 
-import ai.grakn.concept.ResourceType;
 import ai.grakn.concept.Label;
+import ai.grakn.concept.ResourceType;
 
 /**
  * A generator that produces {@link ResourceType}s
@@ -44,5 +44,4 @@ public class ResourceTypes extends AbstractTypeGenerator<ResourceType> {
     protected ResourceType metaOntologyConcept() {
         return graph().admin().getMetaResourceType();
     }
-
 }

--- a/grakn-test-tools/src/main/java/ai/grakn/generator/Resources.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/generator/Resources.java
@@ -38,8 +38,6 @@ public class Resources extends AbstractThingGenerator<Resource, ResourceType> {
 
     @Override
     protected Resource newInstance(ResourceType type) {
-        ResourceType.DataType<?> dataType = type.getDataType();
-        Object value = gen().make(ResourceValues.class).dataType(dataType).generate(random, status);
-        return type.putResource(value);
+        return newResource(type);
     }
 }

--- a/grakn-test/src/test/java/ai/grakn/test/property/ThingPropertyTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/property/ThingPropertyTest.java
@@ -21,9 +21,9 @@ package ai.grakn.test.property;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
+import ai.grakn.generator.AbstractThingGenerator;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 import static java.util.stream.Collectors.toSet;
@@ -43,9 +43,8 @@ public class ThingPropertyTest {
         assertThat(PropertyUtil.directInstances(type), hasItem(thing));
     }
 
-    @Ignore// Ignored because sometimes we fail to generate Things with resources attached to them
     @Property
-    public void whenGettingTheResourceOfAThing_TheResourcesOwnerIsTheThing(Thing thing, long seed) {
+    public void whenGettingTheResourceOfAThing_TheResourcesOwnerIsTheThing(@AbstractThingGenerator.WithResource Thing thing, long seed) {
         Resource<?> resource = PropertyUtil.choose(thing.resources(), seed);
         assertTrue("[" + thing + "] is connected to resource [" + resource + "] but is not in it's owner set", resource.ownerInstances().collect(toSet()).contains(thing));
     }

--- a/grakn-test/src/test/java/ai/grakn/test/property/ThingPropertyTest.java
+++ b/grakn-test/src/test/java/ai/grakn/test/property/ThingPropertyTest.java
@@ -21,7 +21,7 @@ package ai.grakn.test.property;
 import ai.grakn.concept.Resource;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
-import ai.grakn.generator.AbstractThingGenerator;
+import ai.grakn.generator.AbstractThingGenerator.WithResource;
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ public class ThingPropertyTest {
     }
 
     @Property
-    public void whenGettingTheResourceOfAThing_TheResourcesOwnerIsTheThing(@AbstractThingGenerator.WithResource Thing thing, long seed) {
+    public void whenGettingTheResourceOfAThing_TheResourcesOwnerIsTheThing(@WithResource Thing thing, long seed) {
         Resource<?> resource = PropertyUtil.choose(thing.resources(), seed);
         assertTrue("[" + thing + "] is connected to resource [" + resource + "] but is not in it's owner set", resource.ownerInstances().collect(toSet()).contains(thing));
     }


### PR DESCRIPTION
The problem here was the test itself it needed to be more complex and guarantee that a `Thing` ALWAYS had a resource so I have added a `@WithResource` annotation to guarantee that.