### PR TITLE
Fixed error in simplest query

### DIFF
--- a/docs/pages/documentation/0-get-started/quickstart-tutorial.md
+++ b/docs/pages/documentation/0-get-started/quickstart-tutorial.md
@@ -139,7 +139,7 @@ Having started Grakn engine and the Graql shell in its interactive mode, we are 
 Find all the people in the knowledge base, and list their `identifier` attributes (a string that represents their full name):
 
 ```graql
-match $p isa person, has identifier $i; get;
+match $p isa person, $p has identifier $i; get;
 ```
 
 {% include note.html content="In queries, Graql variables start with a `$`, which represent wildcards, and are returned as results in `get` queries. A variable name can contain alphanumeric characters, dashes and underscores." %}

--- a/docs/pages/documentation/0-get-started/quickstart-tutorial.md
+++ b/docs/pages/documentation/0-get-started/quickstart-tutorial.md
@@ -139,7 +139,7 @@ Having started Grakn engine and the Graql shell in its interactive mode, we are 
 Find all the people in the knowledge base, and list their `identifier` attributes (a string that represents their full name):
 
 ```graql
-match $p isa person, $p has identifier $i; get;
+match $p isa person, $p has identifier $i; get;
 ```
 
 {% include note.html content="In queries, Graql variables start with a `$`, which represent wildcards, and are returned as results in `get` queries. A variable name can contain alphanumeric characters, dashes and underscores." %}

--- a/docs/pages/documentation/0-get-started/quickstart-tutorial.md
+++ b/docs/pages/documentation/0-get-started/quickstart-tutorial.md
@@ -139,7 +139,7 @@ Having started Grakn engine and the Graql shell in its interactive mode, we are 
 Find all the people in the knowledge base, and list their `identifier` attributes (a string that represents their full name):
 
 ```graql
-match $p isa person, $p has identifier $i; get;
+match $p isa person; $p has identifier $i; get;
 ```
 
 {% include note.html content="In queries, Graql variables start with a `$`, which represent wildcards, and are returned as results in `get` queries. A variable name can contain alphanumeric characters, dashes and underscores." %}


### PR DESCRIPTION
If you submit query as-is, the result would be like that:

```
$p id V41176 isa person; $i val "Barbara Newman" isa identifier; 
$p id V45224 isa person; $i val "Barbara Newman" isa identifier; 
$p id V49320 isa person; $i val "Barbara Newman" isa identifier; 
$p id V49336 isa person; $i val "Barbara Newman" isa identifier; 
$p id V61568 isa person; $i val "Barbara Newman" isa identifier; 
$p id V61608 isa person; $i val "Barbara Newman" isa identifier; 
$p id V65704 isa person; $i val "Barbara Newman" isa identifier; 
$p id V73896 isa person; $i val "Barbara Newman" isa identifier; 
$p id V73912 isa person; $i val "Barbara Newman" isa identifier; 
$p id V73944 isa person; $i val "Barbara Newman" isa identifier; 
$p id V81920 isa person; $i val "Barbara Newman" isa identifier; 
$p id V86184 isa person; $i val "Barbara Newman" isa identifier; 
$p id V86200 isa person; $i val "Barbara Newman" isa identifier; 
$p id V90296 isa person; $i val "Barbara Newman" isa identifier; 
$p id V94376 isa person; $i val "Barbara Newman" isa identifier; 
$p id V94392 isa person; $i val "Barbara Newman" isa identifier; 
```

This is the fix for above issue.