### PR TITLE
Fix bug where migrator says "Loaded 0 statements"

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
@@ -130,6 +130,13 @@ public class CSVMigratorMainTest {
     }
 
     @Test
+    public void csvMigratorCalled_PrintsNumberOfQueriesExecuted(){
+        run("-u", engine.uri().toString(), "-input", dataFile, "-template", templateFile, "-keyspace", keyspace.getValue());
+
+        assertThat(sysOut.getLog(), containsString("Loaded 9 statements"));
+    }
+
+    @Test
     public void csvMigratorCalledWithNoTemplate_ErrorIsPrintedToSystemErr(){
         run("-input", dataFile, "-u", engine.uri().toString());
         assertThat(sysErr.getLog(), containsString("Template file missing (-t)"));


### PR DESCRIPTION
# Why is this PR needed?

There was a bug where when migrating small files, the migrator would report "Loaded 0 statements".
This fixes that issue.

# What does the PR do?

This sequence of events caused the issue:

1. `BatchExecutorClient` opens
2. `Migrator` registers callback on `BatchExecutorClient` for completed queries
3. `Migrator` submits one query to `BatchExecutorClient`
4. `Migrator` waits for `BatchExecutorClient` to close (waits for all permits to release)
5. On thread 2: The query completes and releases a permit
6. `BatchExecutorClient` closes, `Migrator` continues and prints "Loaded 0 statements"
7. On thread 2: Callback is called, incrementing number of loaded queries

Now we optimistically increment the `queriesLoaded` number when the query is submitted, not when it completes.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.