### PR TITLE
Fix issue when error occurs during gRPC transaction

### DIFF
--- a/grakn-client/pom.xml
+++ b/grakn-client/pom.xml
@@ -74,6 +74,10 @@
             <groupId>ai.grakn</groupId>
             <artifactId>grakn-grpc</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>ai.grakn</groupId>

--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -25,6 +25,8 @@ import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Label;
 import ai.grakn.exception.GraknBackendException;
+import ai.grakn.exception.GraknTxOperationException;
+import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.exception.InvalidKBException;
 import ai.grakn.graql.DefineQuery;
 import ai.grakn.graql.GetQuery;
@@ -61,6 +63,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static ai.grakn.graql.Graql.define;
+import static ai.grakn.graql.Graql.match;
 import static ai.grakn.graql.Graql.var;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
@@ -312,6 +315,47 @@ public class RemoteGraknTxTest {
             exception.expectMessage("do it better next time");
 
             tx.commit();
+        }
+    }
+
+    @Test
+    public void whenAnErrorOccurs_TheTxCloses() {
+        Query<?> query = match(var("x")).get();
+
+        TxRequest execQueryRequest = GrpcUtil.execQueryRequest(query);
+        throwOn(execQueryRequest, ErrorType.GRAQL_QUERY_EXCEPTION, "well something went wrong");
+
+        try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
+            try {
+                tx.graql().match(var("x")).get().execute();
+            } catch (GraqlQueryException e) {
+                // Ignore
+            }
+
+            assertTrue(tx.isClosed());
+        }
+    }
+
+    @Test
+    public void whenAnErrorOccurs_AllFutureActionsThrow() {
+        Query<?> query = match(var("x")).get();
+
+        TxRequest execQueryRequest = GrpcUtil.execQueryRequest(query);
+        throwOn(execQueryRequest, ErrorType.GRAQL_QUERY_EXCEPTION, "well something went wrong");
+
+        try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
+            try {
+                tx.graql().match(var("x")).get().execute();
+            } catch (GraqlQueryException e) {
+                // Ignore
+            }
+
+            exception.expect(GraknTxOperationException.class);
+            exception.expectMessage(
+                    GraknTxOperationException.transactionClosed(null, "The gRPC connection closed").getMessage()
+            );
+
+            tx.admin().getMetaConcept();
         }
     }
 

--- a/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
@@ -33,6 +33,7 @@ import ai.grakn.util.Schema;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Element;
 
+import javax.annotation.Nullable;
 import java.util.stream.Collectors;
 
 import static ai.grakn.util.ErrorMessage.CLOSE_FAILURE;
@@ -189,7 +190,7 @@ public class GraknTxOperationException extends GraknException{
     /**
      * Thrown when attempting to use the graph when the transaction is closed
      */
-    public static GraknTxOperationException transactionClosed(GraknTx tx, String reason){
+    public static GraknTxOperationException transactionClosed(@Nullable GraknTx tx, @Nullable String reason){
         if(reason == null){
             return create(ErrorMessage.TX_CLOSED.getMessage(tx.keyspace()));
         } else {


### PR DESCRIPTION
# Why is this PR needed?

There was a bug where a `RemoteGraknTx` would hang forever after an error occurred. Now an error will cause the transaction to close and future operations to immediately throw.

# What does the PR do?

Adds a check that will throw when the connection is terminated, instead of polling indefinitely.

Also there was a dependency issue I fixed at the same time #efficiency

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

We may want to align the behaviour of `EmbeddedGraknTx` and `RemoteGraknTx` when an error occurs. Right now I think `EmbeddedGraknTx` will allow you to keep working. I don't know which behaviour is better: `EmbeddedGraknTx` is more permissive, but it could also cause odd bugs with broken or invalid transactions etc.