### PR TITLE
Supply storage host to spark

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
+++ b/grakn-core/src/main/java/ai/grakn/GraknConfigKey.java
@@ -79,6 +79,7 @@ public abstract class GraknConfigKey<T> {
     public static final GraknConfigKey<Integer> SERVER_PORT = key("server.port", INT);
     public static final GraknConfigKey<Integer> GRPC_PORT = key("grpc.port", INT);
 
+    public static final GraknConfigKey<String> STORAGE_HOSTNAME = key("storage.hostname", STRING);
 
     public static final GraknConfigKey<List<String>> REDIS_HOST = key("queue.host", CSV);
     public static final GraknConfigKey<List<String>> REDIS_SENTINEL_HOST = key("queue.sentinel.host", CSV);

--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
@@ -26,8 +26,6 @@ import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Properties;
-
 /**
  * <p>
  *     A {@link ai.grakn.GraknTx} on top of {@link HadoopGraph}
@@ -46,19 +44,22 @@ import java.util.Properties;
  * @author fppt
  */
 public class TxFactoryJanusHadoop extends TxFactoryAbstract<EmbeddedGraknTx<HadoopGraph>, HadoopGraph> {
-    private static final String CLUSTER_KEYSPACE = "janusmr.ioformat.conf.storage.cassandra.keyspace";
-    private static final String INPUT_KEYSPACE = "cassandra.input.keyspace";
+    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = "janusmr.ioformat.conf.storage.cassandra.keyspace";
+    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_HOSTNAME = "janusmr.ioformat.conf.storage.hostname";
+    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_HOSTNAME = "janusgraphmr.ioformat.conf.storage.hostname";
+    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = "janusgraphmr.ioformat.conf.storage.cassandra.keyspace";
+    private static final String CASSANDRA_INPUT_KEYSPACE = "cassandra.input.keyspace";
 
     private final Logger LOG = LoggerFactory.getLogger(TxFactoryJanusHadoop.class);
 
     TxFactoryJanusHadoop(EmbeddedGraknSession session) {
         super(session);
 
-        session().config().properties().setProperty(CLUSTER_KEYSPACE, session().keyspace().getValue());
-        session().config().properties().setProperty(INPUT_KEYSPACE, session().keyspace().getValue());
-        session().config().properties().setProperty("janusgraphmr.ioformat.conf.storage.hostname", session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
-        session().config().properties().setProperty("janusmr.ioformat.conf.storage.hostname", session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
-        session().config().properties().setProperty("janusgraphmr.ioformat.conf.storage.cassandra.keyspace", session().keyspace().getValue());
+        session().config().properties().setProperty(JANUSMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE, session().keyspace().getValue());
+        session().config().properties().setProperty(CASSANDRA_INPUT_KEYSPACE, session().keyspace().getValue());
+        session().config().properties().setProperty(JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_HOSTNAME, session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
+        session().config().properties().setProperty(JANUSMR_IOFORMAT_CONF_STORAGE_HOSTNAME, session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
+        session().config().properties().setProperty(JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE, session().keyspace().getValue());
     }
 
     @Override

--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
@@ -44,10 +44,17 @@ import org.slf4j.LoggerFactory;
  * @author fppt
  */
 public class TxFactoryJanusHadoop extends TxFactoryAbstract<EmbeddedGraknTx<HadoopGraph>, HadoopGraph> {
-    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = "janusmr.ioformat.conf.storage.cassandra.keyspace";
-    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_HOSTNAME = "janusmr.ioformat.conf.storage.hostname";
-    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_HOSTNAME = "janusgraphmr.ioformat.conf.storage.hostname";
-    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = "janusgraphmr.ioformat.conf.storage.cassandra.keyspace";
+    public static final String JANUSMR_IOFORMAT_CONF = "janusmr.ioformat.conf.";
+    public static final String JANUSGRAPHMR_IOFORMAT_CONF = "janusgraphmr.ioformat.conf.";
+    public static final String STORAGE_CASSANDRA_KEYSPACE = "storage.cassandra.keyspace";
+    public static final String STORAGE_HOSTNAME = "storage.hostname";
+
+    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = JANUSMR_IOFORMAT_CONF + STORAGE_CASSANDRA_KEYSPACE;
+    private static final String JANUSMR_IOFORMAT_CONF_STORAGE_HOSTNAME = JANUSMR_IOFORMAT_CONF + STORAGE_HOSTNAME;
+
+    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_HOSTNAME = JANUSGRAPHMR_IOFORMAT_CONF + STORAGE_HOSTNAME;
+    private static final String JANUSGRAPHMR_IOFORMAT_CONF_STORAGE_CASSANDRA_KEYSPACE = JANUSGRAPHMR_IOFORMAT_CONF + STORAGE_CASSANDRA_KEYSPACE;
+
     private static final String CASSANDRA_INPUT_KEYSPACE = "cassandra.input.keyspace";
 
     private final Logger LOG = LoggerFactory.getLogger(TxFactoryJanusHadoop.class);

--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
@@ -18,12 +18,15 @@
 
 package ai.grakn.factory;
 
+import ai.grakn.GraknConfigKey;
 import ai.grakn.kb.internal.EmbeddedGraknTx;
 import ai.grakn.util.ErrorMessage;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
 
 /**
  * <p>
@@ -45,6 +48,7 @@ import org.slf4j.LoggerFactory;
 public class TxFactoryJanusHadoop extends TxFactoryAbstract<EmbeddedGraknTx<HadoopGraph>, HadoopGraph> {
     private static final String CLUSTER_KEYSPACE = "janusmr.ioformat.conf.storage.cassandra.keyspace";
     private static final String INPUT_KEYSPACE = "cassandra.input.keyspace";
+
     private final Logger LOG = LoggerFactory.getLogger(TxFactoryJanusHadoop.class);
 
     TxFactoryJanusHadoop(EmbeddedGraknSession session) {
@@ -52,6 +56,9 @@ public class TxFactoryJanusHadoop extends TxFactoryAbstract<EmbeddedGraknTx<Hado
 
         session().config().properties().setProperty(CLUSTER_KEYSPACE, session().keyspace().getValue());
         session().config().properties().setProperty(INPUT_KEYSPACE, session().keyspace().getValue());
+        session().config().properties().setProperty("janusgraphmr.ioformat.conf.storage.hostname", session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
+        session().config().properties().setProperty("janusmr.ioformat.conf.storage.hostname", session().config().getProperty(GraknConfigKey.STORAGE_HOSTNAME));
+        session().config().properties().setProperty("janusgraphmr.ioformat.conf.storage.cassandra.keyspace", session().keyspace().getValue());
     }
 
     @Override

--- a/grakn-factory/src/test/java/ai/grakn/factory/TxFactoryJanusHadoopTest.java
+++ b/grakn-factory/src/test/java/ai/grakn/factory/TxFactoryJanusHadoopTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.when;
 
 public class TxFactoryJanusHadoopTest {
     private final static EmbeddedGraknSession session = mock(EmbeddedGraknSession.class);
-    private static final File TEST_CONFIG_FILE = Paths.get("../../conf/main/grakn.properties").toFile();
+    private static final File TEST_CONFIG_FILE = Paths.get("../conf/main/grakn.properties").toFile();
     private final static GraknConfig TEST_CONFIG = GraknConfig.read(TEST_CONFIG_FILE);
 
     private TxFactoryJanusHadoop factory;

--- a/grakn-factory/src/test/java/ai/grakn/factory/TxFactoryJanusHadoopTest.java
+++ b/grakn-factory/src/test/java/ai/grakn/factory/TxFactoryJanusHadoopTest.java
@@ -42,7 +42,7 @@ public class TxFactoryJanusHadoopTest {
     private TxFactoryJanusHadoop factory;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(session.keyspace()).thenReturn(Keyspace.of("rubbish"));
         when(session.uri()).thenReturn("rubbish");
         when(session.config()).thenReturn(TxFactoryJanusHadoopTest.TEST_CONFIG);
@@ -50,12 +50,12 @@ public class TxFactoryJanusHadoopTest {
     }
 
     @Test(expected=UnsupportedOperationException.class)
-    public void buildGraknGraphFromTinker() throws Exception {
+    public void buildGraknGraphFromTinker() {
         factory.open(GraknTxType.WRITE);
     }
 
     @Test
-    public void buildTinkerPopGraph() throws Exception {
+    public void buildTinkerPopGraph() {
         assertThat(factory.getTinkerPopGraph(false), instanceOf(HadoopGraph.class));
     }
 


### PR DESCRIPTION
# Why is this PR needed?
Compute count does not work when storage.hostname is set to other than 'localhost'.

# What does the PR do?
Tell Janus to talk to Cassandra on the right host

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A