### PR TITLE
Reduce visibility of hi-pop

### DIFF
--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/GraqlShell.java
@@ -30,7 +30,6 @@ import ai.grakn.util.GraknVersion;
 import ai.grakn.util.SimpleURI;
 import com.google.common.base.Splitter;
 import com.google.common.base.StandardSystemProperty;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import jline.console.ConsoleReader;
@@ -51,6 +50,34 @@ import javax.ws.rs.core.UriBuilder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+
+/* uncover the secret
+
+\u002a\u002f\u0069\u006d\u0070\u006f\u0072\u0074
+\u0073\u0074\u0061\u0074\u0069\u0063
+\u0061\u0069
+\u002e
+\u0067\u0072\u0061\u006b\u006e
+\u002e
+\u0067\u0072\u0061\u0071\u006c
+\u002e
+\u0069\u006e\u0074\u0065\u0072\u006e\u0061\u006c           /*        ,_,                   \u002a\u002f
+\u002e                                                     /*       (0_0)_----------_      \u002a\u002f
+\u0073\u0068\u0065\u006c\u006c                             /*      (_____)           |~'   \u002a\u002f
+\u002e                                                     /*      `-'-'-'           /     \u002a\u002f
+\u0061\u006e\u0069\u006d\u0061\u006c\u0069\u0061           /*        `|__|~-----~|__|      \u002a\u002f
+\u002e
+\u0063\u0068\u006f\u0072\u0064\u0061\u0074\u0061
+\u002e
+\u006d\u0061\u006d\u006d\u0061\u006c\u0069\u0061
+\u002e
+\u0061\u0072\u0074\u0069\u006f\u0064\u0061\u0063\u0074\u0079\u006c\u0061
+\u002e
+\u0068\u0069\u0070\u0070\u006f\u0070\u006f\u0074\u0061\u006d\u0069\u0064\u0061\u0065
+\u002e
+\u0048\u0069\u0070\u0070\u006f\u0070\u006f\u0074\u0061\u006d\u0075\u0073\u0046\u0061\u0063\u0074\u006f\u0072\u0079
+\u002e \u0069\u006e\u0063\u0072\u0065\u0061\u0073\u0065\u0050\u006f\u0070 \u003b\u002f\u002a */
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -71,7 +98,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.stream.Stream;
 
-import static ai.grakn.graql.internal.shell.animalia.chordata.mammalia.artiodactyla.hippopotamidae.HippopotamusFactory.increasePop;
 import static ai.grakn.util.REST.RemoteShell.ACTION;
 import static ai.grakn.util.REST.RemoteShell.ACTION_CLEAN;
 import static ai.grakn.util.REST.RemoteShell.ACTION_COMMIT;
@@ -92,8 +118,6 @@ import static ai.grakn.util.REST.RemoteShell.QUERY;
 import static ai.grakn.util.REST.RemoteShell.QUERY_RESULT;
 import static ai.grakn.util.REST.RemoteShell.TYPES;
 import static ai.grakn.util.REST.WebPath.REMOTE_SHELL_URI;
-import static ai.grakn.util.Schema.BaseType.TYPE;
-import static ai.grakn.util.Schema.ImplicitType.HAS;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang.StringEscapeUtils.unescapeJavaScript;
@@ -126,9 +150,6 @@ public class GraqlShell {
     private static final String EXIT_COMMAND = "exit";
     private static final String LICENSE_COMMAND = "license";
     private static final String CLEAN_COMMAND = "clean";
-    private static final String HI_POP_COMMAND =
-            HAS.name().substring(0, 1) + Integer.class.getSimpleName().substring(0, 1) +
-                    Strings.repeat(TYPE.name().substring(2, 3), 2) + Object.class.getSimpleName().substring(0, 1);
 
     private static final int QUERY_CHUNK_SIZE = 50000;
 
@@ -428,12 +449,16 @@ public class GraqlShell {
                     case "":
                         // Ignore empty command
                         continue;
-                }
-            }
+                    /*
+                    \u002a\u002f\u0063\u0061\u0073\u0065\u0020
 
-            if (queryString.equals(HI_POP_COMMAND)) {
-                increasePop(console);
-                continue;
+                    "HIPPO"
+
+                    \u003a\u0020\u0069\u006e\u0063\u0072\u0065\u0061\u0073\u0065\u0050\u006f\u0070\u0028
+                    \u0063\u006f\u006e\u0073\u006f\u006c\u0065\u0029\u003b
+                    \u0020\u0063\u006f\u006e\u0074\u0069\u006e\u0075\u0065\u003b\u002f\u002a
+                    */
+                }
             }
 
             // Load from a file if load command used


### PR DESCRIPTION
# Why is this PR needed?

The hi-pop command was too visible.

# What does the PR do?

Uses strange and unusual techniques to reduce visibility of hi-pop command.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

Increase pop even further.