### PR TITLE
New HttpController interfaces fed into HttpHandler

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
@@ -19,6 +19,7 @@
 package ai.grakn.engine;
 
 import ai.grakn.GraknConfigKey;
+import ai.grakn.engine.controller.HttpController;
 import ai.grakn.engine.data.RedisWrapper;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.engine.lock.JedisLockProvider;
@@ -38,6 +39,8 @@ import redis.clients.util.Pool;
 import spark.Service;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Static configurator for classes
@@ -46,29 +49,16 @@ import java.io.IOException;
  */
 public class GraknCreator {
 
-    protected final EngineID engineID;
-    protected final Service sparkService;
-    protected final GraknEngineStatus graknEngineStatus;
-    protected final MetricRegistry metricRegistry;
-    protected final GraknConfig graknEngineConfig;
+    private final EngineID engineID;
+    private final Service sparkService;
+    private final GraknEngineStatus graknEngineStatus;
+    private final MetricRegistry metricRegistry;
+    private final GraknConfig graknEngineConfig;
 
-    protected GraknEngineServer graknEngineServer;
-    protected RedisWrapper redisWrapper;
-    protected LockProvider lockProvider;
-    protected EngineGraknTxFactory engineGraknTxFactory;
-
-    /**
-     * @deprecated use {@link GraknCreator#create()}.
-     */
-    @Deprecated
-    public GraknCreator() {
-        engineID = engineId();
-        sparkService = sparkService();
-        graknEngineStatus = graknEngineStatus();
-        metricRegistry = metricRegistry();
-        graknEngineConfig = GraknConfig.create();
-        redisWrapper = RedisWrapper.create(graknEngineConfig);
-    }
+    private GraknEngineServer graknEngineServer;
+    private RedisWrapper redisWrapper;
+    private LockProvider lockProvider;
+    private EngineGraknTxFactory engineGraknTxFactory;
 
     private GraknCreator(
             EngineID id, Service spark, GraknEngineStatus status, MetricRegistry metricRegistry, GraknConfig config,
@@ -82,15 +72,15 @@ public class GraknCreator {
         this.redisWrapper = redisWrapper;
     }
 
-    protected static EngineID engineId() {
+    private static EngineID engineId() {
         return EngineID.me();
     }
 
-    protected static Service sparkService() {
+    private static Service sparkService() {
         return Service.ignite();
     }
 
-    protected static GraknEngineStatus graknEngineStatus() {
+    private static GraknEngineStatus graknEngineStatus() {
         return new GraknEngineStatus();
     }
 
@@ -110,7 +100,7 @@ public class GraknCreator {
         return create(engineId(), sparkService(), graknEngineStatus(), metricRegistry(), config, RedisWrapper.create(config));
     }
 
-    public synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime) throws IOException {
+    public synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime, Collection<HttpController> collaborators) throws IOException {
         if (graknEngineServer == null) {
             Pool<Jedis> jedisPool = redisWrapper.getJedisPool();
             LockProvider lockProvider = instantiateLock(jedisPool);
@@ -121,8 +111,7 @@ public class GraknCreator {
             PostProcessor postProcessor = PostProcessor.create(indexPostProcessor, countPostProcessor);
             int grpcPort = graknEngineConfig.getProperty(GraknConfigKey.GRPC_PORT);
             GrpcServer grpcServer = GrpcServer.create(grpcPort, engineGraknTxFactory);
-            HttpHandler httpHandler = new HttpHandler(graknEngineConfig, sparkService, factory, metricRegistry, graknEngineStatus, postProcessor, grpcServer
-            );
+            HttpHandler httpHandler = new HttpHandler(graknEngineConfig, sparkService, factory, metricRegistry, graknEngineStatus, postProcessor, grpcServer, collaborators);
             BackgroundTaskRunner taskRunner = configureBackgroundTaskRunner(factory, indexPostProcessor);
             graknEngineServer = new GraknEngineServer(graknEngineConfig, factory, lockProvider, graknEngineStatus, redisWrapper, httpHandler, engineID, taskRunner);
             Thread thread = new Thread(graknEngineServer::close, "GraknEngineServer-shutdown");
@@ -131,7 +120,11 @@ public class GraknCreator {
         return graknEngineServer;
     }
 
-    private BackgroundTaskRunner configureBackgroundTaskRunner(EngineGraknTxFactory factory, IndexPostProcessor postProcessor) {
+    public synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime) throws IOException {
+        return instantiateGraknEngineServer(runtime, Collections.emptyList());
+    }
+
+        private BackgroundTaskRunner configureBackgroundTaskRunner(EngineGraknTxFactory factory, IndexPostProcessor postProcessor) {
         PostProcessingTask postProcessingTask = new PostProcessingTask(factory, postProcessor, graknEngineConfig);
         BackgroundTaskRunner taskRunner = new BackgroundTaskRunner(graknEngineConfig);
         taskRunner.register(postProcessingTask);

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/CommitLogController.java
@@ -35,14 +35,13 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author Filipe Peliz Pinto Teixeira
  */
-public class CommitLogController {
+public class CommitLogController implements HttpController {
     private static final ObjectMapper mapper = new ObjectMapper();
     private final PostProcessor postProcessor;
 
-    public CommitLogController(Service spark, PostProcessor postProcessor){
+    public CommitLogController(PostProcessor postProcessor){
         this.postProcessor = postProcessor;
 
-        spark.post(REST.WebPath.COMMIT_LOG_URI, (req, res) -> submitConcepts(req));
     }
 
     @POST
@@ -51,5 +50,10 @@ public class CommitLogController {
         CommitLog commitLog = mapper.readValue(req.body(), CommitLog.class);
         CompletableFuture.allOf(CompletableFuture.runAsync(() -> postProcessor.submit(commitLog))).join();
         return "";
+    }
+
+    @Override
+    public void start(Service spark) {
+        spark.post(REST.WebPath.COMMIT_LOG_URI, (req, res) -> submitConcepts(req));
     }
 }

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/ConceptController.java
@@ -71,20 +71,23 @@ import static org.apache.http.HttpStatus.SC_OK;
  *
  * @author Filipe Peliz Pinto Teixeira
  */
-public class ConceptController {
+public class ConceptController implements HttpController {
     private static final ObjectMapper objectMapper = new ObjectMapper();
     private EngineGraknTxFactory factory;
     private Timer conceptIdGetTimer;
     private Timer labelGetTimer;
     private Timer instancesGetTimer;
 
-    public ConceptController(EngineGraknTxFactory factory, Service spark,
+    public ConceptController(EngineGraknTxFactory factory,
                              MetricRegistry metricRegistry){
         this.factory = factory;
         this.conceptIdGetTimer = metricRegistry.timer(name(ConceptController.class, "concept-by-identifier"));
         this.labelGetTimer = metricRegistry.timer(name(ConceptController.class, "concept-by-label"));
         this.instancesGetTimer = metricRegistry.timer(name(ConceptController.class, "instances-of-type"));
+    }
 
+    @Override
+    public void start(Service spark) {
         spark.get(WebPath.CONCEPT_ID,  this::getConceptById);
         spark.get(WebPath.TYPE_LABEL,  this::getSchemaByLabel);
         spark.get(WebPath.RULE_LABEL,  this::getSchemaByLabel);
@@ -106,7 +109,6 @@ public class ConceptController {
         spark.get(WebPath.TYPE_SUBS, this::getSchemaConceptSubs);
         spark.get(WebPath.ROLE_SUBS, this::getSchemaConceptSubs);
         spark.get(WebPath.RULE_SUBS, this::getSchemaConceptSubs);
-
     }
 
     private String getTypeAttributes(Request request, Response response) throws JsonProcessingException {

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
@@ -95,7 +95,7 @@ import static org.apache.http.HttpStatus.SC_OK;
  *
  * @author Marco Scoppetta, alexandraorth
  */
-public class GraqlController {
+public class GraqlController implements HttpController {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final Logger LOG = LoggerFactory.getLogger(GraqlController.class);
     private static final RetryLogger retryLogger = new RetryLogger();
@@ -107,14 +107,17 @@ public class GraqlController {
     private final Timer executeExplanation;
 
     public GraqlController(
-            EngineGraknTxFactory factory, Service spark, PostProcessor postProcessor, Printer<?> printer, MetricRegistry metricRegistry
+            EngineGraknTxFactory factory, PostProcessor postProcessor, Printer<?> printer, MetricRegistry metricRegistry
     ) {
         this.factory = factory;
         this.postProcessor = postProcessor;
         this.printer = printer;
         this.executeGraql = metricRegistry.timer(name(GraqlController.class, "execute-graql"));
         this.executeExplanation = metricRegistry.timer(name(GraqlController.class, "execute-explanation"));
+    }
 
+    @Override
+    public void start(Service spark) {
         spark.post(REST.WebPath.KEYSPACE_GRAQL, this::executeGraql);
         spark.get(REST.WebPath.KEYSPACE_EXPLAIN, this::explainGraql);
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/HttpController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/HttpController.java
@@ -1,0 +1,32 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine.controller;
+
+import spark.Service;
+
+/**
+ *  Interface implemented by all HTTPControllers
+ *
+ *  @author marcoscoppetta
+ */
+
+public interface HttpController {
+
+    void start(Service spark);
+}

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/SystemController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/SystemController.java
@@ -79,7 +79,7 @@ import static org.apache.http.HttpHeaders.CACHE_CONTROL;
  *
  * @author Filipe Peliz Pinto Teixeira
  */
-public class SystemController {
+public class SystemController implements HttpController {
 
     private static final String PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4";
     private static final String PROMETHEUS = "prometheus";
@@ -94,7 +94,7 @@ public class SystemController {
     private final SystemKeyspace systemKeyspace;
     private final GraknConfig config;
 
-    public SystemController(Service spark, GraknConfig config, SystemKeyspace systemKeyspace,
+    public SystemController(GraknConfig config, SystemKeyspace systemKeyspace,
                             GraknEngineStatus graknEngineStatus, MetricRegistry metricRegistry) {
         this.systemKeyspace = systemKeyspace;
         this.config = config;
@@ -104,16 +104,6 @@ public class SystemController {
         DropwizardExports prometheusMetricWrapper = new DropwizardExports(metricRegistry);
         this.prometheusRegistry = new CollectorRegistry();
         prometheusRegistry.register(prometheusMetricWrapper);
-
-        spark.get(REST.WebPath.ROOT, this::getRoot);
-
-        spark.get(REST.WebPath.KB, (req, res) -> getKeyspaces(res));
-        spark.get(REST.WebPath.KB_KEYSPACE, this::getKeyspace);
-        spark.put(REST.WebPath.KB_KEYSPACE, this::putKeyspace);
-        spark.delete(REST.WebPath.KB_KEYSPACE, this::deleteKeyspace);
-        spark.get(REST.WebPath.METRICS, this::getMetrics);
-        spark.get(REST.WebPath.STATUS, (req, res) -> getStatus());
-        spark.get(REST.WebPath.VERSION, (req, res) -> getVersion());
 
         final TimeUnit rateUnit = TimeUnit.SECONDS;
         final TimeUnit durationUnit = TimeUnit.SECONDS;
@@ -125,6 +115,20 @@ public class SystemController {
                         durationUnit,
                         showSamples,
                         filter));
+    }
+
+    @Override
+    public void start(Service spark) {
+
+        spark.get(REST.WebPath.ROOT, this::getRoot);
+
+        spark.get(REST.WebPath.KB, (req, res) -> getKeyspaces(res));
+        spark.get(REST.WebPath.KB_KEYSPACE, this::getKeyspace);
+        spark.put(REST.WebPath.KB_KEYSPACE, this::putKeyspace);
+        spark.delete(REST.WebPath.KB_KEYSPACE, this::deleteKeyspace);
+        spark.get(REST.WebPath.METRICS, this::getMetrics);
+        spark.get(REST.WebPath.STATUS, (req, res) -> getStatus());
+        spark.get(REST.WebPath.VERSION, (req, res) -> getVersion());
     }
 
     @GET

--- a/grakn-engine/src/test/java/ai/grakn/engine/SystemKeyspaceTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/SystemKeyspaceTest.java
@@ -65,9 +65,7 @@ public class SystemKeyspaceTest {
     // the systemKeyspace is initialised. If we make this a ClassRule that load order is broken and this test fails with
     // the janus profile.
     @Rule
-    public final SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        new SystemController(spark, config, systemKeyspace, status, metricRegistry);
-    }).host("0.0.0.0").port(4567);
+    public final SparkContext sparkContext = SparkContext.withControllers(new SystemController(config, systemKeyspace, status, metricRegistry)).host("0.0.0.0").port(4567);
 
     //Needed to start cass depending on profile
     @ClassRule

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/CommitLogControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/CommitLogControllerTest.java
@@ -46,7 +46,7 @@ public class CommitLogControllerTest {
     private static final PostProcessor postProcessor = mock(PostProcessor.class);
 
     @Rule
-    public final SparkContext sparkContext = SparkContext.withControllers(spark -> new CommitLogController(spark, postProcessor));
+    public final SparkContext sparkContext = SparkContext.withControllers(new CommitLogController(postProcessor));
 
     @Before
     public void resetMock(){

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/ConceptControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/ConceptControllerTest.java
@@ -107,9 +107,9 @@ public class ConceptControllerTest {
 
     public static SessionContext sessionContext = SessionContext.create();
 
-    public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        factory = EngineGraknTxFactory.createAndLoadSystemSchema(mockLockProvider, GraknConfig.create());
-        new ConceptController(factory, spark, new MetricRegistry());
+    public static SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
+        factory = EngineGraknTxFactory.createAndLoadSystemSchema(mockLockProvider, config);
+        new ConceptController(factory, new MetricRegistry()).start(spark);
     });
     @ClassRule
     public static final RuleChain chain = RuleChain.emptyRuleChain().around(sessionContext).around(sparkContext);

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerDeleteTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerDeleteTest.java
@@ -62,9 +62,7 @@ public class GraqlControllerDeleteTest {
     private static final Printer printer = mock(Printer.class);
 
     @ClassRule
-    public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        new GraqlController(mockFactory, spark, postProcessor, printer, new MetricRegistry());
-    });
+    public static SparkContext sparkContext = SparkContext.withControllers(new GraqlController(mockFactory, postProcessor, printer, new MetricRegistry()));
 
     @Before
     public void setupMock(){

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerInsertTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerInsertTest.java
@@ -76,12 +76,12 @@ public class GraqlControllerInsertTest {
     private static final Printer printer = mock(Printer.class);
 
     @ClassRule
-    public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        new GraqlController(mockFactory, spark, postProcessor, printer, new MetricRegistry());
-    });
+    public static SparkContext sparkContext = SparkContext.withControllers(
+            new GraqlController(mockFactory, postProcessor, printer, new MetricRegistry())
+    );
 
     @Before
-    public void setupMock(){
+    public void setupMock() {
         when(mockFactory.tx(eq(keyspace), any())).thenReturn(tx);
         when(tx.keyspace()).thenReturn(keyspace);
         when(printer.graqlString(any())).thenReturn(Json.object().toString());
@@ -99,12 +99,12 @@ public class GraqlControllerInsertTest {
     }
 
     @After
-    public void clearExceptions(){
+    public void clearExceptions() {
         reset(postProcessor);
     }
 
     @Test
-    public void POSTGraqlInsert_InsertWasExecutedOnGraph(){
+    public void POSTGraqlInsert_InsertWasExecutedOnGraph() {
         String queryString = "insert $x isa movie;";
 
         sendRequest(queryString);
@@ -118,7 +118,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTMalformedGraqlQuery_ResponseStatusIs400(){
+    public void POSTMalformedGraqlQuery_ResponseStatusIs400() {
         GraqlSyntaxException syntaxError = GraqlSyntaxException.parsingError("syntax error");
         when(tx.graql().parser().parseQuery("insert $x isa ;")).thenThrow(syntaxError);
 
@@ -129,7 +129,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTMalformedGraqlQuery_ResponseExceptionContainsSyntaxError(){
+    public void POSTMalformedGraqlQuery_ResponseExceptionContainsSyntaxError() {
         GraqlSyntaxException syntaxError = GraqlSyntaxException.parsingError("syntax error");
         when(tx.graql().parser().parseQuery("insert $x isa ;")).thenThrow(syntaxError);
 
@@ -140,7 +140,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTWithNoQueryInBody_ResponseIs400(){
+    public void POSTWithNoQueryInBody_ResponseIs400() {
         Response response = RestAssured.with()
                 .post(REST.resolveTemplate(REST.WebPath.KEYSPACE_GRAQL, "somekb"));
 
@@ -149,7 +149,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlInsert_ResponseStatusIs200(){
+    public void POSTGraqlInsert_ResponseStatusIs200() {
         String query = "insert $x isa person;";
         Response response = sendRequest(query);
 
@@ -157,7 +157,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlDefineNotValid_ResponseStatusCodeIs422(){
+    public void POSTGraqlDefineNotValid_ResponseStatusCodeIs422() {
         GraknTxOperationException exception = GraknTxOperationException.invalidCasting(Object.class, Object.class);
         when(tx.graql().parser().parseQuery("define person plays movie;").execute()).thenThrow(exception);
 
@@ -167,7 +167,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlDefineNotValid_ResponseExceptionContainsValidationErrorMessage(){
+    public void POSTGraqlDefineNotValid_ResponseExceptionContainsValidationErrorMessage() {
         GraknTxOperationException exception = GraknTxOperationException.invalidCasting(Object.class, Object.class);
         when(tx.graql().parser().parseQuery("define person plays movie;").execute()).thenThrow(exception);
 
@@ -177,21 +177,21 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlInsertWithJsonType_ResponseContentTypeIsJson(){
+    public void POSTGraqlInsertWithJsonType_ResponseContentTypeIsJson() {
         Response response = sendRequest("insert $x isa person;");
 
         assertThat(response.contentType(), equalTo(APPLICATION_JSON));
     }
 
     @Test
-    public void POSTGraqlInsertWithJsonType_ResponseIsCorrectJson(){
+    public void POSTGraqlInsertWithJsonType_ResponseIsCorrectJson() {
         when(printer.graqlString(any())).thenReturn(Json.array().toString());
         Response response = sendRequest("insert $x isa person;");
         assertThat(jsonResponse(response).asJsonList().size(), equalTo(0));
     }
 
     @Test
-    public void POSTGraqlDefine_GraphCommitNeverCalled(){
+    public void POSTGraqlDefine_GraphCommitNeverCalled() {
         String query = "define thingy sub entity;";
 
         sendRequest(query);
@@ -200,7 +200,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlDefine_GraphCommitSubmitNoLogsIsCalled(){
+    public void POSTGraqlDefine_GraphCommitSubmitNoLogsIsCalled() {
         String query = "define thingy sub entity;";
 
         verify(tx.admin(), times(0)).commitSubmitNoLogs();
@@ -211,7 +211,7 @@ public class GraqlControllerInsertTest {
     }
 
     @Test
-    public void POSTGraqlInsert_CommitLogsAreSubmitted(){
+    public void POSTGraqlInsert_CommitLogsAreSubmitted() {
         String query = "insert $x isa person has name 'Alice';";
 
         CommitLog commitLog = CommitLog.create(tx.keyspace(), Collections.emptyMap(), Collections.emptyMap());
@@ -222,7 +222,7 @@ public class GraqlControllerInsertTest {
         verify(postProcessor, times(1)).submit(commitLog);
     }
 
-    private Response sendRequest(String query){
+    private Response sendRequest(String query) {
         return RestAssured.with()
                 .queryParam(EXECUTE_WITH_INFERENCE, false)
                 .body(query)

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
@@ -81,10 +81,10 @@ public class GraqlControllerReadOnlyTest {
     public static SampleKBContext sampleKB = MovieKB.context();
 
     @ClassRule
-    public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
+    public static SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
         MetricRegistry metricRegistry = new MetricRegistry();
-        new SystemController(spark, mockFactory.config(), mockFactory.systemKeyspace(), new GraknEngineStatus(), metricRegistry);
-        new GraqlController(mockFactory, spark, mock(PostProcessor.class), printer, metricRegistry);
+        new SystemController(mockFactory.config(), mockFactory.systemKeyspace(), new GraknEngineStatus(), metricRegistry);
+        new GraqlController(mockFactory, mock(PostProcessor.class), printer, metricRegistry).start(spark);
     });
 
     @Before

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerReadOnlyTest.java
@@ -83,7 +83,7 @@ public class GraqlControllerReadOnlyTest {
     @ClassRule
     public static SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
         MetricRegistry metricRegistry = new MetricRegistry();
-        new SystemController(mockFactory.config(), mockFactory.systemKeyspace(), new GraknEngineStatus(), metricRegistry);
+        new SystemController(mockFactory.config(), mockFactory.systemKeyspace(), new GraknEngineStatus(), metricRegistry).start(spark);
         new GraqlController(mockFactory, mock(PostProcessor.class), printer, metricRegistry).start(spark);
     });
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/GraqlControllerTest.java
@@ -98,10 +98,10 @@ public class GraqlControllerTest {
 
     public static SampleKBContext genealogyKB = GenealogyKB.context();
 
-    public static SparkContext sparkContext = SparkContext.withControllers(spark -> {
+    public static SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
         EngineGraknTxFactory factory = EngineGraknTxFactory
                 .createAndLoadSystemSchema(mockLockProvider, GraknConfig.create());
-        new GraqlController(factory, spark, mock(PostProcessor.class), printer, new MetricRegistry());
+        new GraqlController(factory, mock(PostProcessor.class), printer, new MetricRegistry()).start(spark);
     });
 
     @ClassRule

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
@@ -31,9 +31,11 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import spark.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static ai.grakn.engine.HttpHandler.configureSpark;
 
@@ -79,8 +81,10 @@ public class SparkContext extends CompositeTestRule {
         return new SparkContext(createControllers);
     }
 
-    public static SparkContext withControllers(Consumer<Service> createControllers) {
-        return new SparkContext((spark, config) -> createControllers.accept(spark));
+    public static SparkContext withControllers(HttpController ... controllers) {
+        return new SparkContext((spark, config) -> {
+            Stream.of(controllers).forEach(controller -> controller.start(spark));
+        });
     }
 
     public SparkContext port(int port) {

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/SystemControllerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/SystemControllerTest.java
@@ -72,7 +72,7 @@ public class SystemControllerTest {
     @ClassRule
     public static final SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
         SystemControllerTest.config = config;
-        new SystemController(spark, config, systemKeyspace, status, metricRegistry);
+        new SystemController(config, systemKeyspace, status, metricRegistry).start(spark);
     });
 
     @BeforeClass

--- a/grakn-engine/src/test/java/ai/grakn/engine/session/EngineGraknSessionTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/session/EngineGraknSessionTest.java
@@ -64,9 +64,7 @@ public class EngineGraknSessionTest {
 
     //Needed so that Grakn.session() can return a session
     @ClassRule
-    public static final SparkContext sparkContext = SparkContext.withControllers(spark -> {
-        new SystemController(spark, config, systemKeyspace, status, metricRegistry);
-    });
+    public static final SparkContext sparkContext = SparkContext.withControllers(new SystemController(config, systemKeyspace, status, metricRegistry));
 
     //Needed to start cass depending on profile
     @ClassRule

--- a/grakn-engine/src/test/java/ai/grakn/engine/session/RemoteSessionTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/session/RemoteSessionTest.java
@@ -79,10 +79,10 @@ public class RemoteSessionTest {
 
     public static final SessionContext sessionContext = SessionContext.create();
 
-    public static final SparkContext sparkContext = SparkContext.withControllers(spark -> {
+    public static final SparkContext sparkContext = SparkContext.withControllers((spark, config) -> {
         GraknConfig graknConfig = GraknConfig.create();
         EngineGraknTxFactory factory = EngineGraknTxFactory.createAndLoadSystemSchema(mockLockProvider, graknConfig);
-        new SystemController(spark, graknConfig, factory.systemKeyspace(), new GraknEngineStatus(), new MetricRegistry());
+        new SystemController(graknConfig, factory.systemKeyspace(), new GraknEngineStatus(), new MetricRegistry()).start(spark);
     }).port(4567);
 
     @ClassRule


### PR DESCRIPTION
# Why is this PR needed?

So that KBMS does not need to extend any GRAKN open-source classes and we avoid duplicate code and high coupling.

# What does the PR do?

Makes `HttpHandler` accept a list of `HttpController` (new interface) upon construction and executes the `start()` method on each of them when `startHTTP()` method is invoked.

Also removed deprecated constructor in `GraknCreator` for we have replaced inheritance with delegation in KBMS.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

Not for now