### PR TITLE
log unhandled exception which causes nasty breakage in post-processing

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -73,6 +73,7 @@ public enum ErrorMessage {
     UNKNOWN_CONCEPT("Uknown concept type [%s]"),
     INVALID_IMPLICIT_TYPE("Label [%s] is not an implicit label"),
     LABEL_TAKEN("The label [%s] has already been used"),
+    BACKGROUND_TASK_UNHANDLED_EXCEPTION("An exception has occurred during the execution of a background task [%s]. Grakn will need to be restarted."),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),


### PR DESCRIPTION
# Why is this PR needed?
If background tasks such as post processing failed due to an exception, the consequences are quite nasty:
1. Fails silently. No logs.
2. Subsequent task will be not be scheduled. This particular behavior is from Java's scheduled executor. In practice, this means that if for any reason (such as the exception due to network error), the scheduled task which perform post processing dies, it will fail, and no more post processing will be scheduled unless grakn is restarted.

Basically this is the same issue as what these guys had: https://stackoverflow.com/a/24902026/1622847

# What does the PR do?
This PR does one thing: logs the exception and informs the user to restart Grakn. Post-processing will still stop working, but at least the user is now informed and advised to restart Grakn.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Define a better behavior instead of simply logging and rethrowing the exception