### PR TITLE
refactored grakn engine

### DIFF
--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -285,9 +285,9 @@ queue_wipe_all_data() {
 grakn_start_process() {
   local status=
   java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}/services" -Dgrakn.conf="${GRAKN_CONFIG}" \
-    ai.grakn.engine.GraknApplication > /dev/null 2>&1 &
+    ai.grakn.engine.Grakn > /dev/null 2>&1 &
   status=$?
-  pid=`ps -ef | grep GraknApplication | grep -v grep | awk '{ print $2}'`
+  pid=`ps -ef | grep Grakn | grep -v grep | awk '{ print $2}'`
   echo $pid > "${GRAKN_PID}"
   return $status
 }

--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -285,9 +285,9 @@ queue_wipe_all_data() {
 grakn_start_process() {
   local status=
   java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}/services" -Dgrakn.conf="${GRAKN_CONFIG}" \
-    ai.grakn.engine.GraknEngineServer > /dev/null 2>&1 &
+    ai.grakn.engine.GraknApplication > /dev/null 2>&1 &
   status=$?
-  pid=`ps -ef | grep GraknEngineServer | grep -v grep | awk '{ print $2}'`
+  pid=`ps -ef | grep GraknApplication | grep -v grep | awk '{ print $2}'`
   echo $pid > "${GRAKN_PID}"
   return $status
 }

--- a/grakn-dist/src/test/bash/distribution-test.sh
+++ b/grakn-dist/src/test/bash/distribution-test.sh
@@ -13,7 +13,7 @@ must_properly_start() {
   "${GRAKN_DIST_TMP}"/grakn server start
   local count_running_cassandra_process=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}' | wc -l`
   local count_running_redis_process=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}' | wc -l`
-  local count_running_grakn_process=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}' | wc -l`
+  local count_running_grakn_process=`ps -ef | grep 'Grakn' | grep -v grep | awk '{ print $2}' | wc -l`
 
   if [[ $count_running_cassandra_process -ne 1 ]]; then
     echo "Error in starting Cassandra: Expected to find 1 running Cassandra process. Found " $count_running_cassandra_process
@@ -100,7 +100,7 @@ must_properly_stop() {
 
   local count_running_cassandra_process=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}' | wc -l`
   local count_running_redis_process=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}' | wc -l`
-  local count_running_grakn_process=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}' | wc -l`
+  local count_running_grakn_process=`ps -ef | grep 'Grakn' | grep -v grep | awk '{ print $2}' | wc -l`
 
   if [[ $count_running_cassandra_process -ne 0 ]]; then
     echo "Error in stopping Cassandra: Expected to find 0 running Cassandra process. Found " $count_running_cassandra_process
@@ -135,7 +135,7 @@ force_kill() {
   echo "Force kill initiated - attempting to clean up any running processes..."
   local cassandra_pid=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}'`
   local redis_pid=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}'`
-  local grakn_pid=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}'`
+  local grakn_pid=`ps -ef | grep 'Grakn' | grep -v grep | awk '{ print $2}'`
 
   if [[ ! -z $grakn_pid ]]; then
     echo "Force killing Grakn (pid=$grakn_pid)"

--- a/grakn-dist/src/test/bash/distribution-test.sh
+++ b/grakn-dist/src/test/bash/distribution-test.sh
@@ -13,7 +13,7 @@ must_properly_start() {
   "${GRAKN_DIST_TMP}"/grakn server start
   local count_running_cassandra_process=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}' | wc -l`
   local count_running_redis_process=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}' | wc -l`
-  local count_running_grakn_process=`ps -ef | grep 'GraknEngineServer' | grep -v grep | awk '{ print $2}' | wc -l`
+  local count_running_grakn_process=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}' | wc -l`
 
   if [[ $count_running_cassandra_process -ne 1 ]]; then
     echo "Error in starting Cassandra: Expected to find 1 running Cassandra process. Found " $count_running_cassandra_process
@@ -100,7 +100,7 @@ must_properly_stop() {
 
   local count_running_cassandra_process=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}' | wc -l`
   local count_running_redis_process=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}' | wc -l`
-  local count_running_grakn_process=`ps -ef | grep 'GraknEngineServer' | grep -v grep | awk '{ print $2}' | wc -l`
+  local count_running_grakn_process=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}' | wc -l`
 
   if [[ $count_running_cassandra_process -ne 0 ]]; then
     echo "Error in stopping Cassandra: Expected to find 0 running Cassandra process. Found " $count_running_cassandra_process
@@ -135,7 +135,7 @@ force_kill() {
   echo "Force kill initiated - attempting to clean up any running processes..."
   local cassandra_pid=`ps -ef | grep 'CassandraDaemon' | grep -v grep | awk '{ print $2}'`
   local redis_pid=`ps -ef | grep 'redis-server' | grep -v grep | awk '{ print $2}'`
-  local grakn_pid=`ps -ef | grep 'GraknEngineServer' | grep -v grep | awk '{ print $2}'`
+  local grakn_pid=`ps -ef | grep 'GraknApplication' | grep -v grep | awk '{ print $2}'`
 
   if [[ ! -z $grakn_pid ]]; then
     echo "Force killing Grakn (pid=$grakn_pid)"

--- a/grakn-engine/pom.xml
+++ b/grakn-engine/pom.xml
@@ -212,6 +212,18 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <version>1.3.4</version>
                 <groupId>org.raml.plugins</groupId>
                 <artifactId>jaxrs-raml-maven-plugin</artifactId>

--- a/grakn-engine/src/main/java/ai/grakn/engine/Grakn.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/Grakn.java
@@ -28,9 +28,9 @@ import org.slf4j.LoggerFactory;
  * @author Michele Orsi
  *
  */
-public class GraknApplication {
+public class Grakn {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(Grakn.class);
 
     public static void main(String[] args) {
         try {

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknApplication.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknApplication.java
@@ -1,0 +1,45 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * Main class invoked by bash scripting
+ *
+ * @author Michele Orsi
+ *
+ */
+public class GraknApplication {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
+
+    public static void main(String[] args) {
+        try {
+            // Start Engine
+            GraknEngineServer graknEngineServer = GraknCreator.instantiateGraknEngineServer(Runtime.getRuntime());
+            graknEngineServer.start();
+        } catch (Exception e) {
+            LOG.error("An exception has occurred", e);
+        }
+    }
+
+}

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
@@ -1,0 +1,151 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine;
+
+import ai.grakn.engine.controller.TasksController;
+import ai.grakn.engine.data.RedisWrapper;
+import ai.grakn.engine.factory.EngineGraknTxFactory;
+import ai.grakn.engine.lock.JedisLockProvider;
+import ai.grakn.engine.lock.LockProvider;
+import ai.grakn.engine.tasks.manager.TaskManager;
+import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
+import ai.grakn.engine.util.EngineID;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import redis.clients.jedis.Jedis;
+import redis.clients.util.Pool;
+import spark.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static ai.grakn.engine.GraknEngineConfig.REDIS_HOST;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_HOST;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_POOL_SIZE;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_MASTER;
+import static ai.grakn.engine.GraknEngineConfig.QUEUE_CONSUMERS;
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * Static configurator for classes
+ *
+ * @author Michele Orsi
+ */
+public class GraknCreator {
+
+    private final static EngineID ENGINE_ID = EngineID.me();
+    private final static Service SPARK_SERVICE = Service.ignite();
+    private final static GraknEngineStatus GRAKN_ENGINE_STATUS = new GraknEngineStatus();
+    private final static MetricRegistry METRIC_REGISTRY = new MetricRegistry();
+    private final static ExecutorService EXECUTOR_SERVICE = TasksController.taskExecutor();
+    private final static GraknEngineConfig GRAKN_ENGINE_CONFIG = GraknEngineConfig.create();
+
+    private static GraknEngineServer graknEngineServer;
+    private static RedisWrapper redisWrapper;
+    private static LockProvider lockProvider;
+    private static EngineGraknTxFactory engineGraknTxFactory;
+    private static TaskManager taskManager;
+
+    static synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime) {
+        if (graknEngineServer == null) {
+            EngineGraknTxFactory factory = instantiateGraknTxFactory(GRAKN_ENGINE_CONFIG);
+            RedisWrapper redisWrapper = instantiateRedis(GRAKN_ENGINE_CONFIG);
+            Pool<Jedis> jedisPool = redisWrapper.getJedisPool();
+            LockProvider lockProvider = instantiateLock(jedisPool);
+            TaskManager taskManager = instantiateTaskManager(METRIC_REGISTRY, GRAKN_ENGINE_CONFIG, ENGINE_ID, factory, jedisPool, lockProvider);
+            HttpHandler httpHandler = new HttpHandler(GRAKN_ENGINE_CONFIG, SPARK_SERVICE, factory, METRIC_REGISTRY, GRAKN_ENGINE_STATUS, taskManager, EXECUTOR_SERVICE);
+            graknEngineServer = new GraknEngineServer(GRAKN_ENGINE_CONFIG, taskManager, factory, lockProvider, GRAKN_ENGINE_STATUS, redisWrapper, EXECUTOR_SERVICE, httpHandler);
+            Thread thread = new Thread(graknEngineServer::close, "GraknEngineServer-shutdown");
+            runtime.addShutdownHook(thread);
+        }
+        return graknEngineServer;
+    }
+
+    static synchronized RedisWrapper instantiateRedis(GraknEngineConfig prop) {
+        if (redisWrapper == null) {
+            List<String> redisUrl = GraknEngineConfig.parseCSValue(prop.tryProperty(REDIS_HOST).orElse("localhost:6379"));
+            List<String> sentinelUrl = GraknEngineConfig.parseCSValue(prop.tryProperty(REDIS_SENTINEL_HOST).orElse(""));
+            int poolSize = prop.tryIntProperty(REDIS_POOL_SIZE, 32);
+            boolean useSentinel = !sentinelUrl.isEmpty();
+            RedisWrapper.Builder builder = RedisWrapper.builder()
+                    .setUseSentinel(useSentinel)
+                    .setPoolSize(poolSize)
+                    .setURI((useSentinel ? sentinelUrl : redisUrl));
+            if (useSentinel) {
+                builder.setMasterName(prop.tryProperty(REDIS_SENTINEL_MASTER).orElse("graknmaster"));
+            }
+            redisWrapper = builder.build();
+        }
+        return redisWrapper;
+    }
+
+    static synchronized LockProvider instantiateLock(Pool<Jedis> jedisPool) {
+        if (lockProvider == null) {
+            lockProvider = new JedisLockProvider(jedisPool);
+        }
+        return lockProvider;
+    }
+
+    static synchronized EngineGraknTxFactory instantiateGraknTxFactory(GraknEngineConfig prop) {
+        if (engineGraknTxFactory == null) {
+            engineGraknTxFactory = EngineGraknTxFactory.create(prop.getProperties());
+        }
+        return engineGraknTxFactory;
+    }
+
+    /**
+     * Check in with the properties file to decide which type of task manager should be started
+     * and return the TaskManager
+     *
+     * @param jedisPool
+     */
+    static synchronized TaskManager instantiateTaskManager(MetricRegistry metricRegistry, GraknEngineConfig prop, EngineID engineId, EngineGraknTxFactory factory,
+                                                           final Pool<Jedis> jedisPool,
+                                                           final LockProvider lockProvider) {
+        if (taskManager == null) {
+            TaskManager result;
+            metricRegistry.register(name(GraknEngineServer.class, "jedis", "idle"), (Gauge<Integer>) jedisPool::getNumIdle);
+            metricRegistry.register(name(GraknEngineServer.class, "jedis", "active"), (Gauge<Integer>) jedisPool::getNumActive);
+            metricRegistry.register(name(GraknEngineServer.class, "jedis", "waiters"), (Gauge<Integer>) jedisPool::getNumWaiters);
+            metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "max"), (Gauge<Long>) jedisPool::getMaxBorrowWaitTimeMillis);
+            metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "mean"), (Gauge<Long>) jedisPool::getMeanBorrowWaitTimeMillis);
+
+            metricRegistry.register(name(GraknEngineServer.class, "System", "gc"), new GarbageCollectorMetricSet());
+            metricRegistry.register(name(GraknEngineServer.class, "System", "threads"), new CachedThreadStatesGaugeSet(15, TimeUnit.SECONDS));
+            metricRegistry.register(name(GraknEngineServer.class, "System", "memory"), new MemoryUsageGaugeSet());
+
+            Optional<String> consumers = prop.tryProperty(QUEUE_CONSUMERS);
+            if (consumers.isPresent()) {
+                Integer threads = Integer.parseInt(consumers.get());
+                result = new RedisTaskManager(engineId, prop, jedisPool, threads, factory, lockProvider, metricRegistry);
+            } else {
+                result = new RedisTaskManager(engineId, prop, jedisPool, factory, lockProvider, metricRegistry);
+            }
+            taskManager = result;
+        }
+        return taskManager;
+    }
+
+}
+

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -17,72 +17,21 @@
  */
 package ai.grakn.engine;
 
-import ai.grakn.engine.controller.AuthController;
-import ai.grakn.engine.controller.CommitLogController;
-import ai.grakn.engine.controller.ConceptController;
-import ai.grakn.engine.controller.DashboardController;
-import ai.grakn.engine.controller.GraqlController;
-import ai.grakn.engine.controller.SystemController;
-import ai.grakn.engine.controller.TasksController;
-import ai.grakn.engine.controller.UserController;
-import ai.grakn.engine.controller.api.AttributeController;
-import ai.grakn.engine.controller.api.AttributeTypeController;
-import ai.grakn.engine.controller.api.EntityController;
-import ai.grakn.engine.controller.api.EntityTypeController;
-import ai.grakn.engine.controller.api.RelationshipController;
-import ai.grakn.engine.controller.api.RelationshipTypeController;
-import ai.grakn.engine.controller.api.RoleController;
-import ai.grakn.engine.controller.api.RuleController;
 import ai.grakn.engine.data.RedisWrapper;
-import ai.grakn.engine.data.RedisWrapper.Builder;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
-import ai.grakn.engine.lock.JedisLockProvider;
 import ai.grakn.engine.lock.LockProvider;
-import ai.grakn.engine.session.RemoteSession;
 import ai.grakn.engine.tasks.manager.TaskManager;
-import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
-import ai.grakn.engine.user.UsersHandler;
-import ai.grakn.engine.util.EngineID;
-import ai.grakn.engine.util.JWTHandler;
-import ai.grakn.exception.GraknBackendException;
-import ai.grakn.exception.GraknServerException;
 import ai.grakn.util.GraknVersion;
-import ai.grakn.util.REST;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.google.common.base.Stopwatch;
-import mjson.Json;
-import org.apache.http.entity.ContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
-import redis.clients.util.Pool;
-import spark.HaltException;
-import spark.Request;
-import spark.Response;
-import spark.Service;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 
-import static ai.grakn.engine.GraknEngineConfig.QUEUE_CONSUMERS;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_HOST;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_POOL_SIZE;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_HOST;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_MASTER;
-import static ai.grakn.engine.GraknEngineConfig.WEBSOCKET_TIMEOUT;
 import static ai.grakn.util.ErrorMessage.VERSION_MISMATCH;
-import static com.codahale.metrics.MetricRegistry.name;
 import static org.apache.commons.lang.exception.ExceptionUtils.getFullStackTrace;
 
 /**
@@ -96,57 +45,29 @@ public class GraknEngineServer implements AutoCloseable {
 
     private static final String LOAD_SYSTEM_SCHEMA_LOCK_NAME = "load-system-schema";
     private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
-    private static final Set<String> unauthenticatedEndPoints = new HashSet<>(Arrays.asList(
-            REST.WebPath.NEW_SESSION_URI,
-            REST.WebPath.REMOTE_SHELL_URI,
-            REST.WebPath.System.CONFIGURATION,
-            REST.WebPath.IS_PASSWORD_PROTECTED_URI));
 
     private final GraknEngineConfig prop;
-    private final EngineID engineId = EngineID.me();
-    private final Service spark = Service.ignite();
     private final TaskManager taskManager;
     private final EngineGraknTxFactory factory;
-    private final MetricRegistry metricRegistry;
     private final LockProvider lockProvider;
-    private final GraknEngineStatus graknEngineStatus = new GraknEngineStatus();
+    private final GraknEngineStatus graknEngineStatus;
     private final RedisWrapper redisWrapper;
     private final ExecutorService taskExecutor;
+    private final HttpHandler httpHandler;
 
-    private GraknEngineServer(GraknEngineConfig prop, RedisWrapper redisWrapper) {
+
+    public GraknEngineServer(GraknEngineConfig prop, TaskManager taskManager, EngineGraknTxFactory factory, LockProvider lockProvider, GraknEngineStatus graknEngineStatus, RedisWrapper redisWrapper, ExecutorService taskExecutor, HttpHandler httpHandler) {
         this.prop = prop;
-        // Metrics
-        this.metricRegistry = new MetricRegistry();
+        this.graknEngineStatus = graknEngineStatus;
         // Redis connection pool
         this.redisWrapper = redisWrapper;
         // Lock provider
-        this.lockProvider = new JedisLockProvider(redisWrapper.getJedisPool());
-        this.factory = EngineGraknTxFactory.create(prop.getProperties());
+        this.lockProvider = lockProvider;
+        this.factory = factory;
         // Task manager
-        this.taskManager = makeTaskManager(redisWrapper.getJedisPool(), lockProvider);
-        this.taskExecutor = TasksController.taskExecutor();
-    }
-
-    public static GraknEngineServer create(GraknEngineConfig prop) {
-        return create(prop, instantiateRedis(prop));
-    }
-
-    public static GraknEngineServer create(GraknEngineConfig prop, RedisWrapper redisWrapper) {
-        return new GraknEngineServer(prop, redisWrapper);
-    }
-
-    public static void main(String[] args) {
-        try {
-            GraknEngineConfig prop = GraknEngineConfig.create();
-            // Start Engine
-            GraknEngineServer graknEngineServer = create(prop);
-            graknEngineServer.start();
-            // close GraknEngineServer on SIGTERM
-            Thread closeThread = new Thread(graknEngineServer::close, "GraknEngineServer-shutdown");
-            Runtime.getRuntime().addShutdownHook(closeThread);
-        } catch (Exception e) {
-            LOG.error("An exception has occurred", e);
-        }
+        this.taskManager = taskManager;
+        this.taskExecutor = taskExecutor;
+        this.httpHandler = httpHandler;
     }
 
     public void start() {
@@ -160,7 +81,7 @@ public class GraknEngineServer implements AutoCloseable {
         synchronized (this){
             checkVersion();
             lockAndInitializeSystemSchema();
-            startHTTP();
+            httpHandler.startHTTP();
         }
         graknEngineStatus.setReady(true);
         LOG.info("Grakn started in {}", timer.stop());
@@ -179,8 +100,12 @@ public class GraknEngineServer implements AutoCloseable {
     @Override
     public void close() {
         synchronized (this) {
-            stopTaskManager();
-            stopHTTP();
+            try {
+                taskManager.close();
+            } catch (Exception e){
+                LOG.error(getFullStackTrace(e));
+            }
+            httpHandler.stopHTTP();
             redisWrapper.close();
             taskExecutor.shutdown();
         }
@@ -192,239 +117,20 @@ public class GraknEngineServer implements AutoCloseable {
             if (lock.tryLock(60, TimeUnit.SECONDS)) {
                 loadAndUnlock(lock);
             } else {
-                LOG.info("{} found system schema lock already acquired by other engine", this.engineId);
+                LOG.info("{} found system schema lock already acquired by other engine");
             }
         } catch (InterruptedException e) {
-            LOG.warn("{} was interrupted while initializing system schema", this.engineId);
+            LOG.warn("{} was interrupted while initializing system schema");
         }
     }
 
     private void loadAndUnlock(Lock lock) {
         try {
-            LOG.info("{} is checking the system schema", this.engineId);
+            LOG.info("{} is checking the system schema");
             factory.systemKeyspace().loadSystemSchema();
         } finally {
             lock.unlock();
         }
-    }
-
-    /**
-     * Check in with the properties file to decide which type of task manager should be started
-     * and return the TaskManager
-     * @param jedisPool
-     */
-    private TaskManager makeTaskManager(
-            final Pool<Jedis> jedisPool,
-            final LockProvider lockProvider) {
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "idle"), (Gauge<Integer>) jedisPool::getNumIdle);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "active"), (Gauge<Integer>) jedisPool::getNumActive);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "waiters"), (Gauge<Integer>) jedisPool::getNumWaiters);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "max"), (Gauge<Long>) jedisPool::getMaxBorrowWaitTimeMillis);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "mean"), (Gauge<Long>) jedisPool::getMeanBorrowWaitTimeMillis);
-
-        metricRegistry.register(name(GraknEngineServer.class, "System", "gc"), new GarbageCollectorMetricSet());
-        metricRegistry.register(name(GraknEngineServer.class, "System", "threads"), new CachedThreadStatesGaugeSet(15, TimeUnit.SECONDS));
-        metricRegistry.register(name(GraknEngineServer.class, "System", "memory"), new MemoryUsageGaugeSet());
-
-        Optional<String> consumers = prop.tryProperty(QUEUE_CONSUMERS);
-        return consumers
-                .map(s -> new RedisTaskManager(engineId, prop, jedisPool, Integer.parseInt(s), factory, lockProvider, metricRegistry))
-                .orElseGet(() -> new RedisTaskManager(engineId, prop, jedisPool, factory, lockProvider, metricRegistry));
-    }
-
-    public void startHTTP() {
-        boolean passwordProtected = prop.getPropertyAsBool(GraknEngineConfig.PASSWORD_PROTECTED_PROPERTY, false);
-
-        // TODO: Make sure controllers handle the null case
-        Optional<String> secret = prop.tryProperty(GraknEngineConfig.JWT_SECRET_PROPERTY);
-        @Nullable JWTHandler jwtHandler = secret.map(JWTHandler::create).orElse(null);
-        UsersHandler usersHandler = UsersHandler.create(prop.getProperty(GraknEngineConfig.ADMIN_PASSWORD_PROPERTY), factory);
-
-        configureSpark(spark, prop, jwtHandler);
-
-        // Start the websocket for Graql
-        RemoteSession graqlWebSocket = passwordProtected ? RemoteSession.passwordProtected(usersHandler) : RemoteSession.create();
-        spark.webSocket(REST.WebPath.REMOTE_SHELL_URI, graqlWebSocket);
-
-        int postProcessingDelay = prop.getPropertyAsInt(GraknEngineConfig.POST_PROCESSING_TASK_DELAY);
-
-        // Start all the controllers
-        new GraqlController(factory, spark, metricRegistry);
-        new ConceptController(factory, spark, metricRegistry);
-        new DashboardController(factory, spark);
-        new SystemController(factory, spark, graknEngineStatus, metricRegistry);
-        new AuthController(spark, passwordProtected, jwtHandler, usersHandler);
-        new UserController(spark, usersHandler);
-        new CommitLogController(spark, postProcessingDelay, taskManager);
-        new TasksController(spark, taskManager, metricRegistry, taskExecutor);
-        new EntityController(factory, spark);
-        new EntityTypeController(factory, spark);
-        new RelationshipController(factory, spark);
-        new RelationshipTypeController(factory, spark);
-        new AttributeController(factory, spark);
-        new AttributeTypeController(factory, spark);
-        new RoleController(factory, spark);
-        new RuleController(factory, spark);
-
-        // This method will block until all the controllers are ready to serve requests
-        spark.awaitInitialization();
-    }
-
-    public static void configureSpark(Service spark, GraknEngineConfig prop, @Nullable JWTHandler jwtHandler) {
-        configureSpark(spark, 
-                       prop.getProperty(GraknEngineConfig.SERVER_HOST_NAME),
-                       Integer.parseInt(prop.getProperty(GraknEngineConfig.SERVER_PORT_NUMBER)),
-                       prop.getPath(GraknEngineConfig.STATIC_FILES_PATH),
-                       prop.getPropertyAsBool(GraknEngineConfig.PASSWORD_PROTECTED_PROPERTY, false),
-                       prop.tryIntProperty(GraknEngineConfig.WEBSERVER_THREADS, 64),
-                       jwtHandler);
-    }
-    
-    public static void configureSpark(Service spark, 
-                                      String hostName, 
-                                      int port, 
-                                      String staticFolder,
-                                      boolean passwordProtected,
-                                      int maxThreads,
-                                      @Nullable JWTHandler jwtHandler){
-        // Set host name
-        spark.ipAddress(hostName);
-
-        // Set port
-        spark.port(port);
-
-        // Set the external static files folder
-        spark.staticFiles.externalLocation(staticFolder);
-
-        spark.threadPool(maxThreads);
-        spark.webSocketIdleTimeoutMillis(WEBSOCKET_TIMEOUT);
-
-        // Register filter to check authentication token in each request
-        if (passwordProtected) {
-            spark.before((req, res) -> checkAuthorization(spark, req, jwtHandler));
-        }
-
-        //Register exception handlers
-        spark.exception(GraknServerException.class, (e, req, res) -> {
-            assert e instanceof GraknServerException; // This is guaranteed by `spark#exception`
-            handleGraknServerError((GraknServerException) e, res);
-        });
-
-        spark.exception(Exception.class, (e, req, res) -> handleInternalError(e, res));
-    }
-
-    public void stopHTTP() {
-        spark.stop();
-
-        // Block until server is truly stopped
-        // This occurs when there is no longer a port assigned to the Spark server
-        boolean running = true;
-        while (running) {
-            try {
-                spark.port();
-            }
-            catch(IllegalStateException e){
-                LOG.debug("Spark server has been stopped");
-                running = false;
-            }
-        }
-    }
-
-    private void stopTaskManager() {
-        try {
-            taskManager.close();
-        } catch (Exception e){
-            LOG.error(getFullStackTrace(e));
-        }
-    }
-
-    public TaskManager getTaskManager(){
-        return taskManager;
-    }
-
-    public EngineGraknTxFactory factory() {
-        return factory;
-    }
-
-    public GraknEngineStatus getGraknEngineStatus() {
-        return graknEngineStatus;
-    }
-
-    /**
-     * If authorization is enabled, check the client has correct JWT Token before allowing
-     * access to specific endpoints.
-     * @param request request information from the client
-     */
-    private static void checkAuthorization(Service spark, Request request, JWTHandler jwtHandler) throws HaltException {
-        //we dont check authorization token if the path requested is one of the unauthenticated ones
-        if (!unauthenticatedEndPoints.contains(request.pathInfo())) {
-            //add check to see if string contains substring "Bearer ", for now a lot of optimism here
-            boolean authenticated;
-            try {
-                if (request.headers("Authorization") == null || !request.headers("Authorization").startsWith("Bearer ")) {
-                    throw GraknServerException.authenticationFailure();
-                }
-
-                String token = request.headers("Authorization").substring(7);
-                authenticated = jwtHandler.verifyJWT(token);
-                request.attribute(REST.Request.USER_ATTR, jwtHandler.extractUserFromJWT(token));
-            }
-            catch (GraknBackendException e) {
-                throw e;
-            }
-            catch (Exception e) {
-                //request is malformed, return 400
-                throw GraknServerException.serverException(400, e);
-            }
-            if (!authenticated) {
-                throw spark.halt(401, "User not authenticated.");
-            }
-        }
-    }
-
-    /**
-     * Handle any {@link GraknBackendException} that are thrown by the server. Configures and returns
-     * the correct JSON response.
-     *
-     * @param exception exception thrown by the server
-     * @param response response to the client
-     */
-    private static void handleGraknServerError(GraknServerException exception, Response response){
-        LOG.error("REST error", exception);
-        response.status(exception.getStatus());
-        response.body(Json.object("exception", exception.getMessage()).toString());
-        response.type(ContentType.APPLICATION_JSON.getMimeType());
-    }
-
-    /**
-     * Handle any exception thrown by the server
-     * @param exception Exception by the server
-     * @param response response to the client
-     */
-    private static void handleInternalError(Exception exception, Response response){
-        LOG.error("REST error", exception);
-        response.status(500);
-        response.body(Json.object("exception", exception.getMessage()).toString());
-        response.type(ContentType.APPLICATION_JSON.getMimeType());
-    }
-
-    public MetricRegistry getMetricRegistry() {
-        return metricRegistry;
-    }
-
-    private static RedisWrapper instantiateRedis(GraknEngineConfig prop) {
-        List<String> redisUrl = GraknEngineConfig.parseCSValue(prop.tryProperty(REDIS_HOST).orElse("localhost:6379"));
-        List<String> sentinelUrl = GraknEngineConfig.parseCSValue(prop.tryProperty(REDIS_SENTINEL_HOST).orElse(""));
-        int poolSize = prop.tryIntProperty(REDIS_POOL_SIZE, 32);
-        boolean useSentinel = !sentinelUrl.isEmpty();
-        Builder builder = RedisWrapper.builder()
-                .setUseSentinel(useSentinel)
-                .setPoolSize(poolSize)
-                .setURI((useSentinel ? sentinelUrl : redisUrl));
-        if (useSentinel) {
-            builder.setMasterName(prop.tryProperty(REDIS_SENTINEL_MASTER).orElse("graknmaster"));
-        }
-        return builder.build();
     }
 
     private void logStartMessage(String host, String port) {
@@ -432,5 +138,21 @@ public class GraknEngineServer implements AutoCloseable {
         LOG.info("\n==================================================");
         LOG.info("\n" + String.format(GraknEngineConfig.GRAKN_ASCII, address));
         LOG.info("\n==================================================");
+    }
+
+    public EngineGraknTxFactory factory() {
+        return factory;
+    }
+
+    public TaskManager getTaskManager() {
+        return taskManager;
+    }
+
+    public GraknEngineStatus getGraknEngineStatus() {
+        return graknEngineStatus;
+    }
+
+    public HttpHandler getHttpHandler() {
+        return httpHandler;
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/HttpHandler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/HttpHandler.java
@@ -68,7 +68,7 @@ import static ai.grakn.engine.GraknEngineConfig.WEBSOCKET_TIMEOUT;
  */
 public class HttpHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpHandler.class);
 
     private final GraknEngineConfig prop;
     private final Service spark;

--- a/grakn-engine/src/main/java/ai/grakn/engine/HttpHandler.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/HttpHandler.java
@@ -1,0 +1,255 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine;
+
+
+import ai.grakn.engine.controller.AuthController;
+import ai.grakn.engine.controller.CommitLogController;
+import ai.grakn.engine.controller.ConceptController;
+import ai.grakn.engine.controller.DashboardController;
+import ai.grakn.engine.controller.GraqlController;
+import ai.grakn.engine.controller.SystemController;
+import ai.grakn.engine.controller.TasksController;
+import ai.grakn.engine.controller.UserController;
+import ai.grakn.engine.controller.api.AttributeController;
+import ai.grakn.engine.controller.api.AttributeTypeController;
+import ai.grakn.engine.controller.api.EntityController;
+import ai.grakn.engine.controller.api.EntityTypeController;
+import ai.grakn.engine.controller.api.RelationshipController;
+import ai.grakn.engine.controller.api.RelationshipTypeController;
+import ai.grakn.engine.controller.api.RoleController;
+import ai.grakn.engine.controller.api.RuleController;
+import ai.grakn.engine.factory.EngineGraknTxFactory;
+import ai.grakn.engine.session.RemoteSession;
+import ai.grakn.engine.tasks.manager.TaskManager;
+import ai.grakn.engine.user.UsersHandler;
+import ai.grakn.engine.util.JWTHandler;
+import ai.grakn.exception.GraknBackendException;
+import ai.grakn.exception.GraknServerException;
+import ai.grakn.util.REST;
+import com.codahale.metrics.MetricRegistry;
+import mjson.Json;
+import org.apache.http.entity.ContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.HaltException;
+import spark.Request;
+import spark.Response;
+import spark.Service;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static ai.grakn.engine.GraknEngineConfig.WEBSOCKET_TIMEOUT;
+
+/**
+ *
+ * @author Michele Orsi
+ */
+public class HttpHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GraknEngineServer.class);
+
+    private final GraknEngineConfig prop;
+    private final Service spark;
+    private final EngineGraknTxFactory factory;
+    private final MetricRegistry metricRegistry;
+    private final GraknEngineStatus graknEngineStatus;
+    private final TaskManager taskManager;
+    private final ExecutorService taskExecutor;
+
+    private static final Set<String> unauthenticatedEndPoints = new HashSet<>(Arrays.asList(
+            REST.WebPath.NEW_SESSION_URI,
+            REST.WebPath.REMOTE_SHELL_URI,
+            REST.WebPath.System.CONFIGURATION,
+            REST.WebPath.IS_PASSWORD_PROTECTED_URI));
+
+    public HttpHandler(GraknEngineConfig prop, Service spark, EngineGraknTxFactory factory, MetricRegistry metricRegistry, GraknEngineStatus graknEngineStatus, TaskManager taskManager, ExecutorService taskExecutor) {
+        this.prop = prop;
+        this.spark = spark;
+        this.factory = factory;
+        this.metricRegistry = metricRegistry;
+        this.graknEngineStatus = graknEngineStatus;
+        this.taskManager = taskManager;
+        this.taskExecutor = taskExecutor;
+    }
+
+
+    public void startHTTP() {
+        boolean passwordProtected = prop.getPropertyAsBool(GraknEngineConfig.PASSWORD_PROTECTED_PROPERTY, false);
+
+        // TODO: Make sure controllers handle the null case
+        Optional<String> secret = prop.tryProperty(GraknEngineConfig.JWT_SECRET_PROPERTY);
+        @Nullable JWTHandler jwtHandler = secret.map(JWTHandler::create).orElse(null);
+        UsersHandler usersHandler = UsersHandler.create(prop.getProperty(GraknEngineConfig.ADMIN_PASSWORD_PROPERTY), factory);
+
+        configureSpark(spark, prop, jwtHandler);
+
+        // Start the websocket for Graql
+        RemoteSession graqlWebSocket = passwordProtected ? RemoteSession.passwordProtected(usersHandler) : RemoteSession.create();
+        spark.webSocket(REST.WebPath.REMOTE_SHELL_URI, graqlWebSocket);
+
+        int postProcessingDelay = prop.getPropertyAsInt(GraknEngineConfig.POST_PROCESSING_TASK_DELAY);
+
+        // Start all the controllers
+        new GraqlController(factory, spark, metricRegistry);
+        new ConceptController(factory, spark, metricRegistry);
+        new DashboardController(factory, spark);
+        new SystemController(factory, spark, graknEngineStatus, metricRegistry);
+        new AuthController(spark, passwordProtected, jwtHandler, usersHandler);
+        new UserController(spark, usersHandler);
+        new CommitLogController(spark, postProcessingDelay, taskManager);
+        new TasksController(spark, taskManager, metricRegistry, taskExecutor);
+        new EntityController(factory, spark);
+        new EntityTypeController(factory, spark);
+        new RelationshipController(factory, spark);
+        new RelationshipTypeController(factory, spark);
+        new AttributeController(factory, spark);
+        new AttributeTypeController(factory, spark);
+        new RoleController(factory, spark);
+        new RuleController(factory, spark);
+
+        // This method will block until all the controllers are ready to serve requests
+        spark.awaitInitialization();
+    }
+
+    public static void configureSpark(Service spark, GraknEngineConfig prop, @Nullable JWTHandler jwtHandler) {
+        configureSpark(spark,
+                prop.getProperty(GraknEngineConfig.SERVER_HOST_NAME),
+                Integer.parseInt(prop.getProperty(GraknEngineConfig.SERVER_PORT_NUMBER)),
+                prop.getPath(GraknEngineConfig.STATIC_FILES_PATH),
+                prop.getPropertyAsBool(GraknEngineConfig.PASSWORD_PROTECTED_PROPERTY, false),
+                prop.tryIntProperty(GraknEngineConfig.WEBSERVER_THREADS, 64),
+                jwtHandler);
+    }
+
+    public static void configureSpark(Service spark,
+                                      String hostName,
+                                      int port,
+                                      String staticFolder,
+                                      boolean passwordProtected,
+                                      int maxThreads,
+                                      @Nullable JWTHandler jwtHandler){
+        // Set host name
+        spark.ipAddress(hostName);
+
+        // Set port
+        spark.port(port);
+
+        // Set the external static files folder
+        spark.staticFiles.externalLocation(staticFolder);
+
+        spark.threadPool(maxThreads);
+        spark.webSocketIdleTimeoutMillis(WEBSOCKET_TIMEOUT);
+
+        // Register filter to check authentication token in each request
+        if (passwordProtected) {
+            spark.before((req, res) -> checkAuthorization(spark, req, jwtHandler));
+        }
+
+        //Register exception handlers
+        spark.exception(GraknServerException.class, (e, req, res) -> {
+            assert e instanceof GraknServerException; // This is guaranteed by `spark#exception`
+            handleGraknServerError((GraknServerException) e, res);
+        });
+
+        spark.exception(Exception.class, (e, req, res) -> handleInternalError(e, res));
+    }
+
+
+    public void stopHTTP() {
+        spark.stop();
+
+        // Block until server is truly stopped
+        // This occurs when there is no longer a port assigned to the Spark server
+        boolean running = true;
+        while (running) {
+            try {
+                spark.port();
+            }
+            catch(IllegalStateException e){
+                LOG.debug("Spark server has been stopped");
+                running = false;
+            }
+        }
+    }
+
+
+    /**
+     * If authorization is enabled, check the client has correct JWT Token before allowing
+     * access to specific endpoints.
+     * @param request request information from the client
+     */
+    private static void checkAuthorization(Service spark, Request request, JWTHandler jwtHandler) throws HaltException {
+        //we dont check authorization token if the path requested is one of the unauthenticated ones
+        if (!unauthenticatedEndPoints.contains(request.pathInfo())) {
+            //add check to see if string contains substring "Bearer ", for now a lot of optimism here
+            boolean authenticated;
+            try {
+                if (request.headers("Authorization") == null || !request.headers("Authorization").startsWith("Bearer ")) {
+                    throw GraknServerException.authenticationFailure();
+                }
+
+                String token = request.headers("Authorization").substring(7);
+                authenticated = jwtHandler.verifyJWT(token);
+                request.attribute(REST.Request.USER_ATTR, jwtHandler.extractUserFromJWT(token));
+            }
+            catch (GraknBackendException e) {
+                throw e;
+            }
+            catch (Exception e) {
+                //request is malformed, return 400
+                throw GraknServerException.serverException(400, e);
+            }
+            if (!authenticated) {
+                throw spark.halt(401, "User not authenticated.");
+            }
+        }
+    }
+
+    /**
+     * Handle any {@link GraknBackendException} that are thrown by the server. Configures and returns
+     * the correct JSON response.
+     *
+     * @param exception exception thrown by the server
+     * @param response response to the client
+     */
+    private static void handleGraknServerError(GraknServerException exception, Response response){
+        LOG.error("REST error", exception);
+        response.status(exception.getStatus());
+        response.body(Json.object("exception", exception.getMessage()).toString());
+        response.type(ContentType.APPLICATION_JSON.getMimeType());
+    }
+
+    /**
+     * Handle any exception thrown by the server
+     * @param exception Exception by the server
+     * @param response response to the client
+     */
+    private static void handleInternalError(Exception exception, Response response){
+        LOG.error("REST error", exception);
+        response.status(500);
+        response.body(Json.object("exception", exception.getMessage()).toString());
+        response.type(ContentType.APPLICATION_JSON.getMimeType());
+    }
+}

--- a/grakn-engine/src/test/java/ai/grakn/engine/EngineTestHelper.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/EngineTestHelper.java
@@ -1,9 +1,36 @@
 package ai.grakn.engine;
 
+import ai.grakn.engine.controller.TasksController;
+import ai.grakn.engine.data.RedisWrapper;
+import ai.grakn.engine.factory.EngineGraknTxFactory;
+import ai.grakn.engine.lock.JedisLockProvider;
+import ai.grakn.engine.lock.LockProvider;
+import ai.grakn.engine.tasks.manager.TaskManager;
+import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
+import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.GraknTestSetup;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
+import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
+import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
+import redis.clients.jedis.Jedis;
+import redis.clients.util.Pool;
+import spark.Service;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static ai.grakn.engine.GraknEngineConfig.QUEUE_CONSUMERS;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_HOST;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_POOL_SIZE;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_HOST;
+import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_MASTER;
+import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * <p>
@@ -54,7 +81,7 @@ public class EngineTestHelper {
         if (server != null) {
             return;
         }
-        server = GraknEngineServer.create(config());
+        server = EngineTestHelper.graknEngineServer(config());
         server.start();
     }
 
@@ -80,5 +107,61 @@ public class EngineTestHelper {
         finally {
             server = null;
         }
+    }
+    
+    public static synchronized GraknEngineServer graknEngineServer(GraknEngineConfig config) {
+        RedisWrapper redisWrapper = redisWrapper(config);
+        return EngineTestHelper.graknEngineServer(config,redisWrapper);
+    }
+
+    private static RedisWrapper redisWrapper(GraknEngineConfig config) {
+        List<String> redisUrl = GraknEngineConfig.parseCSValue(config.tryProperty(REDIS_HOST).orElse("localhost:6379"));
+        List<String> sentinelUrl = GraknEngineConfig.parseCSValue(config.tryProperty(REDIS_SENTINEL_HOST).orElse(""));
+        int poolSize = config.tryIntProperty(REDIS_POOL_SIZE, 32);
+        boolean useSentinel = !sentinelUrl.isEmpty();
+        RedisWrapper.Builder builder = RedisWrapper.builder()
+                .setUseSentinel(useSentinel)
+                .setPoolSize(poolSize)
+                .setURI((useSentinel ? sentinelUrl : redisUrl));
+        if (useSentinel) {
+            builder.setMasterName(config.tryProperty(REDIS_SENTINEL_MASTER).orElse("graknmaster"));
+        }
+        return builder.build();
+    }
+
+    public static synchronized GraknEngineServer graknEngineServer(GraknEngineConfig config, RedisWrapper redisWrapper) {
+        EngineGraknTxFactory factory = EngineGraknTxFactory.create(config.getProperties());
+        Pool<Jedis> jedisPool = redisWrapper.getJedisPool();
+        LockProvider lockProvider = new JedisLockProvider(jedisPool);
+        EngineID engineId = EngineID.me();
+        MetricRegistry metricRegistry = new MetricRegistry();
+        TaskManager result = taskManager(config, factory, jedisPool, lockProvider, engineId, metricRegistry);
+        TaskManager taskManager = result;
+        GraknEngineStatus graknEngineStatus = new GraknEngineStatus();
+        ExecutorService executorService = TasksController.taskExecutor();
+        HttpHandler httpHandler = new HttpHandler(config, Service.ignite(), factory, metricRegistry, graknEngineStatus, taskManager, executorService);
+        return new GraknEngineServer(config, taskManager, factory, lockProvider, graknEngineStatus, redisWrapper, executorService, httpHandler);
+    }
+
+    private static TaskManager taskManager(GraknEngineConfig config, EngineGraknTxFactory factory, Pool<Jedis> jedisPool, LockProvider lockProvider, EngineID engineId, MetricRegistry metricRegistry) {
+        TaskManager result;
+        metricRegistry.register(name(GraknEngineServer.class, "jedis", "idle"), (Gauge<Integer>) jedisPool::getNumIdle);
+        metricRegistry.register(name(GraknEngineServer.class, "jedis", "active"), (Gauge<Integer>) jedisPool::getNumActive);
+        metricRegistry.register(name(GraknEngineServer.class, "jedis", "waiters"), (Gauge<Integer>) jedisPool::getNumWaiters);
+        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "max"), (Gauge<Long>) jedisPool::getMaxBorrowWaitTimeMillis);
+        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "mean"), (Gauge<Long>) jedisPool::getMeanBorrowWaitTimeMillis);
+
+        metricRegistry.register(name(GraknEngineServer.class, "System", "gc"), new GarbageCollectorMetricSet());
+        metricRegistry.register(name(GraknEngineServer.class, "System", "threads"), new CachedThreadStatesGaugeSet(15, TimeUnit.SECONDS));
+        metricRegistry.register(name(GraknEngineServer.class, "System", "memory"), new MemoryUsageGaugeSet());
+
+        Optional<String> consumers = config.tryProperty(QUEUE_CONSUMERS);
+        if (consumers.isPresent()) {
+            Integer threads = Integer.parseInt(consumers.get());
+            result = new RedisTaskManager(engineId, config, jedisPool, threads, factory, lockProvider, metricRegistry);
+        } else {
+            result = new RedisTaskManager(engineId, config, jedisPool, factory, lockProvider, metricRegistry);
+        }
+        return result;
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/EngineTestHelper.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/EngineTestHelper.java
@@ -1,35 +1,19 @@
 package ai.grakn.engine;
 
-import ai.grakn.engine.controller.TasksController;
 import ai.grakn.engine.data.RedisWrapper;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
-import ai.grakn.engine.lock.JedisLockProvider;
 import ai.grakn.engine.lock.LockProvider;
 import ai.grakn.engine.tasks.manager.TaskManager;
-import ai.grakn.engine.tasks.manager.redisqueue.RedisTaskManager;
 import ai.grakn.engine.util.EngineID;
 import ai.grakn.test.GraknTestSetup;
-import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.jvm.CachedThreadStatesGaugeSet;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import redis.clients.jedis.Jedis;
 import redis.clients.util.Pool;
-import spark.Service;
 
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 
-import static ai.grakn.engine.GraknEngineConfig.QUEUE_CONSUMERS;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_HOST;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_POOL_SIZE;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_HOST;
-import static ai.grakn.engine.GraknEngineConfig.REDIS_SENTINEL_MASTER;
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**
@@ -42,7 +26,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  * @author borislav
  *
  */
-public class EngineTestHelper {
+public class EngineTestHelper extends GraknCreator {
     
     private static volatile GraknEngineConfig config = null;
     
@@ -81,7 +65,7 @@ public class EngineTestHelper {
         if (server != null) {
             return;
         }
-        server = EngineTestHelper.graknEngineServer(config());
+        server = EngineTestHelper.cleanGraknEngineServer(config());
         server.start();
     }
 
@@ -109,59 +93,21 @@ public class EngineTestHelper {
         }
     }
     
-    public static synchronized GraknEngineServer graknEngineServer(GraknEngineConfig config) {
-        RedisWrapper redisWrapper = redisWrapper(config);
-        return EngineTestHelper.graknEngineServer(config,redisWrapper);
+    public static synchronized GraknEngineServer cleanGraknEngineServer(GraknEngineConfig config) {
+        return EngineTestHelper.cleanGraknEngineServer(config,redisWrapper(config));
     }
 
-    private static RedisWrapper redisWrapper(GraknEngineConfig config) {
-        List<String> redisUrl = GraknEngineConfig.parseCSValue(config.tryProperty(REDIS_HOST).orElse("localhost:6379"));
-        List<String> sentinelUrl = GraknEngineConfig.parseCSValue(config.tryProperty(REDIS_SENTINEL_HOST).orElse(""));
-        int poolSize = config.tryIntProperty(REDIS_POOL_SIZE, 32);
-        boolean useSentinel = !sentinelUrl.isEmpty();
-        RedisWrapper.Builder builder = RedisWrapper.builder()
-                .setUseSentinel(useSentinel)
-                .setPoolSize(poolSize)
-                .setURI((useSentinel ? sentinelUrl : redisUrl));
-        if (useSentinel) {
-            builder.setMasterName(config.tryProperty(REDIS_SENTINEL_MASTER).orElse("graknmaster"));
-        }
-        return builder.build();
-    }
-
-    public static synchronized GraknEngineServer graknEngineServer(GraknEngineConfig config, RedisWrapper redisWrapper) {
-        EngineGraknTxFactory factory = EngineGraknTxFactory.create(config.getProperties());
+    public static synchronized GraknEngineServer cleanGraknEngineServer(GraknEngineConfig config, RedisWrapper redisWrapper) {
+        EngineGraknTxFactory factory = engineGraknTxFactory(config);
         Pool<Jedis> jedisPool = redisWrapper.getJedisPool();
-        LockProvider lockProvider = new JedisLockProvider(jedisPool);
-        EngineID engineId = EngineID.me();
-        MetricRegistry metricRegistry = new MetricRegistry();
-        TaskManager result = taskManager(config, factory, jedisPool, lockProvider, engineId, metricRegistry);
-        TaskManager taskManager = result;
-        GraknEngineStatus graknEngineStatus = new GraknEngineStatus();
-        ExecutorService executorService = TasksController.taskExecutor();
-        HttpHandler httpHandler = new HttpHandler(config, Service.ignite(), factory, metricRegistry, graknEngineStatus, taskManager, executorService);
-        return new GraknEngineServer(config, taskManager, factory, lockProvider, graknEngineStatus, redisWrapper, executorService, httpHandler);
+        LockProvider lockProvider = lockProvider(jedisPool);
+        MetricRegistry metricRegistry = metricRegistry();
+        EngineID engineID = engineId();
+        TaskManager taskManager = taskManager(config, factory, jedisPool, lockProvider, engineID, metricRegistry);
+        GraknEngineStatus graknEngineStatus = graknEngineStatus();
+        ExecutorService executorService = executorService();
+        HttpHandler httpHandler = new HttpHandler(config, sparkService(), factory, metricRegistry, graknEngineStatus, taskManager, executorService);
+        return new GraknEngineServer(config, taskManager, factory, lockProvider, graknEngineStatus, redisWrapper, executorService, httpHandler, engineID);
     }
 
-    private static TaskManager taskManager(GraknEngineConfig config, EngineGraknTxFactory factory, Pool<Jedis> jedisPool, LockProvider lockProvider, EngineID engineId, MetricRegistry metricRegistry) {
-        TaskManager result;
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "idle"), (Gauge<Integer>) jedisPool::getNumIdle);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "active"), (Gauge<Integer>) jedisPool::getNumActive);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "waiters"), (Gauge<Integer>) jedisPool::getNumWaiters);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "max"), (Gauge<Long>) jedisPool::getMaxBorrowWaitTimeMillis);
-        metricRegistry.register(name(GraknEngineServer.class, "jedis", "borrow_wait_time_ms", "mean"), (Gauge<Long>) jedisPool::getMeanBorrowWaitTimeMillis);
-
-        metricRegistry.register(name(GraknEngineServer.class, "System", "gc"), new GarbageCollectorMetricSet());
-        metricRegistry.register(name(GraknEngineServer.class, "System", "threads"), new CachedThreadStatesGaugeSet(15, TimeUnit.SECONDS));
-        metricRegistry.register(name(GraknEngineServer.class, "System", "memory"), new MemoryUsageGaugeSet());
-
-        Optional<String> consumers = config.tryProperty(QUEUE_CONSUMERS);
-        if (consumers.isPresent()) {
-            Integer threads = Integer.parseInt(consumers.get());
-            result = new RedisTaskManager(engineId, config, jedisPool, threads, factory, lockProvider, metricRegistry);
-        } else {
-            result = new RedisTaskManager(engineId, config, jedisPool, factory, lockProvider, metricRegistry);
-        }
-        return result;
-    }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
@@ -32,7 +32,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static ai.grakn.engine.GraknEngineConfig.JWT_SECRET_PROPERTY;
-import static ai.grakn.engine.GraknEngineServer.configureSpark;
+import static ai.grakn.engine.HttpHandler.configureSpark;
 
 /**
  * Context that starts spark

--- a/grakn-test/test-integration/pom.xml
+++ b/grakn-test/test-integration/pom.xml
@@ -45,6 +45,19 @@
         </dependency>
         <dependency>
             <groupId>ai.grakn</groupId>
+            <artifactId>grakn-engine</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ai.grakn</groupId>
             <artifactId>grakn-graql-shell</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
@@ -20,7 +20,7 @@ package ai.grakn.test;
 
 import ai.grakn.GraknSystemProperty;
 import ai.grakn.client.Client;
-import ai.grakn.engine.GraknApplication;
+import ai.grakn.engine.Grakn;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.util.SimpleURI;
 import ai.grakn.redismock.RedisServer;
@@ -150,7 +150,7 @@ public class DistributionContext extends ExternalResource {
                 "-cp", getClassPath(),
                 "-Dgrakn.dir=" + DIST_DIRECTORY + "/services",
                 "-Dgrakn.conf=" + propertiesFile.getAbsolutePath(),
-                GraknApplication.class.getName(), "&"};
+                Grakn.class.getName(), "&"};
 
         // Start process
         ProcessBuilder processBuilder = new ProcessBuilder(commands);

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/DistributionContext.java
@@ -20,6 +20,7 @@ package ai.grakn.test;
 
 import ai.grakn.GraknSystemProperty;
 import ai.grakn.client.Client;
+import ai.grakn.engine.GraknApplication;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.util.SimpleURI;
 import ai.grakn.redismock.RedisServer;
@@ -149,7 +150,7 @@ public class DistributionContext extends ExternalResource {
                 "-cp", getClassPath(),
                 "-Dgrakn.dir=" + DIST_DIRECTORY + "/services",
                 "-Dgrakn.conf=" + propertiesFile.getAbsolutePath(),
-                "ai.grakn.engine.GraknEngineServer", "&"};
+                GraknApplication.class.getName(), "&"};
 
         // Start process
         ProcessBuilder processBuilder = new ProcessBuilder(commands);

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/EngineContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/EngineContext.java
@@ -58,6 +58,7 @@ public class EngineContext extends ExternalResource {
     private final boolean inMemoryRedis;
     private MockRedisRule mockRedis;
     private JedisPool jedisPool;
+    private MetricRegistry metricRegistry;
 
 
     private EngineContext(boolean inMemoryRedis){
@@ -108,7 +109,8 @@ public class EngineContext extends ExternalResource {
     public RedisCountStorage redis(String host, int port) {
         JedisPoolConfig poolConfig = new JedisPoolConfig();
         this.jedisPool = new JedisPool(poolConfig, host, port);
-        return RedisCountStorage.create(jedisPool, new MetricRegistry());
+        this.metricRegistry = new MetricRegistry();
+        return RedisCountStorage.create(jedisPool, metricRegistry);
     }
 
     public TaskManager getTaskManager(){
@@ -178,5 +180,9 @@ public class EngineContext extends ExternalResource {
 
     public JedisPool getJedisPool() {
         return jedisPool;
+    }
+
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/GraknTestEngineSetup.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/GraknTestEngineSetup.java
@@ -85,7 +85,7 @@ public abstract class GraknTestEngineSetup {
 
         // start engine
         setRestAssuredUri(config);
-        GraknEngineServer server = EngineTestHelper.graknEngineServer(config);
+        GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(config);
         server.start();
 
         LOG.info("engine started.");

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/GraknTestEngineSetup.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/GraknTestEngineSetup.java
@@ -19,6 +19,7 @@ package ai.grakn.test;
 
 import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
+import ai.grakn.engine.EngineTestHelper;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.SystemKeyspace;
@@ -33,7 +34,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static ai.grakn.engine.GraknEngineConfig.JWT_SECRET_PROPERTY;
-import static ai.grakn.engine.GraknEngineServer.configureSpark;
+import static ai.grakn.engine.HttpHandler.configureSpark;
 import static ai.grakn.graql.Graql.var;
 
 /**
@@ -84,7 +85,7 @@ public abstract class GraknTestEngineSetup {
 
         // start engine
         setRestAssuredUri(config);
-        GraknEngineServer server = GraknEngineServer.create(config);
+        GraknEngineServer server = EngineTestHelper.graknEngineServer(config);
         server.start();
 
         LOG.info("engine started.");

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/benchmark/MutatorTaskBenchmark.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/benchmark/MutatorTaskBenchmark.java
@@ -29,7 +29,7 @@ public class MutatorTaskBenchmark extends BenchmarkTest {
         SimpleURI simpleURI = new SimpleURI(engine.uri());
         client = TaskClient.of(simpleURI.getHost(), simpleURI.getPort());
         consoleReporter = ConsoleReporter
-                .forRegistry(engine.server().getMetricRegistry()).build();
+                .forRegistry(engine.getMetricRegistry()).build();
     }
 
     protected EngineContext makeEngine() {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchMutatorClientTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchMutatorClientTest.java
@@ -139,8 +139,8 @@ public class BatchMutatorClientTest {
             loader.add(query());
 
             if(i%10 == 0) {
-                engine.server().stopHTTP();
-                engine.server().startHTTP();
+                engine.server().getHttpHandler().stopHTTP();
+                engine.server().getHttpHandler().startHTTP();
             }
         }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
@@ -84,7 +84,7 @@ public class GraknEngineServerTest {
         mock.server().start();
 
         // Start Engine
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf)) {
             server.start();
             assertThat(server.getTaskManager(), instanceOf(RedisTaskManager.class));
         }
@@ -98,7 +98,7 @@ public class GraknEngineServerTest {
         RedisServer redisServer = MockRedisRule.create(new SimpleURI(conf.getProperty(REDIS_HOST)).getPort()).server();
         redisServer.start();
 
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf)) {
             server.start();
             assertNotNull(server.factory().systemKeyspace());
 
@@ -116,7 +116,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedTheFirstTime_TheVersionIsRecordedInRedis() {
         when(jedis.get(VERSION_KEY)).thenReturn(null);
 
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -127,7 +127,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedASecondTime_TheVersionIsNotChanged() {
         when(jedis.get(VERSION_KEY)).thenReturn(GraknVersion.VERSION);
 
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -139,7 +139,7 @@ public class GraknEngineServerTest {
         when(jedis.get(VERSION_KEY)).thenReturn(OLD_VERSION);
         stdout.enableLog();
 
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -151,7 +151,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedWithDifferentVersion_TheVersionIsNotChanged() {
         when(jedis.get(VERSION_KEY)).thenReturn(OLD_VERSION);
 
-        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.cleanGraknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineServerTest.java
@@ -19,6 +19,7 @@
 package ai.grakn.test.engine;
 
 import ai.grakn.Keyspace;
+import ai.grakn.engine.EngineTestHelper;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.data.RedisWrapper;
@@ -83,7 +84,7 @@ public class GraknEngineServerTest {
         mock.server().start();
 
         // Start Engine
-        try (GraknEngineServer server = GraknEngineServer.create(conf)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf)) {
             server.start();
             assertThat(server.getTaskManager(), instanceOf(RedisTaskManager.class));
         }
@@ -97,7 +98,7 @@ public class GraknEngineServerTest {
         RedisServer redisServer = MockRedisRule.create(new SimpleURI(conf.getProperty(REDIS_HOST)).getPort()).server();
         redisServer.start();
 
-        try (GraknEngineServer server = GraknEngineServer.create(conf)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf)) {
             server.start();
             assertNotNull(server.factory().systemKeyspace());
 
@@ -115,7 +116,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedTheFirstTime_TheVersionIsRecordedInRedis() {
         when(jedis.get(VERSION_KEY)).thenReturn(null);
 
-        try (GraknEngineServer server = GraknEngineServer.create(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -126,7 +127,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedASecondTime_TheVersionIsNotChanged() {
         when(jedis.get(VERSION_KEY)).thenReturn(GraknVersion.VERSION);
 
-        try (GraknEngineServer server = GraknEngineServer.create(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -138,7 +139,7 @@ public class GraknEngineServerTest {
         when(jedis.get(VERSION_KEY)).thenReturn(OLD_VERSION);
         stdout.enableLog();
 
-        try (GraknEngineServer server = GraknEngineServer.create(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 
@@ -150,7 +151,7 @@ public class GraknEngineServerTest {
     public void whenEngineServerIsStartedWithDifferentVersion_TheVersionIsNotChanged() {
         when(jedis.get(VERSION_KEY)).thenReturn(OLD_VERSION);
 
-        try (GraknEngineServer server = GraknEngineServer.create(conf, redisWrapper)) {
+        try (GraknEngineServer server = EngineTestHelper.graknEngineServer(conf, redisWrapper)) {
             server.start();
         }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
@@ -110,6 +110,6 @@ public class GraknEngineStartIT {
         Properties properties = graknEngineConfig.getProperties();
         properties.setProperty(SERVER_PORT_NUMBER, port);
         properties.setProperty(REDIS_HOST, new SimpleURI("localhost", REDIS_PORT).toString());
-        return EngineTestHelper.graknEngineServer(graknEngineConfig);
+        return EngineTestHelper.cleanGraknEngineServer(graknEngineConfig);
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GraknEngineStartIT.java
@@ -21,6 +21,7 @@ package ai.grakn.test.engine;
 
 import ai.grakn.GraknSystemProperty;
 import ai.grakn.Keyspace;
+import ai.grakn.engine.EngineTestHelper;
 import ai.grakn.engine.GraknEngineConfig;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.util.SimpleURI;
@@ -109,6 +110,6 @@ public class GraknEngineStartIT {
         Properties properties = graknEngineConfig.getProperties();
         properties.setProperty(SERVER_PORT_NUMBER, port);
         properties.setProperty(REDIS_HOST, new SimpleURI("localhost", REDIS_PORT).toString());
-        return GraknEngineServer.create(graknEngineConfig);
+        return EngineTestHelper.graknEngineServer(graknEngineConfig);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.resource.encoding>UTF-8</project.resource.encoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
         <tinkerpop.version>3.2.5-grakn-SNAPSHOT</tinkerpop.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
I cleaned up a bit the grakn engine module in order to prepare the modularisation of new components. I focused on the main, because it's the heart of a dependency injection structure. 

The responsibility of 'GraknCreator' is to create singletons to use all across the application. 

I duplicated a bit the creation code also in 'EngineTestHelper' because integration tests need fresh instances (not the already-used ones, learnt in the hard-way after so many test failures ..). 
I could have put those methods in 'GraknCreator', but then it was not clear anymore for a user of 'GraknCreator' which one to use to get an instance of a specific class. This decision forced me to add a new test dependency between 'grakn-engine' module and 'grakn-test', that has only 'test' as a scope. Final thought: I think that duplication is better than risk of misuse!

 