### PR TITLE
`GraqlConverter` refactors

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/GraqlConverter.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/GraqlConverter.java
@@ -55,32 +55,31 @@ public interface GraqlConverter<Builder, T> {
      */
     @CheckReturnValue
     default T convert(Object object) {
-        Builder builder = build(false, object);
+        Builder builder = build(object);
         return complete(builder);
     }
 
     /**
      * Convert any object into a builder
-     * @param inner whether this object is within a collection
      * @param object the object to convert into a builder
      * @return the object as a builder
      */
     @CheckReturnValue
-    default Builder build(boolean inner, Object object) {
+    default Builder build(Object object) {
         if (object instanceof Concept) {
-            return build(inner, (Concept) object);
+            return build((Concept) object);
         } else if (object instanceof Boolean) {
-            return build(inner, (boolean) object);
+            return build((boolean) object);
         } else if (object instanceof Optional) {
-            return build(inner, (Optional<?>) object);
+            return build((Optional<?>) object);
         } else if (object instanceof Collection) {
-            return build(inner, (Collection<?>) object);
+            return build((Collection<?>) object);
         } else if (object instanceof Answer) {
-            return build(inner, (Answer) object);
+            return build((Answer) object);
         } else if (object instanceof Map) {
-            return build(inner, (Map<?, ?>) object);
+            return build((Map<?, ?>) object);
         } else {
-            return buildDefault(inner, object);
+            return buildDefault(object);
         }
     }
 
@@ -94,66 +93,59 @@ public interface GraqlConverter<Builder, T> {
 
     /**
      * Convert any concept into a builder
-     * @param inner whether this concept is within a collection
      * @param concept the concept to convert into a builder
      * @return the concept as a builder
      */
     @CheckReturnValue
-    Builder build(boolean inner, Concept concept);
+    Builder build(Concept concept);
 
     /**
      * Convert any boolean into a builder
-     * @param inner whether this boolean is within a collection
      * @param bool the boolean to convert into a builder
      * @return the boolean as a builder
      */
     @CheckReturnValue
-    Builder build(boolean inner, boolean bool);
+    Builder build(boolean bool);
 
     /**
      * Convert any optional into a builder
-     * @param inner whether this optional is within a collection
      * @param optional the optional to convert into a builder
      * @return the optional as a builder
      */
     @CheckReturnValue
-    Builder build(boolean inner, Optional<?> optional);
+    Builder build(Optional<?> optional);
 
     /**
      * Convert any collection into a builder
-     * @param inner whether this collection is within a collection
      * @param collection the collection to convert into a builder
      * @return the collection as a builder
      */
     @CheckReturnValue
-    Builder build(boolean inner, Collection<?> collection);
+    Builder build(Collection<?> collection);
 
     /**
      * Convert any map into a builder
-     * @param inner whether this map is within a collection
      * @param map the map to convert into a builder
      * @return the map as a builder
      */
     @CheckReturnValue
-    Builder build(boolean inner, Map<?, ?> map);
+    Builder build(Map<?, ?> map);
 
     /**
      * Convert any {@link Answer} into a builder
-     * @param inner whether this map is within a collection
      * @param answer the answer to convert into a builder
      * @return the map as a builder
      */
     @CheckReturnValue
-    default Builder build(boolean inner, Answer answer) {
-        return build(inner, answer.map());
+    default Builder build(Answer answer) {
+        return build(answer.map());
     }
 
     /**
      * Default conversion behaviour if none of the more specific methods can be used
-     * @param inner whether this object is within a collection
      * @param object the object to convert into a builder
      * @return the object as a builder
      */
     @CheckReturnValue
-    Builder buildDefault(boolean inner, Object object);
+    Builder buildDefault(Object object);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/GraqlConverter.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/GraqlConverter.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  *
  * <p>
  *     If you don't need a {@link Builder} type, then set it to the same type as {@link T} and implement
- *     {@link #build(Builder)} to just return its argument.
+ *     {@link #complete(Builder)} to just return its argument.
  * </p>
  *
  * @param <Builder> An intermediate builder type that can be changed into a {@link T}
@@ -55,8 +55,8 @@ public interface GraqlConverter<Builder, T> {
      */
     @CheckReturnValue
     default T convert(Object object) {
-        Builder builder = convert(false, object);
-        return build(builder);
+        Builder builder = build(false, object);
+        return complete(builder);
     }
 
     /**
@@ -66,21 +66,21 @@ public interface GraqlConverter<Builder, T> {
      * @return the object as a builder
      */
     @CheckReturnValue
-    default Builder convert(boolean inner, Object object) {
+    default Builder build(boolean inner, Object object) {
         if (object instanceof Concept) {
-            return convert(inner, (Concept) object);
+            return build(inner, (Concept) object);
         } else if (object instanceof Boolean) {
-            return convert(inner, (boolean) object);
+            return build(inner, (boolean) object);
         } else if (object instanceof Optional) {
-            return convert(inner, (Optional<?>) object);
+            return build(inner, (Optional<?>) object);
         } else if (object instanceof Collection) {
-            return convert(inner, (Collection<?>) object);
+            return build(inner, (Collection<?>) object);
         } else if (object instanceof Answer) {
-            return convert(inner, (Answer) object);
+            return build(inner, (Answer) object);
         } else if (object instanceof Map) {
-            return convert(inner, (Map<?, ?>) object);
+            return build(inner, (Map<?, ?>) object);
         } else {
-            return convertDefault(inner, object);
+            return buildDefault(inner, object);
         }
     }
 
@@ -90,7 +90,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the converted builder
      */
     @CheckReturnValue
-    T build(Builder builder);
+    T complete(Builder builder);
 
     /**
      * Convert any concept into a builder
@@ -99,7 +99,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the concept as a builder
      */
     @CheckReturnValue
-    Builder convert(boolean inner, Concept concept);
+    Builder build(boolean inner, Concept concept);
 
     /**
      * Convert any boolean into a builder
@@ -108,7 +108,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the boolean as a builder
      */
     @CheckReturnValue
-    Builder convert(boolean inner, boolean bool);
+    Builder build(boolean inner, boolean bool);
 
     /**
      * Convert any optional into a builder
@@ -117,7 +117,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the optional as a builder
      */
     @CheckReturnValue
-    Builder convert(boolean inner, Optional<?> optional);
+    Builder build(boolean inner, Optional<?> optional);
 
     /**
      * Convert any collection into a builder
@@ -126,7 +126,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the collection as a builder
      */
     @CheckReturnValue
-    Builder convert(boolean inner, Collection<?> collection);
+    Builder build(boolean inner, Collection<?> collection);
 
     /**
      * Convert any map into a builder
@@ -135,7 +135,7 @@ public interface GraqlConverter<Builder, T> {
      * @return the map as a builder
      */
     @CheckReturnValue
-    Builder convert(boolean inner, Map<?, ?> map);
+    Builder build(boolean inner, Map<?, ?> map);
 
     /**
      * Convert any {@link Answer} into a builder
@@ -144,8 +144,8 @@ public interface GraqlConverter<Builder, T> {
      * @return the map as a builder
      */
     @CheckReturnValue
-    default Builder convert(boolean inner, Answer answer) {
-        return convert(inner, answer.map());
+    default Builder build(boolean inner, Answer answer) {
+        return build(inner, answer.map());
     }
 
     /**
@@ -155,5 +155,5 @@ public interface GraqlConverter<Builder, T> {
      * @return the object as a builder
      */
     @CheckReturnValue
-    Builder convertDefault(boolean inner, Object object);
+    Builder buildDefault(boolean inner, Object object);
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
@@ -47,7 +47,7 @@ public class JacksonPrinter implements Printer<Object>{
     }
 
     @Override
-    public String build(Object object) {
+    public String complete(Object object) {
         try {
             return mapper.writeValueAsString(object);
         } catch (IOException e) {
@@ -56,43 +56,43 @@ public class JacksonPrinter implements Printer<Object>{
     }
 
     @Override
-    public Object convert(boolean inner, Concept concept) {
+    public Object build(boolean inner, Concept concept) {
         return ConceptBuilder.build(concept);
     }
 
     @Override
-    public Object convert(boolean inner, ai.grakn.graql.admin.Answer answer) {
+    public Object build(boolean inner, ai.grakn.graql.admin.Answer answer) {
         return Answer.create(answer);
     }
 
     @Override
-    public Object convert(boolean inner, boolean bool) {
+    public Object build(boolean inner, boolean bool) {
         return bool;
     }
 
     @Override
-    public Object convertDefault(boolean inner, Object object) {
+    public Object buildDefault(boolean inner, Object object) {
         return object;
     }
 
     @Override
-    public Object convert(boolean inner, Map map) {
+    public Object build(boolean inner, Map map) {
         Stream<Map.Entry> entries = map.<Map.Entry>entrySet().stream();
         return entries.collect(Collectors.toMap(
-                entry -> convert(inner, entry.getKey()),
-                entry -> convert(inner, entry.getKey())
+                entry -> build(inner, entry.getKey()),
+                entry -> build(inner, entry.getKey())
         ));
     }
 
     @Override
-    public Object convert(boolean inner, Collection collection) {
-        return collection.stream().map(object -> convert(inner, object)).collect(Collectors.toList());
+    public Object build(boolean inner, Collection collection) {
+        return collection.stream().map(object -> build(inner, object)).collect(Collectors.toList());
     }
 
     @Override
-    public Object convert(boolean inner, Optional optional) {
+    public Object build(boolean inner, Optional optional) {
         if(optional.isPresent()){
-            return convert(inner, optional.get());
+            return build(inner, optional.get());
         } else {
             return null;
         }

--- a/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
@@ -56,43 +56,43 @@ public class JacksonPrinter implements Printer<Object>{
     }
 
     @Override
-    public Object build(boolean inner, Concept concept) {
+    public Object build(Concept concept) {
         return ConceptBuilder.build(concept);
     }
 
     @Override
-    public Object build(boolean inner, ai.grakn.graql.admin.Answer answer) {
+    public Object build(ai.grakn.graql.admin.Answer answer) {
         return Answer.create(answer);
     }
 
     @Override
-    public Object build(boolean inner, boolean bool) {
+    public Object build(boolean bool) {
         return bool;
     }
 
     @Override
-    public Object buildDefault(boolean inner, Object object) {
+    public Object buildDefault(Object object) {
         return object;
     }
 
     @Override
-    public Object build(boolean inner, Map map) {
+    public Object build(Map map) {
         Stream<Map.Entry> entries = map.<Map.Entry>entrySet().stream();
         return entries.collect(Collectors.toMap(
-                entry -> build(inner, entry.getKey()),
-                entry -> build(inner, entry.getKey())
+                entry -> build(entry.getKey()),
+                entry -> build(entry.getKey())
         ));
     }
 
     @Override
-    public Object build(boolean inner, Collection collection) {
-        return collection.stream().map(object -> build(inner, object)).collect(Collectors.toList());
+    public Object build(Collection collection) {
+        return collection.stream().map(object -> build(object)).collect(Collectors.toList());
     }
 
     @Override
-    public Object build(boolean inner, Optional optional) {
+    public Object build(Optional optional) {
         if(optional.isPresent()){
-            return build(inner, optional.get());
+            return build(optional.get());
         } else {
             return null;
         }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/GraqlPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/GraqlPrinter.java
@@ -60,7 +60,7 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, Concept concept) {
+    public Function<StringBuilder, StringBuilder> build(Concept concept) {
         return sb -> {
             // Display values for resources and ids for everything else
             if (concept.isAttribute()) {
@@ -117,7 +117,7 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, boolean bool) {
+    public Function<StringBuilder, StringBuilder> build(boolean bool) {
         if (bool) {
             return sb -> sb.append(ANSI.color("True", ANSI.GREEN));
         } else {
@@ -126,37 +126,32 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, Optional<?> optional) {
+    public Function<StringBuilder, StringBuilder> build(Optional<?> optional) {
         if (optional.isPresent()) {
-            return build(inner, optional.get());
+            return build(optional.get());
         } else {
             return sb -> sb.append("Nothing");
         }
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, Collection<?> collection) {
+    public Function<StringBuilder, StringBuilder> build(Collection<?> collection) {
         return sb -> {
-            if (inner) {
-                sb.append("{");
-                collection.stream().findFirst().ifPresent(item -> build(true, item).apply(sb));
-                collection.stream().skip(1).forEach(item -> build(true, item).apply(sb.append(", ")));
-                sb.append("}");
-            } else {
-                collection.forEach(item -> build(true, item).apply(sb).append("\n"));
-            }
-
+            sb.append("{");
+            collection.stream().findFirst().ifPresent(item -> build(item).apply(sb));
+            collection.stream().skip(1).forEach(item -> build(item).apply(sb.append(", ")));
+            sb.append("}");
             return sb;
         };
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, Map<?, ?> map) {
-        return build(inner, map.entrySet());
+    public Function<StringBuilder, StringBuilder> build(Map<?, ?> map) {
+        return build(map.entrySet());
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> build(boolean inner, Answer answer) {
+    public Function<StringBuilder, StringBuilder> build(Answer answer) {
         return sb -> {
             if (answer.isEmpty()) {
                 sb.append("{}");
@@ -170,12 +165,12 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> buildDefault(boolean inner, Object object) {
+    public Function<StringBuilder, StringBuilder> buildDefault(Object object) {
         if (object instanceof Map.Entry<?, ?>) {
             Map.Entry<?, ?> entry = (Map.Entry<?, ?>) object;
-            return build(true, entry.getKey())
+            return build(entry.getKey())
                     .andThen(sb -> sb.append(": "))
-                    .andThen(build(true, entry.getValue()));
+                    .andThen(build(entry.getValue()));
         } else {
             return sb -> sb.append(Objects.toString(object));
         }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/GraqlPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/GraqlPrinter.java
@@ -55,12 +55,12 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public String build(Function<StringBuilder, StringBuilder> builder) {
+    public String complete(Function<StringBuilder, StringBuilder> builder) {
         return builder.apply(new StringBuilder()).toString();
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, Concept concept) {
+    public Function<StringBuilder, StringBuilder> build(boolean inner, Concept concept) {
         return sb -> {
             // Display values for resources and ids for everything else
             if (concept.isAttribute()) {
@@ -117,7 +117,7 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, boolean bool) {
+    public Function<StringBuilder, StringBuilder> build(boolean inner, boolean bool) {
         if (bool) {
             return sb -> sb.append(ANSI.color("True", ANSI.GREEN));
         } else {
@@ -126,24 +126,24 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, Optional<?> optional) {
+    public Function<StringBuilder, StringBuilder> build(boolean inner, Optional<?> optional) {
         if (optional.isPresent()) {
-            return convert(inner, optional.get());
+            return build(inner, optional.get());
         } else {
             return sb -> sb.append("Nothing");
         }
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, Collection<?> collection) {
+    public Function<StringBuilder, StringBuilder> build(boolean inner, Collection<?> collection) {
         return sb -> {
             if (inner) {
                 sb.append("{");
-                collection.stream().findFirst().ifPresent(item -> convert(true, item).apply(sb));
-                collection.stream().skip(1).forEach(item -> convert(true, item).apply(sb.append(", ")));
+                collection.stream().findFirst().ifPresent(item -> build(true, item).apply(sb));
+                collection.stream().skip(1).forEach(item -> build(true, item).apply(sb.append(", ")));
                 sb.append("}");
             } else {
-                collection.forEach(item -> convert(true, item).apply(sb).append("\n"));
+                collection.forEach(item -> build(true, item).apply(sb).append("\n"));
             }
 
             return sb;
@@ -151,12 +151,12 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, Map<?, ?> map) {
-        return convert(inner, map.entrySet());
+    public Function<StringBuilder, StringBuilder> build(boolean inner, Map<?, ?> map) {
+        return build(inner, map.entrySet());
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convert(boolean inner, Answer answer) {
+    public Function<StringBuilder, StringBuilder> build(boolean inner, Answer answer) {
         return sb -> {
             if (answer.isEmpty()) {
                 sb.append("{}");
@@ -170,12 +170,12 @@ class GraqlPrinter implements Printer<Function<StringBuilder, StringBuilder>> {
     }
 
     @Override
-    public Function<StringBuilder, StringBuilder> convertDefault(boolean inner, Object object) {
+    public Function<StringBuilder, StringBuilder> buildDefault(boolean inner, Object object) {
         if (object instanceof Map.Entry<?, ?>) {
             Map.Entry<?, ?> entry = (Map.Entry<?, ?>) object;
-            return convert(true, entry.getKey())
+            return build(true, entry.getKey())
                     .andThen(sb -> sb.append(": "))
-                    .andThen(convert(true, entry.getValue()));
+                    .andThen(build(true, entry.getValue()));
         } else {
             return sb -> sb.append(Objects.toString(object));
         }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
@@ -35,12 +35,12 @@ import static mjson.Json.nil;
 
 class JsonPrinter implements Printer<Json> {
     @Override
-    public final String build(Json builder) {
+    public final String complete(Json builder) {
         return builder.toString();
     }
 
     @Override
-    public Json convert(boolean inner, Concept concept) {
+    public Json build(boolean inner, Concept concept) {
         Json json = Json.object("id", concept.getId().getValue());
 
         if (concept.isSchemaConcept()) {
@@ -72,35 +72,35 @@ class JsonPrinter implements Printer<Json> {
     }
 
     @Override
-    public final Json convert(boolean inner, boolean bool) {
+    public final Json build(boolean inner, boolean bool) {
         return Json.make(bool);
     }
 
     @Override
-    public final Json convert(boolean inner, Optional<?> optional) {
-        return optional.map(item -> convert(inner, item)).orElse(nil());
+    public final Json build(boolean inner, Optional<?> optional) {
+        return optional.map(item -> build(inner, item)).orElse(nil());
     }
 
     @Override
-    public final Json convert(boolean inner, Collection<?> collection) {
-        return Json.make(collection.stream().map(item -> convert(inner, item)).collect(toList()));
+    public final Json build(boolean inner, Collection<?> collection) {
+        return Json.make(collection.stream().map(item -> build(inner, item)).collect(toList()));
     }
 
     @Override
-    public final Json convert(boolean inner, Map<?, ?> map) {
+    public final Json build(boolean inner, Map<?, ?> map) {
         Json json = Json.object();
 
         map.forEach((Object key, Object value) -> {
             if (key instanceof Var) key = ((Var) key).getValue();
             String keyString = key == null ? "" : key.toString();
-            json.set(keyString, convert(true, value));
+            json.set(keyString, build(true, value));
         });
 
         return json;
     }
 
     @Override
-    public final Json convertDefault(boolean inner, Object object) {
+    public final Json buildDefault(boolean inner, Object object) {
         return Json.make(object);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
@@ -40,7 +40,7 @@ class JsonPrinter implements Printer<Json> {
     }
 
     @Override
-    public Json build(boolean inner, Concept concept) {
+    public Json build(Concept concept) {
         Json json = Json.object("id", concept.getId().getValue());
 
         if (concept.isSchemaConcept()) {
@@ -72,35 +72,35 @@ class JsonPrinter implements Printer<Json> {
     }
 
     @Override
-    public final Json build(boolean inner, boolean bool) {
+    public final Json build(boolean bool) {
         return Json.make(bool);
     }
 
     @Override
-    public final Json build(boolean inner, Optional<?> optional) {
-        return optional.map(item -> build(inner, item)).orElse(nil());
+    public final Json build(Optional<?> optional) {
+        return optional.map(item -> build(item)).orElse(nil());
     }
 
     @Override
-    public final Json build(boolean inner, Collection<?> collection) {
-        return Json.make(collection.stream().map(item -> build(inner, item)).collect(toList()));
+    public final Json build(Collection<?> collection) {
+        return Json.make(collection.stream().map(item -> build(item)).collect(toList()));
     }
 
     @Override
-    public final Json build(boolean inner, Map<?, ?> map) {
+    public final Json build(Map<?, ?> map) {
         Json json = Json.object();
 
         map.forEach((Object key, Object value) -> {
             if (key instanceof Var) key = ((Var) key).getValue();
             String keyString = key == null ? "" : key.toString();
-            json.set(keyString, build(true, value));
+            json.set(keyString, build(value));
         });
 
         return json;
     }
 
     @Override
-    public final Json buildDefault(boolean inner, Object object) {
+    public final Json buildDefault(Object object) {
         return Json.make(object);
     }
 }


### PR DESCRIPTION
# Why is this PR needed?

Refactors to simplify code and make `GraqlConverter` and `Printer` classes easier to understand.

# What does the PR do?

These are refactors from the gRPC PR #2593 .

I renamed some methods and also removed the `inner` parameter, which was pretty silly and used in only one place (where it made some changes to formatting to make aggregate results slightly prettier).

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
