### PR TITLE
marking a constructor argument as @Nullable. Adding method javadocs.

### DIFF
--- a/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
@@ -39,6 +39,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.Objects;
@@ -82,7 +83,14 @@ public class GraknSessionImpl implements GraknSession {
     private GraknTxAbstract<?> tx = null;
     private GraknTxAbstract<?> txBatch = null;
 
-    GraknSessionImpl(Keyspace keyspace, String engineUri, GraknConfig config, boolean remoteSubmissionNeeded){
+    /**
+     * Instantiates {@link GraknSessionImpl}
+     * @param keyspace to which keyspace the session should be bound to
+     * @param engineUri to which Engine the session should be bound to
+     * @param config config to be used. If null is supplied, it will be created
+     * @param remoteSubmissionNeeded whether to create a background task which submits commit logs periodically
+     */
+    GraknSessionImpl(Keyspace keyspace, String engineUri, @Nullable GraknConfig config, boolean remoteSubmissionNeeded){
         Objects.requireNonNull(keyspace);
         Objects.requireNonNull(engineUri);
 
@@ -115,11 +123,27 @@ public class GraknSessionImpl implements GraknSession {
         return commitLogHandler;
     }
 
+    /**
+     * This methods creates a {@link GraknSessionImpl} object for the remote API.
+     * A user should not call this method directly.
+     * See {@link Grakn#session(String, String)} for creating a {@link GraknSession} for the remote API
+     * @param keyspace
+     * @param engineUri
+     * @return
+     */
     @SuppressWarnings("unused")//This must remain public because it is accessed via reflection
     public static GraknSessionImpl create(Keyspace keyspace, String engineUri){
         return new GraknSessionImpl(keyspace, engineUri, null, true);
     }
 
+    /**
+     * Creates a {@link GraknSessionImpl} specific for internal use (within Engine).
+     * See {@link Grakn#session(String, String)} for creating a {@link GraknSession} for the remote API
+     * @param keyspace
+     * @param engineUri
+     * @param config
+     * @return
+     */
     public static GraknSessionImpl createEngineSession(Keyspace keyspace, String engineUri, GraknConfig config){
         return new GraknSessionImpl(keyspace, engineUri, config, false);
     }

--- a/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/GraknSessionImpl.java
@@ -127,9 +127,6 @@ public class GraknSessionImpl implements GraknSession {
      * This methods creates a {@link GraknSessionImpl} object for the remote API.
      * A user should not call this method directly.
      * See {@link Grakn#session(String, String)} for creating a {@link GraknSession} for the remote API
-     * @param keyspace
-     * @param engineUri
-     * @return
      */
     @SuppressWarnings("unused")//This must remain public because it is accessed via reflection
     public static GraknSessionImpl create(Keyspace keyspace, String engineUri){
@@ -139,10 +136,6 @@ public class GraknSessionImpl implements GraknSession {
     /**
      * Creates a {@link GraknSessionImpl} specific for internal use (within Engine).
      * See {@link Grakn#session(String, String)} for creating a {@link GraknSession} for the remote API
-     * @param keyspace
-     * @param engineUri
-     * @param config
-     * @return
      */
     public static GraknSessionImpl createEngineSession(Keyspace keyspace, String engineUri, GraknConfig config){
         return new GraknSessionImpl(keyspace, engineUri, config, false);


### PR DESCRIPTION
# Why is this PR needed?
Adding method-level Javadocs also to get myself familiar with the code.

# What does the PR do?
1. Marking the constructor argument `config`  `@Nullable`
2. Adding method-level Javadocs

# Does it break backwards compatibility?
No. I am marking the constructor argument `config`  `@Nullable`, which shouldn't break any compatibility.

# List of future improvements not on this PR
N/A