### PR TITLE
Make analytics count return the same result as aggregate count

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/analytics/CountQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/analytics/CountQueryImpl.java
@@ -22,7 +22,6 @@ import ai.grakn.GraknTx;
 import ai.grakn.concept.Label;
 import ai.grakn.concept.LabelId;
 import ai.grakn.graql.analytics.CountQuery;
-import ai.grakn.graql.internal.analytics.CountMapReduce;
 import ai.grakn.graql.internal.analytics.CountMapReduceWithAttribute;
 import ai.grakn.graql.internal.analytics.CountVertexProgram;
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
@@ -42,7 +41,7 @@ class CountQueryImpl extends AbstractComputeQuery<Long> implements CountQuery {
 
     @Override
     public Long execute() {
-        LOGGER.info("CountMapReduce is called");
+        LOGGER.info("Count query started");
         long startTime = System.currentTimeMillis();
 
         initSubGraph();
@@ -50,29 +49,21 @@ class CountQueryImpl extends AbstractComputeQuery<Long> implements CountQuery {
 
         if (!selectedTypesHaveInstance()) {
             LOGGER.debug("Count = 0");
-            LOGGER.info("CountMapReduce is done in " + (System.currentTimeMillis() - startTime) + " ms");
+            LOGGER.info("Count query finished in " + (System.currentTimeMillis() - startTime) + " ms");
             return 0L;
         }
 
         Set<LabelId> typeLabelIds = convertLabelsToIds(subLabels);
         Map<Integer, Long> count;
 
-        if (includeAttribute) {
-            Set<LabelId> rolePlayerLabelIds = getRolePlayerLabelIds();
-            rolePlayerLabelIds.addAll(typeLabelIds);
+        Set<LabelId> rolePlayerLabelIds = getRolePlayerLabelIds();
+        rolePlayerLabelIds.addAll(typeLabelIds);
 
-            ComputerResult result = getGraphComputer().compute(
-                    new CountVertexProgram(),
-                    new CountMapReduceWithAttribute(),
-                    rolePlayerLabelIds, false);
-            count = result.memory().get(CountMapReduceWithAttribute.class.getName());
-        } else {
-            ComputerResult result = getGraphComputer().compute(
-                    null,
-                    new CountMapReduce(),
-                    typeLabelIds, false);
-            count = result.memory().get(CountMapReduce.class.getName());
-        }
+        ComputerResult result = getGraphComputer().compute(
+                new CountVertexProgram(),
+                new CountMapReduceWithAttribute(),
+                rolePlayerLabelIds, false);
+        count = result.memory().get(CountMapReduceWithAttribute.class.getName());
 
         long finalCount = count.keySet().stream()
                 .filter(id -> typeLabelIds.contains(LabelId.of(id)))
@@ -82,13 +73,8 @@ class CountQueryImpl extends AbstractComputeQuery<Long> implements CountQuery {
         }
 
         LOGGER.debug("Count = " + finalCount);
-        LOGGER.info("CountMapReduce is done in " + (System.currentTimeMillis() - startTime) + " ms");
+        LOGGER.info("Count query finished in " + (System.currentTimeMillis() - startTime) + " ms");
         return finalCount;
-    }
-
-    @Override
-    public boolean isReadOnly() {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
# Why is this PR needed?
Analytics count and aggregate count may return different numbers
# What does the PR do?
Fix that
# Does it break backwards compatibility?
No
# List of future improvements not on this PR
Remove variable `includeAttributes` from all compute queries