### PR TITLE
[Stable] Make type checking semantically consistent

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -446,7 +446,9 @@ public class RelationshipAtom extends IsaAtom {
                 .collect(toSet());
 
         //types deduced from substitution
-        inferEntityTypes(sub).stream().map(Pair::getValue).forEach(types::add);
+        inferEntityTypes(sub).stream()
+                .map(Pair::getValue)
+                .forEach(types::add);
 
         Multimap<RelationshipType, Role> compatibleTypesFromTypes = compatibleRelationTypesWithRoles(types, new TypeConverter());
 
@@ -743,7 +745,6 @@ public class RelationshipAtom extends IsaAtom {
                                                 if (exact) return childQuery.isTypeRoleCompatible(childVar, parentType) && !areDisjointTypes(parentType, childType);
                                                 else return childQuery.isTypeRoleCompatible(childVar, parentType)
                                                         && (childType == null || !areDisjointTypes(parentType, childType));
-
                                             })
                                             //check for substitution compatibility
                                             .filter(crp ->

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -268,6 +268,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     public boolean isTypeRoleCompatible(Var typedVar, SchemaConcept parentType){
         if (parentType == null || Schema.MetaSchema.isMetaLabel(parentType.getLabel())) return true;
 
+        Set<SchemaConcept> parentTypes = parentType.subs().collect(Collectors.toSet());
         return !getAtoms(RelationshipAtom.class)
                 .filter(ra -> ra.getVarNames().contains(typedVar))
                 .filter(ra -> ra.getRoleVarMap().entries().stream()
@@ -275,7 +276,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
                         .filter(e -> e.getValue().equals(typedVar))
                         .filter(e -> !Schema.MetaSchema.isMetaLabel(e.getKey().getLabel()))
                         //check if it can play it
-                        .filter(e -> !e.getKey().playedByTypes().filter(parentType::equals).findFirst().isPresent())
+                        .filter(e -> !e.getKey().playedByTypes().filter(parentTypes::contains).findFirst().isPresent())
                         .findFirst().isPresent())
                 .findFirst().isPresent();
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/ConjunctiveState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/ConjunctiveState.java
@@ -79,7 +79,6 @@ public class ConjunctiveState extends QueryState {
                     .collect(Collectors.joining("\n"))
             );
         }
-
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
@@ -287,10 +287,11 @@ public class ReasonerUtils {
     public static <T extends SchemaConcept> Multimap<RelationshipType, Role> compatibleRelationTypesWithRoles(Set<T> types, SchemaConceptConverter<T> schemaConceptConverter) {
         Multimap<RelationshipType, Role> compatibleTypes = HashMultimap.create();
         if (types.isEmpty()) return compatibleTypes;
-        Iterator<T> it = types.iterator();
-        compatibleTypes.putAll(schemaConceptConverter.toRelationshipMultimap(it.next()));
-        while(it.hasNext() && !compatibleTypes.isEmpty()) {
-            compatibleTypes = multimapIntersection(compatibleTypes, schemaConceptConverter.toRelationshipMultimap(it.next()));
+        Iterator<T> typeIterator = types.iterator();
+        compatibleTypes.putAll(schemaConceptConverter.toRelationshipMultimap(typeIterator.next()));
+
+        while(typeIterator.hasNext() && compatibleTypes.size() > 1) {
+            compatibleTypes = multimapIntersection(compatibleTypes, schemaConceptConverter.toRelationshipMultimap(typeIterator.next()));
         }
         return compatibleTypes;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/RoleConverter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/RoleConverter.java
@@ -18,10 +18,8 @@
 
 package ai.grakn.graql.internal.reasoner.utils.conversion;
 
-import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import java.util.stream.Stream;
 
 /**
  * <p>
@@ -31,16 +29,9 @@ import com.google.common.collect.Multimap;
  * @author Kasper Piskorski
  */
 public class RoleConverter implements SchemaConceptConverter<Role> {
-    @Override
-    public Multimap<RelationshipType, Role> toRelationshipMultimap(Role entryRole) {
-        Multimap<RelationshipType, Role> relationMap = HashMultimap.create();
 
-        entryRole.subs()
-                .forEach(role -> {
-                    role.relationshipTypes()
-                            .filter(rel -> !rel.isImplicit())
-                            .forEach(rel -> relationMap.put(rel, role));
-                });
-        return relationMap;
+    @Override
+    public Stream<Role> toCompatibleRoles(Role entryRole) {
+        return entryRole.subs();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/RoleConverter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/RoleConverter.java
@@ -18,15 +18,10 @@
 
 package ai.grakn.graql.internal.reasoner.utils.conversion;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
-import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
-import ai.grakn.util.Schema;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-import java.util.Set;
 
 /**
  * <p>
@@ -40,14 +35,7 @@ public class RoleConverter implements SchemaConceptConverter<Role> {
     public Multimap<RelationshipType, Role> toRelationshipMultimap(Role entryRole) {
         Multimap<RelationshipType, Role> relationMap = HashMultimap.create();
 
-        Set<Role> roleHierarchy = Sets.newHashSet(entryRole);
-        if (Schema.MetaSchema.isMetaLabel(entryRole.getLabel())) {
-            entryRole.subs().forEach(roleHierarchy::add);
-        } else {
-            ReasonerUtils.supers(entryRole).stream().map(Concept::asRole).forEach(roleHierarchy::add);
-        }
-
-        roleHierarchy
+        entryRole.subs()
                 .forEach(role -> {
                     role.relationshipTypes()
                             .filter(rel -> !rel.isImplicit())

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/TypeConverter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/TypeConverter.java
@@ -18,16 +18,11 @@
 
 package ai.grakn.graql.internal.reasoner.utils.conversion;
 
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
 import ai.grakn.concept.Type;
-import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
-import ai.grakn.util.Schema;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Sets;
-import java.util.Set;
 
 /**
  * <p>
@@ -42,14 +37,7 @@ public class TypeConverter implements SchemaConceptConverter<Type> {
     public Multimap<RelationshipType, Role> toRelationshipMultimap(Type entryType) {
         Multimap<RelationshipType, Role> relationMap = HashMultimap.create();
 
-        Set<Type> typeHierarchy = Sets.newHashSet(entryType);
-        if (Schema.MetaSchema.isMetaLabel(entryType.getLabel())) {
-            entryType.subs().forEach(typeHierarchy::add);
-        } else {
-            ReasonerUtils.supers(entryType).stream().map(Concept::asType).forEach(typeHierarchy::add);
-        }
-
-        typeHierarchy.stream()
+        entryType.subs()
                 .flatMap(Type::plays)
                 .forEach(roleType -> {
                     roleType.relationshipTypes()

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/TypeConverter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/conversion/TypeConverter.java
@@ -18,11 +18,9 @@
 
 package ai.grakn.graql.internal.reasoner.utils.conversion;
 
-import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
 import ai.grakn.concept.Type;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
+import java.util.stream.Stream;
 
 /**
  * <p>
@@ -34,16 +32,7 @@ import com.google.common.collect.Multimap;
 public class TypeConverter implements SchemaConceptConverter<Type> {
 
     @Override
-    public Multimap<RelationshipType, Role> toRelationshipMultimap(Type entryType) {
-        Multimap<RelationshipType, Role> relationMap = HashMultimap.create();
-
-        entryType.subs()
-                .flatMap(Type::plays)
-                .forEach(roleType -> {
-                    roleType.relationshipTypes()
-                            .filter(rel -> !rel.isImplicit())
-                            .forEach(rel -> relationMap.put(rel, roleType));
-                });
-        return relationMap;
+    public Stream<Role> toCompatibleRoles(Type entryType) {
+        return entryType.subs().flatMap(Type::plays);
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -24,6 +24,7 @@ import ai.grakn.concept.Concept;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.Conjunction;
@@ -584,9 +585,8 @@ public class AtomicQueryTest {
     }
 
     @Test
-    public void testExactUnification_BinaryRelationWithRoleHierarchyAndTypes_ParentWithBaseRoles(){
+    public void testExactUnification_BinaryRelationWithRoleAndTypeHierarchy_BaseRoleParent(){
         GraknTx graph = unificationTestSet.tx();
-        //contains only base types which cannot play any sub roles - no unifier should exist
         String baseParentRelation = "{(role1: $x, role2: $y); $x isa baseRoleEntity; $y isa baseRoleEntity;}";
         String parentRelation = "{(role1: $x, role2: $y); $x isa subSubRoleEntity; $y isa subSubRoleEntity;}";
 
@@ -595,19 +595,19 @@ public class AtomicQueryTest {
         String specialisedRelation3 = "{(subSubRole1: $u, subSubRole2: $v); $u isa subSubRoleEntity; $v isa subSubRoleEntity;}";
         String specialisedRelation4 = "{(subSubRole1: $y, subSubRole2: $x); $y isa subSubRoleEntity; $x isa subSubRoleEntity;}";
 
-        nonExistentUnifier(baseParentRelation, specialisedRelation, graph);
-        nonExistentUnifier(baseParentRelation, specialisedRelation2, graph);
-        nonExistentUnifier(baseParentRelation, specialisedRelation3, graph);
-        nonExistentUnifier(baseParentRelation, specialisedRelation4, graph);
+        queryUnification(baseParentRelation, specialisedRelation, false, false, true, graph);
+        queryUnification(baseParentRelation, specialisedRelation2, false, false, true, graph);
+        queryUnification(baseParentRelation, specialisedRelation3, false, false, true, graph);
+        queryUnification(baseParentRelation, specialisedRelation4, false, false, true, graph);
 
-        queryUnification(parentRelation, specialisedRelation, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation2, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation3, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation4, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation, false, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation2, false, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation3, false, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation4, false, false, false, graph);
     }
 
     @Test
-    public void testExactUnification_BinaryRelationWithRoleAndTypeHierarchy_ParentWithBaseRoles(){
+    public void testExactUnification_BinaryRelationWithRoleAndTypeHierarchy_BaseRoleParent_middleTypes(){
         GraknTx graph = unificationTestSet.tx();
         String parentRelation = "{(role1: $x, role2: $y); $x isa subRoleEntity; $y isa subSubRoleEntity;}";
 
@@ -616,13 +616,13 @@ public class AtomicQueryTest {
         String specialisedRelation3 = "{(subSubRole1: $u, subSubRole2: $v); $u isa subSubRoleEntity; $v isa subSubRoleEntity;}";
         String specialisedRelation4 = "{(subSubRole1: $y, subSubRole2: $x); $y isa subSubRoleEntity; $x isa subSubRoleEntity;}";
 
-        queryUnification(parentRelation, specialisedRelation, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation2, false, false, graph);
-        nonExistentUnifier(parentRelation, specialisedRelation3, graph);
-        nonExistentUnifier(parentRelation, specialisedRelation4, graph);
+        queryUnification(parentRelation, specialisedRelation, false, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation2, false, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation3, false, false, true, graph);
+        queryUnification(parentRelation, specialisedRelation4, false, false, true, graph);
     }
 
-    //TODO this needs subtype checking in results
+    //requires checking type hierarchies
     @Ignore
     @Test
     public void testExactUnification_BinaryRelationWithRoleAndTypeHierarchy_ParentWithBaseRoles_differentTypeHierarchiesInAnswer(){
@@ -632,14 +632,10 @@ public class AtomicQueryTest {
         String specialisedRelation = "{(subRole1: $u, anotherSubRole2: $v); $u isa subRoleEntity; $v isa subRoleEntity;}";
         String specialisedRelation2 = "{(subRole1: $u, anotherSubRole2: $v); $u isa subRoleEntity; $v isa subSubRoleEntity;}";
         String specialisedRelation3 = "{(subRole1: $y, anotherSubRole2: $x); $y isa subRoleEntity; $x isa subSubRoleEntity;}";
-        String specialisedRelation4 = "{(subSubRole1: $u, subSubRole2: $v); $u isa subSubRoleEntity; $v isa subSubRoleEntity;}";
-        String specialisedRelation5 = "{(subSubRole1: $y, subSubRole2: $x); $y isa subSubRoleEntity; $x isa subSubRoleEntity;}";
 
-        queryUnification(parentRelation, specialisedRelation, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation2, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation3, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation4, false, false, graph);
-        queryUnification(parentRelation, specialisedRelation5, false, false, graph);
+        queryUnification(parentRelation, specialisedRelation, false, false, true, graph);
+        queryUnification(parentRelation, specialisedRelation2, false, false, true, graph);
+        queryUnification(parentRelation, specialisedRelation3, false, false, true, graph);
     }
 
     @Test
@@ -1114,30 +1110,14 @@ public class AtomicQueryTest {
     }
 
     /**
-     * checks that the child query is not unifiable with parent - a unifier does not exist
+     * checks the correctness and uniqueness of an exact unifier required to unify child query with parent
      * @param parentQuery parent query
      * @param childQuery child query
+     * @param checkInverse flag specifying whether the inverse equality u^{-1}=u(parent, child) of the unifier u(child, parent) should be checked
+     * @param ignoreTypes flag specifying whether the types should be disregarded and only role players checked for containment
+     * @param checkEquality if true the parent and child answers will be checked for equality, otherwise they are checked for containment of child answers in parent
      */
-    private void nonExistentUnifier(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery){
-        Atom childAtom = childQuery.getAtom();
-        Atom parentAtom = parentQuery.getAtom();
-        assertTrue(childAtom.getMultiUnifier(parentAtom, true).isEmpty());
-    }
-
-    private void nonExistentUnifier(String parentPatternString, String childPatternString, GraknTx graph){
-        nonExistentUnifier(
-                ReasonerQueries.atomic(conjunction(parentPatternString, graph), graph),
-                ReasonerQueries.atomic(conjunction(childPatternString, graph), graph)
-        );
-    }
-
-    /**
-     * @param parentQuery
-     * @param childQuery
-     * @param checkInverse
-     * @param checkEquality
-     */
-    private void queryUnification(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery, boolean checkInverse, boolean checkEquality){
+    private void queryUnification(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery, boolean checkInverse, boolean checkEquality, boolean ignoreTypes){
         Unifier unifier = childQuery.getMultiUnifier(parentQuery).getUnifier();
 
         List<Answer> childAnswers = childQuery.getQuery().execute();
@@ -1158,7 +1138,15 @@ public class AtomicQueryTest {
         assertTrue(!parentAnswers.isEmpty());
 
         if (!checkEquality){
-            assertTrue(parentAnswers.containsAll(unifiedAnswers));
+            if(!ignoreTypes){
+                assertTrue(parentAnswers.containsAll(unifiedAnswers));
+            } else {
+                Set<Var> nonTypeVariables = Sets.difference(parentQuery.getAtom().getVarNames(), Sets.newHashSet(parentQuery.getAtom().getPredicateVariable()));
+                List<Answer> projectedParentAnswers = parentAnswers.stream().map(ans -> ans.project(nonTypeVariables)).collect(Collectors.toList());
+                List<Answer> projectedUnified = unifiedAnswers.stream().map(ans -> ans.project(nonTypeVariables)).collect(Collectors.toList());
+                assertTrue(projectedParentAnswers.containsAll(projectedUnified));
+            }
+
         } else {
             assertCollectionsEqual(parentAnswers, unifiedAnswers);
             Unifier inverse = unifier.inverse();
@@ -1167,12 +1155,13 @@ public class AtomicQueryTest {
         }
     }
 
-    private void queryUnification(String parentPatternString, String childPatternString, boolean checkInverse, boolean checkEquality, GraknTx graph){
+    private void queryUnification(String parentPatternString, String childPatternString, boolean checkInverse, boolean checkEquality, boolean ignoreTypes, GraknTx graph){
         queryUnification(
                 ReasonerQueries.atomic(conjunction(parentPatternString, graph), graph),
                 ReasonerQueries.atomic(conjunction(childPatternString, graph), graph),
                 checkInverse,
-                checkEquality);
+                checkEquality,
+                ignoreTypes);
     }
 
     private Conjunction<VarPatternAdmin> conjunction(PatternAdmin pattern){

--- a/grakn-test-tools/src/main/graql/ruleApplicabilityTest.gql
+++ b/grakn-test-tools/src/main/graql/ruleApplicabilityTest.gql
@@ -22,37 +22,44 @@ role3 sub role;
 
 # Entity hierarchy
 #
-#                  entity
-#                     |
-#               noRoleEntity
-#              /            \
-#  singleRoleEntity    anotherSingleRoleEntity
-#         |                     |
-#  twoRoleEntity        anotherTwoRoleEntity
-#         |
-#  threeRoleEntity
+#                                       entity
+#                                          |
+#                                    noRoleEntity                                                               anotherNoRoleEntity
+#                                          |
+#  singleRoleEntity(R1)    anotherSingleRoleEntity(R1)   twoRoleEntity(R2, R3)   threeRoleEntity (R1, R2, R3)
+#                               |
+#                           anotherTwoRoleEntity(R2)
+#                               |
+#                           anotherThreeRoleEntity(R3)
 
 noRoleEntity sub entity
+    has name;
+
+anotherNoRoleEntity sub entity
     has name;
 
 singleRoleEntity sub noRoleEntity
 	plays role1;
 
 anotherSingleRoleEntity sub noRoleEntity
-	plays role2;
+    plays role1;
 
-# plays role1, role2
-twoRoleEntity sub singleRoleEntity
-    plays symmetricRole
-	plays role2;
-
-# plays role2, role3
 anotherTwoRoleEntity sub anotherSingleRoleEntity
+    plays role2
+    plays symmetricRole;
+
+anotherThreeRoleEntity sub anotherTwoRoleEntity
     plays role3;
 
-# plays role1, role2, role3
-threeRoleEntity sub twoRoleEntity
+twoRoleEntity sub noRoleEntity
+    plays role2
     plays role3;
+
+threeRoleEntity sub noRoleEntity
+    plays role1
+    plays role2
+    plays role3;
+
 
 #Relations
 
@@ -127,8 +134,8 @@ rule-3 sub rule
 
 rule-4 sub rule
     when {
-    	$x isa twoRoleEntity;
-    	$y isa twoRoleEntity;
+    	$x isa anotherTwoRoleEntity;
+    	$y isa anotherTwoRoleEntity;
     }
     then {
     	(symmetricRole:$x, symmetricRole:$y) isa reifying-relation;
@@ -137,8 +144,8 @@ rule-4 sub rule
 rule-5 sub rule
     when {
     	$x isa singleRoleEntity;
-    	$y isa twoRoleEntity;
-    	$z isa anotherTwoRoleEntity;
+    	$y isa anotherTwoRoleEntity;
+    	$z isa twoRoleEntity;
     }
     then {
     	(role1:$x, role2:$y, role3: $z) isa typed-relation;
@@ -173,4 +180,4 @@ insert
 
 #Data
 
-$x isa noRoleEntity, has name 'noRoleEntity';
+$x isa anotherNoRoleEntity, has name 'noRoleEntity';

--- a/grakn-test-tools/src/main/graql/typeInferenceTest.gql
+++ b/grakn-test-tools/src/main/graql/typeInferenceTest.gql
@@ -23,33 +23,36 @@ subRole2 sub role2;
 #                  entity
 #                     |
 #               noRoleEntity
-#              /            \
-#  singleRoleEntity    anotherSingleRoleEntity
-#         |                     |
-#  twoRoleEntity        anotherTwoRoleEntity
+#              /            \                                   \
+#  singleRoleEntity(R3)   anotherSingleRoleEntity(R2)    yetAnotherSingleRoleEntity(R1)
+#           |                   |
+#   twoRoleEntity(R4)     anotherTwoRoleEntity(R3)
 #                               |
-#                         threeRoleEntity
+#                         threeRoleEntity(R4)
 
-#plays in rel1
-singleRoleEntity sub entity
-	plays role1;
+noRoleEntity sub entity;
 
-#plays in rel1, rel3
+#plays in rel2, rel3
+singleRoleEntity sub noRoleEntity
+	plays role3;
+#plays in rel2, rel3
 twoRoleEntity sub singleRoleEntity
     plays role4;
 
 #plays in rel1, rel2
-anotherTwoRoleEntity sub singleRoleEntity
-	plays role2;
-
+anotherSingleRoleEntity sub noRoleEntity
+    plays role2;
 #plays in rel1, rel2, rel3
-threeRoleEntity sub anotherSingleRoleEntity
-    plays role2
+anotherTwoRoleEntity sub anotherSingleRoleEntity
     plays role3;
-
-#plays in rel3
-anotherSingleRoleEntity sub entity
+#plays in rel1, rel2, rel3
+threeRoleEntity sub anotherTwoRoleEntity
     plays role4;
+
+#plays in rel1
+yetAnotherSingleRoleEntity sub noRoleEntity
+	plays role1;
+
 
 #Relations
 
@@ -67,10 +70,12 @@ relation3 sub relationship
     relates role4;
 
 insert
+$e isa noRoleEntity;
 $x isa singleRoleEntity;
 $y isa twoRoleEntity;
 $z isa anotherTwoRoleEntity;
 $u isa threeRoleEntity;
 $v isa anotherSingleRoleEntity;
+$q isa yetAnotherSingleRoleEntity;
 
 


### PR DESCRIPTION
Changes are very fine. Mostly involve adding an extra .subs() call in places so that all the downstream type hierarchy is included.