### PR TITLE
Bug 19627: Removing a role-player can still fail at commit

### DIFF
--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/cache/TxCache.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/cache/TxCache.java
@@ -218,6 +218,10 @@ public class TxCache{
         }
     }
 
+    public void remove(Casting casting){
+        modifiedCastings.remove(casting);
+    }
+
     /**
      * Caches a concept so it does not have to be rebuilt later.
      *

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipReified.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipReified.java
@@ -96,7 +96,10 @@ public class RelationshipReified extends ThingImpl<Relationship, RelationshipTyp
     void removeRolePlayer(Role role, Thing thing) {
         castingsRelation().filter(casting -> casting.getRole().equals(role) && casting.getRolePlayer().equals(thing)).
                 findAny().
-                ifPresent(Casting::delete);
+                ifPresent(casting -> {
+                   casting.delete();
+                   vertex().tx().txCache().remove(casting);
+                });
     }
 
     public void addRolePlayer(Role role, Thing thing) {

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/ValidatorTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/ValidatorTest.java
@@ -549,4 +549,21 @@ public class ValidatorTest extends TxTestBase {
         tx.commit();
     }
 
+
+    @Test
+    public void whenRemovingInvalidRolePlayers_EnsureValidationPasses(){
+        Role chased = tx.putRole("chased");
+        Role chaser = tx.putRole("chaser");
+        RelationshipType chases = tx.putRelationshipType("chases").relates(chased).relates(chaser);
+
+        EntityType puppy = tx.putEntityType("puppy").plays(chaser);
+        Entity dunstan = puppy.addEntity();
+
+        Relationship rel = chases.addRelationship();
+        rel.addRolePlayer(chaser, dunstan);
+        rel.addRolePlayer(chased, dunstan).removeRolePlayer(chased, dunstan);
+
+        tx.commit();
+    }
+
 }


### PR DESCRIPTION
# Why is this PR needed?

It fixes a bug which prevents valid transactions from being committed.

# What does the PR do?

Fixes a caching bug.

# Does it break backwards compatibility?

No

# List of future improvements not on this PR
