### PR TITLE
Settable RF

### DIFF
--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanus.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanus.java
@@ -71,6 +71,13 @@ import static java.util.Arrays.stream;
 final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusGraph> {
     private final static Logger LOG = LoggerFactory.getLogger(TxFactoryJanus.class);
     private static final AtomicBoolean strategiesApplied = new AtomicBoolean(false);
+    private static final String JANUS_PREFIX = "janusmr.ioformat.conf.";
+    private static final String STORAGE_BACKEND = "storage.backend";
+    private static final String STORAGE_HOSTNAME = "storage.hostname";
+    private static final String STORAGE_KEYSPACE = "storage.cassandra.keyspace";
+    private static final String STORAGE_BATCH_LOADING = "storage.batch-loading";
+    private static final String STORAGE_REPLICATION_FACTOR = "storage.cassandra.replication-factor";
+
 
     //These properties are loaded in by default and can optionally be overwritten
     static final Properties DEFAULT_PROPERTIES;
@@ -91,8 +98,9 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
      * The value of the map specifies the key to inject into.
      */
     private static final Map<String, String> overrideMap = ImmutableMap.of(
-            "storage.backend", "janusmr.ioformat.conf.storage.backend",
-            "storage.hostname", "janusmr.ioformat.conf.storage.hostname"
+            STORAGE_BACKEND, JANUS_PREFIX + STORAGE_BACKEND,
+            STORAGE_HOSTNAME, JANUS_PREFIX + STORAGE_HOSTNAME,
+            STORAGE_REPLICATION_FACTOR, JANUS_PREFIX + STORAGE_REPLICATION_FACTOR
     );
 
     //This maps the storage backend to the needed value
@@ -141,11 +149,9 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
 
     private JanusGraph configureGraph(boolean batchLoading){
         JanusGraphFactory.Builder builder = JanusGraphFactory.build().
-                set("storage.hostname", session().uri()).
-                set("storage.cassandra.keyspace", session().keyspace().getValue()).
-                set("storage.batch-loading", batchLoading);
-
-        String storageBackend = "storage.backend";
+                set(STORAGE_HOSTNAME, session().uri()).
+                set(STORAGE_KEYSPACE, session().keyspace().getValue()).
+                set(STORAGE_BATCH_LOADING, batchLoading);
 
         //Load Defaults
         DEFAULT_PROPERTIES.forEach((key, value) -> builder.set(key.toString(), value));
@@ -154,7 +160,7 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
         session().config().properties().forEach((key, value) -> {
 
             //Overwrite storage
-            if(key.equals(storageBackend)){
+            if(key.equals(STORAGE_BACKEND)){
                 value = storageBackendMapper.get(value);
             }
 


### PR DESCRIPTION
# Why is this PR needed?
To be able to set RF.
# What does the PR do?
Recognises RF param in GraknConfig if set and sets it in Janus factory.

# Does it break backwards compatibility?
No
# List of future improvements not on this PR
None.