### PR TITLE
Optimise traversal to avoid checking for edge instances

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
@@ -91,7 +91,7 @@ public class Fragments {
     }
 
     public static Fragment inIsa(VarProperty varProperty, Var start, Var end) {
-        return new AutoValue_InIsaFragment(varProperty, start, end);
+        return new AutoValue_InIsaFragment(varProperty, start, end, true);
     }
 
     public static Fragment outIsa(VarProperty varProperty, Var start, Var end) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/Fragments.java
@@ -90,8 +90,8 @@ public class Fragments {
         return new AutoValue_OutRelatesFragment(varProperty, start, end);
     }
 
-    public static Fragment inIsa(VarProperty varProperty, Var start, Var end) {
-        return new AutoValue_InIsaFragment(varProperty, start, end, true);
+    public static Fragment inIsa(VarProperty varProperty, Var start, Var end, boolean mayHaveEdgeInstances) {
+        return new AutoValue_InIsaFragment(varProperty, start, end, mayHaveEdgeInstances);
     }
 
     public static Fragment outIsa(VarProperty varProperty, Var start, Var end) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
@@ -60,6 +60,8 @@ abstract class InIsaFragment extends Fragment {
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, GraknTx graph, Collection<Var> vars) {
 
+        GraphTraversal<Element, Vertex> vertexTraversal = Fragments.isVertex(traversal);
+
         if (mayHaveEdgeInstances()) {
             GraphTraversal<Vertex, Vertex> isImplicitRelationType =
                     __.<Vertex>hasLabel(RELATIONSHIP_TYPE.name()).has(IS_IMPLICIT.name(), true);
@@ -69,12 +71,12 @@ abstract class InIsaFragment extends Fragment {
                     toEdgeInstances()
             ));
 
-            return choose(Fragments.isVertex(traversal), isImplicitRelationType,
+            return choose(vertexTraversal, isImplicitRelationType,
                     toVertexAndEdgeInstances,
                     toVertexInstances(__.identity())
             );
         } else {
-            return toVertexInstances(Fragments.isVertex(traversal));
+            return toVertexInstances(vertexTraversal);
         }
     }
 
@@ -121,7 +123,7 @@ abstract class InIsaFragment extends Fragment {
 
     @Override
     public String name() {
-        return "<-[isa]-";
+        return String.format("<-[isa:%s]-", mayHaveEdgeInstances() ? "with-edges" : "");
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
@@ -54,22 +54,28 @@ abstract class InIsaFragment extends Fragment {
     @Override
     public abstract Var end();
 
+    abstract boolean mayHaveEdgeInstances();
+
     @Override
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, GraknTx graph, Collection<Var> vars) {
 
-        GraphTraversal<Vertex, Vertex> isImplicitRelationType =
-                __.<Vertex>hasLabel(RELATIONSHIP_TYPE.name()).has(IS_IMPLICIT.name(), true);
+        if (mayHaveEdgeInstances()) {
+            GraphTraversal<Vertex, Vertex> isImplicitRelationType =
+                    __.<Vertex>hasLabel(RELATIONSHIP_TYPE.name()).has(IS_IMPLICIT.name(), true);
 
-        GraphTraversal<Vertex, Element> toVertexAndEdgeInstances = Fragments.union(ImmutableSet.of(
-                toVertexInstances(__.identity()),
-                toEdgeInstances()
-        ));
+            GraphTraversal<Vertex, Element> toVertexAndEdgeInstances = Fragments.union(ImmutableSet.of(
+                    toVertexInstances(__.identity()),
+                    toEdgeInstances()
+            ));
 
-        return choose(Fragments.isVertex(traversal), isImplicitRelationType,
-                toVertexAndEdgeInstances,
-                toVertexInstances(__.identity())
-        );
+            return choose(Fragments.isVertex(traversal), isImplicitRelationType,
+                    toVertexAndEdgeInstances,
+                    toVertexInstances(__.identity())
+            );
+        } else {
+            return toVertexInstances(Fragments.isVertex(traversal));
+        }
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/InIsaFragment.java
@@ -60,7 +60,7 @@ abstract class InIsaFragment extends Fragment {
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, GraknTx graph, Collection<Var> vars) {
 
-        GraphTraversal<Element, Vertex> vertexTraversal = Fragments.isVertex(traversal);
+        GraphTraversal<Vertex, Vertex> vertexTraversal = Fragments.isVertex(traversal);
 
         if (mayHaveEdgeInstances()) {
             GraphTraversal<Vertex, Vertex> isImplicitRelationType =

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/sets/EquivalentFragmentSets.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/sets/EquivalentFragmentSets.java
@@ -46,7 +46,8 @@ public class EquivalentFragmentSets {
             ResourceIndexFragmentSet.RESOURCE_INDEX_OPTIMISATION,
             RolePlayerFragmentSet.RELATION_TYPE_OPTIMISATION,
             LabelFragmentSet.REDUNDANT_LABEL_ELIMINATION_OPTIMISATION,
-            SubFragmentSet.SUB_TRAVERSAL_ELIMINATION_OPTIMISATION
+            SubFragmentSet.SUB_TRAVERSAL_ELIMINATION_OPTIMISATION,
+            IsaFragmentSet.SKIP_EDGE_INSTANCE_CHECK_OPTIMISATION
     );
 
     /**
@@ -92,7 +93,7 @@ public class EquivalentFragmentSets {
      * An {@link EquivalentFragmentSet} that indicates a variable is a direct instance of a type.
      */
     public static EquivalentFragmentSet isa(VarProperty varProperty, Var instance, Var type) {
-        return new IsaFragmentSet(varProperty, instance, type);
+        return new IsaFragmentSet(varProperty, instance, type, true);
     }
 
     /**

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/GraqlTraversalTest.java
@@ -90,7 +90,7 @@ public class GraqlTraversalTest {
     private static final Fragment xValue = value(null, x, eq("hello"));
     private static final Fragment yId = id(null, y, ConceptId.of("movie"));
     private static final Fragment xIsaY = outIsa(null, x, y);
-    private static final Fragment yTypeOfX = inIsa(null, y, x);
+    private static final Fragment yTypeOfX = inIsa(null, y, x, true);
 
     private static final GraqlTraversal fastIsaTraversal = traversal(yId, yTypeOfX);
     private static GraknTx tx;
@@ -136,7 +136,7 @@ public class GraqlTraversalTest {
     @Test
     public void testComplexityConnectedVsDisconnected() {
         GraqlTraversal connectedDoubleIsa = traversal(xIsaY, outIsa(null, y, z));
-        GraqlTraversal disconnectedDoubleIsa = traversal(xIsaY, inIsa(null, z, y));
+        GraqlTraversal disconnectedDoubleIsa = traversal(xIsaY, inIsa(null, z, y, true));
         assertFaster(connectedDoubleIsa, disconnectedDoubleIsa);
     }
 
@@ -159,7 +159,7 @@ public class GraqlTraversalTest {
         GraqlTraversal fromInstance =
                 traversal(outIsa(null, x, xx), id(null, xx, ConceptId.of("_")), inRolePlayer(x, z), outRolePlayer(z, y));
         GraqlTraversal fromType =
-                traversal(id(null, xx, ConceptId.of("_")), inIsa(null, xx, x), inRolePlayer(x, z), outRolePlayer(z, y));
+                traversal(id(null, xx, ConceptId.of("_")), inIsa(null, xx, x, true), inRolePlayer(x, z), outRolePlayer(z, y));
         assertFaster(fromType, fromInstance);
     }
 


### PR DESCRIPTION
If the query can already tell that a traversal does not go to edge instances, then it doesn't have to be checked mid-traversal.