### PR TITLE
Remove docker from distribution docs

### DIFF
--- a/docs/pages/docs/10-resources/windows-os.md
+++ b/docs/pages/docs/10-resources/windows-os.md
@@ -16,4 +16,3 @@ GRAKN is currently not supported natively on Windows.
 
 Your current options are:
 - a virtual machine with Ubuntu (eg. [VirtualBox](https://www.virtualbox.org/wiki/Downloads))
-- [Docker for Windows](https://docs.docker.com/docker-for-windows/) with our [Docker image](https://hub.docker.com/r/graknlabs/grakn/)


### PR DESCRIPTION
# Why is this PR needed?

We have decided to drop docker support

# What does the PR do?

Kills the reference to the docker deployment of docker. It is outdated and we don't have the capacity to support it. 

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

None
