### PR TITLE
Refactor `VarPropertyInternal`

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
@@ -48,7 +48,7 @@ abstract class AbstractVarProperty implements VarPropertyInternal {
     abstract String getName();
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
         throw GraqlQueryException.insertUnsupportedProperty(getName());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
@@ -23,7 +23,6 @@ import ai.grakn.concept.Concept;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.VarPatternAdmin;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.util.CommonUtil;
 
 import java.util.stream.Stream;
@@ -53,7 +52,7 @@ abstract class AbstractVarProperty implements VarPropertyInternal {
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
         throw GraqlQueryException.defineUnsupportedProperty(getName());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -28,7 +28,6 @@ import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import ai.grakn.graql.internal.parser.QueryParser;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.property.DataTypeAtom;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -73,8 +72,10 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).dataType(dataType());
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).dataType(dataType());
+        }).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -70,9 +70,11 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).dataType(dataType());
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -28,7 +28,6 @@ import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import ai.grakn.graql.internal.parser.QueryParser;
-import ai.grakn.graql.internal.query.QueryOperationExecutor;
 import ai.grakn.graql.internal.reasoner.atom.property.DataTypeAtom;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -40,9 +39,6 @@ import java.util.Set;
  * Represents the {@code datatype} property on a {@link AttributeType}.
  *
  * This property can be queried or inserted.
- *
- * The insertion behaviour is not implemented here, but instead in
- * {@link QueryOperationExecutor}.
  *
  * @author Felix Chapman
  */

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -28,6 +28,7 @@ import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import ai.grakn.graql.internal.parser.QueryParser;
+import ai.grakn.graql.internal.query.QueryOperationExecutor;
 import ai.grakn.graql.internal.reasoner.atom.property.DataTypeAtom;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +42,7 @@ import java.util.Set;
  * This property can be queried or inserted.
  *
  * The insertion behaviour is not implemented here, but instead in
- * {@link ai.grakn.graql.internal.query.InsertQueryExecutor}.
+ * {@link QueryOperationExecutor}.
  *
  * @author Felix Chapman
  */

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -79,16 +79,6 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of();
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public Atomic mapToAtom(VarPatternAdmin var, Set<VarPatternAdmin> vars, ReasonerQuery parent) {
         return new DataTypeAtom(var.var(), this, parent);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
@@ -130,11 +130,13 @@ public abstract class HasResourceProperty extends AbstractVarProperty implements
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Attribute attributeConcept = executor.get(resource().var()).asAttribute();
             Thing thing = executor.get(var).asThing();
             thing.attribute(attributeConcept);
-        }).requires(var, resource().var()).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var, resource().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
@@ -34,7 +34,6 @@ import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.ValuePredicateAdmin;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.ResourceAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.ValuePredicate;
@@ -130,10 +129,12 @@ public abstract class HasResourceProperty extends AbstractVarProperty implements
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Attribute attributeConcept = executor.get(resource().var()).asAttribute();
-        Thing thing = executor.get(var).asThing();
-        thing.attribute(attributeConcept);
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Attribute attributeConcept = executor.get(resource().var()).asAttribute();
+            Thing thing = executor.get(var).asThing();
+            thing.attribute(attributeConcept);
+        }).requires(var, resource().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceProperty.java
@@ -138,11 +138,6 @@ public abstract class HasResourceProperty extends AbstractVarProperty implements
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var, resource().var());
-    }
-
-    @Override
     public void delete(GraknTx graph, Concept concept) {
         Optional<ValuePredicateAdmin> predicate =
                 resource().getProperties(ValueProperty.class).map(ValueProperty::predicate).findAny();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
@@ -36,7 +36,6 @@ import ai.grakn.graql.internal.reasoner.atom.binary.type.HasAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.util.Schema;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -150,11 +149,6 @@ public abstract class HasResourceTypeProperty extends AbstractVarProperty implem
                 entityTypeConcept.attribute(attributeTypeConcept);
             }
         }).requires(var, resourceType().var()).build();
-    }
-
-    @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var, resourceType().var());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
@@ -21,8 +21,8 @@ package ai.grakn.graql.internal.pattern.property;
 import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.Label;
 import ai.grakn.concept.RelationshipType;
-import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Role;
+import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Type;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Graql;
@@ -32,7 +32,6 @@ import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.HasAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.util.Schema;
@@ -140,15 +139,17 @@ public abstract class HasResourceTypeProperty extends AbstractVarProperty implem
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Type entityTypeConcept = executor.get(var).asType();
-        AttributeType attributeTypeConcept = executor.get(resourceType().var()).asAttributeType();
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Type entityTypeConcept = executor.get(var).asType();
+            AttributeType attributeTypeConcept = executor.get(resourceType().var()).asAttributeType();
 
-        if (required()) {
-            entityTypeConcept.key(attributeTypeConcept);
-        } else {
-            entityTypeConcept.attribute(attributeTypeConcept);
-        }
+            if (required()) {
+                entityTypeConcept.key(attributeTypeConcept);
+            } else {
+                entityTypeConcept.attribute(attributeTypeConcept);
+            }
+        }).requires(var, resourceType().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasResourceTypeProperty.java
@@ -139,7 +139,7 @@ public abstract class HasResourceTypeProperty extends AbstractVarProperty implem
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Type entityTypeConcept = executor.get(var).asType();
             AttributeType attributeTypeConcept = executor.get(resourceType().var()).asAttributeType();
 
@@ -148,7 +148,9 @@ public abstract class HasResourceTypeProperty extends AbstractVarProperty implem
             } else {
                 entityTypeConcept.attribute(attributeTypeConcept);
             }
-        }).requires(var, resourceType().var()).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var, resourceType().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
@@ -83,16 +83,6 @@ public abstract class IdProperty extends AbstractVarProperty implements NamedPro
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of();
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public boolean uniquelyIdentifiesConcept() {
         return true;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
@@ -71,9 +71,11 @@ public abstract class IdProperty extends AbstractVarProperty implements NamedPro
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).id(id());
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
@@ -71,14 +71,16 @@ public abstract class IdProperty extends AbstractVarProperty implements NamedPro
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).id(id());
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).id(id());
+        }).produces(var).build();
     }
 
     @Override
     public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
         // This property works in both insert and define queries, because it is only for look-ups
-        insert(var, executor);
+        insert(var).execute(executor);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.util.StringConverter;
 import com.google.auto.value.AutoValue;
@@ -78,9 +77,9 @@ public abstract class IdProperty extends AbstractVarProperty implements NamedPro
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
         // This property works in both insert and define queries, because it is only for look-ups
-        insert(var).execute(executor);
+        return insert(var);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
@@ -26,7 +26,6 @@ import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.property.IsAbstractAtom;
 import com.google.common.collect.ImmutableSet;
 
@@ -74,13 +73,15 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Concept concept = executor.get(var);
-        if(concept.isType()){
-            concept.asType().setAbstract(true);
-        } else {
-            throw GraqlQueryException.insertAbstractOnNonType(concept.asSchemaConcept());
-        }
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Concept concept = executor.get(var);
+            if(concept.isType()){
+                concept.asType().setAbstract(true);
+            } else {
+                throw GraqlQueryException.insertAbstractOnNonType(concept.asSchemaConcept());
+            }
+        }).requires(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
@@ -74,14 +74,16 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Concept concept = executor.get(var);
-            if(concept.isType()){
+            if (concept.isType()) {
                 concept.asType().setAbstract(true);
             } else {
                 throw GraqlQueryException.insertAbstractOnNonType(concept.asSchemaConcept());
             }
-        }).requires(var).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
@@ -85,11 +85,6 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public Atomic mapToAtom(VarPatternAdmin var, Set<VarPatternAdmin> vars, ReasonerQuery parent) {
         return new IsAbstractAtom(var.var(), parent);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
@@ -30,7 +30,6 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.IsaAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import com.google.auto.value.AutoValue;
@@ -92,9 +91,11 @@ public abstract class IsaProperty extends AbstractVarProperty implements UniqueV
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Type type = executor.get(this.type().var()).asType();
-        executor.builder(var).isa(type);
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Type type = executor.get(this.type().var()).asType();
+            executor.builder(var).isa(type);
+        }).requires(type().var()).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
@@ -92,10 +92,12 @@ public abstract class IsaProperty extends AbstractVarProperty implements UniqueV
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Type type = executor.get(this.type().var()).asType();
             executor.builder(var).isa(type);
-        }).requires(type().var()).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(type().var()).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
@@ -99,16 +99,6 @@ public abstract class IsaProperty extends AbstractVarProperty implements UniqueV
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(type().var());
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public void checkValidProperty(GraknTx graph, VarPatternAdmin var) throws GraqlQueryException {
         type().getTypeLabel().ifPresent(typeLabel -> {
             SchemaConcept theSchemaConcept = graph.getSchemaConcept(typeLabel);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.util.StringConverter;
 import com.google.auto.value.AutoValue;
@@ -73,12 +72,14 @@ public abstract class LabelProperty extends AbstractVarProperty implements Named
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
         // This is supported in insert queries in order to allow looking up schema concepts by label
-        return PropertyExecutor.builder(executor -> define(var, executor)).produces(var).build();
+        return define(var);
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).label(label());
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).label(label());
+        }).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
@@ -77,9 +77,11 @@ public abstract class LabelProperty extends AbstractVarProperty implements Named
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).label(label());
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
@@ -71,9 +71,9 @@ public abstract class LabelProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
         // This is supported in insert queries in order to allow looking up schema concepts by label
-        define(var, executor);
+        return PropertyExecutor.builder(executor -> define(var, executor)).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
@@ -83,16 +83,6 @@ public abstract class LabelProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of();
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public boolean uniquelyIdentifiesConcept() {
         return true;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/NeqProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/NeqProperty.java
@@ -18,14 +18,12 @@
 
 package ai.grakn.graql.internal.pattern.property;
 
-import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.Sets;
@@ -69,11 +67,6 @@ public abstract class NeqProperty extends AbstractVarProperty implements NamedPr
                 EquivalentFragmentSets.notInternalFragmentSet(this, var().var()),
                 EquivalentFragmentSets.neq(this, start, var().var())
         );
-    }
-
-    @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        // TODO: Throw
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/NeqProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/NeqProperty.java
@@ -70,11 +70,6 @@ public abstract class NeqProperty extends AbstractVarProperty implements NamedPr
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Stream<VarPatternAdmin> innerVarPatterns() {
         return Stream.of(var());
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
@@ -97,11 +97,6 @@ public abstract class PlaysProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var, role().var());
-    }
-
-    @Override
     public void delete(GraknTx graph, Concept concept) {
         Label roleLabel = role().getTypeLabel().orElseThrow(() -> GraqlQueryException.failDelete(this));
         concept.asType().deletePlays(graph.getSchemaConcept(roleLabel));

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
@@ -90,10 +90,12 @@ public abstract class PlaysProperty extends AbstractVarProperty implements Named
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Role role = executor.get(this.role().var()).asRole();
             executor.get(var).asType().plays(role);
-        }).requires(var, role().var()).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var, role().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
@@ -30,7 +30,6 @@ import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.PlaysAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import com.google.auto.value.AutoValue;
@@ -90,9 +89,11 @@ public abstract class PlaysProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Role role = executor.get(this.role().var()).asRole();
-        executor.get(var).asType().plays(role);
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Role role = executor.get(this.role().var()).asRole();
+            executor.get(var).asType().plays(role);
+        }).requires(var, role().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
@@ -41,7 +41,7 @@ import java.util.function.Consumer;
  *     For example:
  *     <pre>
  *         SubProperty property = SubProperty.of(y);
- *         PropertyExecutor executor = property.execute(x);
+ *         PropertyExecutor executor = property.define(x);
  *         executor.requiredVars(); // returns `{y}`
  *         executor.producedVars(); // returns `{x}`
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
@@ -19,6 +19,7 @@
 
 package ai.grakn.graql.internal.pattern.property;
 
+import ai.grakn.concept.Concept;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import com.google.auto.value.AutoValue;
@@ -38,12 +39,39 @@ public abstract class PropertyExecutor {
 
     abstract Consumer<InsertQueryExecutor> executeMethod();
 
+    /**
+     * Apply the given property, if possible.
+     *
+     * @param executor a class providing a map of concepts that are accessible and methods to build new concepts.
+     *                 <p>
+     *                 This method can expect any key to be here that is returned from
+     *                 {@link #requiredVars()}. The method may also build a concept provided that key is returned
+     *                 from {@link #producedVars()}.
+     *                 </p>
+     */
     public void execute(InsertQueryExecutor executor) {
         executeMethod().accept(executor);
     }
 
+    /**
+     * Get all {@link Var}s whose {@link Concept} must exist for the subject {@link Var} to be applied.
+     * For example, for {@link IsaProperty} the type must already be present before an instance can be created.
+     *
+     * <p>
+     *     When calling {@link #execute}, the method can expect any {@link Var} returned here to be available by calling
+     *     {@link InsertQueryExecutor#get}.
+     * </p>
+     */
     public abstract ImmutableSet<Var> requiredVars();
 
+    /**
+     * Get all {@link Var}s whose {@link Concept} can only be created after this property is applied.
+     *
+     * <p>
+     *     When calling {@link #execute}, the method must help build a {@link Concept} for every {@link Var} returned
+     *     from this method, using {@link InsertQueryExecutor#builder}.
+     * </p>
+     */
     public abstract ImmutableSet<Var> producedVars();
 
     @AutoValue.Builder

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
@@ -26,8 +26,6 @@ import ai.grakn.graql.internal.query.QueryOperationExecutor;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
-import java.util.function.Consumer;
-
 // TODO: Add an example of 'undefine' to this description
 /**
  * A class describing an operation to perform using a {@link VarProperty}.
@@ -57,7 +55,7 @@ import java.util.function.Consumer;
 @AutoValue
 public abstract class PropertyExecutor {
 
-    public static PropertyExecutor.Builder builder(Consumer<QueryOperationExecutor> executeMethod) {
+    public static PropertyExecutor.Builder builder(Method executeMethod) {
         return new AutoValue_PropertyExecutor.Builder().executeMethod(executeMethod);
     }
 
@@ -72,7 +70,7 @@ public abstract class PropertyExecutor {
      *                 </p>
      */
     public void execute(QueryOperationExecutor executor) {
-        executeMethod().accept(executor);
+        executeMethod().execute(executor);
     }
 
     /**
@@ -96,11 +94,11 @@ public abstract class PropertyExecutor {
      */
     public abstract ImmutableSet<Var> producedVars();
 
-    abstract Consumer<QueryOperationExecutor> executeMethod();
+    abstract Method executeMethod();
 
     @AutoValue.Builder
     abstract static class Builder {
-        abstract Builder executeMethod(Consumer<QueryOperationExecutor> value);
+        abstract Builder executeMethod(Method value);
 
         abstract ImmutableSet.Builder<Var> requiredVarsBuilder();
 
@@ -127,5 +125,10 @@ public abstract class PropertyExecutor {
         }
 
         abstract PropertyExecutor build();
+    }
+
+    @FunctionalInterface
+    interface Method {
+        void execute(QueryOperationExecutor queryOperationExecutor);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
@@ -42,9 +42,9 @@ public abstract class PropertyExecutor {
         executeMethod().accept(executor);
     }
 
-    abstract ImmutableSet<Var> requiredVars();
+    public abstract ImmutableSet<Var> requiredVars();
 
-    abstract ImmutableSet<Var> producedVars();
+    public abstract ImmutableSet<Var> producedVars();
 
     @AutoValue.Builder
     abstract static class Builder {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PropertyExecutor.java
@@ -1,0 +1,79 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ *
+ */
+
+package ai.grakn.graql.internal.pattern.property;
+
+import ai.grakn.graql.Var;
+import ai.grakn.graql.internal.query.InsertQueryExecutor;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.function.Consumer;
+
+/**
+ * @author Felix Chapman
+ */
+@AutoValue
+public abstract class PropertyExecutor {
+
+    public static PropertyExecutor.Builder builder(Consumer<InsertQueryExecutor> executeMethod) {
+        return new AutoValue_PropertyExecutor.Builder().executeMethod(executeMethod);
+    }
+
+    abstract Consumer<InsertQueryExecutor> executeMethod();
+
+    public void execute(InsertQueryExecutor executor) {
+        executeMethod().accept(executor);
+    }
+
+    abstract ImmutableSet<Var> requiredVars();
+
+    abstract ImmutableSet<Var> producedVars();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+        abstract Builder executeMethod(Consumer<InsertQueryExecutor> value);
+
+        abstract ImmutableSet.Builder<Var> requiredVarsBuilder();
+
+        public Builder requires(Var... values) {
+            requiredVarsBuilder().add(values);
+            return this;
+        }
+
+        public Builder requires(Iterable<Var> values) {
+            requiredVarsBuilder().addAll(values);
+            return this;
+        }
+
+        abstract ImmutableSet.Builder<Var> producedVarsBuilder();
+
+        public Builder produces(Var... values) {
+            producedVarsBuilder().add(values);
+            return this;
+        }
+
+        public Builder produces(Iterable<Var> values) {
+            producedVarsBuilder().addAll(values);
+            return this;
+        }
+
+        abstract PropertyExecutor build();
+    }
+}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
@@ -77,11 +77,6 @@ public abstract class RegexProperty extends AbstractVarProperty implements Uniqu
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public Atomic mapToAtom(VarPatternAdmin var, Set<VarPatternAdmin> vars, ReasonerQuery parent) {
         return new RegexAtom(var.var(), this, parent);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
@@ -71,9 +71,11 @@ public abstract class RegexProperty extends AbstractVarProperty implements Uniqu
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.get(var).asAttributeType().setRegex(regex());
-        }).requires(var).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.property.RegexAtom;
 import ai.grakn.util.StringUtil;
 import com.google.auto.value.AutoValue;
@@ -71,8 +70,10 @@ public abstract class RegexProperty extends AbstractVarProperty implements Uniqu
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.get(var).asAttributeType().setRegex(regex());
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.get(var).asAttributeType().setRegex(regex());
+        }).requires(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -30,7 +30,6 @@ import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.RelatesAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import com.google.auto.value.AutoValue;
@@ -88,9 +87,11 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Role role = executor.get(this.role().var()).asRole();
-        executor.get(var).asRelationshipType().relates(role);
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Role role = executor.get(this.role().var()).asRole();
+            executor.get(var).asRelationshipType().relates(role);
+        }).requires(var, role().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -95,11 +95,6 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(var, this.role().var());
-    }
-
-    @Override
     public void delete(GraknTx graph, Concept concept) {
         Label roleLabel = role().getTypeLabel().orElseThrow(() -> GraqlQueryException.failDelete(this));
         concept.asRelationshipType().deleteRelates(graph.getSchemaConcept(roleLabel));

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -88,10 +88,12 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Role role = executor.get(this.role().var()).asRole();
             executor.get(var).asRelationshipType().relates(role);
-        }).requires(var, role().var()).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(var, role().var()).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
@@ -35,7 +35,7 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
+import ai.grakn.graql.internal.query.QueryOperationExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.RelationAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.util.CommonUtil;
@@ -196,7 +196,7 @@ public abstract class RelationProperty extends AbstractVarProperty implements Un
      * @param relationship the concept representing the {@link Relationship}
      * @param relationPlayer a casting between a role type and role player
      */
-    private void addRoleplayer(InsertQueryExecutor executor, Relationship relationship, RelationPlayer relationPlayer) {
+    private void addRoleplayer(QueryOperationExecutor executor, Relationship relationship, RelationPlayer relationPlayer) {
         VarPatternAdmin roleVar = getRole(relationPlayer);
 
         Role role = executor.get(roleVar.var()).asRole();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
@@ -204,8 +204,7 @@ public abstract class RelationProperty extends AbstractVarProperty implements Un
         relationship.addRolePlayer(role, roleplayer);
     }
 
-    @Override
-    public Set<Var> requiredVars(Var var) {
+    private Set<Var> requiredVars(Var var) {
         Stream<Var> relationPlayers = this.relationPlayers().stream()
                 .flatMap(relationPlayer -> Stream.of(relationPlayer.getRolePlayer(), getRole(relationPlayer)))
                 .map(VarPatternAdmin::var);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
@@ -184,9 +184,11 @@ public abstract class RelationProperty extends AbstractVarProperty implements Un
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        Relationship relationship = executor.get(var).asRelationship();
-        relationPlayers().forEach(relationPlayer -> addRoleplayer(executor, relationship, relationPlayer));
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            Relationship relationship = executor.get(var).asRelationship();
+            relationPlayers().forEach(relationPlayer -> addRoleplayer(executor, relationship, relationPlayer));
+        }).requires(requiredVars(var)).build();
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationProperty.java
@@ -185,10 +185,12 @@ public abstract class RelationProperty extends AbstractVarProperty implements Un
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             Relationship relationship = executor.get(var).asRelationship();
             relationPlayers().forEach(relationPlayer -> addRoleplayer(executor, relationship, relationPlayer));
-        }).requires(requiredVars(var)).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(requiredVars(var)).build();
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RuleProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RuleProperty.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.util.ErrorMessage;
-import com.google.common.collect.ImmutableSet;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -50,16 +49,6 @@ public abstract class RuleProperty extends AbstractVarProperty implements Unique
     @Override
     public Collection<EquivalentFragmentSet> match(Var start) {
         throw new UnsupportedOperationException(ErrorMessage.MATCH_INVALID.getMessage(this.getName()));
-    }
-
-    @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of();
-    }
-
-    @Override
-    public final Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
     }
 
     @Nullable

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
@@ -89,7 +89,7 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
-            SchemaConcept superConcept = executor.get(SubProperty.this.superType().var()).asSchemaConcept();
+            SchemaConcept superConcept = executor.get(superType().var()).asSchemaConcept();
 
             Optional<ConceptBuilder> builder = executor.tryBuilder(var);
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
@@ -28,7 +28,6 @@ import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import ai.grakn.graql.internal.query.ConceptBuilder;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.SubAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import com.google.auto.value.AutoValue;
@@ -88,16 +87,18 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
     }
 
     @Override
-    public void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        SchemaConcept superConcept = executor.get(superType().var()).asSchemaConcept();
+    public PropertyExecutor define(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            SchemaConcept superConcept = executor.get(superType().var()).asSchemaConcept();
 
-        Optional<ConceptBuilder> builder = executor.tryBuilder(var);
+            Optional<ConceptBuilder> builder = executor.tryBuilder(var);
 
-        if (builder.isPresent()) {
-            builder.get().sub(superConcept);
-        } else {
-            ConceptBuilder.setSuper(executor.get(var).asSchemaConcept(), superConcept);
-        }
+            if (builder.isPresent()) {
+                builder.get().sub(superConcept);
+            } else {
+                ConceptBuilder.setSuper(executor.get(var).asSchemaConcept(), superConcept);
+            }
+        }).requires(superType().var()).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
@@ -102,16 +102,6 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of(superType().var());
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public Atomic mapToAtom(VarPatternAdmin var, Set<VarPatternAdmin> vars, ReasonerQuery parent) {
         Var varName = var.var().asUserDefined();
         VarPatternAdmin typeVar = this.superType();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
@@ -88,8 +88,8 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
-            SchemaConcept superConcept = executor.get(superType().var()).asSchemaConcept();
+        PropertyExecutor.Method method = executor -> {
+            SchemaConcept superConcept = executor.get(SubProperty.this.superType().var()).asSchemaConcept();
 
             Optional<ConceptBuilder> builder = executor.tryBuilder(var);
 
@@ -98,7 +98,9 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
             } else {
                 ConceptBuilder.setSuper(executor.get(var).asSchemaConcept(), superConcept);
             }
-        }).requires(superType().var()).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).requires(superType().var()).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
@@ -50,8 +50,10 @@ public abstract class ThenProperty extends RuleProperty {
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).then(pattern());
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
@@ -20,9 +20,8 @@ package ai.grakn.graql.internal.pattern.property;
 
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Pattern;
-import com.google.auto.value.AutoValue;
 import ai.grakn.graql.Var;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
+import com.google.auto.value.AutoValue;
 
 
 /**
@@ -50,7 +49,9 @@ public abstract class ThenProperty extends RuleProperty {
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).then(pattern());
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).then(pattern());
+        }).produces(var).build();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.ValuePredicateAdmin;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
 import ai.grakn.graql.internal.reasoner.atom.predicate.ValuePredicate;
 import ai.grakn.util.CommonUtil;
 import com.google.auto.value.AutoValue;
@@ -73,8 +72,10 @@ public abstract class ValueProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).value(predicate().equalsValue().get()); // TODO
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).value(predicate().equalsValue().get()); // TODO
+        }).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -73,9 +73,11 @@ public abstract class ValueProperty extends AbstractVarProperty implements Named
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).value(predicate().equalsValue().get()); // TODO
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -79,16 +79,6 @@ public abstract class ValueProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public Set<Var> requiredVars(Var var) {
-        return ImmutableSet.of();
-    }
-
-    @Override
-    public Set<Var> producedVars(Var var) {
-        return ImmutableSet.of(var);
-    }
-
-    @Override
     public void checkInsertable(VarPatternAdmin var) {
         if (!predicate().equalsValue().isPresent()) {
             throw GraqlQueryException.insertPredicate();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
@@ -27,7 +27,6 @@ import ai.grakn.graql.admin.VarProperty;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 
 import java.util.Collection;
-import java.util.Set;
 import java.util.stream.Stream;
 
 /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
@@ -68,7 +68,7 @@ public interface VarPropertyInternal extends VarProperty {
      */
     PropertyExecutor insert(Var var) throws GraqlQueryException;
 
-    void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException;
+    PropertyExecutor define(Var var) throws GraqlQueryException;
 
     /**
      * Get all {@link Var}s whose {@link Concept} must exist for the subject {@link Var} to be created.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
@@ -25,8 +25,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.admin.VarProperty;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.Set;
@@ -56,47 +54,13 @@ public interface VarPropertyInternal extends VarProperty {
     Collection<EquivalentFragmentSet> match(Var start);
 
     /**
-     * Insert the given property into the graph, if possible.
+     * Returns a {@link PropertyExecutor} that describes how to insert the given {@link VarProperty} into.
      *
-     * @param var      the subject var of the property
-     * @param executor a class providing a map of concepts already inserted and methods to build new concepts.
-     *                 <p>
-     *                 This method can expect any key to be here that is returned from
-     *                 {@link #requiredVars(Var)}. The method may also build a concept provided that key is returned
-     *                 from {@link #producedVars(Var)}.
-     *                 </p>
+     * @throws GraqlQueryException if this {@link VarProperty} cannot be inserted
      */
     PropertyExecutor insert(Var var) throws GraqlQueryException;
 
     PropertyExecutor define(Var var) throws GraqlQueryException;
-
-    /**
-     * Get all {@link Var}s whose {@link Concept} must exist for the subject {@link Var} to be created.
-     * For example, for {@link IsaProperty} the type must already be present before an instance can be created.
-     *
-     * When calling {@link #insert}, the method can expect any entry returned here to be in the
-     * map of concepts.
-     *
-     * @param var the subject var of the property.
-     */
-    Set<Var> requiredVars(Var var);
-
-    /**
-     * Get all {@link Var}s whose {@link Concept} can only be created after this property is applied.
-     *
-     * <p>
-     *     When calling {@link #insert}, the method must add an entry for every {@link Var} returned
-     *     from this method.
-     * </p>
-     * <p>
-     *     The default implementation returns an empty set.
-     * </p>
-     *
-     * @param var the subject var of the property.
-     */
-    default Set<Var> producedVars(Var var) {
-        return ImmutableSet.of();
-    }
 
     /**
      * Whether this property will uniquely identify a concept in the graph, if one exists.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
@@ -66,7 +66,7 @@ public interface VarPropertyInternal extends VarProperty {
      *                 from {@link #producedVars(Var)}.
      *                 </p>
      */
-    void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException;
+    PropertyExecutor insert(Var var) throws GraqlQueryException;
 
     void define(Var var, InsertQueryExecutor executor) throws GraqlQueryException;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
@@ -49,8 +49,10 @@ public abstract class WhenProperty extends RuleProperty {
 
     @Override
     public PropertyExecutor insert(Var var) throws GraqlQueryException {
-        return PropertyExecutor.builder(executor -> {
+        PropertyExecutor.Method method = executor -> {
             executor.builder(var).when(pattern());
-        }).produces(var).build();
+        };
+
+        return PropertyExecutor.builder(method).produces(var).build();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
@@ -20,9 +20,8 @@ package ai.grakn.graql.internal.pattern.property;
 
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Pattern;
-import com.google.auto.value.AutoValue;
 import ai.grakn.graql.Var;
-import ai.grakn.graql.internal.query.InsertQueryExecutor;
+import com.google.auto.value.AutoValue;
 
 /**
  * Represents the {@code when} property on a {@link ai.grakn.concept.Rule}.
@@ -49,7 +48,9 @@ public abstract class WhenProperty extends RuleProperty {
     }
 
     @Override
-    public void insert(Var var, InsertQueryExecutor executor) throws GraqlQueryException {
-        executor.builder(var).when(pattern());
+    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+        return PropertyExecutor.builder(executor -> {
+            executor.builder(var).when(pattern());
+        }).produces(var).build();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
@@ -80,7 +80,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class ConceptBuilder {
 
-    private final InsertQueryExecutor executor;
+    private final QueryOperationExecutor executor;
 
     private final Var var;
 
@@ -155,7 +155,7 @@ public class ConceptBuilder {
         return set(THEN, then);
     }
 
-    static ConceptBuilder of(InsertQueryExecutor executor, Var var) {
+    static ConceptBuilder of(QueryOperationExecutor executor, Var var) {
         return new ConceptBuilder(executor, var);
     }
 
@@ -246,7 +246,7 @@ public class ConceptBuilder {
     private static final BuilderParam<Pattern> WHEN = () -> WhenProperty.NAME;
     private static final BuilderParam<Pattern> THEN = () -> ThenProperty.NAME;
 
-    private ConceptBuilder(InsertQueryExecutor executor, Var var) {
+    private ConceptBuilder(QueryOperationExecutor executor, Var var) {
         this.executor = executor;
         this.var = var;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
@@ -62,7 +62,7 @@ abstract class DefineQueryImpl implements DefineQuery {
         ImmutableList<VarPatternAdmin> allPatterns =
                 varPatterns().stream().flatMap(v -> v.innerVarPatterns().stream()).collect(toImmutableList());
         
-        return InsertQueryExecutor.defineAll(allPatterns, tx);
+        return QueryOperationExecutor.defineAll(allPatterns, tx);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
@@ -440,7 +440,7 @@ public class InsertQueryExecutor {
         }
 
         void define(InsertQueryExecutor executor) {
-            property().define(var(), executor);
+            property().define(var()).execute(executor);
         }
 
         Set<Var> requiredVars() {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
@@ -436,7 +436,7 @@ public class InsertQueryExecutor {
         }
 
         void insert(InsertQueryExecutor executor) {
-            property().insert(var(), executor);
+            property().insert(var()).execute(executor);
         }
 
         void define(InsertQueryExecutor executor) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryExecutor.java
@@ -319,7 +319,7 @@ public class InsertQueryExecutor {
      * <p>
      * This method is expected to be called from implementations of
      * {@link VarPropertyInternal#insert(Var)}, provided they return the given {@link Var} in the
-     * response to {@link VarPropertyInternal#producedVars(Var)}.
+     * response to {@link PropertyExecutor#producedVars()}.
      * </p>
      * <p>
      * For example, a property may call {@code executor.builder(var).isa(type);} in order to provide a type for a var.
@@ -341,7 +341,7 @@ public class InsertQueryExecutor {
      * <p>
      * This method is expected to be called from implementations of
      * {@link VarPropertyInternal#insert(Var)}, provided they return the given {@link Var} in the
-     * response to {@link VarPropertyInternal#producedVars(Var)}.
+     * response to {@link PropertyExecutor#producedVars()}.
      * </p>
      * <p>
      * For example, a property may call {@code executor.builder(var).isa(type);} in order to provide a type for a var.
@@ -374,7 +374,7 @@ public class InsertQueryExecutor {
      * <p>
      * This method is expected to be called from implementations of
      * {@link VarPropertyInternal#insert(Var)}, provided they return the given {@link Var} in the
-     * response to {@link VarPropertyInternal#requiredVars(Var)}.
+     * response to {@link PropertyExecutor#requiredVars()}.
      * </p>
      */
     public Concept get(Var var) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -109,9 +109,9 @@ class InsertQueryImpl implements InsertQueryAdmin {
         GraknTx theGraph = getTx().orElseThrow(GraqlQueryException::noTx);
 
         return matchQuery.map(
-                query -> query.stream().map(answer -> InsertQueryExecutor.insertAll(vars, theGraph, answer))
+                query -> query.stream().map(answer -> QueryOperationExecutor.insertAll(vars, theGraph, answer))
         ).orElseGet(
-                () -> Stream.of(InsertQueryExecutor.insertAll(vars, theGraph))
+                () -> Stream.of(QueryOperationExecutor.insertAll(vars, theGraph))
         );
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryOperationExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryOperationExecutor.java
@@ -32,7 +32,6 @@ import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.pattern.property.PropertyExecutor;
 import ai.grakn.graql.internal.pattern.property.VarPropertyInternal;
 import ai.grakn.graql.internal.util.Partition;
-import ai.grakn.util.CommonUtil;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -441,14 +440,7 @@ public class QueryOperationExecutor {
         }
 
         private PropertyExecutor executor(ExecutionType executionType) {
-            switch (executionType) {
-                case INSERT:
-                    return property().insert(var());
-                case DEFINE:
-                    return property().define(var());
-                default:
-                    throw CommonUtil.unreachableStatement("enum switch statement");
-            }
+            return executionType.executor(property(), var());
         }
 
         boolean uniquelyIdentifiesConcept() {
@@ -457,6 +449,17 @@ public class QueryOperationExecutor {
     }
 
     private enum ExecutionType {
-        INSERT, DEFINE
+        INSERT {
+            PropertyExecutor executor(VarPropertyInternal property, Var var) {
+                return property.insert(var);
+            }
+        },
+        DEFINE {
+            PropertyExecutor executor(VarPropertyInternal property, Var var) {
+                return property.define(var);
+            }
+        };
+
+        abstract PropertyExecutor executor(VarPropertyInternal property, Var var);
     }
 }


### PR DESCRIPTION
This is to allow us to introduce `undefine` queries, using the same `InsertQueryExecutor` (now `QueryOperationExecutor`).