### PR TITLE
[DO NOT MERGE] mkdir-based lock on 'grakn server xxx'

### DIFF
--- a/grakn-dist/src/main/java/ai/grakn/dist/mkdirlock/LockAlreadyAcquiredException.java
+++ b/grakn-dist/src/main/java/ai/grakn/dist/mkdirlock/LockAlreadyAcquiredException.java
@@ -16,14 +16,14 @@
  * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package ai.grakn.dist;
+package ai.grakn.dist.mkdirlock;
 
 /**
  *
- * @author Michele Orsi
+ * @author Ganeshwara Herawan Hananda
  */
-class ProcessNotStartedException extends RuntimeException {
-    public ProcessNotStartedException() {
+public class LockAlreadyAcquiredException extends RuntimeException {
+    public LockAlreadyAcquiredException() {
         super();
     }
 }

--- a/grakn-dist/src/main/java/ai/grakn/dist/mkdirlock/MkdirBasedLock.java
+++ b/grakn-dist/src/main/java/ai/grakn/dist/mkdirlock/MkdirBasedLock.java
@@ -1,0 +1,48 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.dist.mkdirlock;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+/**
+ *
+ * @author Ganeshwara Herawan Hananda
+ */
+
+public class MkdirBasedLock {
+    public static final String PROCESS_WIDE_LOCK_PATH = "/tmp/.grakn.lock";
+
+    public static void withMkdirLock(Runnable fn) {
+        try {
+            Files.createDirectory(Paths.get(PROCESS_WIDE_LOCK_PATH));
+            fn.run();
+            Files.delete(Paths.get(PROCESS_WIDE_LOCK_PATH));
+        }
+        catch (FileAlreadyExistsException ex) {
+            throw new LockAlreadyAcquiredException();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
1. Prevent concurrent initialization with mkdir-based lock
2. TODO: Properly handle CTRL+C
3. TODO: Add forceful stop in case some components become unresponsive?