### PR TITLE
update the docs where we tell the user to use Java API 0.12.0

### DIFF
--- a/docs/pages/docs/7-java-library/setup.md
+++ b/docs/pages/docs/7-java-library/setup.md
@@ -15,7 +15,7 @@ All Grakn applications require the following Maven dependency:
 
 ```xml
 <properties>
-  <grakn.version>0.12.0</grakn.version>
+  <grakn.version>1.1.0</grakn.version>
 </properties>
 
 <dependencies>


### PR DESCRIPTION
# Why is this PR needed?
The docs shows Java API 0.12.0, that's quite old.

# What does the PR do?
Update it to 1.1.0

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A