### PR TITLE
Fix a bug with toString on equals predicate

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicate.java
@@ -18,7 +18,7 @@
 
 package ai.grakn.graql.internal.query.predicate;
 
-import ai.grakn.concept.AttributeType;
+import ai.grakn.concept.AttributeType.DataType;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.ValuePredicate;
 import ai.grakn.graql.Var;
@@ -35,17 +35,15 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import static ai.grakn.concept.AttributeType.DataType.SUPPORTED_TYPES;
-
 abstract class ComparatorPredicate implements ValuePredicate {
 
-    private final Optional<Object> originalValue;
+    // Exactly one of these fields will be present
     private final Optional<Object> value;
     private final Optional<VarPatternAdmin> var;
 
     private static final String[] VALUE_PROPERTIES =
-            SUPPORTED_TYPES.values().stream()
-                    .map(AttributeType.DataType::getVertexProperty)
+            DataType.SUPPORTED_TYPES.values().stream()
+                    .map(DataType::getVertexProperty)
                     .distinct()
                     .map(Enum::name)
                     .toArray(String[]::new);
@@ -55,7 +53,6 @@ abstract class ComparatorPredicate implements ValuePredicate {
      */
     ComparatorPredicate(Object value) {
         if (value instanceof VarPattern) {
-            this.originalValue = Optional.empty();
             this.value = Optional.empty();
             this.var = Optional.of(((VarPattern) value).admin());
         } else {
@@ -64,20 +61,8 @@ abstract class ComparatorPredicate implements ValuePredicate {
                 value = ((Integer) value).longValue();
             }
 
-            this.originalValue = Optional.of(value);
-
-            // Convert values to how they are stored in the graph
-            AttributeType.DataType dataType = AttributeType.DataType.SUPPORTED_TYPES.get(value.getClass().getName());
-
-            if (dataType == null) {
-                throw GraqlQueryException.invalidValueClass(value);
-            }
-
-            // We can trust the `SUPPORTED_TYPES` map to store things with the right type
-            //noinspection unchecked
-            value = dataType.getPersistenceValue(value);
-
             this.value = Optional.of(value);
+
             this.var = Optional.empty();
         }
     }
@@ -86,7 +71,6 @@ abstract class ComparatorPredicate implements ValuePredicate {
      * @param var the variable that this predicate is testing against
      */
     ComparatorPredicate(VarPattern var) {
-        this.originalValue = Optional.empty();
         this.value = Optional.empty();
         this.var = Optional.of(var.admin());
     }
@@ -95,10 +79,30 @@ abstract class ComparatorPredicate implements ValuePredicate {
 
     abstract <V> P<V> gremlinPredicate(V value);
 
+    final Optional<Object> persistedValue() {
+        return value.map(value -> {
+
+            // Convert values to how they are stored in the graph
+            DataType dataType = DataType.SUPPORTED_TYPES.get(value.getClass().getName());
+
+            if (dataType == null) {
+                throw GraqlQueryException.invalidValueClass(value);
+            }
+
+            // We can trust the `SUPPORTED_TYPES` map to store things with the right type
+            //noinspection unchecked
+            return dataType.getPersistenceValue(value);
+        });
+    }
+
+    final Optional<VarPatternAdmin> var() {
+        return var;
+    }
+
     public String toString() {
         // If there is no value, then there must be a var
         //noinspection OptionalGetWithoutIsPresent
-        String argument = value.map(StringUtil::valueToString).orElseGet(() -> var.get().getPrintableName());
+        String argument = persistedValue().map(StringUtil::valueToString).orElseGet(() -> var().get().getPrintableName());
 
         return getSymbol() + " " + argument;
     }
@@ -109,14 +113,14 @@ abstract class ComparatorPredicate implements ValuePredicate {
         if (o == null || getClass() != o.getClass()) return false;
 
         ComparatorPredicate that = (ComparatorPredicate) o;
-        return value.equals(that.value);
+        return persistedValue().equals(that.persistedValue());
     }
 
     @Override
     public boolean isCompatibleWith(ValuePredicate predicate) {
         if (!(predicate instanceof EqPredicate)) return false;
         EqPredicate p = (EqPredicate) predicate;
-        Object v = value.orElse(null);
+        Object v = persistedValue().orElse(null);
         Object pval = p.equalsValue().orElse(null);
         return v == null
                 || pval == null
@@ -125,22 +129,22 @@ abstract class ComparatorPredicate implements ValuePredicate {
 
     @Override
     public int hashCode() {
-        return value.hashCode();
+        return persistedValue().hashCode();
     }
 
     @Override
     public Optional<P<Object>> getPredicate() {
-        return value.map(this::gremlinPredicate);
+        return persistedValue().map(this::gremlinPredicate);
     }
 
     @Override
     public Optional<VarPatternAdmin> getInnerVar() {
-        return var;
+        return var();
     }
 
     @Override
     public final <S, E> GraphTraversal<S, E> applyPredicate(GraphTraversal<S, E> traversal) {
-        var.ifPresent(theVar -> {
+        var().ifPresent(theVar -> {
             // Compare to another variable
             String thisVar = UUID.randomUUID().toString();
             Var otherVar = theVar.var();
@@ -153,14 +157,13 @@ abstract class ComparatorPredicate implements ValuePredicate {
             traversal.as(thisVar).select(otherVar.name()).or(traversals).select(thisVar);
         });
 
-        value.ifPresent(theValue -> {
+        persistedValue().ifPresent(theValue -> {
             // Compare to a given value
-            AttributeType.DataType<?> dataType = SUPPORTED_TYPES.get(originalValue.get().getClass().getTypeName());
+            DataType<?> dataType = DataType.SUPPORTED_TYPES.get(value.get().getClass().getTypeName());
             Schema.VertexProperty property = dataType.getVertexProperty();
             traversal.has(property.name(), gremlinPredicate(theValue));
         });
 
         return traversal;
     }
-
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicate.java
@@ -80,7 +80,7 @@ abstract class ComparatorPredicate implements ValuePredicate {
     abstract <V> P<V> gremlinPredicate(V value);
 
     final Optional<Object> persistedValue() {
-        return value.map(value -> {
+        return value().map(value -> {
 
             // Convert values to how they are stored in the graph
             DataType dataType = DataType.SUPPORTED_TYPES.get(value.getClass().getName());
@@ -95,14 +95,14 @@ abstract class ComparatorPredicate implements ValuePredicate {
         });
     }
 
-    final Optional<VarPatternAdmin> var() {
-        return var;
+    final Optional<Object> value() {
+        return value;
     }
 
     public String toString() {
         // If there is no value, then there must be a var
         //noinspection OptionalGetWithoutIsPresent
-        String argument = persistedValue().map(StringUtil::valueToString).orElseGet(() -> var().get().getPrintableName());
+        String argument = persistedValue().map(StringUtil::valueToString).orElseGet(() -> var.get().getPrintableName());
 
         return getSymbol() + " " + argument;
     }
@@ -139,12 +139,12 @@ abstract class ComparatorPredicate implements ValuePredicate {
 
     @Override
     public Optional<VarPatternAdmin> getInnerVar() {
-        return var();
+        return var;
     }
 
     @Override
     public final <S, E> GraphTraversal<S, E> applyPredicate(GraphTraversal<S, E> traversal) {
-        var().ifPresent(theVar -> {
+        var.ifPresent(theVar -> {
             // Compare to another variable
             String thisVar = UUID.randomUUID().toString();
             Var otherVar = theVar.var();
@@ -159,11 +159,12 @@ abstract class ComparatorPredicate implements ValuePredicate {
 
         persistedValue().ifPresent(theValue -> {
             // Compare to a given value
-            DataType<?> dataType = DataType.SUPPORTED_TYPES.get(value.get().getClass().getTypeName());
+            DataType<?> dataType = DataType.SUPPORTED_TYPES.get(value().get().getClass().getTypeName());
             Schema.VertexProperty property = dataType.getVertexProperty();
             traversal.has(property.name(), gremlinPredicate(theValue));
         });
 
         return traversal;
     }
+
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -26,14 +26,11 @@ import java.util.Optional;
 
 class EqPredicate extends ComparatorPredicate {
 
-    private final Object value;
-
     /**
      * @param value the value that this predicate is testing against
      */
     EqPredicate(Object value) {
         super(value);
-        this.value = value;
     }
 
     @Override
@@ -53,12 +50,17 @@ class EqPredicate extends ComparatorPredicate {
 
     @Override
     public Optional<Object> equalsValue() {
-        return Optional.of(value);
+        return persistedValue();
     }
 
     @Override
     public String toString() {
-        return StringUtil.valueToString(value);
+        if (persistedValue().isPresent()) {
+            // Omit the `=` if we're using a literal value, not a var
+            return StringUtil.valueToString(persistedValue().get());
+        } else {
+            return super.toString();
+        }
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -55,9 +55,9 @@ class EqPredicate extends ComparatorPredicate {
 
     @Override
     public String toString() {
-        if (persistedValue().isPresent()) {
+        if (value().isPresent()) {
             // Omit the `=` if we're using a literal value, not a var
-            return StringUtil.valueToString(persistedValue().get());
+            return StringUtil.valueToString(value().get());
         } else {
             return super.toString();
         }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -50,7 +50,7 @@ class EqPredicate extends ComparatorPredicate {
 
     @Override
     public Optional<Object> equalsValue() {
-        return persistedValue();
+        return value();
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -1062,6 +1062,13 @@ public class QueryParserTest {
         assertFalse(property.type().var().isUserDefinedName());
     }
 
+    @Test
+    public void whenValueEqualityToString_CreateValidQueryString() {
+        Query<?> query = match(var("x").val(eq(var("y")))).get();
+
+        assertEquals(query, Graql.parse(query.toString()));
+    }
+
     private static void assertParseEquivalence(String query) {
         assertEquals(query, parse(query).toString());
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/predicate/ComparatorPredicateTest.java
@@ -78,7 +78,7 @@ public class ComparatorPredicateTest {
 
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(INVALID_VALUE.getMessage(value.getClass()));
-        new MyComparatorPredicate(value);
+        new MyComparatorPredicate(value).persistedValue();
     }
 }
 


### PR DESCRIPTION
# Why is this PR needed?

There was a bug where `query.toString()` would create a string that was not a valid query (in that it could not be parsed again with `Graql.parse(string)`).

# What does the PR do?

Fixes the bug! And also refactors the predicates because they were a bit messy, which probably caused the bug in the first place.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None. All the bugs are fixed forever now.
