### PR TITLE
Support inference flag on remote gRPC properly

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/remote/GrpcClient.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/GrpcClient.java
@@ -76,8 +76,8 @@ public final class GrpcClient implements AutoCloseable {
         responseOrThrow();
     }
 
-    public Iterator<Object> execQuery(RemoteGraknTx tx, Query<?> query, @Nullable Boolean infer) {
-        communicator.send(GrpcUtil.execQueryRequest(query.toString(), infer));
+    public Iterator<Object> execQuery(RemoteGraknTx tx, Query<?> query) {
+        communicator.send(GrpcUtil.execQueryRequest(query.toString(), query.inferring()));
 
         IteratorId iteratorId = responseOrThrow().getIteratorId();
 

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknTx.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknTx.java
@@ -246,6 +246,6 @@ public final class RemoteGraknTx implements GraknTx, GraknAdmin {
 
     @Override
     public QueryRunner queryRunner() {
-        return RemoteQueryRunner.create(this, client, null);
+        return RemoteQueryRunner.create(this, client);
     }
 }

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteQueryRunner.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteQueryRunner.java
@@ -45,7 +45,6 @@ import ai.grakn.graql.analytics.StdQuery;
 import ai.grakn.graql.analytics.SumQuery;
 import com.google.common.collect.Iterators;
 
-import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -67,16 +66,14 @@ final class RemoteQueryRunner implements QueryRunner {
 
     private final RemoteGraknTx tx;
     private final GrpcClient client;
-    private final @Nullable Boolean infer;
 
-    private RemoteQueryRunner(RemoteGraknTx tx, GrpcClient client, @Nullable Boolean infer) {
+    private RemoteQueryRunner(RemoteGraknTx tx, GrpcClient client) {
         this.tx = tx;
         this.client = client;
-        this.infer = infer;
     }
 
-    public static RemoteQueryRunner create(RemoteGraknTx tx, GrpcClient client, @Nullable Boolean infer) {
-        return new RemoteQueryRunner(tx, client, infer);
+    public static RemoteQueryRunner create(RemoteGraknTx tx, GrpcClient client) {
+        return new RemoteQueryRunner(tx, client);
     }
 
     @Override
@@ -175,7 +172,7 @@ final class RemoteQueryRunner implements QueryRunner {
     }
 
     private Iterator<Object> run(Query<?> query) {
-        return client.execQuery(tx, query, infer);
+        return client.execQuery(tx, query);
     }
 
     private void runVoid(Query<?> query) {

--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -52,7 +52,6 @@ import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -262,7 +261,6 @@ public class RemoteGraknTxTest {
         }
     }
 
-    @Ignore // TODO: dream about supporting this
     @Test
     public void whenExecutingAQueryWithInferenceSet_SendAnExecQueryWithInferenceSetMessageToGrpc() {
         String queryString = "match $x isa person; get $x;";

--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -62,7 +62,9 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static ai.grakn.graql.Graql.ask;
 import static ai.grakn.graql.Graql.define;
+import static ai.grakn.graql.Graql.label;
 import static ai.grakn.graql.Graql.match;
 import static ai.grakn.graql.Graql.var;
 import static java.util.stream.Collectors.toList;
@@ -150,7 +152,8 @@ public class RemoteGraknTxTest {
 
     @Test
     public void whenExecutingAQuery_SendAnExecQueryMessageToGrpc() {
-        String queryString = "match $x isa person; get $x;";
+        Query<?> query = match(var("x").isa("person")).get();
+        String queryString = query.toString();
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request
@@ -158,19 +161,20 @@ public class RemoteGraknTxTest {
             tx.graql().parse(queryString).execute();
         }
 
-        verify(server.requests()).onNext(GrpcUtil.execQueryRequest(queryString));
+        verify(server.requests()).onNext(GrpcUtil.execQueryRequest(query));
     }
 
     @Test
     public void whenExecutingAQuery_GetAResultBack() {
-        String queryString = "match $x isa person; get $x;";
+        Query<?> query = match(var("x").isa("person")).get();
+        String queryString = query.toString();
 
         GraknOuterClass.Concept v123 = GraknOuterClass.Concept.newBuilder().setId(V123).build();
         GraknOuterClass.Answer grpcAnswer = GraknOuterClass.Answer.newBuilder().putAnswer("x", v123).build();
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(queryString), response);
+        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
 
         List<Answer> results;
 
@@ -186,9 +190,10 @@ public class RemoteGraknTxTest {
 
     @Test
     public void whenExecutingAQueryWithAVoidResult_GetANullBack() {
-        String queryString = "match $x isa person; delete $x;";
+        Query<?> query = match(var("x").isa("person")).delete("x");
+        String queryString = query.toString();
 
-        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.doneResponse());
+        server.setResponse(GrpcUtil.execQueryRequest(query), GrpcUtil.doneResponse());
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request
@@ -198,12 +203,13 @@ public class RemoteGraknTxTest {
 
     @Test
     public void whenExecutingAQueryWithABooleanResult_GetABoolBack() {
-        String queryString = "match $x isa person; aggregate ask;";
+        Query<?> query = match(var("x").isa("person")).aggregate(ask());
+        String queryString = query.toString();
 
         TxResponse response =
                 TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("true")).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(queryString), response);
+        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request
@@ -213,14 +219,15 @@ public class RemoteGraknTxTest {
 
     @Test
     public void whenExecutingAQueryWithASingleAnswer_GetAnAnswerBack() {
-        String queryString = "define label person sub entity;";
+        Query<?> query = define(label("person").sub("entity"));
+        String queryString = query.toString();
 
         GraknOuterClass.Concept v123 = GraknOuterClass.Concept.newBuilder().setId(V123).build();
         GraknOuterClass.Answer grpcAnswer = GraknOuterClass.Answer.newBuilder().putAnswer("x", v123).build();
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(queryString), response);
+        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
 
         Answer answer;
 
@@ -235,14 +242,15 @@ public class RemoteGraknTxTest {
 
     @Test(timeout = 5_000)
     public void whenStreamingAQueryWithInfiniteAnswers_Terminate() {
-        String queryString = "match $x sub thing; get $x;";
+        Query<?> query = match(var("x").sub("thing")).get();
+        String queryString = query.toString();
 
         GraknOuterClass.Concept v123 = GraknOuterClass.Concept.newBuilder().setId(V123).build();
         GraknOuterClass.Answer grpcAnswer = GraknOuterClass.Answer.newBuilder().putAnswer("x", v123).build();
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponse(GrpcUtil.execQueryRequest(queryString), GrpcUtil.iteratorResponse(ITERATOR));
+        server.setResponse(GrpcUtil.execQueryRequest(query), GrpcUtil.iteratorResponse(ITERATOR));
         server.setResponse(GrpcUtil.nextRequest(ITERATOR), response);
 
         List<Answer> answers;
@@ -415,21 +423,19 @@ public class RemoteGraknTxTest {
     }
 
     private void verifyCorrectQuerySent(Query query, GraknOuterClass.BaseType baseType, Consumer<GraknTx> txConsumer){
-        String expectedQuery = query.toString();
-
         GraknOuterClass.Concept v123 = GraknOuterClass.Concept.newBuilder().setBaseType(baseType).setId(V123).build();
         GraknOuterClass.Answer grpcAnswer = GraknOuterClass.Answer.newBuilder().putAnswer("x", v123).build();
         QueryResult queryResult = QueryResult.newBuilder().setAnswer(grpcAnswer).build();
         TxResponse response = TxResponse.newBuilder().setQueryResult(queryResult).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(expectedQuery), response);
+        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
 
         try (GraknTx tx = RemoteGraknTx.create(session, GraknTxType.WRITE)) {
             verify(server.requests()).onNext(any()); // The open request
             txConsumer.accept(tx);
         }
 
-        verify(server.requests()).onNext(GrpcUtil.execQueryRequest(expectedQuery));
+        verify(server.requests()).onNext(GrpcUtil.execQueryRequest(query));
     }
 
     @Test

--- a/grakn-core/src/main/java/ai/grakn/graql/Query.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Query.java
@@ -21,6 +21,7 @@ package ai.grakn.graql;
 import ai.grakn.GraknTx;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -71,4 +72,7 @@ public interface Query<T> {
      * Get the transaction associated with this query
      */
     Optional<? extends GraknTx> tx();
+
+    @Nullable
+    Boolean inferring();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -64,4 +65,7 @@ public interface MatchAdmin extends Match {
      */
     @CheckReturnValue
     Set<Var> getSelectedNames();
+
+    @Nullable
+    Boolean inferring();
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -24,8 +24,6 @@ import ai.grakn.concept.Concept;
 import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Label;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
-import ai.grakn.engine.lock.JedisLockProvider;
-import ai.grakn.engine.lock.LockProvider;
 import ai.grakn.exception.GraknBackendException;
 import ai.grakn.exception.GraknException;
 import ai.grakn.exception.GraknTxOperationException;
@@ -266,7 +264,7 @@ public class GrpcServerTest {
     public void whenExecutingAQueryRemotely_TheQueryIsParsedAndExecuted() {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
         }
 
         ai.grakn.graql.Query<?> query = tx.graql().parse(QUERY);
@@ -298,7 +296,7 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator = tx.receive().ok().getIteratorId();
 
             tx.send(nextRequest(iterator));
@@ -356,7 +354,7 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator = tx.receive().ok().getIteratorId();
 
             tx.send(nextRequest(iterator));
@@ -377,7 +375,7 @@ public class GrpcServerTest {
     public void whenExecutingQueryWithoutInferenceSet_InferenceIsNotSet() throws InterruptedException {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator = tx.receive().ok().getIteratorId();
 
             tx.send(nextRequest(iterator));
@@ -526,7 +524,7 @@ public class GrpcServerTest {
     @Test
     public void whenExecutingAQueryBeforeOpeningTx_Throw() throws Throwable {
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
 
             exception.expect(hasStatus(Status.FAILED_PRECONDITION));
 
@@ -592,7 +590,7 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(message)));
             exception.expect(hasMetadata(ErrorType.KEY, ErrorType.GRAQL_SYNTAX_EXCEPTION));
@@ -612,7 +610,7 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
 
             exception.expect(hasStatus(Status.UNKNOWN.withDescription(message)));
             exception.expect(hasMetadata(ErrorType.KEY, ErrorType.GRAQL_QUERY_EXCEPTION));
@@ -655,7 +653,7 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator = tx.receive().ok().getIteratorId();
 
             tx.send(stopRequest(iterator));
@@ -675,10 +673,10 @@ public class GrpcServerTest {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));
             tx.receive();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator1 = tx.receive().ok().getIteratorId();
 
-            tx.send(execQueryRequest(QUERY));
+            tx.send(execQueryRequest(QUERY, null));
             IteratorId iterator2 = tx.receive().ok().getIteratorId();
 
             tx.send(nextRequest(iterator1));

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
@@ -25,6 +25,7 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.admin.Answer;
 import com.google.auto.value.AutoValue;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -62,5 +63,11 @@ abstract class AggregateQueryImpl<T> extends AbstractExecutableQuery<T> implemen
     @Override
     public final String toString() {
         return match().toString() + " aggregate " + aggregate().toString() + ";";
+    }
+
+    @Nullable
+    @Override
+    public final Boolean inferring() {
+        return match().admin().inferring();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
@@ -62,4 +62,10 @@ abstract class DefineQueryImpl extends AbstractExecutableQuery<Answer> implement
     public String toString() {
         return "define " + varPatterns().stream().map(v -> v + ";").collect(Collectors.joining("\n")).trim();
     }
+
+    @Nullable
+    @Override
+    public Boolean inferring() {
+        return null;
+    }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.admin.DeleteQueryAdmin;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -80,5 +81,11 @@ abstract class DeleteQueryImpl extends AbstractQuery<Void, Void> implements Dele
     protected final Stream<Void> stream() {
         execute();
         return Stream.empty();
+    }
+
+    @Nullable
+    @Override
+    public final Boolean inferring() {
+        return match().admin().inferring();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.admin.Answer;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -76,5 +77,11 @@ public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> i
     @Override
     public final List<Answer> execute() {
         return stream().collect(Collectors.toList());
+    }
+
+    @Nullable
+    @Override
+    public final Boolean inferring() {
+        return match().admin().inferring();
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -34,6 +34,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -127,5 +128,11 @@ abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> imple
     @Override
     public final List<Answer> execute() {
         return stream().collect(Collectors.toList());
+    }
+
+    @Nullable
+    @Override
+    public final Boolean inferring() {
+        return match().map(match -> match.admin().inferring()).orElse(null);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/UndefineQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/UndefineQueryImpl.java
@@ -66,4 +66,10 @@ abstract class UndefineQueryImpl extends AbstractQuery<Void, Void> implements Un
         execute();
         return Stream.empty();
     }
+
+    @Nullable
+    @Override
+    public Boolean inferring() {
+        return null;
+    }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/analytics/AbstractComputeQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/analytics/AbstractComputeQuery.java
@@ -26,6 +26,7 @@ import ai.grakn.graql.internal.query.AbstractExecutableQuery;
 import ai.grakn.graql.internal.util.StringConverter;
 import com.google.common.collect.ImmutableSet;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
@@ -123,6 +124,12 @@ abstract class AbstractComputeQuery<T, V extends ComputeQuery<T>>
     @Override
     public final String toString() {
         return "compute " + graqlString();
+    }
+
+    @Nullable
+    @Override
+    public Boolean inferring() {
+        return null;
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchBase.java
@@ -167,6 +167,11 @@ public class MatchBase extends AbstractMatch {
     }
 
     @Override
+    public final Boolean inferring() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "match " + pattern.getPatterns().stream().map(p -> p + ";").collect(joining(" "));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchInfer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchInfer.java
@@ -79,6 +79,11 @@ class MatchInfer extends MatchModifier {
     }
 
     @Override
+    public final Boolean inferring() {
+        return true;
+    }
+
+    @Override
     protected String modifierString() {
         return "";
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
@@ -25,6 +25,7 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 
@@ -72,6 +73,12 @@ abstract class MatchModifier extends AbstractMatch {
      * @return a string representation of this modifier
      */
     protected abstract String modifierString();
+
+    @Nullable
+    @Override
+    public Boolean inferring() {
+        return inner.inferring();
+    }
 
     @Override
     public final String toString() {

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -127,11 +127,7 @@ public class GrpcUtil {
     }
 
     public static TxRequest execQueryRequest(Query<?> query) {
-        return execQueryRequest(query.toString());
-    }
-
-    public static TxRequest execQueryRequest(String queryString) {
-        return execQueryRequest(queryString, null);
+        return execQueryRequest(query.toString(), query.inferring());
     }
 
     public static TxRequest execQueryRequest(String queryString, @Nullable Boolean infer) {


### PR DESCRIPTION
# Why is this PR needed?

The inference flag wasn't supported over gRPC properly, now it is!

# What does the PR do?

We handle inference in a weird way (which I now regret!) using the `MatchInfer` class. This means that the inference setting is part of the query object.

I added a `Query#inferring` method to retrieve this from each query type and read it in the `GrpcClient`.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None! This is the last thing we didn't support 👍 
