### PR TITLE
Bug 19309: Get redis to stop when not bound to localhost 

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -32,7 +32,7 @@ import java.time.LocalDateTime;
  */
 public class QueueProcess extends AbstractProcessHandler {
     private static final String QUEUE_PROCESS_NAME = "redis-server";
-    private static String CONFIG_LOCATION = "/services/redis/redis.conf";
+    private static final String CONFIG_LOCATION = "/services/redis/redis.conf";
     private static final Path QUEUE_PID = Paths.get(File.separator,"tmp","grakn-queue.pid");
     private static final long QUEUE_STARTUP_TIMEOUT_S = 10;
     private static final String NAME = "Queue";
@@ -115,8 +115,8 @@ public class QueueProcess extends AbstractProcessHandler {
     }
 
     private String getHostFromConfig() {
-        String fileLocation = homePath + CONFIG_LOCATION;
-        return GraknConfig.read(new File(fileLocation)).getProperty(GraknConfigKey.REDIS_BIND);
+        Path fileLocation = Paths.get(homePath.toString(), CONFIG_LOCATION);
+        return GraknConfig.read(fileLocation.toFile()).getProperty(GraknConfigKey.REDIS_BIND);
     }
 
     public void status() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -18,14 +18,13 @@
 
 package ai.grakn.bootup;
 
+import ai.grakn.GraknConfigKey;
+import ai.grakn.engine.GraknConfig;
+
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
-import java.util.Properties;
 
 /**
  *
@@ -117,14 +116,7 @@ public class QueueProcess extends AbstractProcessHandler {
 
     private String getHostFromConfig() {
         String fileLocation = homePath + CONFIG_LOCATION;
-        try (InputStream input = new FileInputStream(fileLocation)){
-            Properties prop = new Properties();
-            prop.load(input);
-            return prop.getProperty("bind");
-        } catch (IOException ex) {
-            System.out.println(String.format("Cannot load config {%s}", fileLocation));
-            throw new RuntimeException(ex);
-        }
+        return GraknConfig.read(new File(fileLocation)).getProperty(GraknConfigKey.REDIS_BIND);
     }
 
     public void status() {

--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -59,6 +59,7 @@ public abstract class GraknConfigKey<T> {
             withDefault(GraknConfigKey::parseCSValue, ImmutableList.of()),
             GraknConfigKey::toStringCSValue
     );
+    public static final GraknConfigKey<String> REDIS_BIND = key("bind");
     public static final GraknConfigKey<String> REDIS_SENTINEL_MASTER =
             key("redis.sentinel.master", withDefault(Function.identity(), "graknmaster"));
     public static final GraknConfigKey<Integer> REDIS_POOL_SIZE = key("redis.pool-size", INT);


### PR DESCRIPTION
# Why is this PR needed?

Without this PR Redis does not stop when not bound to `localhost`

# What does the PR do?

Reads the Redis IP from the config and uses it in killing the redis instance

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Not sure. 
