### PR TITLE
More explicit count post processor method names

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/CountPostProcessor.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/CountPostProcessor.java
@@ -91,7 +91,7 @@ public class CountPostProcessor {
                 Timer.Context contextSingle = metricRegistry
                         .timer(name(CountPostProcessor.class, "execution-single")).time();
                 try {
-                    if (updateShardCounts(redis, commitLog.keyspace(), key, value, shardingThreshold)) {
+                    if (incrementInstanceCountAndCheckIfShardingIsNeeded(redis, commitLog.keyspace(), key, value, shardingThreshold)) {
                         conceptToShard.add(key);
                     }
                 } finally {
@@ -120,14 +120,13 @@ public class CountPostProcessor {
      *
      * @param keyspace The keyspace of the graph which the type comes from
      * @param conceptId The id of the concept with counts to update
-     * @param value The number of instances which the type has gained/lost
+     * @param incrementBy The number of instances which the type has gained/lost
      * @return true if sharding is needed.
      */
-    private static boolean updateShardCounts(RedisCountStorage redis, Keyspace keyspace, ConceptId conceptId, long value, long shardingThreshold){
+    private static boolean incrementInstanceCountAndCheckIfShardingIsNeeded(RedisCountStorage redis, Keyspace keyspace, ConceptId conceptId, long incrementBy, long shardingThreshold){
         long numShards = redis.getCount(RedisCountStorage.getKeyNumShards(keyspace, conceptId));
         if(numShards == 0) numShards = 1;
-        long numInstances = redis.adjustCount(
-                RedisCountStorage.getKeyNumInstances(keyspace, conceptId), value);
+        long numInstances = redis.incrementCount(RedisCountStorage.getKeyNumInstances(keyspace, conceptId), incrementBy);
         return numInstances > shardingThreshold * numShards;
     }
 
@@ -148,7 +147,7 @@ public class CountPostProcessor {
 
         try {
             //Check if sharding is still needed. Another engine could have sharded whilst waiting for lock
-            if (updateShardCounts(redis, keyspace, conceptId, 0, shardingThreshold)) {
+            if (incrementInstanceCountAndCheckIfShardingIsNeeded(redis, keyspace, conceptId, 0, shardingThreshold)) {
 
 
                 try(GraknTx graph = factory.tx(keyspace, GraknTxType.WRITE)) {
@@ -156,7 +155,7 @@ public class CountPostProcessor {
                     graph.admin().commitSubmitNoLogs();
                 }
                 //Update number of shards
-                redis.adjustCount(RedisCountStorage.getKeyNumShards(keyspace, conceptId), 1);
+                redis.incrementCount(RedisCountStorage.getKeyNumShards(keyspace, conceptId), 1);
             }
         } finally {
             engineLock.unlock();

--- a/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/RedisCountStorage.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/task/postprocessing/RedisCountStorage.java
@@ -48,13 +48,13 @@ public class RedisCountStorage {
      * Adjusts the count for a specific key.
      *
      * @param key the key of the value to adjust
-     * @param count the number to adjust the key by
+     * @param incrementBy the number to adjust the key by
      * @return true
      */
-    public long adjustCount(String key, long count){
+    public long incrementCount(String key, long incrementBy){
         return redisStorage.contactRedis(jedis -> {
-            if(count != 0) {
-                return jedis.incrBy(key, count); //Number is decremented when count is negative
+            if(incrementBy != 0) {
+                return jedis.incrBy(key, incrementBy); //Number is decremented when count is negative
             } else {
                return getCount(key);
             }

--- a/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/CountPostProcessorTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/CountPostProcessorTest.java
@@ -103,7 +103,7 @@ public class CountPostProcessorTest {
         newInstanceCounts.forEach((id, value) -> {
             //Redis is updated
             verify(countStorage, Mockito.times(1)).getCount(RedisCountStorage.getKeyNumShards(keyspace, id));
-            verify(countStorage, Mockito.times(1)).adjustCount(RedisCountStorage.getKeyNumInstances(keyspace, id), value);
+            verify(countStorage, Mockito.times(1)).incrementCount(RedisCountStorage.getKeyNumInstances(keyspace, id), value);
 
             //No Sharding takes place
             verify(factoryMock, Mockito.times(0)).tx(any(String.class), any());
@@ -115,8 +115,8 @@ public class CountPostProcessorTest {
         //Configure mock to return value which breaches threshold
         ConceptId id = ConceptId.of("e");
         newInstanceCounts.put(id, 6L);
-        when(countStorage.adjustCount(RedisCountStorage.getKeyNumInstances(keyspace, id), 6L)).thenReturn(6L);
-        when(countStorage.adjustCount(RedisCountStorage.getKeyNumInstances(keyspace, id), 0L)).thenReturn(6L);
+        when(countStorage.incrementCount(RedisCountStorage.getKeyNumInstances(keyspace, id), 6L)).thenReturn(6L);
+        when(countStorage.incrementCount(RedisCountStorage.getKeyNumInstances(keyspace, id), 0L)).thenReturn(6L);
 
         //Create fake commit log
         CommitLog commitLog = CommitLog.create(keyspace, newInstanceCounts, Collections.emptyMap());
@@ -126,6 +126,6 @@ public class CountPostProcessorTest {
 
         //Check Sharding Takes Place
         verify(factoryMock, Mockito.times(1)).tx(keyspace, GraknTxType.WRITE);
-        verify(countStorage, Mockito.times(1)).adjustCount(RedisCountStorage.getKeyNumShards(keyspace, id), 1);
+        verify(countStorage, Mockito.times(1)).incrementCount(RedisCountStorage.getKeyNumShards(keyspace, id), 1);
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/RedisCountStorageTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/task/postprocessing/RedisCountStorageTest.java
@@ -67,7 +67,7 @@ public class RedisCountStorageTest {
 
         for(int i =0; i < counts.length; i ++) {
             int finalI = i;
-            futures.add(pool.submit(() -> redis.adjustCount(
+            futures.add(pool.submit(() -> redis.incrementCount(
                     RedisCountStorage.getKeyNumInstances(keyspace, conceptId), counts[finalI])));
         }
         for (Future future : futures) {
@@ -87,11 +87,11 @@ public class RedisCountStorageTest {
         assertEquals(0, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace1, roach)));
         assertEquals(0, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace2, roach)));
 
-        redis.adjustCount(RedisCountStorage.getKeyNumInstances(keyspace1, roach), 1);
+        redis.incrementCount(RedisCountStorage.getKeyNumInstances(keyspace1, roach), 1);
         assertEquals(1, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace1, roach)));
         assertEquals(0, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace2, roach)));
 
-        redis.adjustCount(RedisCountStorage.getKeyNumInstances(keyspace2, ciri), 1);
+        redis.incrementCount(RedisCountStorage.getKeyNumInstances(keyspace2, ciri), 1);
         assertEquals(0, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace1, ciri)));
         assertEquals(1, redis.getCount(RedisCountStorage.getKeyNumInstances(keyspace2, ciri)));
     }


### PR DESCRIPTION
# Why is this PR needed?
Minor stuff - renaming methods and method parameters to be more explicit

# What does the PR do?
Minor stuff - renaming methods and method parameters to be more explicit

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
`incrementInstanceCountAndCheckIfShardingIsNeeded` can be split into two - `incrementInstanceCount` and `checkIfShardingIsNeeded`, but this will do for now.