### PR TITLE
Improve GraknConfigKey abstraction

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -127,3 +127,5 @@ cache.db-cache-size=0.25
 # IP or hostname on which Redis is listening for connections.
 queue.host=localhost:6379
 redis.pool-size=32
+redis.sentinel.master=graknmaster
+redis.sentinel.host=

--- a/conf/test/cluster/grakn.properties
+++ b/conf/test/cluster/grakn.properties
@@ -39,6 +39,8 @@ queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
 redis.pool-size=32
+redis.sentinel.master=graknmaster
+redis.sentinel.host=
 
 #Background tasks Config
 backgroundTasks.time-lapse=300000

--- a/conf/test/janus/grakn.properties
+++ b/conf/test/janus/grakn.properties
@@ -36,6 +36,8 @@ queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
 redis.pool-size=32
+redis.sentinel.master=graknmaster
+redis.sentinel.host=
 
 ####################################
 # Grakn Config                     #

--- a/conf/test/tinker/grakn.properties
+++ b/conf/test/tinker/grakn.properties
@@ -37,6 +37,8 @@ queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
 redis.pool-size=32
+redis.sentinel.master=graknmaster
+redis.sentinel.host=
 
 ####################################
 # Grakn Config                     #

--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -20,7 +20,6 @@ package ai.grakn;
 
 import ai.grakn.util.ErrorMessage;
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,14 +53,10 @@ public abstract class GraknConfigKey<T> {
 
     public static final GraknConfigKey<List<String>> REDIS_HOST =
             key("queue.host", required(GraknConfigKey::parseCSValue), GraknConfigKey::toStringCSValue);
-    public static final GraknConfigKey<List<String>> REDIS_SENTINEL_HOST = key(
-            "redis.sentinel.host",
-            withDefault(GraknConfigKey::parseCSValue, ImmutableList.of()),
-            GraknConfigKey::toStringCSValue
-    );
+    public static final GraknConfigKey<List<String>> REDIS_SENTINEL_HOST =
+            key("redis.sentinel.host", required(GraknConfigKey::parseCSValue), GraknConfigKey::toStringCSValue);
     public static final GraknConfigKey<String> REDIS_BIND = key("bind");
-    public static final GraknConfigKey<String> REDIS_SENTINEL_MASTER =
-            key("redis.sentinel.master", withDefault(Function.identity(), "graknmaster"));
+    public static final GraknConfigKey<String> REDIS_SENTINEL_MASTER = key("redis.sentinel.master");
     public static final GraknConfigKey<Integer> REDIS_POOL_SIZE = key("redis.pool-size", INT);
     public static final GraknConfigKey<Integer> POST_PROCESSOR_POOL_SIZE = key("post-processor.pool-size", INT);
     public static final GraknConfigKey<Integer> POST_PROCESSOR_DELAY = key("post-processor.delay", INT);
@@ -145,13 +140,6 @@ public abstract class GraknConfigKey<T> {
      */
     private static <T> Function<Optional<String>, Optional<T>> required(Function<String, T> parseFunction) {
         return opt -> opt.map(parseFunction);
-    }
-
-    /**
-     * A function for parsing a parameter using the given parse function, including a default value.
-     */
-    private static <T> Function<Optional<String>, Optional<T>> withDefault(Function<String, T> parseFunction, T def) {
-        return opt -> Optional.of(opt.map(parseFunction).orElse(def));
     }
 
     private static List<String> parseCSValue(String s) {

--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -48,11 +47,12 @@ public abstract class GraknConfigKey<T> {
         }
     }
 
-    // These are helpful parser to describe how to parse required parameters of certain types.
+    // These are helpful parser to describe how to parse parameters of certain types.
     private static final KeyParser<String> STRING = string -> string;
-    private static final KeyParser<Integer> INT = required(Integer::parseInt);
-    private static final KeyParser<Boolean> BOOL = required(Boolean::parseBoolean);
-    private static final KeyParser<Long> LONG = required(Long::parseLong);
+    private static final KeyParser<Integer> INT = Integer::parseInt;
+    private static final KeyParser<Boolean> BOOL = Boolean::parseBoolean;
+    private static final KeyParser<Long> LONG = Long::parseLong;
+    private static final KeyParser<Path> PATH = Paths::get;
 
     private static final KeyParser<List<String>> CSV = new KeyParser<List<String>>() {
         @Override
@@ -83,7 +83,7 @@ public abstract class GraknConfigKey<T> {
     public static final GraknConfigKey<Integer> POST_PROCESSOR_POOL_SIZE = key("post-processor.pool-size", INT);
     public static final GraknConfigKey<Integer> POST_PROCESSOR_DELAY = key("post-processor.delay", INT);
 
-    public static final GraknConfigKey<Path> STATIC_FILES_PATH = key("server.static-file-dir", required(Paths::get));
+    public static final GraknConfigKey<Path> STATIC_FILES_PATH = key("server.static-file-dir", PATH);
 
     public static final GraknConfigKey<Integer> SESSION_CACHE_TIMEOUT_MS = key("knowledge-base.schema-cache-timeout-ms", INT);
 
@@ -133,7 +133,7 @@ public abstract class GraknConfigKey<T> {
     }
 
     /**
-     * Create a key for a required string property
+     * Create a key for a string property
      */
     public static GraknConfigKey<String> key(String value) {
         return key(value, STRING);
@@ -146,10 +146,4 @@ public abstract class GraknConfigKey<T> {
         return new AutoValue_GraknConfigKey<>(value, parser);
     }
 
-    /**
-     * A function for parsing a required parameter using the given parse function.
-     */
-    private static <T> KeyParser<T> required(Function<String, T> parseFunction) {
-        return parseFunction::apply;
-    }
 }

--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -38,7 +38,13 @@ import java.util.stream.Stream;
 @AutoValue
 public abstract class GraknConfigKey<T> {
 
-    interface KeyParser<T> {
+    /**
+     * Parser for a {@link GraknConfigKey}.
+     * Describes how to {@link #read(String)} and {@link #write(Object)} properties.
+     *
+     * @param <T> The type of the property value
+     */
+    public interface KeyParser<T> {
 
         T read(String string);
 
@@ -48,13 +54,12 @@ public abstract class GraknConfigKey<T> {
     }
 
     // These are helpful parser to describe how to parse parameters of certain types.
-    private static final KeyParser<String> STRING = string -> string;
-    private static final KeyParser<Integer> INT = Integer::parseInt;
-    private static final KeyParser<Boolean> BOOL = Boolean::parseBoolean;
-    private static final KeyParser<Long> LONG = Long::parseLong;
-    private static final KeyParser<Path> PATH = Paths::get;
-
-    private static final KeyParser<List<String>> CSV = new KeyParser<List<String>>() {
+    public static final KeyParser<String> STRING = string -> string;
+    public static final KeyParser<Integer> INT = Integer::parseInt;
+    public static final KeyParser<Boolean> BOOL = Boolean::parseBoolean;
+    public static final KeyParser<Long> LONG = Long::parseLong;
+    public static final KeyParser<Path> PATH = Paths::get;
+    public static final KeyParser<List<String>> CSV = new KeyParser<List<String>>() {
         @Override
         public List<String> read(String string) {
             Stream<String> split = Arrays.stream(string.split(","));


### PR DESCRIPTION
# Why is this PR needed?

Because we love @marco-scoppetta very much.

`GraknConfigKey` was a confusing place. Now it is not. Also some stuff was not public for KBMS to use.

# What does the PR do?

- Make some important things public so KBMS can also use `GraknConfigKey`.
- Added a new abstraction `KeyParser` that contains a `read` and `write` method to read and write property values.
- Removed the idea of "optional" properties. Now all properties must be in the config file. This is good because it means the default value is not a secret!

# Does it break backwards compatibility?

No, but KBMS might be upset.

# List of future improvements not on this PR

None, it is completely perfect now and will never change.
