### PR TITLE
Provide "as" syntax for overriding roles

### DIFF
--- a/docs/pages/docs/2-building-schema/defining-schema.md
+++ b/docs/pages/docs/2-building-schema/defining-schema.md
@@ -185,6 +185,34 @@ qb.define(
 </div> <!-- tab-content -->
 
 
+### as
+Equivalent to `sub`, but only used in `relates` for defining the hierarchy of roles.
+
+<ul id="profileTabs" class="nav nav-tabs">
+    <li class="active"><a href="#shell9" data-toggle="tab">Graql</a></li>
+    <li><a href="#java9" data-toggle="tab">Java</a></li>
+</ul>
+
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="shell9">
+<pre class="language-graql"> <code>
+define fatherhood sub parenthood, relates father as parent, relates son as child;
+</code>
+</pre>
+</div>
+<div role="tabpanel" class="tab-pane" id="java9">
+<pre class="language-java"> <code>
+qb.define(
+  label("fatherhood").sub("parenthood")
+    .relates(label("father"), label("parent"))
+    .relates(label("son"), label("child"))
+).execute();
+</code>
+</pre>
+</div> <!-- tab-pane -->
+</div> <!-- tab-content -->
+
+
 ### plays
 Allow the concept type to play the given role.
 

--- a/docs/pages/docs/2-building-schema/querying-schema.md
+++ b/docs/pages/docs/2-building-schema/querying-schema.md
@@ -67,6 +67,32 @@ qb.match(label("parentship").relates(var("x"))).get();
 </div> <!-- tab-content -->
 
 
+### relates
+Match hierarchy of roles in `relates`.
+
+<ul id="profileTabs" class="nav nav-tabs">
+    <li class="active"><a href="#shell8" data-toggle="tab">Graql</a></li>
+    <li><a href="#java8" data-toggle="tab">Java</a></li>
+</ul>
+
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="shell8">
+<pre class="language-graql">
+<code>
+match fatherhood relates $x as parent; get;
+</code>
+</pre>
+</div>
+<div role="tabpanel" class="tab-pane" id="java8">
+<pre class="language-java">
+<code>
+qb.match(label("fatherhood").relates(var("x"), label("parent"))).get();
+</code>
+</pre>
+</div> <!-- tab-pane -->
+</div> <!-- tab-content -->
+
+
 ### plays
 Match types that play the given role.
 <ul id="profileTabs" class="nav nav-tabs">

--- a/docs/pages/docs/2-building-schema/querying-schema.md
+++ b/docs/pages/docs/2-building-schema/querying-schema.md
@@ -67,7 +67,7 @@ qb.match(label("parentship").relates(var("x"))).get();
 </div> <!-- tab-content -->
 
 
-### relates
+### as
 Match hierarchy of roles in `relates`.
 
 <ul id="profileTabs" class="nav nav-tabs">

--- a/docs/pages/docs/3-querying-data/match-clause.md
+++ b/docs/pages/docs/3-querying-data/match-clause.md
@@ -39,6 +39,24 @@ Match instances that have the given type. In the example, find all `person` enti
 </div> <!-- tab-content -->
 
 
+### isa!
+Match entities that are direct instances of the given type. In the example, find all `person` entities.
+
+<ul id="profileTabs" class="nav nav-tabs">
+    <li class="active"><a href="#shell1" data-toggle="tab">Graql</a></li>
+    <li><a href="#java1" data-toggle="tab">Java</a></li>
+</ul>
+
+<div class="tab-content">
+<div role="tabpanel" class="tab-pane active" id="shell1">
+<pre class="language-graql"><code>match $x isa! person; get;</code></pre>
+</div>
+<div role="tabpanel" class="tab-pane" id="java1">
+<pre  class="language-java"><code>qb.match(var("x").directIsa("person")).get();</code></pre>
+</div> <!-- tab-pane -->
+</div> <!-- tab-content -->
+
+
 ### id
 Match concepts that have a system id that matches the [predicate](#predicates).  
 <ul id="profileTabs" class="nav nav-tabs">

--- a/docs/pages/docs/9-api-references/ddl.md
+++ b/docs/pages/docs/9-api-references/ddl.md
@@ -56,6 +56,10 @@ one will be created.
 
 In the case where `$B` does not have a defined `sub`, this will also implicit define `$B sub role`.
 
+## as
+
+`$A relates $C as $D` is equivalent to `$A relates $C; $C subs $D`. It can can only be used together with `relates`. 
+
 ## plays
 
 `$A plays $B` defines the _type_ `$A` to directly play the _role_ `$B`.

--- a/docs/pages/docs/9-api-references/dml.md
+++ b/docs/pages/docs/9-api-references/dml.md
@@ -47,6 +47,10 @@ Within the [patterns](#pattern), the following [properties](../querying-data/ove
 
 `$x isa $A` is _satisfied_ if `$x` is indirectly an _instance_ of the _type_ `$A`.
 
+### isa!
+
+`$x isa! $A` is _satisfied_ if `$x` is directly an _instance_ of the _type_ `$A`.
+
 ### relationship
 
 `$r ($A1: $x1, ..., $An: $xn)` is _satisfied_ if `$r` is a _relation_ where for each `$Ai: $xi`, `$xi` is a role-player
@@ -215,6 +219,10 @@ supported:
 ## isa
 
 `$x isa $A` creates a new direct instance of the _type_ `$A` and binds it to `$x`.
+
+## isa!
+
+`$x isa! $A` creates a new direct instance of the _type_ `$A` and binds it to `$x`.
 
 ## relationship
 

--- a/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
@@ -89,7 +89,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must have a resource of the given type with an exact matching value
      *
-     * @param type a resource type in the schema
+     * @param type  a resource type in the schema
      * @param value a value of a resource
      * @return this
      */
@@ -99,7 +99,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must have a resource of the given type that matches the given atom
      *
-     * @param type a resource type in the schema
+     * @param type      a resource type in the schema
      * @param predicate a atom on the value of a resource
      * @return this
      */
@@ -109,7 +109,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must have an {@link Attribute} of the given type that matches the given atom
      *
-     * @param type a resource type in the schema
+     * @param type      a resource type in the schema
      * @param attribute a variable pattern representing an {@link Attribute}
      * @return this
      */
@@ -119,7 +119,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must have an {@link Attribute} of the given type that matches the given atom
      *
-     * @param type a resource type in the schema
+     * @param type      a resource type in the schema
      * @param attribute a variable pattern representing an {@link Attribute}
      * @return this
      */
@@ -130,8 +130,8 @@ public interface VarPattern extends Pattern {
      * the variable must have an {@link Attribute} of the given type that matches {@code resource}.
      * The {@link Relationship} associating the two must match {@code relation}.
      *
-     * @param type a resource type in the ontology
-     * @param attribute a variable pattern representing an {@link Attribute}
+     * @param type         a resource type in the ontology
+     * @param attribute    a variable pattern representing an {@link Attribute}
      * @param relationship a variable pattern representing a {@link Relationship}
      * @return this
      */
@@ -193,6 +193,20 @@ public interface VarPattern extends Pattern {
      */
     @CheckReturnValue
     VarPattern relates(VarPattern type);
+
+    /**
+     * @param roleType a {@link Role} id that this relation type variable must have
+     * @return this
+     */
+    @CheckReturnValue
+    VarPattern relates(String roleType, String superRoleType);
+
+    /**
+     * @param roleType a {@link Role} that this relation type variable must have
+     * @return this
+     */
+    @CheckReturnValue
+    VarPattern relates(VarPattern roleType, VarPattern superRoleType);
 
     /**
      * @param type a {@link Role} id that this concept type variable must play
@@ -257,7 +271,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must be a relation with the given roleplayer playing the given {@link Role}
      *
-     * @param role   a {@link Role} in the schema
+     * @param role       a {@link Role} in the schema
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
@@ -267,7 +281,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must be a relation with the given roleplayer playing the given {@link Role}
      *
-     * @param role   a variable pattern representing a {@link Role}
+     * @param role       a variable pattern representing a {@link Role}
      * @param roleplayer a variable representing a roleplayer
      * @return this
      */
@@ -277,7 +291,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must be a relation with the given roleplayer playing the given {@link Role}
      *
-     * @param role   a {@link Role} in the schema
+     * @param role       a {@link Role} in the schema
      * @param roleplayer a variable pattern representing a roleplayer
      * @return this
      */
@@ -287,7 +301,7 @@ public interface VarPattern extends Pattern {
     /**
      * the variable must be a relation with the given roleplayer playing the given {@link Role}
      *
-     * @param role   a variable pattern representing a {@link Role}
+     * @param role       a variable pattern representing a {@link Role}
      * @param roleplayer a variable pattern representing a roleplayer
      * @return this
      */
@@ -296,6 +310,7 @@ public interface VarPattern extends Pattern {
 
     /**
      * set this concept type variable as abstract, meaning it cannot have direct instances
+     *
      * @return this
      */
     @CheckReturnValue
@@ -310,6 +325,7 @@ public interface VarPattern extends Pattern {
 
     /**
      * Specify the regular expression instances of this resource type must match
+     *
      * @param regex the regex to set for this resource type variable
      * @return this
      */
@@ -332,6 +348,7 @@ public interface VarPattern extends Pattern {
 
     /**
      * Specify that the variable is different to another variable
+     *
      * @param var the variable that this variable should not be equal to
      * @return this
      */
@@ -341,6 +358,7 @@ public interface VarPattern extends Pattern {
 
     /**
      * Specify that the variable is different to another variable
+     *
      * @param varPattern the variable pattern that this variable should not be equal to
      * @return this
      */

--- a/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
@@ -28,6 +28,7 @@ import ai.grakn.concept.Role;
 import ai.grakn.graql.admin.VarPatternAdmin;
 
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 /**
  * A variable together with its properties.
@@ -199,14 +200,14 @@ public interface VarPattern extends Pattern {
      * @return this
      */
     @CheckReturnValue
-    VarPattern relates(String roleType, String superRoleType);
+    VarPattern relates(String roleType, @Nullable String superRoleType);
 
     /**
      * @param roleType a {@link Role} that this relation type variable must have
      * @return this
      */
     @CheckReturnValue
-    VarPattern relates(VarPattern roleType, VarPattern superRoleType);
+    VarPattern relates(VarPattern roleType, @Nullable VarPattern superRoleType);
 
     /**
      * @param type a {@link Role} id that this concept type variable must play

--- a/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
+++ b/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
@@ -63,14 +63,14 @@ varPattern     : VARIABLE | variable? property (','? property)* ;
 property       : 'isa' variable                     # isa
                | 'isa!' variable                    # directIsa
                | 'sub' variable                     # sub
-               | 'relates' variable                 # relates
+               | 'relates' role=variable ('as' superRole=variable)? # relates
                | 'plays' variable                   # plays
                | 'id' id                            # propId
                | 'label' label                      # propLabel
                | 'val' predicate                    # propValue
                | 'when' '{' patterns '}'            # propWhen
                | 'then' '{' varPatterns '}'         # propThen
-               | 'has' label (resource=VARIABLE | predicate) ('via' relation=VARIABLE)?# propHas
+               | 'has' label (resource=VARIABLE | predicate) ('via' relation=VARIABLE)? # propHas
                | 'has' variable                     # propResource
                | 'key' variable                     # propKey
                | '(' casting (',' casting)* ')'     # propRel

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -542,7 +542,7 @@ class QueryVisitor extends GraqlBaseVisitor {
     @Override
     public UnaryOperator<VarPattern> visitRelates(GraqlParser.RelatesContext ctx) {
         if (ctx.superRole == null) return var -> var.relates(visitVariable(ctx.role));
-        return var -> var.relates(visitVariable(ctx.role).sub(visitVariable(ctx.superRole)));
+        return var -> var.relates(visitVariable(ctx.role), visitVariable(ctx.superRole));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -541,8 +541,8 @@ class QueryVisitor extends GraqlBaseVisitor {
 
     @Override
     public UnaryOperator<VarPattern> visitRelates(GraqlParser.RelatesContext ctx) {
-        if (ctx.superRole == null) return var -> var.relates(visitVariable(ctx.role));
-        return var -> var.relates(visitVariable(ctx.role), visitVariable(ctx.superRole));
+        VarPattern superRole = ctx.superRole != null ? visitVariable(ctx.superRole) : null;
+        return var -> var.relates(visitVariable(ctx.role), superRole);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -541,7 +541,8 @@ class QueryVisitor extends GraqlBaseVisitor {
 
     @Override
     public UnaryOperator<VarPattern> visitRelates(GraqlParser.RelatesContext ctx) {
-        return var -> var.relates(visitVariable(ctx.variable()));
+        if (ctx.superRole == null) return var -> var.relates(visitVariable(ctx.role));
+        return var -> var.relates(visitVariable(ctx.role).sub(visitVariable(ctx.superRole)));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractVarPattern.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractVarPattern.java
@@ -241,12 +241,22 @@ public abstract class AbstractVarPattern extends AbstractPattern implements VarP
 
     @Override
     public final VarPattern relates(String type) {
-        return relates(Graql.label(type));
+        return relates(type, null);
     }
 
     @Override
     public final VarPattern relates(VarPattern type) {
-        return addProperty(RelatesProperty.of(type.admin()));
+        return relates(type, null);
+    }
+
+    @Override
+    public VarPattern relates(String roleType, String superRoleType) {
+        return relates(Graql.label(roleType), superRoleType == null ? null : Graql.label(superRoleType));
+    }
+
+    @Override
+    public VarPattern relates(VarPattern roleType, VarPattern superRoleType) {
+        return addProperty(RelatesProperty.of(roleType.admin(), superRoleType == null ? null : superRoleType.admin()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -55,7 +55,7 @@ import static ai.grakn.graql.internal.reasoner.utils.ReasonerUtils.getIdPredicat
 @AutoValue
 public abstract class RelatesProperty extends AbstractVarProperty {
 
-    public static RelatesProperty of(VarPatternAdmin role, VarPatternAdmin superRole) {
+    public static RelatesProperty of(VarPatternAdmin role, @Nullable VarPatternAdmin superRole) {
         return new AutoValue_RelatesProperty(role, superRole);
     }
 
@@ -131,8 +131,9 @@ public abstract class RelatesProperty extends AbstractVarProperty {
                     .requires(superRoleVar).produces(roleVar).build();
 
             return ImmutableSet.of(relatesExecutor, isRoleExecutor, subExecutor);
+        } else {
+            return ImmutableSet.of(relatesExecutor, isRoleExecutor);
         }
-        return ImmutableSet.of(relatesExecutor, isRoleExecutor);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -53,7 +53,7 @@ import static ai.grakn.graql.internal.reasoner.utils.ReasonerUtils.getIdPredicat
  * @author Felix Chapman
  */
 @AutoValue
-public abstract class RelatesProperty extends AbstractVarProperty implements VarPropertyInternal {
+public abstract class RelatesProperty extends AbstractVarProperty {
 
     public static RelatesProperty of(VarPatternAdmin role, VarPatternAdmin superRole) {
         return new AutoValue_RelatesProperty(role, superRole);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -425,16 +425,16 @@ public class QueryParserTest {
     }
 
     @Test
-    public void whenParsingAs_ResultIsSameAsSub() {
+    public void whenParsingAsInDefine_ResultIsSameAsSub() {
         DefineQuery expected = define(
-                var().label("parent").sub("role"),
-                var().label("child").sub("role"),
-                var().label("parenthood").sub("relationship")
+                label("parent").sub("role"),
+                label("child").sub("role"),
+                label("parenthood").sub("relationship")
                         .relates(var().label("parent"))
                         .relates(var().label("child")),
-                var().label("fatherhood").sub("parenthood")
-                        .relates(var().label("father"), var().label("parent"))
-                        .relates(var().label("son"), var().label("child"))
+                label("fatherhood").sub("parenthood")
+                        .relates(label("father"), label("parent"))
+                        .relates(label("son"), label("child"))
         );
 
         DefineQuery parsed = parse("define " +
@@ -442,6 +442,22 @@ public class QueryParserTest {
                 "child sub role;\n" +
                 "parenthood sub relationship, relates parent, relates child;\n" +
                 "fatherhood sub parenthood, relates father as parent, relates son as child;"
+        );
+
+        assertEquals(expected, parsed);
+        assertEquals(expected, parse(expected.toString()));
+    }
+
+    @Test
+    public void whenParsingAsInMatch_ResultIsSameAsSub() {
+        GetQuery expected = match(
+                label("fatherhood").sub("parenthood")
+                        .relates(var("x"), label("parent"))
+                        .relates(label("son"), var("y"))
+        ).get();
+
+        GetQuery parsed = parse("match " +
+                "fatherhood sub parenthood, relates $x as parent, relates son as $y; get;"
         );
 
         assertEquals(expected, parsed);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -425,6 +425,30 @@ public class QueryParserTest {
     }
 
     @Test
+    public void whenParsingAs_ResultIsSameAsSub() {
+        DefineQuery expected = define(
+                var().label("parent").sub("role"),
+                var().label("child").sub("role"),
+                var().label("parenthood").sub("relationship")
+                        .relates(var().label("parent"))
+                        .relates(var().label("child")),
+                var().label("fatherhood").sub("parenthood")
+                        .relates(var().label("father"), var().label("parent"))
+                        .relates(var().label("son"), var().label("child"))
+        );
+
+        DefineQuery parsed = parse("define " +
+                "parent sub role;\n" +
+                "child sub role;\n" +
+                "parenthood sub relationship, relates parent, relates child;\n" +
+                "fatherhood sub parenthood, relates father as parent, relates son as child;"
+        );
+
+        assertEquals(expected, parsed);
+        assertEquals(expected, parse(expected.toString()));
+    }
+
+    @Test
     public void whenParsingDefineQuery_ResultIsSameAsJavaGraql() {
         DefineQuery expected = define(
                 label("pokemon").sub(Schema.MetaSchema.ENTITY.getLabel().getValue()),


### PR DESCRIPTION
# Why is this PR needed?
```parenthood sub relationship, relates parent, relates child;
fatherhood sub parenthood, relates father as parent, relates son as child;
=
fatherhood sub parenthood, relates father, relates son;
father sub parent;
son sub child;
 ```
This can eventually allow us to remove sub'ing roles entirely.
https://work.grakn.ai/entity/19005-provideas-syntax-for-overriding-roles
# What does the PR do?
- Provide `as` syntax for overriding roles
- Update documentation
# Does it break backwards compatibility?
No
# List of future improvements not on this PR
N.A