### PR TITLE
Refactor GraqlShell to be more extensible

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
@@ -18,13 +18,19 @@
 
 package ai.grakn.bootup;
 
-import ai.grakn.graql.shell.GraqlShell;
+import ai.grakn.engine.GraknConfig;
+import ai.grakn.graql.shell.GraknSessionProvider;
+import ai.grakn.graql.shell.GraqlConsole;
+import ai.grakn.graql.shell.GraqlShellOptions;
+import ai.grakn.graql.shell.SessionProvider;
 import ai.grakn.migration.csv.CSVMigrator;
 import ai.grakn.migration.export.Main;
 import ai.grakn.migration.json.JsonMigrator;
 import ai.grakn.migration.sql.SQLMigrator;
 import ai.grakn.migration.xml.XmlMigrator;
 import ai.grakn.util.GraknVersion;
+import com.google.common.base.StandardSystemProperty;
+import org.apache.commons.cli.ParseException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -35,6 +41,14 @@ import java.util.Arrays;
  */
 public class Graql {
 
+    private SessionProvider sessionProvider;
+    private static final String HISTORY_FILENAME = StandardSystemProperty.USER_HOME.value() + "/.graql-history";
+
+
+    public Graql(SessionProvider sessionProvider) {
+        this.sessionProvider = sessionProvider;
+    }
+
     /**
      *
      * Invocation from bash script 'graql'
@@ -42,7 +56,7 @@ public class Graql {
      * @param args
      */
     public static void main(String[] args) throws IOException, InterruptedException {
-        new Graql().run(args);
+        new Graql(new GraknSessionProvider(GraknConfig.create())).run(args);
     }
 
     public void run(String[] args) throws IOException, InterruptedException {
@@ -50,7 +64,16 @@ public class Graql {
 
         switch (context) {
             case "console":
-                GraqlShell.main(valuesFrom(args, 1));
+                GraqlShellOptions options;
+
+                try {
+                    options = GraqlShellOptions.create(valuesFrom(args, 1));
+                } catch (ParseException e) {
+                    System.err.println(e.getMessage());
+                    return;
+                }
+
+                GraqlConsole.start(options, sessionProvider, HISTORY_FILENAME);
                 break;
             case "migrate":
                 migrate(valuesFrom(args, 1));

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraknSessionProvider.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraknSessionProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.shell;
+
+import ai.grakn.Grakn;
+import ai.grakn.GraknConfigKey;
+import ai.grakn.GraknSession;
+import ai.grakn.Keyspace;
+import ai.grakn.engine.GraknConfig;
+import ai.grakn.remote.RemoteGrakn;
+import ai.grakn.util.SimpleURI;
+import jline.console.ConsoleReader;
+
+/**
+ *
+ *  Implementation of SessionProvider interface - this is used by GraqlConsole to retrieve a GraknSession given terminal options
+ *
+ * @author marcoscoppetta
+ */
+
+public class GraknSessionProvider implements SessionProvider{
+
+    private final GraknConfig config;
+
+    public GraknSessionProvider(GraknConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public GraknSession getSession(GraqlShellOptions options, ConsoleReader console) {
+        int defaultGrpcPort = config.getProperty(GraknConfigKey.GRPC_PORT);
+        SimpleURI defaultGrpcUri = new SimpleURI(Grakn.DEFAULT_URI.getHost(), defaultGrpcPort);
+        SimpleURI location = options.getUri();
+
+        SimpleURI uri = location != null ? location : defaultGrpcUri;
+        Keyspace keyspace = options.getKeyspace();
+
+        return RemoteGrakn.session(uri, keyspace);
+    }
+}

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
@@ -1,0 +1,139 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.shell;
+
+import ai.grakn.Grakn;
+import ai.grakn.GraknSession;
+import ai.grakn.Keyspace;
+import ai.grakn.util.CommonUtil;
+import ai.grakn.util.ErrorMessage;
+import ai.grakn.util.GraknVersion;
+import ai.grakn.util.SimpleURI;
+import com.google.common.base.StandardSystemProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import jline.console.ConsoleReader;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import static ai.grakn.graql.shell.GraqlShell.loadQuery;
+
+/**
+ *
+ *  Graql console class that executes actions associated to options, if any option is set
+ *  otherwise instantiates a GraqlShell
+ *
+ * @author marcoscoppetta
+ */
+
+public class GraqlConsole {
+
+    public static boolean start(GraqlShellOptions options, SessionProvider sessionProvider, String historyFile) throws InterruptedException, IOException {
+        List<String> queries = null;
+
+
+
+        //  ------- Check option  ------------------------
+        String query = options.getQuery();
+
+        // This is a best-effort guess as to whether the user has made a mistake, without parsing the query
+        if (query != null) {
+            queries = ImmutableList.of(query);
+
+            if (!query.contains("$") && query.trim().startsWith("match")) {
+                System.err.println(ErrorMessage.NO_VARIABLE_IN_QUERY.getMessage());
+            }
+        }
+
+
+        //  ------- Check option  ------------------------
+
+        // Print usage message if requested or if invalid arguments provided
+        if (options.displayHelp()) {
+            GraqlShellOptions.printUsage();
+            return true;
+        }
+
+        //  ------- Check option  ------------------------
+
+        if (options.displayVersion()) {
+            System.out.println(GraknVersion.VERSION);
+            return true;
+        }
+
+
+        //  ------- Check option  ------------------------
+
+        Path path = options.getBatchLoadPath();
+
+        if (path != null) {
+            Keyspace keyspace = options.getKeyspace();
+            SimpleURI location = options.getUri();
+            SimpleURI httpUri = location != null ? location : Grakn.DEFAULT_URI;
+            try {
+                BatchLoader.sendBatchRequest(httpUri, keyspace, path);
+            } catch (Exception e) {
+                System.out.println("Batch failed \n" + CommonUtil.simplifyExceptionMessage(e));
+                return false;
+            }
+            return true;
+        }
+
+
+        //   --------   If no option set we start GraqlShell   ----------
+
+        OutputFormat outputFormat = options.getOutputFormat();
+
+        boolean infer = options.shouldInfer();
+        ConsoleReader console = new ConsoleReader(System.in, System.out);
+        GraknSession  session = sessionProvider.getSession(options, console);
+
+        try (GraqlShell shell = new GraqlShell(historyFile, session, console, outputFormat, infer)) {
+            List<Path> filePaths = options.getFiles();
+            if (filePaths != null) {
+                queries = loadQueries(filePaths);
+            }
+
+            // Start shell
+            shell.start(queries);
+            return !shell.errorOccurred();
+        } catch (StatusRuntimeException e) {
+            if (e.getStatus().getCode().equals(Status.Code.UNAVAILABLE)) {
+                System.err.println(ErrorMessage.COULD_NOT_CONNECT.getMessage());
+                return false;
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    private static List<String> loadQueries(Iterable<Path> filePaths) throws IOException {
+        List<String> queries = Lists.newArrayList();
+
+        for (Path filePath : filePaths) {
+            queries.add(loadQuery(filePath));
+        }
+
+        return queries;
+    }
+}

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
@@ -25,7 +25,6 @@ import ai.grakn.util.CommonUtil;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.GraknVersion;
 import ai.grakn.util.SimpleURI;
-import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import io.grpc.Status;

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
@@ -106,6 +106,8 @@ public class GraqlShell implements AutoCloseable {
     private static final String LICENSE_COMMAND = "license";
     private static final String CLEAN_COMMAND = "clean";
 
+    private boolean errorOccurred = false;
+
     /**
      * Array of available commands in shell
      */
@@ -113,8 +115,6 @@ public class GraqlShell implements AutoCloseable {
             EDIT_COMMAND, COMMIT_COMMAND, ROLLBACK_COMMAND, LOAD_COMMAND, DISPLAY_COMMAND, CLEAR_COMMAND, EXIT_COMMAND,
             LICENSE_COMMAND, CLEAN_COMMAND
     );
-
-    private static final String HISTORY_FILENAME = StandardSystemProperty.USER_HOME.value() + "/.graql-history";
 
     private final OutputFormat outputFormat;
     private final boolean infer;
@@ -129,111 +129,9 @@ public class GraqlShell implements AutoCloseable {
     private final GraqlCompleter graqlCompleter;
     private final ExternalEditor editor = ExternalEditor.create();
 
-    private boolean errorOccurred = false;
 
-    /**
-     * Run a Graql REPL
-     *
-     * @param args arguments to the Graql shell. Possible arguments can be listed by running {@code graql console --help}
-     */
-    public static void main(String[] args) throws InterruptedException, IOException {
-        boolean success = runShell(args, GraknVersion.VERSION, HISTORY_FILENAME, GraknConfig.create());
-        System.exit(success ? 0 : 1);
-    }
 
-    public static boolean runShell(
-            String[] args, String version, String historyFilename, GraknConfig config
-    ) throws InterruptedException, IOException {
-
-        GraqlShellOptions options;
-
-        try {
-            options = GraqlShellOptions.create(args);
-        } catch (ParseException e) {
-            System.err.println(e.getMessage());
-            return false;
-        }
-
-        List<String> queries = null;
-
-        String query = options.getQuery();
-
-        // This is a best-effort guess as to whether the user has made a mistake, without parsing the query
-        if (query != null) {
-            queries = ImmutableList.of(query);
-
-            if (!query.contains("$") && query.trim().startsWith("match")) {
-                System.err.println(ErrorMessage.NO_VARIABLE_IN_QUERY.getMessage());
-            }
-        }
-
-        List<Path> filePaths = options.getFiles();
-
-        // Print usage message if requested or if invalid arguments provided
-        if (options.displayHelp()) {
-            GraqlShellOptions.printUsage();
-            return true;
-        }
-
-        if (options.displayVersion()) {
-            System.out.println(version);
-            return true;
-        }
-
-        Keyspace keyspace = options.getKeyspace();
-
-        int defaultGrpcPort = config.getProperty(GraknConfigKey.GRPC_PORT);
-        SimpleURI defaultGrpcUri = new SimpleURI(Grakn.DEFAULT_URI.getHost(), defaultGrpcPort);
-
-        SimpleURI location = options.getUri();
-        OutputFormat outputFormat = options.getOutputFormat();
-
-        SimpleURI httpUri = location != null ? location : Grakn.DEFAULT_URI;
-        SimpleURI grpcUri = location != null ? location : defaultGrpcUri;
-
-        boolean infer = options.shouldInfer();
-
-        Path path = options.getBatchLoadPath();
-
-        if (path != null) {
-            try {
-                BatchLoader.sendBatchRequest(httpUri, keyspace, path);
-            } catch (Exception e) {
-                System.out.println("Batch failed \n" + CommonUtil.simplifyExceptionMessage(e));
-                return false;
-            }
-            return true;
-        }
-
-        try (GraqlShell shell = new GraqlShell(historyFilename, keyspace, grpcUri, outputFormat, infer)) {
-            if (filePaths != null) {
-                queries = loadQueries(filePaths);
-            }
-
-            // Start shell
-            shell.start(queries);
-            return !shell.errorOccurred;
-        } catch (StatusRuntimeException e) {
-            if (e.getStatus().getCode().equals(Status.Code.UNAVAILABLE)) {
-                System.err.println(ErrorMessage.COULD_NOT_CONNECT.getMessage());
-                return false;
-            } else {
-                throw e;
-            }
-        }
-    }
-
-    private static List<String> loadQueries(Iterable<Path> filePaths) throws IOException {
-        List<String> queries = Lists.newArrayList();
-
-        for (Path filePath : filePaths) {
-            queries.add(loadQuery(filePath));
-        }
-
-        return queries;
-    }
-
-    private static String loadQuery(Path filePath) throws IOException {
+    public static String loadQuery(Path filePath) throws IOException {
         List<String> lines = Files.readAllLines(filePath, StandardCharsets.UTF_8);
         return lines.stream().collect(joining("\n"));
     }
@@ -241,21 +139,19 @@ public class GraqlShell implements AutoCloseable {
     /**
      * Create a new Graql shell
      */
-    private GraqlShell(
-            String historyFilename, Keyspace keyspace, SimpleURI uri, OutputFormat outputFormat, boolean infer
-    ) throws IOException {
+    public GraqlShell(String historyFilename, GraknSession session, ConsoleReader console, OutputFormat outputFormat, boolean infer) throws IOException {
         this.outputFormat = outputFormat;
         this.infer = infer;
-        console = new ConsoleReader(System.in, System.out);
+        this.console = console;
+        this.session = session;
+        this.graqlCompleter = GraqlCompleter.create(session);
+        this.historyFile = HistoryFile.create(console, historyFilename);
 
-        session = RemoteGrakn.session(uri, keyspace);
+
         tx = session.open(GraknTxType.WRITE);
-
-        graqlCompleter = GraqlCompleter.create(session);
-        historyFile = HistoryFile.create(console, historyFilename);
     }
 
-    private void start(@Nullable List<String> queryStrings) throws IOException, InterruptedException {
+    public void start(@Nullable List<String> queryStrings) throws IOException, InterruptedException {
         try {
             if (queryStrings != null) {
                 for (String queryString : queryStrings) {
@@ -422,6 +318,10 @@ public class GraqlShell implements AutoCloseable {
     private void reopenTx() {
         if (!tx.isClosed()) tx.close();
         tx = session.open(GraknTxType.WRITE);
+    }
+
+    public boolean errorOccurred() {
+        return errorOccurred;
     }
 
     @Override

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
@@ -18,31 +18,17 @@
 
 package ai.grakn.graql.shell;
 
-import ai.grakn.Grakn;
-import ai.grakn.GraknConfigKey;
 import ai.grakn.GraknSession;
 import ai.grakn.GraknTx;
 import ai.grakn.GraknTxType;
-import ai.grakn.Keyspace;
 import ai.grakn.concept.AttributeType;
-import ai.grakn.engine.GraknConfig;
 import ai.grakn.exception.GraknException;
 import ai.grakn.graql.GraqlConverter;
 import ai.grakn.graql.Query;
-import ai.grakn.remote.RemoteGrakn;
-import ai.grakn.util.CommonUtil;
-import ai.grakn.util.ErrorMessage;
-import ai.grakn.util.GraknVersion;
-import ai.grakn.util.SimpleURI;
-import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import io.grpc.Status;
-import io.grpc.StatusRuntimeException;
 import jline.console.ConsoleReader;
 import jline.console.completer.AggregateCompleter;
-import org.apache.commons.cli.ParseException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/SessionProvider.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/SessionProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.shell;
+
+import ai.grakn.GraknSession;
+import jline.console.ConsoleReader;
+
+
+/**
+ * Classes implementing this inferace will create new GraknSession from Terminal options
+ *
+ * @author marcoscoppetta
+ */
+
+public interface SessionProvider {
+
+    GraknSession getSession(GraqlShellOptions options, ConsoleReader console);
+}


### PR DESCRIPTION
# Why is this PR needed?

So that `GraqlShell` uses more IoC and we can inject different `SessionProvider` from KGMS

# What does the PR do?

Introduces new `SessionProvider` interface
Introduces new `GraknSessionProvider` implementation class
Introduces new `GraqlConsole` which in turn will instantiate `GraqlShell` if no options are specified

# Does it break backwards compatibility?

no

# List of future improvements not on this PR

 - maybe create an `OptionsExecutor` class so that we don't have to accept/execute the same options in open source and KGMS