### PR TITLE
Stop exposing observables in BatchExecutorClient

### DIFF
--- a/docs/pages/docs/7-java-library/loader-api.md
+++ b/docs/pages/docs/7-java-library/loader-api.md
@@ -44,11 +44,9 @@ The loader client can be thought of as an empty bucket in which to dump insert q
 InsertQuery insert = insert(var().isa("person"));
 
 for(int i = 0; i < 100; i++){
-    loader.add(insert, keyspace).subscribe({System.out.println(it)});
+    loader.add(insert, keyspace);
 }
 ```
-
-Note that  the output is  a Java RX Observable that needs subscription or blocking.
 
 ## Close
 

--- a/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
+++ b/grakn-client/src/main/java/ai/grakn/client/BatchExecutorClient.java
@@ -136,13 +136,6 @@ public class BatchExecutorClient implements Closeable {
         Observable<QueryResponse> observable = new QueriesObservableCollapser(queryRequest, keyspace)
                 .observe()
                 .doOnError(error -> failureMeter.mark())
-                .doOnEach(a -> {
-                    if (a.getThrowable() != null) {
-                        LOG.error("Error while executing statement", a.getThrowable());
-                    } else if (a.isOnNext()) {
-                        LOG.trace("Executed {}", a.getValue());
-                    }
-                })
                 .subscribeOn(scheduler)
                 .doOnTerminate(contextAddTimer::close);
 

--- a/grakn-client/src/main/java/ai/grakn/client/GraknClientImpl.java
+++ b/grakn-client/src/main/java/ai/grakn/client/GraknClientImpl.java
@@ -24,6 +24,7 @@ import ai.grakn.util.REST;
 import ai.grakn.util.SimpleURI;
 import com.sun.jersey.api.client.Client;
 import com.sun.jersey.api.client.ClientResponse;
+import mjson.Json;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,7 +83,9 @@ public class GraknClientImpl implements GraknClient {
             String entity = response.getEntity(String.class);
             if (!status.getFamily().equals(Family.SUCCESSFUL)) {
                 String queries = queryList.stream().map(Object::toString).collect(Collectors.joining("\n"));
-                throw new GraknClientException("Failed graqlExecute. Error status: " + status.getStatusCode() + ", error info: " + entity + "\nqueries: " + queries, response.getStatusInfo());
+
+                String error = Json.read(entity).at("exception").asString();
+                throw new GraknClientException("Failed graqlExecute. Error status: " + status.getStatusCode() + ", error info: " + error + "\nqueries: " + queries, response.getStatusInfo());
             }
             LOG.debug("Received {}", status.getStatusCode());
             return queryList.stream().map(q -> QueryResponse.INSTANCE).collect(Collectors.toList());

--- a/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
+++ b/grakn-migration/base/src/main/java/ai/grakn/migration/base/Migrator.java
@@ -149,7 +149,7 @@ public class Migrator {
         });
 
         batchExecutorClient.onError(error -> {
-            LOG.debug("Error in execution", error);
+            System.err.println("Error in execution: " + error);
             if (failFast) {
                 throw GraknBackendException
                         .migrationFailure(error.getMessage());

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchExecutorClientIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchExecutorClientIT.java
@@ -23,7 +23,6 @@ import ai.grakn.GraknTxType;
 import ai.grakn.Keyspace;
 import ai.grakn.client.BatchExecutorClient;
 import ai.grakn.client.GraknClient;
-import ai.grakn.client.QueryResponse;
 import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.EntityType;
 import ai.grakn.concept.Role;
@@ -42,14 +41,15 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import rx.Observable;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static ai.grakn.graql.Graql.var;
-import static ai.grakn.util.ConcurrencyUtil.allObservable;
 import static ai.grakn.util.GraknTestUtil.usingTinker;
 import static ai.grakn.util.SampleKBLoader.randomKeyspace;
 import static java.util.stream.Stream.generate;
@@ -81,45 +81,48 @@ public class BatchExecutorClientIT {
 
     @Test
     public void whenSingleQueryLoadedAndServerDown_RequestIsRetried() throws InterruptedException {
-        List<Observable<QueryResponse>> all = new ArrayList<>();
+        AtomicInteger numLoaded = new AtomicInteger(0);
         // Create a BatchExecutorClient with a callback that will fail
         try (BatchExecutorClient loader = loader(MAX_DELAY)) {
+            loader.onNext(response -> numLoaded.incrementAndGet());
+
             // Engine goes down
             engine.server().getHttpHandler().stopHTTP();
             // Most likely the first call doesn't find the server but it's retried
-            generate(this::query).limit(1).forEach(q -> all.add(loader.add(q, keyspace, true)));
+            generate(this::query).limit(1).forEach(q -> loader.add(q, keyspace));
             engine.server().getHttpHandler().startHTTP();
-            int completed = allObservable(all).toBlocking().first().size();
-            // Verify that the logger received the failed log message
-            assertEquals(1, completed);
         }
+
+        // Verify that the logger received the failed log message
+        assertEquals(1, numLoaded.get());
     }
 
     @Test
     public void whenSingleQueryLoaded_TaskCompletionExecutesExactlyOnce() {
-        List<Observable<QueryResponse>> all = new ArrayList<>();
+        AtomicInteger numLoaded = new AtomicInteger(0);
+
         // Create a BatchExecutorClient with a callback that will fail
         try (BatchExecutorClient loader = loader(MAX_DELAY)) {
+            loader.onNext(response -> numLoaded.incrementAndGet());
+
             // Load some queries
             generate(this::query).limit(1).forEach(q ->
-                    all.add(loader.add(q, keyspace, true))
+                    loader.add(q, keyspace)
             );
-            int completed = allObservable(all).toBlocking().first().size();
-            // Verify that the logger received the failed log message
-            assertEquals(1, completed);
         }
+
+        // Verify that the logger received the failed log message
+        assertEquals(1, numLoaded.get());
     }
 
     @Test
     public void whenSending100InsertQueries_100EntitiesAreLoadedIntoGraph() {
         int n = 100;
-        List<Observable<QueryResponse>> all = new ArrayList<>();
+
         try (BatchExecutorClient loader = loader(MAX_DELAY)) {
-            generate(this::query).limit(n).forEach(q ->
-                    all.add(loader.add(q, keyspace, true))
+            generate(this::query).limit(100).forEach(q ->
+                    loader.add(q, keyspace)
             );
-            int completed = allObservable(all).toBlocking().first().size();
-            assertEquals(n, completed);
         }
         try (GraknTx graph = session.open(GraknTxType.READ)) {
             assertEquals(n, graph.getEntityType("name_tag").instances().count());
@@ -128,18 +131,20 @@ public class BatchExecutorClientIT {
 
     @Ignore("This test interferes with other tests using the BEC (they probably use the same HystrixRequestLog)")
     @Test
-    public void whenSending100Queries_TheyAreSentInBatch() {
-        List<Observable<QueryResponse>> all = new ArrayList<>();
+    public void whenSending100Queries_TheyAreSentInBatch() throws InterruptedException {
+        Condition everythingLoaded = new ReentrantLock().newCondition();
+
         // Increasing the max delay so eveyrthing goes in a single batch
         try (BatchExecutorClient loader = loader(MAX_DELAY * 100)) {
+            loader.onNext(queryResponse -> everythingLoaded.signal());
+
             int n = 100;
             generate(this::query).limit(n).forEach(q ->
-                    all.add(loader.add(q, keyspace, true))
+                    loader.add(q, keyspace)
             );
 
-            int completed = allObservable(all).toBlocking().first().size();
+            everythingLoaded.await();
 
-            assertEquals(n, completed);
             assertEquals(1, HystrixRequestLog.getCurrentRequest().getAllExecutedCommands().size());
             HystrixCommand<?> command = HystrixRequestLog.getCurrentRequest()
                     .getAllExecutedCommands()
@@ -158,14 +163,12 @@ public class BatchExecutorClientIT {
     @Test
     public void whenEngineRESTFailsWhileLoadingWithRetryTrue_LoaderRetriesAndWaits()
             throws Exception {
-        List<Observable<QueryResponse>> all = new ArrayList<>();
+
         int n = 20;
+
         try (BatchExecutorClient loader = loader(MAX_DELAY)) {
             for (int i = 0; i < n; i++) {
-                all.add(
-                        loader
-                                .add(query(), keyspace, true)
-                                .doOnError(ex -> System.out.println("Error " + ex)));
+                loader.add(query(), keyspace);
 
                 if (i % 5 == 0) {
                     Thread.sleep(200);
@@ -175,9 +178,8 @@ public class BatchExecutorClientIT {
                     engine.server().getHttpHandler().startHTTP();
                 }
             }
-            int completed = allObservable(all).toBlocking().first().size();
-            assertEquals(n, completed);
         }
+
         if(GraknTestUtil.usingJanus()) {
             try (GraknTx graph = session.open(GraknTxType.READ)) {
                 assertEquals(n, graph.getEntityType("name_tag").instances().count());

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchExecutorClientTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/client/BatchExecutorClientTest.java
@@ -61,8 +61,7 @@ public class BatchExecutorClientTest {
 
         try (BatchExecutorClient client = clientBuilder.build()) {
             for (Query<?> query : queriesToExecute) {
-                // If we don't subscribe, the query won't execute
-                client.add(query, keyspace).subscribe(a -> {});
+                client.add(query, keyspace);
             }
         }
 
@@ -88,8 +87,7 @@ public class BatchExecutorClientTest {
 
         try (BatchExecutorClient client = clientBuilder.build()) {
             for (Query<?> query : queriesToExecute) {
-                // If we don't subscribe, the query won't execute
-                client.add(query, keyspace).subscribe(a -> {});
+                client.add(query, keyspace);
             }
         }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
@@ -94,7 +94,7 @@ public class BenchmarkIT {
         try(BatchExecutorClient loader = BatchExecutorClient.newBuilder().taskClient(graknClient).build()){
             for(int i = 0 ; i < N ;i++){
                 InsertQuery entityInsert = Graql.insert(var().asUserDefined().isa(entityLabel));
-                loader.add(entityInsert, keyspace).subscribe();
+                loader.add(entityInsert, keyspace);
             }
         }
     }
@@ -128,7 +128,7 @@ public class BenchmarkIT {
                         .isa(Graql.label(relationType.getLabel()))
                         .and(fromRolePlayer.asUserDefined().id(instances[from]))
                         .and(toRolePlayer.asUserDefined().id(instances[to]));
-                loader.add(Graql.insert(relationInsert.admin().varPatterns()), keyspace).subscribe();
+                loader.add(Graql.insert(relationInsert.admin().varPatterns()), keyspace);
             }
             tx.close();
         }
@@ -230,7 +230,7 @@ public class BenchmarkIT {
                                 .has(attributeLabel, "first")
                                 .id(instances[0])
                                 .admin().varPatterns()
-                ), keyspace).subscribe();
+                ), keyspace);
 
                 for(int i = 1; i < instances.length; i++){
                     Var fromRolePlayer = Graql.var();
@@ -242,12 +242,12 @@ public class BenchmarkIT {
                             .isa(Graql.label(baseRelation.getLabel()))
                             .and(fromRolePlayer.asUserDefined().id(instances[i - 1]))
                             .and(toRolePlayer.asUserDefined().id(instances[i]));
-                    loader.add(Graql.insert(relationInsert.admin().varPatterns()), keyspace).subscribe();
+                    loader.add(Graql.insert(relationInsert.admin().varPatterns()), keyspace);
 
                     Pattern resourceInsert = Graql.var().asUserDefined()
                             .has(attributeLabel, String.valueOf(i))
                             .id(instances[i]);
-                    loader.add(Graql.insert(resourceInsert.admin().varPatterns()), keyspace).subscribe();
+                    loader.add(Graql.insert(resourceInsert.admin().varPatterns()), keyspace);
                 }
             }
         }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
@@ -37,6 +37,7 @@ import static ai.grakn.test.migration.MigratorTestUtils.assertPokemonGraphCorrec
 import static ai.grakn.test.migration.MigratorTestUtils.getFile;
 import static ai.grakn.test.migration.MigratorTestUtils.load;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 
 public class CSVMigratorMainTest {
@@ -70,6 +71,12 @@ public class CSVMigratorMainTest {
     @Test
     public void whenAFailureOccursDuringLoadingAndTheDebugFlagIsNotSet_DontThrow(){
         run("-u", engine.uri().toString(), "-input", dataFile, "-template", templateCorruptFile, "-keyspace", keyspace.getValue());
+    }
+
+    @Test
+    public void whenAFailureOccursDuringLoading_PrintError(){
+        run("-u", engine.uri().toString(), "-input", dataFile, "-template", templateCorruptFile, "-keyspace", keyspace.getValue());
+        assertThat(sysErr.getLog(), anyOf(containsString("bob"), containsString("fridge"), containsString("potato")));
     }
 
     @Test

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/migration/csv/CSVMigratorMainTest.java
@@ -130,6 +130,13 @@ public class CSVMigratorMainTest {
     }
 
     @Test
+    public void csvMigratorCalled_PrintsNumberOfQueriesExecuted(){
+        run("-u", engine.uri().toString(), "-input", dataFile, "-template", templateFile, "-keyspace", keyspace.getValue());
+
+        assertThat(sysOut.getLog(), containsString("Loaded 9 statements"));
+    }
+
+    @Test
     public void csvMigratorCalledWithNoTemplate_ErrorIsPrintedToSystemErr(){
         run("-input", dataFile, "-u", engine.uri().toString());
         assertThat(sysErr.getLog(), containsString("Template file missing (-t)"));


### PR DESCRIPTION
# Why is this PR needed?

The `BatchExecutorClient` was a bit difficult to use:

1. If you didn't `subscribe` to each observable after submitting, that query wouldn't actually load, which was confusing.
2. The callbacks when subscribing to an observable were not guaranteed to run before the `BatchExecutorClient` closed, leading to race conditions and other subtle bugs.

# What does the PR do?

Now, `BatchExecutorClient#add` returns `void` instead of an observable. To do the same observable-like behaviour, call `BatchExecutorClient#onNext` and `BatchExecutorClient#onError` to provide callbacks to execute. These callbacks _are_ guaranteed to run before the `BatchExecutorClient` closes.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.