### PR TITLE
extracting RedisWrapper dependency out from GraknEngineServer

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServer.java
@@ -19,7 +19,6 @@ package ai.grakn.engine;
 
 import ai.grakn.GraknConfigKey;
 import ai.grakn.engine.data.QueueSanityCheck;
-import ai.grakn.engine.data.RedisSanityCheck;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.engine.lock.LockProvider;
 import ai.grakn.engine.task.BackgroundTaskRunner;

--- a/grakn-engine/src/main/java/ai/grakn/engine/data/QueueSanityCheck.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/data/QueueSanityCheck.java
@@ -1,0 +1,32 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine.data;
+
+/**
+ * The {@link QueueSanityCheck} class is responsible for performing sanity check of the Queue component
+ *
+ * @author Ganeshwara Herawan Hananda
+ */
+public interface QueueSanityCheck {
+    void testConnection();
+
+    void checkVersion();
+
+    void close();
+}

--- a/grakn-engine/src/main/java/ai/grakn/engine/data/RedisSanityCheck.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/data/RedisSanityCheck.java
@@ -1,0 +1,62 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.engine.data;
+
+import ai.grakn.util.GraknVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import redis.clients.jedis.Jedis;
+
+import static ai.grakn.util.ErrorMessage.VERSION_MISMATCH;
+
+/**
+ * The {@link RedisSanityCheck} class is responsible for performing sanity check to the Grakn Queue component which is backed by Redis
+ *
+ * @author Ganeshwara Herawan Hananda
+ */
+public class RedisSanityCheck implements QueueSanityCheck {
+    private static final Logger LOG = LoggerFactory.getLogger(RedisSanityCheck.class);
+    private static final String REDIS_VERSION_KEY = "info:version";
+    private RedisWrapper redisWrapper;
+
+    public RedisSanityCheck(RedisWrapper redisWrapper) {
+        this.redisWrapper = redisWrapper;
+    }
+
+    @Override
+    public void testConnection() {
+        redisWrapper.testConnection();
+    }
+
+    @Override
+    public void checkVersion() {
+        Jedis jedis = redisWrapper.getJedisPool().getResource();
+        String storedVersion = jedis.get(REDIS_VERSION_KEY);
+        if (storedVersion == null) {
+            jedis.set(REDIS_VERSION_KEY, GraknVersion.VERSION);
+        } else if (!storedVersion.equals(GraknVersion.VERSION)) {
+            LOG.warn(VERSION_MISMATCH.getMessage(GraknVersion.VERSION, storedVersion));
+        }
+    }
+
+    @Override
+    public void close() {
+        redisWrapper.close();
+    }
+}

--- a/grakn-engine/src/test/java/ai/grakn/engine/GraknEngineServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/GraknEngineServerTest.java
@@ -20,6 +20,8 @@ package ai.grakn.engine;
 
 import ai.grakn.GraknConfigKey;
 import ai.grakn.Keyspace;
+import ai.grakn.engine.data.QueueSanityCheck;
+import ai.grakn.engine.data.RedisSanityCheck;
 import ai.grakn.engine.data.RedisWrapper;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.engine.lock.JedisLockProvider;
@@ -190,7 +192,9 @@ public class GraknEngineServerTest {
         GrpcOpenRequestExecutor requestExecutor = new GrpcOpenRequestExecutorImpl(engineGraknTxFactory);
         Server server = ServerBuilder.forPort(grpcPort).addService(new GrpcGraknService(requestExecutor)).build();
         GrpcServer grpcServer = GrpcServer.create(server);
-        return GraknEngineServerFactory.createGraknEngineServer(id, spark, status, metricRegistry, config, redisWrapper,
+        QueueSanityCheck queueSanityCheck = new RedisSanityCheck(redisWrapper);
+
+        return GraknEngineServerFactory.createGraknEngineServer(id, spark, status, metricRegistry, config, queueSanityCheck,
                 indexStorage, countStorage, lockProvider, Runtime.getRuntime(), Collections.emptyList(), engineGraknTxFactory, grpcServer);
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
@@ -26,6 +26,8 @@ import ai.grakn.engine.GraknEngineServerFactory;
 import ai.grakn.engine.GraknEngineServer;
 import ai.grakn.engine.GraknEngineStatus;
 import ai.grakn.engine.SystemKeyspace;
+import ai.grakn.engine.data.QueueSanityCheck;
+import ai.grakn.engine.data.RedisSanityCheck;
 import ai.grakn.engine.data.RedisWrapper;
 import ai.grakn.engine.factory.EngineGraknTxFactory;
 import ai.grakn.engine.lock.JedisLockProvider;
@@ -283,7 +285,9 @@ public class EngineContext extends CompositeTestRule {
         GrpcOpenRequestExecutor requestExecutor = new GrpcOpenRequestExecutorImpl(engineGraknTxFactory);
         Server server = ServerBuilder.forPort(grpcPort).addService(new GrpcGraknService(requestExecutor)).build();
         GrpcServer grpcServer = GrpcServer.create(server);
-        return GraknEngineServerFactory.createGraknEngineServer(id, spark, status, metricRegistry, config, redisWrapper,
+        QueueSanityCheck queueSanityCheck = new RedisSanityCheck(redisWrapper);
+
+        return GraknEngineServerFactory.createGraknEngineServer(id, spark, status, metricRegistry, config, queueSanityCheck,
                 indexStorage, countStorage, lockProvider, Runtime.getRuntime(), Collections.emptyList(), engineGraknTxFactory, grpcServer);
     }
 }


### PR DESCRIPTION
# Why is this PR needed?
We need to extract RedisWrapper from GraknEngineServer for modularity. With this PR, the GraknEngineServer class will have no hard-coded dependency to Redis.

# What does the PR do?
1. Extract `RedisWrapper` out of `GraknEngineServer`
2. Added an interface `QueueSanityCheck` which is used by `GraknEngineServer`
3. Added a concrete implementation of the aforementioned in the form of `RedisSanityCheck`, since Grakn Queue uses Redis as its concrete implementation

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A