### PR TITLE
[Stable] Fix don't show attribute nodes when executing Explore

### DIFF
--- a/grakn-dashboard/src/components/graphPage/modules/CanvasEvents.js
+++ b/grakn-dashboard/src/components/graphPage/modules/CanvasEvents.js
@@ -47,7 +47,7 @@ function doubleClick(param) {
   } else {
     EngineClient.request({
       url: nodeObj.href,
-    }).then(resp => CanvasHandler.onGraphResponse(resp, false, false, node))
+    }).then(resp => CanvasHandler.onGraphResponse(resp, false, false, false, node))
     .then((instances) => { CanvasHandler.loadInstancesAttributes(0, instances); })
     .catch((err) => { EventHub.$emit('error-message', err.message); });
     if (nodeObj.baseType === API.GENERATED_RELATIONSHIP_TYPE) {
@@ -77,7 +77,7 @@ function requestExplore(nodeObj) {
   if (nodeObj.explore) {
     EngineClient.request({
       url: nodeObj.explore,
-    }).then(resp => CanvasHandler.onGraphResponse(resp, false, true, nodeObj.id), (err) => {
+    }).then(resp => CanvasHandler.onGraphResponse(resp, false, true, true, nodeObj.id), (err) => {
       EventHub.$emit('error-message', err.message);
     });
   }

--- a/grakn-dashboard/src/components/graphPage/modules/CanvasEvents.js
+++ b/grakn-dashboard/src/components/graphPage/modules/CanvasEvents.js
@@ -43,7 +43,7 @@ function doubleClick(param) {
   const nodeObj = visualiser.getNode(node);
 
   if (eventKeys.shiftKey) {
-    requestExplore(nodeObj);
+    if (nodeObj.baseType !== API.INFERRED_RELATIONSHIP_TYPE) { requestExplore(nodeObj); }
   } else {
     EngineClient.request({
       url: nodeObj.href,


### PR DESCRIPTION
- added new boolean to check whether render attributes as nodes when attached to relationships
- fixed empty error message box
- check to avoid executing Explore on inferred-relationships