### PR TITLE
Get rid of CompareTo on Concepts

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/Concept.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/Concept.java
@@ -42,7 +42,7 @@ import javax.annotation.CheckReturnValue;
  * @author fppt
  *
  */
-public interface Concept extends Comparable<Concept>{
+public interface Concept {
     //------------------------------------- Accessors ----------------------------------
     /**
      * Get the unique ID associated with the Concept.

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/RemoteConcept.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/RemoteConcept.java
@@ -52,8 +52,4 @@ abstract class RemoteConcept implements Concept {
         throw new UnsupportedOperationException(); // TODO
     }
 
-    @Override
-    public int compareTo(Concept concept) {
-        return getId().compareTo(concept.getId());
-    }
 }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ConceptImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ConceptImpl.java
@@ -204,11 +204,6 @@ public abstract class ConceptImpl implements Concept, ConceptVertex, CacheOwner{
         return message;
     }
 
-    @Override
-    public int compareTo(Concept o) {
-        return this.getId().compareTo(o.getId());
-    }
-
     //----------------------------------- Sharding Functionality
     public void createShard(){
         VertexElement shardVertex = vertex().tx().addVertexElement(Schema.BaseType.SHARD);

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipImpl.java
@@ -21,7 +21,6 @@ package ai.grakn.kb.internal.concept;
 import ai.grakn.Keyspace;
 import ai.grakn.concept.Attribute;
 import ai.grakn.concept.AttributeType;
-import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Relationship;
 import ai.grakn.concept.RelationshipType;
@@ -235,11 +234,6 @@ public class RelationshipImpl implements Relationship, ConceptVertex, CacheOwner
     @Override
     public boolean isDeleted() {
         return structure().isDeleted();
-    }
-
-    @Override
-    public int compareTo(Concept o) {
-        return getId().compareTo(o.getId());
     }
 
     @Override


### PR DESCRIPTION
# Why is this PR needed?

Simplify implementation of concepts

# What does the PR do?

Get rid of comparable methods

# Does it break backwards compatibility?

Possibly no

# List of future improvements not on this PR

none
