### PR TITLE
Update distribution management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1263,7 +1263,7 @@
                     <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
                 </snapshotRepository>
                 <repository>
-                    <id>grakn-releases</id>
+                    <id>releases</id>
                     <url>https://maven.grakn.ai/content/repositories/releases/</url>
                 </repository>
             </distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -957,7 +957,7 @@
     <repositories>
         <!--Snapshot repository for 3rd party libraries -->
         <repository>
-            <id>development-snapshots</id>
+            <id>snapshots</id>
             <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
         </repository>
         <repository>
@@ -1259,7 +1259,7 @@
             </properties>
             <distributionManagement>
                 <snapshotRepository>
-                    <id>grakn-snapshots</id>
+                    <id>snapshots</id>
                     <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
                 </snapshotRepository>
                 <repository>


### PR DESCRIPTION
# Why is this PR needed?
The configuration for deploying and pulling from https://maven.grakn.ai is incorrect

# What does the PR do?
Fixes the repository ID configuration for https://maven.grakn.ai for both snapshots and releases.

To deploy to Sonatype repository: `mvn deploy -DskipTests`

To deploy to https://maven.grakn.ai: `mvn deploy -P graknRepo -DskipTests`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
1. Update the docs at https://wiki.grakn.ai/infrastructure/office/Nexus-Maven.html