### PR TITLE
Make get meta's default methods

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknTx.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknTx.java
@@ -227,36 +227,6 @@ public final class RemoteGraknTx implements GraknTx, GraknAdmin {
     }
 
     @Override
-    public Type getMetaConcept() {
-        return getSchemaConcept(Schema.MetaSchema.THING.getLabel());
-    }
-
-    @Override
-    public RelationshipType getMetaRelationType() {
-        return getSchemaConcept(Schema.MetaSchema.RELATIONSHIP.getLabel());
-    }
-
-    @Override
-    public Role getMetaRole() {
-        return getSchemaConcept(Schema.MetaSchema.ROLE.getLabel());
-    }
-
-    @Override
-    public AttributeType getMetaAttributeType() {
-        return getSchemaConcept(Schema.MetaSchema.ATTRIBUTE.getLabel());
-    }
-
-    @Override
-    public EntityType getMetaEntityType() {
-        return getSchemaConcept(Schema.MetaSchema.ENTITY.getLabel());
-    }
-
-    @Override
-    public Rule getMetaRule() {
-        return getSchemaConcept(Schema.MetaSchema.RULE.getLabel());
-    }
-
-    @Override
     public Stream<SchemaConcept> sups(SchemaConcept schemaConcept) {
         throw new UnsupportedOperationException(); // TODO
     }

--- a/grakn-core/src/main/java/ai/grakn/kb/admin/GraknAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/kb/admin/GraknAdmin.java
@@ -27,6 +27,7 @@ import ai.grakn.concept.Role;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Type;
+import ai.grakn.util.Schema;
 
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;
@@ -36,7 +37,7 @@ import java.util.stream.Stream;
  *
  * @author Filipe Teixeira
  */
-public interface GraknAdmin {
+public interface GraknAdmin extends GraknTx{
 
 
     //------------------------------------- Meta Types ----------------------------------
@@ -46,7 +47,9 @@ public interface GraknAdmin {
      * @return The meta type -> type.
      */
     @CheckReturnValue
-    Type getMetaConcept();
+    default Type getMetaConcept(){
+        return getSchemaConcept(Schema.MetaSchema.THING.getLabel());
+    }
 
     /**
      * Get the root of all {@link RelationshipType}.
@@ -54,7 +57,9 @@ public interface GraknAdmin {
      * @return The meta relation type -> relation-type.
      */
     @CheckReturnValue
-    RelationshipType getMetaRelationType();
+    default RelationshipType getMetaRelationType(){
+        return getSchemaConcept(Schema.MetaSchema.RELATIONSHIP.getLabel());
+    }
 
     /**
      * Get the root of all the {@link Role}.
@@ -62,7 +67,9 @@ public interface GraknAdmin {
      * @return The meta role type -> role-type.
      */
     @CheckReturnValue
-    Role getMetaRole();
+    default Role getMetaRole(){
+        return getSchemaConcept(Schema.MetaSchema.ROLE.getLabel());
+    }
 
     /**
      * Get the root of all the {@link AttributeType}.
@@ -70,7 +77,9 @@ public interface GraknAdmin {
      * @return The meta resource type -> resource-type.
      */
     @CheckReturnValue
-    AttributeType getMetaAttributeType();
+    default AttributeType getMetaAttributeType(){
+        return getSchemaConcept(Schema.MetaSchema.ATTRIBUTE.getLabel());
+    }
 
     /**
      * Get the root of all the Entity Types.
@@ -78,7 +87,9 @@ public interface GraknAdmin {
      * @return The meta entity type -> entity-type.
      */
     @CheckReturnValue
-    EntityType getMetaEntityType();
+    default EntityType getMetaEntityType(){
+        return getSchemaConcept(Schema.MetaSchema.ENTITY.getLabel());
+    }
 
     /**
      * Get the root of all {@link Rule}s;
@@ -86,7 +97,9 @@ public interface GraknAdmin {
      * @return The meta {@link Rule}
      */
     @CheckReturnValue
-    Rule getMetaRule();
+    default Rule getMetaRule(){
+        return getSchemaConcept(Schema.MetaSchema.RULE.getLabel());
+    }
 
     //------------------------------------- Admin Specific Operations ----------------------------------
 

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -31,10 +31,10 @@ import ai.grakn.concept.Role;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Type;
-import com.google.common.collect.ImmutableSet;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 import static ai.grakn.util.ErrorMessage.INVALID_IMPLICIT_TYPE;
 
@@ -88,9 +88,6 @@ public final class Schema {
         RELATIONSHIP("relationship", 5),
         RULE("rule", 6);
 
-        public static final ImmutableSet<MetaSchema> METATYPES =
-                ImmutableSet.of(THING, ENTITY, ATTRIBUTE, RELATIONSHIP);
-
         private final Label label;
         private final LabelId id;
 
@@ -115,6 +112,18 @@ public final class Schema {
                 if (metaSchema.getLabel().equals(label)) return true;
             }
             return false;
+        }
+
+        @Nullable
+        @CheckReturnValue
+        public static MetaSchema valueOf(Label label){
+            if(THING.getLabel().equals(label)) return THING;
+            if(ENTITY.getLabel().equals(label)) return ENTITY;
+            if(ROLE.getLabel().equals(label)) return ROLE;
+            if(ATTRIBUTE.getLabel().equals(label)) return ATTRIBUTE;
+            if(RELATIONSHIP.getLabel().equals(label)) return RELATIONSHIP;
+            if(RULE.getLabel().equals(label)) return RULE;
+            return null;
         }
     }
 

--- a/grakn-core/src/main/java/ai/grakn/util/Schema.java
+++ b/grakn-core/src/main/java/ai/grakn/util/Schema.java
@@ -108,21 +108,15 @@ public final class Schema {
 
         @CheckReturnValue
         public static boolean isMetaLabel(Label label) {
-            for (MetaSchema metaSchema : MetaSchema.values()) {
-                if (metaSchema.getLabel().equals(label)) return true;
-            }
-            return false;
+            return valueOf(label) != null;
         }
 
         @Nullable
         @CheckReturnValue
         public static MetaSchema valueOf(Label label){
-            if(THING.getLabel().equals(label)) return THING;
-            if(ENTITY.getLabel().equals(label)) return ENTITY;
-            if(ROLE.getLabel().equals(label)) return ROLE;
-            if(ATTRIBUTE.getLabel().equals(label)) return ATTRIBUTE;
-            if(RELATIONSHIP.getLabel().equals(label)) return RELATIONSHIP;
-            if(RULE.getLabel().equals(label)) return RULE;
+            for (MetaSchema metaSchema : MetaSchema.values()) {
+                if (metaSchema.getLabel().equals(label)) return metaSchema;
+            }
             return null;
         }
     }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/EmbeddedGraknTx.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/EmbeddedGraknTx.java
@@ -107,7 +107,7 @@ import static java.util.stream.Collectors.toSet;
  * @param <G> A vendor specific implementation of a Tinkerpop {@link Graph}.
  * @author fppt
  */
-public abstract class EmbeddedGraknTx<G extends Graph> implements GraknTx, GraknAdmin {
+public abstract class EmbeddedGraknTx<G extends Graph> implements GraknAdmin {
     final Logger LOG = LoggerFactory.getLogger(EmbeddedGraknTx.class);
     private static final String QUERY_BUILDER_CLASS_NAME = "ai.grakn.graql.internal.query.QueryBuilderImpl";
     private static final String QUERY_RUNNER_CLASS_NAME = "ai.grakn.graql.internal.query.runner.TinkerQueryRunner";
@@ -618,6 +618,8 @@ public abstract class EmbeddedGraknTx<G extends Graph> implements GraknTx, Grakn
 
     @Override
     public <T extends SchemaConcept> T getSchemaConcept(Label label) {
+        Schema.MetaSchema meta = Schema.MetaSchema.valueOf(label);
+        if(meta != null) return getSchemaConcept(meta.getId());
         return getSchemaConcept(label, Schema.BaseType.SCHEMA_CONCEPT);
     }
 
@@ -649,36 +651,6 @@ public abstract class EmbeddedGraknTx<G extends Graph> implements GraknTx, Grakn
     @Override
     public Rule getRule(String label) {
         return getSchemaConcept(Label.of(label), Schema.BaseType.RULE);
-    }
-
-    @Override
-    public Type getMetaConcept() {
-        return getSchemaConcept(Schema.MetaSchema.THING.getId());
-    }
-
-    @Override
-    public RelationshipType getMetaRelationType() {
-        return getSchemaConcept(Schema.MetaSchema.RELATIONSHIP.getId());
-    }
-
-    @Override
-    public Role getMetaRole() {
-        return getSchemaConcept(Schema.MetaSchema.ROLE.getId());
-    }
-
-    @Override
-    public AttributeType getMetaAttributeType() {
-        return getSchemaConcept(Schema.MetaSchema.ATTRIBUTE.getId());
-    }
-
-    @Override
-    public EntityType getMetaEntityType() {
-        return getSchemaConcept(Schema.MetaSchema.ENTITY.getId());
-    }
-
-    @Override
-    public Rule getMetaRule() {
-        return getSchemaConcept(Schema.MetaSchema.RULE.getId());
     }
 
     @Override


### PR DESCRIPTION
# Why is this PR needed?

Cleans up the code a bit and removes some redundant implementations.

# What does the PR do?

Makes the getting of meta concepts default methods

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

none
