### PR TITLE
Add constructors for creating inferred instances

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/Thing.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Thing.java
@@ -109,6 +109,14 @@ public interface Thing extends Concept{
      */
     Thing deleteAttribute(Attribute attribute);
 
+    /**
+     * Used to indicate if this {@link Thing} has been created as the result of a {@link Rule} inference.
+     * @see Rule
+     *
+     * @return true if this {@link Thing} exists due to a rule
+     */
+    boolean isInferred();
+
     //------------------------------------- Other ---------------------------------
     @Deprecated
     @CheckReturnValue

--- a/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
@@ -318,10 +318,10 @@ public class GraknTxOperationException extends GraknException{
     }
 
     /**
-     * Thrown when attempting to create an {@link Attribute} via the execution of a {@link ai.grakn.concept.Rule} when
-     * the {@link Attribute} already exists
+     * Thrown when attempting to create a {@link Thing} via the execution of a {@link ai.grakn.concept.Rule} when
+     * the {@link Thing} already exists.
      */
-    public static GraknTxOperationException nonInferredAttributeExists(Attribute attribute){
-        return new GraknTxOperationException(String.format("Attribute {%s} was already created and cannot be set to inferred", attribute));
+    public static GraknTxOperationException nonInferredThingExists(Thing thing){
+        return new GraknTxOperationException(String.format("Thing {%s} was already created and cannot be set to inferred", thing));
     }
 }

--- a/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
@@ -24,8 +24,8 @@ import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Label;
-import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Role;
+import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
 import ai.grakn.util.ErrorMessage;
@@ -38,7 +38,6 @@ import java.util.stream.Collectors;
 import static ai.grakn.util.ErrorMessage.CLOSE_FAILURE;
 import static ai.grakn.util.ErrorMessage.HAS_INVALID;
 import static ai.grakn.util.ErrorMessage.INVALID_DIRECTION;
-import static ai.grakn.util.ErrorMessage.INVALID_PATH_TO_CONFIG;
 import static ai.grakn.util.ErrorMessage.INVALID_PROPERTY_USE;
 import static ai.grakn.util.ErrorMessage.LABEL_TAKEN;
 import static ai.grakn.util.ErrorMessage.META_TYPE_IMMUTABLE;
@@ -224,13 +223,6 @@ public class GraknTxOperationException extends GraknException{
     }
 
     /**
-     * Thrown when attempting to read a config file which cannot be accessed
-     */
-    public static GraknTxOperationException invalidConfig(String pathToFile){
-        return new GraknTxOperationException(INVALID_PATH_TO_CONFIG.getMessage(pathToFile));
-    }
-
-    /**
      * Thrown when trying to create something using a label reserved by the system
      */
     public static GraknTxOperationException reservedLabel(Label label){
@@ -323,5 +315,13 @@ public class GraknTxOperationException extends GraknException{
      */
     public static GraknTxOperationException invalidLabelStart(Label label){
         return new GraknTxOperationException(String.format("Cannot create a label {%s} starting with character {%s} as it is a reserved starting character", label, Schema.ImplicitType.RESERVED.getValue()));
+    }
+
+    /**
+     * Thrown when attempting to create an {@link Attribute} via the execution of a {@link ai.grakn.concept.Rule} when
+     * the {@link Attribute} already exists
+     */
+    public static GraknTxOperationException nonInferredAttributeExists(Attribute attribute){
+        return new GraknTxOperationException(String.format("Attribute {%s} was already created and cannot be set to inferred", attribute));
     }
 }

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -155,7 +155,8 @@ public final class Schema {
         SCHEMA_LABEL(String.class), INDEX(String.class), ID(String.class), LABEL_ID(Integer.class),
 
         //Other Properties
-        THING_TYPE_LABEL_ID(Integer.class), IS_ABSTRACT(Boolean.class), IS_IMPLICIT(Boolean.class),
+        THING_TYPE_LABEL_ID(Integer.class),
+        IS_ABSTRACT(Boolean.class), IS_IMPLICIT(Boolean.class), IS_INFERRED(Boolean.class),
         REGEX(String.class), DATA_TYPE(String.class), CURRENT_LABEL_ID(Integer.class),
         RULE_WHEN(String.class), RULE_THEN(String.class), CURRENT_SHARD(String.class),
 
@@ -185,7 +186,8 @@ public final class Schema {
         RELATIONSHIP_ROLE_VALUE_LABEL_ID(Integer.class),
         ROLE_LABEL_ID(Integer.class),
         RELATIONSHIP_TYPE_LABEL_ID(Integer.class),
-        REQUIRED(Boolean.class);
+        REQUIRED(Boolean.class),
+        IS_INFERRED(Boolean.class);
 
         private final Class dataType;
 

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/GraknTxAbstract.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/GraknTxAbstract.java
@@ -491,12 +491,12 @@ public abstract class GraknTxAbstract<G extends Graph> implements GraknTx, Grakn
     @Override
     public RelationshipType putRelationshipType(Label label) {
         return putSchemaConcept(label, Schema.BaseType.RELATIONSHIP_TYPE, false,
-                v -> factory().buildRelationType(v, getMetaRelationType()));
+                v -> factory().buildRelationshipType(v, getMetaRelationType()));
     }
 
     public RelationshipType putRelationTypeImplicit(Label label) {
         return putSchemaConcept(label, Schema.BaseType.RELATIONSHIP_TYPE, true,
-                v -> factory().buildRelationType(v, getMetaRelationType()));
+                v -> factory().buildRelationshipType(v, getMetaRelationType()));
     }
 
     @Override
@@ -525,7 +525,7 @@ public abstract class GraknTxAbstract<G extends Graph> implements GraknTx, Grakn
     public <V> AttributeType<V> putAttributeType(Label label, AttributeType.DataType<V> dataType) {
         @SuppressWarnings("unchecked")
         AttributeType<V> attributeType = putSchemaConcept(label, Schema.BaseType.ATTRIBUTE_TYPE, false,
-                v -> factory().buildResourceType(v, getMetaResourceType(), dataType));
+                v -> factory().buildAttributeType(v, getMetaResourceType(), dataType));
 
         //These checks is needed here because caching will return a type by label without checking the datatype
         if (Schema.MetaSchema.isMetaLabel(label)) {

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
@@ -130,10 +130,6 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
             Object persistenceValue = castValue(value);
             AttributeImpl<D> attribute = vertex().tx().factory().buildAttribute(vertex, type, persistenceValue);
 
-            if(isInferred && !attribute.isInferred()){
-                throw GraknTxOperationException.nonInferredAttributeExists(attribute);
-            }
-
             try{
                 attribute.vertex().propertyUnique(Schema.VertexProperty.INDEX, Schema.generateAttributeIndex(getLabel(), value.toString()));
             } catch (PropertyNotUniqueException e){
@@ -211,6 +207,10 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Override
     public String getRegex() {
         return vertex().property(Schema.VertexProperty.REGEX);
+    }
+
+    public static AttributeTypeImpl from(AttributeType attributeType){
+        return (AttributeTypeImpl) attributeType;
     }
 
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
@@ -24,8 +24,6 @@ import ai.grakn.exception.GraknTxOperationException;
 import ai.grakn.exception.PropertyNotUniqueException;
 import ai.grakn.kb.internal.structure.VertexElement;
 import ai.grakn.util.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -52,7 +50,6 @@ import java.util.regex.Pattern;
  *           Supported Types include: {@link String}, {@link Long}, {@link Double}, and {@link Boolean}
  */
 public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D>> implements AttributeType<D> {
-    final Logger LOG = LoggerFactory.getLogger(AttributeTypeImpl.class);
 
     private AttributeTypeImpl(VertexElement vertexElement) {
         super(vertexElement);

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ElementFactory.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ElementFactory.java
@@ -89,17 +89,17 @@ public final class ElementFactory {
     }
 
     // ---------------------------------------- Building Attribute Types  -----------------------------------------------
-    public <V> AttributeTypeImpl<V> buildResourceType(VertexElement vertex, AttributeType<V> type, AttributeType.DataType<V> dataType){
+    public <V> AttributeTypeImpl<V> buildAttributeType(VertexElement vertex, AttributeType<V> type, AttributeType.DataType<V> dataType){
         return getOrBuildConcept(vertex, (v) -> AttributeTypeImpl.create(v, type, dataType));
     }
 
-    // ------------------------------------------ Building Resources
-    <V> AttributeImpl<V> buildResource(VertexElement vertex, AttributeType<V> type, Object persitedValue){
+    // ------------------------------------------ Building Attribute
+    <V> AttributeImpl<V> buildAttribute(VertexElement vertex, AttributeType<V> type, Object persitedValue){
         return getOrBuildConcept(vertex, (v) -> AttributeImpl.create(v, type, persitedValue));
     }
 
     // ---------------------------------------- Building Relationship Types  -----------------------------------------------
-    public RelationshipTypeImpl buildRelationType(VertexElement vertex, RelationshipType type){
+    public RelationshipTypeImpl buildRelationshipType(VertexElement vertex, RelationshipType type){
         return getOrBuildConcept(vertex, (v) -> RelationshipTypeImpl.create(v, type));
     }
 

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
@@ -56,6 +56,10 @@ public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements Enti
 
     @Override
     public Entity addEntity() {
-        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true);
+        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), false, true);
+    }
+
+    public Entity addEntityInferred() {
+        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true, true);
     }
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
@@ -62,4 +62,8 @@ public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements Enti
     public Entity addEntityInferred() {
         return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true, true);
     }
+
+    public static EntityTypeImpl from(EntityType entityType){
+        return (EntityTypeImpl) entityType;
+    }
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipEdge.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipEdge.java
@@ -185,6 +185,11 @@ public class RelationshipEdge implements RelationshipStructure, CacheOwner {
     }
 
     @Override
+    public boolean isInferred() {
+        return edge().propertyBoolean(Schema.EdgeProperty.IS_INFERRED);
+    }
+
+    @Override
     public String toString(){
         return "ID [" + getId() + "] Type [" + type().getLabel() + "] Roles and Role Players: \n" +
                 "Role [" + ownerRole().getLabel() + "] played by [" + owner().getId() + "] \n" +

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipImpl.java
@@ -176,6 +176,11 @@ public class RelationshipImpl implements Relationship, ConceptVertex, CacheOwner
     }
 
     @Override
+    public boolean isInferred() {
+        return structure().isInferred();
+    }
+
+    @Override
     public void removeRolePlayer(Role role, Thing thing) {
         reified().ifPresent(relationshipReified -> relationshipReified.removeRolePlayer(role, thing));
     }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipStructure.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipStructure.java
@@ -22,6 +22,7 @@ import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Relationship;
 import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
+import ai.grakn.concept.Rule;
 import ai.grakn.concept.Thing;
 import ai.grakn.kb.internal.cache.CacheOwner;
 import ai.grakn.kb.internal.structure.EdgeElement;
@@ -94,4 +95,12 @@ interface RelationshipStructure extends CacheOwner{
      * Return whether the relationship has been deleted.
      */
     boolean isDeleted();
+
+    /**
+     * Used to indicate if this {@link Relationship} has been created as the result of a {@link Rule} inference.
+     * @see Rule
+     *
+     * @return true if this {@link Relationship} exists due to a rule
+     */
+    boolean isInferred();
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
@@ -70,7 +70,12 @@ public class RelationshipTypeImpl extends TypeImpl<RelationshipType, Relationshi
     @Override
     public Relationship addRelationship() {
         return addInstance(Schema.BaseType.RELATIONSHIP,
-                (vertex, type) -> vertex().tx().factory().buildRelation(vertex, type), true);
+                (vertex, type) -> vertex().tx().factory().buildRelation(vertex, type), false, true);
+    }
+
+    public Relationship addRelationshipInferred() {
+        return addInstance(Schema.BaseType.RELATIONSHIP,
+                (vertex, type) -> vertex().tx().factory().buildRelation(vertex, type), true, true);
     }
 
     @Override

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
@@ -177,4 +177,8 @@ public class RelationshipTypeImpl extends TypeImpl<RelationshipType, Relationshi
                             flatMap(CommonUtil::optionalToStream);
                 });
     }
+
+    public static RelationshipTypeImpl from(RelationshipType relationshipType){
+        return (RelationshipTypeImpl) relationshipType;
+    }
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
@@ -109,6 +109,10 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         }
     }
 
+    public boolean isInferred(){
+        return vertex().propertyBoolean(Schema.VertexProperty.IS_INFERRED);
+    }
+
     /**
      * Deletes the concept as an Thing
      */

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
@@ -254,8 +254,17 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         return getThis();
     }
 
+    public T attributeInferred(Attribute attribute) {
+        attributeRelationship(attribute, true);
+        return getThis();
+    }
+
     @Override
     public Relationship attributeRelationship(Attribute attribute) {
+        return attributeRelationship(attribute, false);
+    }
+
+    private Relationship attributeRelationship(Attribute attribute, boolean isInferred) {
         Schema.ImplicitType has = Schema.ImplicitType.HAS;
         Schema.ImplicitType hasValue = Schema.ImplicitType.HAS_VALUE;
         Schema.ImplicitType hasOwner  = Schema.ImplicitType.HAS_OWNER;
@@ -267,7 +276,6 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
             hasOwner  = Schema.ImplicitType.KEY_OWNER;
         }
 
-
         Label label = attribute.type().getLabel();
         RelationshipType hasAttribute = vertex().tx().getSchemaConcept(has.getLabel(label));
         Role hasAttributeOwner = vertex().tx().getSchemaConcept(hasOwner.getLabel(label));
@@ -278,6 +286,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         }
 
         EdgeElement attributeEdge = addEdge(AttributeImpl.from(attribute), Schema.EdgeLabel.ATTRIBUTE);
+        if(isInferred) attributeEdge.property(Schema.EdgeProperty.IS_INFERRED, true);
         return vertex().tx().factory().buildRelation(attributeEdge, hasAttribute, hasAttributeOwner, hasAttributeValue);
     }
 

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
@@ -104,11 +104,11 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
      * @param producer The factory method to produce the instance if it doesn't exist
      * @return A new or already existing instance
      */
-    V putInstance(Schema.BaseType instanceBaseType, Supplier<V> finder, BiFunction<VertexElement, T, V> producer) {
+    V putInstance(Schema.BaseType instanceBaseType, Supplier<V> finder, BiFunction<VertexElement, T, V> producer, boolean isInferred) {
         preCheckForInstanceCreation();
 
         V instance = finder.get();
-        if(instance == null) instance = addInstance(instanceBaseType, producer, false);
+        if(instance == null) instance = addInstance(instanceBaseType, producer, isInferred, false);
         return instance;
     }
 
@@ -120,7 +120,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
      * @param checkNeeded indicates if a check is necessary before adding the instance
      * @return A new instance
      */
-    V addInstance(Schema.BaseType instanceBaseType, BiFunction<VertexElement, T, V> producer, boolean checkNeeded){
+    V addInstance(Schema.BaseType instanceBaseType, BiFunction<VertexElement, T, V> producer, boolean isInferred, boolean checkNeeded){
         if(checkNeeded) preCheckForInstanceCreation();
 
         if(isAbstract()) throw GraknTxOperationException.addingInstancesToAbstractType(this);
@@ -128,6 +128,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         VertexElement instanceVertex = vertex().tx().addVertexElement(instanceBaseType);
         if(!Schema.MetaSchema.isMetaLabel(getLabel())) {
             vertex().tx().txCache().addedInstance(getId());
+            if(isInferred) vertex().property(Schema.VertexProperty.IS_INFERRED, true);
         }
         return producer.apply(instanceVertex, getThis());
     }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
@@ -108,7 +108,13 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         preCheckForInstanceCreation();
 
         V instance = finder.get();
-        if(instance == null) instance = addInstance(instanceBaseType, producer, isInferred, false);
+        if(instance == null) {
+            instance = addInstance(instanceBaseType, producer, isInferred, false);
+        } else {
+            if(isInferred && !instance.isInferred()){
+                throw GraknTxOperationException.nonInferredThingExists(instance);
+            }
+        }
         return instance;
     }
 
@@ -128,7 +134,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         VertexElement instanceVertex = vertex().tx().addVertexElement(instanceBaseType);
         if(!Schema.MetaSchema.isMetaLabel(getLabel())) {
             vertex().tx().txCache().addedInstance(getId());
-            if(isInferred) vertex().property(Schema.VertexProperty.IS_INFERRED, true);
+            if(isInferred) instanceVertex.property(Schema.VertexProperty.IS_INFERRED, true);
         }
         return producer.apply(instanceVertex, getThis());
     }

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/AttributeTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/AttributeTest.java
@@ -44,6 +44,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -249,6 +250,26 @@ public class AttributeTest extends TxTestBase {
         Relationship rel2 = Iterables.getOnlyElement(e2.relationships().collect(toSet()));
 
         assertThat(attribute.relationships().collect(toSet()), containsInAnyOrder(rel1, rel2));
+    }
+
+    @Test
+    public void whenCreatingAnInferredAttribute_EnsureMarkedAsInferred(){
+        AttributeTypeImpl at = AttributeTypeImpl.from(tx.putAttributeType("at", AttributeType.DataType.STRING));
+        Attribute attribute = at.putAttribute("blergh");
+        Attribute attributeInferred = at.putAttributeInferred("bloorg");
+        assertFalse(attribute.isInferred());
+        assertTrue(attributeInferred.isInferred());
+    }
+
+    @Test
+    public void whenCreatingAnInferredAttributeWhichIsAlreadyNonInferred_Throw(){
+        AttributeTypeImpl at = AttributeTypeImpl.from(tx.putAttributeType("at", AttributeType.DataType.STRING));
+        Attribute attribute = at.putAttribute("blergh");
+
+        expectedException.expect(GraknTxOperationException.class);
+        expectedException.expectMessage(GraknTxOperationException.nonInferredThingExists(attribute).getMessage());
+
+        at.putAttributeInferred("blergh");
     }
 
 }

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTest.java
@@ -38,9 +38,11 @@ import org.junit.Test;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class EntityTest extends TxTestBase {
 
@@ -207,6 +209,15 @@ public class EntityTest extends TxTestBase {
         EntityType et = tx.putEntityType("et");
         EntityImpl e = (EntityImpl) et.addEntity();
         assertEquals(et.getLabel(), e.getInternalType());
+    }
+
+    @Test
+    public void whenCreatingAnInferredEntity_EnsureMarkedAsInferred(){
+        EntityTypeImpl et = EntityTypeImpl.from(tx.putEntityType("et"));
+        Entity entity = et.addEntity();
+        Entity entityInferred = et.addEntityInferred();
+        assertFalse(entity.isInferred());
+        assertTrue(entityInferred.isInferred());
     }
 
     @Test

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTest.java
@@ -234,4 +234,28 @@ public class EntityTest extends TxTestBase {
         aPerson.deleteAttribute(tim);
         assertThat(aPerson.attributes().collect(toSet()), containsInAnyOrder(fim, pim));
     }
+
+
+    @Test
+    public void whenCreatingInferredAttributeLink_EnsureMarkedAsInferred(){
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        Attribute<String> attribute1 = name.putAttribute("An attribute 1");
+        Attribute<String> attribute2 = name.putAttribute("An attribute 2");
+        EntityType et = tx.putEntityType("et").attribute(name);
+        Entity e = et.addEntity();
+
+        //Link Attributes
+        e.attribute(attribute1);
+        EntityImpl.from(e).attributeInferred(attribute2);
+
+        e.relationships().forEach(relationship -> {
+            relationship.rolePlayers().forEach(roleplayer ->{
+                if(roleplayer.equals(attribute1)){
+                    assertFalse(relationship.isInferred());
+                } else if(roleplayer.equals(attribute2)){
+                    assertTrue(relationship.isInferred());
+                }
+            });
+        });
+    }
 }

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/RelationshipTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/RelationshipTest.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -89,6 +90,15 @@ public class RelationshipTest extends TxTestBase {
         relationship.addRolePlayer(role, entity1);
         assertThat(relationship.allRolePlayers().keySet(), containsInAnyOrder(role1, role2, role3, role));
         assertThat(relationship.allRolePlayers().get(role), containsInAnyOrder(entity1));
+    }
+
+    @Test
+    public void whenCreatingAnInferredRelationship_EnsureMarkedAsInferred(){
+        RelationshipTypeImpl rt = RelationshipTypeImpl.from(tx.putRelationshipType("rt"));
+        Relationship relationship = rt.addRelationship();
+        Relationship relationshipInferred = rt.addRelationshipInferred();
+        assertFalse(relationship.isInferred());
+        assertTrue(relationshipInferred.isInferred());
     }
 
     @Test


### PR DESCRIPTION
@kasper-piskorski this is what you need. So to create inferred instances you do the following:

### Creating Inferred Instances

```
EntityTypeImpl.from(entityType).addEntityInferred();
RelationshipTypeImpl.from(relationshipType).addRelationshipInferred();
AttributeTypeImpl.from(attributeType).putAttributeInferred("bob");
```

Word of warning: With regards to inferred attributes the following will cause an error:

```
AttributeTypeImpl.from(attributeType).putAttribute("bob");
AttributeTypeImpl.from(attributeType).putAttributeInferred("bob");
```

This is because you can't mark an attribute as inferred when it has been created normally. 

### Creating Inferred Attribute links

Lets say you create the following rule:

```
when
{
    $x isa person
}
then
{
    $x has name "Bob"
}
```

now lets assume that "Bob" already exists in the DB. The question now becomes how can you create the inferred attribute relationship between `x` and `bob`. It is done like so:

```
EntityImpl.from(x).attributeInferred(bob)
```