### PR TITLE
Replace `redis` with `queue` in properties

### DIFF
--- a/conf/main/grakn.properties
+++ b/conf/main/grakn.properties
@@ -129,6 +129,6 @@ cache.db-cache-size=0.25
 ############################# Redis Configuration #############################
 # IP or hostname on which Redis is listening for connections.
 queue.host=localhost:6379
-redis.pool-size=32
-redis.sentinel.master=graknmaster
-redis.sentinel.host=
+queue.pool-size=32
+queue.sentinel.master=graknmaster
+queue.sentinel.host=

--- a/conf/test/cluster/grakn.properties
+++ b/conf/test/cluster/grakn.properties
@@ -38,9 +38,9 @@ grpc.port=48555
 queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
-redis.pool-size=32
-redis.sentinel.master=graknmaster
-redis.sentinel.host=
+queue.pool-size=32
+queue.sentinel.master=graknmaster
+queue.sentinel.host=
 
 #Background tasks Config
 backgroundTasks.time-lapse=300000

--- a/conf/test/janus/grakn.properties
+++ b/conf/test/janus/grakn.properties
@@ -35,9 +35,9 @@ grpc.port=48555
 queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
-redis.pool-size=32
-redis.sentinel.master=graknmaster
-redis.sentinel.host=
+queue.pool-size=32
+queue.sentinel.master=graknmaster
+queue.sentinel.host=
 
 ####################################
 # Grakn Config                     #

--- a/conf/test/tinker/grakn.properties
+++ b/conf/test/tinker/grakn.properties
@@ -39,9 +39,9 @@ grpc.port=48555
 queue.host=localhost:6379
 post-processor.pool-size=32
 post-processor.delay=300
-redis.pool-size=32
-redis.sentinel.master=graknmaster
-redis.sentinel.host=
+queue.pool-size=32
+queue.sentinel.master=graknmaster
+queue.sentinel.host=
 
 ####################################
 # Grakn Config                     #

--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -81,10 +81,10 @@ public abstract class GraknConfigKey<T> {
 
 
     public static final GraknConfigKey<List<String>> REDIS_HOST = key("queue.host", CSV);
-    public static final GraknConfigKey<List<String>> REDIS_SENTINEL_HOST = key("redis.sentinel.host", CSV);
+    public static final GraknConfigKey<List<String>> REDIS_SENTINEL_HOST = key("queue.sentinel.host", CSV);
     public static final GraknConfigKey<String> REDIS_BIND = key("bind");
-    public static final GraknConfigKey<String> REDIS_SENTINEL_MASTER = key("redis.sentinel.master");
-    public static final GraknConfigKey<Integer> REDIS_POOL_SIZE = key("redis.pool-size", INT);
+    public static final GraknConfigKey<String> REDIS_SENTINEL_MASTER = key("queue.sentinel.master");
+    public static final GraknConfigKey<Integer> REDIS_POOL_SIZE = key("queue.pool-size", INT);
     public static final GraknConfigKey<Integer> POST_PROCESSOR_POOL_SIZE = key("post-processor.pool-size", INT);
     public static final GraknConfigKey<Integer> POST_PROCESSOR_DELAY = key("post-processor.delay", INT);
 


### PR DESCRIPTION
# Why is this PR needed?

Because we want our queue parameters to be generic and not indicate Redis!

# What does the PR do?

Replaces `redis` with `queue` in `grakn.properties`.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.