### PR TITLE
Support autocompleting roles and rules in shell

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -21,7 +21,6 @@ package ai.grakn.test.graql.shell;
 import ai.grakn.engine.GraknConfig;
 import ai.grakn.graql.shell.GraknSessionProvider;
 import ai.grakn.graql.shell.GraqlConsole;
-import ai.grakn.graql.shell.GraqlShell;
 import ai.grakn.graql.shell.GraqlShellOptions;
 import ai.grakn.test.rule.DistributionContext;
 import ai.grakn.util.ErrorMessage;
@@ -36,7 +35,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import mjson.Json;
-import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.hamcrest.Matcher;
 import org.junit.AfterClass;
@@ -273,7 +271,8 @@ public class GraqlShellIT {
         assertThat(
                 result,
                 allOf(
-                        containsString(Schema.MetaSchema.THING.getLabel().getValue()), containsString("match"),
+                        containsString(Schema.MetaSchema.THING.getLabel().getValue()),
+                        containsString(Schema.MetaSchema.ROLE.getLabel().getValue()), containsString("match"),
                         not(containsString("exit")), containsString("$x")
                 )
         );


### PR DESCRIPTION
# Why is this PR needed?

There was a bug where pressing tab in shell would autocomplete types, such as `person` and `marriage` but not roles or rules like `wife` or `grandparent-rule`.

# What does the PR do?

Adds all the roles and rules to the list of potential autocomplete candidates.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
