### PR TITLE
Fix grakn logback (targets stable branch)

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknProcess.java
@@ -79,7 +79,7 @@ public class GraknProcess extends AbstractProcessHandler {
         }
         Stream<File> jars = Stream.of(values);
         File conf = new File(home + File.separator+"conf"+File.separator); // /conf
-        File graknLogback = new File(home + File.separator+"services"+File.separator+"grakn"+File.separator); // services/grakn lib
+        File graknLogback = new File(home + File.separator+"services"+File.separator+"grakn"+File.separator + "server"+File.separator); // services/grakn/server lib
         return ":"+Stream.concat(jars, Stream.of(conf, graknLogback))
                 .filter(f -> !f.getName().contains("slf4j-log4j12"))
                 .map(File::getAbsolutePath)


### PR DESCRIPTION
# Why is this PR needed?
Grakn does not output logs due to misconfiguration

# What does the PR do?
Fix the misconfiguration by pointing to the correct directory containing `logback.xml`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A