### PR TITLE
remove the ability of overriding GRAKN_HOME

### DIFF
--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -18,10 +18,8 @@
 # <http://www.gnu.org/licenses/gpl.txt>.
 
 # Grakn global variables
-if [ -z "${GRAKN_HOME}" ]; then
-    [[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
-    GRAKN_HOME=$(cd "$(dirname "${path}")" && pwd -P)
-fi
+[[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
+GRAKN_HOME=$(cd "$(dirname "${path}")" && pwd -P)
 
 # ================================================
 # common helper functions


### PR DESCRIPTION
# Why is this PR needed?
There's nothing good out of being able to override GRAKN_HOME. By definition, GRAKN_HOME should always points to, well, Grakn's home directory

# What does the PR do?
1. Remove the clause which says "if GRAKN_HOME is defined from outside, use that instead"

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A