### PR TITLE
Faster 'grakn server status' with curl instead of ai.grakn.client.Client

### DIFF
--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -301,7 +301,9 @@ grakn_check_if_running() {
 }
 
 grakn_check_if_ready() {
-  java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}/services" -Dgrakn.conf="${GRAKN_CONFIG}" ai.grakn.client.Client > /dev/null 2>&1
+  local host=`cat "${GRAKN_HOME}"/conf/grakn.properties| grep server.host | awk -F "=" '{print $2}'`
+  local port=`cat "${GRAKN_HOME}"/conf/grakn.properties| grep server.port | awk -F "=" '{print $2}'`
+  curl $host:$port/configuration > /dev/null 2>&1
   return $?
 }
 


### PR DESCRIPTION
I just noticed today that `grakn server status` takes a loo...oong time to execute. about 8 seconds.

Upon further investigation, the program which checks if engine is up (i.e. `ai.grakn.client.Client`), took 6 seconds JUST to start, due to the amount of jars in `$CLASSPATH` it needs to load (I confirmed this fact,  by manually specifying less JARs it did speed up the load time).
 
As we're nearing towards a release, I assume our users will grow disappointed if such a trivial command takes a long time to execute. Hence why I am proposing a workaround.

In this PR, the script will use `curl` instead of `ai.grakn.client.Client` for querying engine status, which sped up the process nicely.