### PR TITLE
Add `GraqlParser` with parameter to define all vars

### DIFF
--- a/docs/pages/documentation/6-developing-with-java/java-api.md
+++ b/docs/pages/documentation/6-developing-with-java/java-api.md
@@ -282,11 +282,11 @@ Pattern rule2then = var().rel("ancestor", "p").rel("descendant", "d").isa("Ances
 If we have a specific `GraknTx tx` already defined, we can use the Graql pattern parser:
 
 ```java
-rule1when = and(tx.graql().parsePatterns("(parent: $p, child: $c) isa Parent;"));
-rule1then = and(tx.graql().parsePatterns("(ancestor: $p, descendant: $c) isa Ancestor;"));
+rule1when = and(tx.graql().parser().parsePatterns("(parent: $p, child: $c) isa Parent;"));
+rule1then = and(tx.graql().parser().parsePatterns("(ancestor: $p, descendant: $c) isa Ancestor;"));
 
-rule2when = and(tx.graql().parsePatterns("(parent: $p, child: $c) isa Parent;(ancestor: $c, descendant: $d) isa Ancestor;"));
-rule2then = and(tx.graql().parsePatterns("(ancestor: $p, descendant: $d) isa Ancestor;"));
+rule2when = and(tx.graql().parser().parsePatterns("(parent: $p, child: $c) isa Parent;(ancestor: $c, descendant: $d) isa Ancestor;"));
+rule2then = and(tx.graql().parser().parsePatterns("(ancestor: $p, descendant: $d) isa Ancestor;"));
 ```
 
 We conclude the rule creation with defining the rules from their constituent patterns:

--- a/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryBuilder.java
@@ -19,14 +19,9 @@
 package ai.grakn.graql;
 
 import ai.grakn.concept.SchemaConcept;
-import ai.grakn.graql.macro.Macro;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Stream;
 
 /**
  * Starting point for creating queries
@@ -98,18 +93,9 @@ public interface QueryBuilder {
     ComputeQueryBuilder compute();
 
     /**
-     * @param patternsString a string representing a list of patterns
-     * @return a list of patterns
+     * Get a {@link QueryParser} for parsing queries from strings
      */
-    @CheckReturnValue
-    List<Pattern> parsePatterns(String patternsString);
-
-    /**
-     * @param patternString a string representing a pattern
-     * @return a pattern
-     */
-    @CheckReturnValue
-    Pattern parsePattern(String patternString);
+    QueryParser parser();
 
     /**
      * @param queryString a string representing a query
@@ -117,34 +103,6 @@ public interface QueryBuilder {
      */
     @CheckReturnValue
     <T extends Query<?>> T parse(String queryString);
-
-    /**
-     * @param queryString a string representing several queries
-     * @return a list of queries
-     */
-    @CheckReturnValue
-    <T extends Query<?>> Stream<T> parseList(String queryString);
-
-    /**
-     * @param template a string representing a templated graql query
-     * @param data data to use in template
-     * @return a query, the type will depend on the type of template.
-     */
-    @CheckReturnValue
-    <T extends Query<?>> Stream<T> parseTemplate(String template, Map<String, Object> data);
-
-    /**
-     * Register an aggregate that can be used when parsing a Graql query
-     * @param name the name of the aggregate
-     * @param aggregateMethod a function that will produce an aggregate when passed a list of arguments
-     */
-    void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod);
-
-    /**
-     * Register a macro that can be used when parsing a Graql template
-     * @param macro the macro to register
-     */
-    void registerMacro(Macro macro);
 
     /**
      * Enable or disable inference

--- a/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
@@ -1,0 +1,60 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ *
+ */
+
+package ai.grakn.graql;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * Class for parsing query strings into valid queries
+ *
+ * @author Felix Chapman
+ */
+public interface QueryParser {
+
+    void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod);
+
+    /**
+     * @param queryString a string representing a query
+     * @return
+     * a query, the type will depend on the type of query.
+     */
+    @SuppressWarnings("unchecked")
+    <T extends Query<?>> T parseQuery(String queryString);
+
+    /**
+     * @param queryString a string representing several queries
+     * @return a list of queries
+     */
+    <T extends Query<?>> Stream<T> parseList(String queryString);
+
+    /**
+     * @param patternsString a string representing a list of patterns
+     * @return a list of patterns
+     */
+    List<Pattern> parsePatterns(String patternsString);
+
+    /**
+     * @param patternString a string representing a pattern
+     * @return a pattern
+     */
+    Pattern parsePattern(String patternString);
+}

--- a/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
@@ -78,4 +78,17 @@ public interface QueryParser {
      * @param macro the macro to register
      */
     void registerMacro(Macro macro);
+
+    /**
+     * Set whether the parser should set all {@link Var}s as user-defined. If it does, then every variable will
+     * generate a user-defined name and be returned in results. For example:
+     * <pre>
+     *     match ($x, $y);
+     * </pre>
+     *
+     * The previous query would normally return only two concepts per result for {@code $x} and {@code $y}. However,
+     * if the flag is set it will also return a third variable with a random name representing the relation
+     * {@code $123 ($x, $y)}.
+     */
+    void defineAllVars(boolean defineAllVars);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/QueryParser.java
@@ -19,7 +19,10 @@
 
 package ai.grakn.graql;
 
+import ai.grakn.graql.macro.Macro;
+
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -29,8 +32,6 @@ import java.util.stream.Stream;
  * @author Felix Chapman
  */
 public interface QueryParser {
-
-    void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod);
 
     /**
      * @param queryString a string representing a query
@@ -57,4 +58,24 @@ public interface QueryParser {
      * @return a pattern
      */
     Pattern parsePattern(String patternString);
+
+    /**
+     * @param template a string representing a templated graql query
+     * @param data     data to use in template
+     * @return a resolved graql query
+     */
+    <T extends Query<?>> Stream<T> parseTemplate(String template, Map<String, Object> data);
+
+    /**
+     * Register an aggregate that can be used when parsing a Graql query
+     * @param name the name of the aggregate
+     * @param aggregateMethod a function that will produce an aggregate when passed a list of arguments
+     */
+    void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod);
+
+    /**
+     * Register a macro that can be used when parsing a Graql template
+     * @param macro the macro to register
+     */
+    void registerMacro(Macro macro);
 }

--- a/grakn-core/src/main/java/ai/grakn/util/REST.java
+++ b/grakn-core/src/main/java/ai/grakn/util/REST.java
@@ -190,6 +190,7 @@ public class REST {
             public static final String INFER = "infer";
             public static final String MATERIALISE = "materialise";
             public static final String LIMIT_EMBEDDED = "limitEmbedded";
+            public static final String DEFINE_ALL_VARS = "defineAllVars";
         }
     }
 

--- a/grakn-dist/src/test/java/ai/grakn/dist/ExamplesTest.java
+++ b/grakn-dist/src/test/java/ai/grakn/dist/ExamplesTest.java
@@ -68,6 +68,6 @@ public class ExamplesTest {
 
     private void runInsertQuery(String path) throws IOException {
         String query = Files.readAllLines(Paths.get(path)).stream().collect(joining("\n"));
-        tx.graql().parseList(query).forEach(Query::execute);
+        tx.graql().parser().parseList(query).forEach(Query::execute);
     }
 }

--- a/grakn-dist/src/test/java/ai/grakn/dist/PhilosophersExampleIT.java
+++ b/grakn-dist/src/test/java/ai/grakn/dist/PhilosophersExampleIT.java
@@ -70,7 +70,7 @@ public class PhilosophersExampleIT {
 
     private static void runQueries(String path) throws IOException {
         String query = Files.readAllLines(Paths.get(path)).stream().collect(joining("\n"));
-        qb.parseList(query).forEach(Query::execute);
+        qb.parser().parseList(query).forEach(Query::execute);
     }
 
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
@@ -54,6 +54,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.util.ArrayList;
+import java.util.Optional;
 
 import static ai.grakn.GraknTxType.WRITE;
 import static ai.grakn.engine.controller.util.Requests.mandatoryBody;
@@ -119,11 +120,11 @@ public class GraqlController {
         int limitEmbedded = queryParameter(request, LIMIT_EMBEDDED).map(Integer::parseInt).orElse(-1);
         String acceptType = getAcceptType(request);
 
-        boolean defineAllVars = queryParameter(request, DEFINE_ALL_VARS).map(Boolean::parseBoolean).orElse(false);
+        Optional<Boolean> defineAllVars = queryParameter(request, DEFINE_ALL_VARS).map(Boolean::parseBoolean);
 
         try(GraknTx graph = factory.tx(keyspace, WRITE); Timer.Context context = executeGraqlPostTimer.time()) {
             QueryParser parser = graph.graql().materialise(materialise).infer(infer).parser();
-            parser.defineAllVars(defineAllVars);
+            defineAllVars.ifPresent(parser::defineAllVars);
             Query<?> query = parser.parseQuery(queryString);
             Object resp = respond(response, acceptType, executeQuery(graph.getKeyspace(), limitEmbedded, query, acceptType));
             graph.commit();

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeTypeController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/AttributeTypeController.java
@@ -24,7 +24,7 @@ import ai.grakn.Keyspace;
 import ai.grakn.concept.AttributeType;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.exception.GraknServerException;
-import ai.grakn.graql.internal.parser.QueryParser;
+import ai.grakn.graql.internal.parser.QueryParserImpl;
 import mjson.Json;
 import org.apache.commons.httpclient.HttpStatus;
 import org.slf4j.Logger;
@@ -113,7 +113,7 @@ public class AttributeTypeController {
 
     private AttributeType.DataType<?> fromString(String dataType) {
         Optional<AttributeType.DataType> fromStringOpt =
-            Optional.ofNullable(QueryParser.DATA_TYPES.get(dataType));
+            Optional.ofNullable(QueryParserImpl.DATA_TYPES.get(dataType));
 
         return fromStringOpt.orElseThrow(() ->
             GraknServerException.invalidQueryExplaination("invalid data type supplied: '" + dataType + "'")
@@ -122,7 +122,7 @@ public class AttributeTypeController {
 
     private String toString(AttributeType.DataType<?> dataType) {
         Optional<String> toStringOpt =
-            Optional.ofNullable(QueryParser.DATA_TYPES.inverse().get(dataType));
+            Optional.ofNullable(QueryParserImpl.DATA_TYPES.inverse().get(dataType));
 
         return toStringOpt.orElseThrow(() ->
             GraknServerException.invalidQueryExplaination("invalid data type supplied: '" + dataType + "'")

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RuleController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/api/RuleController.java
@@ -99,8 +99,8 @@ public class RuleController {
         try (GraknTx tx = factory.tx(Keyspace.of(keyspace), GraknTxType.WRITE)) {
             Rule rule = tx.putRule(
                 ruleLabel,
-                tx.graql().parsePattern(when),
-                tx.graql().parsePattern(then)
+                    tx.graql().parser().parsePattern(when),
+                    tx.graql().parser().parsePattern(then)
             );
             tx.commit();
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/session/GraqlSession.java
@@ -218,7 +218,7 @@ class GraqlSession {
                 String queryString = queryStringBuilder.toString();
                 queryStringBuilder = new StringBuilder();
 
-                queries = tx.graql().infer(infer).materialise(materialise).parseList(queryString).collect(toList());
+                queries = tx.graql().infer(infer).materialise(materialise).parser().parseList(queryString).collect(toList());
 
                 // Return results unless query is cancelled
                 queries.stream().flatMap(query -> query.resultsString(printer)).forEach(this::sendQueryResult);

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerDeleteTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerDeleteTest.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.controller;
 import ai.grakn.GraknTx;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.test.SampleKBContext;
 import ai.grakn.test.kbs.MovieKB;
 import ai.grakn.util.REST;
@@ -73,7 +74,11 @@ public class GraqlControllerDeleteTest {
 
         when(mockQueryBuilder.materialise(anyBoolean())).thenReturn(mockQueryBuilder);
         when(mockQueryBuilder.infer(anyBoolean())).thenReturn(mockQueryBuilder);
-        when(mockQueryBuilder.parse(any()))
+
+        QueryParser mockParser = mock(QueryParser.class);
+
+        when(mockQueryBuilder.parser()).thenReturn(mockParser);
+        when(mockParser.parseQuery(any()))
                 .thenAnswer(invocation -> sampleKB.tx().graql().parse(invocation.getArgument(0)));
 
         tx = mock(GraknTx.class, RETURNS_DEEP_STUBS);

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerInsertTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerInsertTest.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.controller;
 import ai.grakn.GraknTx;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.test.SampleKBContext;
 import ai.grakn.test.kbs.MovieKB;
 import ai.grakn.util.REST;
@@ -76,7 +77,11 @@ public class GraqlControllerInsertTest {
 
         when(mockQueryBuilder.materialise(anyBoolean())).thenReturn(mockQueryBuilder);
         when(mockQueryBuilder.infer(anyBoolean())).thenReturn(mockQueryBuilder);
-        when(mockQueryBuilder.parse(any()))
+
+        QueryParser mockParser = mock(QueryParser.class);
+
+        when(mockQueryBuilder.parser()).thenReturn(mockParser);
+        when(mockParser.parseQuery(any()))
                 .thenAnswer(invocation -> sampleKB.tx().graql().parse(invocation.getArgument(0)));
 
         mockTx = mock(GraknTx.class, RETURNS_DEEP_STUBS);

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
@@ -26,6 +26,7 @@ import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.graql.Printer;
 import ai.grakn.graql.Query;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.internal.printer.Printers;
 import ai.grakn.test.GraknTestSetup;
 import ai.grakn.test.SampleKBContext;
@@ -105,7 +106,11 @@ public class GraqlControllerReadOnlyTest {
 
         when(mockQueryBuilder.materialise(anyBoolean())).thenReturn(mockQueryBuilder);
         when(mockQueryBuilder.infer(anyBoolean())).thenReturn(mockQueryBuilder);
-        when(mockQueryBuilder.parse(any()))
+
+        QueryParser mockParser = mock(QueryParser.class);
+
+        when(mockQueryBuilder.parser()).thenReturn(mockParser);
+        when(mockParser.parseQuery(any()))
                 .thenAnswer(invocation -> sampleKB.tx().graql().parse(invocation.getArgument(0)));
 
         mockTx = mock(GraknTx.class, RETURNS_DEEP_STUBS);
@@ -125,8 +130,8 @@ public class GraqlControllerReadOnlyTest {
         String query = "match $x isa movie;";
         sendRequest(query, APPLICATION_TEXT);
 
-        verify(mockTx.graql().materialise(anyBoolean()).infer(anyBoolean()))
-                .parse(argThat(argument -> argument.equals(query)));
+        verify(mockTx.graql().materialise(anyBoolean()).infer(anyBoolean()).parser())
+                .parseQuery(argThat(argument -> argument.equals(query)));
     }
 
     @Test

--- a/grakn-engine/src/test/java/ai/grakn/engine/session/GraqlSessionTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/session/GraqlSessionTest.java
@@ -53,7 +53,7 @@ public class GraqlSessionTest {
         when(graph.graql()).thenReturn(qb);
         when(qb.infer(false)).thenReturn(qb);
         when(qb.materialise(false)).thenReturn(qb);
-        when(qb.parseList("compute count;")).thenReturn(Stream.of(count));
+        when(qb.parser().parseList("compute count;")).thenReturn(Stream.of(count));
 
         GraqlSession session = new GraqlSession(jettySesssion, factory, "json", false, false);
         session.receiveQuery(Json.object(QUERY, "compute count;"));

--- a/grakn-engine/src/test/java/ai/grakn/engine/session/GraqlSessionTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/session/GraqlSessionTest.java
@@ -19,10 +19,11 @@
 
 package ai.grakn.engine.session;
 
-import ai.grakn.GraknTx;
 import ai.grakn.GraknSession;
+import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.analytics.CountQuery;
 import mjson.Json;
 import org.eclipse.jetty.websocket.api.Session;
@@ -47,13 +48,15 @@ public class GraqlSessionTest {
         GraknSession factory = mock(GraknSession.class);
         GraknTx graph = mock(GraknTx.class, RETURNS_DEEP_STUBS);
         QueryBuilder qb = mock(QueryBuilder.class);
+        QueryParser parser = mock(QueryParser.class);
         CountQuery count = mock(CountQuery.class);
 
         when(factory.open(GraknTxType.WRITE)).thenReturn(graph);
         when(graph.graql()).thenReturn(qb);
         when(qb.infer(false)).thenReturn(qb);
         when(qb.materialise(false)).thenReturn(qb);
-        when(qb.parser().parseList("compute count;")).thenReturn(Stream.of(count));
+        when(qb.parser()).thenReturn(parser);
+        when(parser.parseList("compute count;")).thenReturn(Stream.of(count));
 
         GraqlSession session = new GraqlSession(jettySesssion, factory, "json", false, false);
         session.receiveQuery(Json.object(QUERY, "compute count;"));

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
@@ -325,7 +325,7 @@ public class GraqlShell {
 
         String queries = loadQuery(graqlPath);
 
-        Graql.parseList(queries).forEach(batchMutatorClient::add);
+        Graql.parser().parseList(queries).forEach(batchMutatorClient::add);
 
         batchMutatorClient.waitToFinish();
         batchMutatorClient.close();

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * Main class containing static methods for creating Graql queries.
@@ -143,12 +142,10 @@ public class Graql {
     }
 
     /**
-     * @param patternsString a string representing a list of patterns
-     * @return a list of patterns
+     * Get a {@link QueryParser} for parsing queries from strings
      */
-    @CheckReturnValue
-    public static List<Pattern> parsePatterns(String patternsString) {
-        return withoutGraph().parsePatterns(patternsString);
+    public static QueryParser parser() {
+        return withoutGraph().parser();
     }
 
     /**
@@ -158,27 +155,6 @@ public class Graql {
     @CheckReturnValue
     public static <T extends Query<?>> T parse(String queryString) {
         return withoutGraph().parse(queryString);
-    }
-
-    /**
-     * @param queryString a string representing several queries
-     * @return a list of queries
-     */
-    @CheckReturnValue
-    public static Stream<Query<?>> parseList(String queryString) {
-        return withoutGraph().parseList(queryString);
-    }
-
-    // TEMPLATING
-
-    /**
-     * @param template a string representing a templated graql query
-     * @param data data to use in template
-     * @return a query, the type will depend on the type indicated in the template
-     */
-    @CheckReturnValue
-    public static <T extends Query<?>> Stream<T> parseTemplate(String template, Map<String, Object> data){
-        return withoutGraph().parseTemplate(template, data);
     }
 
     // PATTERNS AND VARS

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParser.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParser.java
@@ -201,7 +201,7 @@ public class QueryParser {
         ImmutableMap<String, Function<List<Object>, Aggregate>> immutableAggregates =
                 ImmutableMap.copyOf(aggregateMethods);
 
-        return new QueryVisitor(immutableAggregates, queryBuilder);
+        return new QueryVisitor(immutableAggregates, queryBuilder, false);
     }
 
     // Aggregate methods that include other aggregates, such as group are not necessarily safe at runtime.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
@@ -58,6 +58,7 @@ public class QueryParserImpl implements QueryParser {
     private final QueryBuilder queryBuilder;
     private final TemplateParser templateParser = TemplateParser.create();
     private final Map<String, Function<List<Object>, Aggregate>> aggregateMethods = new HashMap<>();
+    private boolean defineAllVars = false;
 
     public static final ImmutableBiMap<String, AttributeType.DataType> DATA_TYPES = ImmutableBiMap.of(
             "long", AttributeType.DataType.LONG,
@@ -108,6 +109,11 @@ public class QueryParserImpl implements QueryParser {
     @Override
     public void registerMacro(Macro macro) {
         templateParser.registerMacro(macro);
+    }
+
+    @Override
+    public void defineAllVars(boolean defineAllVars) {
+        this.defineAllVars = defineAllVars;
     }
 
     @Override
@@ -203,7 +209,7 @@ public class QueryParserImpl implements QueryParser {
         ImmutableMap<String, Function<List<Object>, Aggregate>> immutableAggregates =
                 ImmutableMap.copyOf(aggregateMethods);
 
-        return new QueryVisitor(immutableAggregates, queryBuilder, false);
+        return new QueryVisitor(immutableAggregates, queryBuilder, defineAllVars);
     }
 
     // Aggregate methods that include other aggregates, such as group are not necessarily safe at runtime.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.Graql;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Query;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.internal.antlr.GraqlLexer;
 import ai.grakn.graql.internal.antlr.GraqlParser;
@@ -46,11 +47,11 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
- * Class for parsing query strings into valid queries
+ * Default implementation of {@link QueryParser}
  *
  * @author Felix Chapman
  */
-public class QueryParser {
+public class QueryParserImpl implements QueryParser {
 
     private final QueryBuilder queryBuilder;
     private final Map<String, Function<List<Object>, Aggregate>> aggregateMethods = new HashMap<>();
@@ -67,7 +68,7 @@ public class QueryParser {
      * Create a query parser with the specified graph
      *  @param queryBuilder the QueryBuilderImpl to operate the query on
      */
-    private QueryParser(QueryBuilder queryBuilder) {
+    private QueryParserImpl(QueryBuilder queryBuilder) {
         this.queryBuilder = queryBuilder;
     }
 
@@ -77,7 +78,7 @@ public class QueryParser {
      *  @return a query parser that operates with the specified graph
      */
     public static QueryParser create(QueryBuilder queryBuilder) {
-        QueryParser parser = new QueryParser(queryBuilder);
+        QueryParserImpl parser = new QueryParserImpl(queryBuilder);
         parser.registerDefaultAggregates();
         return parser;
     }
@@ -96,15 +97,12 @@ public class QueryParser {
         });
     }
 
+    @Override
     public void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod) {
         aggregateMethods.put(name, aggregateMethod);
     }
 
-    /**
-     * @param queryString a string representing a query
-     * @return
-     * a query, the type will depend on the type of query.
-     */
+    @Override
     @SuppressWarnings("unchecked")
     public <T extends Query<?>> T parseQuery(String queryString) {
         // We can't be sure the returned query type is correct - even at runtime(!) because Java erases generics.
@@ -117,10 +115,7 @@ public class QueryParser {
         return (T) parseQueryFragment(GraqlParser::queryEOF, QueryVisitor::visitQueryEOF, queryString, getLexer(queryString));
     }
 
-    /**
-     * @param queryString a string representing several queries
-     * @return a list of queries
-     */
+    @Override
     public <T extends Query<?>> Stream<T> parseList(String queryString) {
         GraqlLexer lexer = getLexer(queryString);
 
@@ -137,18 +132,12 @@ public class QueryParser {
         return queries.map(query -> (T) query);
     }
 
-    /**
-     * @param patternsString a string representing a list of patterns
-     * @return a list of patterns
-     */
+    @Override
     public List<Pattern> parsePatterns(String patternsString) {
         return parseQueryFragment(GraqlParser::patterns, QueryVisitor::visitPatterns, patternsString, getLexer(patternsString));
     }
 
-    /**
-     * @param patternString a string representing a pattern
-     * @return a pattern
-     */
+    @Override
     public Pattern parsePattern(String patternString){
         return parseQueryFragment(GraqlParser::pattern, QueryVisitor::visitPattern, patternString, getLexer(patternString));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -738,6 +738,6 @@ class QueryVisitor extends GraqlBaseVisitor {
     }
 
     private AttributeType.DataType getDatatype(TerminalNode datatype) {
-        return QueryParser.DATA_TYPES.get(datatype.getText());
+        return QueryParserImpl.DATA_TYPES.get(datatype.getText());
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -89,11 +89,15 @@ class QueryVisitor extends GraqlBaseVisitor {
 
     private final QueryBuilder queryBuilder;
     private final ImmutableMap<String, Function<List<Object>, Aggregate>> aggregateMethods;
+    private final boolean makeEverythingUserDefined;
 
     QueryVisitor(
-            ImmutableMap<String, Function<List<Object>, Aggregate>> aggregateMethods, QueryBuilder queryBuilder) {
+            ImmutableMap<String, Function<List<Object>, Aggregate>> aggregateMethods, QueryBuilder queryBuilder,
+            boolean makeEverythingUserDefined
+    ) {
         this.aggregateMethods = aggregateMethods;
         this.queryBuilder = queryBuilder;
+        this.makeEverythingUserDefined = makeEverythingUserDefined;
     }
 
     @Override
@@ -670,7 +674,11 @@ class QueryVisitor extends GraqlBaseVisitor {
 
     private Var getVariable(Token variable) {
         // Remove '$' prefix
-        return var(variable.getText().substring(1));
+        Var var = var(variable.getText().substring(1));
+
+        if (makeEverythingUserDefined) var = var.asUserDefined();
+
+        return var;
     }
 
     private String getRegex(TerminalNode string) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -27,7 +27,7 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
 import ai.grakn.graql.internal.gremlin.sets.EquivalentFragmentSets;
-import ai.grakn.graql.internal.parser.QueryParser;
+import ai.grakn.graql.internal.parser.QueryParserImpl;
 import ai.grakn.graql.internal.reasoner.atom.property.DataTypeAtom;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -60,7 +60,7 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
 
     @Override
     public String getProperty() {
-        return QueryParser.DATA_TYPES.inverse().get(dataType());
+        return QueryParserImpl.DATA_TYPES.inverse().get(dataType());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
@@ -33,7 +33,8 @@ import ai.grakn.graql.VarPattern;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarPatternAdmin;
-import ai.grakn.graql.internal.parser.QueryParser;
+import ai.grakn.graql.QueryParser;
+import ai.grakn.graql.internal.parser.QueryParserImpl;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.query.analytics.ComputeQueryBuilderImpl;
 import ai.grakn.graql.internal.query.match.MatchBase;
@@ -71,13 +72,13 @@ public class QueryBuilderImpl implements QueryBuilder {
 
     public QueryBuilderImpl() {
         this.tx = Optional.empty();
-        queryParser = QueryParser.create(this);
+        queryParser = QueryParserImpl.create(this);
         templateParser = TemplateParser.create();
     }
 
     public QueryBuilderImpl(GraknTx tx) {
         this.tx = Optional.of(tx);
-        queryParser = QueryParser.create(this);
+        queryParser = QueryParserImpl.create(this);
         templateParser = TemplateParser.create();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
@@ -20,7 +20,6 @@
 package ai.grakn.graql.internal.query;
 
 import ai.grakn.GraknTx;
-import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.ComputeQueryBuilder;
 import ai.grakn.graql.DefineQuery;
 import ai.grakn.graql.InsertQuery;
@@ -28,28 +27,23 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Query;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.UndefineQuery;
 import ai.grakn.graql.VarPattern;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.VarPatternAdmin;
-import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.internal.parser.QueryParserImpl;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.query.analytics.ComputeQueryBuilderImpl;
 import ai.grakn.graql.internal.query.match.MatchBase;
-import ai.grakn.graql.internal.template.TemplateParser;
 import ai.grakn.graql.internal.util.AdminConverter;
-import ai.grakn.graql.macro.Macro;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -65,21 +59,16 @@ import java.util.stream.Stream;
 public class QueryBuilderImpl implements QueryBuilder {
 
     private final Optional<GraknTx> tx;
-    private final QueryParser queryParser;
-    private final TemplateParser templateParser;
+    private final QueryParser queryParser = QueryParserImpl.create(this);
     private boolean infer = false;
     private boolean materialise = false;
 
     public QueryBuilderImpl() {
         this.tx = Optional.empty();
-        queryParser = QueryParserImpl.create(this);
-        templateParser = TemplateParser.create();
     }
 
     public QueryBuilderImpl(GraknTx tx) {
         this.tx = Optional.of(tx);
-        queryParser = QueryParserImpl.create(this);
-        templateParser = TemplateParser.create();
     }
 
     @Override
@@ -164,20 +153,15 @@ public class QueryBuilderImpl implements QueryBuilder {
         return new ComputeQueryBuilderImpl(tx);
     }
 
-    /**
-     * @param patternsString a string representing a list of patterns
-     * @return a list of patterns
-     */
     @Override
-    public List<Pattern> parsePatterns(String patternsString) {
-        return queryParser.parsePatterns(patternsString);
+    public QueryParser parser() {
+        return queryParser;
     }
 
     /**
      * @param patternString a string representing a pattern
      * @return a pattern
      */
-    @Override
     public Pattern parsePattern(String patternString) {
         return queryParser.parsePattern(patternString);
     }
@@ -191,28 +175,7 @@ public class QueryBuilderImpl implements QueryBuilder {
         return queryParser.parseQuery(queryString);
     }
 
-    @Override
     public <T extends Query<?>> Stream<T> parseList(String queryString) {
         return queryParser.parseList(queryString);
-    }
-
-    /**
-     * @param template a string representing a templated graql query
-     * @param data     data to use in template
-     * @return a resolved graql query
-     */
-    @Override
-    public <T extends Query<?>> Stream<T> parseTemplate(String template, Map<String, Object> data){
-        return parseList(templateParser.parseTemplate(template, data));
-    }
-
-    @Override
-    public void registerAggregate(String name, Function<List<Object>, Aggregate> aggregateMethod) {
-        queryParser.registerAggregate(name, aggregateMethod);
-    }
-
-    @Override
-    public void registerMacro(Macro macro){
-        templateParser.registerMacro(macro);
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
@@ -104,12 +104,12 @@ public class QueryToStringTest {
 
     @Test
     public void testQueryWithThenToString() {
-        assertValidToString(qb.insert(var("x").isa("a-rule-type").then(and(qb.parsePatterns("$x isa movie;")))));
+        assertValidToString(qb.insert(var("x").isa("a-rule-type").then(and(qb.parser().parsePatterns("$x isa movie;")))));
     }
 
     @Test
     public void testQueryWithWhenToString() {
-        assertValidToString(qb.insert(var("x").isa("a-rule-type").when(and(qb.parsePatterns("$x isa movie;")))));
+        assertValidToString(qb.insert(var("x").isa("a-rule-type").when(and(qb.parser().parsePatterns("$x isa movie;")))));
     }
 
     private void assertValidToString(InsertQuery query){

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -293,8 +293,8 @@ public class DefineQueryTest {
 
     @Test
     public void whenDefiningARule_TheRuleIsInTheKB() {
-        Pattern when = qb.parsePattern("$x isa entity");
-        Pattern then = qb.parsePattern("$x isa entity");
+        Pattern when = qb.parser().parsePattern("$x isa entity");
+        Pattern then = qb.parser().parsePattern("$x isa entity");
         VarPattern vars = label("my-rule").sub(label(RULE.getLabel())).when(when).then(then);
         qb.define(vars).execute();
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
@@ -579,7 +579,7 @@ public class MatchTest {
 
     @Test
     public void testMatchRuleRightHandSide() {
-        Match query = qb.match(x.when(qb.parsePattern("$x id 'expect-when'")).then(qb.parsePattern("$x id 'expect-then'")));
+        Match query = qb.match(x.when(qb.parser().parsePattern("$x id 'expect-when'")).then(qb.parser().parsePattern("$x id 'expect-then'")));
 
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage(MATCH_INVALID.getMessage("when"));

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -768,7 +768,7 @@ public class AtomicQueryTest {
     }
 
     private Conjunction<VarPatternAdmin> conjunction(String patternString, GraknTx graph){
-        Set<VarPatternAdmin> vars = graph.graql().parsePattern(patternString).admin()
+        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
@@ -940,8 +940,8 @@ public class AtomicTest {
         String childPatternString = "(superRole1: $x, superRole2: $y) isa relation1";
         InferenceRule testRule = new InferenceRule(
                 graph.putRule("Checking Rewrite & Unification",
-                        graph.graql().parsePattern(childPatternString),
-                        graph.graql().parsePattern(childPatternString)),
+                        graph.graql().parser().parsePattern(childPatternString),
+                        graph.graql().parser().parsePattern(childPatternString)),
                 graph)
                 .rewriteToUserDefined(parentAtom);
 
@@ -969,8 +969,8 @@ public class AtomicTest {
         String parentString = "{$r($a, $x);}";
         RelationshipAtom parent = (RelationshipAtom) ReasonerQueries.atomic(conjunction(parentString, graph), graph).getAtom();
 
-        PatternAdmin body = graph.graql().parsePattern("(role1: $z, role2: $b) isa relation1").admin();
-        PatternAdmin head = graph.graql().parsePattern("(role1: $z, role2: $b) isa relation1").admin();
+        PatternAdmin body = graph.graql().parser().parsePattern("(role1: $z, role2: $b) isa relation1").admin();
+        PatternAdmin head = graph.graql().parser().parsePattern("(role1: $z, role2: $b) isa relation1").admin();
         InferenceRule rule = new InferenceRule(graph.putRule("Rule: Checking Unification", body, head), graph);
 
         Unifier unifier = rule.getUnifier(parent);
@@ -1051,7 +1051,7 @@ public class AtomicTest {
     }
 
     private Conjunction<VarPatternAdmin> conjunction(String patternString, GraknTx graph){
-        Set<VarPatternAdmin> vars = graph.graql().parsePattern(patternString).admin()
+        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/LazyTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/LazyTest.java
@@ -201,7 +201,7 @@ public class LazyTest {
     }
 
     private Conjunction<VarPatternAdmin> conjunction(String patternString, GraknTx graph){
-        Set<VarPatternAdmin> vars = graph.graql().parsePattern(patternString).admin()
+        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryTest.java
@@ -230,7 +230,7 @@ public class QueryTest {
     }
 
     private Conjunction<VarPatternAdmin> conjunction(String patternString, GraknTx graph){
-        Set<VarPatternAdmin> vars = graph.graql().parsePattern(patternString).admin()
+        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
@@ -114,8 +114,8 @@ public class ReasonerTest {
         roleMap.put(tx.getRole("member-location").getLabel(), tx.getRole("subject-location").getLabel());
         roleMap.put(tx.getRole("container-location").getLabel(), tx.getRole("located-subject").getLabel());
 
-        Pattern body = and(tx.graql().parsePatterns("(subject-location: $x, located-subject: $x1) isa resides;"));
-        Pattern head = and(tx.graql().parsePatterns("(member-location: $x, container-location: $x1) isa sublocate;"));
+        Pattern body = and(tx.graql().parser().parsePatterns("(subject-location: $x, located-subject: $x1) isa resides;"));
+        Pattern head = and(tx.graql().parser().parsePatterns("(member-location: $x, container-location: $x1) isa sublocate;"));
 
         InferenceRule R2 = new InferenceRule(tx.putRule("Rule: Sub Property Creation", body, head), tx);
         Rule rule = ReasonerUtils.createSubPropertyRule("Rule: Sb Property Rule", parent, child, roleMap, tx);
@@ -136,10 +136,9 @@ public class ReasonerTest {
                 tx);
         InferenceRule R = new InferenceRule(rule, tx);
 
-        Pattern body = and(tx.graql().parsePatterns(
-                "(member-location: $x, container-location: $z) isa sublocate;" +
+        Pattern body = and(tx.graql().parser().parsePatterns("(member-location: $x, container-location: $z) isa sublocate;" +
                 "(member-location: $z, container-location: $y) isa sublocate;"));
-        Pattern head = and(tx.graql().parsePatterns("(member-location: $x, container-location: $y) isa sublocate;"));
+        Pattern head = and(tx.graql().parser().parsePatterns("(member-location: $x, container-location: $y) isa sublocate;"));
 
         InferenceRule R2 = new InferenceRule(tx.putRule("Another Rule", body, head), tx);
         assertTrue(R.getHead().equals(R2.getHead()));
@@ -157,8 +156,8 @@ public class ReasonerTest {
                 tx);
         InferenceRule R = new InferenceRule(rule, tx);
 
-        Pattern body = and(tx.graql().parsePatterns("(acquaintance1: $x, acquaintance2: $y) isa knows;"));
-        Pattern head = and(tx.graql().parsePatterns("(acquaintance1: $x, acquaintance2: $x) isa knows;"));
+        Pattern body = and(tx.graql().parser().parsePatterns("(acquaintance1: $x, acquaintance2: $y) isa knows;"));
+        Pattern head = and(tx.graql().parser().parsePatterns("(acquaintance1: $x, acquaintance2: $x) isa knows;"));
 
         InferenceRule R2 = new InferenceRule(tx.putRule("Another Reflexive Rule", body, head), tx);
         assertTrue(R.getHead().equals(R2.getHead()));
@@ -185,10 +184,9 @@ public class ReasonerTest {
                 tx);
         InferenceRule R = new InferenceRule(rule, tx);
 
-        Pattern body = and(tx.graql().parsePatterns(
-                "(located-subject: $x, subject-location: $y) isa resides;" +
+        Pattern body = and(tx.graql().parser().parsePatterns("(located-subject: $x, subject-location: $y) isa resides;" +
                 "(member-location: $z, container-location: $y) isa sublocate;"));
-        Pattern head = and(tx.graql().parsePatterns("(located-subject: $x, subject-location: $z) isa resides;"));
+        Pattern head = and(tx.graql().parser().parsePatterns("(located-subject: $x, subject-location: $z) isa resides;"));
 
         InferenceRule R2 = new InferenceRule(tx.putRule("Another Property Chain Rule", body, head), tx);
         assertTrue(R.getHead().equals(R2.getHead()));
@@ -201,10 +199,9 @@ public class ReasonerTest {
 
         Rule rule1 = tx.getRule("Geo Rule");
 
-        Pattern body2 = Graql.and(tx.graql().parsePatterns(
-                        "(geo-entity: $l1, entity-location: $l2) isa is-located-in;" +
-                        "(geo-entity: $l2, entity-location: $l3) isa is-located-in;"));
-        Pattern head2 = Graql.and(tx.graql().parsePatterns("(geo-entity: $l1, entity-location: $l3) isa is-located-in;"));
+        Pattern body2 = Graql.and(tx.graql().parser().parsePatterns("(geo-entity: $l1, entity-location: $l2) isa is-located-in;" +
+                "(geo-entity: $l2, entity-location: $l3) isa is-located-in;"));
+        Pattern head2 = Graql.and(tx.graql().parser().parsePatterns("(geo-entity: $l1, entity-location: $l3) isa is-located-in;"));
         Rule rule2 = tx.putRule("Rule 2", body2, head2);
 
         InferenceRule R1 = new InferenceRule(rule1, tx);
@@ -246,8 +243,8 @@ public class ReasonerTest {
     @Test
     public void testParsingQueryWithResourceVariable2(){
         String queryString = "match $x has firstname $y;";
-        Pattern body = and(snbKB.tx().graql().parsePatterns("$x isa person;$x has name 'Bob';"));
-        Pattern head = and(snbKB.tx().graql().parsePatterns("$x has firstname 'Bob';"));
+        Pattern body = and(snbKB.tx().graql().parser().parsePatterns("$x isa person;$x has name 'Bob';"));
+        Pattern head = and(snbKB.tx().graql().parser().parsePatterns("$x has firstname 'Bob';"));
         snbKB.tx().putRule("Rule 1000", body, head);
 
         snbKB.tx().commit();
@@ -901,7 +898,7 @@ public class ReasonerTest {
     }
 
     private Conjunction<VarPatternAdmin> conjunction(String patternString, GraknTx graph){
-        Set<VarPatternAdmin> vars = graph.graql().parsePattern(patternString).admin()
+        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/CWInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/CWInferenceTest.java
@@ -207,8 +207,8 @@ public class CWInferenceTest {
 
         tx.putEntityType("region");
 
-        Pattern R6_LHS = and(tx.graql().parsePatterns("$x isa region;"));
-        Pattern R6_RHS = and(tx.graql().parsePatterns("$x isa country;"));
+        Pattern R6_LHS = and(tx.graql().parser().parsePatterns("$x isa region;"));
+        Pattern R6_RHS = and(tx.graql().parser().parsePatterns("$x isa country;"));
         tx.putRule("R6: If something is a region it is a country", R6_LHS, R6_RHS);
         tx.admin().commitNoLogs();
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/template/TemplateParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/template/TemplateParserTest.java
@@ -703,7 +703,7 @@ public class TemplateParserTest {
     public void templateIsInvalid_ThrowsGraqlSyntaxException(){
         exception.expect(GraqlSyntaxException.class);
         String template = "<<<<<<<";
-        Graql.parseTemplate(template, new HashMap<>()).forEach(q -> {});
+        Graql.parser().parseTemplate(template, new HashMap<>()).forEach(q -> {});
     }
 
     @Test
@@ -780,14 +780,14 @@ public class TemplateParserTest {
     }
 
     private void assertParseContains(String template, Map<String, Object> data, String... expected){
-        List<String> result = Graql.parseTemplate(template, data).map(Query::toString).collect(toList());
+        List<String> result = Graql.parser().parseTemplate(template, data).map(Query::toString).collect(toList());
         for(String e:expected){
             assertThat(result, hasItem(e));
         }
     }
 
     private void assertParseEquals(String template, Map<String, Object> data, String expected){
-        List<Query> result = Graql.parseTemplate(template, data).collect(toList());
+        List<Query> result = Graql.parser().parseTemplate(template, data).collect(toList());
         assertEquals(parse(expected), result.get(0));
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/template/macro/DateMacroTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/template/macro/DateMacroTest.java
@@ -137,7 +137,7 @@ public class DateMacroTest {
 
         exception.expect(GraqlQueryException.class);
 
-        Graql.parseTemplate(template, Collections.singletonMap("date", "10/09/1993"));
+        Graql.parser().parseTemplate(template, Collections.singletonMap("date", "10/09/1993"));
     }
 
     // Templating tests

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/template/macro/MacroTestUtilities.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/template/macro/MacroTestUtilities.java
@@ -31,7 +31,7 @@ import static junit.framework.TestCase.assertEquals;
 public class MacroTestUtilities {
 
     public static void assertParseEquals(String template, Map<String, Object> data, String expected){
-        List<Query> result = Graql.parseTemplate(template, data).collect(Collectors.toList());
+        List<Query> result = Graql.parser().parseTemplate(template, data).collect(Collectors.toList());
         assertEquals(parse(expected), result.get(0));
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
@@ -58,8 +58,8 @@ public class RuleTest {
     public void setupRules(){
         session = Grakn.session(Grakn.IN_MEMORY, "absd");
         graknTx = Grakn.session(Grakn.IN_MEMORY, "absd").open(GraknTxType.WRITE);
-        when = graknTx.graql().parsePattern("$x isa entity-type");
-        then = graknTx.graql().parsePattern("$x isa entity-type");
+        when = graknTx.graql().parser().parsePattern("$x isa entity-type");
+        then = graknTx.graql().parser().parsePattern("$x isa entity-type");
     }
 
     @After
@@ -78,8 +78,8 @@ public class RuleTest {
     public void whenCreatingRulesWithNonExistentEntityType_Throw() throws InvalidKBException {
         graknTx.putEntityType("My-Type");
 
-        when = graknTx.graql().parsePattern("$x isa Your-Type");
-        then = graknTx.graql().parsePattern("$x isa My-Type");
+        when = graknTx.graql().parser().parsePattern("$x isa Your-Type");
+        then = graknTx.graql().parser().parsePattern("$x isa My-Type");
         Rule rule = graknTx.putRule("My-Sad-Rule-Type", when, then);
 
         expectedException.expect(InvalidKBException.class);
@@ -92,8 +92,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithDisjunctionInTheBody_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role: $x) or (role: $x, role: $y)"),
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role: $x) or (role: $x, role: $y)"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_BODY
         );
     }
@@ -101,8 +101,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithDisjunctionInTheHead_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role1: $x) or (role1: $x, role2: $y)"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x) or (role1: $x, role2: $y)"),
                 ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_HEAD
         );
     }
@@ -110,13 +110,13 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithNonAtomicHead_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("{(role1: $x, role2: $y) isa relation1; $x has res1 'value';}"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("{(role1: $x, role2: $y) isa relation1; $x has res1 'value';}"),
                 ErrorMessage.VALIDATION_RULE_HEAD_NON_ATOMIC
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("{role1: $x, role2: $y) isa relation1; role1: $y, role2: $z) isa relation1;}"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("{role1: $x, role2: $y) isa relation1; role1: $y, role2: $z) isa relation1;}"),
                 ErrorMessage.VALIDATION_RULE_HEAD_NON_ATOMIC
         );
     }
@@ -124,8 +124,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_ResourceWithInequality_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x has res1 >10"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x has res1 >10"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -133,8 +133,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_RelationWithMetaRoles_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role: $y, role: $x) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role: $y, role: $x) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -142,8 +142,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_RelationWithMissingRoles_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("($x, $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("($x, $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -151,8 +151,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_RelationWithoutType_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role3: $y, role3: $x)"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role3: $y, role3: $x)"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -160,23 +160,23 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_IllegalTypeAtoms_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x isa $z"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x isa $z"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x sub entity1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x sub entity1"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x plays role1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x plays role1"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x has res1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x has res1"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -184,13 +184,13 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_Predicate_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x id '100'"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x id '100'"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x label 'entity1'"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x label 'entity1'"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -198,18 +198,18 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithIllegalAtomicInHead_PropertyAtoms_Throw() throws InvalidKBException {
         validateIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x is-abstract"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x is-abstract"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("$x has res1 $y"),
-                graknTx.graql().parsePattern("$y datatype string"),
+                graknTx.graql().parser().parsePattern("$x has res1 $y"),
+                graknTx.graql().parser().parsePattern("$y datatype string"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(
-                graknTx.graql().parsePattern("$x isa entity1"),
-                graknTx.graql().parsePattern("$x regex /entity/"),
+                graknTx.graql().parser().parsePattern("$x isa entity1"),
+                graknTx.graql().parser().parsePattern("$x regex /entity/"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
     }
@@ -217,13 +217,13 @@ public class RuleTest {
     @Test
     public void whenAddingRuleInvalidOntologically_RelationDoesntRelateARole_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role3: $y) isa relation2"),
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role3: $y) isa relation2"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_ROLE_CANNOT_BE_PLAYED.getMessage("role1", "relation2")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role1: $x, role3: $y) isa relation2"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role3: $y) isa relation2"),
                 ErrorMessage.VALIDATION_RULE_ROLE_CANNOT_BE_PLAYED.getMessage("role1", "relation2")
         );
     }
@@ -231,18 +231,18 @@ public class RuleTest {
     @Test
     public void whenAddingRuleInvalidOntologically_TypeCantPlayARole_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("{$y isa entity1; }"),
-                graknTx.graql().parsePattern("(role3: $x, role3: $y) isa relation2"),
+                graknTx.graql().parser().parsePattern("{$y isa entity1; }"),
+                graknTx.graql().parser().parsePattern("(role3: $x, role3: $y) isa relation2"),
                 ErrorMessage.VALIDATION_RULE_TYPE_CANNOT_PLAY_ROLE.getMessage("entity1", "role3", "relation2")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("{$y isa entity1; (role3: $x, role3: $y) isa relation2;}"),
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("{$y isa entity1; (role3: $x, role3: $y) isa relation2;}"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_TYPE_CANNOT_PLAY_ROLE.getMessage("entity1", "role3", "relation2")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("{$y isa entity1; (role3: $x, role3: $y) isa relation2;}"),
+                graknTx.graql().parser().parsePattern("role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("{$y isa entity1; (role3: $x, role3: $y) isa relation2;}"),
                 ErrorMessage.VALIDATION_RULE_TYPE_CANNOT_PLAY_ROLE.getMessage("entity1", "role3", "relation2")
         );
     }
@@ -250,18 +250,18 @@ public class RuleTest {
     @Test
     public void whenAddingRuleInvalidOntologically_EntityCantHaveResource_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("$x isa relation1"),
-                graknTx.graql().parsePattern("$x has res1 'value'"),
+                graknTx.graql().parser().parsePattern("$x isa relation1"),
+                graknTx.graql().parser().parsePattern("$x has res1 'value'"),
                 ErrorMessage.VALIDATION_RULE_RESOURCE_OWNER_CANNOT_HAVE_RESOURCE.getMessage("res1", "relation1")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("{$x isa relation1, has res1 'value';}"),
-                graknTx.graql().parsePattern("$x isa relation2"),
+                graknTx.graql().parser().parsePattern("{$x isa relation1, has res1 'value';}"),
+                graknTx.graql().parser().parsePattern("$x isa relation2"),
                 ErrorMessage.VALIDATION_RULE_RESOURCE_OWNER_CANNOT_HAVE_RESOURCE.getMessage("res1", "relation1")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("$x isa relation2"),
-                graknTx.graql().parsePattern("{$x isa relation1, has res1 'value';"),
+                graknTx.graql().parser().parsePattern("$x isa relation2"),
+                graknTx.graql().parser().parsePattern("{$x isa relation1, has res1 'value';"),
                 ErrorMessage.VALIDATION_RULE_RESOURCE_OWNER_CANNOT_HAVE_RESOURCE.getMessage("res1", "relation1")
         );
     }
@@ -269,13 +269,13 @@ public class RuleTest {
     @Test
     public void whenAddingRuleInvalidOntologically_RelationWithInvalidType_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role3: $y) isa res1"),
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role3: $y) isa res1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_INVALID_RELATION_TYPE.getMessage("res1")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role1: $x, role3: $y) isa res1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role3: $y) isa res1"),
                 ErrorMessage.VALIDATION_RULE_INVALID_RELATION_TYPE.getMessage("res1")
         );
     }
@@ -283,13 +283,13 @@ public class RuleTest {
     @Test
     public void whenAddingRuleInvalidOntologically_ResourceWithInvalidType_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("$x has relation1 'value'"),
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x has relation1 'value'"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
                 ErrorMessage.VALIDATION_RULE_INVALID_RESOURCE_TYPE.getMessage("relation1")
         );
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("$x has relation1 'value'"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("$x has relation1 'value'"),
                 ErrorMessage.VALIDATION_RULE_INVALID_RESOURCE_TYPE.getMessage("relation1")
         );
     }
@@ -297,8 +297,8 @@ public class RuleTest {
     @Test
     public void whenAddingRuleWithOntologicallyInvalidHead_RelationDoesntRelateARole_Throw() throws InvalidKBException {
         validateOntologicallyIllegalRule(
-                graknTx.graql().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parsePattern("(role1: $x, role3: $y) isa relation2"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
+                graknTx.graql().parser().parsePattern("(role1: $x, role3: $y) isa relation2"),
                 ErrorMessage.VALIDATION_RULE_ROLE_CANNOT_BE_PLAYED.getMessage("role1", "relation2")
         );
     }
@@ -348,8 +348,8 @@ public class RuleTest {
         EntityType t1 = graknTx.putEntityType("type1");
         EntityType t2 = graknTx.putEntityType("type2");
 
-        when = graknTx.graql().parsePattern("$x isa type1");
-        then = graknTx.graql().parsePattern("$x isa type2");
+        when = graknTx.graql().parser().parsePattern("$x isa type1");
+        then = graknTx.graql().parser().parsePattern("$x isa type2");
 
         Rule rule = graknTx.putRule("My-Happy-Rule", when, then);
         assertThat(rule.getHypothesisTypes().collect(Collectors.toSet()), empty());
@@ -364,8 +364,8 @@ public class RuleTest {
     @Test
     public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_ReturnTheSameRule(){
         graknTx.putEntityType("type1");
-        when = graknTx.graql().parsePattern("$x isa type1");
-        then = graknTx.graql().parsePattern("$x isa type1");
+        when = graknTx.graql().parser().parsePattern("$x isa type1");
+        then = graknTx.graql().parser().parsePattern("$x isa type1");
 
         Rule rule1 = graknTx.putRule("My-Angry-Rule", when, then);
         Rule rule2 = graknTx.putRule("My-Angry-Rule", when, then);
@@ -377,8 +377,8 @@ public class RuleTest {
     @Test
     public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_ReturnTheSameRule(){
         graknTx.putEntityType("type1");
-        when = graknTx.graql().parsePattern("$x isa type1");
-        then = graknTx.graql().parsePattern("$y isa type1");
+        when = graknTx.graql().parser().parsePattern("$x isa type1");
+        then = graknTx.graql().parser().parsePattern("$y isa type1");
 
         Rule rule1 = graknTx.putRule("My-Angry-Rule", when, then);
         Rule rule2 = graknTx.putRule("My-Angry-Rule", when, then);

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
@@ -106,7 +106,7 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
         if(value == null) {
             return null;
         } else {
-            return vertex().tx().graql().parsePattern(value);
+            return vertex().tx().graql().parser().parsePattern(value);
         }
     }
 

--- a/grakn-kb/src/main/java/ai/grakn/util/SampleKBLoader.java
+++ b/grakn-kb/src/main/java/ai/grakn/util/SampleKBLoader.java
@@ -176,8 +176,7 @@ public class SampleKBLoader {
         try {
             File graql = new File(file);
 
-            graph.graql()
-                    .parseList(Files.readLines(graql, StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")))
+            graph.graql().parser().parseList(Files.readLines(graql, StandardCharsets.UTF_8).stream().collect(Collectors.joining("\n")))
                     .forEach(Query::execute);
         } catch (IOException |InvalidKBException e){
             throw new RuntimeException(e);

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
@@ -25,7 +25,7 @@ import ai.grakn.exception.GraknBackendException;
 import ai.grakn.exception.GraqlSyntaxException;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.Query;
-import ai.grakn.graql.internal.query.QueryBuilderImpl;
+import ai.grakn.graql.QueryParser;
 import ai.grakn.graql.macro.Macro;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class Migrator {
     private final static AtomicInteger numberBatchesCompleted = new AtomicInteger(0);
 
     private final static Logger LOG = LoggerFactory.getLogger(Migrator.class);
-    private final QueryBuilderImpl queryBuilder = (QueryBuilderImpl) Graql.withoutGraph().infer(false);
+    private final QueryParser queryParser = Graql.withoutGraph().infer(false).parser();
     public static final int BATCH_SIZE = 25;
     public static final int ACTIVE_TASKS = 16;
     public static final int DEFAULT_MAX_RETRY = 1;
@@ -79,7 +79,7 @@ public class Migrator {
      * Register a macro to use in templating
      */
     public Migrator registerMacro(Macro macro){
-        queryBuilder.registerMacro(macro);
+        queryParser.registerMacro(macro);
         return this;
     }
 
@@ -155,7 +155,7 @@ public class Migrator {
      */
     protected Stream<Query> template(String template, Map<String, Object> data){
         try {
-            return queryBuilder.parseTemplate(template, data);
+            return queryParser.parseTemplate(template, data);
         } catch (GraqlSyntaxException e){
             LOG.warn("Query not sent to server: " + e.getMessage());
         }

--- a/grakn-test-tools/src/main/java/ai/grakn/generator/PutSchemaConceptFunctions.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/generator/PutSchemaConceptFunctions.java
@@ -46,7 +46,7 @@ public class PutSchemaConceptFunctions extends AbstractGenerator<BiFunction> {
                 GraknTx::putRelationshipType,
                 GraknTx::putRole,
                 //TODO: Make smarter rules
-                (graph, label) -> graph.putRule(label, graph.graql().parsePattern("$x"), graph.graql().parsePattern("$x"))
+                (graph, label) -> graph.putRule(label, graph.graql().parser().parsePattern("$x"), graph.graql().parser().parsePattern("$x"))
         ));
     }
 }

--- a/grakn-test-tools/src/main/java/ai/grakn/generator/Rules.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/generator/Rules.java
@@ -38,7 +38,7 @@ public class Rules extends AbstractSchemaConceptGenerator<Rule> {
     protected Rule newSchemaConcept(Label label) {
         // TODO: generate more complicated rules
         QueryBuilder graql = this.tx().graql();
-        return tx().putRule(label, graql.parsePattern("$x"), graql.parsePattern("$x"));
+        return tx().putRule(label, graql.parser().parsePattern("$x"), graql.parser().parsePattern("$x"));
     }
 
     @Override

--- a/grakn-test-tools/src/main/java/ai/grakn/test/kbs/CWKB.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/test/kbs/CWKB.java
@@ -169,40 +169,38 @@ public class CWKB extends TestKB {
     @Override
     protected void buildRules(GraknTx tx) {
         //R1: "It is a crime for an American to sell weapons to hostile nations"
-        Pattern R1_LHS = tx.graql().parsePattern("{$x isa person;$x has nationality 'American';" +
-                        "$y isa weapon;" +
-                        "$z isa country;$z has alignment 'hostile';" +
-                        "(seller: $x, transaction-item: $y, buyer: $z) isa transaction;}");
+        Pattern R1_LHS = tx.graql().parser().parsePattern("{$x isa person;$x has nationality 'American';" +
+                "$y isa weapon;" +
+                "$z isa country;$z has alignment 'hostile';" +
+                "(seller: $x, transaction-item: $y, buyer: $z) isa transaction;}");
 
-        Pattern R1_RHS = tx.graql().parsePattern("{$x isa criminal;}");
+        Pattern R1_RHS = tx.graql().parser().parsePattern("{$x isa criminal;}");
         tx.putRule("R1: It is a crime for an American to sell weapons to hostile nations" , R1_LHS, R1_RHS);
 
         //R2: "Missiles are a kind of a weapon"
-        Pattern R2_LHS = tx.graql().parsePattern("{$x isa missile;}");
-        Pattern R2_RHS = tx.graql().parsePattern("{$x isa weapon;}");
+        Pattern R2_LHS = tx.graql().parser().parsePattern("{$x isa missile;}");
+        Pattern R2_RHS = tx.graql().parser().parsePattern("{$x isa weapon;}");
         tx.putRule("R2: Missiles are a kind of a weapon\"" , R2_LHS, R2_RHS);
 
         //R3: "If a country is an enemy of America then it is hostile"
-        Pattern R3_LHS = tx.graql().parsePattern(
-                "{$x isa country;" +
+        Pattern R3_LHS = tx.graql().parser().parsePattern("{$x isa country;" +
                 "($x, $y) isa is-enemy-of;" +
                 "$y isa country;$y has name 'America';}");
-        Pattern R3_RHS = tx.graql().parsePattern("{$x has alignment 'hostile';}");
+        Pattern R3_RHS = tx.graql().parser().parsePattern("{$x has alignment 'hostile';}");
         tx.putRule("R3: If a country is an enemy of America then it is hostile" , R3_LHS, R3_RHS);
 
         //R4: "If a rocket is self-propelled and guided, it is a missile"
-        Pattern R4_LHS = tx.graql().parsePattern("{$x isa rocket;$x has propulsion 'gsp';}");
-        Pattern R4_RHS = tx.graql().parsePattern("{$x isa missile;}");
+        Pattern R4_LHS = tx.graql().parser().parsePattern("{$x isa rocket;$x has propulsion 'gsp';}");
+        Pattern R4_RHS = tx.graql().parser().parsePattern("{$x isa missile;}");
         tx.putRule("R4: If a rocket is self-propelled and guided, it is a missile" , R4_LHS, R4_RHS);
 
-        Pattern R5_LHS = tx.graql().parsePattern(
-                "{$x isa person;" +
+        Pattern R5_LHS = tx.graql().parser().parsePattern("{$x isa person;" +
                 "$y isa country;" +
                 "$z isa weapon;" +
                 "($x, $y) isa is-paid-by;" +
                 "($y, $z) isa owns;}");
 
-        Pattern R5_RHS = tx.graql().parsePattern("{(seller: $x, buyer: $y, transaction-item: $z) isa transaction;}");
+        Pattern R5_RHS = tx.graql().parser().parsePattern("{(seller: $x, buyer: $y, transaction-item: $z) isa transaction;}");
         tx.putRule("R5: If a country pays a person and that country now owns a weapon then the person has sold the country a weapon" , R5_LHS, R5_RHS);
     }
 }

--- a/grakn-test-tools/src/main/java/ai/grakn/test/kbs/GeoKB.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/test/kbs/GeoKB.java
@@ -203,10 +203,9 @@ public class GeoKB extends TestKB {
 
     @Override
     public void buildRules(GraknTx tx) {
-        Pattern transitivity_LHS = tx.graql().parsePattern(
-                "{(geo-entity: $x, entity-location: $y) isa is-located-in;" +
+        Pattern transitivity_LHS = tx.graql().parser().parsePattern("{(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                 "(geo-entity: $y, entity-location: $z) isa is-located-in;}");
-        Pattern transitivity_RHS = tx.graql().parsePattern("{(geo-entity: $x, entity-location: $z) isa is-located-in;}");
+        Pattern transitivity_RHS = tx.graql().parser().parsePattern("{(geo-entity: $x, entity-location: $z) isa is-located-in;}");
         tx.putRule("Geo Rule", transitivity_LHS, transitivity_RHS);
     }
 }

--- a/grakn-test-tools/src/main/java/ai/grakn/test/kbs/MovieKB.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/test/kbs/MovieKB.java
@@ -287,12 +287,12 @@ public class MovieKB extends TestKB {
     @Override
     protected void buildRules(GraknTx tx) {
         // These rules are totally made up for testing purposes and don't work!
-        Pattern when = tx.graql().parsePattern("$x plays actor");
-        Pattern then = tx.graql().parsePattern("$x isa person");
+        Pattern when = tx.graql().parser().parsePattern("$x plays actor");
+        Pattern then = tx.graql().parser().parsePattern("$x isa person");
         tx.putRule("expectation-rule", when, then);
 
-        when = tx.graql().parsePattern("$x has name 'materialize-when'");
-        then = tx.graql().parsePattern("$x has name 'materialize-then'");
+        when = tx.graql().parser().parsePattern("$x has name 'materialize-when'");
+        then = tx.graql().parser().parsePattern("$x has name 'materialize-then'");
         tx.putRule("materialize-rule", when, then);
     }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
@@ -159,7 +159,7 @@ public class GraqlDocsTest {
 
     private void assertGraqlTemplateValidSyntax(GraknTx graph, String fileName, String templateBlock){
         try {
-            graph.graql().parseTemplate(templateBlock, new HashMap<>());
+            graph.graql().parser().parseTemplate(templateBlock, new HashMap<>());
         } catch (GraqlSyntaxException e){
             DocTestUtil.codeBlockFail(fileName, templateBlock, e.getMessage());
         } catch (Exception e){}
@@ -170,7 +170,7 @@ public class GraqlDocsTest {
         Matcher matcher = GRAQL_COMMIT.matcher(line);
         matcher.find();
         line = matcher.group(1);
-        graph.graql().parseList(line).forEach(Query::execute);
+        graph.graql().parser().parseList(line).forEach(Query::execute);
     }
 
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/property/GraknTxPutPropertyTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/property/GraknTxPutPropertyTest.java
@@ -186,14 +186,14 @@ public class GraknTxPutPropertyTest {
 
     @Property
     public void whenCallingPutRule_CreateATypeWithSuperTypeRule(@Open GraknTx tx, @Unused Label label) {
-        Rule rule = tx.putRule(label, tx.graql().parsePattern("$x"), tx.graql().parsePattern("$x"));
+        Rule rule = tx.putRule(label, tx.graql().parser().parsePattern("$x"), tx.graql().parser().parsePattern("$x"));
         assertEquals(tx.admin().getMetaRule(), rule.sup());
     }
 
     @Property
     public void whenCallingPutRuleWithAnExistingRuleTypeLabel_ItReturnsThatType(
             @Open GraknTx tx, @FromTx Rule rule) {
-        Rule newType = tx.putRule(rule.getLabel(), tx.graql().parsePattern("$x"), tx.graql().parsePattern("$x"));
+        Rule newType = tx.putRule(rule.getLabel(), tx.graql().parser().parsePattern("$x"), tx.graql().parser().parsePattern("$x"));
         assertEquals(rule, newType);
     }
 
@@ -209,7 +209,7 @@ public class GraknTxPutPropertyTest {
             exception.expectMessage(PropertyNotUniqueException.cannotCreateProperty(type, Schema.VertexProperty.SCHEMA_LABEL, type.getLabel()).getMessage());
         }
 
-        tx.putRule(type.getLabel(), tx.graql().parsePattern("$x"), tx.graql().parsePattern("$x"));
+        tx.putRule(type.getLabel(), tx.graql().parser().parsePattern("$x"), tx.graql().parser().parsePattern("$x"));
     }
 
     @Property


### PR DESCRIPTION
This includes:
- a refactor to introduce a `GraqlParser` interface housing most of the `parseSomething` methods.
- a flag on `GraqlParser` to "define all vars", meaning give names for things like relations so they will be returned in the results