### PR TITLE
Java API Endpoints: Informative error message in case of missing field 

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
@@ -74,7 +74,7 @@ import static java.util.stream.Collectors.toList;
  *
  * @author alexandraorth
  */
-@Path("/graph")
+@Path("/kb")
 public class ConceptController {
 
     private static final int separationDegree = 1;

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeController.java
@@ -34,6 +34,7 @@ import spark.Service;
 
 import java.util.Optional;
 
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
 import static ai.grakn.engine.controller.util.Requests.mandatoryPathParameter;
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
@@ -66,7 +67,7 @@ public class AttributeController {
         LOG.debug("postAttribute - request received.");
         String attributeTypeLabel = mandatoryPathParameter(request, ATTRIBUTE_TYPE_LABEL_PARAMETER);
         Json requestBody = Json.read(mandatoryBody(request));
-        String attributeValue = requestBody.at(VALUE_JSON_FIELD).asString();
+        String attributeValue = extractJsonField(requestBody, VALUE_JSON_FIELD).asString();
         String keyspace = mandatoryQueryParameter(request, KEYSPACE);
         LOG.debug("postAttribute - attempting to find attributeType " + attributeTypeLabel + " in keyspace " + keyspace);
         try (GraknTx tx = factory.tx(Keyspace.of(keyspace), GraknTxType.WRITE)) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeTypeController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeTypeController.java
@@ -35,6 +35,7 @@ import spark.Service;
 
 import java.util.Optional;
 
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
 import static ai.grakn.engine.controller.util.Requests.mandatoryPathParameter;
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
@@ -67,8 +68,8 @@ public class AttributeTypeController {
     private Json postAttributeType(Request request, Response response) {
         LOG.debug("postAttributeType - request received.");
         Json requestBody = Json.read(mandatoryBody(request));
-        String attributeTypeLabel = requestBody.at(ATTRIBUTE_TYPE_OBJECT_JSON_FIELD).at(LABEL_JSON_FIELD).asString();
-        String attributeTypeDataTypeRaw = requestBody.at(ATTRIBUTE_TYPE_OBJECT_JSON_FIELD).at(TYPE_JSON_FIELD).asString();
+        String attributeTypeLabel = extractJsonField(requestBody, ATTRIBUTE_TYPE_OBJECT_JSON_FIELD, LABEL_JSON_FIELD).asString();
+        String attributeTypeDataTypeRaw = extractJsonField(requestBody, ATTRIBUTE_TYPE_OBJECT_JSON_FIELD, TYPE_JSON_FIELD).asString();
         AttributeType.DataType<?> attributeTypeDataType = fromString(attributeTypeDataTypeRaw);
         String keyspace = mandatoryQueryParameter(request, KEYSPACE);
         LOG.debug("postAttributeType - attempting to add new attributeType " + attributeTypeLabel + " of type " + attributeTypeDataTypeRaw);

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/EntityTypeController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/EntityTypeController.java
@@ -36,6 +36,7 @@ import spark.Service;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
 import static ai.grakn.engine.controller.util.Requests.mandatoryPathParameter;
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
@@ -96,7 +97,7 @@ public class EntityTypeController {
     private Json postEntityType(Request request, Response response) {
         LOG.debug("postEntityType - request received");
         Json requestBody = Json.read(mandatoryBody(request));
-        String entityTypeLabel = requestBody.at(ENTITY_TYPE_OBJECT_JSON_FIELD).at(LABEL_JSON_FIELD).asString();
+        String entityTypeLabel = extractJsonField(requestBody, ENTITY_TYPE_OBJECT_JSON_FIELD, LABEL_JSON_FIELD).asString();
         String keyspace = mandatoryQueryParameter(request, KEYSPACE);
         LOG.debug("postEntityType - attempting to add entityType " + entityTypeLabel + " in keyspace " + keyspace);
         try (GraknTx tx = factory.tx(Keyspace.of(keyspace), GraknTxType.WRITE)) {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RelationshipTypeController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RelationshipTypeController.java
@@ -35,6 +35,7 @@ import spark.Service;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
 import static ai.grakn.engine.controller.util.Requests.mandatoryPathParameter;
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
@@ -90,8 +91,8 @@ public class RelationshipTypeController {
     private Json postRelationshipType(Request request, Response response) {
         LOG.debug("postRelationshipType - request received.");
         Json requestBody = Json.read(mandatoryBody(request));
-        String relationshipTypeLabel = requestBody.at(RELATIONSHIP_TYPE_OBJECT_JSON_FIELD).at(LABEL_JSON_FIELD).asString();
-        Stream<String> roleLabels = requestBody.at(RELATIONSHIP_TYPE_OBJECT_JSON_FIELD).at(ROLE_ARRAY_JSON_FIELD).asList().stream().map(e -> (String) e);
+        String relationshipTypeLabel = extractJsonField(requestBody, RELATIONSHIP_TYPE_OBJECT_JSON_FIELD, LABEL_JSON_FIELD).asString();
+        Stream<String> roleLabels = extractJsonField(requestBody, RELATIONSHIP_TYPE_OBJECT_JSON_FIELD, ROLE_ARRAY_JSON_FIELD).asList().stream().map(e -> (String) e);
         String keyspace = mandatoryQueryParameter(request, KEYSPACE);
 
         LOG.debug("postRelationshipType - attempting to add a new relationshipType " + relationshipTypeLabel + " on keyspace " + keyspace);

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RuleController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RuleController.java
@@ -32,6 +32,7 @@ import spark.Service;
 
 import java.util.Optional;
 
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
 import static ai.grakn.engine.controller.util.Requests.mandatoryPathParameter;
 import static ai.grakn.engine.controller.util.Requests.mandatoryQueryParameter;
@@ -89,9 +90,9 @@ public class RuleController {
     private Json postRule(Request request, Response response) {
         LOG.debug("postRule - request received.");
         Json requestBody = Json.read(mandatoryBody(request));
-        String ruleLabel = requestBody.at(RULE_OBJECT_JSON_FIELD).at(LABEL_JSON_FIELD).asString();
-        String when = requestBody.at(RULE_OBJECT_JSON_FIELD).at(WHEN_JSON_FIELD).asString();
-        String then = requestBody.at(RULE_OBJECT_JSON_FIELD).at(THEN_JSON_FIELD).asString();
+        String ruleLabel = extractJsonField(requestBody, RULE_OBJECT_JSON_FIELD, LABEL_JSON_FIELD).asString();
+        String when = extractJsonField(requestBody, RULE_OBJECT_JSON_FIELD, WHEN_JSON_FIELD).asString();
+        String then = extractJsonField(requestBody, RULE_OBJECT_JSON_FIELD, THEN_JSON_FIELD).asString();
 
         String keyspace = mandatoryQueryParameter(request, KEYSPACE);
         LOG.debug("postRule - attempting to add a new rule " + ruleLabel + " on keyspace " + keyspace);

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
@@ -95,7 +95,7 @@ public class Requests {
      * Given a {@link Json} object, attempt to extract a single field as supplied,
      * or throw a user-friendly exception clearly indicating the missing field
      * @param json the {@link Json} object containing the field to be extracted
-     * @param fieldPath vargargs denoting the path of the field to be extracted
+     * @param fieldPath String varargs representing the path of the field to be extracted
      * @return the extracted {@link Json} object
      * @throws {@link GraknServerException} with a clear indication of the missing field
      */

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/util/Requests.java
@@ -21,6 +21,8 @@ package ai.grakn.engine.controller.util;
 import ai.grakn.exception.GraknServerException;
 import java.util.Optional;
 import java.util.function.Function;
+
+import mjson.Json;
 import spark.Request;
 
 /**
@@ -88,4 +90,28 @@ public class Requests {
 
         return parameterValue;
     }
+
+    /**
+     * Given a {@link Json} object, attempt to extract a single field as supplied,
+     * or throw a user-friendly exception clearly indicating the missing field
+     * @param json the {@link Json} object containing the field to be extracted
+     * @param fieldPath vargargs denoting the path of the field to be extracted
+     * @return the extracted {@link Json} object
+     * @throws {@link GraknServerException} with a clear indication of the missing field
+     */
+    public static Json extractJsonField(Json json, String... fieldPath) {
+        Json currentField = json;
+
+        for (String field : fieldPath) {
+            Json tmp = currentField.at(field);
+            if (tmp != null) {
+                currentField = tmp;
+            } else {
+                throw GraknServerException.requestMissingBodyParameters(field);
+            }
+        }
+
+        return currentField;
+    }
+
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/util/RequestsTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/util/RequestsTest.java
@@ -1,0 +1,47 @@
+package ai.grakn.engine.controller.util;
+
+import ai.grakn.exception.GraknServerException;
+import mjson.Json;
+import org.junit.Test;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import static ai.grakn.engine.controller.util.Requests.extractJsonField;
+
+public class RequestsTest {
+    @Test
+    public void extractJsonField_MustExtractTopLevelFieldCorrectly() {
+        String topLevelFieldValue = "topLevelFieldValue";
+        Json input = Json.object("topLevelField", topLevelFieldValue);
+        String extractedTopLevelField = extractJsonField(input, "topLevelField").asString();
+        assertThat(extractedTopLevelField, equalTo(topLevelFieldValue));
+    }
+
+    @Test
+    public void extractJsonField_MustExtractNestedFieldCorrectly() {
+        String nestedFieldValue = "nestedFieldValue";
+        Json input = Json.object("topLevelField",
+            Json.object("nestedField", nestedFieldValue)
+        );
+        String extractedNestedField = extractJsonField(input, "topLevelField", "nestedField").asString();
+        assertThat(extractedNestedField, equalTo(nestedFieldValue));
+    }
+
+    @Test
+    public void extractJsonField_MustThrowInformativeError() {
+        String nestedFieldValue = "nestedFieldValue";
+        Json input = Json.object("topLevelField",
+            Json.object("incorrectlyNamedNestedField", nestedFieldValue)
+        );
+
+        // test if exception is properly thrown
+        boolean errorMessageThrown_ContainingMissingFieldInfo;
+        try {
+            extractJsonField(input, "topLevelField", "nestedField").asString();
+            errorMessageThrown_ContainingMissingFieldInfo = false;
+        } catch (GraknServerException e) {
+            errorMessageThrown_ContainingMissingFieldInfo = e.getMessage().contains("nestedField");
+        }
+        assertThat(errorMessageThrown_ContainingMissingFieldInfo, equalTo(true));
+    }
+}

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/util/RequestsTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/util/RequestsTest.java
@@ -29,6 +29,9 @@ public class RequestsTest {
 
     @Test
     public void extractJsonField_MustThrowInformativeError() {
+        // in this test, extractJsonField expects the existence of a field "topLevelField.nestedField"
+        // however, the input incorrectly contains "topLevelField.incorrectlyNamedNestedField" instead
+
         String nestedFieldValue = "nestedFieldValue";
         Json input = Json.object("topLevelField",
             Json.object("incorrectlyNamedNestedField", nestedFieldValue)
@@ -37,11 +40,12 @@ public class RequestsTest {
         // test if exception is properly thrown
         boolean errorMessageThrown_ContainingMissingFieldInfo;
         try {
-            extractJsonField(input, "topLevelField", "nestedField").asString();
+            extractJsonField(input, "topLevelField", "nestedField");
             errorMessageThrown_ContainingMissingFieldInfo = false;
         } catch (GraknServerException e) {
             errorMessageThrown_ContainingMissingFieldInfo = e.getMessage().contains("nestedField");
         }
+
         assertThat(errorMessageThrown_ContainingMissingFieldInfo, equalTo(true));
     }
 }


### PR DESCRIPTION
When a JSON field is missing in the request body, Grakn will now respond with a better error message.

For example, `{"exception":"Missing mandatory parameter in body [label]"}` is returned when a mandatory field `label` is missing in the request