### PR TITLE
fixed limit-offset bug in dashboard

### DIFF
--- a/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
+++ b/grakn-dashboard/src/components/graqlEditor/graqlEditor.vue
@@ -281,14 +281,19 @@ export default {
       this.state.eventHub.$emit('click-submit', query);
     },
     limitQuery(query){
+      let getRegex = /^(.*;)\s*(get\b.*;)$/;
       let limitedQuery = query;
-      let getPos = query.indexOf('get');
+
       //If there is no `get` the user mistyped the query
-      if(getPos>=0){
-        let getPattern = limitedQuery.slice(getPos);
-        limitedQuery = limitedQuery.slice(0,getPos).trim();
-        if (!(limitedQuery.includes('offset')) && !(limitedQuery.includes('delete'))) { limitedQuery = `${limitedQuery} offset 0;`; }
-        if (!(limitedQuery.includes('limit')) && !(limitedQuery.includes('delete'))) { limitedQuery = `${limitedQuery} limit ${User.getQueryLimit()};`; }
+      if(getRegex.test(query)){
+        let limitRegex = /.*;\s*(limit\b.*?;).*/;
+        let offsetRegex = /.*;\s*(offset\b.*?;).*/;
+        let deleteRegex = /^(.*;)\s*(delete\b.*;)$/;
+        let match = getRegex.exec(query);
+        limitedQuery = match[1];
+        let getPattern = match[2];
+        if (!(offsetRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} offset 0;`; }
+        if (!(limitRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} limit ${User.getQueryLimit()};`; }
         limitedQuery = `${limitedQuery} ${getPattern}`;
       }
 

--- a/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
@@ -93,7 +93,7 @@ public class GraknSessionImpl implements GraknSession {
         //Create commit log submitter if needed
         if(remoteSubmissionNeeded) {
             ThreadFactory namedThreadFactory = new ThreadFactoryBuilder()
-                    .setNameFormat("commit-log-subbmit-%d").build();
+                    .setNameFormat("commit-log-submit-%d").build();
             commitLogSubmitter = Executors.newSingleThreadScheduledExecutor(namedThreadFactory);
             commitLogSubmitter.scheduleAtFixedRate(this::submitLogs, 0, LOG_SUBMISSION_PERIOD, TimeUnit.SECONDS);
         }


### PR DESCRIPTION
# Why is this PR needed?

To fix a bug in dashboard that would autocomplete in a wrong way queries that don't contain `offset` and `limit`.

See [HERE](https://discuss.grakn.ai/t/visualiser-error-when-using-word-target-in-query/662/2).

# What does the PR do?

Uses regex instead of substring

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
No