### PR TITLE
disable janus cache

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -112,7 +112,7 @@ storage.connection-timeout=20000
 # Enabling this option speeds up traversals by holding hot elements in memory,
 # but also increases the likelihood of reading stale data. Disabling it forces each transaction
 # to independently fetch elements from storage before reading/writing them.
-cache.db-cache=true
+cache.db-cache=false
 # How long in milliseconds database-level cache will keep entries after flushing them.
 cache.db-cache-clean-wait=20
 # Default expiration time in milliseconds for entries in the database-level cache.


### PR DESCRIPTION
# Why is this PR needed?
Caching would lead to stale result when performing a query, which is unwanted.

My stance on performance optimisation (such as caching) is to enable them only when we have a clear benchmark showing that the said optimisation greatly improves the experience.

With this in mind I am disabling the cache which may cause staleness issue in distributed systems.

# What does the PR do?
Disable Janus cache

# Does it break backwards compatibility?
No 

# List of future improvements not on this PR
N/A