### PR TITLE
redis process check bugfix by not using queue full path

### DIFF
--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -186,7 +186,7 @@ get_redis_binary_name() {
 
 queue_start_process() {
   # run queue
-  # queue needs to be ran with $GRAKN_HOME as the working directory
+  # the pushd "$GRAKN_HOME" line is needed because queue needs to be ran with $GRAKN_HOME as the working directory
   # otherwise it won't be able to find its data directory located at $GRAKN_HOME/db/redis
   local queue_bin=`get_redis_binary_name`
   pushd "$GRAKN_HOME" > /dev/null
@@ -198,8 +198,8 @@ queue_start_process() {
 }
 
 queue_check_if_running() {
-  local queue_fullpath="${GRAKN_HOME}/services/redis/`get_redis_binary_name`"
-  local count_running_queue_process=`ps_ef_grep_processname "$queue_fullpath" | wc -l`
+  local queue_path="services/redis/`get_redis_binary_name`"
+  local count_running_queue_process=`ps_ef_grep_processname "$queue_path" | wc -l`
   local status=
   if [ $count_running_queue_process -gt 0 ] ; then
     status=0 # queue running


### PR DESCRIPTION
`grep`-ing a full path (i.e. 

```
ps x | grep /path/to/grakn-1.0.0/services/redis/redis-server-{linux|osx}
```

seems to cause problem in the jenkins machine. therefore i opted to change it:
```
ps -ef | grep services/redis/redis-server-{linux|osx}
```