### PR TITLE
Make match benchmark test a bit more similar to real use case

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/benchmark/MatchBenchmark.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/benchmark/MatchBenchmark.java
@@ -5,6 +5,7 @@ import ai.grakn.GraknSession;
 import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
 import ai.grakn.Keyspace;
+import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.EntityType;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.Match;
@@ -23,7 +24,8 @@ import static ai.grakn.graql.Graql.var;
 public class MatchBenchmark extends BenchmarkTest {
 
     private static final Keyspace KEYSPACE = SampleKBLoader.randomKeyspace();
-    private static final String BENCHMARK_ENTITYTYPE = "benchmarkEntitytype";
+    private static final String BENCHMARK_ENTITY_TYPE = "benchmarkEntityType";
+    private static final String BENCHMARK_ATTRIBUTE_TYPE = "benchmarkAttributeType";
 
     private EngineContext engine;
     private GraknSession session;
@@ -35,8 +37,16 @@ public class MatchBenchmark extends BenchmarkTest {
         engine.before();
         session = Grakn.session(engine.uri(), KEYSPACE);
         GraknTx graphEntity = session.open(GraknTxType.WRITE);
-        EntityType entityType = graphEntity.putEntityType("benchmarkEntitytype");
-        entityType.addEntity();
+        EntityType entityType = graphEntity.putEntityType(BENCHMARK_ENTITY_TYPE);
+        AttributeType<String> attributeType =
+                graphEntity.putAttributeType(BENCHMARK_ATTRIBUTE_TYPE, AttributeType.DataType.STRING);
+        entityType.attribute(attributeType);
+
+        for (int i = 0; i < 100; i++) {
+            for (int j = 0; j < 100; j++) {
+                entityType.addEntity().attribute(attributeType.putAttribute(String.valueOf(i)));
+            }
+        }
         graphEntity.commit();
         graph = session.open(GraknTxType.WRITE);
     }
@@ -50,7 +60,11 @@ public class MatchBenchmark extends BenchmarkTest {
 
     @Benchmark
     public void match() {
-        Match match = graph.graql().match(var("x").isa(BENCHMARK_ENTITYTYPE));
+        Match match = graph.graql().match(
+                var("x")
+                        .isa(BENCHMARK_ENTITY_TYPE)
+                        .has(BENCHMARK_ATTRIBUTE_TYPE, "0")
+        );
         GetQuery answers = match.get();
         Optional<Answer> first = answers.stream().findFirst();
         first.get();


### PR DESCRIPTION
so I don't have to change this every time.