### PR TITLE
Fix load-SNB.sh help message

### DIFF
--- a/grakn-test/test-snb/src/main/bash/load-SNB.sh
+++ b/grakn-test/test-snb/src/main/bash/load-SNB.sh
@@ -35,7 +35,7 @@ function extractArchData {
             tar -xf ${SF1_DATA}
             ;;
         *)
-            echo "Usage: arch {SF1}"
+            echo "Usage: arch {validate|SF1}"
             exit 1
             ;;
     esac


### PR DESCRIPTION
# Why is this PR needed?
In order to fix a typo in the `load-SNB.sh` script.  It can either be invoked with `SF1` or `validate`, but the help does not mention the latter.

# What does the PR do?
Edit the help message of `load-SNB.sh`

# Does it break backwards compatibility?
No.

# List of future improvements not on this PR
N/A