### PR TITLE
[Stable] Bug #18869: Refine resolution plan to ensure more optimal substitution use

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -32,7 +32,7 @@ import ai.grakn.graql.admin.UnifierComparison;
 import ai.grakn.graql.admin.VarProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.MultiUnifierImpl;
-import ai.grakn.graql.internal.reasoner.ResolutionPlan;
+import ai.grakn.graql.internal.reasoner.plan.SimplePlanner;
 import ai.grakn.graql.internal.reasoner.atom.binary.RelationshipAtom;
 import ai.grakn.graql.internal.reasoner.atom.binary.TypeAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
@@ -100,6 +100,18 @@ public abstract class Atom extends AtomicBase {
                 .findFirst().isPresent();
     }
 
+    /**
+     * @return true if the atom is ground (all variables are bound)
+     */
+    public boolean isGround(){
+        Set<Var> varNames = getVarNames();
+        return Stream.concat(
+                getPredicates(),
+                getInnerPredicates())
+                .map(AtomicBase::getVarName)
+                .allMatch(varNames::contains);
+    }
+
     public abstract Class<? extends VarProperty> getVarPropertyClass();
 
     @Override
@@ -158,21 +170,21 @@ public abstract class Atom extends AtomicBase {
      */
     public int computePriority(Set<Var> subbedVars){
         int priority = 0;
-        priority += Sets.intersection(getVarNames(), subbedVars).size() * ResolutionPlan.PARTIAL_SUBSTITUTION;
-        priority += isRuleResolvable()? ResolutionPlan.RULE_RESOLVABLE_ATOM : 0;
-        priority += isRecursive()? ResolutionPlan.RECURSIVE_ATOM : 0;
+        priority += Sets.intersection(getVarNames(), subbedVars).size() * SimplePlanner.PARTIAL_SUBSTITUTION;
+        priority += isRuleResolvable()? SimplePlanner.RULE_RESOLVABLE_ATOM : 0;
+        priority += isRecursive()? SimplePlanner.RECURSIVE_ATOM : 0;
 
-        priority += getTypeConstraints().count() * ResolutionPlan.GUARD;
+        priority += getTypeConstraints().count() * SimplePlanner.GUARD;
         Set<Var> otherVars = getParentQuery().getAtoms().stream()
                 .filter(a -> a != this)
                 .flatMap(at -> at.getVarNames().stream())
                 .collect(Collectors.toSet());
-        priority += Sets.intersection(getVarNames(), otherVars).size() * ResolutionPlan.BOUND_VARIABLE;
+        priority += Sets.intersection(getVarNames(), otherVars).size() * SimplePlanner.BOUND_VARIABLE;
 
         //inequality predicates with unmapped variable
         priority += getPredicates(NeqPredicate.class)
                 .map(Predicate::getPredicate)
-                .filter(v -> !subbedVars.contains(v)).count() * ResolutionPlan.INEQUALITY_PREDICATE;
+                .filter(v -> !subbedVars.contains(v)).count() * SimplePlanner.INEQUALITY_PREDICATE;
         return priority;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -45,7 +45,7 @@ import ai.grakn.graql.internal.pattern.property.IsaProperty;
 import ai.grakn.graql.internal.pattern.property.RelationshipProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.MultiUnifierImpl;
-import ai.grakn.graql.internal.reasoner.ResolutionPlan;
+import ai.grakn.graql.internal.reasoner.plan.SimplePlanner;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.UnifierType;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
@@ -392,7 +392,7 @@ public class RelationshipAtom extends IsaAtom {
     @Override
     public int computePriority(Set<Var> subbedVars) {
         int priority = super.computePriority(subbedVars);
-        priority += ResolutionPlan.IS_RELATION_ATOM;
+        priority += SimplePlanner.IS_RELATION_ATOM;
         return priority;
     }
 
@@ -846,7 +846,7 @@ public class RelationshipAtom extends IsaAtom {
                         List<RelationPlayer> compatibleRelationPlayers = new ArrayList<>();
                         compatibleRoles.stream()
                                 .filter(childRoleRPMap::containsKey)
-                                .forEach(role -> {
+                                .forEach(role ->
                                     childRoleRPMap.get(role).stream()
                                             //check for inter-type compatibility
                                             .filter(crp -> {
@@ -867,8 +867,8 @@ public class RelationshipAtom extends IsaAtom {
                                                 ValuePredicate childVP = this.getPredicate(crp.getRolePlayer().var(), ValuePredicate.class);
                                                 return matchType.atomicCompatibility(parentVP, childVP);
                                             })
-                                            .forEach(compatibleRelationPlayers::add);
-                                });
+                                            .forEach(compatibleRelationPlayers::add)
+                                );
                         if (!compatibleRelationPlayers.isEmpty()) {
                             compatibleMappingsPerParentRP.add(
                                     compatibleRelationPlayers.stream()

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -39,7 +39,7 @@ import ai.grakn.graql.admin.VarProperty;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.pattern.property.HasAttributeProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
-import ai.grakn.graql.internal.reasoner.ResolutionPlan;
+import ai.grakn.graql.internal.reasoner.plan.SimplePlanner;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.AtomicFactory;
@@ -325,7 +325,7 @@ public class ResourceAtom extends Binary{
 
     private boolean isSuperNode(){
         return tx().graql().match(getCombinedPattern()).admin().stream()
-                .skip(ResolutionPlan.RESOURCE_SUPERNODE_SIZE)
+                .skip(SimplePlanner.RESOURCE_SUPERNODE_SIZE)
                 .findFirst().isPresent();
     }
 
@@ -333,21 +333,21 @@ public class ResourceAtom extends Binary{
     public int computePriority(Set<Var> subbedVars){
         int priority = super.computePriority(subbedVars);
         Set<ai.grakn.graql.ValuePredicate> vps = getPredicates(ValuePredicate.class).map(ValuePredicate::getPredicate).collect(Collectors.toSet());
-        priority += ResolutionPlan.IS_RESOURCE_ATOM;
+        priority += SimplePlanner.IS_RESOURCE_ATOM;
 
         if (vps.isEmpty()) {
             if (subbedVars.contains(getVarName()) || subbedVars.contains(getPredicateVariable())
                     && !isSuperNode()) {
-                    priority += ResolutionPlan.SPECIFIC_VALUE_PREDICATE;
+                    priority += SimplePlanner.SPECIFIC_VALUE_PREDICATE;
             } else{
-                    priority += ResolutionPlan.VARIABLE_VALUE_PREDICATE;
+                    priority += SimplePlanner.VARIABLE_VALUE_PREDICATE;
             }
         } else {
             int vpsPriority = 0;
             for (ai.grakn.graql.ValuePredicate vp : vps) {
                 //vp with a value
                 if (vp.isSpecific() && !isSuperNode()) {
-                    vpsPriority += ResolutionPlan.SPECIFIC_VALUE_PREDICATE;
+                    vpsPriority += SimplePlanner.SPECIFIC_VALUE_PREDICATE;
                 } //vp with a variable
                 else if (vp.getInnerVar().isPresent()) {
                     VarPatternAdmin inner = vp.getInnerVar().orElse(null);
@@ -355,16 +355,16 @@ public class ResourceAtom extends Binary{
                     if (subbedVars.contains(getVarName())
                         || subbedVars.contains(inner.var())
                             && !isSuperNode()) {
-                        vpsPriority += ResolutionPlan.SPECIFIC_VALUE_PREDICATE;
+                        vpsPriority += SimplePlanner.SPECIFIC_VALUE_PREDICATE;
                     } //variable equality
                     else if (vp.equalsValue().isPresent()){
-                        vpsPriority += ResolutionPlan.VARIABLE_VALUE_PREDICATE;
+                        vpsPriority += SimplePlanner.VARIABLE_VALUE_PREDICATE;
                     } //variable inequality
                     else {
-                        vpsPriority += ResolutionPlan.COMPARISON_VARIABLE_VALUE_PREDICATE;
+                        vpsPriority += SimplePlanner.COMPARISON_VARIABLE_VALUE_PREDICATE;
                     }
                 } else {
-                    vpsPriority += ResolutionPlan.NON_SPECIFIC_VALUE_PREDICATE;
+                    vpsPriority += SimplePlanner.NON_SPECIFIC_VALUE_PREDICATE;
                 }
             }
             //normalise
@@ -377,7 +377,7 @@ public class ResourceAtom extends Binary{
                 .filter(at -> at.getVarName().equals(this.getVarName()))
                 .findFirst().isPresent();
 
-        priority += reifiesRelation ? ResolutionPlan.RESOURCE_REIFYING_RELATION : 0;
+        priority += reifiesRelation ? SimplePlanner.RESOURCE_REIFYING_RELATION : 0;
 
         return priority;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/TypeAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/TypeAtom.java
@@ -25,7 +25,7 @@ import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.internal.pattern.property.HasAttributeTypeProperty;
 import ai.grakn.graql.internal.pattern.property.IsaProperty;
-import ai.grakn.graql.internal.reasoner.ResolutionPlan;
+import ai.grakn.graql.internal.reasoner.plan.SimplePlanner;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 
@@ -101,8 +101,8 @@ public abstract class TypeAtom extends Binary{
     @Override
     public int computePriority(Set<Var> subbedVars){
         int priority = super.computePriority(subbedVars);
-        priority += ResolutionPlan.IS_TYPE_ATOM;
-        priority += getSchemaConcept() == null && !isRelation()? ResolutionPlan.NON_SPECIFIC_TYPE_ATOM : 0;
+        priority += SimplePlanner.IS_TYPE_ATOM;
+        priority += getSchemaConcept() == null && !isRelation()? SimplePlanner.NON_SPECIFIC_TYPE_ATOM : 0;
         return priority;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
@@ -1,0 +1,175 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.internal.reasoner.plan;
+
+import ai.grakn.GraknTx;
+import ai.grakn.concept.ConceptId;
+import ai.grakn.graql.admin.Atomic;
+import ai.grakn.graql.admin.Conjunction;
+import ai.grakn.graql.admin.PatternAdmin;
+import ai.grakn.graql.admin.VarProperty;
+import ai.grakn.graql.internal.gremlin.GraqlTraversal;
+import ai.grakn.graql.internal.gremlin.GreedyTraversalPlan;
+import ai.grakn.graql.internal.gremlin.fragment.Fragment;
+import ai.grakn.graql.internal.pattern.Patterns;
+import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.atom.binary.OntologicalAtom;
+import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
+import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ *
+ * <p>
+ * Resolution planner using {@link GreedyTraversalPlan} to establish optimal resolution order..
+ * </p>
+ *
+ * @author Kasper Piskorski
+ *
+ */
+public class GraqlTraversalPlanner {
+
+    /**
+     * @param query for which the plan should be constructed
+     * @return list of atoms in order they should be resolved using {@link GraqlTraversal}.
+     */
+    public static ImmutableList<Atom> plan(ReasonerQueryImpl query){
+        List<Atom> atoms = query.getAtoms(Atom.class)
+                .filter(Atomic::isSelectable)
+                .collect(Collectors.toList());
+        return planFromTraversal(atoms, query.getPattern(), query.tx());
+    }
+
+    /**
+     *
+     * Refined plan procedure:
+     * - establish a list of starting atom candidates based on their substitutions
+     * - create a plan using {@link GreedyTraversalPlan}
+     * - if the graql plan picks an atom that is not a candidate
+     *   - pick an optimal candidate
+     *   - call the procedure on atoms with removed candidate
+     * - otherwise return
+     *
+     * @param query for which the plan should be constructed
+     * @return list of atoms in order they should be resolved using a refined {@link GraqlTraversal} procedure.
+     */
+    public static ImmutableList<Atom> refinedPlan(ReasonerQueryImpl query) {
+        List<Atom> startCandidates = query.getAtoms(Atom.class)
+                .filter(Atomic::isSelectable)
+                .collect(Collectors.toList());
+        Set<IdPredicate> subs = query.getAtoms(IdPredicate.class).collect(Collectors.toSet());
+        return ImmutableList.copyOf(refinedPlan(query, startCandidates, subs));
+    }
+
+    private static Atom optimalCandidate(List<Atom> candidates){
+        return candidates.stream()
+                .sorted(Comparator.comparing(at -> !at.isGround()))
+                .sorted(Comparator.comparing(at -> -at.getPredicates().count()))
+                .findFirst().orElse(null);
+    }
+
+    /**
+     * @param query top level query for which the plan is constructed
+     * @param atoms list of current atoms of interest
+     * @param subs extra substitutions
+     * @return an optimally ordered list of provided atoms
+     */
+    private static List<Atom> refinedPlan(ReasonerQueryImpl query, List<Atom> atoms, Set<IdPredicate> subs){
+        List<Atom> candidates = subs.isEmpty()?
+                atoms :
+                atoms.stream()
+                        .filter(at -> at.getPredicates(IdPredicate.class).findFirst().isPresent())
+                        .collect(Collectors.toList());
+
+        ImmutableList<Atom> initialPlan = planFromTraversal(atoms, atomsToPattern(atoms, subs), query.tx());
+        if (candidates.contains(initialPlan.get(0)) || candidates.isEmpty()) {
+            return initialPlan;
+        } else {
+            Atom first = optimalCandidate(candidates);
+
+            List<Atom> atomsToPlan = new ArrayList<>(atoms);
+            atomsToPlan.remove(first);
+
+            Set<IdPredicate> extraSubs = first.getVarNames().stream()
+                    .filter(v -> !subs.stream().anyMatch(s -> s.getVarName().equals(v)))
+                    .map(v -> new IdPredicate(v, ConceptId.of("placeholderId"), query))
+                    .collect(Collectors.toSet());
+            return Stream.concat(
+                    Stream.of(first),
+                    refinedPlan(query, atomsToPlan, Sets.union(subs, extraSubs)).stream()
+            ).collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * @param atoms of interest
+     * @param subs extra substitutions in the form of id predicates
+     * @return conjunctive pattern composed of atoms + their constraints + subs
+     */
+    private static Conjunction<PatternAdmin> atomsToPattern(List<Atom> atoms, Set<IdPredicate> subs){
+        return Patterns.conjunction(
+                Stream.concat(
+                        atoms.stream().flatMap(at -> Stream.concat(Stream.of(at), at.getNonSelectableConstraints())),
+                        subs.stream()
+                )
+                        .map(Atomic::getCombinedPattern)
+                        .flatMap(p -> p.admin().varPatterns().stream())
+                        .collect(Collectors.toSet())
+        );
+    }
+
+    /**
+     *
+     * @param atoms list of current atoms of interest
+     * @param queryPattern corresponding pattern
+     * @return an optimally ordered list of provided atoms
+     */
+    private static ImmutableList<Atom> planFromTraversal(List<Atom> atoms, PatternAdmin queryPattern, GraknTx tx){
+        Multimap<VarProperty, Atom> propertyMap = HashMultimap.create();
+        atoms.stream()
+                .filter(at -> !(at instanceof OntologicalAtom))
+                .forEach(at -> at.getVarProperties().forEach(p -> propertyMap.put(p, at)));
+        Set<VarProperty> properties = propertyMap.keySet();
+
+        GraqlTraversal graqlTraversal = GreedyTraversalPlan.createTraversal(queryPattern, tx);
+        ImmutableList<Fragment> fragments = graqlTraversal.fragments().iterator().next();
+
+        ImmutableList.Builder<Atom> builder = ImmutableList.builder();
+        builder.addAll(atoms.stream().filter(at -> at instanceof OntologicalAtom).iterator());
+        builder.addAll(fragments.stream()
+                .map(Fragment::varProperty)
+                .filter(Objects::nonNull)
+                .filter(properties::contains)
+                .distinct()
+                .flatMap(p -> propertyMap.get(p).stream())
+                .distinct()
+                .iterator());
+        return builder.build();
+    }
+}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
@@ -1,9 +1,9 @@
 /*
  * Grakn - A Distributed Semantic Database
- * Copyright (C) 2016  Grakn Labs Limited
+ * Copyright (C) 2016-2018 Grakn Labs Limited
  *
  * Grakn is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/SimplePlanner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/SimplePlanner.java
@@ -1,0 +1,129 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016  Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.internal.reasoner.plan;
+
+import ai.grakn.graql.internal.gremlin.GraqlTraversal;
+import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
+import com.google.common.collect.ImmutableList;
+import java.util.Comparator;
+
+/**
+ *
+ * <p>
+ * Simple resolution planner using predefined weights for different {@link Atom} configurations.}.
+ * </p>
+ *
+ * @author Kasper Piskorski
+ *
+ */
+public class SimplePlanner {
+
+    /**
+     * priority modifier for each partial substitution a given atom has
+     */
+    public static final int PARTIAL_SUBSTITUTION = 30;
+
+    /**
+     * priority modifier if a given atom is a resource atom
+     */
+    public static final int IS_RESOURCE_ATOM = 0;
+
+    /**
+     * priority modifier if a given atom is a resource atom attached to a relation
+     */
+    public static final int RESOURCE_REIFYING_RELATION = 20;
+
+    /**
+     * priority modifier if a given atom is a type atom
+     */
+    public static final int IS_TYPE_ATOM = 0;
+
+    /**
+     * priority modifier if a given atom is a relation atom
+     */
+    public static final int IS_RELATION_ATOM = 2;
+
+    /**
+     * priority modifier if a given atom is a type atom without specific type
+     * NB: atom satisfying this criterion should be resolved last
+     */
+    public static final int NON_SPECIFIC_TYPE_ATOM = -1000;
+
+
+    public static final int RULE_RESOLVABLE_ATOM = -10;
+
+    /**
+     * priority modifier if a given atom is recursive atom
+     */
+    public static final int RECURSIVE_ATOM = -5;
+
+    /**
+     * priority modifier for guard (type atom) the atom has
+     */
+    public static final int GUARD = 1;
+
+    /**
+     * priority modifier for guard (type atom) the atom has - favour boundary rather than bulk atoms
+     */
+    public static final int BOUND_VARIABLE = -2;
+
+    /**
+     * priority modifier if an atom has an inequality predicate
+     */
+    public static final int INEQUALITY_PREDICATE = -1000;
+
+    /**
+     * priority modifier for each specific value predicate a given atom (resource) has
+     */
+    public static final int SPECIFIC_VALUE_PREDICATE = 20;
+
+    /**
+     * priority modifier for each non-specific value predicate a given atom (resource) has
+     */
+    public static final int NON_SPECIFIC_VALUE_PREDICATE = 5;
+
+    /**
+     * priority modifier for each value predicate with variable
+     */
+    public static final int VARIABLE_VALUE_PREDICATE = -100;
+
+    /**
+     * number of entities that need to be attached to a resource wtih a specific value to be considered a supernode
+     */
+    public static final int RESOURCE_SUPERNODE_SIZE = 5;
+
+    /**
+     * priority modifier for each value predicate with variable requiring comparison
+     * NB: atom satisfying this criterion should be resolved last
+     */
+    public static final int COMPARISON_VARIABLE_VALUE_PREDICATE = - 1000;
+
+    /**
+     * @param query for which the plan should be constructed
+     * @return list of atoms in order they should be resolved using {@link GraqlTraversal}.
+     */
+    static public ImmutableList<Atom> plan(ReasonerQueryImpl query){
+        return ImmutableList.<Atom>builder().addAll(
+                query.selectAtoms().stream()
+                        .sorted(Comparator.comparing(at -> -at.baseResolutionPriority()))
+                        .iterator())
+                .build();
+    }
+}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/SimplePlanner.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/plan/SimplePlanner.java
@@ -1,9 +1,9 @@
 /*
  * Grakn - A Distributed Semantic Database
- * Copyright (C) 2016  Grakn Labs Limited
+ * Copyright (C) 2016-2018 Grakn Labs Limited
  *
  * Grakn is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
+ * it under the terms of the GNU Affero General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -38,7 +38,7 @@ import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.MultiUnifierImpl;
 import ai.grakn.graql.internal.reasoner.ResolutionIterator;
-import ai.grakn.graql.internal.reasoner.ResolutionPlan;
+import ai.grakn.graql.internal.reasoner.plan.ResolutionPlan;
 import ai.grakn.graql.internal.reasoner.UnifierType;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.AtomicBase;

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
@@ -268,13 +268,16 @@ public class ExplanationTest {
     @Test
     public void testExplanationConsistency(){
         GraknTx genealogyGraph = genealogyKB.tx();
+        final long limit = 3;
         QueryBuilder iqb = genealogyGraph.graql().infer(true);
         String queryString = "match " +
                 "($x, $y) isa cousins;" +
-                "limit 3; get;";
+                "limit " + limit + ";"+
+                "get;";
 
         List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
 
+        assertEquals(answers.size(), limit);
         answers.forEach(answer -> {
             testExplanation(answer);
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -19,6 +19,7 @@
 package ai.grakn.graql.internal.reasoner;
 
 import ai.grakn.GraknTx;
+import ai.grakn.concept.Concept;
 import ai.grakn.concept.Label;
 import ai.grakn.concept.Type;
 import ai.grakn.graql.Var;
@@ -26,6 +27,7 @@ import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.plan.ResolutionPlan;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.test.rule.SampleKBContext;
@@ -37,8 +39,10 @@ import java.util.Set;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static ai.grakn.graql.Graql.var;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 public class ResolutionPlanTest {
@@ -175,6 +179,29 @@ public class ResolutionPlanTest {
             assertTrue(!Sets.intersection(varNames, vars).isEmpty());
             varNames.forEach(vars::add);
         }
+    }
+
+    @Test
+    public void makeSureOptimalOrderPickedWhenResourcesWithSubstitutionsArePresent() {
+        GraknTx testTx = testContext.tx();
+        Concept concept = testTx.graql().match(var("x").isa("baseEntity")).get("x").findAny().orElse(null);
+        String basePatternString =
+                "(role1:$x, role2: $y) isa relation;" +
+                "$x has resource 'this';" +
+                "$y has anotherResource 'that';";
+
+        String xPatternString = "{" +
+                "$x id '" + concept.getId() + "';" +
+                basePatternString +
+                "}";
+        String yPatternString = "{" +
+                "$y id '" + concept.getId() + "';" +
+                basePatternString +
+                "}";
+        ReasonerQueryImpl queryX = ReasonerQueries.create(conjunction(xPatternString, testTx), testTx);
+        ReasonerQueryImpl queryY = ReasonerQueries.create(conjunction(yPatternString, testTx), testTx);
+        assertNotEquals(new ResolutionPlan(queryX).plan().get(0), getAtom(queryX, "anotherResource", testTx));
+        assertNotEquals(new ResolutionPlan(queryY).plan().get(0), getAtom(queryX, "resource", testTx));
     }
 
     private Atom getAtom(ReasonerQueryImpl query, String typeString, GraknTx tx){

--- a/grakn-test-tools/src/main/graql/resolution-plan-test.gql
+++ b/grakn-test-tools/src/main/graql/resolution-plan-test.gql
@@ -5,16 +5,16 @@ define
 role1 sub role;
 role2 sub role;
 
-
 #Entities
 
-entity1 sub entity
+baseEntity sub entity
     plays role1
-    plays role2;
+    plays role2
+    has resource
+    has anotherResource;
 
-entity2 sub entity
-    plays role1
-    plays role2;
+entity1 sub baseEntity;
+entity2 sub baseEntity;
 
 #Relations
 
@@ -32,3 +32,8 @@ yetAnotherRelation sub relationship
 
 resource sub attribute datatype string;
 anotherResource sub attribute datatype string;
+
+insert
+
+$x isa entity1;
+$y isa entity2;


### PR DESCRIPTION
**NB: This refinement is already present on master. Pushing to stable as it makes example queries significantly more performant.**

# Why is this PR needed?
There is a range of queries for which highly suboptimal plans can possibly be constructed.

# What does the PR do?
Introduces resolution plan refinements to ensure most subbed atoms are favoured.

# Does it break backwards compatibility?
No.

# List of future improvements not on this PR
Incorporate key enforcement for resolution tree pruning.
