### PR TITLE
add java-opts

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -23,6 +23,7 @@ import ai.grakn.bootup.graknengine.Grakn;
 import ai.grakn.engine.GraknConfig;
 import ai.grakn.util.REST;
 import ai.grakn.util.SimpleURI;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.File;
@@ -35,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -125,7 +127,10 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     protected String commandToRun() {
-        return "java -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath + " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
+        Optional<String> javaOpts = Optional.ofNullable(System.getProperty("grakn.engine.javaopts"));
+        String cmd = "java " + javaOpts.orElse("") + " -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath + " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
+
+        return cmd;
     }
 
     private boolean graknCheckIfReady(String host, int port, String path) {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -23,7 +23,6 @@ import ai.grakn.bootup.graknengine.Grakn;
 import ai.grakn.engine.GraknConfig;
 import ai.grakn.util.REST;
 import ai.grakn.util.SimpleURI;
-import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.File;
@@ -49,6 +48,7 @@ public class EngineProcess extends AbstractProcessHandler {
     private static final String GRAKN_NAME = "Grakn";
     private static final long GRAKN_STARTUP_TIMEOUT_S = 300;
     public static final Path ENGINE_PID = Paths.get(File.separator,"tmp","grakn-engine.pid");
+    public static final Optional<String> javaOpts = Optional.ofNullable(System.getProperty("engine.javaopts"));
 
     protected final Path homePath;
     protected final Path configPath;
@@ -127,7 +127,6 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     protected String commandToRun() {
-        Optional<String> javaOpts = Optional.ofNullable(System.getProperty("grakn.engine.javaopts"));
         String cmd = "java " + javaOpts.orElse("") + " -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath + " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
 
         return cmd;

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -19,6 +19,7 @@
 package ai.grakn.bootup;
 
 import ai.grakn.GraknConfigKey;
+import ai.grakn.GraknSystemProperty;
 import ai.grakn.bootup.graknengine.Grakn;
 import ai.grakn.engine.GraknConfig;
 import ai.grakn.util.REST;
@@ -48,7 +49,7 @@ public class EngineProcess extends AbstractProcessHandler {
     private static final String GRAKN_NAME = "Grakn";
     private static final long GRAKN_STARTUP_TIMEOUT_S = 300;
     public static final Path ENGINE_PID = Paths.get(File.separator,"tmp","grakn-engine.pid");
-    public static final Optional<String> javaOpts = Optional.ofNullable(System.getProperty("engine.javaopts"));
+    public static final String javaOpts = Optional.ofNullable(GraknSystemProperty.ENGINE_JAVAOPTS.value()).orElse("");
 
     protected final Path homePath;
     protected final Path configPath;
@@ -127,7 +128,8 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     protected String commandToRun() {
-        String cmd = "java " + javaOpts.orElse("") + " -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath + " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
+        String cmd = "java " + javaOpts + " -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath +
+                " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
 
         return cmd;
     }

--- a/grakn-core/src/main/java/ai/grakn/GraknSystemProperty.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknSystemProperty.java
@@ -33,7 +33,8 @@ public enum GraknSystemProperty {
     CONFIGURATION_FILE("grakn.conf"),
     TEST_PROFILE("grakn.test-profile"),
     PROJECT_RELATIVE_DIR("main.basedir"),
-    GRAKN_PID_FILE("grakn.pidfile");
+    GRAKN_PID_FILE("grakn.pidfile"),
+    ENGINE_JAVAOPTS("engine.javaopts");
 
     private String key;
 

--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -49,6 +49,6 @@ update_classpath_global_var
 
 GRAKN_CONFIG="conf/grakn.properties"
 
-java -cp ${CLASSPATH} -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dgrakn.pidfile=/tmp/grakn.pid ai.grakn.bootup.GraknBootup $@
+java -cp ${CLASSPATH} -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dgrakn.javaopts="${GRAKN_JAVAOPTS}" -Dgrakn.pidfile=/tmp/grakn.pid ai.grakn.bootup.GraknBootup $@
 
 popd > /dev/null

--- a/grakn-dist/src/grakn
+++ b/grakn-dist/src/grakn
@@ -49,6 +49,6 @@ update_classpath_global_var
 
 GRAKN_CONFIG="conf/grakn.properties"
 
-java -cp ${CLASSPATH} -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dgrakn.javaopts="${GRAKN_JAVAOPTS}" -Dgrakn.pidfile=/tmp/grakn.pid ai.grakn.bootup.GraknBootup $@
+java -cp ${CLASSPATH} -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dengine.javaopts="${ENGINE_JAVAOPTS}" -Dgrakn.pidfile=/tmp/grakn.pid ai.grakn.bootup.GraknBootup $@
 
 popd > /dev/null


### PR DESCRIPTION
# Why is this PR needed?
This will allow you to add Java options before starting engine.

For example: `ENGINE_JAVAOPTS='-Xdebug ...' ./grakn server start`

# What does the PR do?
`grakn` command now accepts `ENGINE_JAVAOPTS`, which will be passed down to `GraknBootup` via `-Dengine.javaopts`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A