### PR TITLE
Fix variable binding for daughter-in-law rules

### DIFF
--- a/grakn-dist/src/examples/basic-genealogy.gql
+++ b/grakn-dist/src/examples/basic-genealogy.gql
@@ -438,13 +438,13 @@ then
 inLaws3 sub rule
 when
 {(husband: $x, wife: $y) isa marriage;
-(father: $il, child: $y) isa parentship;}
+(father: $il, child: $x) isa parentship;}
 then
 {(father-in-law: $il, daughter-in-law: $y) isa in-laws;};
 
 inLaws4 sub rule
 when
 {(husband: $x, wife: $y) isa marriage;
-(mother: $il, child: $y) isa parentship;}
+(mother: $il, child: $x) isa parentship;}
 then
 {(mother-in-law: $il, daughter-in-law: $y) isa in-laws;};


### PR DESCRIPTION
# Why is this PR needed?
Rule was defined incorrectly

# What does the PR do?
Fixes variable binding in example rules.

# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
None.