### PR TITLE
Remove text output from `graql` script

### DIFF
--- a/grakn-dist/src/graql
+++ b/grakn-dist/src/graql
@@ -48,7 +48,6 @@ update_classpath() {
 }
 
 graql_console() {
-  echo "Starting Graql console..."
   java -cp ${CLASSPATH} -Dgrakn.dir="${GRAKN_HOME}/services" ai.grakn.graql.GraqlShell "${@:1}"
 }
 
@@ -70,9 +69,6 @@ help     Print this message"
 # =============================================
 
 update_classpath
-
-echo "Grakn: Database For AI"
-echo ""
 
 case "$1" in
   console)


### PR DESCRIPTION
The `graql console` command should not produce unnecessary output to allow it to be used by other programs, such as piping the output to another program to parse.