### PR TITLE
Bug #18867: Fix clashing rules

### DIFF
--- a/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
@@ -89,6 +89,22 @@ public class RuleTest {
     }
 
     @Test
+    public void whenCreatingDistinctRulesWithSimilarStringHashes_EnsureRulesDoNotClash(){
+        String productRefused = "productRefused";
+        Pattern when1 = graknTx.graql().parser().parsePattern("{$step has step-id 9; $e (process-case: $case) isa process-record; $case has consent false;}");
+        Pattern then1 = graknTx.graql().parser().parsePattern("{(record: $e, step: $step) isa record-step;}");
+        Rule rule1 = graknTx.putRule(productRefused, when1, then1);
+
+        String productAccepted = "productAccepted";
+        Pattern when2 = graknTx.graql().parser().parsePattern("{$step has step-id 7; $e (process-case: $case) isa process-record; $case has consent true;}");
+        Pattern then2 = graknTx.graql().parser().parsePattern("{(record: $e, step: $step) isa record-step;}");
+        Rule rule2 = graknTx.putRule(productAccepted, when2, then2);
+
+        assertEquals(rule1, graknTx.getRule(productRefused));
+        assertEquals(rule2, graknTx.getRule(productAccepted));
+    }
+
+    @Test
     public void whenAddingRuleWithDisjunctionInTheBody_Throw() throws InvalidKBException {
         validateIllegalRule(
                 graknTx.graql().parser().parsePattern("(role: $x) or (role: $x, role: $y)"),

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
@@ -48,7 +48,6 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
         super(vertexElement, type);
         vertex().propertyImmutable(Schema.VertexProperty.RULE_WHEN, when, getWhen(), Pattern::toString);
         vertex().propertyImmutable(Schema.VertexProperty.RULE_THEN, then, getThen(), Pattern::toString);
-        vertex().propertyUnique(Schema.VertexProperty.INDEX, generateRuleIndex(sup(), when, then));
     }
 
     public static RuleImpl get(VertexElement vertexElement){
@@ -108,13 +107,6 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
         } else {
             return vertex().tx().graql().parser().parsePattern(value);
         }
-    }
-
-    /**
-     * Generate the internal hash in order to perform a faster lookups and ensure rules are unique
-     */
-    static String generateRuleIndex(Rule type, Pattern when, Pattern then){
-        return "RuleType_" + type.getLabel().getValue() + "_LHS:" + when.hashCode() + "_RHS:" + then.hashCode();
     }
 
     public static <X extends Type, Y extends Thing> RuleImpl from(Rule type){


### PR DESCRIPTION
Sometimes rules with different patterns would clash because of accidentally resulting in the same index. Turns out we don't actually need that index anymore so this PR removes that index. 