### PR TITLE
Fix performance issue with insert queries

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
@@ -30,7 +30,6 @@ import org.apache.tinkerpop.gremlin.util.function.TriConsumer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,7 +51,6 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-@Ignore("Ignored because there has been a general slow down in graql and these are the tests we can most safely ignore without regressing")
 @RunWith(Parameterized.class)
 public class GraqlDocsTest {
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/JavaDocsTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/JavaDocsTest.java
@@ -25,7 +25,6 @@ import groovy.util.Eval;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -47,7 +46,6 @@ import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-@Ignore("Ignored because there has been a general slow down in graql and these are the tests we can most safely ignore without regressing")
 @RunWith(Parameterized.class)
 public class JavaDocsTest {
 


### PR DESCRIPTION
This was because my previous method to find equivalent properties was O(n^2), now it should be O(n).