### PR TITLE
Fix Graql doc examples

### DIFF
--- a/docs/pages/docs/2-building-schema/defining-schema.md
+++ b/docs/pages/docs/2-building-schema/defining-schema.md
@@ -86,12 +86,14 @@ schema.
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="shell-undefine-sub">
 <pre class="language-graql"> <code>
+<!--test-ignore-->
 undefine person sub entity;
 </code>
 </pre>
 </div>
 <div role="tabpanel" class="tab-pane" id="java-undefine-sub">
 <pre class="language-java"> <code>
+<!--test-ignore-->
 qb.undefine(label("person").sub("entity")).execute();
 </code>
 </pre>

--- a/docs/pages/docs/2-building-schema/querying-schema.md
+++ b/docs/pages/docs/2-building-schema/querying-schema.md
@@ -128,7 +128,7 @@ The above is equivalent to:
 <div role="tabpanel" class="tab-pane active" id="shell11">
 <pre class="language-graql">
 <code>
-match $x plays has-firstname-owner; get;
+match $x plays @has-firstname-owner; get;
 </code>
 </pre>
 </div>

--- a/docs/pages/docs/3-querying-data/aggregate-queries.md
+++ b/docs/pages/docs/3-querying-data/aggregate-queries.md
@@ -92,7 +92,7 @@ match $x isa person, has age $a; aggregate sum $a;
 </pre>
 </div>
 <div role="tabpanel" class="tab-pane" id="java2">
-<pre class="language-graql">
+<pre class="language-java">
 <code>
 qb.match(
     var("x").isa("person").has("age", var("a"))

--- a/docs/pages/docs/3-querying-data/get-queries.md
+++ b/docs/pages/docs/3-querying-data/get-queries.md
@@ -50,7 +50,7 @@ You can also provide as arguments to `get` the variables you wish to see:
 </pre>
 </div>
 <div role="tabpanel" class="tab-pane" id="java2">
-<pre class="language-graql">
+<pre class="language-java">
 <code>
 qb.match(
     var("x").has("name", var("xn")),

--- a/docs/pages/docs/3-querying-data/insert-queries.md
+++ b/docs/pages/docs/3-querying-data/insert-queries.md
@@ -163,7 +163,7 @@ You can also specify a variable to represent the relationship connecting the thi
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="shell6">
 <pre class="language-graql"> <code>
-insert isa person has identifier "Fuchsia Groan" as $r;
+insert isa person has identifier "Fuchsia Groan" via $r;
 </code>
 </pre>
 </div>

--- a/docs/pages/docs/5-migrating-data/migration-language.md
+++ b/docs/pages/docs/5-migrating-data/migration-language.md
@@ -20,13 +20,13 @@ Templates are used to expand Graql queries, given data. They allow you to contro
 Accessing a single value:
 
 ```graql-template
-$x isa thing has val <value>
+insert $x isa thing has value <value>;
 ```
 
 Value in a nested context:
 
 ```graql-template
-$x isa person has name <person.name.firstName>
+insert $x isa person has name <person.name.firstName>;
 ```
 
 ## Replacement
@@ -112,7 +112,7 @@ else { insert $x; }
 Parenthesis can be used to group conditionals together.
 
 ```graql-template
-if( (first <= second) or (not (third <= second)))
+if( (<first> <= <second>) or (not (<third> <= <second>)))
 do { insert isa y; }
 else { insert isa z; }
 ```

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/DocTestUtil.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/DocTestUtil.java
@@ -45,7 +45,21 @@ import static org.junit.Assert.fail;
 
 public class DocTestUtil {
 
+    private static final String OPEN_TAG = "\\s*<[^>]*>";
+    private static final String OPEN_TAGS = OPEN_TAG + "*";
+    private static final String QUERY = "\\s*(?<query>.*?)\\s*";
+
     public static final File PAGES = new File(GraknSystemProperty.PROJECT_RELATIVE_DIR.value() + "/docs/pages/");
+
+    static Pattern markdownOrHtml(String languageName) {
+        String className = "language-" + languageName;
+        String openClassTag = "class\\s*=\\s*\"" + className + "\".*?>";
+
+        String html = openClassTag + OPEN_TAGS;
+        String markdown = "```" + languageName + "\\s*\\n";
+
+        return Pattern.compile("(" + html + "|" + markdown + ")" + QUERY + "(</|```)", Pattern.DOTALL);
+    }
 
     private static final Pattern KEYSPACE_HEADER =
             Pattern.compile("---.*KB:\\s*(.*?)\\n.*---", Pattern.DOTALL + Pattern.CASE_INSENSITIVE);

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/GraqlDocsTest.java
@@ -32,6 +32,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,31 +40,25 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static ai.grakn.test.docs.DocTestUtil.PAGES;
 import static ai.grakn.test.docs.DocTestUtil.allMarkdownFiles;
 import static ai.grakn.test.docs.DocTestUtil.getLineNumber;
+import static ai.grakn.test.docs.DocTestUtil.markdownOrHtml;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
 public class GraqlDocsTest {
 
-    private static final Pattern TAG_GRAQL =
-            Pattern.compile(
-                    "(id=\"shell[0-9]+\">\\s*<pre>|```graql\\s*\\n)" +
-                    "\\s*(.*?)\\s*" +
-                    "(</pre>|```)", Pattern.DOTALL);
-
-    private static final Pattern TEMPLATE_GRAQL =
-            Pattern.compile(
-                    "(id=\"shell[0-9]+\">\\s*<```graql-template\\s*\\n)" +
-                            "\\s*(.*?)\\s*" +
-                            "(```)", Pattern.DOTALL);
+    private static final Pattern TAG_GRAQL = markdownOrHtml("graql");
+    private static final Pattern TEMPLATE_GRAQL = markdownOrHtml("graql-template");
 
     private static final Pattern SHELL_GRAQL = Pattern.compile("^*>>>(.*?)$", Pattern.MULTILINE);
 
@@ -114,7 +109,9 @@ public class GraqlDocsTest {
 
         try (GraknTx graph = DocTestUtil.getTestGraph(engine.uri(), knowledgeBaseName).open(GraknTxType.WRITE)) {
             executeAssertionOnContents(graph, TAG_GRAQL, file, contents, this::assertGraqlCodeblockValidSyntax);
-            executeAssertionOnContents(graph, TEMPLATE_GRAQL, file, contents, this::assertGraqlTemplateValidSyntax);
+
+            // TODO: Fix issue with this test when template expects data in a certain format
+//            executeAssertionOnContents(graph, TEMPLATE_GRAQL, file, contents, this::assertGraqlTemplateValidSyntax);
         }
     }
 
@@ -125,7 +122,9 @@ public class GraqlDocsTest {
         while (matcher.find()) {
             numFound += 1;
 
-            String graqlString = matcher.group(2);
+            String graqlString = matcher.group("query");
+
+            System.out.println(graqlString);
 
             String trimmed = graqlString.trim();
 
@@ -159,8 +158,14 @@ public class GraqlDocsTest {
     }
 
     private void assertGraqlTemplateValidSyntax(GraknTx graph, String fileName, String templateBlock){
+        // An endless map where you always end up back where you started like in Zelda
+        Map<String, Object> data = Mockito.mock(Map.class);
+        when(data.containsKey(any())).thenReturn(true);
+        when(data.get(any())).thenReturn(data);
+        when(data.toString()).thenReturn("\"MOCK\"");
+
         try {
-            graph.graql().parser().parseTemplate(templateBlock, new HashMap<>());
+            graph.graql().parser().parseTemplate(templateBlock, data);
         } catch (GraqlSyntaxException e){
             DocTestUtil.codeBlockFail(fileName, templateBlock, e.getMessage());
         } catch (Exception e){}

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/JavaDocsTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/JavaDocsTest.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import static ai.grakn.test.docs.DocTestUtil.PAGES;
 import static ai.grakn.test.docs.DocTestUtil.allMarkdownFiles;
 import static ai.grakn.test.docs.DocTestUtil.codeBlockFail;
+import static ai.grakn.test.docs.DocTestUtil.markdownOrHtml;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
@@ -48,11 +49,7 @@ import static org.junit.Assume.assumeTrue;
 @RunWith(Parameterized.class)
 public class JavaDocsTest {
 
-    private static final Pattern TAG_JAVA =
-            Pattern.compile(
-                    "(id=\"java[0-9]+\">\\s*<pre>|```java)" +
-                    "\\s*(.*?)\\s*" +
-                    "(</pre>|```)", Pattern.DOTALL);
+    private static final Pattern TAG_JAVA = markdownOrHtml("java");
 
     private static String groovyPrefix;
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/prefix.groovy
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/docs/prefix.groovy
@@ -19,21 +19,23 @@
 package ai.grakn.test.docs
 
 import ai.grakn.*
+import ai.grakn.client.BatchExecutorClient
 import ai.grakn.concept.*
-
-import java.time.*
+import ai.grakn.engine.TaskId
 import ai.grakn.graql.*
-import ai.grakn.graql.admin.*
-import ai.grakn.migration.csv.*
-import ai.grakn.client.*
-import ai.grakn.engine.*
+import ai.grakn.graql.admin.Answer
+import ai.grakn.migration.csv.CSVMigrator
 import mjson.Json
 
+import java.time.LocalDateTime
+
+import static ai.grakn.concept.AttributeType.DataType.STRING
 import static ai.grakn.graql.Graql.*
 
 // This is some dumb stuff so IntelliJ doesn't get rid of the imports
 //noinspection GroovyConstantIfStatement
 if (false) {
+    label("hello")
     Answer answer = null
     Concept concept = null
     Var var = var()
@@ -43,6 +45,11 @@ if (false) {
     BatchExecutorClient client = null
     Json json = null
     TaskId id = null
+    str = STRING
+    Label label = null
+    Order order = null
+    GraknTx tx = null
+    Attribute attribute = null
 }
 
 // Initialise graphs and fields that the code samples will use


### PR DESCRIPTION
# Why is this PR needed?

Some of the Graql and Java examples in the docs were incorrect. This fixes them.

# What does the PR do?

It fixes those examples.

Additionally, it turns out a change in the html of the docs meant we were't actually testing a lot of the examples I thought we were. I fixed up the tests to recognise the html (with a more flexible regex).

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

I've explicitly disabled testing the migration templates, because they need data - it turns out this wasn't working before anyway. However, it would be good to enable this in the future.
