### PR TITLE
update from where we pull redis prebuilt

### DIFF
--- a/grakn-dist/pom.xml
+++ b/grakn-dist/pom.xml
@@ -148,7 +148,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/burukuru/redis-prebuilt/archive/redis-3.2.9.tar.gz</url>
+                            <url>https://github.com/graknlabs/redis-prebuilt/archive/redis-3.2.9.tar.gz</url>
                             <unpack>true</unpack>
                             <outputDirectory>${project.basedir}/target</outputDirectory>
                         </configuration>


### PR DESCRIPTION
# Why is this PR needed?
Because we're currently still using a prebuilt Redis binary hosted on Thanh's repository.

# What does the PR do?
Update the settings to refer to the one in graknlabs: https://github.com/burukuru/redis-prebuilt

# Does it break backwards compatibility?
No.

# List of future improvements not on this PR
N/A