### PR TITLE
Support executing multiple queries simultaneously over gRPC

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/remote/GrpcClient.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/GrpcClient.java
@@ -35,6 +35,7 @@ import ai.grakn.grpc.TxGrpcCommunicator.Response;
 import ai.grakn.remote.concept.RemoteConcepts;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknOuterClass;
+import ai.grakn.rpc.generated.GraknOuterClass.IteratorId;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
 import ai.grakn.util.CommonUtil;
 import com.google.common.collect.AbstractIterator;
@@ -78,16 +79,12 @@ public final class GrpcClient implements AutoCloseable {
     public Iterator<Object> execQuery(RemoteGraknTx tx, Query<?> query, @Nullable Boolean infer) {
         communicator.send(GrpcUtil.execQueryRequest(query.toString(), infer));
 
-        return new AbstractIterator<Object>() {
-            private boolean firstElem = true;
+        IteratorId iteratorId = responseOrThrow().getIteratorId();
 
+        return new AbstractIterator<Object>() {
             @Override
             protected Object computeNext() {
-                if (firstElem) {
-                    firstElem = false;
-                } else {
-                    communicator.send(GrpcUtil.nextRequest());
-                }
+                communicator.send(GrpcUtil.nextRequest(iteratorId));
 
                 TxResponse response = responseOrThrow();
 

--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -38,6 +38,7 @@ import ai.grakn.grpc.GrpcUtil;
 import ai.grakn.grpc.GrpcUtil.ErrorType;
 import ai.grakn.rpc.generated.GraknGrpc;
 import ai.grakn.rpc.generated.GraknOuterClass;
+import ai.grakn.rpc.generated.GraknOuterClass.IteratorId;
 import ai.grakn.rpc.generated.GraknOuterClass.QueryResult;
 import ai.grakn.rpc.generated.GraknOuterClass.TxRequest;
 import ai.grakn.rpc.generated.GraknOuterClass.TxResponse;
@@ -88,6 +89,7 @@ public class RemoteGraknTxTest {
     private static final Keyspace KEYSPACE = Keyspace.of("blahblah");
     private static final GraknOuterClass.ConceptId V123 =
             GraknOuterClass.ConceptId.newBuilder().setValue("V123").build();
+    private static final IteratorId ITERATOR = IteratorId.newBuilder().setId(100).build();
 
     @Before
     public void setUp() {
@@ -161,8 +163,13 @@ public class RemoteGraknTxTest {
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponse(GrpcUtil.execQueryRequest(queryString), response);
-        server.setResponse(GrpcUtil.nextRequest(), GrpcUtil.doneResponse());
+        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.iteratorResponse(ITERATOR));
+
+        // Mock next response after this one
+        server.setResponse(GrpcUtil.nextRequest(ITERATOR), responseObserver -> {
+            responseObserver.onNext(response);
+            server.setResponse(GrpcUtil.nextRequest(ITERATOR), GrpcUtil.doneResponse());
+        });
 
         List<Answer> results;
 
@@ -192,12 +199,16 @@ public class RemoteGraknTxTest {
     public void whenExecutingAQueryWithABooleanResult_GetABoolBack() {
         String queryString = "match $x isa person; aggregate ask;";
 
-        server.setResponse(
-                GrpcUtil.execQueryRequest(queryString),
-                TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("true")).build()
-        );
+        TxResponse response =
+                TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("true")).build();
 
-        server.setResponse(GrpcUtil.nextRequest(), GrpcUtil.doneResponse());
+        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.iteratorResponse(ITERATOR));
+
+        // Mock next response after this one
+        server.setResponse(GrpcUtil.nextRequest(ITERATOR), responseObserver -> {
+            responseObserver.onNext(response);
+            server.setResponse(GrpcUtil.nextRequest(ITERATOR), GrpcUtil.doneResponse());
+        });
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request
@@ -214,8 +225,13 @@ public class RemoteGraknTxTest {
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponse(GrpcUtil.execQueryRequest(queryString), response);
-        server.setResponse(GrpcUtil.nextRequest(), GrpcUtil.doneResponse());
+        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.iteratorResponse(ITERATOR));
+
+        // Mock next response after this one
+        server.setResponse(GrpcUtil.nextRequest(ITERATOR), responseObserver -> {
+            responseObserver.onNext(response);
+            server.setResponse(GrpcUtil.nextRequest(ITERATOR), GrpcUtil.doneResponse());
+        });
 
         Answer answer;
 
@@ -237,8 +253,8 @@ public class RemoteGraknTxTest {
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponse(GrpcUtil.execQueryRequest(queryString), response);
-        server.setResponse(GrpcUtil.nextRequest(), response);
+        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.iteratorResponse(ITERATOR));
+        server.setResponse(GrpcUtil.nextRequest(ITERATOR), response);
 
         List<Answer> answers;
         int numAnswers = 10;
@@ -357,9 +373,13 @@ public class RemoteGraknTxTest {
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponse(GrpcUtil.execQueryRequest(expectedQuery), response);
+        server.setResponse(GrpcUtil.execQueryRequest(expectedQuery), GrpcUtil.iteratorResponse(ITERATOR));
 
-        server.setResponse(GrpcUtil.nextRequest(), GrpcUtil.doneResponse());
+        // Mock next response after this one
+        server.setResponse(GrpcUtil.nextRequest(ITERATOR), responseObserver -> {
+            responseObserver.onNext(response);
+            server.setResponse(GrpcUtil.nextRequest(ITERATOR), GrpcUtil.doneResponse());
+        });
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -42,6 +42,7 @@ import ai.grakn.rpc.generated.GraknOuterClass.Done;
 import ai.grakn.rpc.generated.GraknOuterClass.ExecQuery;
 import ai.grakn.rpc.generated.GraknOuterClass.GetConceptProperty;
 import ai.grakn.rpc.generated.GraknOuterClass.Infer;
+import ai.grakn.rpc.generated.GraknOuterClass.IteratorId;
 import ai.grakn.rpc.generated.GraknOuterClass.Next;
 import ai.grakn.rpc.generated.GraknOuterClass.Open;
 import ai.grakn.rpc.generated.GraknOuterClass.Stop;
@@ -137,12 +138,12 @@ public class GrpcUtil {
         return TxRequest.newBuilder().setExecQuery(execQueryRequest).build();
     }
 
-    public static TxRequest nextRequest() {
-        return TxRequest.newBuilder().setNext(Next.getDefaultInstance()).build();
+    public static TxRequest nextRequest(IteratorId iteratorId) {
+        return TxRequest.newBuilder().setNext(Next.newBuilder().setIteratorId(iteratorId).build()).build();
     }
 
-    public static TxRequest stopRequest() {
-        return TxRequest.newBuilder().setStop(Stop.getDefaultInstance()).build();
+    public static TxRequest stopRequest(IteratorId iteratorId) {
+        return TxRequest.newBuilder().setStop(Stop.newBuilder().setIteratorId(iteratorId).build()).build();
     }
 
     public static TxRequest getConceptPropertyRequest(ConceptId id, ai.grakn.grpc.ConceptProperty<?> property) {
@@ -155,6 +156,10 @@ public class GrpcUtil {
 
     public static TxResponse doneResponse() {
         return TxResponse.newBuilder().setDone(Done.getDefaultInstance()).build();
+    }
+
+    public static TxResponse iteratorResponse(IteratorId iteratorId) {
+        return TxResponse.newBuilder().setIteratorId(iteratorId).build();
     }
 
     public static Keyspace getKeyspace(Open open) {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -37,13 +37,11 @@ import ai.grakn.concept.Type;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.admin.Answer;
-import ai.grakn.grpc.GrpcTestUtil;
 import ai.grakn.remote.RemoteGrakn;
 import ai.grakn.test.kbs.MovieKB;
 import ai.grakn.test.rule.EngineContext;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Sets;
-import io.grpc.Status;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -185,19 +183,17 @@ public class GrpcServerIT {
         assertEquals(answers1, answers2);
     }
 
-    @Test // This behaviour is temporary - we should eventually support it correctly
-    public void whenExecutingTwoParallelQueries_Throw() throws Throwable {
+    @Test
+    public void whenExecutingTwoParallelQueries_GetBothResults() throws Throwable {
         try (GraknTx tx = remoteSession.open(GraknTxType.READ)) {
             GetQuery query = tx.graql().match(var("x").sub("thing")).get();
 
             Iterator<Answer> iterator1 = query.iterator();
             Iterator<Answer> iterator2 = query.iterator();
 
-            exception.expect(GrpcTestUtil.hasStatus(Status.FAILED_PRECONDITION));
-
             while (iterator1.hasNext() || iterator2.hasNext()) {
-                if (iterator1.hasNext()) iterator1.next();
-                if (iterator2.hasNext()) iterator2.next();
+                assertEquals(iterator1.next(), iterator2.next());
+                assertEquals(iterator1.hasNext(), iterator2.hasNext());
             }
         }
     }


### PR DESCRIPTION
Requires [this PR](https://github.com/graknlabs/grakn-spec/pull/11) to be merged first.

# Why is this PR needed?

To support running more than one query at a time over gRPC. This is important in loops, or if you just don't finish executing a query before you start the next one.

# What does the PR do?

gRPC now includes an `IteratorId` for communicating which set of results we're asking for. The gRPC server keeps a map of open iterators.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None! This should do the trick. It's also extensible if we need to support iterating on things other than query results.
