### PR TITLE
[Stable] Fix inconsistencies of atomic states wrt type inference

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -68,7 +68,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import ai.grakn.graql.internal.reasoner.utils.Pair;
@@ -110,7 +109,7 @@ public class RelationshipAtom extends IsaAtom {
     private ImmutableMultimap<Role, Var> roleVarMap = null;
     private ImmutableMultimap<Role, Type> roleTypeMap = null;
     private ImmutableMultimap<Role, String> roleConceptIdMap = null;
-    private ImmutableList<RelationshipType> possibleRelations = null;
+    private ImmutableList<Type> possibleRelations = null;
     private final ImmutableList<RelationPlayer> relationPlayers;
     private final ImmutableSet<Label> roleLabels;
 
@@ -131,7 +130,7 @@ public class RelationshipAtom extends IsaAtom {
         ).build();
     }
 
-    private RelationshipAtom(VarPatternAdmin pattern, Var predicateVar, @Nullable IdPredicate predicate, ImmutableList<RelationshipType> possibleRelations, ReasonerQuery par) {
+    private RelationshipAtom(VarPatternAdmin pattern, Var predicateVar, @Nullable IdPredicate predicate, ImmutableList<Type> possibleRelations, ReasonerQuery par) {
         this(pattern, predicateVar, predicate, par);
         this.possibleRelations = possibleRelations;
     }
@@ -165,7 +164,7 @@ public class RelationshipAtom extends IsaAtom {
     public String toString(){
         String typeString = getSchemaConcept() != null?
                 getSchemaConcept().getLabel().getValue() :
-                "{" + inferPossibleRelationTypes(new QueryAnswer()).stream().map(rt -> rt.getLabel().getValue()).collect(Collectors.joining(", ")) + "}";
+                "{" + inferPossibleTypes(new QueryAnswer()).stream().map(rt -> rt.getLabel().getValue()).collect(Collectors.joining(", ")) + "}";
         String relationString = (isUserDefined()? getVarName() + " ": "") +
                 typeString +
                 getRelationPlayers().toString();
@@ -194,7 +193,7 @@ public class RelationshipAtom extends IsaAtom {
                 .collect(Collectors.toSet());
     }
 
-    public Answer getRoleSubstitution(){
+    private Answer getRoleSubstitution(){
         Map<Var, Concept> roleSub = new HashMap<>();
         getRolePredicates().forEach(p -> roleSub.put(p.getVarName(), tx().getConcept(p.getPredicate())));
         return new QueryAnswer(roleSub);
@@ -541,7 +540,7 @@ public class RelationshipAtom extends IsaAtom {
      * {@link EntityType}s only play the explicitly defined {@link Role}s (not the relevant part of the hierarchy of the specified {@link Role}) and the {@link Role} inherited from parent
      * @return list of {@link RelationshipType}s this atom can have ordered by the number of compatible {@link Role}s
      */
-    public ImmutableList<RelationshipType> inferPossibleRelationTypes(Answer sub) {
+    public ImmutableList<Type> inferPossibleTypes(Answer sub) {
         if (getSchemaConcept() != null) return ImmutableList.of(getSchemaConcept().asRelationshipType());
         if (possibleRelations == null) {
             Multimap<RelationshipType, Role> compatibleConfigurations = inferPossibleRelationConfigurations(sub);
@@ -550,7 +549,7 @@ public class RelationshipAtom extends IsaAtom {
                     .filter(at -> !Sets.intersection(at.getVarNames(), untypedRoleplayers).isEmpty())
                     .collect(toSet());
 
-            ImmutableList.Builder<RelationshipType> builder = ImmutableList.builder();
+            ImmutableList.Builder<Type> builder = ImmutableList.builder();
             //prioritise relations with higher chance of yielding answers
             compatibleConfigurations.asMap().entrySet().stream()
                     //prioritise relations with more allowed roles
@@ -583,6 +582,8 @@ public class RelationshipAtom extends IsaAtom {
                     //retain super types only
                     .filter(t -> Sets.intersection(supers(t), compatibleConfigurations.keySet()).isEmpty())
                     .forEach(builder::add);
+
+            //TODO need to add THING and meta relation type as well to make it complete
             this.possibleRelations = builder.build();
         }
         return possibleRelations;
@@ -596,7 +597,7 @@ public class RelationshipAtom extends IsaAtom {
     private RelationshipAtom inferRelationshipType(Answer sub){
         if (getTypePredicate() != null) return this;
         if (sub.containsVar(getPredicateVariable())) return addType(sub.get(getPredicateVariable()).asType());
-        List<RelationshipType> relationshipTypes = inferPossibleRelationTypes(sub);
+        List<Type> relationshipTypes = inferPossibleTypes(sub);
         if (relationshipTypes.size() == 1) return addType(Iterables.getOnlyElement(relationshipTypes));
         return this;
     }
@@ -610,7 +611,7 @@ public class RelationshipAtom extends IsaAtom {
 
     @Override
     public List<Atom> atomOptions(Answer sub) {
-        return this.inferPossibleRelationTypes(sub).stream()
+        return this.inferPossibleTypes(sub).stream()
                 .map(this::addType)
                 .map(at -> at.inferRoles(sub))
                 //order by number of distinct roles
@@ -707,7 +708,10 @@ public class RelationshipAtom extends IsaAtom {
         //TODO make restrictions based on cardinality constraints
         Set<Role> possibleRoles = relType != null?
                 relType.relates().collect(toSet()) :
-                inferPossibleRelationTypes(sub).stream().flatMap(RelationshipType::relates).collect(toSet());
+                inferPossibleTypes(sub).stream()
+                        .filter(Concept::isRelationshipType)
+                        .map(Concept::asRelationshipType)
+                        .flatMap(RelationshipType::relates).collect(toSet());
 
         //possible role types for each casting based on its type
         Map<RelationPlayer, Set<Role>> mappings = new HashMap<>();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/type/IsaAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/type/IsaAtom.java
@@ -50,6 +50,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static ai.grakn.util.CommonUtil.toImmutableList;
+
 /**
  *
  * <p>
@@ -114,7 +116,7 @@ public class IsaAtom extends TypeAtom {
     private ImmutableList<Type> inferPossibleEntityTypes(Answer sub){
         if (getSchemaConcept() != null) return ImmutableList.of(this.getSchemaConcept().asType());
         if (sub.containsVar(getPredicateVariable())) return ImmutableList.of(sub.get(getPredicateVariable()).asType());
-        return ImmutableList.copyOf(tx().admin().getMetaConcept().subs().iterator());
+        return tx().admin().getMetaConcept().subs().collect(toImmutableList());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -44,8 +44,7 @@ import ai.grakn.graql.internal.reasoner.explanation.RuleExplanation;
 import ai.grakn.graql.internal.reasoner.iterator.ReasonerQueryIterator;
 import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
 import ai.grakn.graql.internal.reasoner.state.AnswerState;
-import ai.grakn.graql.internal.reasoner.state.AtomicState;
-import ai.grakn.graql.internal.reasoner.state.NeqComplementState;
+import ai.grakn.graql.internal.reasoner.state.AtomicStateProducer;
 import ai.grakn.graql.internal.reasoner.state.QueryStateBase;
 import ai.grakn.graql.internal.reasoner.state.ResolutionState;
 import ai.grakn.graql.internal.reasoner.utils.Pair;
@@ -302,14 +301,20 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     @Override
-    public AtomicState subGoal(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
-        return getAtoms(NeqPredicate.class).findFirst().isPresent()?
-                new NeqComplementState(this, sub, u, parent, subGoals, cache) :
-                new AtomicState(this, sub, u, parent, subGoals, cache);
+    public ResolutionState subGoal(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
+        return new AtomicStateProducer(this, sub, u, parent, subGoals, cache);
     }
 
     @Override
-    public Pair<Iterator<ResolutionState>, MultiUnifier> queryStateIterator(QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache) {
+    protected Stream<ReasonerQueryImpl> getQueryStream(Answer sub){
+        Atom atom = getAtom();
+        return atom.getSchemaConcept() == null?
+                atom.atomOptions(sub).stream().map(ReasonerAtomicQuery::new) :
+                Stream.of(this);
+    }
+
+    @Override
+    public Pair<Iterator<ResolutionState>, MultiUnifier> queryStateIterator(QueryStateBase parent, Set<ReasonerAtomicQuery> visitedSubGoals, QueryCache<ReasonerAtomicQuery> cache) {
         Pair<Stream<Answer>, MultiUnifier> cacheEntry = cache.getAnswerStreamWithUnifier(this);
         MultiUnifier cacheUnifier = cacheEntry.getValue().inverse();
         Iterator<AnswerState> dbIterator = cacheEntry.getKey()
@@ -317,29 +322,21 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
                 .map(ans -> new AnswerState(ans, parent.getUnifier(), parent))
                 .iterator();
 
-        Iterator<QueryStateBase> subGoalIterator;
+        Iterator<ResolutionState> subGoalIterator;
         //if this is ground and exists in the db then do not resolve further
-        if(subGoals.contains(this)
+        if(visitedSubGoals.contains(this)
                 || (this.isGround() && dbIterator.hasNext())){
             subGoalIterator = Collections.emptyIterator();
         } else {
-            subGoals.add(this);
+            visitedSubGoals.add(this);
             subGoalIterator = this.getRuleStream()
-                    .map(rulePair -> rulePair.getKey().subGoal(this.getAtom(), rulePair.getValue(), parent, subGoals, cache))
+                    .map(rulePair -> rulePair.getKey().subGoal(this.getAtom(), rulePair.getValue(), parent, visitedSubGoals, cache))
                     .iterator();
         }
         return new Pair<>(
                 Iterators.concat(dbIterator, subGoalIterator),
                 cacheUnifier
         );
-    }
-
-    @Override
-    protected Stream<ReasonerQueryImpl> getQueryStream(Answer sub){
-        Atom atom = getAtom();
-        return atom.getSchemaConcept() == null?
-            atom.atomOptions(sub).stream().map(ReasonerAtomicQuery::new) :
-            Stream.of(this);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -56,7 +56,6 @@ import ai.grakn.graql.internal.reasoner.rule.RuleUtils;
 import ai.grakn.graql.internal.reasoner.state.AnswerState;
 import ai.grakn.graql.internal.reasoner.state.ConjunctiveState;
 import ai.grakn.graql.internal.reasoner.state.CumulativeState;
-import ai.grakn.graql.internal.reasoner.state.QueryState;
 import ai.grakn.graql.internal.reasoner.state.QueryStateBase;
 import ai.grakn.graql.internal.reasoner.state.ResolutionState;
 import ai.grakn.graql.internal.reasoner.utils.Pair;
@@ -607,7 +606,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
      * @param cache query cache
      * @return resolution subGoal formed from this query
      */
-    public QueryState subGoal(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
+    public ResolutionState subGoal(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
         return new ConjunctiveState(this, sub, u, parent, subGoals, cache);
     }
 
@@ -619,7 +618,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
      * @param cache query cache
      * @return resolution subGoals formed from this query obtained by expanding the inferred types contained in the query
      */
-    public Stream<QueryState> subGoals(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
+    public Stream<ResolutionState> subGoals(Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache){
         return getQueryStream(sub)
                 .map(q -> q.subGoal(sub, u, parent, subGoals, cache));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
@@ -42,6 +42,7 @@ import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.graql.internal.reasoner.state.QueryStateBase;
+import ai.grakn.graql.internal.reasoner.state.ResolutionState;
 import ai.grakn.graql.internal.reasoner.state.RuleState;
 import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
 import com.google.common.collect.Sets;
@@ -319,7 +320,7 @@ public class InferenceRule {
      * @param cache query cache
      * @return resolution subGoal formed from this rule
      */
-    public QueryStateBase subGoal(Atom parentAtom, Unifier ruleUnifier, QueryStateBase parent, Set<ReasonerAtomicQuery> visitedSubGoals, QueryCache<ReasonerAtomicQuery> cache){
+    public ResolutionState subGoal(Atom parentAtom, Unifier ruleUnifier, QueryStateBase parent, Set<ReasonerAtomicQuery> visitedSubGoals, QueryCache<ReasonerAtomicQuery> cache){
         Unifier ruleUnifierInverse = ruleUnifier.inverse();
 
         //delta' = theta . thetaP . delta

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicStateProducer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicStateProducer.java
@@ -1,0 +1,75 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.internal.reasoner.state;
+
+import ai.grakn.graql.admin.Answer;
+import ai.grakn.graql.admin.Unifier;
+import ai.grakn.graql.internal.reasoner.atom.predicate.NeqPredicate;
+import ai.grakn.graql.internal.reasoner.cache.QueryCache;
+import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ *
+ * <p>
+ * State producing {@link AtomicState}s:
+ * - typed {@link AtomicState}s if type inference is required
+ * - {@link AtomicState} for non-negated non-ambiguous {@link ReasonerAtomicQuery}
+ * - {@link NeqComplementState} for non-ambiguous {@link ReasonerAtomicQuery} with negation
+ * </p>
+ *
+ * @author Kasper Piskorski
+ *
+ */
+public class AtomicStateProducer extends QueryStateBase {
+
+    private final Iterator<ResolutionState> subGoalIterator;
+
+    public AtomicStateProducer(ReasonerAtomicQuery query, Answer sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, QueryCache<ReasonerAtomicQuery> cache) {
+        super(sub, u, parent, subGoals, cache);
+
+        if(query.getAtom().getSchemaConcept() == null){
+            this.subGoalIterator = query.subGoals(sub, u, parent, subGoals, cache).iterator();
+        } else {
+            this.subGoalIterator = Iterators.singletonIterator(
+                    query.getAtoms(NeqPredicate.class).findFirst().isPresent() ?
+                            new NeqComplementState(query, sub, u, parent, subGoals, cache) :
+                            new AtomicState(query, sub, u, parent, subGoals, cache)
+            );
+        }
+    }
+
+    @Override
+    public ResolutionState generateSubGoal() {
+        return subGoalIterator.hasNext() ? subGoalIterator.next() : null;
+    }
+
+    @Override
+    ResolutionState propagateAnswer(AnswerState state) {
+        return new AnswerState(state.getSubstitution(), state.getUnifier(), getParentState());
+    }
+
+    @Override
+    Answer consumeAnswer(AnswerState state) {
+        return state.getSubstitution();
+    }
+}
+

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicStateProducer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicStateProducer.java
@@ -1,9 +1,9 @@
 /*
  * Grakn - A Distributed Semantic Database
- * Copyright (C) 2016  Grakn Labs Limited
+ * Copyright (C) 2016-2018 Grakn Labs Limited
  *
  * Grakn is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public class CumulativeState extends QueryStateBase{
 
     private final LinkedList<ReasonerQueryImpl> subQueries;
-    private final Iterator<QueryState> feederStateIterator;
+    private final Iterator<ResolutionState> feederStateIterator;
 
     public CumulativeState(LinkedList<ReasonerQueryImpl> qs,
                            Answer sub,
@@ -50,6 +50,8 @@ public class CumulativeState extends QueryStateBase{
                            QueryCache<ReasonerAtomicQuery> cache) {
         super(sub, u, parent, subGoals, cache);
         this.subQueries = new LinkedList<>(qs);
+
+        //NB: we need lazy subGoal initialisation here, otherwise they are marked as visited before visit happens
         this.feederStateIterator = !subQueries.isEmpty()?
                 subQueries.removeFirst().subGoals(sub, u, this, subGoals, cache).iterator() :
                 Collections.emptyIterator();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/NeqComplementState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/NeqComplementState.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
 public class NeqComplementState extends AtomicState {
 
     private final Answer predicateSub;
-    private final AtomicState complementState;
+    private final ResolutionState complementState;
     private boolean visited = false;
 
     private final Set<NeqPredicate> predicates;

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
@@ -33,6 +33,7 @@ import ai.grakn.test.kbs.PathKB;
 import ai.grakn.test.kbs.TransitivityChainKB;
 import ai.grakn.test.kbs.TransitivityMatrixKB;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
@@ -29,6 +29,7 @@ import ai.grakn.test.rule.SampleKBContext;
 import com.google.common.collect.Sets;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,6 +44,34 @@ public class OntologicalQueryTest {
 
     @Rule
     public final SampleKBContext testContext = SampleKBContext.load("ruleApplicabilityTest.gql");
+
+    //TODO need to correctly return THING and RELATIONSHIP mapping for %type
+    @Ignore
+    @Test
+    public void allInstancesAndTheirType(){
+        GraknTx tx = testContext.tx();
+        QueryBuilder qb = tx.graql().infer(true);
+        String queryString = "match $x isa $type; get;";
+
+        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+    }
+
+    @Test
+    public void allRolePlayerPairsAndTheirRelationType(){
+        GraknTx tx = testContext.tx();
+        QueryBuilder qb = tx.graql().infer(true);
+        String relationString = "match $x isa relationship;get;";
+        String rolePlayerPairString = "match ($u, $v) isa $type; get;";
+
+        List<Answer> rolePlayerPairs = qb.<GetQuery>parse(rolePlayerPairString).execute();
+        //TODO doesn't include THING and RELATIONSHIP, with RELATIONSHIP it's 38, with THING as well it should be 57
+        assertEquals(rolePlayerPairs.size(), 25);
+
+        List<Answer> relations = qb.<GetQuery>parse(relationString).execute();
+        //one implicit, 3 x binary, 2 x ternary, 7 (3 reflexive) x reifying-relation
+        assertEquals(relations.size(), 13);
+    }
 
     /** HasAtom **/
 
@@ -135,10 +164,11 @@ public class OntologicalQueryTest {
         String queryString = "match $x isa $type; $type relates role1; get;";
 
         List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
         List<Answer> relations = qb.<GetQuery>parse("match $x isa relationship;get;").execute();
         //plus extra 3 cause there are 3 binary relations which are not extra counted as reifiable-relations
-        assertEquals(answers.size(),  relations.stream().filter(ans -> !ans.get("x").asRelationship().type().isImplicit()).count() + 3);
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertEquals(answers.size(), relations.stream().filter(ans -> !ans.get("x").asRelationship().type().isImplicit()).count() + 3);
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
@@ -482,6 +482,7 @@ public class ReasonerTest {
         GetQuery query = qb.infer(true).parse(queryString);
         GetQuery query2 = qb.infer(true).materialise(true).parse(queryString);
         GetQuery query3 = qb.infer(false).parse(queryString2);
+
         assertQueriesEqual(query, query2);
         assertQueriesEqual(query2, query3);
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTests.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTests.java
@@ -203,8 +203,6 @@ public class ReasoningTests {
         assertEquals(answers.size(), 1);
     }
 
-    //TODO unrelated problem, will fix in another PR
-    @Ignore
     @Test //Expected result: The query should return 3 results: one for meta type, one for db, one for inferred type.
     public void queryingForGenericType_ruleDefinesNewType() {
         QueryBuilder qb = testSet2.tx().graql().infer(true);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
@@ -285,7 +285,7 @@ public class TypeInferenceQueryTest {
     private void typeInference(List<RelationshipType> possibleTypes, String pattern, GraknTx graph){
         ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(pattern, graph), graph);
         RelationshipAtom atom = (RelationshipAtom) query.getAtom();
-        List<RelationshipType> relationshipTypes = atom.inferPossibleRelationTypes(new QueryAnswer());
+        List<Type> relationshipTypes = atom.inferPossibleTypes(new QueryAnswer());
 
         if (possibleTypes.size() == 1){
             assertEquals(possibleTypes, relationshipTypes);
@@ -304,8 +304,8 @@ public class TypeInferenceQueryTest {
         RelationshipAtom atom = (RelationshipAtom) query.getAtom();
         RelationshipAtom subbedAtom = (RelationshipAtom) subbedQuery.getAtom();
 
-        List<RelationshipType> relationshipTypes = atom.inferPossibleRelationTypes(new QueryAnswer());
-        List<RelationshipType> subbedRelationshipTypes = subbedAtom.inferPossibleRelationTypes(new QueryAnswer());
+        List<Type> relationshipTypes = atom.inferPossibleTypes(new QueryAnswer());
+        List<Type> subbedRelationshipTypes = subbedAtom.inferPossibleTypes(new QueryAnswer());
         if (possibleTypes.size() == 1){
             assertEquals(possibleTypes, relationshipTypes);
             assertEquals(relationshipTypes, subbedRelationshipTypes);


### PR DESCRIPTION
Fixes the following inconsistency in handling atomic states, for an atomic query with a missing type:
- for an atomic query being the top query or atomic rule body, the corresponding AtomicState would not expand possible types (leading to ambiguous entries in cache and other problems)
- in other cases, i.e. atomic query produced as a part of a conjunction will have its possible types expanded