### PR TITLE
fixing incorrect path in DistributionContext

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
@@ -151,7 +151,7 @@ public class DistributionContext extends ExternalResource {
         // Java commands to start Engine process
         String[] commands = {"java",
                 "-cp", getClassPath(),
-                "-Dgrakn.dir=" + DIST_DIRECTORY + "/bin",
+                "-Dgrakn.dir=" + DIST_DIRECTORY + "/services",
                 "-Dgrakn.conf=" + propertiesFile.getAbsolutePath(),
                 "ai.grakn.engine.GraknEngineServer", "&"};
 


### PR DESCRIPTION
I recently noticed that the test throws a couple of `java.io.FileNotFoundException`s. It failed to find the path to log files as can be observed [here](https://travis-ci.org/graknlabs/grakn/jobs/278270538).

The reason was an incorrect path in `DistributionContext`, which is what this PR fixes.
