### PR TITLE
Allow skipping `sub rule` when defining rules

### DIFF
--- a/docs/pages/academy/5-reasoner/2-inference-rules.md
+++ b/docs/pages/academy/5-reasoner/2-inference-rules.md
@@ -27,7 +27,7 @@ From a syntax point of view, to define a new rule, you will need something like 
 
 ```
 define
-RULE_LABEL sub rule,
+RULE_LABEL
 
   when {
         PRECONDITIONS

--- a/docs/pages/docs/1-knowledge-model/inference.md
+++ b/docs/pages/docs/1-knowledge-model/inference.md
@@ -36,7 +36,7 @@ define
   located-in sub relationship,
     relates located-subject, relates subject-location;
 
-  transitive-location sub rule,
+  transitive-location
     when {
       ($x, $y) isa located-in;
       ($y, $z) isa located-in;

--- a/docs/pages/docs/2-building-schema/defining-rules.md
+++ b/docs/pages/docs/2-building-schema/defining-rules.md
@@ -48,7 +48,7 @@ The implication form of Horn clauses aligns more naturally with Graql semantics 
 In Graql we refer to the body of the rule as the "when" of the rule (antecedent of the implication) and the head as the "then" of the rule (consequent of the implication). Therefore, in Graql terms, we define rule objects in the following way:
 
 ```graql-test-ignore
-optional-label sub rule,
+optional-label
 when {
     ...;
     ...;
@@ -68,7 +68,7 @@ A classic reasoning example is the ancestor example. The two Graql rules `R1` an
 ```graql
 define
 
-R1 sub rule,
+R1
 when {
     (parent: $p, child: $c) isa Parent;
 },
@@ -76,7 +76,7 @@ then {
     (ancestor: $p, descendant: $c) isa Ancestor;
 };
 
-R2 sub rule,
+R2
 when {
     (parent: $p, child: $c) isa Parent;
     (ancestor: $c, descendant: $d) isa Ancestor;

--- a/docs/pages/docs/7-java-library/core-api.md
+++ b/docs/pages/docs/7-java-library/core-api.md
@@ -241,7 +241,7 @@ Rules can be added to the knowledge base both through the Core API as well as th
 ```graql
 define
 
-R1 sub rule,
+R1
 when {
     (parent: $p, child: $c) isa Parent;
 },
@@ -249,7 +249,7 @@ then {
     (ancestor: $p, descendant: $c) isa Ancestor;
 };
 
-R2 sub rule,
+R2
 when {
     (parent: $p, child: $c) isa Parent;
     (ancestor: $c, descendant: $d) isa Ancestor;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ThenProperty.java
@@ -54,7 +54,8 @@ public abstract class ThenProperty extends RuleProperty {
     @Override
     public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
-            executor.builder(var).then(pattern());
+            // This allows users to skip stating `$ruleVar sub rule` when they say `$ruleVar then { ... }`
+            executor.builder(var).isRule().then(pattern());
         };
 
         return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/WhenProperty.java
@@ -53,7 +53,8 @@ public abstract class WhenProperty extends RuleProperty {
     @Override
     public Collection<PropertyExecutor> define(Var var) throws GraqlQueryException {
         PropertyExecutor.Method method = executor -> {
-            executor.builder(var).when(pattern());
+            // This allows users to skip stating `$ruleVar sub rule` when they say `$ruleVar when { ... }`
+            executor.builder(var).isRule().when(pattern());
         };
 
         return ImmutableSet.of(PropertyExecutor.builder(method).produces(var).build());

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/runner/ConceptBuilder.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/runner/ConceptBuilder.java
@@ -136,6 +136,10 @@ public class ConceptBuilder {
         return set(IS_ROLE, Unit.INSTANCE);
     }
 
+    public ConceptBuilder isRule() {
+        return set(IS_RULE, Unit.INSTANCE);
+    }
+
     public ConceptBuilder label(Label label) {
         return set(LABEL, label);
     }
@@ -224,6 +228,19 @@ public class ConceptBuilder {
             }
 
             concept = role;
+        } else if (has(IS_RULE)) {
+            use(IS_RULE);
+
+            Label label = use(LABEL);
+            Pattern when = use(WHEN);
+            Pattern then = use(THEN);
+            Rule rule = executor.tx().putRule(label, when, then);
+
+            if (has(SUPER_CONCEPT)) {
+                setSuper(rule, use(SUPER_CONCEPT));
+            }
+
+            concept = rule;
         } else if (has(SUPER_CONCEPT)) {
             concept = putSchemaConcept();
         } else if (has(TYPE)) {
@@ -282,6 +299,7 @@ public class ConceptBuilder {
     private static final BuilderParam<Pattern> WHEN = BuilderParam.of(WhenProperty.NAME);
     private static final BuilderParam<Pattern> THEN = BuilderParam.of(ThenProperty.NAME);
     private static final BuilderParam<Unit> IS_ROLE = BuilderParam.of("role");
+    private static final BuilderParam<Unit> IS_RULE = BuilderParam.of("rule");
 
     /**
      * Class with no fields and exactly one instance.

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
@@ -32,19 +32,19 @@ import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarPattern;
 import ai.grakn.graql.admin.Answer;
-import ai.grakn.test.rule.SampleKBContext;
-import ai.grakn.test.rule.SessionContext;
 import ai.grakn.test.kbs.DiagonalKB;
 import ai.grakn.test.kbs.LinearTransitivityMatrixKB;
 import ai.grakn.test.kbs.PathTreeKB;
 import ai.grakn.test.kbs.TransitivityChainKB;
 import ai.grakn.test.kbs.TransitivityMatrixKB;
+import ai.grakn.test.rule.SampleKBContext;
+import ai.grakn.test.rule.SessionContext;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -100,7 +100,6 @@ public class BenchmarkTests {
                 Var toVar = Graql.var().asUserDefined();
                 VarPattern rulePattern = Graql
                         .label("rule" + i)
-                        .sub("rule")
                         .when(
                                 Graql.and(
                                         Graql.var()

--- a/grakn-test-tools/src/main/graql/admission-rules.gql
+++ b/grakn-test-tools/src/main/graql/admission-rules.gql
@@ -4,18 +4,18 @@ define
 ##########Language requirement###########
 #########################################
 
-rule-1 sub rule,
+rule-1
 when {$x isa applicant;
 $x has degreeOrigin 'US';
 $x has TOEFL >499;},
 then {$x has languageRequirement 'satisfied';};
 
-rule-2 sub rule,
+rule-2
 when {$x isa applicant;
 $x has degreeOrigin 'nonUS';},
 then {$x has languageRequirement 'unsatisfied';};
 
-rule-3 sub rule,
+rule-3
 when {$x isa applicant;
 $x has TOEFL <500;},
 then {$x has languageRequirement 'unsatisfied';};
@@ -25,12 +25,12 @@ then {$x has languageRequirement 'unsatisfied';};
 ##########Consider GPR###########
 #########################################
 
-rule-4 sub rule,
+rule-4
 when {$x isa applicant;
 $x has priorGraduateWork 'none';},
 then {$x has considerGPR 'true';};
 
-rule-5 sub rule,
+rule-5
 when {$x isa applicant;
 $x has priorGraduateWork 'completed';
 $x has GPR >2.99;},
@@ -40,13 +40,13 @@ then {$x has considerGPR 'true';};
 ##################Decision###############
 #########################################
 
-rule-6 sub rule,
+rule-6
 when {$x isa applicant;
 $x has languageRequirement 'satisfied';
 $x has transcript 'available';},
 then {$x has decisionType 'full';};
 
-rule-7 sub rule,
+rule-7
 when {$x isa applicant;
 $x has languageRequirement 'satisfied';
 $x has transcript 'unavailable';},
@@ -56,13 +56,13 @@ then {$x has decisionType 'conditional';};
 #############Conditional evaluation######
 #########################################
 
-rule-8 sub rule,
+rule-8
 when {$x isa applicant;
 $x has GPR >3.29;
 $x has specialHonours 'honour student';},
 then {$x has admissionStatus 'conditional';};
 
-rule-9 sub rule,
+rule-9
 when {$x isa applicant;
 $x has decisionType 'conditional';
 $x has specialHonours 'none';
@@ -74,7 +74,7 @@ then {$x has admissionStatus 'conditional';};
 ##############Admission accepted##############
 ##########################################
 
-rule-10 sub rule,
+rule-10
 when {$x isa applicant;
 $x has decisionType 'full';
 $x has considerGPR 'true';
@@ -84,14 +84,14 @@ $x has GRE >1099;
 $x has vGRE >399;},
 then {$x has admissionStatus 'full';};
 
-rule-11 sub rule,
+rule-11
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.99;
 $x has specialHonours !='none';},
 then {$x has admissionStatus 'full';};
 
-rule-12 sub rule,
+rule-12
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.99;
@@ -104,14 +104,14 @@ then {$x has admissionStatus 'admit at department\'s discretion';};
 #############Wait for transcript######
 #########################################
 
-rule-13 sub rule,
+rule-13
 when {$x isa applicant;
 $x has decisionType 'conditional';
 $x has specialHonours 'none';
 $x has GRE <1100;},
 then {$x has admissionStatus 'wait for transcript';};
 
-rule-14 sub rule,
+rule-14
 when {$x isa applicant;
 $x has decisionType 'conditional';
 $x has GPR <3.3;},
@@ -122,30 +122,30 @@ then {$x has admissionStatus 'wait for transcript';};
 #########Admission denied#########
 #########################################
 
-rule-15 sub rule,
+rule-15
 when {$x isa applicant;
 $x has languageRequirement 'unsatisfied';},
 then {$x has admissionStatus 'denied';};
 
-rule-16 sub rule,
+rule-16
 when {$x isa applicant;
 $x has considerGPR 'true';$x has GPR <2.5;},
 then {$x has admissionStatus 'denied';};
 
-rule-17 sub rule,
+rule-17
 when {$x isa applicant;
 $x has priorGraduateWork 'completed';
 $x has GPR <3.0;},
 then {$x has admissionStatus 'denied';};
 
-rule-18 sub rule,
+rule-18
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.49;
 $x has GRE <900;},
 then {$x has admissionStatus 'denied';};
 
-rule-19 sub rule,
+rule-19
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has specialHonours 'none';
@@ -157,7 +157,7 @@ then {$x has admissionStatus 'denied';};
 ##############Provisional admission##############
 #########################################
 
-rule-20 sub rule,
+rule-20
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.49;
@@ -167,7 +167,7 @@ $x has GRE <1100;
 $x has vGRE <400;},
 then {$x has admissionStatus 'provisional with English remediation';};
 
-rule-21 sub rule,
+rule-21
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.99;
@@ -177,7 +177,7 @@ $x has GRE <1100;
 $x has vGRE >399;},
 then {$x has admissionStatus 'provisional';};
 
-rule-22 sub rule,
+rule-22
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.49;
@@ -187,7 +187,7 @@ $x has GRE >899;
 $x has vGRE <400;},
 then {$x has admissionStatus 'provisional with English remediation';};
 
-rule-23 sub rule,
+rule-23
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.49;

--- a/grakn-test-tools/src/main/graql/ancestor-friend-test.gql
+++ b/grakn-test-tools/src/main/graql/ancestor-friend-test.gql
@@ -47,13 +47,13 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (friend: $x, friend: $y) isa Friend;},
 then {
 (ancestor: $x, ancestor-friend: $y) isa Ancestor-friend;};
 
-rule-2 sub rule,
+rule-2
 when {
 (parent: $x, child: $z) isa Parent;
 (ancestor: $z, ancestor-friend: $y) isa Ancestor-friend;},

--- a/grakn-test-tools/src/main/graql/ancestor-test.gql
+++ b/grakn-test-tools/src/main/graql/ancestor-test.gql
@@ -48,14 +48,14 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (parent: $x, child: $z) isa Parent;
 (ancestor: $z, descendant: $y) isa Ancestor;},
 then {
 (ancestor: $x, descendant: $y) isa Ancestor;};
 
-rule-2 sub rule,
+rule-2
 when {
 (parent: $x, child: $y) isa Parent;},
 then {

--- a/grakn-test-tools/src/main/graql/dualLinearTransitivity.gql
+++ b/grakn-test-tools/src/main/graql/dualLinearTransitivity.gql
@@ -55,33 +55,33 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (R1-from: $x, R1-to: $y) isa R1;},
 then {
 (Q1-from: $x, Q1-to: $y) isa Q1;};
 
-rule-2 sub rule,
+rule-2
 when {
 (R1-from: $x, R1-to: $z) isa R1;
 (Q1-from: $z, Q1-to: $y) isa Q1;},
 then {
 (Q1-from: $x, Q1-to: $y) isa Q1;};
 
-rule-3 sub rule,
+rule-3
 when {
 (R2-from: $x, R2-to: $y) isa R2;},
 then {
 (Q2-from: $x, Q2-to: $y) isa Q2;};
 
-rule-4 sub rule,
+rule-4
 when {
 (R2-from: $x, R2-to: $z) isa R2;
 (Q2-from: $z, Q2-to: $y) isa Q2;},
 then {
 (Q2-from: $x, Q2-to: $y) isa Q2;};
 
-rule-5 sub rule,
+rule-5
 when {
 (Q1-from: $x, Q1-to: $y) isa Q1;},
 then {

--- a/grakn-test-tools/src/main/graql/ldbc-snb-rule-test.gql
+++ b/grakn-test-tools/src/main/graql/ldbc-snb-rule-test.gql
@@ -1,6 +1,6 @@
 define
 
-rule-1 sub rule,
+rule-1
 when {$x isa person;
 $t isa tag;$t has name 'Ludwig van Beethoven';
 ($x, $t) isa tagging;
@@ -8,7 +8,7 @@ $y isa product;$y has name 'Nocturnes';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-2 sub rule,
+rule-2
 when {$x isa person;
 $t isa tag;$t has name 'Roger Waters';
 ($x, $t) isa tagging;
@@ -16,7 +16,7 @@ $y isa tag;$y has name 'Pink Floyd';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-3 sub rule,
+rule-3
 when {$x isa person;
 $x has gender 'male';$x has age >=18;
 $y isa product;$y has min-age >=18;

--- a/grakn-test-tools/src/main/graql/ldbc-snb-rules-transitivity.gql
+++ b/grakn-test-tools/src/main/graql/ldbc-snb-rules-transitivity.gql
@@ -1,13 +1,13 @@
 insert
 
-"R1" sub rule,
+"R1"
 when {
 ($x, $y) isa resides;
 (member-location $y, container-location $z) isa sublocate},
 then {($x, $z) isa resides};
 
 # transitivity of sublocate
-"R2" sub rule,
+"R2"
 when {
 (member-location $x, container-location $y) isa sublocate;
 (member-location $y, container-location $z) isa sublocate},

--- a/grakn-test-tools/src/main/graql/ldbc-snb-rules.gql
+++ b/grakn-test-tools/src/main/graql/ldbc-snb-rules.gql
@@ -1,25 +1,25 @@
 define
 
 #transitivity of resides & sublocate
-rule-1 sub rule,
+rule-1
 when {(located-subject: $x, subject-location: $y) isa resides;
 (member-location: $y, container-location: $z) isa sublocate;
 },
 then {(located-subject: $x, subject-location: $z) isa resides;};
 
 # transitivity of sublocate
-rule-2 sub rule,
+rule-2
 when {
 (member-location: $x, container-location: $y) isa sublocate;
 (member-location: $y, container-location: $z) isa sublocate;
 },
 then {(member-location: $x, container-location: $z) isa sublocate;};
 
-rule-3 sub rule,
+rule-3
 when {(moderator: $x, moderated: $y) isa moderates;},
 then {(forum-member: $x, membered-forum: $y) isa membership;};
 
-rule-4 sub rule,
+rule-4
 when {$x isa person;
 $t1 isa tag;$t1 has name 'Ennio Morricone';
 $t2 isa tag;$t2 has name 'John Wayne';
@@ -30,7 +30,7 @@ $y has name 'The Good the Bad the Ugly';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-5 sub rule,
+#rule-5
 #when {$x isa person;
 #$t isa tag;{$t has name 'Ozzy Osbourne';} or {$t has name 'Rising Force';};
 #($x, $t) isa tagging;
@@ -39,7 +39,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-6 sub rule,
+rule-6
 when {$x isa person;
 $t isa tag;$t has name 'Ozzy Osbourne';
 ($x, $t) isa tagging;
@@ -48,7 +48,7 @@ $y has name 'Blizzard of Ozz';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-7 sub rule,
+rule-7
 when {$x isa person;
 $t isa tag;$t has name 'Ozzy Osbourne';
 ($x, $t) isa tagging;
@@ -57,7 +57,7 @@ $y has name 'Stratocaster';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-8 sub rule,
+rule-8
 when {$x isa person;
 $t isa tag;$t has name 'Rising Force';
 ($x, $t) isa tagging;
@@ -66,7 +66,7 @@ $y has name 'Blizzard of Ozz';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-9 sub rule,
+rule-9
 when {$x isa person;
 $t isa tag;$t has name 'Rising Force';
 ($x, $t) isa tagging;
@@ -75,7 +75,7 @@ $y has name 'Stratocaster';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-10 sub rule,
+rule-10
 when {$x isa person;
 $x has gender 'male';$x has age >=18;
 $y isa product;$y has min-age >=18;
@@ -84,7 +84,7 @@ $z isa country;$z has name 'Italy';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-11 sub rule,
+#rule-11
 #when {$x isa person;
 #$t isa tag;{$t has name 'Ludwig van Beethoven';} or {$t has name 'Johann Sebastian Bach';} or {$t has name 'Wolfgang Amadeus Mozart';};
 #($x, $t) isa tagging;
@@ -92,7 +92,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-12 sub rule,
+rule-12
 when {$x isa person;
 $t isa tag;$t has name 'Ludwig van Beethoven';
 ($x, $t) isa tagging;
@@ -100,7 +100,7 @@ $y isa product;$y has name 'Nocturnes';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-13 sub rule,
+rule-13
 when {$x isa person;
 $t isa tag;$t has name 'Johann Sebastian Bach';
 ($x, $t) isa tagging;
@@ -108,7 +108,7 @@ $y isa product;$y has name 'Nocturnes';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-14 sub rule,
+rule-14
 when {$x isa person;
 $t isa tag;$t has name 'Wolfgang Amadeus Mozart';
 ($x, $t) isa tagging;
@@ -116,7 +116,7 @@ $y isa product;$y has name 'Nocturnes';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-15 sub rule,
+rule-15
 when {$x isa person;
 $t isa tag;$t has name 'Roger Waters';
 ($x, $t) isa tagging;
@@ -128,7 +128,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 ##################Writer->Book######################
 #############################################
 
-#rule-16 sub rule,
+#rule-16
 #when {
 #$x isa person;$t isa tag;
 #($x, $t) isa tagging;
@@ -140,7 +140,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #then {
 #(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-17 sub rule,
+rule-17
 when {$x isa person;
 $t isa tag;$t has name 'H. G. Wells';
 ($x, $t) isa tagging;
@@ -148,7 +148,7 @@ $y isa product;$y has name 'War of the Worlds';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-18 sub rule,
+rule-18
 when {$x isa person;
 $t isa tag;$t has name 'Fyodor Dostoyevsky';
 ($x, $t) isa tagging;
@@ -156,7 +156,7 @@ $y isa product;$y has name 'Crime and Punishment';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-19 sub rule,
+rule-19
 when {$x isa person;
 $t isa tag;$t has name 'George Orwell';
 ($x, $t) isa tagging;
@@ -164,7 +164,7 @@ $y isa product;$y has name 'Animal Farm';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-20 sub rule,
+rule-20
 when {$x isa person;
 $t isa tag;$t has name 'Lewis Carroll';
 ($x, $t) isa tagging;
@@ -172,7 +172,7 @@ $y isa product;$y has name 'Adventures in Wonderland';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-21 sub rule,
+rule-21
 when {$x isa person;
 $t isa tag;$t has name 'Agatha Christie';
 ($x, $t) isa tagging;
@@ -180,7 +180,7 @@ $y isa product;$y has name 'Orient Express';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-22 sub rule,
+rule-22
 when {$x isa person;
 $t isa tag;$t has name 'Hans Christian Andersen';
 ($x, $t) isa tagging;
@@ -188,7 +188,7 @@ $y isa product;$y has name 'Fairy Tales';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-23 sub rule,
+rule-23
 when {$x isa person;
 $t isa tag;$t has name 'Terry Pratchett';
 ($x, $t) isa tagging;
@@ -196,7 +196,7 @@ $y isa product;$y has name 'Colour of Magic';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-24 sub rule,
+rule-24
 when {$x isa person;
 $t isa tag;$t has name 'P. G. Wodehouse';
 ($x, $t) isa tagging;
@@ -204,7 +204,7 @@ $y isa product;$y has name 'My Man Jeeves';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-25 sub rule,
+rule-25
 when {$x isa person;
 $t isa tag;$t has name 'Oscar Wilde';
 ($x, $t) isa tagging;
@@ -212,7 +212,7 @@ $y isa product;$y has name 'Dorian Gray';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-26 sub rule,
+rule-26
 when {$x isa person;
 $t isa tag;$t has name 'J. R. R. Tolkien';
 ($x, $t) isa tagging;
@@ -220,7 +220,7 @@ $y isa product;$y has name 'Lord of the Rings';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-27 sub rule,
+rule-27
 when {$x isa person;
 $t isa tag;$t has name 'J. K. Rowling';
 ($x, $t) isa tagging;
@@ -228,7 +228,7 @@ $y isa product;$y has name 'Harry Potter';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-28 sub rule,
+rule-28
 when {$x isa person;
 $t isa tag;$t has name 'Arthur Conan Doyle';
 ($x, $t) isa tagging;
@@ -236,7 +236,7 @@ $y isa product;$y has name 'Sherlock Holmes';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-29 sub rule,
+rule-29
 when {$x isa person;
 $t isa tag;$t has name 'Ernest Hemingway';
 ($x, $t) isa tagging;
@@ -244,7 +244,7 @@ $y isa product;$y has name 'For Whom the Bell Tolls';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-30 sub rule,
+rule-30
 when {$x isa person;
 $t isa tag;$t has name 'John Steinbeck';
 ($x, $t) isa tagging;
@@ -252,7 +252,7 @@ $y isa product;$y has name 'Of Mice and Men';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-31 sub rule,
+rule-31
 when {$x isa person;
 $t isa tag;$t has name 'Franz Kafka';
 ($x, $t) isa tagging;
@@ -260,7 +260,7 @@ $y isa product;$y has name 'Trial';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-32 sub rule,
+rule-32
 when {$x isa person;
 $t isa tag;$t has name 'Johann Wolfgang von Goethe';
 ($x, $t) isa tagging;
@@ -272,7 +272,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 ##############MusicalArtist->Band############
 #############################################
 
-rule-33 sub rule,
+rule-33
 when {$x isa person;
 $t isa tag;$t has name 'Ozzy Osbourne';
 ($x, $t) isa tagging;
@@ -280,7 +280,7 @@ $y isa tag;$y has name 'Black Sabbath';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-34 sub rule, # lol
+#rule-34 # lol
 #when {$x isa person;
 #$t isa tag;{$t has name 'Paul McCartney';} or {$t has name 'George Harrison';};
 #($x, $t) isa tagging;
@@ -288,7 +288,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-35 sub rule,
+rule-35
 when {$x isa person;
 $t isa tag;$t has name 'Paul McCartney';
 ($x, $t) isa tagging;
@@ -296,7 +296,7 @@ $y isa tag;$y has name 'Beatles';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-36 sub rule,
+rule-36
 when {$x isa person;
 $t isa tag;$t has name 'George Harrison';
 ($x, $t) isa tagging;
@@ -304,7 +304,7 @@ $y isa tag;$y has name 'Beatles';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-37 sub rule,
+rule-37
 when {$x isa person;
 $t isa tag;$t has name 'Roger Waters';
 ($x, $t) isa tagging;
@@ -312,7 +312,7 @@ $y isa tag;$y has name 'Pink Floyd';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-38 sub rule,
+rule-38
 when {$x isa person;
 $t isa tag;$t has name 'Keith Richards';
 ($x, $t) isa tagging;
@@ -320,7 +320,7 @@ $y isa tag;$y has name 'Rolling Stones';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-39 sub rule,
+rule-39
 when {$x isa person;
 $t isa tag;$t has name 'Paul Simon';
 ($x, $t) isa tagging;
@@ -328,7 +328,7 @@ $y isa tag;$y has name 'Simon and Garfunkel';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-40 sub rule,
+#rule-40
 #when {$x isa person;
 #$t isa tag;$t has name 'Eric Clapton';
 #($x, $t) isa tagging;
@@ -337,7 +337,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-41 sub rule,
+rule-41
 when {$x isa person;
 $t isa tag;$t has name 'Eric Clapton';
 ($x, $t) isa tagging;
@@ -346,7 +346,7 @@ $y has name 'Cream';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-42 sub rule,
+rule-42
 when {$x isa person;
 $t isa tag;$t has name 'Eric Clapton';
 ($x, $t) isa tagging;
@@ -355,7 +355,7 @@ $y has name 'Yardbirds';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-43 sub rule,
+rule-43
 when {$x isa person;
 $t isa tag;$t has name 'Bob Marley';
 ($x, $t) isa tagging;
@@ -367,7 +367,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 ##############Album->Band##################
 #############################################
 
-#rule-44 sub rule,
+#rule-44
 #when {$x isa person;
 #$t isa tag;$t has name 'Master of Puppets';
 #($x, $t) isa tagging;
@@ -376,7 +376,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-45 sub rule,
+#rule-45
 #when {$x isa person;
 #$t isa tag;$t has name 'Far Beyond Driven';
 #($x, $t) isa tagging;
@@ -385,7 +385,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-46 sub rule,
+#rule-46
 #when {$x isa person;
 #$t isa tag;$t has name 'Hybrhas name Theory';
 #($x, $t) isa tagging;
@@ -394,7 +394,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-47 sub rule,
+#rule-47
 #when {$x isa person;
 #$t isa tag;$t has name 'Powerslave';
 #($x, $t) isa tagging;
@@ -403,7 +403,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-48 sub rule,
+#rule-48
 #when {$x isa person;
 #$t isa tag;$t has name 'Enter the Chicken';
 #($x, $t) isa tagging;
@@ -412,7 +412,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-49 sub rule,
+#rule-49
 #when {$x isa person;
 #$t isa tag;$t has name 'Rising Force';
 #($x, $t) isa tagging;
@@ -421,7 +421,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 #},
 #then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-50 sub rule,
+rule-50
 when {$x isa person;
 $t isa tag;$t has name 'Rising Force';
 ($x, $t) isa tagging;
@@ -430,7 +430,7 @@ $y has name 'Yngwie Malmsteen';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-51 sub rule,
+rule-51
 when {$x isa person;
 $t isa tag;$t has name 'Rising Force';
 ($x, $t) isa tagging;
@@ -439,7 +439,7 @@ $y has name 'Steve Vai';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-52 sub rule,
+rule-52
 when {$x isa person;
 $t isa tag;$t has name 'Rising Force';
 ($x, $t) isa tagging;
@@ -448,7 +448,7 @@ $y has name 'Cacophony';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-#rule-53 sub rule,
+#rule-53
 #when {$x isa person;
 #$t isa tag;$t has name 'Led Zeppelin IV';
 #($x, $t) isa tagging;
@@ -461,7 +461,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 ##############Song/Single->Band##################
 #############################################
 
-rule-54 sub rule,
+rule-54
 when {$x isa person;
 $t isa tag;$t has name 'All_Along_the_Watchtower';
 ($x, $t) isa tagging;
@@ -469,7 +469,7 @@ $y isa tag;$y has name 'Jimi Hendrix';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-55 sub rule,
+rule-55
 when {$x isa person;
 $t isa tag;$t has name 'These_Are_the_Days_of_Our_Lives';
 ($x, $t) isa tagging;
@@ -477,7 +477,7 @@ $y isa tag;$y has name 'Queen';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-56 sub rule,
+rule-56
 when {$x isa person;
 $t isa tag;$t has name 'Come_Together';
 ($x, $t) isa tagging;
@@ -485,7 +485,7 @@ $y isa tag;$y has name ' Beatles';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-57 sub rule,
+rule-57
 when {$x isa person;
 $t isa tag;$t has name 'Smoke_on_the_Water';
 ($x, $t) isa tagging;
@@ -493,7 +493,7 @@ $y isa tag;$y has name 'Deep Purple';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-58 sub rule,
+rule-58
 when {$x isa person;
 $t isa tag;$t has name 'Immigrant_Song';
 ($x, $t) isa tagging;
@@ -505,7 +505,7 @@ then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 ##################Artist->Painting####################
 #######################################################
 
-rule-59 sub rule,
+rule-59
 when {$x isa person;
 $t isa tag;$t has name 'Claude Monet';
 ($x, $t) isa tagging;
@@ -513,7 +513,7 @@ $y isa product;$y has name 'Water Lillies';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-60 sub rule,
+rule-60
 when {$x isa person;
 $t isa tag;$t has name 'Rembrandt';
 ($x, $t) isa tagging;
@@ -521,7 +521,7 @@ $y isa product;$y has name 'The Night Watch';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-61 sub rule,
+rule-61
 when {$x isa person;
 $t isa tag;$t has name 'Leonardo da Vinci';
 ($x, $t) isa tagging;
@@ -529,7 +529,7 @@ $y isa product;$y has name 'Mona Lisa';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-62 sub rule,
+rule-62
 when {$x isa person;
 $t isa tag;$t has name 'Raphael';
 ($x, $t) isa tagging;
@@ -537,7 +537,7 @@ $y isa product;$y has name 'Madonna';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-63 sub rule,
+rule-63
 when {$x isa person;
 $t isa tag;$t has name 'Titian';
 ($x, $t) isa tagging;
@@ -545,7 +545,7 @@ $y isa product;$y has name 'Bacchus and Ariadne';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-64 sub rule,
+rule-64
 when {$x isa person;
 $t isa tag;$t has name 'Vincent van Gogh';
 ($x, $t) isa tagging;
@@ -553,7 +553,7 @@ $y isa product;$y has name 'Sunflowers';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-65 sub rule,
+rule-65
 when {$x isa person;
 $t isa tag;$t has name 'Diego Rivera';
 ($x, $t) isa tagging;
@@ -561,7 +561,7 @@ $y isa product;$y has name 'Controller of the Universe';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-66 sub rule,
+rule-66
 when {$x isa person;
 $t isa tag;$t has name 'Piet Mondrian';
 ($x, $t) isa tagging;
@@ -569,7 +569,7 @@ $y isa product;$y has name 'Gray Tree';
 },
 then {(recommended-customer: $x, recommended-product: $y) isa recommendation;};
 
-rule-67 sub rule,
+rule-67
 when {$x isa person;$t isa tag;$t has name 'Michelangelo';
 ($x, $t) isa tagging;
 $y isa product;$y has name 'Last Judgement';

--- a/grakn-test-tools/src/main/graql/linearTransitivity.gql
+++ b/grakn-test-tools/src/main/graql/linearTransitivity.gql
@@ -30,20 +30,20 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (Q-from: $x, Q-to: $y) isa Q;},
 then {
 (P-from: $x, P-to: $y) isa P;};
 
-rule-2 sub rule,
+rule-2
 when {
 (Q-from: $x, Q-to: $z) isa Q;
 (P-from: $z, P-to: $y) isa P;},
 then {
 (P-from: $x, P-to: $y) isa P;};
 
-rule-3 sub rule,
+rule-3
 when {
 (P-from: $x, P-to: $y) isa P;},
 then {

--- a/grakn-test-tools/src/main/graql/multiJoin.gql
+++ b/grakn-test-tools/src/main/graql/multiJoin.gql
@@ -28,28 +28,28 @@ index sub attribute, datatype long;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (fromRole: $x, toRole: $z) isa B1;
 (fromRole: $z, toRole: $y) isa B2;},
 then {
 (fromRole: $x, toRole: $y) isa A;};
 
-rule-2 sub rule,
+rule-2
 when {
 (fromRole: $x, toRole: $z) isa C1;
 (fromRole: $z, toRole: $y) isa C2;},
 then {
 (fromRole: $x, toRole: $y) isa B1;};
 
-rule-3 sub rule,
+rule-3
 when {
 (fromRole: $x, toRole: $z) isa C3;
 (fromRole: $z, toRole: $y) isa C4;},
 then {
 (fromRole: $x, toRole: $y) isa B2;};
 
-rule-4 sub rule,
+rule-4
 when {
 (fromRole: $x, toRole: $z) isa D1;
 (fromRole: $z, toRole: $y) isa D2;},

--- a/grakn-test-tools/src/main/graql/nguyen-test.gql
+++ b/grakn-test-tools/src/main/graql/nguyen-test.gql
@@ -36,13 +36,13 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (R-rA: $x, R-rB: $y) isa R;},
 then {
 (N-rA: $x, N-rB: $y) isa N;};
 
-rule-2 sub rule,
+rule-2
 when {
 (P-rA: $x, P-rB: $z) isa P;
 (N-rA: $z, N-rB: $w) isa N;
@@ -50,7 +50,7 @@ when {
 then {
 (N-rA: $x, N-rB: $y) isa N;};
 
-rule-3 sub rule,
+rule-3
 when {
 (N-rA: $x, N-rB: $y) isa N;
 $x has index 'c';},

--- a/grakn-test-tools/src/main/graql/path-test-symmetric.gql
+++ b/grakn-test-tools/src/main/graql/path-test-symmetric.gql
@@ -24,13 +24,13 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 ($x, $y) isa arc;},
 then {
 ($x, $y) isa path;};
 
-rule-2 sub rule,
+rule-2
 when {
 ($x, $z) isa path;
 ($z, $y) isa path;},

--- a/grakn-test-tools/src/main/graql/path-test.gql
+++ b/grakn-test-tools/src/main/graql/path-test.gql
@@ -27,13 +27,13 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (arc-from: $x, arc-to: $y) isa arc;},
 then {
 (path-from: $x, path-to: $y) isa path;};
 
-rule-2 sub rule,
+rule-2
 when {
 (path-from: $x, path-to: $z) isa path;
 (path-from: $z, path-to: $y) isa path;},

--- a/grakn-test-tools/src/main/graql/quadraticTransitivity.gql
+++ b/grakn-test-tools/src/main/graql/quadraticTransitivity.gql
@@ -20,7 +20,7 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (Q-from: $x, Q-to: $z) isa Q;
 (Q-from: $z, Q-to: $y) isa Q;},

--- a/grakn-test-tools/src/main/graql/reachability-test-symmetric.gql
+++ b/grakn-test-tools/src/main/graql/reachability-test-symmetric.gql
@@ -20,13 +20,13 @@ index sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 ($x, $y) isa link;},
 then {
 ($x, $y) isa reachable;};
 
-rule-2 sub rule,
+rule-2
 when {
 ($x, $z) isa link;
 ($z, $y) isa reachable;},

--- a/grakn-test-tools/src/main/graql/reachability-test.gql
+++ b/grakn-test-tools/src/main/graql/reachability-test.gql
@@ -41,13 +41,13 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (link-from: $x, link-to: $y) isa link;},
 then {
 (reach-from: $x, reach-to: $y) isa reachable;};
 
-rule-2 sub rule,
+rule-2
 when {
 (link-from: $x, link-to: $z) isa link;
 (reach-from: $z, reach-to: $y) isa reachable;},

--- a/grakn-test-tools/src/main/graql/recursivity-rsg-test.gql
+++ b/grakn-test-tools/src/main/graql/recursivity-rsg-test.gql
@@ -83,13 +83,13 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (flat-from: $x, flat-to: $y) isa flat;},
 then {
 (RSG-from: $x, RSG-to: $y) isa RevSG;};
 
-rule-2 sub rule,
+rule-2
 when {
 (up-from: $x, up-to: $x1) isa up;
 (RSG-from: $y1, RSG-to: $x1) isa RevSG;

--- a/grakn-test-tools/src/main/graql/recursivity-sg-test.gql
+++ b/grakn-test-tools/src/main/graql/recursivity-sg-test.gql
@@ -23,14 +23,14 @@ name sub attribute, datatype string;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 $x isa Human;},
 then {
 (SG-role: $x, SG-role: $x) isa SameGen;
 };
 
-rule-2 sub rule,
+rule-2
 when {
 (parent: $x, child: $u) isa Parent;
 (parent: $y, child: $v) isa Parent;

--- a/grakn-test-tools/src/main/graql/recursivity-tc-test.gql
+++ b/grakn-test-tools/src/main/graql/recursivity-tc-test.gql
@@ -44,20 +44,20 @@ define
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 $x isa q;
 (TC-roleA: $x, TC-roleB: $y) isa TC;},
 then {
 (N-TC-roleA: $x, N-TC-roleB: $y) isa N-TC;};
 
-rule-2 sub rule,
+rule-2
 when {
 (P-roleA: $x, P-roleB: $y) isa P;},
 then {
 (TC-roleA: $x, TC-roleB: $y) isa TC;};
 
-rule-3 sub rule,
+rule-3
 when {
 (P-roleA: $x, P-roleB: $z) isa P;
 (TC-roleA:$z, TC-roleB: $y) isa TC;},

--- a/grakn-test-tools/src/main/graql/recursivity-test.gql
+++ b/grakn-test-tools/src/main/graql/recursivity-test.gql
@@ -55,47 +55,47 @@ entity2 plays B5-role-A, plays B5-role-B;
 ####################RULES##########################
 ##################################################
 
-rule-1 sub rule,
+rule-1
 when {
 ($x, $z) isa P1;
 ($z, $y) isa Q;},
 then {
 ($x, $y) isa P;};
 
-rule-2 sub rule,
+rule-2
 when {
 ($x, $z) isa P;
 ($z, $y) isa P2;},
 then {
 ($x, $y) isa Q;};
 
-rule-3 sub rule,
+rule-3
 when {
 ($x, $y) isa B3;},
 then {
 ($x, $y) isa P;};
 
-rule-4 sub rule,
+rule-4
 when {
 ($x, $z) isa B1;
 ($z, $y) isa P1;},
 then {
 ($x, $y) isa P1;};
 
-rule-5 sub rule,
+rule-5
 when {
 ($x, $y) isa B4;}
 then {
 ($x, $y) isa P1;};
 
-rule-6 sub rule,
+rule-6
 when {
 ($x, $z) isa B2;
 ($z, $y) isa P2;},
 then {
 ($x, $y) isa P2;};
 
-rule-7 sub rule,
+rule-7
 when {
 ($x, $y) isa B5;},
 then {

--- a/grakn-test-tools/src/main/graql/same-generation-test.gql
+++ b/grakn-test-tools/src/main/graql/same-generation-test.gql
@@ -28,13 +28,13 @@ person plays SG-role-A, plays SG-role-B;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (sibA: $x, sibB: $y) isa Sibling;},
 then {
 (SG-role-A: $x, SG-role-B: $y) isa SameGen;};
 
-rule-2 sub rule,
+rule-2
 when {
 (parent: $x, child: $u) isa Parent;
 ($u, $v) isa SameGen;
@@ -42,7 +42,7 @@ when {
 then {
 (SG-role-A: $x, SG-role-B: $y) isa SameGen;};
 
-rule-3 sub rule,
+rule-3
 when {
 (parent: $z, child: $x) isa Parent;
 (parent: $z, child: $y) isa Parent;},

--- a/grakn-test-tools/src/main/graql/tail-recursion-test.gql
+++ b/grakn-test-tools/src/main/graql/tail-recursion-test.gql
@@ -25,13 +25,13 @@ entity2 plays Q-from plays Q-to;
 ##################RULES#############################
 ####################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (Q-from: $x, Q-to: $y) isa Q;},
 then {
 (P-from: $x, P-to: $y) isa P;};
 
-rule-2 sub rule,
+rule-2
 when {
 (Q-from: $x, Q-to: $z) isa Q;
 (P-from: $z, P-to: $y) isa P;},

--- a/grakn-test-tools/src/main/graql/transitivity-test.gql
+++ b/grakn-test-tools/src/main/graql/transitivity-test.gql
@@ -79,13 +79,13 @@ define
 ################################RULES#################################
 ################################################################
 
-rule-1 sub rule,
+rule-1
 when {
 (E-role-A: $x, E-role-B: $y) isa E;},
 then {
 (R-role-A: $x, R-role-B: $y) isa R;};
 
-rule-2 sub rule,
+rule-2
 when {
 (F-role-A: $x, F-role-B: $t) isa F;
 (R-role-A: $t, R-role-B: $u) isa R;

--- a/grakn-test-tools/src/main/graql/wines-rules.gql
+++ b/grakn-test-tools/src/main/graql/wines-rules.gql
@@ -1,20 +1,20 @@
 define
 ###############APERITIF WINES##################
 
-rule-1 sub rule,
+rule-1
 when {
 $x isa person;
 $x has preferred-context 'aperitif';},
 then { $x has recommended-generic-wine-type 'Romanian wine';};
 
-rule-2 sub rule,
+rule-2
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Romanian wine';
 $x has preferred-body 'full';},
 then { $x has recommended-generic-wine-type 'Cotnary vineyard wine';};
 
-rule-3 sub rule,
+rule-3
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Cotnary vineyard wine';
@@ -22,13 +22,13 @@ $x has preferred-sparklingness 'sparkling';},
 then { $x has recommended-generic-wine-type 'sparkling wine';};
 
 ###############Champagne###############
-rule-4 sub rule,
+rule-4
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'sparkling wine';},
 then { $x has recommended-generic-wine-type 'Champagne';};
 
-rule-5 sub rule,
+rule-5
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Champagne';
@@ -37,7 +37,7 @@ $y isa wine;
 $y has name 'White Champagne';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-6 sub rule,
+rule-6
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Champagne';
@@ -46,7 +46,7 @@ $y isa wine;
 $y has name 'Pink Champagne';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-7 sub rule,
+rule-7
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Champagne';
@@ -57,14 +57,14 @@ then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;
 
 ###############Table###############
 
-rule-8 sub rule,
+rule-8
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Cotnary vineyard wine';
 $x has preferred-sparklingness 'non-sparkling';},
 then { $x has recommended-generic-wine-type 'table wine';};
 
-rule-9 sub rule,
+rule-9
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'table wine';
@@ -73,7 +73,7 @@ $y isa wine;
 $y has name 'Tamaioasa Romaneasca';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-10 sub rule,
+rule-10
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'table wine';
@@ -82,7 +82,7 @@ $y isa wine;
 $y has name 'Busuioaca Romaneasca';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-11 sub rule,
+rule-11
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'table wine';
@@ -94,14 +94,14 @@ then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;
 
 ###############DEALU MARE VINEYARD###############
 
-rule-12 sub rule,
+rule-12
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Romanian wine';
 $x has preferred-body 'medium';},
 then { $x has recommended-generic-wine-type 'Dealu Mare vineyard wine';};
 
-rule-13 sub rule,
+rule-13
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Dealu Mare vineyard wine';
@@ -111,7 +111,7 @@ $y isa wine;
 $y has name 'Feteasca Regala';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-14 sub rule,
+rule-14
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Dealu Mare vineyard wine';
@@ -121,7 +121,7 @@ $y isa wine;
 $y has name 'Feteasca Roz';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-15 sub rule,
+rule-15
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Dealu Mare vineyard wine';
@@ -133,14 +133,14 @@ then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;
 
 ###############Jidvei vineyard###############
 
-rule-16 sub rule,
+rule-16
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Romanian wine';
 $x has preferred-body 'light';},
 then { $x has recommended-generic-wine-type 'Jidvei vineyard wine';};
 
-rule-17 sub rule,
+rule-17
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Jidvei vineyard wine';
@@ -150,7 +150,7 @@ $y isa wine;
 $y has name 'Sauvignion Blanc';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-18 sub rule,
+rule-18
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Jidvei vineyard wine';
@@ -160,7 +160,7 @@ $y isa wine;
 $y has name 'Feteasca Regala';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-19 sub rule,
+rule-19
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'Jidvei vineyard wine';
@@ -172,13 +172,13 @@ then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;
 
 ###############ENTREE WINES###############
 
-rule-20 sub rule,
+rule-20
 when {
 $x isa person;
 $x has preferred-context 'entree';},
 then { $x has recommended-generic-wine-type 'entree wine';};
 
-rule-21 sub rule,
+rule-21
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -188,7 +188,7 @@ $y isa wine;
 $y has name 'Muscat Sec';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-22 sub rule,
+rule-22
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -198,7 +198,7 @@ $y isa wine;
 $y has name 'Pinot Grigio Rose';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-23 sub rule,
+rule-23
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -208,7 +208,7 @@ $y isa wine;
 $y has name 'Corbieres 2003';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-24 sub rule,
+rule-24
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -218,7 +218,7 @@ $y isa wine;
 $y has name 'Chateau Agnel 2000';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-25 sub rule,
+rule-25
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -228,7 +228,7 @@ $y isa wine;
 $y has name 'Busuioaca Romaneasca';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-26 sub rule,
+rule-26
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';
@@ -238,7 +238,7 @@ $y isa wine;
 $y has name 'Rosso di Sicilia 2004';},
 then {(recommendation-owner: $x, recommended-wine: $y)  isa wine-recommendation;};
 
-rule-27 sub rule,
+rule-27
 when {
 $x isa person;
 $x has recommended-generic-wine-type 'entree wine';

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
@@ -186,7 +186,6 @@ public class BenchmarkIT {
                 Var toVar = Graql.var().asUserDefined();
                 VarPattern rulePattern = Graql
                         .label("rule" + i)
-                        .sub("rule")
                         .when(
                                 Graql.and(
                                         Graql.var()


### PR DESCRIPTION
# Why is this PR needed?

`sub rule` can already be inferred from a rule definition, so it's boilerplate. Additionally, we may want to deprecate and remove being able to `sub` between rules at all in the future.

# What does the PR do?

When Graql sees `$x when { ... }` or `$x then { ... }`, it automatically adds a `$x sub rule` under the hood.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

The breaking change of stopping `sub`s between rules completely.