### PR TITLE
When `$x relates $y`, infer `$y sub role`

### DIFF
--- a/docs/pages/docs/0-get-started/quickstart-tutorial.md
+++ b/docs/pages/docs/0-get-started/quickstart-tutorial.md
@@ -92,15 +92,9 @@ marriage sub relationship
   relates spouse2
   has picture;
 
-spouse1 sub role;
-spouse2 sub role;
-
 parentship sub relationship
   relates parent
   relates child;
-
-parent sub role;
-child sub role;
 ```
 
 There are a number of things we can say about schema shown above:

--- a/docs/pages/docs/1-knowledge-model/data.md
+++ b/docs/pages/docs/1-knowledge-model/data.md
@@ -89,9 +89,6 @@ define
   marriage sub relationship;
   marriage relates husband;
 
-  husband sub role;
-  wife sub role;
-
   woman plays wife;
 
 insert
@@ -138,8 +135,6 @@ define
   marriage relates husband;
   marriage relates wife; # Fix (2) and (3)
 
-  husband sub role;
-  wife sub role;
   man plays husband; # Fix (4)
   woman plays wife;
 

--- a/docs/pages/docs/1-knowledge-model/inference.md
+++ b/docs/pages/docs/1-knowledge-model/inference.md
@@ -36,9 +36,6 @@ define
   located-in sub relationship,
     relates located-subject, relates subject-location;
 
-  located-subject sub role;
-  subject-location sub role;
-
   transitive-location sub rule,
     when {
       ($x, $y) isa located-in;

--- a/docs/pages/docs/1-knowledge-model/model.md
+++ b/docs/pages/docs/1-knowledge-model/model.md
@@ -107,8 +107,6 @@ define
 
   employment sub relationship,
     relates employee, relates employer;
-  employee sub role;
-  employer sub role;
 ```
 
 <br /> <img src="/images/knowledge-model4.png" style="width: 400px;" alt="
@@ -156,9 +154,6 @@ define
   employment sub relationship,
     relates employee, relates employer,
     has "date";
-
-  employee sub role;
-  employer sub role;
 ```
 
 <br /> <img src="/images/knowledge-model6.png" style="width: 400px;" alt="
@@ -174,10 +169,6 @@ define
     relates employee,
     relates employer,
     relates office;
-
-  employee sub role;
-  employer sub role;
-  office sub role;
 ```
 
 <br /> <img src="/images/knowledge-model8.png" style="width: 400px;" alt="

--- a/docs/pages/docs/11-examples/CSV-migration.md
+++ b/docs/pages/docs/11-examples/CSV-migration.md
@@ -67,15 +67,9 @@ marriage sub relationship
   relates spouse2
   has picture;
 
-spouse1 sub role;
-spouse2 sub role;
-
 parentship sub relationship
   relates parent
   relates child;
-
-parent sub role;
-child sub role;
 
 # Resources
 

--- a/docs/pages/docs/11-examples/JSON-migration-NOT-PUBLISHED.md
+++ b/docs/pages/docs/11-examples/JSON-migration-NOT-PUBLISHED.md
@@ -84,11 +84,6 @@ publication sub relationship
     relates publication-item
     relates publication-author
     relates publication-subject;
-
-publication-item sub role;
-publication-author sub role;
-publication-subject sub role;
-
 ```
 
 Here, there are three entities, to reflect the book, author of the book and possible book subjects. There is one relationship, `publication` which between all three entities.

--- a/docs/pages/docs/11-examples/analytics.md
+++ b/docs/pages/docs/11-examples/analytics.md
@@ -78,9 +78,6 @@ economical sub attribute datatype string;
 manufactured sub relationship
     relates maker
     relates made;
-
-maker sub role;
-made sub role;
 ```
 
 To load *schema.gql* into Grakn, make sure the engine is running and choose a clean keyspace in which to work (here we use the default keyspace, so we are cleaning it before we get started).

--- a/docs/pages/docs/11-examples/modern.md
+++ b/docs/pages/docs/11-examples/modern.md
@@ -70,11 +70,9 @@ define weight sub attribute datatype double;
 Let's first define the relationship between people. The diagram shows that marko knows vadas, but we don't have any information about whether the inverse is true (though it seems likely that vadas probably also knows marko). Let's set up a relationship called `knows`, which has two roles - `knower` (for marko) and `known-about` (for vadas):
 
 ```graql
-define knower sub role;
-define known-about sub role;
+define knows sub relationship, relates knower, relates known-about, has weight;
 define person plays knower;
 define person plays known-about;
-define knows sub relationship, relates knower, relates known-about, has weight;
 ```
 
 Note that the `knows` relationship also has an attribute, in the form of an attribute called `weight`.
@@ -82,13 +80,9 @@ Note that the `knows` relationship also has an attribute, in the form of an attr
 We can set up a similar relationship between software and the people that created it:
 
 ```graql
-define programmer sub role;
-define programmed sub role;
-
+define programming sub relationship, relates programmer, relates programmed, has weight;
 define person plays programmer;
 define software plays programmed;
-
-define programming sub relationship, relates programmer, relates programmed, has weight;
 ```
 
 And that's it. At this point, we have defined the schema of the knowledge base.
@@ -175,16 +169,13 @@ insert $peter isa person, has age 35, has name "peter";
 
 define weight sub attribute datatype double;
 
-knower sub role;
-known-about sub role;
-
-person plays knower;
-person plays known-about;
-
 knows sub relationship
     relates knower
     relates known-about
     has weight;
+
+person plays knower;
+person plays known-about;
 
 match $marko has name "marko"; $josh has name "josh"; insert (knower: $marko, known-about: $josh) isa knows has weight 1.0;
 match $marko has name "marko"; $vadas has name "vadas"; insert (knower: $marko, known-about: $vadas) isa knows has weight 0.5;
@@ -198,16 +189,14 @@ insert $lop isa software, has lang "java", has name "lop";
 insert $ripple isa software, has lang "java", has name "ripple";
 
 define
-programmer sub role;
-programmed sub role;
-
-person plays programmer;
-software plays programmed;
 
 programming sub relationship
     relates programmer
     relates programmed
     has weight;
+
+person plays programmer;
+software plays programmed;
 
 
 match $marko has name "marko"; $lop has name "lop"; insert (programmer: $marko, programmed: $lop) isa programming has weight 0.4;

--- a/docs/pages/docs/2-building-schema/basic-schema.md
+++ b/docs/pages/docs/2-building-schema/basic-schema.md
@@ -88,15 +88,9 @@ marriage sub relationship
   relates spouse2
   has picture;
 
-spouse1 sub role;
-spouse2 sub role;
-
 parentship sub relationship
   relates parent
   relates child;
-
-parent sub role;
-child sub role;
 ```
 
 ## Allowing Roles to be Played
@@ -162,16 +156,9 @@ define
     relates spouse2
     has picture;
 
-  spouse1 sub role;
-  spouse2 sub role;
-
   parentship sub relationship
     relates parent
     relates child;
-
-  parent sub role;
-  child sub role;
-
 ```
 
 ![Schema](/images/basic-schema1.png)

--- a/docs/pages/docs/2-building-schema/hierarchical-schema.md
+++ b/docs/pages/docs/2-building-schema/hierarchical-schema.md
@@ -60,15 +60,9 @@ define
     relates spouse2
     has picture;
 
-  spouse1 sub role;
-  spouse2 sub role;
-
   parentship sub relationship
     relates parent
     relates child;
-
-  parent sub role;
-  child sub role;
 ```
 
 This schema represents a genealogy knowledge base which models a family tree.

--- a/docs/pages/docs/2-building-schema/rule-driven-schema.md
+++ b/docs/pages/docs/2-building-schema/rule-driven-schema.md
@@ -126,9 +126,6 @@ The relationship will be defined through a `siblings` relationship. We define bo
 ```graql
 define
 
-sibling sub role;
-cousin sub role;
-
 siblings sub relationship
     relates sibling;
 

--- a/docs/pages/docs/5-migrating-data/migrating-sql.md
+++ b/docs/pages/docs/5-migrating-data/migrating-sql.md
@@ -119,9 +119,6 @@ occurs sub relationship
   relates event-occurred
   relates pet-in-event;
 
-event-occurred sub role;
-pet-in-event sub role;
-
 pet plays pet-in-event;
 event plays event-occurred;
 ```

--- a/docs/pages/docs/7-java-library/core-api.md
+++ b/docs/pages/docs/7-java-library/core-api.md
@@ -71,15 +71,9 @@ marriage sub relationship
   relates spouse2
   has picture;
 
-spouse1 sub role;
-spouse2 sub role;
-
 parentship sub relationship
   relates parent
   relates child;
-
-parent sub role;
-child sub role;
 ```
 
 Using the Core API:

--- a/docs/pages/docs/9-api-references/ddl.md
+++ b/docs/pages/docs/9-api-references/ddl.md
@@ -54,6 +54,8 @@ one will be created.
 
 `$A relates $B` define the _relationship type_ `$A` to directly relate the _role_ `$B`.
 
+In the case where `$B` does not have a defined `sub`, this will also implicit define `$B sub role`.
+
 ## plays
 
 `$A plays $B` defines the _type_ `$A` to directly play the _role_ `$B`.

--- a/grakn-dist/src/examples/philosophers.gql
+++ b/grakn-dist/src/examples/philosophers.gql
@@ -32,21 +32,15 @@ description sub attribute datatype string;
 practice sub relationship
     relates philosopher
     relates philosophy;
-philosopher sub role;
-philosophy sub role;
 
 education sub relationship
     relates teacher
     relates student;
-teacher sub role;
-student sub role;
 
 knowledge sub relationship
     relates thinker
     relates thought
     plays thought;
-thinker sub role;
-thought sub role;
 
 
 insert

--- a/grakn-dist/src/examples/pokemon.gql
+++ b/grakn-dist/src/examples/pokemon.gql
@@ -25,20 +25,14 @@ weight sub attribute datatype double;
 evolution sub relationship
     relates ancestor
     relates descendant;
-ancestor sub role;
-descendant sub role;
 
 has-type sub relationship
     relates pokemon-with-type
     relates type-of-pokemon;
-pokemon-with-type sub role;
-type-of-pokemon sub role;
 
 super-effective sub relationship
     relates defending-type
     relates attacking-type;
-defending-type sub role;
-attacking-type sub role;
 
 insert
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/AbstractVarProperty.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.util.CommonUtil;
 
+import java.util.Collection;
 import java.util.stream.Stream;
 
 abstract class AbstractVarProperty implements VarPropertyInternal {
@@ -46,17 +47,17 @@ abstract class AbstractVarProperty implements VarPropertyInternal {
     abstract String getName();
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         throw GraqlQueryException.insertUnsupportedProperty(getName());
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         throw GraqlQueryException.defineUnsupportedProperty(getName());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         throw GraqlQueryException.defineUnsupportedProperty(getName());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/DataTypeProperty.java
@@ -69,16 +69,16 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).dataType(dataType());
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         // TODO: resolve the below issue correctly
         // undefine for datatype must be supported, because it is supported in define.
         // However, making it do the right thing is difficult. Ideally we want the same as define:
@@ -90,7 +90,7 @@ public abstract class DataTypeProperty extends AbstractVarProperty implements Na
         //
         // Doing this is tough because it means the `datatype` property needs to be aware of the context somehow.
         // As a compromise, we make all the cases succeed (where some do nothing)
-        return PropertyExecutor.builder(executor -> {}).build();
+        return ImmutableSet.of(PropertyExecutor.builder(executor -> {}).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasAttributeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasAttributeProperty.java
@@ -134,7 +134,7 @@ public abstract class HasAttributeProperty extends AbstractVarProperty implement
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Attribute attributeConcept = executor.get(attribute().var()).asAttribute();
             Thing thing = executor.get(var).asThing();
@@ -142,7 +142,12 @@ public abstract class HasAttributeProperty extends AbstractVarProperty implement
             executor.builder(relationship().var()).id(relationshipId);
         };
 
-        return PropertyExecutor.builder(method).produces(relationship().var()).requires(var, attribute().var()).build();
+        PropertyExecutor executor = PropertyExecutor.builder(method)
+                .produces(relationship().var())
+                .requires(var, attribute().var())
+                .build();
+
+        return ImmutableSet.of(executor);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasAttributeTypeProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/HasAttributeTypeProperty.java
@@ -37,6 +37,7 @@ import ai.grakn.graql.internal.reasoner.atom.binary.type.HasAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.util.Schema;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -141,7 +142,7 @@ public abstract class HasAttributeTypeProperty extends AbstractVarProperty imple
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Type entityTypeConcept = executor.get(var).asType();
             AttributeType attributeTypeConcept = executor.get(resourceType().var()).asAttributeType();
@@ -153,11 +154,11 @@ public abstract class HasAttributeTypeProperty extends AbstractVarProperty imple
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var, resourceType().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, resourceType().var()).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Type type = executor.get(var).asType();
             AttributeType<?> attributeType = executor.get(resourceType().var()).asAttributeType();
@@ -171,7 +172,7 @@ public abstract class HasAttributeTypeProperty extends AbstractVarProperty imple
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var, resourceType().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, resourceType().var()).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IdProperty.java
@@ -70,22 +70,22 @@ public abstract class IdProperty extends AbstractVarProperty implements NamedPro
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).id(id());
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         // This property works in both insert and define queries, because it is only for look-ups
         return insert(var);
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         // This property works in undefine queries, because it is only for look-ups
         return insert(var);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsAbstractProperty.java
@@ -74,7 +74,7 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Concept concept = executor.get(var);
             if (concept.isType()) {
@@ -84,11 +84,11 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Type type = executor.get(var).asType();
             if (!type.isDeleted()) {
@@ -96,7 +96,7 @@ public class IsAbstractProperty extends AbstractVarProperty implements UniqueVar
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaProperty.java
@@ -97,13 +97,13 @@ public abstract class IsaProperty extends AbstractVarProperty implements UniqueV
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Type type = executor.get(this.type().var()).asType();
             executor.builder(var).isa(type);
         };
 
-        return PropertyExecutor.builder(method).requires(type().var()).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(type().var()).produces(var).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/LabelProperty.java
@@ -71,22 +71,22 @@ public abstract class LabelProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         // This is supported in insert queries in order to allow looking up schema concepts by label
         return define(var);
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).label(label());
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         // This is supported in undefine queries in order to allow looking up schema concepts by label
         return define(var);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/PlaysProperty.java
@@ -87,17 +87,17 @@ public abstract class PlaysProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Role role = executor.get(this.role().var()).asRole();
             executor.get(var).asType().plays(role);
         };
 
-        return PropertyExecutor.builder(method).requires(var, role().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, role().var()).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Type type = executor.get(var).asType();
             Role role = executor.get(this.role().var()).asRole();
@@ -107,7 +107,7 @@ public abstract class PlaysProperty extends AbstractVarProperty implements Named
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var, role().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, role().var()).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RegexProperty.java
@@ -70,16 +70,16 @@ public abstract class RegexProperty extends AbstractVarProperty implements Uniqu
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.get(var).asAttributeType().setRegex(regex());
         };
 
-        return PropertyExecutor.builder(method).requires(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             AttributeType<Object> attributeType = executor.get(var).asAttributeType();
             if (!attributeType.isDeleted() && regex().equals(attributeType.getRegex())) {
@@ -87,7 +87,7 @@ public abstract class RegexProperty extends AbstractVarProperty implements Uniqu
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -85,7 +85,7 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         Var roleVar = role().var();
 
         PropertyExecutor.Method method = executor -> {
@@ -96,11 +96,11 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
             executor.get(var).asRelationshipType().relates(role);
         };
 
-        return PropertyExecutor.builder(method).requires(var, roleVar).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, roleVar).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             RelationshipType relationshipType = executor.get(var).asRelationshipType();
             Role role = executor.get(this.role().var()).asRole();
@@ -110,7 +110,7 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var, role().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, role().var()).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -86,13 +86,17 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
 
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
+        Var roleVar = role().var();
+
         PropertyExecutor.Method method = executor -> {
-            executor.tryBuilder(role().var()).ifPresent(ConceptBuilder::usedInRelates);
-            Role role = executor.get(role().var()).asRole();
+            // This allows users to skip stating `$roleVar sub role` when they say `$var relates $roleVar`
+            executor.tryBuilder(roleVar).ifPresent(ConceptBuilder::isRole);
+
+            Role role = executor.get(roleVar).asRole();
             executor.get(var).asRelationshipType().relates(role);
         };
 
-        return PropertyExecutor.builder(method).requires(var, role().var()).build();
+        return PropertyExecutor.builder(method).requires(var, roleVar).build();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -27,6 +27,7 @@ import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.gremlin.EquivalentFragmentSet;
+import ai.grakn.graql.internal.query.ConceptBuilder;
 import ai.grakn.graql.internal.reasoner.atom.binary.type.RelatesAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import com.google.auto.value.AutoValue;
@@ -86,7 +87,8 @@ public abstract class RelatesProperty extends AbstractVarProperty implements Nam
     @Override
     public PropertyExecutor define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
-            Role role = executor.get(this.role().var()).asRole();
+            executor.tryBuilder(role().var()).ifPresent(ConceptBuilder::usedInRelates);
+            Role role = executor.get(role().var()).asRole();
             executor.get(var).asRelationshipType().relates(role);
         };
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationshipProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationshipProperty.java
@@ -185,13 +185,13 @@ public abstract class RelationshipProperty extends AbstractVarProperty implement
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             Relationship relationship = executor.get(var).asRelationship();
             relationPlayers().forEach(relationPlayer -> addRoleplayer(executor, relationship, relationPlayer));
         };
 
-        return PropertyExecutor.builder(method).requires(requiredVars(var)).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(requiredVars(var)).build());
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/SubProperty.java
@@ -87,7 +87,7 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             SchemaConcept superConcept = executor.get(superType().var()).asSchemaConcept();
 
@@ -100,11 +100,11 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
             }
         };
 
-        return PropertyExecutor.builder(method).requires(superType().var()).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(superType().var()).produces(var).build());
     }
 
     @Override
-    public PropertyExecutor undefine(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             SchemaConcept concept = executor.get(var).asSchemaConcept();
 
@@ -116,7 +116,7 @@ public abstract class SubProperty extends AbstractVarProperty implements NamedPr
             }
         };
 
-        return PropertyExecutor.builder(method).requires(var, superType().var()).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).requires(var, superType().var()).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
@@ -22,6 +22,9 @@ import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
 
 
 /**
@@ -49,11 +52,11 @@ public abstract class ThenProperty extends RuleProperty {
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).then(pattern());
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -71,12 +71,12 @@ public abstract class ValueProperty extends AbstractVarProperty implements Named
     }
 
     @Override
-    public PropertyExecutor insert(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).value(predicate().equalsValue().get()); // TODO
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/VarPropertyInternal.java
@@ -57,11 +57,11 @@ public interface VarPropertyInternal extends VarProperty {
      *
      * @throws GraqlQueryException if this {@link VarProperty} cannot be inserted
      */
-    PropertyExecutor insert(Var var) throws GraqlQueryException;
+    Collection<PropertyExecutor> insert(Var var) throws GraqlQueryException;
 
-    PropertyExecutor define(Var var) throws GraqlQueryException;
+    Collection<PropertyExecutor> define(Var var) throws GraqlQueryException;
 
-    PropertyExecutor undefine(Var var) throws GraqlQueryException;
+    Collection<PropertyExecutor> undefine(Var var) throws GraqlQueryException;
 
     /**
      * Whether this property will uniquely identify a concept in the graph, if one exists.

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
@@ -22,6 +22,9 @@ import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collection;
 
 /**
  * Represents the {@code when} property on a {@link ai.grakn.concept.Rule}.
@@ -48,11 +51,11 @@ public abstract class WhenProperty extends RuleProperty {
     }
 
     @Override
-    public PropertyExecutor define(Var var) throws GraqlQueryException {
+    public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
             executor.builder(var).when(pattern());
         };
 
-        return PropertyExecutor.builder(method).produces(var).build();
+        return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
@@ -133,8 +133,8 @@ public class ConceptBuilder {
         return set(SUPER_CONCEPT, superConcept);
     }
 
-    public ConceptBuilder usedInRelates() {
-        return set(USED_IN_RELATES, Unit.INSTANCE);
+    public ConceptBuilder isRole() {
+        return set(IS_ROLE, Unit.INSTANCE);
     }
 
     public ConceptBuilder label(Label label) {
@@ -214,8 +214,8 @@ public class ConceptBuilder {
 
         Concept concept;
 
-        if (has(USED_IN_RELATES)) {
-            use(USED_IN_RELATES);
+        if (has(IS_ROLE)) {
+            use(IS_ROLE);
 
             Label label = use(LABEL);
             Role role = executor.tx().putRole(label);
@@ -282,10 +282,15 @@ public class ConceptBuilder {
     private static final BuilderParam<AttributeType.DataType<?>> DATA_TYPE = BuilderParam.of(DataTypeProperty.NAME);
     private static final BuilderParam<Pattern> WHEN = BuilderParam.of(WhenProperty.NAME);
     private static final BuilderParam<Pattern> THEN = BuilderParam.of(ThenProperty.NAME);
-    private static final BuilderParam<Unit> USED_IN_RELATES = BuilderParam.of("related");
+    private static final BuilderParam<Unit> IS_ROLE = BuilderParam.of("role");
 
     /**
-     * Marker class with no fields and exactly one instance.
+     * Class with no fields and exactly one instance.
+     *
+     * Similar in use to {@link Void}, but the single instance is {@link Unit#INSTANCE} instead of {@code null}. Useful
+     * when {@code null} is not allowed.
+     *
+     * @see <a href=https://en.wikipedia.org/wiki/Unit_type>Wikipedia</a>
      */
     private static final class Unit {
         private Unit() {}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/ConceptBuilder.java
@@ -260,12 +260,12 @@ public class ConceptBuilder {
             this.name = name;
         }
 
-        final String name() {
+        String name() {
             return name;
         }
 
         @Override
-        public final String toString() {
+        public String toString() {
             return name;
         }
 
@@ -298,7 +298,7 @@ public class ConceptBuilder {
         private static Unit INSTANCE = new Unit();
 
         @Override
-        public final String toString() {
+        public String toString() {
             return "";
         }
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryOperationExecutor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryOperationExecutor.java
@@ -90,18 +90,13 @@ public class QueryOperationExecutor {
     // A map, where `dependencies.containsEntry(x, y)` implies that `y` must be inserted before `x` is inserted.
     private final ImmutableMultimap<VarAndProperty, VarAndProperty> dependencies;
 
-    // The method that is applied on every `VarProperty`
-    private final ExecutionType executionType;
-
     private QueryOperationExecutor(GraknTx tx, ImmutableSet<VarAndProperty> properties,
                                    Partition<Var> equivalentVars,
-                                   ImmutableMultimap<VarAndProperty, VarAndProperty> dependencies,
-                                   ExecutionType executionType) {
+                                   ImmutableMultimap<VarAndProperty, VarAndProperty> dependencies) {
         this.tx = tx;
         this.properties = properties;
         this.equivalentVars = equivalentVars;
         this.dependencies = dependencies;
-        this.executionType = executionType;
     }
 
     /**
@@ -130,8 +125,9 @@ public class QueryOperationExecutor {
     private static QueryOperationExecutor create(
             Collection<VarPatternAdmin> patterns, GraknTx graph, ExecutionType executionType
     ) {
-        ImmutableSet<VarAndProperty> properties =
-                patterns.stream().flatMap(VarAndProperty::fromPattern).collect(toImmutableSet());
+        ImmutableSet<VarAndProperty> properties = patterns.stream()
+                .flatMap(pattern -> VarAndProperty.fromPattern(pattern, executionType))
+                .collect(toImmutableSet());
 
         /*
             We build several many-to-many relations, indicated by a `Multimap<X, Y>`. These are used to represent
@@ -145,7 +141,7 @@ public class QueryOperationExecutor {
         Multimap<VarAndProperty, Var> propDependencies = HashMultimap.create();
 
         for (VarAndProperty property : properties) {
-            for (Var requiredVar : property.executor(executionType).requiredVars()) {
+            for (Var requiredVar : property.executor().requiredVars()) {
                 propDependencies.put(property, requiredVar);
             }
         }
@@ -159,7 +155,7 @@ public class QueryOperationExecutor {
         Multimap<Var, VarAndProperty> varDependencies = HashMultimap.create();
 
         for (VarAndProperty property : properties) {
-            for (Var producedVar : property.executor(executionType).producedVars()) {
+            for (Var producedVar : property.executor().producedVars()) {
                 varDependencies.put(producedVar, property);
             }
         }
@@ -220,9 +216,7 @@ public class QueryOperationExecutor {
          */
         Multimap<VarAndProperty, VarAndProperty> dependencies = composeMultimaps(propDependencies, varDependencies);
 
-        return new QueryOperationExecutor(
-                graph, properties, equivalentVars, ImmutableMultimap.copyOf(dependencies), executionType
-        );
+        return new QueryOperationExecutor(graph, properties, equivalentVars, ImmutableMultimap.copyOf(dependencies));
     }
 
     private static Multimap<VarProperty, Var> equivalentProperties(Set<VarAndProperty> properties) {
@@ -259,7 +253,7 @@ public class QueryOperationExecutor {
     private Answer insertAll(Answer results) {
         concepts.putAll(results.map());
 
-        sortProperties().forEach(property -> property.executor(executionType).execute(this));
+        sortProperties().forEach(property -> property.executor().execute(this));
 
         conceptBuilders.forEach(this::buildConcept);
 
@@ -448,17 +442,16 @@ public class QueryOperationExecutor {
 
         abstract Var var();
         abstract VarPropertyInternal property();
+        abstract PropertyExecutor executor();
 
-        static VarAndProperty of(Var var, VarProperty property) {
-            return new AutoValue_QueryOperationExecutor_VarAndProperty(var, VarPropertyInternal.from(property));
+        static VarAndProperty of(Var var, VarProperty property, ExecutionType executionType) {
+            VarPropertyInternal propertyInternal = VarPropertyInternal.from(property);
+            PropertyExecutor executor = executionType.executor(propertyInternal, var);
+            return new AutoValue_QueryOperationExecutor_VarAndProperty(var, propertyInternal, executor);
         }
 
-        static Stream<VarAndProperty> fromPattern(VarPatternAdmin pattern) {
-            return pattern.getProperties().map(prop -> VarAndProperty.of(pattern.var(), prop));
-        }
-
-        private PropertyExecutor executor(ExecutionType executionType) {
-            return executionType.executor(property(), var());
+        static Stream<VarAndProperty> fromPattern(VarPatternAdmin pattern, ExecutionType executionType) {
+            return pattern.getProperties().map(prop -> VarAndProperty.of(pattern.var(), prop, executionType));
         }
 
         boolean uniquelyIdentifiesConcept() {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -71,6 +71,7 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -456,7 +457,8 @@ public class DefineQueryTest {
         Role husband = movies.tx().getRole("husband");
         Role wife = movies.tx().getRole("wife");
         assertThat(marriage.relates().toArray(), arrayContainingInAnyOrder(husband, wife));
-        assertThat(person.plays().toArray(), arrayContainingInAnyOrder(husband, wife));
+        assertThat(person.plays().toArray(), hasItemInArray(wife));
+        assertThat(person.plays().toArray(), hasItemInArray(husband));
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -23,6 +23,9 @@ import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Label;
+import ai.grakn.concept.RelationshipType;
+import ai.grakn.concept.Role;
+import ai.grakn.exception.GraknException;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.DefineQuery;
 import ai.grakn.graql.Graql;
@@ -35,8 +38,8 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.internal.pattern.property.HasAttributeProperty;
 import ai.grakn.graql.internal.pattern.property.IsaProperty;
 import ai.grakn.graql.internal.pattern.property.ValueProperty;
-import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.test.kbs.MovieKB;
+import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import org.hamcrest.Matchers;
@@ -66,6 +69,7 @@ import static ai.grakn.util.Schema.MetaSchema.ROLE;
 import static ai.grakn.util.Schema.MetaSchema.RULE;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -428,6 +432,26 @@ public class DefineQueryTest {
         String queryString = "define label my-entity sub entity;";
         DefineQuery defineQuery = parse(queryString);
         assertEquals(queryString, defineQuery.toString());
+    }
+
+    @Test
+    public void whenDefiningARelationship_SubRoleDeclarationsCanBeSkipped() {
+        qb.define(label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife")).execute();
+
+        RelationshipType marriage = movies.tx().getRelationshipType("marriage");
+        Role husband = movies.tx().getRole("husband");
+        Role wife = movies.tx().getRole("wife");
+        assertThat(marriage.relates().toArray(), arrayContainingInAnyOrder(husband, wife));
+    }
+
+    @Test
+    public void whenDefiningARelationshipWithNonRoles_Throw() {
+        exception.expect(GraknException.class);
+
+        qb.define(
+                label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife"),
+                label("wife").sub(label(ENTITY.getLabel()))
+        ).execute();
     }
 
     private void assertDefine(VarPattern... vars) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -445,6 +445,21 @@ public class DefineQueryTest {
     }
 
     @Test
+    public void whenDefiningARelationship_SubRoleDeclarationsCanBeSkipped_EvenWhenRoleInReferredToInOtherContexts() {
+        qb.define(
+                label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife"),
+                label("person").plays("husband").plays("wife")
+        ).execute();
+
+        RelationshipType marriage = movies.tx().getRelationshipType("marriage");
+        EntityType person = movies.tx().getEntityType("person");
+        Role husband = movies.tx().getRole("husband");
+        Role wife = movies.tx().getRole("wife");
+        assertThat(marriage.relates().toArray(), arrayContainingInAnyOrder(husband, wife));
+        assertThat(person.plays().toArray(), arrayContainingInAnyOrder(husband, wife));
+    }
+
+    @Test
     public void whenDefiningARelationshipWithNonRoles_Throw() {
         exception.expect(GraknException.class);
 


### PR DESCRIPTION
For this to work, I had to make some things a bit more flexible:
- `VarProperty#define` etc. return `Collection<PropertyExecutor>` instead of `PropertyExecutor`.
- `RelatesProperty#define` returns two `PropertyExecutor`s - one for the `sub role` and one for the `relates` with different dependencies (to avoid a cycle).
- Since each `VarProperty` can now have multiple `PropertyExecutor`s, `QueryOperationExecutor` decides on a plan by using dependencies between `PropertyExecutor`s rather than between `VarProperty`s.
  