### PR TITLE
Logback config is passed during benchmarks

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknSystemProperty.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknSystemProperty.java
@@ -31,7 +31,8 @@ public enum GraknSystemProperty {
     CURRENT_DIRECTORY("grakn.dir"),
     CONFIGURATION_FILE("grakn.conf"),
     TEST_PROFILE("grakn.test-profile"),
-    PROJECT_RELATIVE_DIR("main.basedir");
+    PROJECT_RELATIVE_DIR("main.basedir"),
+    LOGBACK_CONFIG("logback.configurationFile");
 
     private String key;
 


### PR DESCRIPTION
This should reduce the amount of logs benchmarks produce (and speed things up?)