### PR TITLE
Temporary fix to get master loading.

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
@@ -20,6 +20,7 @@ package ai.grakn.client;
 
 import ai.grakn.Keyspace;
 import ai.grakn.graql.Query;
+import ai.grakn.util.SimpleURI;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -144,6 +145,11 @@ public class BatchExecutorClient implements Closeable {
 
     public static Builder newBuilder() {
         return new Builder();
+    }
+
+    //TODO: Remove this method used only by docs tests
+    public static Builder newBuilderforURI(SimpleURI simpleURI) {
+        return new Builder().taskClient(new GraknClient(simpleURI));
     }
 
     /**

--- a/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
@@ -20,10 +20,8 @@ package ai.grakn.client;
 
 import ai.grakn.Keyspace;
 import ai.grakn.graql.Query;
-import ai.grakn.util.SimpleURI;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import static com.codahale.metrics.MetricRegistry.name;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.Timer.Context;
 import com.github.rholder.retry.Attempt;
@@ -40,6 +38,12 @@ import com.netflix.hystrix.HystrixCommandGroupKey;
 import com.netflix.hystrix.HystrixCommandProperties;
 import com.netflix.hystrix.HystrixThreadPoolProperties;
 import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
 import java.io.Closeable;
 import java.net.ConnectException;
 import java.util.Collection;
@@ -51,11 +55,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import rx.Observable;
-import rx.Scheduler;
-import rx.schedulers.Schedulers;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * Client to batch load qraql queries into Grakn that mutate the graph.
@@ -143,10 +144,6 @@ public class BatchExecutorClient implements Closeable {
 
     public static Builder newBuilder() {
         return new Builder();
-    }
-
-    public static Builder newBuilderforURI(SimpleURI simpleURI) {
-        return new Builder().taskClient(new GraknClient(simpleURI));
     }
 
     /**

--- a/grakn-client/src/main/java/ai/grakn/client/GraknClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/GraknClient.java
@@ -46,7 +46,7 @@ import static ai.grakn.util.REST.Response.ContentType.APPLICATION_JSON_GRAQL;
  */
 public class GraknClient {
 
-    public static final int CONNECT_TIMEOUT_MS = 5 * 60 * 1000;
+    public static final int CONNECT_TIMEOUT_MS = 30 * 1000;
     public static final int DEFAULT_MAX_RETRY = 3;
     private final Logger LOG = LoggerFactory.getLogger(GraknClient.class);
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
@@ -127,6 +127,7 @@ public class GraqlController {
 
         Optional<Boolean> defineAllVars = queryParameter(request, DEFINE_ALL_VARS).map(Boolean::parseBoolean);
 
+        LOG.trace(String.format("Executing graql statements: {%s}", queryString));
         try (GraknTx graph = factory.tx(keyspace, WRITE); Timer.Context context = executeGraqlPostTimer.time()) {
             QueryBuilder builder = graph.graql();
 

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlClient.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlClient.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graql;
 
-import ai.grakn.Keyspace;
 import ai.grakn.client.BatchExecutorClient;
 import ai.grakn.client.Client;
 import ai.grakn.client.GraknClient;
@@ -67,7 +66,7 @@ class GraqlClient {
         }
     }
 
-    public BatchExecutorClient loaderClient(Keyspace keyspace, SimpleURI uri) {
+    public BatchExecutorClient loaderClient(SimpleURI uri) {
         return BatchExecutorClient.newBuilder()
                 .threadPoolCoreSize(Runtime.getRuntime().availableProcessors() * 8)
                 .taskClient(new GraknClient(uri))

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlClient.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlClient.java
@@ -68,7 +68,7 @@ class GraqlClient {
 
     public BatchExecutorClient loaderClient(SimpleURI uri) {
         return BatchExecutorClient.newBuilder()
-                .threadPoolCoreSize(Runtime.getRuntime().availableProcessors() * 8)
+                .threadPoolCoreSize(Runtime.getRuntime().availableProcessors() * 4)
                 .taskClient(new GraknClient(uri))
                 .maxRetries(DEFAULT_MAX_RETRY)
                 .build();

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
@@ -231,7 +231,7 @@ public class GraqlShell {
 
         if (cmd.hasOption("b")) {
             try {
-                sendBatchRequest(client.loaderClient(keyspace, location), cmd.getOptionValue("b"), keyspace);
+                sendBatchRequest(client.loaderClient(location), cmd.getOptionValue("b"), keyspace);
             } catch (NumberFormatException e) {
                 printUsage(options, "Cannot cast argument to an integer " + e.getMessage());
                 return false;

--- a/grakn-graql-shell/src/test/java/ai/grakn/graql/GraqlShellTest.java
+++ b/grakn-graql-shell/src/test/java/ai/grakn/graql/GraqlShellTest.java
@@ -20,7 +20,6 @@
 package ai.grakn.graql;
 
 import ai.grakn.Grakn;
-import ai.grakn.Keyspace;
 import ai.grakn.client.BatchExecutorClient;
 import mjson.Json;
 import org.eclipse.jetty.websocket.api.Session;
@@ -66,7 +65,7 @@ public class GraqlShellTest {
 
         batchExecutorClient = mock(BatchExecutorClient.class);
 
-        when(client.loaderClient(any(Keyspace.class), any())).thenReturn(batchExecutorClient);
+        when(client.loaderClient(any())).thenReturn(batchExecutorClient);
     }
 
    @Test


### PR DESCRIPTION
The Batch Mutator Client is sending so many simultaneous requests that it's killing spark. I have not been able to make spark more resilient (yet).

So this is just a temporary patch which throttles the client so we can start loading again until we make spark more resilient.