### PR TITLE
Jenkinsfile rtg

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ class Constants {
 //This sets properties in the Jenkins server. In this case run every 8 hours
 properties([
     pipelineTriggers([
-      issueCommentTrigger('.*!rtg.*')
+      issueCommentTrigger('.*!ci.*')
     ]),
     buildDiscarder(logRotator(numToKeepStr: '30', artifactNumToKeepStr: '7'))
 ])


### PR DESCRIPTION
This should stop the old trigger phrase starting tests on both test suites which is super annoying as tests are unstable right now.

rtg will retest unit-test-pull-request-grakn-titan
ci will retest continuous-integration/jenkins/pr-merge