### PR TITLE
Make public method used to create new GraknConfigKeys

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -147,7 +147,7 @@ public abstract class GraknConfigKey<T> {
     /**
      * Create a key with the given parser
      */
-    private static <T> GraknConfigKey<T> key(String value, KeyParser<T> parser) {
+    public static <T> GraknConfigKey<T> key(String value, KeyParser<T> parser) {
         return new AutoValue_GraknConfigKey<>(value, parser);
     }
 


### PR DESCRIPTION
# Why is this PR needed?

To be able to create new `GraknConfigKey`s from outside the class itself.

# What does the PR do?

Makes the method `<T> GraknConfigKey<T> key(String value, KeyParser<T> parser)` public

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

No