### PR TITLE
updated docs deploy script

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -5,6 +5,7 @@ echo "Building _site"
 rake build
 echo "Staging new files"
 git add -A
+# Forcefully add the _jekyll and _site folder before pushing to Heroku, this is necessary because both folders are ignored under the main .gitignore
 git add --force -- _jekyll _site
 git commit -m "Site update"
 echo "Pushing to Heroku"

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -4,11 +4,12 @@ git checkout -b docs-deploy-temp stable
 echo "Building _site"
 rake build
 echo "Staging new files"
-git add -A 
+git add -A
+git add --force -- _jekyll _site
 git commit -m "Site update"
 echo "Pushing to Heroku"
 cd ../
 git push git@heroku.com:dev-grakn.git `git subtree split --prefix docs docs-deploy-temp`:master --force
 echo "Deleting temporary branch"
-git checkout stable
+git checkout @{-1}
 git branch -D docs-deploy-temp


### PR DESCRIPTION
# Why is this PR needed?

Add `_jekyll` and `_site` folders even though they are ignored in the main `.gitignore`
Checkout to previous branch instead of `stable`

# What does the PR do?

Updates the `./deploy.sh`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Maybe