### PR TITLE
moving error messages into ErrorMessage class

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -19,6 +19,7 @@
 package ai.grakn.bootup;
 
 import ai.grakn.GraknSystemProperty;
+import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.GraknVersion;
 
 import java.io.IOException;
@@ -55,20 +56,24 @@ public class GraknBootup {
             Path homeStatic = Paths.get(GraknSystemProperty.CURRENT_DIRECTORY.value());
             Path configStatic = Paths.get(GraknSystemProperty.CONFIGURATION_FILE.value());
 
-            if(!Files.exists(homeStatic.resolve("grakn"))) {
-                throw new RuntimeException("Cannot find home folder");
-            }
-            if(!Files.exists(homeStatic)) {
-                throw new RuntimeException("Cannot find config folder");
-            }
+            assertConfigurationCorrect(homeStatic, configStatic);
 
-            newDistGrakn(homeStatic, configStatic).run(args);
+            newGraknBootup(homeStatic, configStatic).run(args);
         } catch (RuntimeException ex) {
             System.out.println("Problem with bash script: cannot run Grakn");
         }
     }
 
-    private static GraknBootup newDistGrakn(Path homePathFolder, Path configPath) {
+    private static void assertConfigurationCorrect(Path homeStatic, Path configStatic) {
+        if (!Files.exists(homeStatic.resolve("grakn"))) {
+            throw new RuntimeException(ErrorMessage.UNABLE_TO_GET_GRAKN_HOME_FOLDER.getMessage());
+        }
+        if (!Files.exists(configStatic)) {
+            throw new RuntimeException(ErrorMessage.UNABLE_TO_GET_GRAKN_CONFIG_FOLDER.getMessage());
+        }
+    }
+
+    private static GraknBootup newGraknBootup(Path homePathFolder, Path configPath) {
         return new GraknBootup(new StorageProcess(homePathFolder),
                 new QueueProcess(homePathFolder),
                 new GraknProcess(homePathFolder, configPath));

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
@@ -23,6 +23,7 @@ import ai.grakn.bootup.graknengine.grakn_pid.GraknPidManager;
 import ai.grakn.bootup.graknengine.grakn_pid.GraknPidManagerFactory;
 import ai.grakn.engine.GraknCreator;
 import ai.grakn.engine.GraknEngineServer;
+import ai.grakn.util.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,7 @@ public class Grakn {
     public static void main(String[] args) {
         try {
             String graknPidFileProperty = Optional.ofNullable(GraknSystemProperty.GRAKN_PID_FILE.value())
-                    .orElseThrow(() -> new RuntimeException("Unable to find the Java system property 'grakn.pidfile'. Don't forget to specify -Dgrakn.pidfile=/path/to/grakn.pid"));
+                    .orElseThrow(() -> new RuntimeException(ErrorMessage.GRAKN_PIDFILE_SYSTEM_PROPERTY_UNDEFINED.getMessage()));
             Path pidfile = Paths.get(graknPidFileProperty);
             GraknPidManager graknPidManager = GraknPidManagerFactory.newGraknPidManagerForUnixOS(pidfile);
             graknPidManager.trackGraknPid();

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/grakn_pid/GraknPidManagerFactory.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/grakn_pid/GraknPidManagerFactory.java
@@ -28,6 +28,9 @@ import java.nio.file.Path;
  *
  */
 public class GraknPidManagerFactory {
+    /*
+     * instantiates a GraknPidManager which supports *nix systems such as Linux and OS X
+     */
     public static GraknPidManager newGraknPidManagerForUnixOS(Path pidfilePath) {
         GraknPidStore graknPidStore = new GraknPidFileStore(pidfilePath);
         GraknPidRetriever graknPidRetriever = new UnixGraknPidRetriever();

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -29,6 +29,12 @@ import javax.annotation.CheckReturnValue;
  * @author Filipe Teixeira
  */
 public enum ErrorMessage {
+    //--------------------------------------------- Bootup Errors -----------------------------------------------
+    GRAKN_PIDFILE_SYSTEM_PROPERTY_UNDEFINED("Unable to find the Java system property 'grakn.pidfile'. Don't forget to specify -Dgrakn.pidfile=/path/to/grakn.pid"),
+    UNABLE_TO_START_GRAKN("Unable to start Grakn"),
+    UNABLE_TO_GET_GRAKN_HOME_FOLDER("Unable to find Grakn home folder"),
+    UNABLE_TO_GET_GRAKN_CONFIG_FOLDER("Unable to find Grakn config folder"),
+
     //--------------------------------------------- Core Errors -----------------------------------------------
     CANNOT_DELETE("Type [%s] cannot be deleted as it still has incoming edges"),
     SUPER_LOOP_DETECTED("By setting the super of concept [%s] to [%s]. You will be creating a loop. This is prohibited"),


### PR DESCRIPTION
# Why is this PR needed?
Minor cleanups.

# What does the PR do?
1. Centralises error messages to `ErrorMessage` class.
2. Extracted assert-style system property sanity check into a single method `assertConfigurationCorrect`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A