### PR TITLE
Fix an issue with port allocation in tests

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/factory/EngineGraknTxFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/factory/EngineGraknTxFactory.java
@@ -53,7 +53,6 @@ import java.util.Map;
  */
 public class EngineGraknTxFactory {
     private final GraknConfig engineConfig;
-    private final String engineURI;
     private final SystemKeyspace systemKeyspace;
     private final Map<Keyspace, EmbeddedGraknSession> openedSessions;
 
@@ -69,7 +68,6 @@ public class EngineGraknTxFactory {
     private EngineGraknTxFactory(GraknConfig engineConfig, LockProvider lockProvider, boolean loadSchema) {
         this.openedSessions = new HashMap<>();
         this.engineConfig = engineConfig;
-        this.engineURI = engineConfig.getProperty(GraknConfigKey.SERVER_HOST_NAME) + ":" + engineConfig.getProperty(GraknConfigKey.SERVER_PORT);
         this.systemKeyspace = SystemKeyspaceImpl.create(this, lockProvider, loadSchema);
     }
 
@@ -99,7 +97,7 @@ public class EngineGraknTxFactory {
      */
     private EmbeddedGraknSession session(Keyspace keyspace){
         if(!openedSessions.containsKey(keyspace)){
-            openedSessions.put(keyspace, EmbeddedGraknSession.createEngineSession(keyspace, engineURI, engineConfig));
+            openedSessions.put(keyspace, EmbeddedGraknSession.createEngineSession(keyspace, engineURI(), engineConfig));
         }
         return openedSessions.get(keyspace);
     }
@@ -118,5 +116,9 @@ public class EngineGraknTxFactory {
 
     public SystemKeyspace systemKeyspace(){
         return systemKeyspace;
+    }
+
+    private String engineURI() {
+        return engineConfig.getProperty(GraknConfigKey.SERVER_HOST_NAME) + ":" + engineConfig.getProperty(GraknConfigKey.SERVER_PORT);
     }
 }

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
@@ -31,10 +31,8 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import spark.Service;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import static ai.grakn.engine.HttpHandler.configureSpark;
@@ -54,9 +52,6 @@ public class SparkContext extends CompositeTestRule {
     private SparkContext(BiConsumer<Service, GraknConfig> createControllers) {
         this.createControllers = createControllers;
 
-        int port = GraknTestUtil.getEphemeralPort();
-        config.setConfigProperty(GraknConfigKey.SERVER_PORT, port);
-
         if ("0.0.0.0".equals(config.getProperty(GraknConfigKey.SERVER_HOST_NAME))) {
             config.setConfigProperty(GraknConfigKey.SERVER_HOST_NAME, "localhost");
         }
@@ -67,8 +62,10 @@ public class SparkContext extends CompositeTestRule {
 
         String hostName = config.getProperty(GraknConfigKey.SERVER_HOST_NAME);
 
-        configureSpark(spark, hostName, port(), config.getPath(GraknConfigKey.STATIC_FILES_PATH),
-                        64);
+        GraknTestUtil.allocateSparkPort(config);
+
+        configureSpark(spark, hostName, port(), config.getPath(GraknConfigKey.STATIC_FILES_PATH), 64);
+        spark.init();
 
         RestAssured.baseURI = "http://" + hostName + ":" + port();
 

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/SparkContext.java
@@ -55,6 +55,8 @@ public class SparkContext extends CompositeTestRule {
         if ("0.0.0.0".equals(config.getProperty(GraknConfigKey.SERVER_HOST_NAME))) {
             config.setConfigProperty(GraknConfigKey.SERVER_HOST_NAME, "localhost");
         }
+
+        config.setConfigProperty(GraknConfigKey.SERVER_PORT, 0);
     }
 
     private Service startSparkCopyOnNewPort() {
@@ -62,7 +64,9 @@ public class SparkContext extends CompositeTestRule {
 
         String hostName = config.getProperty(GraknConfigKey.SERVER_HOST_NAME);
 
-        GraknTestUtil.allocateSparkPort(config);
+        if (config.getProperty(GraknConfigKey.SERVER_PORT) == 0) {
+            GraknTestUtil.allocateSparkPort(config);
+        }
 
         configureSpark(spark, hostName, port(), config.getPath(GraknConfigKey.STATIC_FILES_PATH), 64);
         spark.init();

--- a/grakn-test-tools/src/main/java/ai/grakn/test/rule/InMemoryRedisContext.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/test/rule/InMemoryRedisContext.java
@@ -94,4 +94,10 @@ public class InMemoryRedisContext extends ExternalResource {
     private void checkInitialised() {
         Preconditions.checkState(server != null, "InMemoryRedisContext not initialised");
     }
+
+    public int port() {
+        checkInitialised();
+        assert server != null;
+        return server.getBindPort();
+    }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
@@ -82,16 +82,14 @@ public class EngineContext extends CompositeTestRule {
     private JedisPool jedisPool;
     private Service spark;
 
-    private final TestRule redis;
+    private final InMemoryRedisContext redis;
 
     private EngineContext(){
         config = createTestConfig();
-        SimpleURI redisURI = new SimpleURI(Iterables.getOnlyElement(config.getProperty(GraknConfigKey.REDIS_HOST)));
-        int redisPort = redisURI.getPort();
-        redis = InMemoryRedisContext.create(redisPort);
+        redis = InMemoryRedisContext.create();
     }
 
-    private EngineContext(GraknConfig config, TestRule redis){
+    private EngineContext(GraknConfig config, InMemoryRedisContext redis){
         this.config = config;
         this.redis = redis;
     }
@@ -99,7 +97,7 @@ public class EngineContext extends CompositeTestRule {
     public static EngineContext create(GraknConfig config){
         SimpleURI redisURI = new SimpleURI(Iterables.getOnlyElement(config.getProperty(GraknConfigKey.REDIS_HOST)));
         int redisPort = redisURI.getPort();
-        TestRule redis = InMemoryRedisContext.create(redisPort);
+        InMemoryRedisContext redis = InMemoryRedisContext.create(redisPort);
         return new EngineContext(config, redis);
     }
 
@@ -182,10 +180,11 @@ public class EngineContext extends CompositeTestRule {
         setRestAssuredUri(config);
 
         spark = Service.ignite();
+
+        config.setConfigProperty(GraknConfigKey.REDIS_HOST, Collections.singletonList("localhost:" + redis.port()));
         RedisWrapper redis = RedisWrapper.create(config);
 
-        server = createGraknEngineServer(redis);
-        server.start();
+        server = startGraknEngineServer(redis);
 
         LOG.info("engine started on " + uri());
     }
@@ -256,9 +255,7 @@ public class EngineContext extends CompositeTestRule {
     public static GraknConfig createTestConfig() {
         GraknConfig config = GraknConfig.create();
 
-        config.setConfigProperty(GraknConfigKey.SERVER_PORT, GraknTestUtil.getEphemeralPort());
-        config.setConfigProperty(GraknConfigKey.REDIS_HOST, Collections.singletonList("localhost:" + GraknTestUtil.getEphemeralPort()));
-        config.setConfigProperty(GraknConfigKey.GRPC_PORT, GraknTestUtil.getEphemeralPort());
+        config.setConfigProperty(GraknConfigKey.SERVER_PORT, 0);
 
         return config;
     }
@@ -271,7 +268,7 @@ public class EngineContext extends CompositeTestRule {
         return jedisPool;
     }
 
-    private GraknEngineServer createGraknEngineServer(RedisWrapper redisWrapper) throws IOException {
+    private GraknEngineServer startGraknEngineServer(RedisWrapper redisWrapper) throws IOException {
         EngineID id = EngineID.me();
         GraknEngineStatus status = new GraknEngineStatus();
         MetricRegistry metricRegistry = new MetricRegistry();
@@ -279,11 +276,23 @@ public class EngineContext extends CompositeTestRule {
         CountStorage countStorage = RedisCountStorage.create(redisWrapper.getJedisPool(), metricRegistry);
         LockProvider lockProvider = new JedisLockProvider(redisWrapper.getJedisPool());
         EngineGraknTxFactory engineGraknTxFactory = EngineGraknTxFactory.create(lockProvider, config);
-        int grpcPort = config.getProperty(GraknConfigKey.GRPC_PORT);
         GrpcOpenRequestExecutor requestExecutor = new GrpcOpenRequestExecutorImpl(engineGraknTxFactory);
-        Server server = ServerBuilder.forPort(grpcPort).addService(new GrpcGraknService(requestExecutor)).build();
+
+        Server server = ServerBuilder.forPort(0).addService(new GrpcGraknService(requestExecutor)).build();
         GrpcServer grpcServer = GrpcServer.create(server);
-        return GraknEngineServerFactory.createGraknEngineServer(id, spark, status, metricRegistry, config, redisWrapper,
-                indexStorage, countStorage, lockProvider, Runtime.getRuntime(), Collections.emptyList(), engineGraknTxFactory, grpcServer);
+
+        GraknTestUtil.allocateSparkPort(config);
+
+        GraknEngineServer graknEngineServer = GraknEngineServerFactory.createGraknEngineServer(
+                id, spark, status, metricRegistry, config, redisWrapper, indexStorage, countStorage, lockProvider,
+                Runtime.getRuntime(), Collections.emptyList(), engineGraknTxFactory, grpcServer);
+
+        graknEngineServer.start();
+
+        // Read the automatically allocated ports and write them back into the config
+        config.setConfigProperty(GraknConfigKey.GRPC_PORT, server.getPort());
+
+        return graknEngineServer;
     }
+
 }


### PR DESCRIPTION
# Why is this PR needed?

The way we allocate unused ports within tests is not perfect:

1. Ask for a socket to an unused port
2. Record the port and close the socket
3. Write the port into the config file
4. Start up gRPC/spark/redis with the port

After the socket is closed, there is a potential race condition: something else can jump in and steal the port before we start a service using it.

We see this occasionally (when we get tests saying "address already in use"). It's not super-common but it has been a problem for a long time.

# What does the PR do?

Eliminates this race condition. We don't generate ports ourselves but instead tell gRPC and Redis to use port 0, meaning "pick your own port!". Then we write the port they choose into the config file. 

Spark is not so easy, because they don't report the port they choose correctly. For them, we just minimise the risk of the race condition.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

If we switch from Spark, we can avoid that race condition too.