### PR TITLE
Fix New Post Processing

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/PostProcessingTask.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/PostProcessingTask.java
@@ -60,10 +60,12 @@ public class PostProcessingTask implements BackgroundTask{
     public void run() {
         Set<Keyspace> kespaces = factory.systemKeyspace().keyspaces();
         kespaces.forEach(keyspace -> {
-            String index = indexPostProcessor.popIndex(keyspace);
-            if(index != null) {
-                threadPool.schedule(() -> processIndex(keyspace, index), postprocessingDelay, TimeUnit.SECONDS);
-            }
+            String index;
+            do{
+                 index = indexPostProcessor.popIndex(keyspace);
+                 final String i = index;
+                 if(index != null) threadPool.schedule(() -> processIndex(keyspace, i), postprocessingDelay, TimeUnit.SECONDS);
+            } while(index != null);
         });
     }
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/PostProcessingTaskTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/PostProcessingTaskTest.java
@@ -71,7 +71,7 @@ public class PostProcessingTaskTest {
     public void whenThereIsSomethingInTheIndexCache_PPStarts() throws InterruptedException {
         //Configure Data For Mocks
         String index1 = "index1";
-        when(indexPostProcessor.popIndex(keyspaceA)).thenReturn(index1);
+        when(indexPostProcessor.popIndex(keyspaceA)).thenReturn(index1).thenReturn(null);
 
         Set<ConceptId> ids = Stream.of("id1", "id2", "id3").map(ConceptId::of).collect(Collectors.toSet());
         when(indexPostProcessor.popIds(keyspaceA, index1)).thenReturn(ids);
@@ -106,7 +106,8 @@ public class PostProcessingTaskTest {
                 thenReturn(index1).
                 thenReturn(index2).
                 thenReturn(index3).
-                thenReturn(index4);
+                thenReturn(index4).
+                thenReturn(null);
 
         Set<ConceptId> ids = Stream.of("id1", "id2", "id3").map(ConceptId::of).collect(Collectors.toSet());
         when(indexPostProcessor.popIds(keyspaceA, index1)).thenReturn(ids);
@@ -121,6 +122,6 @@ public class PostProcessingTaskTest {
         Thread.sleep(config.getProperty(GraknConfigKey.POST_PROCESSOR_DELAY) * 2000);
 
         //Check methods are called
-        verify(indexPostProcessor, Mockito.times(4)).popIds(keyspaceA, any());
+        verify(indexPostProcessor, Mockito.times(4)).mergeDuplicateConcepts(any(), any(), eq(ids));
     }
 }


### PR DESCRIPTION
# Why is this PR needed?

The new PP works but only executes one job per keyspace per second. This means that graph with 10000 attributes will take 10000 seconds to completely post process. That is just dumb. 

# What does the PR do?

Submit multiple jobs for post processing per second rather than just one job.

# Does it break backwards compatibility?

No. 

# List of future improvements not on this PR

Smart job submission. Right now it submits however many jobs there are threads. Ideally it should submit jobs based on load. 
