### PR TITLE
expose metrics registry

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
@@ -84,8 +84,8 @@ public class GraknCreator {
         return new GraknEngineStatus();
     }
 
-    protected static MetricRegistry metricRegistry() {
-        return new MetricRegistry();
+    public MetricRegistry getMetricRegistry() {
+        return metricRegistry;
     }
 
     public static GraknCreator create(
@@ -97,7 +97,7 @@ public class GraknCreator {
 
     public static GraknCreator create() {
         GraknConfig config = GraknConfig.create();
-        return create(engineId(), sparkService(), graknEngineStatus(), metricRegistry(), config, RedisWrapper.create(config));
+        return create(engineId(), sparkService(), graknEngineStatus(), new MetricRegistry(), config, RedisWrapper.create(config));
     }
 
     public synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime, Collection<HttpController> collaborators) throws IOException {

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknCreator.java
@@ -80,8 +80,12 @@ public class GraknCreator {
         return Service.ignite();
     }
 
-    private static GraknEngineStatus graknEngineStatus() {
+    private static GraknEngineStatus newGraknEngineStatus() {
         return new GraknEngineStatus();
+    }
+
+    protected static MetricRegistry newMetricRegistry() {
+        return new MetricRegistry();
     }
 
     public MetricRegistry getMetricRegistry() {
@@ -97,7 +101,7 @@ public class GraknCreator {
 
     public static GraknCreator create() {
         GraknConfig config = GraknConfig.create();
-        return create(engineId(), sparkService(), graknEngineStatus(), new MetricRegistry(), config, RedisWrapper.create(config));
+        return create(engineId(), sparkService(), newGraknEngineStatus(), newMetricRegistry(), config, RedisWrapper.create(config));
     }
 
     public synchronized GraknEngineServer instantiateGraknEngineServer(Runtime runtime, Collection<HttpController> collaborators) throws IOException {


### PR DESCRIPTION
# Why is this PR needed?
We need to expose metrics registry so that KBMS can use the same metrics registry endpoints

# What does the PR do?
1. made a new public method `getMetricRegistry()`
2. renaming method `metricRegistry()` and `graknEngineStatus()` to `newMetricRegistry()` and `newGraknEngineStatus()` respectively, so the intention is clearer

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A