### PR TITLE
TxFactoryBuilder changes to make it use custom TxFactories

### DIFF
--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanus.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanus.java
@@ -78,8 +78,9 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
     private static final String STORAGE_BATCH_LOADING = "storage.batch-loading";
     private static final String STORAGE_REPLICATION_FACTOR = "storage.cassandra.replication-factor";
 
+
     //These properties are loaded in by default and can optionally be overwritten
-    static final Properties DEFAULT_PROPERTIES;
+    private static final Properties DEFAULT_PROPERTIES;
     static {
         String DEFAULT_CONFIG = "default-configs.properties";
         DEFAULT_PROPERTIES = new Properties();
@@ -89,6 +90,10 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
         } catch (IOException e) {
             throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage(DEFAULT_CONFIG), e);
         }
+    }
+
+    public static Properties getDefaultProperties() {
+        return DEFAULT_PROPERTIES;
     }
 
     /**
@@ -120,12 +125,12 @@ final public class TxFactoryJanus extends TxFactoryAbstract<GraknTxJanus, JanusG
     }
 
     @Override
-    GraknTxJanus buildGraknTxFromTinkerGraph(JanusGraph graph) {
+    protected GraknTxJanus buildGraknTxFromTinkerGraph(JanusGraph graph) {
         return new GraknTxJanus(session(), graph);
     }
 
     @Override
-    JanusGraph buildTinkerPopGraph(boolean batchLoading) {
+    protected JanusGraph buildTinkerPopGraph(boolean batchLoading) {
         return newJanusGraph(batchLoading);
     }
 

--- a/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
+++ b/grakn-factory/src/main/java/ai/grakn/factory/TxFactoryJanusHadoop.java
@@ -83,16 +83,16 @@ public class TxFactoryJanusHadoop extends TxFactoryAbstract<EmbeddedGraknTx<Hado
     }
 
     @Override
-    EmbeddedGraknTx<HadoopGraph> buildGraknTxFromTinkerGraph(HadoopGraph graph) {
+    protected EmbeddedGraknTx<HadoopGraph> buildGraknTxFromTinkerGraph(HadoopGraph graph) {
         throw new UnsupportedOperationException(ErrorMessage.CANNOT_PRODUCE_TX.getMessage(HadoopGraph.class.getName()));
     }
 
     @Override
-    HadoopGraph buildTinkerPopGraph(boolean batchLoading) {
+    protected HadoopGraph buildTinkerPopGraph(boolean batchLoading) {
         LOG.warn("Hadoop graph ignores parameter address [" + session().uri() + "]");
 
         //Load Defaults
-        TxFactoryJanus.DEFAULT_PROPERTIES.forEach((key, value) -> {
+        TxFactoryJanus.getDefaultProperties().forEach((key, value) -> {
             if(!session().config().properties().containsKey(key)){
                 session().config().properties().put(key, value);
             }

--- a/grakn-kb/src/main/java/ai/grakn/factory/GraknTxFactoryBuilder.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/GraknTxFactoryBuilder.java
@@ -21,6 +21,7 @@ package ai.grakn.factory;
 import ai.grakn.GraknConfigKey;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.MissingResourceException;
@@ -37,6 +38,12 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GraknTxFactoryBuilder extends TxFactoryBuilder {
 
     private static final Map<String, TxFactory<?>> openFactories = new ConcurrentHashMap<>();
+
+    //This is used to map grakn value properties into the underlying properties
+    private static final Map<String, String> factoryMapper = ImmutableMap.of(
+            "in-memory", "ai.grakn.factory.TxFactoryTinker",
+            "production", "ai.grakn.factory.TxFactoryJanus",
+            "distributed", "ai.grakn.factory.TxFactoryJanusHadoop");
 
     private static TxFactoryBuilder instance = null;
 

--- a/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryAbstract.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryAbstract.java
@@ -41,19 +41,19 @@ import static javax.annotation.meta.When.NEVER;
  * @param <G>  A vendor implementation of a Tinkerpop {@link Graph}
  * @author fppt
  */
-abstract class TxFactoryAbstract<Tx extends EmbeddedGraknTx<G>, G extends Graph> implements TxFactory<G> {
+public abstract class TxFactoryAbstract<Tx extends EmbeddedGraknTx<G>, G extends Graph> implements TxFactory<G> {
     private final EmbeddedGraknSession session;
 
     protected final GraphWithTx batchTinkerPopGraphWithTx = new GraphWithTx(true);
     protected final GraphWithTx tinkerPopGraphWithTx = new GraphWithTx(false);
 
-    TxFactoryAbstract(EmbeddedGraknSession session) {
+    protected TxFactoryAbstract(EmbeddedGraknSession session) {
         this.session = session;
     }
 
-    abstract Tx buildGraknTxFromTinkerGraph(G graph);
+    protected abstract Tx buildGraknTxFromTinkerGraph(G graph);
 
-    abstract G buildTinkerPopGraph(boolean batchLoading);
+    protected abstract G buildTinkerPopGraph(boolean batchLoading);
 
     @Override
     final public synchronized Tx open(GraknTxType txType) {

--- a/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryBuilder.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryBuilder.java
@@ -21,12 +21,10 @@ package ai.grakn.factory;
 
 import ai.grakn.GraknSession;
 import ai.grakn.util.ErrorMessage;
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Map;
 
 
 /**
@@ -50,14 +48,7 @@ public abstract class TxFactoryBuilder {
     static final String IN_MEMORY = "in-memory";
     private static final Logger LOG = LoggerFactory.getLogger(GraknTxFactoryBuilder.class);
 
-    //This is used to map grakn value properties into the underlying properties
-    protected static final Map<String, String> factoryMapper = ImmutableMap.of(
-            "in-memory", "ai.grakn.factory.TxFactoryTinker",
-            "production", "ai.grakn.factory.TxFactoryJanus",
-            "distributed", "ai.grakn.factory.TxFactoryJanusHadoop");
-
     public abstract TxFactory<?> getFactory(EmbeddedGraknSession session, boolean isComputerFactory);
-
 
     /**
      * @param factoryType The type of the factory to initialise. Any factory which implements {@link TxFactory}

--- a/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryTinker.java
+++ b/grakn-kb/src/main/java/ai/grakn/factory/TxFactoryTinker.java
@@ -45,12 +45,10 @@ public class TxFactoryTinker extends TxFactoryAbstract<GraknTxTinker, TinkerGrap
     }
 
     @Override
-    GraknTxTinker buildGraknTxFromTinkerGraph(TinkerGraph graph) {
-        return new GraknTxTinker(session(), graph);
-    }
+    protected GraknTxTinker buildGraknTxFromTinkerGraph(TinkerGraph graph) { return new GraknTxTinker(session(), graph); }
 
     @Override
-    TinkerGraph buildTinkerPopGraph(boolean batchLoading) {
+    protected TinkerGraph buildTinkerPopGraph(boolean batchLoading) {
         return tinkerGraph;
     }
 


### PR DESCRIPTION
# Why is this PR needed?

So that we can use customised `TxFactory`s in `TxFactoryBuilder` implementations.
In KGMS we will need to use a customised `TxFactoryJanusHadoop` that appends strange prefixes also to username and password fields

# What does the PR do?

Moves `factoryMapper` inside implementation of abstract class

# Does it break backwards compatibility?
no
# List of future improvements not on this PR
no