### PR TITLE
Add `grakn-grpc` module

### DIFF
--- a/grakn-engine/pom.xml
+++ b/grakn-engine/pom.xml
@@ -62,6 +62,10 @@
             <groupId>ai.grakn</groupId>
             <artifactId>grakn-kb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>ai.grakn</groupId>
+            <artifactId>grakn-grpc</artifactId>
+        </dependency>
         <!-- Exposes metrics as a servlet -->
         <dependency>
           <groupId>io.dropwizard.metrics</groupId>
@@ -120,51 +124,5 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-protobuf</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-stub</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty</artifactId>
-        </dependency>
     </dependencies>
-
-    <build>
-        <!-- This is required so we fetch the OS-specific GRPC implementation -->
-        <extensions>
-            <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
-            </extension>
-        </extensions>
-
-        <plugins>
-            <plugin>
-                <groupId>org.xolstice.maven.plugins</groupId>
-                <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.0</version>
-                <configuration>
-                    <!-- Get the (OS-specific) executable to generate Java code from proto files -->
-                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
-                    <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.2.0:exe:${os.detected.classifier}</pluginArtifact>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>compile-custom</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/TxObserver.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/TxObserver.java
@@ -43,8 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static ai.grakn.grpc.GrpcUtil.doneResponse;
-
 /**
  * A {@link StreamObserver} that implements the transaction-handling behaviour for {@link GrpcServer}.
  * <p>
@@ -153,7 +151,7 @@ class TxObserver implements StreamObserver<TxRequest>, AutoCloseable {
         GraknTxType txType = GrpcUtil.getTxType(request);
         tx = txFactory.tx(keyspace, txType);
 
-        responseObserver.onNext(doneResponse());
+        responseObserver.onNext(GrpcUtil.doneResponse());
     }
 
     private void commit() {

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/TxObserver.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/TxObserver.java
@@ -150,8 +150,8 @@ class TxObserver implements StreamObserver<TxRequest>, AutoCloseable {
             throw error(Status.FAILED_PRECONDITION);
         }
 
-        Keyspace keyspace = GrpcUtil.convert(request.getKeyspace());
-        GraknTxType txType = GrpcUtil.convert(request.getTxType());
+        Keyspace keyspace = GrpcUtil.getKeyspace(request);
+        GraknTxType txType = GrpcUtil.getTxType(request);
         tx = txFactory.tx(keyspace, txType);
 
         responseObserver.onNext(doneResponse());

--- a/grakn-engine/src/main/proto
+++ b/grakn-engine/src/main/proto
@@ -1,1 +1,0 @@
-../../../grakn-spec/proto

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -124,7 +124,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningAReadTransactionRemotely_AReadTransactionIsOpened() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Read));
         }
 
@@ -133,7 +133,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningAWriteTransactionRemotely_AWriteTransactionIsOpened() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
         }
 
@@ -142,7 +142,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningABatchTransactionRemotely_ABatchTransactionIsOpened() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Batch));
         }
 
@@ -151,7 +151,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningATransactionRemotely_ReceiveADoneMessage() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Read));
             TxResponse response = tx.receive().elem();
 
@@ -161,7 +161,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingATransactionRemotely_TheTransactionIsCommitted() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(commitRequest());
         }
@@ -171,7 +171,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingATransactionRemotely_ReceiveADoneMessage() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -192,8 +192,8 @@ public class GrpcServerTest {
         });
 
         try (
-                SynchronousObserver<TxRequest, TxResponse> tx1 = startTx();
-                SynchronousObserver<TxRequest, TxResponse> tx2 = startTx()
+                SynchronousObserver tx1 = startTx();
+                SynchronousObserver tx2 = startTx()
         ) {
             tx1.send(openRequest(MYKS, TxType.Write));
             tx2.send(openRequest(MYKS, TxType.Write));
@@ -207,7 +207,7 @@ public class GrpcServerTest {
         GraknOuterClass.Keyspace keyspace = GraknOuterClass.Keyspace.newBuilder().setValue("not!@akeyspace").build();
         Open open = Open.newBuilder().setKeyspace(keyspace).setTxType(TxType.Write).build();
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(TxRequest.newBuilder().setOpen(open).build());
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(GraknTxOperationException.invalidKeyspace("not!@akeyspace").getMessage())));
@@ -231,7 +231,7 @@ public class GrpcServerTest {
             return null;
         }).when(tx).close();
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
         }
 
@@ -241,7 +241,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingAQueryRemotely_TheQueryIsParsedAndExecuted() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY));
         }
@@ -271,7 +271,7 @@ public class GrpcServerTest {
         when(query.results(any())).thenAnswer(params -> query.stream().map(params.<GrpcConverter>getArgument(0)::convert));
         when(query.stream()).thenAnswer(params -> answers.stream());
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -324,7 +324,7 @@ public class GrpcServerTest {
         // Produce an endless stream of results - this means if the behaviour is not lazy this will never terminate
         when(query.stream()).thenAnswer(params -> Stream.generate(answers::stream).flatMap(Function.identity()));
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -344,7 +344,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithoutInferenceSet_InferenceIsNotSet() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY));
             tx.send(nextRequest());
@@ -356,7 +356,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithInferenceOff_InferenceIsTurnedOff() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY, false));
             tx.send(nextRequest());
@@ -368,7 +368,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithInferenceOn_InferenceIsTurnedOn() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY, true));
             tx.send(nextRequest());
@@ -380,7 +380,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingBeforeOpeningTx_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(commitRequest());
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
@@ -391,7 +391,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingAQueryBeforeOpeningTx_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(execQueryRequest(QUERY));
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
@@ -402,7 +402,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningTxTwice_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -418,7 +418,7 @@ public class GrpcServerTest {
     public void whenOpeningTxFails_Throw() throws Throwable {
         when(txFactory.tx(MYKS, GraknTxType.WRITE)).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
@@ -431,7 +431,7 @@ public class GrpcServerTest {
     public void whenCommittingFails_Throw() throws Throwable {
         doThrow(EXCEPTION).when(tx).commit();
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -447,7 +447,7 @@ public class GrpcServerTest {
     public void whenParsingQueryFails_Throw() throws Throwable {
         when(tx.graql().parse(QUERY)).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -463,7 +463,7 @@ public class GrpcServerTest {
     public void whenExecutingQueryFails_Throw() throws Throwable {
         when(query.results(any())).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -477,7 +477,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingNextBeforeQuery_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -491,7 +491,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingStopBeforeQuery_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -505,7 +505,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingNextAfterStop_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -525,7 +525,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingAnotherQueryDuringQueryExecution_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -540,7 +540,7 @@ public class GrpcServerTest {
         }
     }
 
-    private SynchronousObserver<TxRequest, TxResponse> startTx() {
+    private SynchronousObserver startTx() {
         return SynchronousObserver.create(stub::tx);
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -124,7 +124,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningAReadTransactionRemotely_AReadTransactionIsOpened() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Read));
         }
 
@@ -133,7 +133,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningAWriteTransactionRemotely_AWriteTransactionIsOpened() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
         }
 
@@ -142,7 +142,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningABatchTransactionRemotely_ABatchTransactionIsOpened() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Batch));
         }
 
@@ -151,7 +151,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningATransactionRemotely_ReceiveADoneMessage() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Read));
             TxResponse response = tx.receive().elem();
 
@@ -161,7 +161,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingATransactionRemotely_TheTransactionIsCommitted() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(commitRequest());
         }
@@ -171,7 +171,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingATransactionRemotely_ReceiveADoneMessage() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -192,8 +192,8 @@ public class GrpcServerTest {
         });
 
         try (
-                SynchronousObserver tx1 = startTx();
-                SynchronousObserver tx2 = startTx()
+                SynchronousObserver tx1 = SynchronousObserver.create(stub);
+                SynchronousObserver tx2 = SynchronousObserver.create(stub)
         ) {
             tx1.send(openRequest(MYKS, TxType.Write));
             tx2.send(openRequest(MYKS, TxType.Write));
@@ -207,7 +207,7 @@ public class GrpcServerTest {
         GraknOuterClass.Keyspace keyspace = GraknOuterClass.Keyspace.newBuilder().setValue("not!@akeyspace").build();
         Open open = Open.newBuilder().setKeyspace(keyspace).setTxType(TxType.Write).build();
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(TxRequest.newBuilder().setOpen(open).build());
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(GraknTxOperationException.invalidKeyspace("not!@akeyspace").getMessage())));
@@ -231,7 +231,7 @@ public class GrpcServerTest {
             return null;
         }).when(tx).close();
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
         }
 
@@ -241,7 +241,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingAQueryRemotely_TheQueryIsParsedAndExecuted() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY));
         }
@@ -271,7 +271,7 @@ public class GrpcServerTest {
         when(query.results(any())).thenAnswer(params -> query.stream().map(params.<GrpcConverter>getArgument(0)::convert));
         when(query.stream()).thenAnswer(params -> answers.stream());
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -324,7 +324,7 @@ public class GrpcServerTest {
         // Produce an endless stream of results - this means if the behaviour is not lazy this will never terminate
         when(query.stream()).thenAnswer(params -> Stream.generate(answers::stream).flatMap(Function.identity()));
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -344,7 +344,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithoutInferenceSet_InferenceIsNotSet() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY));
             tx.send(nextRequest());
@@ -356,7 +356,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithInferenceOff_InferenceIsTurnedOff() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY, false));
             tx.send(nextRequest());
@@ -368,7 +368,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingQueryWithInferenceOn_InferenceIsTurnedOn() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.send(execQueryRequest(QUERY, true));
             tx.send(nextRequest());
@@ -380,7 +380,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenCommittingBeforeOpeningTx_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(commitRequest());
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
@@ -391,7 +391,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenExecutingAQueryBeforeOpeningTx_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(execQueryRequest(QUERY));
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
@@ -402,7 +402,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenOpeningTxTwice_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -418,7 +418,7 @@ public class GrpcServerTest {
     public void whenOpeningTxFails_Throw() throws Throwable {
         when(txFactory.tx(MYKS, GraknTxType.WRITE)).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
@@ -431,7 +431,7 @@ public class GrpcServerTest {
     public void whenCommittingFails_Throw() throws Throwable {
         doThrow(EXCEPTION).when(tx).commit();
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -447,7 +447,7 @@ public class GrpcServerTest {
     public void whenParsingQueryFails_Throw() throws Throwable {
         when(tx.graql().parse(QUERY)).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -463,7 +463,7 @@ public class GrpcServerTest {
     public void whenExecutingQueryFails_Throw() throws Throwable {
         when(query.results(any())).thenThrow(EXCEPTION);
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -477,7 +477,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingNextBeforeQuery_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -491,7 +491,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingStopBeforeQuery_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -505,7 +505,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingNextAfterStop_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -525,7 +525,7 @@ public class GrpcServerTest {
 
     @Test
     public void whenSendingAnotherQueryDuringQueryExecution_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
 
@@ -538,10 +538,6 @@ public class GrpcServerTest {
 
             throw tx.receive().throwable();
         }
-    }
-
-    private SynchronousObserver startTx() {
-        return SynchronousObserver.create(stub::tx);
     }
 }
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -58,7 +58,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static ai.grakn.engine.rpc.GrpcTestUtil.hasStatus;
+import static ai.grakn.grpc.GrpcTestUtil.hasStatus;
 import static ai.grakn.grpc.GrpcUtil.commitRequest;
 import static ai.grakn.grpc.GrpcUtil.doneResponse;
 import static ai.grakn.grpc.GrpcUtil.execQueryRequest;

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -212,7 +212,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(GraknTxOperationException.invalidKeyspace("not!@akeyspace").getMessage())));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -385,7 +385,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -396,7 +396,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -410,7 +410,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -423,7 +423,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -439,7 +439,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -455,7 +455,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -471,7 +471,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -485,7 +485,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -499,7 +499,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -519,7 +519,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -536,7 +536,7 @@ public class GrpcServerTest {
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -150,7 +150,7 @@ public class GrpcServerTest {
     }
 
     @Test
-    public void whenOpeningATransactionRemotely_ReceiveADoneMessage() {
+    public void whenOpeningATransactionRemotely_ReceiveADoneMessage() throws InterruptedException {
         try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Read));
             TxResponse response = tx.receive().elem();
@@ -170,7 +170,7 @@ public class GrpcServerTest {
     }
 
     @Test
-    public void whenCommittingATransactionRemotely_ReceiveADoneMessage() {
+    public void whenCommittingATransactionRemotely_ReceiveADoneMessage() throws InterruptedException {
         try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(MYKS, TxType.Write));
             tx.receive();
@@ -251,7 +251,7 @@ public class GrpcServerTest {
     }
 
     @Test
-    public void whenExecutingAQueryRemotely_AResultIsReturned() {
+    public void whenExecutingAQueryRemotely_AResultIsReturned() throws InterruptedException {
         Concept conceptX = mock(Concept.class, RETURNS_DEEP_STUBS);
         when(conceptX.getId()).thenReturn(ConceptId.of("V123"));
         when(conceptX.isThing()).thenReturn(true);

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -35,14 +35,7 @@ import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknGrpc.GraknStub;
 import ai.grakn.rpc.generated.GraknOuterClass;
-import ai.grakn.rpc.generated.GraknOuterClass.Commit;
-import ai.grakn.rpc.generated.GraknOuterClass.Done;
-import ai.grakn.rpc.generated.GraknOuterClass.ExecQuery;
-import ai.grakn.rpc.generated.GraknOuterClass.Infer;
-import ai.grakn.rpc.generated.GraknOuterClass.Next;
-import ai.grakn.rpc.generated.GraknOuterClass.Open;
 import ai.grakn.rpc.generated.GraknOuterClass.QueryResult;
-import ai.grakn.rpc.generated.GraknOuterClass.Stop;
 import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
 import ai.grakn.rpc.generated.GraknOuterClass.TxType;
@@ -63,7 +56,13 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import static ai.grakn.engine.rpc.GrpcUtil.hasStatus;
+import static ai.grakn.engine.rpc.GrpcTestUtil.hasStatus;
+import static ai.grakn.grpc.GrpcUtil.commitRequest;
+import static ai.grakn.grpc.GrpcUtil.doneResponse;
+import static ai.grakn.grpc.GrpcUtil.execQueryRequest;
+import static ai.grakn.grpc.GrpcUtil.nextRequest;
+import static ai.grakn.grpc.GrpcUtil.openRequest;
+import static ai.grakn.grpc.GrpcUtil.stopRequest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -538,44 +537,6 @@ public class GrpcServerTest {
 
     private SynchronousObserver<TxRequest, TxResponse> startTx() {
         return SynchronousObserver.create(stub::tx);
-    }
-
-    private static TxRequest openRequest(String keyspaceString, TxType txType) {
-        GraknOuterClass.Keyspace keyspace = GraknOuterClass.Keyspace.newBuilder().setValue(keyspaceString).build();
-        Open.Builder open = Open.newBuilder().setKeyspace(keyspace).setTxType(txType);
-        return TxRequest.newBuilder().setOpen(open).build();
-    }
-
-    private static TxRequest commitRequest() {
-        return TxRequest.newBuilder().setCommit(Commit.getDefaultInstance()).build();
-    }
-
-    private static TxRequest execQueryRequest(String queryString) {
-        return execQueryRequest(queryString, Infer.getDefaultInstance());
-    }
-
-    private static TxRequest execQueryRequest(String queryString, boolean infer) {
-        Infer inferMessage = Infer.newBuilder().setValue(infer).setIsSet(true).build();
-        return execQueryRequest(queryString, inferMessage);
-    }
-
-    private static TxRequest execQueryRequest(String queryString, Infer infer) {
-        GraknOuterClass.Query query = GraknOuterClass.Query.newBuilder().setValue(queryString).build();
-        ExecQuery.Builder execQueryRequest = ExecQuery.newBuilder().setQuery(query);
-        execQueryRequest.setInfer(infer);
-        return TxRequest.newBuilder().setExecQuery(execQueryRequest).build();
-    }
-
-    private static TxRequest nextRequest() {
-        return TxRequest.newBuilder().setNext(Next.getDefaultInstance()).build();
-    }
-
-    private static TxRequest stopRequest() {
-        return TxRequest.newBuilder().setStop(Stop.getDefaultInstance()).build();
-    }
-
-    private static TxResponse doneResponse() {
-        return TxResponse.newBuilder().setDone(Done.getDefaultInstance()).build();
     }
 }
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -125,7 +125,7 @@ public class GrpcServerTest {
     @Test
     public void whenOpeningAReadTransactionRemotely_AReadTransactionIsOpened() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Read));
+            tx.send(openRequest(MYKS, GraknTxType.READ));
         }
 
         verify(txFactory).tx(MYKS, GraknTxType.READ);
@@ -134,7 +134,7 @@ public class GrpcServerTest {
     @Test
     public void whenOpeningAWriteTransactionRemotely_AWriteTransactionIsOpened() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
         }
 
         verify(txFactory).tx(MYKS, GraknTxType.WRITE);
@@ -143,7 +143,7 @@ public class GrpcServerTest {
     @Test
     public void whenOpeningABatchTransactionRemotely_ABatchTransactionIsOpened() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Batch));
+            tx.send(openRequest(MYKS, GraknTxType.BATCH));
         }
 
         verify(txFactory).tx(MYKS, GraknTxType.BATCH);
@@ -152,7 +152,7 @@ public class GrpcServerTest {
     @Test
     public void whenOpeningATransactionRemotely_ReceiveADoneMessage() throws InterruptedException {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Read));
+            tx.send(openRequest(MYKS, GraknTxType.READ));
             TxResponse response = tx.receive().ok();
 
             assertEquals(doneResponse(), response);
@@ -162,7 +162,7 @@ public class GrpcServerTest {
     @Test
     public void whenCommittingATransactionRemotely_TheTransactionIsCommitted() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.send(commitRequest());
         }
 
@@ -172,7 +172,7 @@ public class GrpcServerTest {
     @Test
     public void whenCommittingATransactionRemotely_ReceiveADoneMessage() throws InterruptedException {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(commitRequest());
@@ -195,8 +195,8 @@ public class GrpcServerTest {
                 TxGrpcCommunicator tx1 = TxGrpcCommunicator.create(stub);
                 TxGrpcCommunicator tx2 = TxGrpcCommunicator.create(stub)
         ) {
-            tx1.send(openRequest(MYKS, TxType.Write));
-            tx2.send(openRequest(MYKS, TxType.Write));
+            tx1.send(openRequest(MYKS, GraknTxType.WRITE));
+            tx2.send(openRequest(MYKS, GraknTxType.WRITE));
         }
 
         assertNotEquals(threads.get(0), threads.get(1));
@@ -232,7 +232,7 @@ public class GrpcServerTest {
         }).when(tx).close();
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
         }
 
         verify(tx).close();
@@ -242,7 +242,7 @@ public class GrpcServerTest {
     @Test
     public void whenExecutingAQueryRemotely_TheQueryIsParsedAndExecuted() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.send(execQueryRequest(QUERY));
         }
 
@@ -272,7 +272,7 @@ public class GrpcServerTest {
         when(query.stream()).thenAnswer(params -> answers.stream());
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));
@@ -325,7 +325,7 @@ public class GrpcServerTest {
         when(query.stream()).thenAnswer(params -> Stream.generate(answers::stream).flatMap(Function.identity()));
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));
@@ -345,7 +345,7 @@ public class GrpcServerTest {
     @Test
     public void whenExecutingQueryWithoutInferenceSet_InferenceIsNotSet() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.send(execQueryRequest(QUERY));
             tx.send(nextRequest());
             tx.send(stopRequest());
@@ -357,7 +357,7 @@ public class GrpcServerTest {
     @Test
     public void whenExecutingQueryWithInferenceOff_InferenceIsTurnedOff() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.send(execQueryRequest(QUERY, false));
             tx.send(nextRequest());
             tx.send(stopRequest());
@@ -369,7 +369,7 @@ public class GrpcServerTest {
     @Test
     public void whenExecutingQueryWithInferenceOn_InferenceIsTurnedOn() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.send(execQueryRequest(QUERY, true));
             tx.send(nextRequest());
             tx.send(stopRequest());
@@ -403,10 +403,10 @@ public class GrpcServerTest {
     @Test
     public void whenOpeningTxTwice_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
@@ -419,7 +419,7 @@ public class GrpcServerTest {
         when(txFactory.tx(MYKS, GraknTxType.WRITE)).thenThrow(EXCEPTION);
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(EXCEPTION_MESSAGE)));
 
@@ -432,7 +432,7 @@ public class GrpcServerTest {
         doThrow(EXCEPTION).when(tx).commit();
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(commitRequest());
@@ -448,7 +448,7 @@ public class GrpcServerTest {
         when(tx.graql().parse(QUERY)).thenThrow(EXCEPTION);
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));
@@ -464,7 +464,7 @@ public class GrpcServerTest {
         when(query.results(any())).thenThrow(EXCEPTION);
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));
@@ -478,7 +478,7 @@ public class GrpcServerTest {
     @Test
     public void whenSendingNextBeforeQuery_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(nextRequest());
@@ -492,7 +492,7 @@ public class GrpcServerTest {
     @Test
     public void whenSendingStopBeforeQuery_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(stopRequest());
@@ -506,7 +506,7 @@ public class GrpcServerTest {
     @Test
     public void whenSendingNextAfterStop_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));
@@ -526,7 +526,7 @@ public class GrpcServerTest {
     @Test
     public void whenSendingAnotherQueryDuringQueryExecution_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(MYKS, TxType.Write));
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
             tx.send(execQueryRequest(QUERY));

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -32,6 +32,7 @@ import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.internal.query.QueryAnswer;
+import ai.grakn.grpc.SynchronousObserver;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknGrpc.GraknStub;
 import ai.grakn.rpc.generated.GraknOuterClass;

--- a/grakn-grpc/pom.xml
+++ b/grakn-grpc/pom.xml
@@ -31,6 +31,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>ai.grakn</groupId>
+            <artifactId>grakn-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
         </dependency>

--- a/grakn-grpc/pom.xml
+++ b/grakn-grpc/pom.xml
@@ -46,6 +46,10 @@
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/grakn-grpc/pom.xml
+++ b/grakn-grpc/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Grakn - A Distributed Semantic Database
+  ~ Copyright (C) 2016-2018 Grakn Labs Limited
+  ~
+  ~ Grakn is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ Grakn is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>grakn</artifactId>
+        <groupId>ai.grakn</groupId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>grakn-grpc</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <!-- This is required so we fetch the OS-specific GRPC implementation -->
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.1.Final</version>
+            </extension>
+        </extensions>
+
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <configuration>
+                    <!-- Get the (OS-specific) executable to generate Java code from proto files -->
+                    <protocArtifact>com.google.protobuf:protoc:3.0.2:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.2.0:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -31,6 +31,7 @@ import ai.grakn.rpc.generated.GraknOuterClass.Stop;
 import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
 import ai.grakn.rpc.generated.GraknOuterClass.TxType;
+import ai.grakn.util.CommonUtil;
 
 import javax.annotation.Nullable;
 
@@ -39,8 +40,8 @@ import javax.annotation.Nullable;
  */
 public class GrpcUtil {
 
-    public static TxRequest openRequest(Keyspace keyspace, TxType txType) {
-        Open.Builder open = Open.newBuilder().setKeyspace(convert(keyspace)).setTxType(txType);
+    public static TxRequest openRequest(Keyspace keyspace, GraknTxType txType) {
+        Open.Builder open = Open.newBuilder().setKeyspace(convert(keyspace)).setTxType(convert(txType));
         return TxRequest.newBuilder().setOpen(open).build();
     }
 
@@ -92,6 +93,19 @@ public class GrpcUtil {
             default:
             case UNRECOGNIZED:
                 throw new IllegalArgumentException("Unrecognised " + txType);
+        }
+    }
+
+    private static TxType convert(GraknTxType txType) {
+        switch (txType) {
+            case READ:
+                return TxType.Read;
+            case WRITE:
+                return TxType.Write;
+            case BATCH:
+                return TxType.Batch;
+            default:
+                throw CommonUtil.unreachableStatement("Unrecognised " + txType);
         }
     }
 

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -32,6 +32,8 @@ import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
 import ai.grakn.rpc.generated.GraknOuterClass.TxType;
 
+import javax.annotation.Nullable;
+
 /**
  * @author Felix Chapman
  */
@@ -47,18 +49,15 @@ public class GrpcUtil {
     }
 
     public static TxRequest execQueryRequest(String queryString) {
-        return execQueryRequest(queryString, Infer.getDefaultInstance());
+        return execQueryRequest(queryString, null);
     }
 
-    public static TxRequest execQueryRequest(String queryString, boolean infer) {
-        Infer inferMessage = Infer.newBuilder().setValue(infer).setIsSet(true).build();
-        return execQueryRequest(queryString, inferMessage);
-    }
-
-    private static TxRequest execQueryRequest(String queryString, Infer infer) {
+    public static TxRequest execQueryRequest(String queryString, @Nullable Boolean infer) {
         GraknOuterClass.Query query = GraknOuterClass.Query.newBuilder().setValue(queryString).build();
         ExecQuery.Builder execQueryRequest = ExecQuery.newBuilder().setQuery(query);
-        execQueryRequest.setInfer(infer);
+        if (infer != null) {
+            execQueryRequest.setInfer(Infer.newBuilder().setValue(infer));
+        }
         return TxRequest.newBuilder().setExecQuery(execQueryRequest).build();
     }
 

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -36,9 +36,9 @@ import ai.grakn.rpc.generated.GraknOuterClass.TxType;
  * @author Felix Chapman
  */
 public class GrpcUtil {
-    public static TxRequest openRequest(String keyspaceString, TxType txType) {
-        GraknOuterClass.Keyspace keyspace = GraknOuterClass.Keyspace.newBuilder().setValue(keyspaceString).build();
-        Open.Builder open = Open.newBuilder().setKeyspace(keyspace).setTxType(txType);
+
+    public static TxRequest openRequest(Keyspace keyspace, TxType txType) {
+        Open.Builder open = Open.newBuilder().setKeyspace(convert(keyspace)).setTxType(txType);
         return TxRequest.newBuilder().setOpen(open).build();
     }
 
@@ -55,7 +55,7 @@ public class GrpcUtil {
         return execQueryRequest(queryString, inferMessage);
     }
 
-    public static TxRequest execQueryRequest(String queryString, Infer infer) {
+    private static TxRequest execQueryRequest(String queryString, Infer infer) {
         GraknOuterClass.Query query = GraknOuterClass.Query.newBuilder().setValue(queryString).build();
         ExecQuery.Builder execQueryRequest = ExecQuery.newBuilder().setQuery(query);
         execQueryRequest.setInfer(infer);
@@ -74,7 +74,15 @@ public class GrpcUtil {
         return TxResponse.newBuilder().setDone(Done.getDefaultInstance()).build();
     }
 
-    public static GraknTxType convert(TxType txType) {
+    public static Keyspace getKeyspace(Open open) {
+        return convert(open.getKeyspace());
+    }
+
+    public static GraknTxType getTxType(Open open) {
+        return convert(open.getTxType());
+    }
+
+    private static GraknTxType convert(TxType txType) {
         switch (txType) {
             case Read:
                 return GraknTxType.READ;
@@ -88,7 +96,11 @@ public class GrpcUtil {
         }
     }
 
-    public static Keyspace convert(GraknOuterClass.Keyspace keyspace) {
+    private static Keyspace convert(GraknOuterClass.Keyspace keyspace) {
         return Keyspace.of(keyspace.getValue());
+    }
+
+    private static GraknOuterClass.Keyspace convert(Keyspace keyspace) {
+        return GraknOuterClass.Keyspace.newBuilder().setValue(keyspace.getValue()).build();
     }
 }

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -1,0 +1,94 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.grpc;
+
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.rpc.generated.GraknOuterClass;
+import ai.grakn.rpc.generated.GraknOuterClass.Commit;
+import ai.grakn.rpc.generated.GraknOuterClass.Done;
+import ai.grakn.rpc.generated.GraknOuterClass.ExecQuery;
+import ai.grakn.rpc.generated.GraknOuterClass.Infer;
+import ai.grakn.rpc.generated.GraknOuterClass.Next;
+import ai.grakn.rpc.generated.GraknOuterClass.Open;
+import ai.grakn.rpc.generated.GraknOuterClass.Stop;
+import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
+import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
+import ai.grakn.rpc.generated.GraknOuterClass.TxType;
+
+/**
+ * @author Felix Chapman
+ */
+public class GrpcUtil {
+    public static TxRequest openRequest(String keyspaceString, TxType txType) {
+        GraknOuterClass.Keyspace keyspace = GraknOuterClass.Keyspace.newBuilder().setValue(keyspaceString).build();
+        Open.Builder open = Open.newBuilder().setKeyspace(keyspace).setTxType(txType);
+        return TxRequest.newBuilder().setOpen(open).build();
+    }
+
+    public static TxRequest commitRequest() {
+        return TxRequest.newBuilder().setCommit(Commit.getDefaultInstance()).build();
+    }
+
+    public static TxRequest execQueryRequest(String queryString) {
+        return execQueryRequest(queryString, Infer.getDefaultInstance());
+    }
+
+    public static TxRequest execQueryRequest(String queryString, boolean infer) {
+        Infer inferMessage = Infer.newBuilder().setValue(infer).setIsSet(true).build();
+        return execQueryRequest(queryString, inferMessage);
+    }
+
+    public static TxRequest execQueryRequest(String queryString, Infer infer) {
+        GraknOuterClass.Query query = GraknOuterClass.Query.newBuilder().setValue(queryString).build();
+        ExecQuery.Builder execQueryRequest = ExecQuery.newBuilder().setQuery(query);
+        execQueryRequest.setInfer(infer);
+        return TxRequest.newBuilder().setExecQuery(execQueryRequest).build();
+    }
+
+    public static TxRequest nextRequest() {
+        return TxRequest.newBuilder().setNext(Next.getDefaultInstance()).build();
+    }
+
+    public static TxRequest stopRequest() {
+        return TxRequest.newBuilder().setStop(Stop.getDefaultInstance()).build();
+    }
+
+    public static TxResponse doneResponse() {
+        return TxResponse.newBuilder().setDone(Done.getDefaultInstance()).build();
+    }
+
+    public static GraknTxType convert(TxType txType) {
+        switch (txType) {
+            case Read:
+                return GraknTxType.READ;
+            case Write:
+                return GraknTxType.WRITE;
+            case Batch:
+                return GraknTxType.BATCH;
+            default:
+            case UNRECOGNIZED:
+                throw new IllegalArgumentException("Unrecognised " + txType);
+        }
+    }
+
+    public static Keyspace convert(GraknOuterClass.Keyspace keyspace) {
+        return Keyspace.of(keyspace.getValue());
+    }
+}

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/SynchronousObserver.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/SynchronousObserver.java
@@ -16,7 +16,7 @@
  * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package ai.grakn.engine.rpc;
+package ai.grakn.grpc;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
@@ -192,7 +192,7 @@ public class SynchronousObserver<Request, Response> implements AutoCloseable {
 
         private static <T> QueueElem<T> create(@Nullable T elem, @Nullable Throwable throwable) {
             Preconditions.checkArgument(elem == null || throwable == null);
-            return new ai.grakn.engine.rpc.AutoValue_SynchronousObserver_QueueElem<>(elem, throwable);
+            return new AutoValue_SynchronousObserver_QueueElem<>(elem, throwable);
         }
 
         static <T> QueueElem<T> completed() {

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/TxGrpcCommunicator.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/TxGrpcCommunicator.java
@@ -108,6 +108,7 @@ public class TxGrpcCommunicator implements AutoCloseable {
         @Override
         public void onError(Throwable throwable) {
             terminated.set(true);
+            assert throwable instanceof StatusRuntimeException : "The server only yields these exceptions";
             queue.add(Response.error((StatusRuntimeException) throwable));
         }
 

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/TxGrpcCommunicator.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/TxGrpcCommunicator.java
@@ -190,7 +190,7 @@ public class TxGrpcCommunicator implements AutoCloseable {
 
         private static Response create(@Nullable TxResponse response, @Nullable StatusRuntimeException error) {
             Preconditions.checkArgument(response == null || error == null);
-            return new AutoValue_SynchronousObserver_Response(response, error);
+            return new AutoValue_TxGrpcCommunicator_Response(response, error);
         }
 
         static Response completed() {

--- a/grakn-grpc/src/main/proto
+++ b/grakn-grpc/src/main/proto
@@ -1,0 +1,1 @@
+../../../grakn-spec/proto/

--- a/grakn-test-tools/src/main/java/ai/grakn/engine/rpc/GrpcTestUtil.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/engine/rpc/GrpcTestUtil.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.isA;
 /**
  * @author Felix Chapman
  */
-public class GrpcUtil {
+public class GrpcTestUtil {
 
     public static Matcher<StatusRuntimeException> hasStatus(Status status) {
 

--- a/grakn-test-tools/src/main/java/ai/grakn/grpc/GrpcTestUtil.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/grpc/GrpcTestUtil.java
@@ -16,7 +16,7 @@
  * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
-package ai.grakn.engine.rpc;
+package ai.grakn.grpc;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -30,7 +30,6 @@ import ai.grakn.rpc.generated.GraknGrpc.GraknStub;
 import ai.grakn.rpc.generated.GraknOuterClass;
 import ai.grakn.rpc.generated.GraknOuterClass.QueryResult;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
-import ai.grakn.rpc.generated.GraknOuterClass.TxType;
 import ai.grakn.test.rule.EngineContext;
 import ai.grakn.util.CommonUtil;
 import ai.grakn.util.Schema;
@@ -82,7 +81,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() throws InterruptedException {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Write));
+            tx.send(openRequest(session.keyspace(), GraknTxType.WRITE));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
             queryResults(tx);
@@ -98,7 +97,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() throws InterruptedException {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Write));
+            tx.send(openRequest(session.keyspace(), GraknTxType.WRITE));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
             queryResults(tx);
@@ -114,7 +113,7 @@ public class GrpcServerIT {
         List<QueryResult> results;
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), GraknTxType.READ));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
 
@@ -141,7 +140,7 @@ public class GrpcServerIT {
         Set<QueryResult> results2;
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), GraknTxType.READ));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
             results1 = Sets.newHashSet(queryResults(tx));
@@ -155,7 +154,7 @@ public class GrpcServerIT {
     @Test // This behaviour is temporary - we should eventually support it correctly
     public void whenExecutingTwoParallelQueries_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), GraknTxType.READ));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
             tx.receive();
@@ -170,7 +169,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAnInvalidQuery_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(openRequest(session.keyspace(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), GraknTxType.READ));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get $y;"));
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -23,7 +23,7 @@ import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.engine.rpc.GrpcTestUtil;
-import ai.grakn.engine.rpc.SynchronousObserver;
+import ai.grakn.grpc.SynchronousObserver;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknGrpc.GraknStub;

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -83,7 +83,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() {
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Write));
+            tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
             queryResults(tx);
@@ -99,7 +99,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() {
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Write));
+            tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
             queryResults(tx);
@@ -115,7 +115,7 @@ public class GrpcServerIT {
         List<QueryResult> results;
 
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
 
@@ -142,7 +142,7 @@ public class GrpcServerIT {
         Set<QueryResult> results2;
 
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
             results1 = Sets.newHashSet(queryResults(tx));
@@ -156,7 +156,7 @@ public class GrpcServerIT {
     @Test // This behaviour is temporary - we should eventually support it correctly
     public void whenExecutingTwoParallelQueries_Throw() throws Throwable {
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
             tx.receive();
@@ -171,7 +171,7 @@ public class GrpcServerIT {
     @Test
     public void whenExecutingAnInvalidQuery_Throw() throws Throwable {
         try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
-            tx.send(openRequest(session.keyspace().getValue(), TxType.Read));
+            tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get $y;"));
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -163,7 +163,7 @@ public class GrpcServerIT {
 
             exception.expect(GrpcTestUtil.hasStatus(Status.FAILED_PRECONDITION));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 
@@ -176,7 +176,7 @@ public class GrpcServerIT {
 
             exception.expect(GrpcTestUtil.hasStatus(Status.UNKNOWN.withDescription(GraqlQueryException.varNotInQuery(var("y")).getMessage())));
 
-            throw tx.receive().throwable();
+            throw tx.receive().error();
         }
     }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -81,7 +81,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
@@ -97,7 +97,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
@@ -113,7 +113,7 @@ public class GrpcServerIT {
     public void whenExecutingAQuery_ResultsAreReturned() {
         List<QueryResult> results;
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -140,7 +140,7 @@ public class GrpcServerIT {
         Set<QueryResult> results1;
         Set<QueryResult> results2;
 
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -154,7 +154,7 @@ public class GrpcServerIT {
 
     @Test // This behaviour is temporary - we should eventually support it correctly
     public void whenExecutingTwoParallelQueries_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -169,7 +169,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAnInvalidQuery_Throw() throws Throwable {
-        try (SynchronousObserver tx = startTx()) {
+        try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get $y;"));
@@ -178,10 +178,6 @@ public class GrpcServerIT {
 
             throw tx.receive().throwable();
         }
-    }
-
-    private SynchronousObserver startTx() {
-        return SynchronousObserver.create(stub::tx);
     }
 
     private static List<QueryResult> queryResults(SynchronousObserver tx) {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -22,14 +22,13 @@ import ai.grakn.GraknSession;
 import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
 import ai.grakn.concept.ConceptId;
+import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.grpc.GrpcTestUtil;
 import ai.grakn.grpc.SynchronousObserver;
-import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknGrpc.GraknStub;
 import ai.grakn.rpc.generated.GraknOuterClass;
 import ai.grakn.rpc.generated.GraknOuterClass.QueryResult;
-import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
 import ai.grakn.rpc.generated.GraknOuterClass.TxType;
 import ai.grakn.test.rule.EngineContext;
@@ -82,7 +81,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
@@ -98,7 +97,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
             tx.send(execQueryRequest("define person sub entity;"));
@@ -114,7 +113,7 @@ public class GrpcServerIT {
     public void whenExecutingAQuery_ResultsAreReturned() {
         List<QueryResult> results;
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -141,7 +140,7 @@ public class GrpcServerIT {
         Set<QueryResult> results1;
         Set<QueryResult> results2;
 
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -155,7 +154,7 @@ public class GrpcServerIT {
 
     @Test // This behaviour is temporary - we should eventually support it correctly
     public void whenExecutingTwoParallelQueries_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get;"));
@@ -170,7 +169,7 @@ public class GrpcServerIT {
 
     @Test
     public void whenExecutingAnInvalidQuery_Throw() throws Throwable {
-        try (SynchronousObserver<TxRequest, TxResponse> tx = startTx()) {
+        try (SynchronousObserver tx = startTx()) {
             tx.send(openRequest(session.keyspace(), TxType.Read));
             tx.receive();
             tx.send(execQueryRequest("match $x sub thing; get $y;"));
@@ -181,11 +180,11 @@ public class GrpcServerIT {
         }
     }
 
-    private SynchronousObserver<TxRequest, TxResponse> startTx() {
+    private SynchronousObserver startTx() {
         return SynchronousObserver.create(stub::tx);
     }
 
-    private static List<QueryResult> queryResults(SynchronousObserver<TxRequest, TxResponse> tx) {
+    private static List<QueryResult> queryResults(SynchronousObserver tx) {
         ImmutableList.Builder<QueryResult> results = ImmutableList.builder();
 
         while (true) {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -80,7 +80,7 @@ public class GrpcServerIT {
     private final GraknStub stub = GraknGrpc.newStub(channel);
 
     @Test
-    public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() {
+    public void whenExecutingAndCommittingAQuery_TheQueryIsCommitted() throws InterruptedException {
         try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
@@ -96,7 +96,7 @@ public class GrpcServerIT {
     }
 
     @Test
-    public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() {
+    public void whenExecutingAQueryAndNotCommitting_TheQueryIsNotCommitted() throws InterruptedException {
         try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
             tx.send(openRequest(session.keyspace(), TxType.Write));
             tx.receive();
@@ -110,7 +110,7 @@ public class GrpcServerIT {
     }
 
     @Test
-    public void whenExecutingAQuery_ResultsAreReturned() {
+    public void whenExecutingAQuery_ResultsAreReturned() throws InterruptedException {
         List<QueryResult> results;
 
         try (SynchronousObserver tx = SynchronousObserver.create(stub)) {
@@ -136,7 +136,7 @@ public class GrpcServerIT {
     }
 
     @Test
-    public void whenExecutingTwoSequentialQueries_ResultsAreTheSame() {
+    public void whenExecutingTwoSequentialQueries_ResultsAreTheSame() throws InterruptedException {
         Set<QueryResult> results1;
         Set<QueryResult> results2;
 
@@ -180,7 +180,7 @@ public class GrpcServerIT {
         }
     }
 
-    private static List<QueryResult> queryResults(SynchronousObserver tx) {
+    private static List<QueryResult> queryResults(SynchronousObserver tx) throws InterruptedException {
         ImmutableList.Builder<QueryResult> results = ImmutableList.builder();
 
         while (true) {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -22,7 +22,7 @@ import ai.grakn.GraknSession;
 import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
 import ai.grakn.concept.ConceptId;
-import ai.grakn.engine.rpc.GrpcTestUtil;
+import ai.grakn.grpc.GrpcTestUtil;
 import ai.grakn.grpc.SynchronousObserver;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.rpc.generated.GraknGrpc;

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <module>grakn-client</module>
         <module>grakn-test-tools</module>
         <module>grakn-bootup</module>
+        <module>grakn-grpc</module>
     </modules>
 
     <properties>
@@ -290,6 +291,11 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-graql-shell</artifactId>
+                <version>1.1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>ai.grakn</groupId>
+                <artifactId>grakn-grpc</artifactId>
                 <version>1.1.0-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
                     </exclusion>
                     <exclusion>
                         <groupId>io.netty</groupId>
-                        <artifactId>netty-common</artifactId>
+                        <artifactId>netty-handler</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -667,6 +667,10 @@
                         <groupId>io.dropwizard.metrics</groupId>
                         <artifactId>metrics-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-common</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
# Why is this PR needed?

There was a lot of code and behaviour shared between the gRPC server, server tests, client and client tests. This is a module where we can put it all.

# What does the PR do?

Adds a new module `grakn-grpc` that `grakn-engine` depends on. `grakn-grpc` also includes the gRPC dependencies and plugin that generates gRPC code.

I also took the opportunity to try and simplify the `SynchronousObserver` class. I specialised it to work only with Tx calls to gRPC, so hopefully it is easier to understand now.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

The gRPC client will also use this module in the future.
