### PR TITLE
adding a link to contribution guide section on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Compiling Grakn from source requires:
 * Maven 3
 * nodejs
 * yarn installed and configured correctly
-
 You should be able to install packages global for your user via npm without needing sudo).
 
 ## Disclaimer  

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ This product includes software developed by [Grakn Labs](http://grakn.ai/).  It'
 
 [Contribute To Grakn](https://grakn.ai/pages/contributors/index.html) - Contributions are *very* welcome! The section contains information which covers the contribution process to Grakn.
 
-
 ## System Requirements
 
 Operating System: Unix based systems (Linux and Mac OS X)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ This product includes software developed by [Grakn Labs](http://grakn.ai/).  It'
 
 [Grakn Community](https://grakn.ai/community.html) - a useful page with links to various communication channels such as Slack and our Discussion boards.
 
+[Contribute To Grakn](https://grakn.ai/pages/contributors/index.html) - Contributions are *very* welcome! The link will bring you to a section which covers the contribution process to Grakn.
+
 
 ## System Requirements
 
@@ -45,7 +47,7 @@ Compiling Grakn from source requires:
 * yarn installed and configured correctly
 
 You should be able to install packages global for your user via npm without needing sudo).
-  
+
 ## Disclaimer  
 We don't claim Grakn will change your life, though it may improve it: we'll leave that for you to decide.  But if you lose a billion dollars or a limb while using Grakn, that's not our fault. We reserve the right to
 do the absolute minimum provided by law, up to and including nothing.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Compiling Grakn from source requires:
 * yarn installed and configured correctly
 
 You should be able to install packages global for your user via npm without needing sudo).
+
 ## Disclaimer  
 We don't claim Grakn will change your life, though it may improve it: we'll leave that for you to decide.  But if you lose a billion dollars or a limb while using Grakn, that's not our fault. We reserve the right to
 do the absolute minimum provided by law, up to and including nothing.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This product includes software developed by [Grakn Labs](http://grakn.ai/).  It'
 
 [Grakn Community](https://grakn.ai/community.html) - a useful page with links to various communication channels such as Slack and our Discussion boards.
 
-[Contribute To Grakn](https://grakn.ai/pages/contributors/index.html) - Contributions are *very* welcome! The link will bring you to a section which covers the contribution process to Grakn.
+[Contribute To Grakn](https://grakn.ai/pages/contributors/index.html) - Contributions are *very* welcome! The section contains information which covers the contribution process to Grakn.
 
 
 ## System Requirements

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Compiling Grakn from source requires:
 * Maven 3
 * nodejs
 * yarn installed and configured correctly
-You should be able to install packages global for your user via npm without needing sudo).
 
+You should be able to install packages global for your user via npm without needing sudo).
 ## Disclaimer  
 We don't claim Grakn will change your life, though it may improve it: we'll leave that for you to decide.  But if you lose a billion dollars or a limb while using Grakn, that's not our fault. We reserve the right to
 do the absolute minimum provided by law, up to and including nothing.


### PR DESCRIPTION
Let's make the contribution links visible from Github, in order to grow community contributions. As we've had our first community PR, I think the time is ripe!

Let me know what you guys think.

Just to add a bit from my experience contributing to open source projects:
- We can start with adding a tag "community-contrib" for issues we can get help from the community with
- For growing the contribution, We can think of straightforward issues such as typo, documentation, code cleanup, and tests