### PR TITLE
log uncaught exception

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
@@ -52,6 +52,8 @@ public class Grakn {
      * @param args
      */
     public static void main(String[] args) {
+        Thread.setDefaultUncaughtExceptionHandler(newUncaughtExceptionHandler(LOG));
+
         try {
             String graknPidFileProperty = Optional.ofNullable(GraknSystemProperty.GRAKN_PID_FILE.value())
                     .orElseThrow(() -> new RuntimeException(ErrorMessage.GRAKN_PIDFILE_SYSTEM_PROPERTY_UNDEFINED.getMessage()));
@@ -62,9 +64,13 @@ public class Grakn {
             // Start Engine
             GraknEngineServer graknEngineServer = GraknCreator.create().instantiateGraknEngineServer(Runtime.getRuntime());
             graknEngineServer.start();
-        } catch (IOException | RuntimeException e) {
-            LOG.error("An exception has occurred", e);
+        } catch (IOException e) {
+            LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(), e);
         }
+    }
+
+    private static Thread.UncaughtExceptionHandler newUncaughtExceptionHandler(Logger logger) {
+        return (Thread t, Throwable e) -> logger.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(t.getName()), e);
     }
 }
 

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -34,6 +34,7 @@ public enum ErrorMessage {
     UNABLE_TO_START_GRAKN("Unable to start Grakn"),
     UNABLE_TO_GET_GRAKN_HOME_FOLDER("Unable to find Grakn home folder"),
     UNABLE_TO_GET_GRAKN_CONFIG_FOLDER("Unable to find Grakn config folder"),
+    UNCAUGHT_EXCEPTION("Uncaught exception at thread [%s]"),
 
     //--------------------------------------------- Core Errors -----------------------------------------------
     CANNOT_DELETE("Type [%s] cannot be deleted as it still has incoming edges"),


### PR DESCRIPTION
# Why is this PR needed?
Grakn will log `IOException` and `RuntimeException`, but fails silently in case of other types of exception.

# What does the PR do?
Add a `setDefaultUncaughtExceptionHandler`. 

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A