### PR TITLE
Updated deploy script to always load central stable

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 echo "Checking out temporary branch from stable"
-git checkout -b docs-deploy-temp stable
+git remote add grakn-docs-origin git@github.com:graknlabs/grakn.git
+git fetch grakn-docs-origin
+git checkout -b docs-deploy-temp grakn-docs-origin/stable
 echo "Building _site"
 rake build
 echo "Staging new files"
-git add -A 
+git add -A
+# Forcefully add the _jekyll and _site folder before pushing to Heroku, this is necessary because both folders are ignored under the main .gitignore
+git add --force -- _jekyll _site
 git commit -m "Site update"
 echo "Pushing to Heroku"
 cd ../
 git push git@heroku.com:dev-grakn.git `git subtree split --prefix docs docs-deploy-temp`:master --force
 echo "Deleting temporary branch"
-git checkout stable
+git checkout @{-1}
+git remote remove grakn-docs-origin
 git branch -D docs-deploy-temp


### PR DESCRIPTION
# Why is this PR needed?

Temporarily add a new remote so that we can branch out from latest stable branch in graknlabs repo

# What does the PR do?

# Does it break backwards compatibility?

# List of future improvements not on this PR
