### PR TITLE
Fix incorrect error message regarding datatypes

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/concept/AttributeType.java
+++ b/grakn-core/src/main/java/ai/grakn/concept/AttributeType.java
@@ -285,7 +285,7 @@ public interface AttributeType<D> extends Type {
                 (o) -> {
                     if (o == null) return null;
                     if (!(o instanceof Long)) {
-                        throw GraknTxOperationException.invalidResourceValue(o, LONG);
+                        throw GraknTxOperationException.invalidAttributeValue(o, LONG);
                     }
                     return LocalDateTime.ofInstant(Instant.ofEpochMilli((long) o), ZoneId.of("Z"));
                 });

--- a/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
+++ b/grakn-core/src/main/java/ai/grakn/exception/GraknTxOperationException.java
@@ -130,10 +130,11 @@ public class GraknTxOperationException extends GraknException{
     }
 
     /**
-     * Thrown when creating a resource whose value {@code object} does not match it's resource's  {@code dataType}.
+     * Thrown when creating a {@link Attribute} whose value {@link Object} does not match it's {@link AttributeType}'s
+     * {@link ai.grakn.concept.AttributeType.DataType}
      */
-    public static GraknTxOperationException invalidResourceValue(Object object, AttributeType.DataType dataType){
-        return create(ErrorMessage.INVALID_DATATYPE.getMessage(object, dataType.getVertexProperty().getDataType().getName()));
+    public static GraknTxOperationException invalidAttributeValue(Object object, AttributeType.DataType dataType){
+        return create(ErrorMessage.INVALID_DATATYPE.getMessage(object, dataType.getName()));
     }
 
     /**

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeImpl.java
@@ -90,7 +90,7 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
                 return dataType.getPersistenceValue(value);
             }
         } catch (ClassCastException e) {
-            throw GraknTxOperationException.invalidResourceValue(value, dataType);
+            throw GraknTxOperationException.invalidAttributeValue(value, dataType);
         }
     }
 

--- a/grakn-kb/src/test/java/ai/grakn/exception/GraknTxOperationExceptionTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/exception/GraknTxOperationExceptionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.exception;
+
+import ai.grakn.concept.AttributeType.DataType;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class GraknTxOperationExceptionTest {
+
+    @Test
+    public void whenGettingErrorMessageForInvalidAttributeValue_MessageIncludesExpectedClass() {
+        String message = GraknTxOperationException.invalidAttributeValue("bob", DataType.DATE).getMessage();
+        assertThat(message, containsString(LocalDateTime.class.getName()));
+    }
+}

--- a/grakn-kb/src/test/java/ai/grakn/exception/GraknTxOperationExceptionTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/exception/GraknTxOperationExceptionTest.java
@@ -33,4 +33,5 @@ public class GraknTxOperationExceptionTest {
         String message = GraknTxOperationException.invalidAttributeValue("bob", DataType.DATE).getMessage();
         assertThat(message, containsString(LocalDateTime.class.getName()));
     }
+
 }

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/AttributeTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/AttributeTest.java
@@ -121,7 +121,18 @@ public class AttributeTest extends TxTestBase {
         String invalidThing = "Invalid Thing";
         AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.DataType.LONG);
         expectedException.expect(GraknTxOperationException.class);
-        expectedException.expectMessage(GraknTxOperationException.invalidResourceValue(invalidThing, AttributeType.DataType.LONG).getMessage());
+        expectedException.expectMessage(GraknTxOperationException.invalidAttributeValue(invalidThing, AttributeType.DataType.LONG).getMessage());
+        longAttributeType.putAttribute(invalidThing);
+    }
+
+    // this is deliberately an incorrect type for the test
+    @SuppressWarnings("unchecked")
+    @Test
+    public void whenCreatingResourceWithAnInvalidDataTypeOnADate_Throw(){
+        String invalidThing = "Invalid Thing";
+        AttributeType longAttributeType = tx.putAttributeType("date", AttributeType.DataType.DATE);
+        expectedException.expect(GraknTxOperationException.class);
+        expectedException.expectMessage(GraknTxOperationException.invalidAttributeValue(invalidThing, AttributeType.DataType.DATE).getMessage());
         longAttributeType.putAttribute(invalidThing);
     }
 


### PR DESCRIPTION
# Why is this PR needed?

Fixes issue #2367 

# What does the PR do?

Fixes up the error message to report the user-facing type of the attribute (not the type that is persisted).

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
