### PR TITLE
Fix an issue with nullness annotations

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteAttributeType.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteAttributeType.java
@@ -26,9 +26,7 @@ import ai.grakn.grpc.ConceptMethod;
 import ai.grakn.remote.RemoteGraknTx;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -88,11 +86,5 @@ abstract class RemoteAttributeType<D> extends RemoteType<AttributeType<D>, Attri
     @Override
     protected final Attribute<D> asInstance(Concept concept) {
         return concept.asAttribute();
-    }
-
-    @Nonnull
-    @Override
-    public AttributeType<D> sup() {
-        return Objects.requireNonNull(super.sup());
     }
 }

--- a/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteEntityType.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteEntityType.java
@@ -25,9 +25,6 @@ import ai.grakn.concept.EntityType;
 import ai.grakn.remote.RemoteGraknTx;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nonnull;
-import java.util.Objects;
-
 /**
  * @author Felix Chapman
  */
@@ -51,11 +48,5 @@ abstract class RemoteEntityType extends RemoteType<EntityType, Entity> implement
     @Override
     protected final Entity asInstance(Concept concept) {
         return concept.asEntity();
-    }
-
-    @Nonnull
-    @Override
-    public EntityType sup() {
-        return Objects.requireNonNull(super.sup());
     }
 }

--- a/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteRelationshipType.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteRelationshipType.java
@@ -26,8 +26,6 @@ import ai.grakn.concept.Role;
 import ai.grakn.remote.RemoteGraknTx;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nonnull;
-import java.util.Objects;
 import java.util.stream.Stream;
 
 /**
@@ -68,11 +66,5 @@ abstract class RemoteRelationshipType extends RemoteType<RelationshipType, Relat
     @Override
     protected final Relationship asInstance(Concept concept) {
         return concept.asRelationship();
-    }
-
-    @Nonnull
-    @Override
-    public RelationshipType sup() {
-        return Objects.requireNonNull(super.sup());
     }
 }

--- a/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteSchemaConcept.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/concept/RemoteSchemaConcept.java
@@ -66,7 +66,7 @@ abstract class RemoteSchemaConcept<Self extends SchemaConcept> extends RemoteCon
 
     @Nullable
     @Override
-    public Self sup() {
+    public final Self sup() {
         Concept concept = runNullableMethod(ConceptMethod.GET_DIRECT_SUPER);
         if (concept != null && notMetaThing(concept)) {
             return asSelf(concept);

--- a/grakn-core/src/main/java/ai/grakn/concept/AttributeType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/AttributeType.java
@@ -24,7 +24,6 @@ import ai.grakn.util.Schema;
 import com.google.common.collect.ImmutableMap;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -162,7 +161,7 @@ public interface AttributeType<D> extends Type {
      * @return The supertype of this {@link AttributeType},
      */
     @Override
-    @Nonnull
+    @Nullable
     AttributeType<D> sup();
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/concept/EntityType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/EntityType.java
@@ -21,7 +21,7 @@ package ai.grakn.concept;
 import ai.grakn.exception.GraknTxOperationException;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
 /**
@@ -149,7 +149,7 @@ public interface EntityType extends Type{
      * @return The supertype of this EntityType
      */
     @Override
-    @Nonnull
+    @Nullable
     EntityType sup();
 
     /**

--- a/grakn-core/src/main/java/ai/grakn/concept/RelationshipType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/RelationshipType.java
@@ -21,7 +21,7 @@ package ai.grakn.concept;
 import ai.grakn.exception.GraknTxOperationException;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
 /**
@@ -137,7 +137,7 @@ public interface RelationshipType extends Type {
      * @return The direct supertype of this {@link RelationshipType}
      */
     @Override
-    @Nonnull
+    @Nullable
     RelationshipType sup();
 
     /**


### PR DESCRIPTION
# Why is this PR needed?

Methods such as `EntityType#sup` were marked `@Nonull`, when they are actually `@Nullable` when operating on the meta types such as `metaEntity.sup()`.

# What does the PR do?

Changes `EntityType#sup` and similar to be `@Nullable` and also fix gRPC to reflect this change.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
