### PR TITLE
Make GraqlShellOptions extensible for KGMS

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
@@ -22,6 +22,7 @@ import ai.grakn.engine.GraknConfig;
 import ai.grakn.graql.shell.GraknSessionProvider;
 import ai.grakn.graql.shell.GraqlConsole;
 import ai.grakn.graql.shell.GraqlShellOptions;
+import ai.grakn.graql.shell.GraqlShellOptionsFactory;
 import ai.grakn.graql.shell.SessionProvider;
 import ai.grakn.migration.csv.CSVMigrator;
 import ai.grakn.migration.export.Main;
@@ -41,12 +42,14 @@ import java.util.Arrays;
  */
 public class Graql {
 
+    private final GraqlShellOptionsFactory graqlShellOptionsFactory;
     private SessionProvider sessionProvider;
     private static final String HISTORY_FILENAME = StandardSystemProperty.USER_HOME.value() + "/.graql-history";
 
 
-    public Graql(SessionProvider sessionProvider) {
+    public Graql(SessionProvider sessionProvider, GraqlShellOptionsFactory graqlShellOptionsFactory) {
         this.sessionProvider = sessionProvider;
+        this.graqlShellOptionsFactory = graqlShellOptionsFactory;
     }
 
     /**
@@ -56,7 +59,10 @@ public class Graql {
      * @param args
      */
     public static void main(String[] args) throws IOException, InterruptedException {
-        new Graql(new GraknSessionProvider(GraknConfig.create())).run(args);
+        GraknSessionProvider sessionProvider = new GraknSessionProvider(GraknConfig.create());
+        GraqlShellOptionsFactory graqlShellOptionsFactory = GraqlShellOptions::create;
+
+        new Graql(sessionProvider, graqlShellOptionsFactory).run(args);
     }
 
     public void run(String[] args) throws IOException, InterruptedException {
@@ -67,7 +73,7 @@ public class Graql {
                 GraqlShellOptions options;
 
                 try {
-                    options = GraqlShellOptions.create(valuesFrom(args, 1));
+                    options = graqlShellOptionsFactory.createGraqlShellOptions(valuesFrom(args, 1));
                 } catch (ParseException e) {
                     System.err.println(e.getMessage());
                     return;

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlConsole.java
@@ -69,7 +69,7 @@ public class GraqlConsole {
 
         // Print usage message if requested or if invalid arguments provided
         if (options.displayHelp()) {
-            GraqlShellOptions.printUsage();
+            options.printUsage();
             return true;
         }
 

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
@@ -96,6 +96,10 @@ public class GraqlShellOptions {
         return new GraqlShellOptions(additionalOptions, cmd);
     }
 
+    public CommandLine cmd() {
+        return cmd;
+    }
+
     public void printUsage() {
         HelpFormatter helpFormatter = new HelpFormatter();
         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(System.out, Charset.defaultCharset());

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
@@ -24,6 +24,7 @@ import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 
@@ -58,13 +59,15 @@ public class GraqlShellOptions {
     private static final String HELP = "h";
     private static final String VERSION = "v";
 
-    private CommandLine cmd;
+    private final Options options;
+    private final CommandLine cmd;
 
-    private GraqlShellOptions(CommandLine cmd) {
+    private GraqlShellOptions(Options options, CommandLine cmd) {
+        this.options = options;
         this.cmd = cmd;
     }
 
-    private static Options options() {
+    private static Options defaultOptions() {
         Options options = new Options();
         options.addOption(KEYSPACE, "keyspace", true, "keyspace of the graph");
         options.addOption(EXECUTE, "execute", true, "query to execute");
@@ -79,19 +82,28 @@ public class GraqlShellOptions {
     }
 
     public static GraqlShellOptions create(String[] args) throws ParseException {
-        CommandLineParser parser = new DefaultParser();
-        CommandLine cmd = parser.parse(options(), args);
-        return new GraqlShellOptions(cmd);
+        return create(args, new Options());
     }
 
-    public static void printUsage() {
+    public static GraqlShellOptions create(String[] args, Options additionalOptions) throws ParseException {
+        Options options = defaultOptions();
+        for (Option option : additionalOptions.getOptions()) {
+            options.addOption(option);
+        }
+
+        CommandLineParser parser = new DefaultParser();
+        CommandLine cmd = parser.parse(options, args);
+        return new GraqlShellOptions(additionalOptions, cmd);
+    }
+
+    public void printUsage() {
         HelpFormatter helpFormatter = new HelpFormatter();
         OutputStreamWriter outputStreamWriter = new OutputStreamWriter(System.out, Charset.defaultCharset());
         PrintWriter printWriter = new PrintWriter(new BufferedWriter(outputStreamWriter));
         int width = helpFormatter.getWidth();
         int leftPadding = helpFormatter.getLeftPadding();
         int descPadding = helpFormatter.getDescPadding();
-        helpFormatter.printHelp(printWriter, width, "graql console", null, options(), leftPadding, descPadding, null);
+        helpFormatter.printHelp(printWriter, width, "graql console", null, options, leftPadding, descPadding, null);
         printWriter.flush();
     }
 

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptions.java
@@ -93,7 +93,7 @@ public class GraqlShellOptions {
 
         CommandLineParser parser = new DefaultParser();
         CommandLine cmd = parser.parse(options, args);
-        return new GraqlShellOptions(additionalOptions, cmd);
+        return new GraqlShellOptions(options, cmd);
     }
 
     public CommandLine cmd() {

--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptionsFactory.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShellOptionsFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
+ */
+
+package ai.grakn.graql.shell;
+
+import org.apache.commons.cli.ParseException;
+
+/**
+ * Factory to produce {@link GraqlShellOptions}. Can be extended to produce a {@link GraqlShellOptions} that accepts
+ * extra arguments.
+ *
+ * @author Felix Chapman
+ */
+public interface GraqlShellOptionsFactory {
+    GraqlShellOptions createGraqlShellOptions(String[] args) throws ParseException;
+}


### PR DESCRIPTION
# Why is this PR needed?

So we can add additional options to GraqlShellOptions in KGMS. They will also appear when you say `--help`!

# What does the PR do?

1. Allows passing in additional options to `GraqlShellOptions#create`
2. Allows retrieving the parsed options using `GraqlShellOptions#cmd`

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
