### PR TITLE
Change GetQuery and InsertQuery to return streams by default

### DIFF
--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -208,7 +208,7 @@ public class RemoteGraknTxTest {
         TxResponse response =
                 TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("true")).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
+        server.setResponse(GrpcUtil.execQueryRequest(query), response);
 
         try (GraknTx tx = RemoteGraknTx.create(session, GrpcUtil.openRequest(KEYSPACE, GraknTxType.WRITE))) {
             verify(server.requests()).onNext(any()); // The open request

--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -179,7 +179,7 @@ public class RemoteGraknTxTest {
 
         try (GraknTx tx = RemoteGraknTx.create(session, GrpcUtil.openRequest(KEYSPACE, GraknTxType.WRITE))) {
             verify(server.requests()).onNext(any()); // The open request
-            results = tx.graql().<GetQuery>parse(queryString).execute();
+            results = tx.graql().<GetQuery>parse(queryString).toList();
         }
 
         Answer answer = Iterables.getOnlyElement(results);
@@ -337,7 +337,7 @@ public class RemoteGraknTxTest {
 
         try (GraknTx tx = RemoteGraknTx.create(session, GrpcUtil.openRequest(KEYSPACE, GraknTxType.WRITE))) {
             try {
-                tx.graql().match(var("x")).get().execute();
+                tx.graql().match(var("x")).get().toList();
             } catch (GraqlQueryException e) {
                 // Ignore
             }
@@ -355,7 +355,7 @@ public class RemoteGraknTxTest {
 
         try (GraknTx tx = RemoteGraknTx.create(session, GrpcUtil.openRequest(KEYSPACE, GraknTxType.WRITE))) {
             try {
-                tx.graql().match(var("x")).get().execute();
+                tx.graql().match(var("x")).get().toList();
             } catch (GraqlQueryException e) {
                 // Ignore
             }

--- a/grakn-core/src/main/java/ai/grakn/graql/GetQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/GetQuery.java
@@ -44,6 +44,8 @@ public interface GetQuery extends Query<List<Answer>>, Streamable<Answer> {
     @Override
     GetQuery withTx(GraknTx tx);
 
+    List<Answer> toList();
+
     /**
      * Get the {@link Match} this {@link GetQuery} contains
      */

--- a/grakn-core/src/main/java/ai/grakn/graql/GetQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/GetQuery.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.admin.Answer;
 import javax.annotation.CheckReturnValue;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * a query used for finding data in a knowledge base that matches the given patterns.
@@ -35,7 +36,7 @@ import java.util.Set;
  *
  * @author Felix Chapman
  */
-public interface GetQuery extends Query<List<Answer>>, Streamable<Answer> {
+public interface GetQuery extends Query<Stream<Answer>>, Streamable<Answer> {
 
     /**
      * @param tx the transaction to execute the query on

--- a/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
@@ -46,6 +46,8 @@ public interface InsertQuery extends Query<List<Answer>>, Streamable<Answer> {
     @Override
     InsertQuery withTx(GraknTx tx);
 
+    List<Answer> toList();
+
     /**
      * @return admin instance for inspecting and manipulating this query
      */

--- a/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/InsertQuery.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.admin.InsertQueryAdmin;
 
 import javax.annotation.CheckReturnValue;
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * A query for inserting data.
@@ -37,7 +38,7 @@ import java.util.List;
  *
  * @author Felix Chapman
  */
-public interface InsertQuery extends Query<List<Answer>>, Streamable<Answer> {
+public interface InsertQuery extends Query<Stream<Answer>>, Streamable<Answer> {
 
     /**
      * @param tx the graph to execute the query on

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/GraqlController.java
@@ -140,7 +140,7 @@ public class GraqlController implements HttpController {
 
         return executeFunctionWithRetrying(() -> {
             try (GraknTx tx = factory.tx(keyspace, GraknTxType.WRITE); Timer.Context context = executeExplanation.time()) {
-                Answer answer = tx.graql().infer(true).parser().<GetQuery>parseQuery(queryString).execute().stream().findFirst().orElse(new QueryAnswer());
+                Answer answer = tx.graql().infer(true).parser().<GetQuery>parseQuery(queryString).toList().stream().findFirst().orElse(new QueryAnswer());
                 return mapper.writeValueAsString(ExplanationBuilder.buildExplanation(answer));
             }
         });

--- a/grakn-engine/src/test/java/ai/grakn/engine/controller/response/ExplanationBuilderTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/controller/response/ExplanationBuilderTest.java
@@ -59,7 +59,7 @@ public class ExplanationBuilderTest {
                     "(cousin: $x, cousin: $y) isa cousins; limit 1;get;";
 
             GetQuery query = genealogyKB.tx().graql().infer(true).parse(specificQuery);
-            ai.grakn.graql.admin.Answer specificAnswer = query.execute().stream().findFirst().orElse(new QueryAnswer());
+                    ai.grakn.graql.admin.Answer specificAnswer = query.toList().stream().findFirst().orElse(new QueryAnswer());
 
             Set<ConceptId> originalEntityIds = specificAnswer.getExplanation().getAnswers().stream()
                     .flatMap(ans -> ans.concepts().stream())

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
@@ -40,7 +40,7 @@ import static java.util.stream.Collectors.joining;
  * @author Felix Chapman
  */
 @AutoValue
-public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> implements GetQuery {
+public abstract class GetQueryImpl extends AbstractQuery<Stream<Answer>, Answer> implements GetQuery {
 
     public abstract ImmutableSet<Var> vars();
     public abstract Match match();
@@ -74,8 +74,8 @@ public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> i
         return match().toString() + " get " + vars().stream().map(Object::toString).collect(joining(", ")) + ";";
     }
 
-    public final List<Answer> execute() {
-        return stream().collect(Collectors.toList());
+    public final Stream<Answer> execute() {
+        return stream();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
@@ -74,8 +74,12 @@ public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> i
         return match().toString() + " get " + vars().stream().map(Object::toString).collect(joining(", ")) + ";";
     }
 
-    @Override
     public final List<Answer> execute() {
+        return stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Answer> toList() {
         return stream().collect(Collectors.toList());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  * A query that will insert a collection of variables into a graph
  */
 @AutoValue
-abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> implements InsertQueryAdmin {
+abstract class InsertQueryImpl extends AbstractQuery<Stream<Answer>, Answer> implements InsertQueryAdmin {
 
     /**
      * At least one of {@code tx} and {@code match} must be absent.
@@ -119,8 +119,8 @@ abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> imple
     }
 
     @Override
-    public List<Answer> execute() {
-        return toList();
+    public Stream<Answer> execute() {
+        return toList().stream();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -119,7 +119,12 @@ abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> imple
     }
 
     @Override
-    public final List<Answer> execute() {
+    public List<Answer> execute() {
+        return toList();
+    }
+
+    @Override
+    public final List<Answer> toList() {
         return stream().collect(Collectors.toList());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/QueryCache.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/QueryCache.java
@@ -168,7 +168,7 @@ public class QueryCache<Q extends ReasonerQueryImpl> extends Cache<Q, QueryAnswe
         }
 
         //TODO should it create a cache entry?
-        List<Answer> answers = ReasonerQueries.create(query, ans).getQuery().execute();
+        List<Answer> answers = ReasonerQueries.create(query, ans).getQuery().toList();
         return answers.isEmpty()? new QueryAnswer() : answers.iterator().next();
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/fragment/DirectIsaTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/fragment/DirectIsaTest.java
@@ -111,7 +111,7 @@ public class DirectIsaTest {
     @Test
     public void whenInsertDirectIsa_InsertsADirectInstanceOfAType() {
         QueryBuilder queryBuilder = tx.graql();
-        queryBuilder.insert(x.directIsa(thingy)).execute();
+        queryBuilder.insert(x.directIsa(thingy)).toList();
         assertEquals(1L, queryBuilder.parse("match $z isa! thingy; aggregate count;").execute());
         assertEquals(2L, queryBuilder.parse("match $z isa thingy; aggregate count;").execute());
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
@@ -228,7 +228,7 @@ public class QueryToStringTest {
     }
 
     private void assertSameResults(GetQuery query) {
-        assertEquals(query.execute(), qb.parse(query.toString()).execute());
+        assertEquals(query.toList(), qb.parse(query.toString()).execute());
     }
 
     private void assertEquivalent(Query<?> query, String queryString) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -192,7 +192,7 @@ public class DefineQueryTest {
                 label("new-type").plays(roleTypeLabel)
         ).execute();
 
-        qb.insert(var("x").isa("new-type")).execute();
+        qb.insert(var("x").isa("new-type")).toList();
 
         Match typeQuery = qb.match(var("n").label("new-type"));
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DeleteQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DeleteQueryTest.java
@@ -86,7 +86,7 @@ public class DeleteQueryTest {
     @Test
     public void testDeleteMultiple() {
         qb.define(label("fake-type").sub(ENTITY)).execute();
-        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).toList();
 
         assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
 
@@ -194,7 +194,7 @@ public class DeleteQueryTest {
     @Test
     public void whenDeletingMultipleVariables_AllVariablesGetDeleted() {
         qb.define(label("fake-type").sub(ENTITY)).execute();
-        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).toList();
 
         assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
 
@@ -206,7 +206,7 @@ public class DeleteQueryTest {
     @Test
     public void whenDeletingWithNoArguments_AllVariablesGetDeleted() {
         qb.define(label("fake-type").sub(Schema.MetaSchema.ENTITY.getLabel().getValue())).execute();
-        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).toList();
 
         assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/GetQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/GetQueryTest.java
@@ -73,7 +73,7 @@ public class GetQueryTest {
     @Test
     public void whenRunningExecute_ResultIsSameAsParallelStreamingToAList() {
         GetQuery query = qb.match(x.isa("movie")).get();
-        List<Answer> list = query.execute();
+        List<Answer> list = query.toList();
         assertEquals(list, query.parallelStream().collect(toList()));
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
@@ -156,7 +156,7 @@ public class InsertQueryTest {
 
         assertNotExists(qb.match(patterns));
 
-        qb.insert(vars).execute();
+        qb.insert(vars).toList();
         assertExists(qb, patterns);
 
         qb.match(patterns).delete("r").execute();
@@ -165,7 +165,7 @@ public class InsertQueryTest {
 
     @Test
     public void testInsertSameVarName() {
-        qb.insert(var("x").has("title", "SW"), var("x").has("title", "Star Wars").isa("movie")).execute();
+        qb.insert(var("x").has("title", "SW"), var("x").has("title", "Star Wars").isa("movie")).toList();
 
         assertExists(qb, var().isa("movie").has("title", "SW"));
         assertExists(qb, var().isa("movie").has("title", "Star Wars"));
@@ -178,11 +178,11 @@ public class InsertQueryTest {
         InsertQuery query = qb.insert(language);
 
         assertEquals(0, qb.match(language).stream().count());
-        query.execute();
+        query.toList();
         assertEquals(1, qb.match(language).stream().count());
-        query.execute();
+        query.toList();
         assertEquals(2, qb.match(language).stream().count());
-        query.execute();
+        query.toList();
         assertEquals(3, qb.match(language).stream().count());
 
         qb.match(language).delete("x").execute();
@@ -194,11 +194,11 @@ public class InsertQueryTest {
         VarPattern language1 = var().isa("language").has("name", "123");
         VarPattern language2 = var().isa("language").has("name", "456");
 
-        qb.insert(language1, language2).execute();
+        qb.insert(language1, language2).toList();
         assertExists(qb, language1);
         assertExists(qb, language2);
 
-        qb.match(var("x").isa("language")).insert(var("x").has("name", "HELLO")).execute();
+        qb.match(var("x").isa("language")).insert(var("x").has("name", "HELLO")).toList();
         assertExists(qb, var().isa("language").has("name", "123").has("name", "HELLO"));
         assertExists(qb, var().isa("language").has("name", "456").has("name", "HELLO"));
 
@@ -226,7 +226,7 @@ public class InsertQueryTest {
         VarPattern language1 = var().isa("language").has("name", "123");
         VarPattern language2 = var().isa("language").has("name", "456");
 
-        qb.insert(language1, language2).execute();
+        qb.insert(language1, language2).toList();
         assertExists(qb, language1);
         assertExists(qb, language2);
 
@@ -260,14 +260,14 @@ public class InsertQueryTest {
     public void testErrorWhenInsertWithPredicate() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage("predicate");
-        qb.insert(var().id(ConceptId.of("123")).val(gt(3))).execute();
+        qb.insert(var().id(ConceptId.of("123")).val(gt(3))).toList();
     }
 
     @Test
     public void testErrorWhenInsertWithMultipleIds() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(allOf(containsString("id"), containsString("123"), containsString("456")));
-        qb.insert(var().id(ConceptId.of("123")).id(ConceptId.of("456")).isa("movie")).execute();
+        qb.insert(var().id(ConceptId.of("123")).id(ConceptId.of("456")).isa("movie")).toList();
     }
 
     @Test
@@ -280,7 +280,7 @@ public class InsertQueryTest {
                 GraqlQueryException.insertMultipleProperties(varPattern, "val", "456", "123").getMessage()
         ));
 
-        qb.insert(varPattern).execute();
+        qb.insert(varPattern).toList();
     }
 
     @Test
@@ -291,7 +291,7 @@ public class InsertQueryTest {
                 var().sub("has-genre").rel("genre-of-production", "x").rel("production-with-genre", "y"),
                 var("x").id(ConceptId.of("Godfather")).isa("movie"),
                 var("y").id(ConceptId.of("comedy")).isa("genre")
-        ).execute();
+        ).toList();
     }
 
     @Test
@@ -309,7 +309,7 @@ public class InsertQueryTest {
                 label("a-new-resource-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
         ).execute();
 
-        qb.insert(var().isa("a-new-type").has("a-new-resource-type", "hello")).execute();
+        qb.insert(var().isa("a-new-type").has("a-new-resource-type", "hello")).toList();
     }
 
     @Test
@@ -323,7 +323,7 @@ public class InsertQueryTest {
 
         qb.insert(
                 var().isa("a-new-type").has("a-new-attribute-type", "hello").has("a-new-attribute-type", "goodbye")
-        ).execute();
+        ).toList();
 
         exception.expect(InvalidKBException.class);
         movieKB.tx().commit();
@@ -344,7 +344,7 @@ public class InsertQueryTest {
         qb.insert(
                 var("x").isa("a-new-type").has("a-new-resource-type", "hello"),
                 var("y").isa("a-new-type").has("a-new-resource-type", "hello")
-        ).execute();
+        ).toList();
 
         exception.expect(InvalidKBException.class);
         movieKB.tx().commit();
@@ -359,7 +359,7 @@ public class InsertQueryTest {
                 label("a-new-resource-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
         ).execute();
 
-        qb.insert(var().isa("a-new-type")).execute();
+        qb.insert(var().isa("a-new-type")).toList();
 
         exception.expect(InvalidKBException.class);
         movieKB.tx().commit();
@@ -386,7 +386,7 @@ public class InsertQueryTest {
                 w.isa("movie").has(title, x.val("My Movie"), y)
         );
 
-        Answer answer = Iterables.getOnlyElement(query.execute());
+        Answer answer = Iterables.getOnlyElement(query.toList());
 
         Entity movie = answer.get(w).asEntity();
         Attribute<String> theTitle = answer.get(x).asAttribute();
@@ -403,7 +403,7 @@ public class InsertQueryTest {
                 .match(w.isa("movie").has(title, x.val("The Muppets"), y))
                 .insert(x, w, y.has("provenance", z.val("Someone told me")));
 
-        Answer answer = Iterables.getOnlyElement(query.execute());
+        Answer answer = Iterables.getOnlyElement(query.toList());
 
         Entity movie = answer.get(w).asEntity();
         Attribute<String> theTitle = answer.get(x).asAttribute();
@@ -423,7 +423,7 @@ public class InsertQueryTest {
         qb.insert(
                 var().rel("genre-of-production", "x").rel("production-with-genre", "y").isa("has-genre"),
                 var("x").isa("genre").has("name", "drama")
-        ).execute();
+        ).toList();
     }
 
     @Test
@@ -432,33 +432,33 @@ public class InsertQueryTest {
         exception.expectMessage(
                 allOf(containsString("meta-type"), containsString("my-thing"), containsString(Schema.MetaSchema.THING.getLabel().getValue()))
         );
-        qb.insert(var("my-thing").isa(Schema.MetaSchema.THING.getLabel().getValue())).execute();
+        qb.insert(var("my-thing").isa(Schema.MetaSchema.THING.getLabel().getValue())).toList();
     }
 
     @Test
     public void whenInsertingAResourceWithoutAValue_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(allOf(containsString("name"), containsString("val")));
-        qb.insert(var("x").isa("name")).execute();
+        qb.insert(var("x").isa("name")).toList();
     }
 
     @Test
     public void whenInsertingAnInstanceWithALabel_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(allOf(containsString("label"), containsString("abc")));
-        qb.insert(label("abc").isa("movie")).execute();
+        qb.insert(label("abc").isa("movie")).toList();
     }
 
     @Test
     public void whenInsertingAResourceWithALabel_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(allOf(containsString("label"), containsString("bobby")));
-        qb.insert(label("bobby").val("bob").isa("name")).execute();
+        qb.insert(label("bobby").val("bob").isa("name")).toList();
     }
 
     @Test
     public void testInsertDuplicatePattern() {
-        qb.insert(var().isa("person").has("name", "a name"), var().isa("person").has("name", "a name")).execute();
+        qb.insert(var().isa("person").has("name", "a name"), var().isa("person").has("name", "a name")).toList();
         assertEquals(2, qb.match(x.has("name", "a name")).stream().count());
     }
 
@@ -467,7 +467,7 @@ public class InsertQueryTest {
         ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x").findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
-        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).execute();
+        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).toList();
         assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
     }
 
@@ -476,7 +476,7 @@ public class InsertQueryTest {
         ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x").findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
-        qb.insert(var().id(apocalypseNow).isa("movie").has("title", "Apocalypse Maybe Tomorrow")).execute();
+        qb.insert(var().id(apocalypseNow).isa("movie").has("title", "Apocalypse Maybe Tomorrow")).toList();
         assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
     }
 
@@ -485,7 +485,7 @@ public class InsertQueryTest {
         ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x").findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
-        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).execute();
+        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).toList();
         assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
     }
 
@@ -494,7 +494,7 @@ public class InsertQueryTest {
         ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x").findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
-        qb.insert(var().id(apocalypseNow).isa("title").has("title", "Apocalypse Maybe Tomorrow")).execute();
+        qb.insert(var().id(apocalypseNow).isa("title").has("title", "Apocalypse Maybe Tomorrow")).toList();
         assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
     }
 
@@ -502,7 +502,7 @@ public class InsertQueryTest {
     public void testInsertInstanceWithoutType() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(allOf(containsString("isa")));
-        qb.insert(var().has("name", "Bob")).execute();
+        qb.insert(var().has("name", "Bob")).toList();
     }
 
     @Test
@@ -513,7 +513,7 @@ public class InsertQueryTest {
         ).insert(
                 var("c").isa("cluster").has("name", "2"),
                 var("r").rel("cluster-of-production", "c").rel("production-with-cluster", "g").rel("production-with-cluster", "m").isa("has-cluster")
-        ).execute();
+        ).toList();
 
         Thing cluster = results.get(0).get("c").asThing();
         Thing godfather = results.get(0).get("g").asThing();
@@ -542,7 +542,7 @@ public class InsertQueryTest {
                 w.rel("friend", x).rel("friend", y).isa("maybe-friends")
         );
 
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
 
         for (Answer answer : answers) {
             assertThat(
@@ -557,36 +557,36 @@ public class InsertQueryTest {
 
     @Test(expected = Exception.class)
     public void matchInsertNullVar() {
-        movieKB.tx().graql().match(var("x").isa("movie")).insert((VarPattern) null).execute();
+        movieKB.tx().graql().match(var("x").isa("movie")).insert((VarPattern) null).toList();
     }
 
     @Test(expected = Exception.class)
     public void matchInsertNullCollection() {
-        movieKB.tx().graql().match(var("x").isa("movie")).insert((Collection<? extends VarPattern>) null).execute();
+        movieKB.tx().graql().match(var("x").isa("movie")).insert((Collection<? extends VarPattern>) null).toList();
     }
 
     @Test
     public void whenMatchInsertingAnEmptyPattern_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
-        movieKB.tx().graql().match(var()).insert(Collections.EMPTY_SET).execute();
+        movieKB.tx().graql().match(var()).insert(Collections.EMPTY_SET).toList();
     }
 
     @Test(expected = Exception.class)
     public void insertNullVar() {
-        movieKB.tx().graql().insert((VarPattern) null).execute();
+        movieKB.tx().graql().insert((VarPattern) null).toList();
     }
 
     @Test(expected = Exception.class)
     public void insertNullCollection() {
-        movieKB.tx().graql().insert((Collection<? extends VarPattern>) null).execute();
+        movieKB.tx().graql().insert((Collection<? extends VarPattern>) null).toList();
     }
 
     @Test
     public void whenInsertingAnEmptyPattern_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
-        movieKB.tx().graql().insert(Collections.EMPTY_SET).execute();
+        movieKB.tx().graql().insert(Collections.EMPTY_SET).toList();
     }
 
     @Test
@@ -608,7 +608,7 @@ public class InsertQueryTest {
                 GraqlQueryException.insertMultipleProperties(varPattern, "isa", person, movie).getMessage()
         ));
 
-        movieKB.tx().graql().insert(var("x").isa("movie"), var("x").isa("person")).execute();
+        movieKB.tx().graql().insert(var("x").isa("movie"), var("x").isa("person")).toList();
     }
 
     @Test
@@ -621,7 +621,7 @@ public class InsertQueryTest {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.insertPropertyOnExistingConcept("isa", person, aMovie).getMessage());
 
-        movieKB.tx().graql().insert(var("x").id(aMovie.getId()).isa("person")).execute();
+        movieKB.tx().graql().insert(var("x").id(aMovie.getId()).isa("person")).toList();
     }
 
     @Test
@@ -629,7 +629,7 @@ public class InsertQueryTest {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(SubProperty.NAME).getMessage());
 
-        qb.insert(label("new-type").sub(label(ENTITY.getLabel()))).execute();
+        qb.insert(label("new-type").sub(label(ENTITY.getLabel()))).toList();
     }
 
     @Test
@@ -637,7 +637,7 @@ public class InsertQueryTest {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(PlaysProperty.NAME).getMessage());
 
-        qb.insert(label("movie").plays("actor")).execute();
+        qb.insert(label("movie").plays("actor")).toList();
     }
 
     private void assertInsert(VarPattern... vars) {
@@ -647,7 +647,7 @@ public class InsertQueryTest {
         }
 
         // Insert all vars
-        qb.insert(vars).execute();
+        qb.insert(vars).toList();
 
         // Make sure all vars exist
         for (VarPattern var : vars) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryBuilderTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryBuilderTest.java
@@ -77,14 +77,14 @@ public class QueryBuilderTest {
     public void whenBuildingInsertQueryWithGraphLast_ItExecutes() {
         assertNotExists(movieKB.tx(), var().has("title", "a-movie"));
         InsertQuery query = insert(var().has("title", "a-movie").isa("movie")).withTx(movieKB.tx());
-        query.execute();
+        query.toList();
         assertExists(movieKB.tx(), var().has("title", "a-movie"));
     }
 
     @Test
     public void whenBuildingDeleteQueryWithGraphLast_ItExecutes() {
         // Insert some data to delete
-        movieKB.tx().graql().insert(var().has("title", "123").isa("movie")).execute();
+        movieKB.tx().graql().insert(var().has("title", "123").isa("movie")).toList();
 
         assertExists(movieKB.tx(), var().has("title", "123"));
 
@@ -109,7 +109,7 @@ public class QueryBuilderTest {
         InsertQuery query =
                 match(x.label("movie")).
                 insert(var().has("title", "a-movie").isa("movie")).withTx(movieKB.tx());
-        query.execute();
+        query.toList();
         assertExists(movieKB.tx(), var().has("title", "a-movie"));
     }
 
@@ -127,7 +127,7 @@ public class QueryBuilderTest {
         InsertQuery query = insert(var().id(ConceptId.of("another-movie")).isa("movie"));
         exception.expect(GraqlQueryException.class);
         exception.expectMessage("graph");
-        query.execute();
+        query.toList();
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryErrorTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryErrorTest.java
@@ -92,14 +92,14 @@ public class QueryErrorTest {
     public void whenMatchingWildcardHas_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.noLabelSpecifiedForHas(var("x")).getMessage());
-        qb.match(label("thing").has(var("x"))).get().execute();
+        qb.match(label("thing").has(var("x"))).get().toList();
     }
 
     @Test
     public void whenMatchingHasWithNonExistentType_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.labelNotFound(Label.of("heffalump")).getMessage());
-        qb.match(var("x").has("heffalump", "foo")).get().execute();
+        qb.match(var("x").has("heffalump", "foo")).get().toList();
     }
 
     @Test
@@ -176,7 +176,7 @@ public class QueryErrorTest {
                 containsString("person"),
                 containsString("name")
         ));
-        emptyQb.insert(var().isa("person").has("name", "Bob")).execute();
+        emptyQb.insert(var().isa("person").has("name", "Bob")).toList();
     }
 
     @Test
@@ -234,6 +234,6 @@ public class QueryErrorTest {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(containsString("person"));
 
-        qb.match(var("x").id(movie.getId())).insert(var("x").isa(label(person.getLabel()))).execute();
+        qb.match(var("x").id(movie.getId())).insert(var("x").isa(label(person.getLabel()))).toList();
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/UndefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/UndefineQueryTest.java
@@ -322,7 +322,7 @@ public class UndefineQueryTest {
 
     @Test
     public void whenUndefiningAnInstanceProperty_Throw() {
-        Concept movie = qb.insert(x.isa("movie")).execute().get(0).get(x);
+        Concept movie = qb.insert(x.isa("movie")).toList().get(0).get(x);
 
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(GraqlQueryException.defineUnsupportedProperty(IsaProperty.NAME).getMessage());

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
@@ -1039,7 +1039,7 @@ public class MatchTest {
     public void whenSelectingVarNotInQuery_Throw() {
         expectedException.expect(GraqlQueryException.class);
         expectedException.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(x));
-        movieKB.tx().graql().match(var()).get(ImmutableSet.of(x)).execute();
+        movieKB.tx().graql().match(var()).get(ImmutableSet.of(x)).toList();
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -142,9 +142,9 @@ public class AtomicQueryTest {
     public void testWhenMaterialisingResources_MaterialisedInformationIsCorrectlyFlaggedAsInferred(){
         EmbeddedGraknTx<?> graph = materialisationTestSet.tx();
         QueryBuilder qb = graph.graql().infer(false);
-        Concept firstEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity1; get;").execute()).get("x");
-        Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").execute()).get("x");
-        Concept resource = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa resource; get;").execute()).get("x");
+        Concept firstEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity1; get;").toList()).get("x");
+        Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").toList()).get("x");
+        Concept resource = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa resource; get;").toList()).get("x");
 
         ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r val 'inferred';$x id " + firstEntity.getId().getValue() + ";}", graph), graph);
         String reuseResourcePatternString =
@@ -164,21 +164,21 @@ public class AtomicQueryTest {
                         "$x has resource $r via $rel;" +
                         "$x id " + secondEntity.getId().getValue() + ";" +
                         "$r id " + resource.getId().getValue() + ";" +
-                        "get;").execute()).get("rel").asRelationship().isInferred(), true);
+                        "get;").toList()).get("rel").asRelationship().isInferred(), true);
         assertEquals(Iterables.getOnlyElement(
                 qb.<GetQuery>parse("match" +
                         "$x has resource $r via $rel;" +
                         "$x id " + firstEntity.getId().getValue() + ";" +
                         "$r id " + resource.getId().getValue() + ";" +
-                        "get;").execute()).get("rel").asRelationship().isInferred(), false);
+                        "get;").toList()).get("rel").asRelationship().isInferred(), false);
     }
 
     @Test
     public void testWhenMaterialisingRelations_MaterialisedInformationIsCorrectlyFlaggedAsInferred(){
         EmbeddedGraknTx<?> graph = materialisationTestSet.tx();
         QueryBuilder qb = graph.graql().infer(false);
-        Concept firstEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity1; get;").execute()).get("x");
-        Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").execute()).get("x");
+        Concept firstEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity1; get;").toList()).get("x");
+        Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").toList()).get("x");
 
         ReasonerAtomicQuery relationQuery = ReasonerQueries.atomic(conjunction(
                 "{" +
@@ -1242,12 +1242,12 @@ public class AtomicQueryTest {
     private void queryUnification(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery, boolean checkInverse, boolean checkEquality, boolean ignoreTypes){
         Unifier unifier = childQuery.getMultiUnifier(parentQuery).getUnifier();
 
-        List<Answer> childAnswers = childQuery.getQuery().execute();
+        List<Answer> childAnswers = childQuery.getQuery().toList();
         List<Answer> unifiedAnswers = childAnswers.stream()
                 .map(a -> a.unify(unifier))
                 .filter(a -> !a.isEmpty())
                 .collect(Collectors.toList());
-        List<Answer> parentAnswers = parentQuery.getQuery().execute();
+        List<Answer> parentAnswers = parentQuery.getQuery().toList();
 
         if (checkInverse) {
             Unifier inverse = parentQuery.getMultiUnifier(childQuery).getUnifier();

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
@@ -985,7 +985,7 @@ public class AtomicTest {
     @Test
     public void testUnification_RelationWithMetaRolesAndIds(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
-        Concept instance = graph.graql().<GetQuery>parse("match $x isa subRoleEntity; get;").execute().iterator().next().get(var("x"));
+        Concept instance = graph.graql().<GetQuery>parse("match $x isa subRoleEntity; get;").toList().iterator().next().get(var("x"));
         String relation = "{(role: $x, role: $y) isa binary; $y id '" + instance.getId().getValue() + "';}";
         String relation2 = "{(role: $z, role: $v) isa binary; $z id '" + instance.getId().getValue() + "';}";
         String relation3 = "{(role: $z, role: $v) isa binary; $v id '" + instance.getId().getValue() + "';}";
@@ -1144,9 +1144,9 @@ public class AtomicTest {
         Atom parentAtom = parentQuery.getAtom();
         Atom parentAtom2 = parentQuery2.getAtom();
 
-        List<Answer> childAnswers = childQuery.getQuery().execute();
-        List<Answer> parentAnswers = parentQuery.getQuery().execute();
-        List<Answer> parentAnswers2 = parentQuery2.getQuery().execute();
+        List<Answer> childAnswers = childQuery.getQuery().toList();
+        List<Answer> parentAnswers = parentQuery.getQuery().toList();
+        List<Answer> parentAnswers2 = parentQuery2.getQuery().toList();
 
         Unifier unifier = childAtom.getUnifier(parentAtom);
         Unifier unifier2 = childAtom.getUnifier(parentAtom2);
@@ -1180,7 +1180,7 @@ public class AtomicTest {
         ReasonerAtomicQuery resourceQuery2 = ReasonerQueries.atomic(conjunction(resource2, graph), graph);
         ReasonerAtomicQuery resourceQuery3 = ReasonerQueries.atomic(conjunction(resource3, graph), graph);
 
-        String type = "{$x isa resource;$x id '" + resourceQuery.getQuery().execute().iterator().next().get("r").getId().getValue()  + "';}";
+        String type = "{$x isa resource;$x id '" + resourceQuery.getQuery().toList().iterator().next().get("r").getId().getValue()  + "';}";
         ReasonerAtomicQuery typeQuery = ReasonerQueries.atomic(conjunction(type, graph), graph);
         Atom typeAtom = typeQuery.getAtom();
 
@@ -1192,10 +1192,10 @@ public class AtomicTest {
         Unifier unifier2 = resourceAtom2.getUnifier(typeAtom);
         Unifier unifier3 = resourceAtom3.getUnifier(typeAtom);
 
-        Answer typeAnswer = typeQuery.getQuery().execute().iterator().next();
-        Answer resourceAnswer = resourceQuery.getQuery().execute().iterator().next();
-        Answer resourceAnswer2 = resourceQuery2.getQuery().execute().iterator().next();
-        Answer resourceAnswer3 = resourceQuery3.getQuery().execute().iterator().next();
+        Answer typeAnswer = typeQuery.getQuery().toList().iterator().next();
+        Answer resourceAnswer = resourceQuery.getQuery().toList().iterator().next();
+        Answer resourceAnswer2 = resourceQuery2.getQuery().toList().iterator().next();
+        Answer resourceAnswer3 = resourceQuery3.getQuery().toList().iterator().next();
 
         assertEquals(typeAnswer.get(var("x")), resourceAnswer.unify(unifier).get(var("x")));
         assertEquals(typeAnswer.get(var("x")), resourceAnswer2.unify(unifier2).get(var("x")));
@@ -1351,12 +1351,12 @@ public class AtomicTest {
 
         Unifier unifier = childAtom.getMultiUnifier(parentAtom, UnifierType.EXACT).getUnifier();
 
-        List<Answer> childAnswers = childQuery.getQuery().execute();
+        List<Answer> childAnswers = childQuery.getQuery().toList();
         List<Answer> unifiedAnswers = childAnswers.stream()
                 .map(a -> a.unify(unifier))
                 .filter(a -> !a.isEmpty())
                 .collect(Collectors.toList());
-        List<Answer> parentAnswers = parentQuery.getQuery().execute();
+        List<Answer> parentAnswers = parentQuery.getQuery().toList();
 
         if (checkInverse) {
             Unifier unifier2 = parentAtom.getUnifier(childAtom);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/BenchmarkTests.java
@@ -260,7 +260,7 @@ public class BenchmarkTests {
         GetQuery query2 = iqb.parse(queryString2);
 
         //with substitution
-        Concept id = iqb.<GetQuery>parse("match $x has index 'a'; get;").execute().iterator().next().get("x");
+        Concept id = iqb.<GetQuery>parse("match $x has index 'a'; get;").toList().iterator().next().get("x");
         String queryString3 = "match (Q-from: $x, Q-to: $y) isa Q;$x id '" + id.getId().getValue() + "'; get;";
         GetQuery query3 = iqb.parse(queryString3);
 
@@ -372,7 +372,7 @@ public class BenchmarkTests {
 
     private List<Answer> executeQuery(GetQuery query, String msg) {
         final long startTime = System.currentTimeMillis();
-        List<Answer> results = query.execute();
+        List<Answer> results = query.toList();
         final long answerTime = System.currentTimeMillis() - startTime;
         LOG.debug(msg + " results = " + results.size() + " answerTime: " + answerTime);
         return results;

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
@@ -92,7 +92,7 @@ public class ExplanationTest {
         Answer answer3 = new QueryAnswer(ImmutableMap.of(var("x"), polibuda, var("y"), poland));
         Answer answer4 = new QueryAnswer(ImmutableMap.of(var("x"), polibuda, var("y"), europe));
 
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         testExplanation(answers);
 
         Answer queryAnswer1 = findAnswer(answer1, answers);
@@ -134,7 +134,7 @@ public class ExplanationTest {
         Answer answer1 = new QueryAnswer(ImmutableMap.of(var("x"), polibuda, var("y"), poland));
         Answer answer2 = new QueryAnswer(ImmutableMap.of(var("x"), uw, var("y"), poland));
 
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         testExplanation(answers);
 
         Answer queryAnswer1 = findAnswer(answer1, answers);
@@ -165,7 +165,7 @@ public class ExplanationTest {
                 "$y id '" + europe.getId() + "'; get;";
 
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 1);
 
         Answer answer = answers.iterator().next();
@@ -186,7 +186,7 @@ public class ExplanationTest {
                 "get $y;";
 
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 1);
         testExplanation(answers);
     }
@@ -199,7 +199,7 @@ public class ExplanationTest {
                 "$y id '" + uw.getId() + "'; get;";
 
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 0);
     }
 
@@ -208,7 +208,7 @@ public class ExplanationTest {
         String queryString = "match $x isa city, has name $n; get;";
 
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         answers.forEach(ans -> assertEquals(ans.getExplanation().isEmpty(), true));
     }
 
@@ -225,7 +225,7 @@ public class ExplanationTest {
                 "$y id '" + a2.getId() + "'; get;";
 
         GetQuery query = eiqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 0);
     }
 
@@ -240,7 +240,7 @@ public class ExplanationTest {
                 "$w has name $wName; get;";
 
         GetQuery query = eiqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         testExplanation(answers);
     }
 
@@ -255,7 +255,7 @@ public class ExplanationTest {
                 "get;";
 
         GetQuery query = eiqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         testExplanation(answers);
         Answer inferredAnswer = answers.stream()
                 .filter(ans -> ans.getExplanations().stream().filter(AnswerExplanation::isRuleExplanation).findFirst().isPresent())
@@ -275,7 +275,7 @@ public class ExplanationTest {
                 "limit " + limit + ";"+
                 "get;";
 
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
 
         assertEquals(answers.size(), limit);
         answers.forEach(answer -> {
@@ -286,7 +286,7 @@ public class ExplanationTest {
                     "$y id '" + answer.get(var("y")).getId().getValue() + "';" +
                     "(cousin: $x, cousin: $y) isa cousins;" +
                     "limit 1; get;";
-            Answer specificAnswer = Iterables.getOnlyElement(iqb.<GetQuery>parse(specificQuery).execute());
+            Answer specificAnswer = Iterables.getOnlyElement(iqb.<GetQuery>parse(specificQuery).toList());
             assertEquals(answer, specificAnswer);
             testExplanation(specificAnswer);
         });

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
@@ -53,8 +53,8 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -64,11 +64,11 @@ public class OntologicalQueryTest {
         String relationString = "match $x isa relationship;get;";
         String rolePlayerPairString = "match ($u, $v) isa $type; get;";
 
-        List<Answer> rolePlayerPairs = qb.<GetQuery>parse(rolePlayerPairString).execute();
+        List<Answer> rolePlayerPairs = qb.<GetQuery>parse(rolePlayerPairString).toList();
         //TODO doesn't include THING and RELATIONSHIP, with RELATIONSHIP it's 38, with THING as well it should be 57
         assertEquals(rolePlayerPairs.size(), 25);
 
-        List<Answer> relations = qb.<GetQuery>parse(relationString).execute();
+        List<Answer> relations = qb.<GetQuery>parse(relationString).toList();
         //one implicit, 3 x binary, 2 x ternary, 7 (3 reflexive) x reifying-relation
         assertEquals(relations.size(), 13);
     }
@@ -81,10 +81,10 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; $type has name; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         //1 x noRoleEntity + 3 x 3 (hierarchy) anotherTwoRoleEntities
         assertEquals(answers.size(), 10);
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -94,10 +94,10 @@ public class OntologicalQueryTest {
 
         String queryString = "match $x isa $type; $type has description; get;";
         String specificQueryString = "match $x isa reifiable-relation;get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
 
-        assertEquals(answers.size(), qb.<GetQuery>parse(specificQueryString).execute().size() * tx.getRelationshipType("reifiable-relation").subs().count());
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertEquals(answers.size(), qb.<GetQuery>parse(specificQueryString).toList().size() * tx.getRelationshipType("reifiable-relation").subs().count());
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     /** SubAtom **/
@@ -108,9 +108,9 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; $type sub noRoleEntity; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), tx.getEntityType("noRoleEntity").subs().flatMap(EntityType::instances).count());
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -118,10 +118,10 @@ public class OntologicalQueryTest {
         GraknTx tx = testContext.tx();
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; $type sub relationship; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
 
         assertEquals(answers.size(), tx.getRelationshipType("relationship").subs().flatMap(RelationshipType::instances).count());
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -129,7 +129,7 @@ public class OntologicalQueryTest {
         GraknTx tx = testContext.tx();
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match binary sub $x; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
 
         assertEquals(
                 answers.stream().map(ans -> ans.get("x")).collect(Collectors.toSet()),
@@ -149,10 +149,10 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; $type plays role1; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> reifiableRelations = qb.<GetQuery>parse("match $x isa reifiable-relation;get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> reifiableRelations = qb.<GetQuery>parse("match $x isa reifiable-relation;get;").toList();
         assertEquals(answers.size(), tx.getEntityType("noRoleEntity").subs().flatMap(EntityType::instances).count() + reifiableRelations.size());
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
     }
 
     /** RelatesAtom **/
@@ -163,10 +163,10 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa $type; $type relates role1; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
 
-        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
-        List<Answer> relations = qb.<GetQuery>parse("match $x isa relationship;get;").execute();
+        assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).toList());
+        List<Answer> relations = qb.<GetQuery>parse("match $x isa relationship;get;").toList();
         //plus extra 3 cause there are 3 binary relations which are not extra counted as reifiable-relations
         assertEquals(answers.size(), relations.stream().filter(ans -> !ans.get("x").asRelationship().type().isImplicit()).count() + 3);
     }
@@ -177,7 +177,7 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match reifying-relation relates $x; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(
                 answers.stream().map(ans -> ans.get("x")).collect(Collectors.toSet()),
                 tx.getRelationshipType("reifying-relation").relates().collect(Collectors.toSet())
@@ -192,7 +192,7 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match (role1: $x, role2: $y) isa reifiable-relation;$x isa $type; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         //3 instances * {anotherTwoRoleEntity, anotherSingleRoleEntity, noRoleEntity, entity, Thing}
         assertEquals(answers.size(), qb.<GetQuery>parse("match $x isa reifiable-relation; get;").stream().count() * 5);
     }
@@ -204,7 +204,7 @@ public class OntologicalQueryTest {
         String queryString = "match ($x, $y) isa reifiable-relation;$x isa $type; get;";
 
         //3 instances * {anotherTwoRoleEntity, anotherSingleRoleEntity, noRoleEntity, entity, Thing} * arity
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), qb.<GetQuery>parse("match $x isa reifiable-relation; get;").stream().count() * 5 * 2);
     }
 
@@ -217,7 +217,7 @@ public class OntologicalQueryTest {
         long noOfEntities = tx.admin().getMetaEntityType().instances().count();
         String queryString = "match $x isa entity;get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), noOfEntities);
     }
 
@@ -227,7 +227,7 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa relationship;get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 13);
     }
 
@@ -237,7 +237,7 @@ public class OntologicalQueryTest {
         QueryBuilder qb = tx.graql().infer(true);
         String queryString = "match $x isa attribute;get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 2);
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryCacheTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryCacheTest.java
@@ -87,7 +87,7 @@ public class QueryCacheTest {
     @Test
     public void recordRetrieveAnswers(){
         QueryCache<ReasonerAtomicQuery> cache = new QueryCache<>();
-        QueryAnswers record = cache.record(recordQuery, new QueryAnswers(recordQuery.getQuery().execute()));
+        QueryAnswers record = cache.record(recordQuery, new QueryAnswers(recordQuery.getQuery().toList()));
         assertEquals(record, cache.getAnswers(retrieveQuery).unify(retrieveToRecordUnifier));
         assertEquals(record, cache.getAnswers(recordQuery));
     }
@@ -95,7 +95,7 @@ public class QueryCacheTest {
     @Test
     public void recordUpdateRetrieveAnswers(){
         QueryCache<ReasonerAtomicQuery> cache = new QueryCache<>();
-        cache.record(recordQuery, new QueryAnswers(recordQuery.getQuery().execute()));
+        cache.record(recordQuery, new QueryAnswers(recordQuery.getQuery().toList()));
         cache.recordAnswer(recordQuery, singleAnswer);
         assertTrue(cache.getAnswers(recordQuery).contains(singleAnswer));
         assertTrue(cache.getAnswers(retrieveQuery).contains(singleAnswer.unify(recordToRetrieveUnifier)));

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryValidityTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryValidityTest.java
@@ -42,14 +42,14 @@ public class QueryValidityTest {
     public void whenQueryingForInexistentConceptId_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x id 'V123'; $y id 'V456'; ($x, $y); get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
     public void whenQueryingForInexistentEntityTypeId_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x isa $type; $type id 'V123'; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
@@ -57,8 +57,8 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa $type; $type id 'V123'; get;";
         String queryString2 = "match $r ($x, $y) isa $type; $r id 'V123'; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
-        assertThat(qb.<GetQuery>parse(queryString2).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
+        assertThat(qb.<GetQuery>parse(queryString2).toList(), empty());
     }
 
     @Test
@@ -67,9 +67,9 @@ public class QueryValidityTest {
         String queryString = "match $x has name $y; $x id 'V123'; get;";
         String queryString2 = "match $x has name $y; $y id 'V123'; get;";
         String queryString3 = "match $x has name $y via $r; $r id 'V123'; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
-        assertThat(qb.<GetQuery>parse(queryString2).execute(), empty());
-        assertThat(qb.<GetQuery>parse(queryString3).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
+        assertThat(qb.<GetQuery>parse(queryString2).toList(), empty());
+        assertThat(qb.<GetQuery>parse(queryString3).toList(), empty());
     }
 
     @Test
@@ -77,14 +77,14 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x isa polok; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
     public void whenQueryingForInexistentEntityTypeLabelViaVariable_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x isa $type; $type label polok; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
@@ -92,7 +92,7 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x has binary $r; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
@@ -100,7 +100,7 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa jakas-relacja; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
@@ -108,14 +108,14 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa name; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
     public void whenQueryingForInexistentRelationTypeLabelViaVariable_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa $type; $type label jakas-relacja; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match (entity: $x, entity: $y) isa relationship; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
@@ -131,27 +131,27 @@ public class QueryValidityTest {
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match (rola: $x, rola: $y) isa relationship; get;";
         expectedException.expect(GraqlQueryException.class);
-        qb.<GetQuery>parse(queryString).execute();
+        qb.<GetQuery>parse(queryString).toList();
     }
 
     @Test
     public void whenQueryingForRelationWithIllegalRoles_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match (role3: $x) isa binary; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
     public void whenQueryingForIllegalRolePlayer_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa binary; $x isa anotherNoRoleEntity; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
     public void whenQueryingForIllegalResource_emptyResultReturned(){
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x has name $n; $x isa binary; get;";
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasonerTest.java
@@ -331,7 +331,7 @@ public class ReasonerTest {
         //geoObject sub city always returns an empty set
         String queryString = "match ($x, $y) isa is-located-in;geoObject sub city; get;";
         QueryBuilder iqb = graph.graql().infer(true);
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertThat(answers, empty());
     }
 
@@ -519,8 +519,8 @@ public class ReasonerTest {
         GetQuery limitQuery = iqb.parse(limitQueryString);
         GetQuery query = iqb.parse(queryString);
 
-        List<Answer> limitedAnswers = limitQuery.execute();
-        List<Answer> answers = query.execute();
+        List<Answer> limitedAnswers = limitQuery.toList();
+        List<Answer> answers = query.toList();
         assertEquals(limitedAnswers.size(), 5);
         assertTrue(answers.size() > limitedAnswers.size());
         assertTrue(answers.containsAll(limitedAnswers));
@@ -531,7 +531,7 @@ public class ReasonerTest {
         String queryString = "match $p isa person, has age $a;$pr isa product;($p, $pr) isa recommendation;order by $a; get;";
         GetQuery query = snbKB.tx().graql().infer(true).parse(queryString);
 
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.iterator().next().get("a").asAttribute().getValue().toString(), "19");
     }
 
@@ -541,9 +541,9 @@ public class ReasonerTest {
         GetQuery query = nonMaterialisedSnbKB.tx().graql().infer(true).parse(queryString);
 
         final int offset = 4;
-        List<Answer> fullAnswers = query.execute();
-        List<Answer> answers = query.match().orderBy(Graql.var("a")).get().execute();
-        List<Answer> answers2 = query.match().orderBy(Graql.var("a")).offset(offset).get().execute();
+        List<Answer> fullAnswers = query.toList();
+        List<Answer> answers = query.match().orderBy(Graql.var("a")).get().toList();
+        List<Answer> answers2 = query.match().orderBy(Graql.var("a")).offset(offset).get().toList();
 
         assertEquals(fullAnswers.size(), answers2.size() + offset);
         assertEquals(answers.size(), answers2.size() + offset);
@@ -592,8 +592,8 @@ public class ReasonerTest {
         QueryBuilder iqb = graph.graql().infer(true);
         GetQuery query = iqb.parse(queryString);
         GetQuery query2 = iqb.parse(queryString2);
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
         assertTrue(answers2.containsAll(answers));
         assertEquals(2*answers.size(), answers2.size());
     }
@@ -624,9 +624,9 @@ public class ReasonerTest {
         assertQueriesEqual(query, query2);
         assertQueriesEqual(query2, query3);
 
-        List<Answer> requeriedAnswers = query.execute();
-        List<Answer> requeriedAnswers2 = query2.execute();
-        List<Answer> requeriedAnswers3 = query3.execute();
+        List<Answer> requeriedAnswers = query.toList();
+        List<Answer> requeriedAnswers2 = query2.toList();
+        List<Answer> requeriedAnswers3 = query3.toList();
 
         assertCollectionsEqual(requeriedAnswers, requeriedAnswers2);
         assertCollectionsEqual(requeriedAnswers2, requeriedAnswers3);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTests.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTests.java
@@ -176,8 +176,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet1.tx().graql().infer(true);
         String queryString = "match (role1:$x, role2:$x) isa relation1; get;";
         String queryString2 = "match (role1:$x, role2:$y) isa relation1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
 
         assertEquals(1, answers.size());
         assertEquals(4, answers2.size());
@@ -191,8 +191,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet1b.tx().graql().infer(true);
         String queryString = "match (symmetricRole: $x, symmetricRole: $x) isa relation1; get;";
         String queryString2 = "match (symmetricRole: $x, symmetricRole: $y) isa relation1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
 
         assertEquals(2, answers.size());
         assertEquals(8, answers2.size());
@@ -205,7 +205,7 @@ public class ReasoningTests {
     public void generatingMultipleIsaEdges() {
         QueryBuilder qb = testSet2.tx().graql().infer(true);
         String queryString = "match $x isa derivedEntity; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -215,9 +215,9 @@ public class ReasoningTests {
         String queryString = "match $x isa derivedEntity; get;";
         String queryString2 = "match $x isa! derivedEntity; get;";
         String queryString3 = "match $x isa directDerivedEntity; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
         assertEquals(answers.size(), 2);
         assertEquals(answers2.size(), 2);
         assertEquals(answers3.size(), 1);
@@ -229,9 +229,9 @@ public class ReasoningTests {
         String queryString = "match ($x, $y) isa derivedRelation; get;";
         String queryString2 = "match ($x, $y) isa! derivedRelation; get;";
         String queryString3 = "match ($x, $y) isa directDerivedRelation; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
         assertEquals(answers.size(), 2);
         assertEquals(answers2.size(), 2);
         assertEquals(answers3.size(), 1);
@@ -241,7 +241,7 @@ public class ReasoningTests {
     public void queryingForGenericType_ruleDefinesNewType() {
         QueryBuilder qb = testSet2.tx().graql().infer(true);
         String queryString = "match $x isa $type; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 4);
         answers.forEach(ans -> assertEquals(ans.size(), 2));
     }
@@ -251,8 +251,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet4.tx().graql().infer(true);
         String queryString = "match $x isa entity1; get;";
         String queryString2 = "match $x isa entity2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers.size(), 2);
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
@@ -265,8 +265,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet3.tx().graql().infer(true);
         String queryString = "match $x isa entity1; get;";
         String queryString2 = "match $x isa entity2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers.size(), answers2.size());
         assertFalse(answers.containsAll(answers2));
         assertFalse(answers2.containsAll(answers));
@@ -280,8 +280,8 @@ public class ReasoningTests {
         QueryBuilder iqb = testSet5.tx().graql().infer(true);
         String queryString = "match $x isa entity2; get;";
         String explicitQuery = "match $x isa entity1; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(explicitQuery).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(explicitQuery).toList();
 
         assertEquals(answers2.size(), 3);
         assertTrue(!answers2.containsAll(answers));
@@ -293,7 +293,7 @@ public class ReasoningTests {
     public void generatingFreshRelation() {
         QueryBuilder qb = testSet6.tx().graql().infer(true);
         String queryString = "match $x isa relation1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 3);
     }
 
@@ -302,16 +302,16 @@ public class ReasoningTests {
         QueryBuilder iqb = testSet7.tx().graql().infer(true);
         QueryBuilder qb = testSet7.tx().graql().infer(false);
         String queryString = "match $x isa relation1; limit 10; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 10);
-        assertEquals(answers.size(), qb.<GetQuery>parse(queryString).execute().size());
+        assertEquals(answers.size(), qb.<GetQuery>parse(queryString).toList().size());
     }
 
     @Test //Expected result: The query should not return any matches (or possibly return a single match with $x=$y)
     public void roleUnificationWithRoleHierarchiesInvolved() {
         QueryBuilder qb = testSet8.tx().graql().infer(true);
         String queryString = "match (role2:$x, role3:$y) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertThat(answers.stream().collect(toSet()), empty());
     }
 
@@ -319,7 +319,7 @@ public class ReasoningTests {
     public void roleUnificationWithRepeatingRoleTypes() {
         QueryBuilder qb = testSet9.tx().graql().infer(true);
         String queryString = "match (role1:$x, role1:$y) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertThat(answers.stream().collect(toSet()), empty());
     }
 
@@ -327,7 +327,7 @@ public class ReasoningTests {
     public void roleUnificationWithLessRelationPlayersInQueryThanHead() {
         QueryBuilder qb = testSet9.tx().graql().infer(true);
         String queryString = "match (role1:$x) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -339,7 +339,7 @@ public class ReasoningTests {
     public void transRelationWithEntityGuardsAtBothEnds() {
         QueryBuilder qb = testSet10.tx().graql().infer(true);
         String queryString = "match (role1: $x, role2: $y) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -347,14 +347,14 @@ public class ReasoningTests {
     public void transRelationWithRelationGuardsAtBothEnds() {
         QueryBuilder qb = testSet11.tx().graql().infer(true);
         String queryString = "match (role1:$x, role2:$y) isa relation3; get;";
-        assertEquals(qb.<GetQuery>parse(queryString).execute().size(), 1);
+        assertEquals(qb.<GetQuery>parse(queryString).toList().size(), 1);
     }
 
     @Test //Expected result: The query should return two unique matches
     public void circularRuleDependencies() {
         QueryBuilder qb = testSet12.tx().graql().infer(true);
         String queryString = "match (role1:$x, role2:$y) isa relation3; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 2);
     }
 
@@ -362,7 +362,7 @@ public class ReasoningTests {
     public void rulesInteractingWithTypeHierarchy() {
         QueryBuilder qb = testSet13.tx().graql().infer(true);
         String queryString = "match (role1:$x, role2:$y) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -371,9 +371,9 @@ public class ReasoningTests {
         QueryBuilder qb = testSet14.tx().graql().infer(true);
 
         String queryString = "match $x isa entity1, has resource $y; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         String queryString2 = "match $x isa resource; get;";
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
 
         assertEquals(answers.size(), 2);
         assertEquals(answers2.size(), 1);
@@ -384,7 +384,7 @@ public class ReasoningTests {
         QueryBuilder qb = testSet14.tx().graql().infer(true);
 
         String queryString = "match $x isa entity1;($x, $y); get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
 
         assertEquals(answers.size(), 3);
         assertEquals(answers.stream().filter(answer -> answer.get("y").isAttribute()).count(), 2);
@@ -396,15 +396,15 @@ public class ReasoningTests {
     public void reusingResources_usingExistingResourceToDefineSubResource() {
         QueryBuilder qb = testSet14.tx().graql().infer(true);
         String queryString = "match $x isa entity1, has subResource $y;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
 
         String queryString2 = "match $x isa subResource;";
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers2.size(), 1);
         assertTrue(answers2.iterator().next().get(var("x")).isAttribute());
         String queryString3 = "match $x isa resource; $y isa subResource;";
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
         assertEquals(answers3.size(), 1);
 
         assertTrue(answers3.iterator().next().get(var("x")).isAttribute());
@@ -416,7 +416,7 @@ public class ReasoningTests {
         QueryBuilder qb = testSet14.tx().graql().infer(true);
 
         VarPattern has = var("x").has(Label.of("resource"), var("y"), var("r"));
-        List<Answer> answers = qb.match(has).get().execute();
+        List<Answer> answers = qb.match(has).get().toList();
         assertEquals(answers.size(), 3);
         answers.forEach(a -> assertTrue(a.vars().contains(var("r"))));
     }
@@ -448,7 +448,7 @@ public class ReasoningTests {
         QueryBuilder qb = testSet14.tx().graql().infer(true);
 
         String queryString = "match $x isa entity1, has resource $y; $z isa relation; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 2);
         answers.forEach(ans ->
                 {
@@ -459,7 +459,7 @@ public class ReasoningTests {
         );
 
         String queryString2 = "match $x isa relation, has resource $y; get;";
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers2.size(), 1);
         answers2.forEach(ans ->
                 {
@@ -473,7 +473,7 @@ public class ReasoningTests {
     public void reusingResources_definingResourceThroughOtherResourceWithConditionalValue() {
         QueryBuilder qb = testSet15.tx().graql().infer(true);
         String queryString = "match $x has boolean-resource $r; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -484,9 +484,9 @@ public class ReasoningTests {
         String queryString2 = "match $x has resource $r; get;";
         GetQuery query = qb.parse(queryString);
         GetQuery query2 = qb.parse(queryString2);
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
-        List<Answer> requeriedAnswers = query.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
+        List<Answer> requeriedAnswers = query.toList();
         assertEquals(answers.size(), 2);
         assertEquals(answers.size(), answers2.size());
         assertEquals(answers.size(), requeriedAnswers.size());
@@ -511,12 +511,12 @@ public class ReasoningTests {
         GetQuery query5 = qb.parse(queryString5);
         GetQuery query6 = qb.parse(queryString6);
 
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
-        List<Answer> answers3 = query3.execute();
-        List<Answer> answers4 = query4.execute();
-        List<Answer> answers5 = query5.execute();
-        List<Answer> answers6 = query6.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
+        List<Answer> answers3 = query3.toList();
+        List<Answer> answers4 = query4.toList();
+        List<Answer> answers5 = query5.toList();
+        List<Answer> answers6 = query6.toList();
 
         assertEquals(answers.size(), 2);
         assertEquals(answers2.size(), 1);
@@ -544,12 +544,12 @@ public class ReasoningTests {
         GetQuery query5 = qb.parse(queryString5);
         GetQuery query6 = qb.parse(queryString6);
 
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
-        List<Answer> answers3 = query3.execute();
-        List<Answer> answers4 = query4.execute();
-        List<Answer> answers5 = query5.execute();
-        List<Answer> answers6 = query6.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
+        List<Answer> answers3 = query3.toList();
+        List<Answer> answers4 = query4.toList();
+        List<Answer> answers5 = query5.toList();
+        List<Answer> answers6 = query6.toList();
 
         assertEquals(answers.size(), 3);
         assertEquals(answers2.size(), 3);
@@ -567,9 +567,9 @@ public class ReasoningTests {
                 "$y isa entity1;" +
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
-        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").toList();
         assertEquals(answers.size(), 2);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").toList();
         assertEquals(answers2.size(), 2);
     }
 
@@ -582,9 +582,9 @@ public class ReasoningTests {
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").toList();
         assertEquals(answers.size(), 1);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").toList();
         assertEquals(answers2.size(), 1);
     }
 
@@ -597,9 +597,9 @@ public class ReasoningTests {
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").toList();
         assertEquals(answers.size(), 2);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + "get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + "get;").toList();
         assertEquals(answers2.size(), 2);
     }
 
@@ -611,9 +611,9 @@ public class ReasoningTests {
                 "$y isa entity1;" +
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
-        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").toList();
         assertEquals(answers.size(), 2);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").toList();
         assertEquals(answers2.size(), 2);
     }
 
@@ -626,9 +626,9 @@ public class ReasoningTests {
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").toList();
         assertEquals(answers.size(), 1);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").toList();
         assertEquals(answers2.size(), 1);
     }
 
@@ -641,9 +641,9 @@ public class ReasoningTests {
                 "(role1: $x, role2: $y) isa relation1;";
         String queryString2 = queryString + "$y has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + " get;").toList();
         assertEquals(answers.size(), 2);
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2 + " get;").toList();
         assertEquals(answers2.size(), 2);
     }
 
@@ -652,8 +652,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet20.tx().graql().infer(true);
         String queryString = "match (role1: $x, role2: $y) isa relation1; get;";
         String queryString2 = "match (role1: $x, role2: $y) isa sub-relation1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers.size(), 1);
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
@@ -664,8 +664,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet21.tx().graql().infer(true);
         String queryString = "match $x isa entity1; get;";
         String queryString2 = "match $x isa sub-entity1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers.size(), 1);
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
@@ -675,7 +675,7 @@ public class ReasoningTests {
     public void reasoningWithRepeatingRoles(){
         QueryBuilder qb = testSet22.tx().graql().infer(true);
         String queryString = "match (friend:$x1, friend:$x2) isa knows-trans; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 16);
     }
 
@@ -683,9 +683,9 @@ public class ReasoningTests {
     public void reasoningWithLimitHigherThanNumberOfResults_ReturnsConsistentResults(){
         QueryBuilder qb = testSet23.tx().graql().infer(true);
         String queryString = "match (friend1:$x1, friend2:$x2) isa knows-trans;limit 60; get;";
-        List<Answer> oldAnswers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> oldAnswers = qb.<GetQuery>parse(queryString).toList();
         for(int i = 0; i < 5 ; i++) {
-            List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+            List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
             assertEquals(answers.size(), 6);
             assertTrue(answers.containsAll(oldAnswers));
             assertTrue(oldAnswers.containsAll(answers));
@@ -697,8 +697,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet24.tx().graql().infer(true);
         QueryBuilder qbm = testSet24.tx().graql().infer(true);
         String queryString = "match (role1:$x1, role2:$x2) isa relation1; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qbm.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qbm.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 9);
         assertEquals(answers2.size(), 9);
         assertTrue(answers.containsAll(answers2));
@@ -710,9 +710,9 @@ public class ReasoningTests {
         QueryBuilder qb = testSet24.tx().graql().infer(true);
         QueryBuilder qbm = testSet24.tx().graql().infer(true).materialise(true);
         String queryString = "match (role1:$x1, role2:$x2) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 6);
-        List<Answer> answers2 = qbm.<GetQuery>parse(queryString).execute();
+        List<Answer> answers2 = qbm.<GetQuery>parse(queryString).toList();
         assertEquals(answers2.size(), 6);
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
@@ -722,7 +722,7 @@ public class ReasoningTests {
     public void reasoningWithResourceValueComparison() {
         QueryBuilder qb = testSet25.tx().graql().infer(true);
         String queryString = "match (predecessor:$x1, successor:$x2) isa message-succession; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 10);
     }
 
@@ -731,7 +731,7 @@ public class ReasoningTests {
     public void reasoningWithReifiedRelations() {
         QueryBuilder qb = testSet26.tx().graql().infer(true);
         String queryString = "match (role1: $x1, role2: $x2) isa relation2; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 2);
 
         String queryString2 = "match " +
@@ -741,7 +741,7 @@ public class ReasoningTests {
                 "$rel1 (role1: $p, role2: $b) isa relation1;" +
                 "$rel2 has res2 'value2';" +
                 "$rel2 (role1: $c, role2: $b) isa relation1; get;";
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers2.size(), 2);
         Set<Var> vars = Sets.newHashSet(var("b"), var("p"), var("c"), var("rel1"), var("rel2"));
         answers2.forEach(ans -> assertTrue(ans.vars().containsAll(vars)));
@@ -752,8 +752,8 @@ public class ReasoningTests {
         QueryBuilder qb = testSet27.tx().graql().infer(true);
         String queryString = "match (related-state: $s) isa holds; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> exact = qb.<GetQuery>parse("match $s isa state, has name 's2'; get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> exact = qb.<GetQuery>parse("match $s isa state, has name 's2'; get;").toList();
         assertTrue(answers.containsAll(exact));
         assertTrue(exact.containsAll(answers));
     }
@@ -767,7 +767,7 @@ public class ReasoningTests {
                 "(role3: $z, role4: $w) isa relation3;" +
                 "limit 3; get;";
 
-        assertEquals(qb.<GetQuery>parse(queryString).execute().size(), 3);
+        assertEquals(qb.<GetQuery>parse(queryString).toList().size(), 3);
     }
 
     @Test //Expected result: no answers (if types were incorrectly inferred the query would yield answers)
@@ -778,7 +778,7 @@ public class ReasoningTests {
                 "(role1: $y, role2: $z) isa relation1;" +
                 "(role3: $z, role4: $w) isa relation3; get;";
 
-        assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
+        assertThat(qb.<GetQuery>parse(queryString).toList(), empty());
     }
 
     @Test
@@ -790,7 +790,7 @@ public class ReasoningTests {
                 "($b, $c);" +
                 "get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 4);
         answers.forEach(ans -> assertEquals(ans.size(), 3));
     }
@@ -805,17 +805,17 @@ public class ReasoningTests {
                 pattern +
                 pattern2 +
                 "get;";
-        List<Answer> partialAnswers = qb.match(Graql.parser().parsePatterns(pattern)).get().execute();
+        List<Answer> partialAnswers = qb.match(Graql.parser().parsePatterns(pattern)).get().toList();
 
         //single relation that satisfies the types
         assertEquals(partialAnswers.size(), 1);
 
-        List<Answer> partialAnswers2 = qb.match(Graql.parser().parsePatterns(pattern2)).get().execute();
+        List<Answer> partialAnswers2 = qb.match(Graql.parser().parsePatterns(pattern2)).get().toList();
         //(4 db relations  + 1 inferred + 1 resource) x 2 for variable swap
         assertEquals(partialAnswers2.size(), 12);
 
         //1 relation satisfying ($a, $b) with types x (4 db relations + 1 inferred + 1 resource) x 2 for var change
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), partialAnswers.size() * partialAnswers2.size());
         answers.forEach(ans -> assertEquals(ans.size(), 4));
     }
@@ -834,7 +834,7 @@ public class ReasoningTests {
                 "($a, $b);" +
                 "};";
 
-        List<Answer> entryAnswers = qb.match(Graql.parser().parsePatterns(entryPattern)).get().execute();
+        List<Answer> entryAnswers = qb.match(Graql.parser().parsePatterns(entryPattern)).get().toList();
         assertEquals(entryAnswers.size(), 3);
 
         String partialPattern = "{" +
@@ -843,14 +843,14 @@ public class ReasoningTests {
                 "($b, $c);" +
                 "};";
 
-        List<Answer> partialAnswers = qb.match(Graql.parser().parsePatterns(partialPattern)).get().execute();
+        List<Answer> partialAnswers = qb.match(Graql.parser().parsePatterns(partialPattern)).get().toList();
         assertEquals(partialAnswers.size(), 4);
         String queryString = "match " +
                 partialPattern +
                 "($c, $d);" +
                 "get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 7);
         answers.forEach(ans -> assertEquals(ans.size(), 4));
     }
@@ -863,7 +863,7 @@ public class ReasoningTests {
                 "$x != $y;";
         String queryString = baseQueryString + "$y has name 'c'; get;";
 
-        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").execute();
+        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").toList();
         assertEquals(baseAnswers.size(), 6);
         baseAnswers.forEach(ans -> {
             assertEquals(ans.size(), 2);
@@ -875,8 +875,8 @@ public class ReasoningTests {
                 "$y has name 'c';" +
                 "{$x has name 'a';} or {$x has name 'b';}; get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(explicitString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(explicitString).toList();
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
     }
@@ -899,7 +899,7 @@ public class ReasoningTests {
                 "(role1: $x, role2: $z) isa binary-base;" +
                 "$y != $z;";
 
-        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").execute();
+        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").toList();
         assertEquals(baseAnswers.size(), 18);
         baseAnswers.forEach(ans -> {
             assertEquals(ans.size(), 3);
@@ -916,8 +916,8 @@ public class ReasoningTests {
                 "{$y has name 'c';$z has name 'a';} or " +
                 "{$y has name 'c';$z has name 'b';};";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").execute();
-        List<Answer> answers2 = qb.infer(false).<GetQuery>parse(explicitString + "get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").toList();
+        List<Answer> answers2 = qb.infer(false).<GetQuery>parse(explicitString + "get;").toList();
         assertTrue(baseAnswers.containsAll(answers));
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
@@ -941,7 +941,7 @@ public class ReasoningTests {
                 "(role1: $y, role2: $z) isa binary-base;" +
                 "$x != $z;";
 
-        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").execute();
+        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").toList();
         assertEquals(baseAnswers.size(), 18);
         baseAnswers.forEach(ans -> {
             assertEquals(ans.size(), 3);
@@ -959,8 +959,8 @@ public class ReasoningTests {
                 "{$y has name 'c';$z has name 'c';} or " +
                 "{$y has name 'c';$z has name 'b';};";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").execute();
-        List<Answer> answers2 = qb.infer(false).<GetQuery>parse(explicitString + "get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").toList();
+        List<Answer> answers2 = qb.infer(false).<GetQuery>parse(explicitString + "get;").toList();
         assertTrue(answers.containsAll(answers2));
         assertTrue(answers2.containsAll(answers));
     }
@@ -991,7 +991,7 @@ public class ReasoningTests {
                 "$y1 != $z1;" +
                 "$y2 != $z2;";
 
-        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").execute();
+        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").toList();
         assertEquals(baseAnswers.size(), 108);
         baseAnswers.forEach(ans -> {
             assertEquals(ans.size(), 5);
@@ -1001,7 +1001,7 @@ public class ReasoningTests {
 
         String queryString = baseQueryString + "$x has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").toList();
         assertEquals(answers.size(), 36);
         answers.forEach(ans -> {
             assertEquals(ans.size(), 5);
@@ -1030,7 +1030,7 @@ public class ReasoningTests {
                 "(role1: $x, role2: $z1) isa binary-base;" +
                 "(role1: $y, role2: $z2) isa binary-base;";
 
-        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").execute();
+        List<Answer> baseAnswers = qb.<GetQuery>parse(baseQueryString + "get;").toList();
         assertEquals(baseAnswers.size(), 36);
         baseAnswers.forEach(ans -> {
             assertEquals(ans.size(), 4);
@@ -1040,7 +1040,7 @@ public class ReasoningTests {
 
         String queryString = baseQueryString + "$x has name 'a';";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString + "get;").toList();
         assertEquals(answers.size(), 12);
         answers.forEach(ans -> {
             assertEquals(ans.size(), 4);
@@ -1071,9 +1071,9 @@ public class ReasoningTests {
                 "$y has name 'a';" +
                 "get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
 
         assertEquals(answers.size(), 3);
         answers.forEach(ans -> {
@@ -1111,16 +1111,16 @@ public class ReasoningTests {
                 "$b has name 'b';" +
                 "get;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 27);
 
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
         assertEquals(answers2.size(), 9);
 
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
         assertEquals(answers3.size(), 12);
 
-        List<Answer> answers4 = qb.<GetQuery>parse(queryString4).execute();
+        List<Answer> answers4 = qb.<GetQuery>parse(queryString4).toList();
         assertEquals(answers4.size(), 4);
     }
 
@@ -1138,8 +1138,8 @@ public class ReasoningTests {
                 "$r1 label 'role1';" +
                 "get $a, $b, $r2;";
 
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> equivalentAnswers = qb.<GetQuery>parse(equivalentQueryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> equivalentAnswers = qb.<GetQuery>parse(equivalentQueryString).toList();
         assertEquals(answers.size(), 18);
         assertTrue(CollectionUtils.isEqualCollection(answers, equivalentAnswers));
 
@@ -1153,8 +1153,8 @@ public class ReasoningTests {
                 "$r1 label 'role';" +
                 "get $a, $b, $r2;";
 
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).execute();
-        List<Answer> equivalentAnswers2 = qb.<GetQuery>parse(equivalentQueryString2).execute();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString2).toList();
+        List<Answer> equivalentAnswers2 = qb.<GetQuery>parse(equivalentQueryString2).toList();
         assertEquals(answers2.size(), 27);
         assertTrue(CollectionUtils.isEqualCollection(answers2, equivalentAnswers2));
 
@@ -1169,8 +1169,8 @@ public class ReasoningTests {
                 "(role1: $a, role2: $b) isa binary-base;" +
                 "get;";
 
-        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).execute();
-        List<Answer> equivalentAnswers3 = qb.<GetQuery>parse(equivalentQueryString3).execute();
+        List<Answer> answers3 = qb.<GetQuery>parse(queryString3).toList();
+        List<Answer> equivalentAnswers3 = qb.<GetQuery>parse(equivalentQueryString3).toList();
         assertEquals(answers3.size(), 9);
         assertTrue(CollectionUtils.isEqualCollection(answers3, equivalentAnswers3));
 
@@ -1179,7 +1179,7 @@ public class ReasoningTests {
                 "($r1: $a, $r2: $b) isa binary-base;" +
                 "get;";
 
-        List<Answer> answers4 = qb.<GetQuery>parse(queryString4).execute();
+        List<Answer> answers4 = qb.<GetQuery>parse(queryString4).toList();
         assertEquals(answers4.size(), 63);
     }
 
@@ -1252,11 +1252,11 @@ public class ReasoningTests {
         for(int i = 2; i <= arity ; i++) pattern = pattern.rel(var("r" + i), "a" + i);
         pattern = pattern.isa(label);
 
-        List<Answer> answers = qb.match(pattern.and(resourcePattern)).get().execute();
+        List<Answer> answers = qb.match(pattern.and(resourcePattern)).get().toList();
         assertEquals(answers.size(), answerCombinations(arity-1, conceptDOF));
 
         //We get extra conceptDOF degrees of freedom by removing the resource constraint on $a1 and the set is symmetric.
-        List<Answer> answers2 = qb.match(pattern).get().execute();
+        List<Answer> answers2 = qb.match(pattern).get().toList();
         assertEquals(answers2.size(), answerCombinations(arity-1, conceptDOF) * conceptDOF);
 
 
@@ -1265,7 +1265,7 @@ public class ReasoningTests {
         for(int i = 1; i <= arity ; i++) generalPattern = generalPattern.rel(var("r" + i), "a" + i);
         generalPattern = generalPattern.isa(label);
 
-        List<Answer> answers3 = qb.match(generalPattern).get().execute();
+        List<Answer> answers3 = qb.match(generalPattern).get().toList();
         assertEquals(answers3.size(), answerCombinations(arity, conceptDOF));
     }
 
@@ -1317,7 +1317,7 @@ public class ReasoningTests {
         QueryBuilder qb = testSet30.tx().graql().infer(true);
 
         String queryString = "match $p isa pair, has name 'ff'; get;";
-        List<Answer> answers = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 16);
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
@@ -326,7 +326,7 @@ public class TypeInferenceQueryTest {
     private void typeInferenceQueries(List<RelationshipType> possibleTypes, String pattern, EmbeddedGraknTx<?> graph) {
         QueryBuilder qb = graph.graql();
         List<Answer> typedAnswers = typedAnswers(possibleTypes, pattern, graph);
-        List<Answer> unTypedAnswers = qb.match(qb.parser().parsePattern(pattern)).get().execute();
+        List<Answer> unTypedAnswers = qb.match(qb.parser().parsePattern(pattern)).get().toList();
         assertEquals(typedAnswers.size(), unTypedAnswers.size());
         GraqlTestUtil.assertCollectionsEqual(typedAnswers, unTypedAnswers);
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GenealogyTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GenealogyTest.java
@@ -66,7 +66,7 @@ public class GenealogyTest {
     public void matchAllRelationsWithDocumentPlayingARole(){
         String queryString = "match $x isa document; ($x, $y); get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertTrue(answers.isEmpty());
     }
 
@@ -74,7 +74,7 @@ public class GenealogyTest {
     public void matchAllRelationsWithDocumentPlayingARole_redundantEntityBound(){
         String queryString = "match $x isa document; ($x, $y); $y isa entity; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertThat(answers, empty());
     }
 
@@ -87,7 +87,7 @@ public class GenealogyTest {
         String queryString = "match $x id '" + concept.getId() + "' has gender $g; get;";
 
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 1);
     }
 
@@ -95,49 +95,49 @@ public class GenealogyTest {
     public void testSpecificGender() {
         String queryString = "match $x isa person has gender 'female'; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 32);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testGender() {
         String queryString = "match $x isa person has gender $gender; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
-        assertEquals(answers.size(), qb.<GetQuery>parse("match $x isa person; get;").execute().size());
+        List<Answer> answers = query.toList();
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
+        assertEquals(answers.size(), qb.<GetQuery>parse("match $x isa person; get;").toList().size());
     }
 
     @Test
     public void testName() {
         String queryString = "match $x isa person, has firstname $n; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 60);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testMiddleName() {
         String queryString = "match $x has identifier $i has middlename $mn; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 60);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testSurName() {
         String queryString = "match $x isa person has surname $srn; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 60);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testParentship() {
         String queryString = "match (child: $c, parent: $p) isa parentship; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 76);
         assertTrue(!hasDuplicates(answers));
         answers.forEach(answer -> assertEquals(answer.size(), 2));
@@ -148,12 +148,12 @@ public class GenealogyTest {
         String queryString = "match (child: $x, $y) isa parentship;get $x;";
         String queryString2 = "match (child: $x) isa parentship; get;";
         String queryString3 = "match ($x, son: $y) isa parentship; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.<GetQuery>parse(queryString2).execute();
-        List<Answer> answers3 = iqb.<GetQuery>parse(queryString3).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.<GetQuery>parse(queryString2).toList();
+        List<Answer> answers3 = iqb.<GetQuery>parse(queryString3).toList();
         answers.forEach(answer -> assertEquals(answer.size(), 1));
         assertCollectionsEqual(answers, answers2);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
         assertThat(answers3, empty());
     }
 
@@ -165,7 +165,7 @@ public class GenealogyTest {
                 "(husband: $w, wife: $b);" +
                 "$a != $b;" +
                 "get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertTrue(!hasDuplicates(answers));
         assertEquals(answers.size(), 1);
     }
@@ -177,7 +177,7 @@ public class GenealogyTest {
                     "($y, $z) isa marriage;" +
                     "$x != $z;" +
                      "get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertTrue(!hasDuplicates(answers));
         assertEquals(answers.size(), 4);
     }
@@ -185,7 +185,7 @@ public class GenealogyTest {
     @Test
     public void marriedToThemselves(){
         String queryString = "match (spouse: $x, spouse: $x) isa marriage; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
         assertThat(answers, empty());
     }
 
@@ -200,9 +200,9 @@ public class GenealogyTest {
         String qs = "match ($x, $y) isa marriage; ($y, $z) isa marriage; get;";
         iqb.parse(qs).execute();
 
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 66);
-        List<Answer> answers2 = query2.execute();
+        List<Answer> answers2 = query2.toList();
         assertCollectionsEqual(answers, answers2);
         assertEquals(answers2.size(), 66);
     }
@@ -211,8 +211,8 @@ public class GenealogyTest {
     @Test
     public void testMarriageMaterialisation() {
         String queryString = "match $rel (spouse: $x, spouse: $y) isa marriage; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString).toList();
         assertEquals(132, answers.size());
         assertTrue(!hasDuplicates(answers));
         assertCollectionsEqual(answers, answers2);
@@ -223,8 +223,8 @@ public class GenealogyTest {
     @Test
     public void testMarriage() {
         String queryString = "match (spouse: $x, spouse: $y) isa marriage; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 44);
         assertTrue(!hasDuplicates(answers));
         assertCollectionsEqual(answers, answers2);
@@ -233,8 +233,8 @@ public class GenealogyTest {
     @Test
     public void testMarriage_specialisedRoles() {
         String queryString = "match (wife: $x, husband: $y) isa marriage; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = qb.<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 22);
         assertTrue(!hasDuplicates(answers));
         assertCollectionsEqual(answers, answers2);
@@ -243,11 +243,11 @@ public class GenealogyTest {
     @Test
     public void testWife(){
         String queryString = "match $r (wife: $x) isa marriage; get;";
-        List<Answer> answers = iqb.<GetQuery>parse(queryString).execute();
-        List<Answer> answerList = qb.<GetQuery>parse(queryString).execute();
-        List<Answer> requeriedAnswers = iqb.<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.<GetQuery>parse(queryString).toList();
+        List<Answer> answerList = qb.<GetQuery>parse(queryString).toList();
+        List<Answer> requeriedAnswers = iqb.<GetQuery>parse(queryString).toList();
         assertCollectionsEqual(answers, requeriedAnswers);
-        List<Answer> answerList2 = qb.<GetQuery>parse(queryString).execute();
+        List<Answer> answerList2 = qb.<GetQuery>parse(queryString).toList();
         assertCollectionsEqual(answerList, answerList2);
     }
 
@@ -257,9 +257,9 @@ public class GenealogyTest {
         String queryString2 = "match (wife: $x) isa marriage; get;";
         GetQuery query = iqb.parse(queryString);
         GetQuery query2 = iqb.parse(queryString2);
-        List<Answer> answers2 = query2.execute();
-        assertCollectionsEqual(answers2, qb.<GetQuery>parse(queryString2).execute());
-        List<Answer> answers = query.execute();
+        List<Answer> answers2 = query2.toList();
+        assertCollectionsEqual(answers2, qb.<GetQuery>parse(queryString2).toList());
+        List<Answer> answers = query.toList();
         assertTrue(!answers.isEmpty());
         assertCollectionsEqual(answers, answers2);
     }
@@ -275,10 +275,10 @@ public class GenealogyTest {
         String queryString = "match (sibling:$x, sibling:$y) isa siblings; get;";
         GetQuery query = iqb.materialise(true).parse(queryString);
 
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 166);
         assertTrue(!hasDuplicates(answers));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -286,10 +286,10 @@ public class GenealogyTest {
         String queryString = "match ($x, $y) isa cousins; get;";
         GetQuery query = iqb.parse(queryString);
 
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 192);
         assertTrue(!hasDuplicates(answers));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -303,10 +303,10 @@ public class GenealogyTest {
         GetQuery query3 = iqb.parse(queryString3);
         GetQuery query4 = iqb.parse(queryString4);
 
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
-        List<Answer> answers3 = query3.execute();
-        List<Answer> answers4 = query4.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
+        List<Answer> answers3 = query3.toList();
+        List<Answer> answers4 = query4.toList();
 
         assertEquals(answers.size(), 22);
         assertEquals(answers2.size(), 92);
@@ -320,12 +320,12 @@ public class GenealogyTest {
         String queryString2 = "match (parent-in-law: $x, child-in-law: $y) isa in-laws;$x has gender $g;$g val 'female'; get $x, $g;";
         GetQuery query = iqb.parse(queryString);
         GetQuery query2 = iqb.parse(queryString2);
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
         assertEquals(answers.size(), 8);
         assertCollectionsEqual(answers, answers2);
         assertTrue(checkResource(answers, "g", "female"));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -334,30 +334,30 @@ public class GenealogyTest {
         String queryString2 = "match (parent-in-law: $x, child-in-law: $y) isa in-laws;$x has gender $g;$g val'male'; get $x, $g;";
         GetQuery query = iqb.parse(queryString);
         GetQuery query2 = iqb.parse(queryString2);
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 = query2.execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = query2.toList();
         assertEquals(answers.size(), 9);
         assertCollectionsEqual(answers, answers2);
         assertTrue(checkResource(answers, "g", "male"));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testSonInLaw() {
         String queryString = "match (son-in-law: $x);$x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 11);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testDaughterInLaw() {
         String queryString = "match (daughter-in-law: $x); $x has identifier $id; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 14);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     /*
@@ -371,9 +371,9 @@ public class GenealogyTest {
     public void testSon() {
         String queryString = "match (son: $x);$x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 18);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
         assertTrue(checkResource(answers, "g", "male"));
     }
 
@@ -381,9 +381,9 @@ public class GenealogyTest {
     public void testDaughter() {
         String queryString = "match (daughter: $x);$x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 20);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
         assertTrue(checkResource(answers, "g", "female"));
     }
 
@@ -391,44 +391,44 @@ public class GenealogyTest {
     public void testChild() {
         String queryString = "match (child: $x); get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 38);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testFather() {
         String queryString = "match (father: $x); get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 10);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testMother() {
         String queryString = "match (mother: $x); get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 9);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testParent() {
         String queryString = "match (parent: $x); get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 19);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testFemaleFather() {
         String queryString = "match (father: $x) isa parentship; $x has gender $g; $g val 'female'; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
-        List<Answer> answers2 =  genealogyKB.tx().graql().infer(true).materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = query.toList();
+        List<Answer> answers2 = genealogyKB.tx().graql().infer(true).materialise(true).<GetQuery>parse(queryString).toList();
         assertThat(answers, empty());
         assertThat(answers2, empty());
     }
@@ -437,20 +437,20 @@ public class GenealogyTest {
     public void testGrandMother() {
         String queryString = "match (grandmother: $x) isa grandparentship; $x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 4);
         assertTrue(checkResource(answers, "g", "female"));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
     public void testGrandDaughter(){
         String queryString = "match (granddaughter: $x); $x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 18);
         assertTrue(checkResource(answers, "g", "female"));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     @Test
@@ -458,10 +458,10 @@ public class GenealogyTest {
         String queryString = "match "+
                 "(grandchild: $x); (granddaughter: $x);$x has gender $g; get;";
         GetQuery query = iqb.parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertEquals(answers.size(), 18);
         assertTrue(checkResource(answers, "g", "female"));
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(queryString).toList());
     }
 
     private boolean checkResource(List<Answer> answers, String var, String value){

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GeoInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GeoInferenceTest.java
@@ -59,7 +59,7 @@ public class GeoInferenceTest {
         String queryString = "match (geo-entity: $x, entity-location: $x) isa is-located-in; get;";
 
         GetQuery query = iqb.materialise(false).parse(queryString);
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         assertThat(answers, empty());
     }
 
@@ -122,12 +122,12 @@ public class GeoInferenceTest {
         Concept poland = getConcept(graph, "name", "Poland");
         Concept europe = getConcept(graph, "name", "Europe");
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         answers.forEach(ans -> assertEquals(ans.size(), 2));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), poland.getId().getValue()));
         assertEquals(answers.size(), 6);
 
-        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
         answers2.forEach(ans -> assertEquals(ans.size(), 2));
         answers2.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), europe.getId().getValue()));
         assertEquals(answers2.size(), 21);
@@ -146,12 +146,12 @@ public class GeoInferenceTest {
                 "(geo-entity: $y, entity-location: $x) isa is-located-in;};" +
                 "$y has name 'Masovia'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
 
         answers.forEach(ans -> assertEquals(ans.size(), 2));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), masovia.getId().getValue()));
         assertEquals(answers.size(), 5);
-        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
         assertCollectionsEqual(answers, answers2);
     }
 
@@ -169,13 +169,13 @@ public class GeoInferenceTest {
                 "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                 "$y id '" + europe.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         answers.forEach(ans -> assertEquals(ans.size(), 2));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), poland.getId().getValue()));
         assertEquals(answers.size(), 6);
 
 
-        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
         answers2.forEach(ans -> assertEquals(ans.size(), 2));
         answers2.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), europe.getId().getValue()));
         assertEquals(answers2.size(), 21);
@@ -195,11 +195,11 @@ public class GeoInferenceTest {
                 "(geo-entity: $y, entity-location: $x) isa is-located-in;};" +
                 "$y id '" + masovia.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         answers.forEach(ans -> assertEquals(ans.size(), 2));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), masovia.getId().getValue()));
         assertEquals(answers.size(), 5);
-        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
+        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
         assertCollectionsEqual(answers, answers2);
     }
 
@@ -212,8 +212,8 @@ public class GeoInferenceTest {
                 "($r1: $x, $r2: $y) isa is-located-in;" +
                 "$y id '" + masovia.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
 
         answers.forEach(ans -> assertEquals(ans.size(), 4));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), masovia.getId().getValue()));
@@ -228,9 +228,9 @@ public class GeoInferenceTest {
         QueryBuilder iqb = geoKB.tx().graql().infer(true);
         String queryString = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 51);
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         assertCollectionsEqual(answers, answers2);
     }
 
@@ -239,8 +239,8 @@ public class GeoInferenceTest {
         QueryBuilder iqb = geoKB.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 102);
         assertCollectionsEqual(answers, answers2);
     }
@@ -254,8 +254,8 @@ public class GeoInferenceTest {
                 "($x, $y) isa is-located-in;" +
                 "$y id '" + masovia.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
 
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), masovia.getId().getValue()));
         assertEquals(answers.size(), 5);
@@ -268,11 +268,11 @@ public class GeoInferenceTest {
         QueryBuilder iqb = geoKB.tx().graql().infer(true);
         String queryString = "match ($r1: $x, $r2: $y) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         answers.forEach(ans -> assertEquals(ans.size(), 4));
         assertEquals(answers.size(), 408);
 
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         answers2.forEach(ans -> assertEquals(ans.size(), 4));
         assertCollectionsEqual(answers, answers2);
     }
@@ -286,11 +286,11 @@ public class GeoInferenceTest {
                 "$x ($r1: $x1, $r2: $x2) isa is-located-in;" +
                 "$x2 id '" + masovia.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 20);
         answers.forEach(ans -> assertEquals(ans.size(), 5));
 
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         answers2.forEach(ans -> assertEquals(ans.size(), 5));
         assertCollectionsEqual(answers, answers2);
     }
@@ -303,8 +303,8 @@ public class GeoInferenceTest {
                 .rel(var("r1").label("geo-entity"), var("x"))
                 .rel(var("r2").label("entity-location"), var("y"));
 
-        List<Answer> answers = iqb.match(rolePattern).get().execute();
-        List<Answer> answers2 = iqb.materialise(true).match(rolePattern).get().execute();
+        List<Answer> answers = iqb.match(rolePattern).get().toList();
+        List<Answer> answers2 = iqb.materialise(true).match(rolePattern).get().toList();
 
         answers.forEach(ans -> assertEquals(ans.size(), 4));
         assertEquals(answers.size(), 51);
@@ -317,8 +317,8 @@ public class GeoInferenceTest {
         QueryBuilder iqb = geoKB.tx().graql().infer(true);
         String queryString = "match ($x, $r2: $y) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
 
         answers.forEach(ans -> assertEquals(ans.size(), 3));
         assertEquals(answers.size(), 204);
@@ -335,8 +335,8 @@ public class GeoInferenceTest {
                 "($x, $r2: $y) isa is-located-in;" +
                 "$y id '" + masovia.getId().getValue() + "'; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
 
         answers.forEach(ans -> assertEquals(ans.size(), 3));
         answers.forEach(ans -> assertEquals(ans.get(var("y")).getId().getValue(), masovia.getId().getValue()));
@@ -352,8 +352,8 @@ public class GeoInferenceTest {
         QueryBuilder iqb = geoKB.tx().graql().infer(true);
         String queryString = "match $x (geo-entity: $x1, entity-location: $x2) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         assertEquals(answers.size(), 51);
         assertCollectionsEqual(answers, answers2);
     }
@@ -364,10 +364,10 @@ public class GeoInferenceTest {
         String queryString = "match $x isa is-located-in; get;";
         String queryString2 = "match $x ($x1, $x2) isa is-located-in;get $x;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
-        List<Answer> answers3 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
-        List<Answer> answers4 = iqb.materialise(true).<GetQuery>parse(queryString2).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
+        List<Answer> answers3 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
+        List<Answer> answers4 = iqb.materialise(true).<GetQuery>parse(queryString2).toList();
         assertCollectionsEqual(answers, answers2);
         assertCollectionsEqual(answers3, answers4);
         assertEquals(answers.size(), 51);
@@ -381,9 +381,9 @@ public class GeoInferenceTest {
         String queryString2 = "match (geo-entity: $x, entity-location: $y) isa is-located-in; limit 22; get;";
         String queryString3 = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).execute();
-        List<Answer> answers3 = iqb.materialise(false).<GetQuery>parse(queryString3).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 = iqb.materialise(false).<GetQuery>parse(queryString2).toList();
+        List<Answer> answers3 = iqb.materialise(false).<GetQuery>parse(queryString3).toList();
         assertTrue(answers3.containsAll(answers));
         assertTrue(answers3.containsAll(answers2));
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/RecursiveInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/RecursiveInferenceTest.java
@@ -345,10 +345,10 @@ public class RecursiveInferenceTest {
         String queryString = "match (N-rA: $x, N-rB: $y) isa N; $x has index 'c'; get $y;";
         String explicitQuery = "match $y isa a-entity; get;";
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> explicitAnswers = qb.<GetQuery>parse(explicitQuery).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> explicitAnswers = qb.<GetQuery>parse(explicitQuery).toList();
         assertCollectionsEqual(answers, explicitAnswers);
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
         assertCollectionsEqual(answers, answers2);
     }
 
@@ -399,9 +399,9 @@ public class RecursiveInferenceTest {
         String explicitQuery = "match $y isa vertex; get;";
 
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> explicitAnswers = qb.<GetQuery>parse(explicitQuery).execute();
-        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).execute();
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> explicitAnswers = qb.<GetQuery>parse(explicitQuery).toList();
+        List<Answer> answers2 = iqb.materialise(true).<GetQuery>parse(queryString).toList();
 
         assertCollectionsEqual(answers, explicitAnswers);
         assertCollectionsEqual(answers, answers2);
@@ -532,8 +532,8 @@ public class RecursiveInferenceTest {
 
         String queryString = "match (rel-from: $x, rel-to: $y) isa diagonal; get;";
 
-        assertEquals(iqb.materialise(false).<GetQuery>parse(queryString).execute().size(), 64);
-        assertEquals(iqb.materialise(true).<GetQuery>parse(queryString).execute().size(), 64);
+        assertEquals(iqb.materialise(false).<GetQuery>parse(queryString).toList().size(), 64);
+        assertEquals(iqb.materialise(true).<GetQuery>parse(queryString).toList().size(), 64);
     }
 
     private Concept getConcept(GraknTx graph, String typeName, Object val){

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/SNBInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/SNBInferenceTest.java
@@ -136,13 +136,13 @@ public class SNBInferenceTest {
                 "{$x has name 'Gary';$y has name 'Pink Floyd';}; get;";
 
         long startTime = System.nanoTime();
-        List<Answer> limitedAnswers = limitedQuery.execute();
+        List<Answer> limitedAnswers = limitedQuery.toList();
         System.out.println("limited time: " + (System.nanoTime() - startTime)/1e6);
 
         startTime = System.nanoTime();
-        List<Answer> answers = query.execute();
+        List<Answer> answers = query.toList();
         System.out.println("full time: " + (System.nanoTime()- startTime)/1e6);
-        assertCollectionsEqual(answers, qb.<GetQuery>parse(explicitQuery).execute());
+        assertCollectionsEqual(answers, qb.<GetQuery>parse(explicitQuery).toList());
         assertTrue(answers.containsAll(limitedAnswers));
     }
 
@@ -315,8 +315,8 @@ public class SNBInferenceTest {
                         "$z isa place; ($x, $y) isa knows; ($x, $z) isa resides; get $x, $z;";
         Unifier unifier = new UnifierImpl(ImmutableMap.of(Graql.var("z"), Graql.var("y")));
 
-        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).execute();
-        List<Answer> answers2 =  iqb.materialise(false).<GetQuery>parse(queryString2).execute().stream().map(a -> a.unify(unifier)).collect(Collectors.toList());
+        List<Answer> answers = iqb.materialise(false).<GetQuery>parse(queryString).toList();
+        List<Answer> answers2 =  iqb.materialise(false).<GetQuery>parse(queryString2).toList().stream().map(a -> a.unify(unifier)).collect(Collectors.toList());
         assertCollectionsEqual(answers, answers2);
     }
 

--- a/grakn-test-tools/src/main/java/ai/grakn/util/GraqlTestUtil.java
+++ b/grakn-test-tools/src/main/java/ai/grakn/util/GraqlTestUtil.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.Pattern;
 import ai.grakn.graql.QueryBuilder;
 
 import java.util.Collection;
+
 import org.apache.commons.collections.CollectionUtils;
 
 import static org.junit.Assert.assertFalse;
@@ -65,6 +66,6 @@ public class GraqlTestUtil {
     }
 
     public static void assertQueriesEqual(GetQuery q1, GetQuery q2) {
-        assertCollectionsEqual(q1.execute(), q2.execute());
+        assertCollectionsEqual(q1.toList(), q2.toList());
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -157,12 +157,12 @@ public class GrpcServerIT {
         List<Answer> answers;
 
         try (GraknTx tx = remoteSession.open(GraknTxType.READ)) {
-            answers = tx.graql().match(var("x").sub("thing")).get().execute();
+            answers = tx.graql().match(var("x").sub("thing")).get().toList();
         }
 
         int size;
         try (GraknTx tx = localSession.open(GraknTxType.READ)) {
-            size = tx.graql().match(var("x").sub("thing")).get().execute().size();
+            size = tx.graql().match(var("x").sub("thing")).get().toList().size();
         }
 
         assertThat(answers.toString(), answers, hasSize(size));
@@ -566,7 +566,7 @@ public class GrpcServerIT {
             exception.expect(GraqlQueryException.class);
             exception.expectMessage(GraqlQueryException.labelNotFound(Label.of("not-a-thing")).getMessage());
 
-            query.execute();
+            query.toList();
         }
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/reasoner/BenchmarkIT.java
@@ -104,7 +104,7 @@ public class BenchmarkIT {
         try(BatchExecutorClient loader = BatchExecutorClient.newBuilder().taskClient(graknClient).build()) {
             GraknTx tx = session.open(GraknTxType.READ);
             Var entityVar = var().asUserDefined();
-            ConceptId[] instances = tx.graql().match(entityVar.isa(entityLabel)).get().execute().stream()
+            ConceptId[] instances = tx.graql().match(entityVar.isa(entityLabel)).get().toList().stream()
                     .map(ans -> ans.get(entityVar).getId())
                     .toArray(ConceptId[]::new);
 
@@ -218,7 +218,7 @@ public class BenchmarkIT {
         try(BatchExecutorClient loader = BatchExecutorClient.newBuilder().taskClient(graknClient).build()){
             try(GraknTx tx = session.open(GraknTxType.READ)) {
                 Var entityVar = var().asUserDefined();
-                ConceptId[] instances = tx.graql().match(entityVar.isa(entityLabel)).get().execute().stream()
+                ConceptId[] instances = tx.graql().match(entityVar.isa(entityLabel)).get().toList().stream()
                         .map(ans -> ans.get(entityVar).getId())
                         .toArray(ConceptId[]::new);
 
@@ -349,8 +349,8 @@ public class BenchmarkIT {
         loadRuleChainData(N);
 
         try(GraknTx tx = session.open(GraknTxType.READ)) {
-            ConceptId firstId = Iterables.getOnlyElement(tx.graql().<GetQuery>parse("match $x has index 'first';get;").execute()).get("x").getId();
-            ConceptId lastId = Iterables.getOnlyElement(tx.graql().<GetQuery>parse("match $x has index '" + N + "';get;").execute()).get("x").getId();
+            ConceptId firstId = Iterables.getOnlyElement(tx.graql().<GetQuery>parse("match $x has index 'first';get;").toList()).get("x").getId();
+            ConceptId lastId = Iterables.getOnlyElement(tx.graql().<GetQuery>parse("match $x has index '" + N + "';get;").toList()).get("x").getId();
             String queryPattern = "(fromRole: $x, toRole: $y) isa relation" + N + ";";
             String queryString = "match " + queryPattern + " get;";
             String subbedQueryString = "match " +
@@ -378,7 +378,7 @@ public class BenchmarkIT {
 
     private List<Answer> executeQuery(GetQuery query, String msg) {
         final long startTime = System.currentTimeMillis();
-        List<Answer> results = query.execute();
+        List<Answer> results = query.toList();
         final long answerTime = System.currentTimeMillis() - startTime;
         LOG.debug(msg + " results = " + results.size() + " answerTime: " + answerTime);
         return results;

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/property/graql/GetQueryPropertyTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/property/graql/GetQueryPropertyTest.java
@@ -141,7 +141,7 @@ public class GetQueryPropertyTest {
     public void anyPropertyCanBeExecutedOnAMatchQuery(@Open GraknTx tx, VarProperty property){
         VarPatternAdmin pattern = Patterns.varPattern(Graql.var(), Collections.singleton(property));
         try {
-            tx.graql().match(pattern).get().execute();
+            tx.graql().match(pattern).get().toList();
         } catch(GraqlQueryException e){
             //Ignore
         }
@@ -164,7 +164,7 @@ public class GetQueryPropertyTest {
             return ;
         }
 
-        assertFalse(tx.graql().match(pattern).get().execute().isEmpty());
+        assertFalse(tx.graql().match(pattern).get().toList().isEmpty());
     }
 
     private Set<Answer> matchSet(GraknTx tx, Pattern pattern) {

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/property/graql/PatternPropertyTests.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/property/graql/PatternPropertyTests.java
@@ -77,7 +77,7 @@ public class PatternPropertyTests {
     @Property
     public void ifAPropertyUniquelyIdentifiesAConcept_0or1ResultsAreReturned(@Open GraknTx tx, VarProperty property){
         if(VarPropertyInternal.from(property).uniquelyIdentifiesConcept()){
-            List<Answer> results = tx.graql().match(Patterns.varPattern(Graql.var("x"), Collections.singleton(property))).get().execute();
+            List<Answer> results = tx.graql().match(Patterns.varPattern(Graql.var("x"), Collections.singleton(property))).get().toList();
             assertThat(results, hasSize(lessThanOrEqualTo(1)));
         }
     }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/property/kb/InsertQueryPropertyTest.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/property/kb/InsertQueryPropertyTest.java
@@ -53,7 +53,7 @@ public class InsertQueryPropertyTest {
     public void ifAPropertyCanBeInserted_AResultShouldBeReturned(@Open GraknTx tx, VarProperty property){
         VarPatternAdmin pattern = Patterns.varPattern(Graql.var("x"), Collections.singleton(property));
         try {
-            assertThat(tx.graql().insert(pattern).execute(), not(empty()));
+            assertThat(tx.graql().insert(pattern).toList(), not(empty()));
         } catch(GraqlQueryException | GraknTxOperationException e){
             // IGNORED
         }
@@ -69,6 +69,6 @@ public class InsertQueryPropertyTest {
 
         exception.expect(GraqlQueryException.class);
 
-        tx.graql().insert(pattern).execute();
+        tx.graql().insert(pattern).toList();
     }
 }

--- a/grakn-test/test-snb/src/main/java/ai/grakn/GraknShortQueryHandlers.java
+++ b/grakn-test/test-snb/src/main/java/ai/grakn/GraknShortQueryHandlers.java
@@ -198,7 +198,7 @@ public class GraknShortQueryHandlers {
                         var().rel(CREATOR, $person).rel(PRODUCT, $message).isa(HAS_CREATOR),
                         var().rel($message).rel($date).isa(has(CREATION_DATE)),
                         var().rel($message).rel($messageId).isa(key(MESSAGE_ID))
-                ).orderBy($date, Order.desc).limit(operation.limit()).get().execute();
+                ).orderBy($date, Order.desc).limit(operation.limit()).get().toList();
 
                 List<Answer> allResults = new ArrayList<>();
                 messageResults.forEach(a -> {
@@ -216,7 +216,7 @@ public class GraknShortQueryHandlers {
                             var().rel($author).rel($authorId).isa(key(PERSON_ID)),
                             var().rel($author).rel($firstName).isa(has(FIRST_NAME)),
                             var().rel($author).rel($lastName).isa(has(LAST_NAME))
-                    ).get().execute();
+                    ).get().toList();
 
                     allResults.addAll(results);
                 });
@@ -256,7 +256,7 @@ public class GraknShortQueryHandlers {
                         $person.has(PERSON_ID, operation.personId()),
                         var().rel($person).rel($friend).isa(KNOWS).has(CREATION_DATE, $date),
                         $friend.has(PERSON_ID, $friendId).has(FIRST_NAME, $firstName).has(LAST_NAME, $lastName)
-                ).get().execute();
+                ).get().toList();
 
                 List<LdbcShortQuery3PersonFriendsResult> result = results.stream()
                         .sorted(comparing(by($date)).reversed().thenComparing(by($friendId)))
@@ -290,7 +290,7 @@ public class GraknShortQueryHandlers {
                         $message.has(MESSAGE_ID, operation.messageId()),
                         var().rel($message).rel($date).isa(has(CREATION_DATE)),
                         (var().rel($message).rel($content).isa(has(CONTENT))).or(var().rel($message).rel($content).isa(has(IMAGE_FILE)))
-                ).get().execute();
+                ).get().toList();
 
                 if (!results.isEmpty()) {
                     Answer fres = results.get(0);
@@ -331,7 +331,7 @@ public class GraknShortQueryHandlers {
                         var().rel($person).rel($firstName).isa(has(FIRST_NAME)),
                         var().rel($person).rel($lastName).isa(has(LAST_NAME)),
                         var().rel($person).rel($personId).isa(key(PERSON_ID))
-                ).get().execute();
+                ).get().toList();
 
                 if (!results.isEmpty()) {
                     Answer fres = results.get(0);
@@ -370,7 +370,7 @@ public class GraknShortQueryHandlers {
                         $forum.has(FORUM_ID, $forumId).has(TITLE, $title),
                         var().rel(MODERATED, $forum).rel(MODERATOR, $mod).isa(HAS_MODERATOR),
                         $mod.isa(PERSON).has(PERSON_ID, $modId).has(FIRST_NAME, $firstName).has(LAST_NAME, $lastName)
-                ).get().execute();
+                ).get().toList();
 
                 if (!results.isEmpty()) {
                     Answer fres = results.get(0);
@@ -417,7 +417,7 @@ public class GraknShortQueryHandlers {
                         var().rel($author2).rel($personId).isa(key(PERSON_ID)),
                         var().rel($author2).rel($firstName).isa(has(FIRST_NAME)),
                         var().rel($author2).rel($lastName).isa(has(LAST_NAME))
-                ).get().execute();
+                ).get().toList();
 
                 List<LdbcShortQuery7MessageRepliesResult> result = results.stream()
                         .sorted(comparing(by($date)).reversed().thenComparing(by($personId)))

--- a/grakn-test/test-snb/src/main/java/ai/grakn/GraknUpdateQueryHandlers.java
+++ b/grakn-test/test-snb/src/main/java/ai/grakn/GraknUpdateQueryHandlers.java
@@ -175,7 +175,7 @@ public class GraknUpdateQueryHandlers {
 
                 insert.add(var().rel(LOCATED, $person).rel(REGION, $city).isa(IS_LOCATED_IN));
 
-                graph.graql().match(match.build()).insert(insert.build()).execute();
+                graph.graql().match(match.build()).insert(insert.build()).toList();
                 graph.commit();
 
                 reporter.report(0, LdbcNoResult.INSTANCE, operation);
@@ -198,12 +198,12 @@ public class GraknUpdateQueryHandlers {
             try (GraknTx graph = session.open(GraknTxType.WRITE)) {
 
                 graph.graql().match(
-                        $person.has(PERSON_ID, operation.personId()),
-                        $message.has(MESSAGE_ID, operation.postId())
-                ).insert(var()
-                        .rel(ADMIRER, $person).rel(LIKE, $message).isa(LIKES)
-                        .has(CREATION_DATE, fromDate(operation.creationDate()))
-                ).execute();
+                                $person.has(PERSON_ID, operation.personId()),
+                                $message.has(MESSAGE_ID, operation.postId())
+                        ).insert(var()
+                                .rel(ADMIRER, $person).rel(LIKE, $message).isa(LIKES)
+                                .has(CREATION_DATE, fromDate(operation.creationDate()))
+                        ).toList();
 
                 graph.commit();
 
@@ -227,12 +227,12 @@ public class GraknUpdateQueryHandlers {
             try (GraknTx graph = session.open(GraknTxType.WRITE)) {
 
                 graph.graql().match(
-                        $person.has(PERSON_ID, operation.personId()),
-                        $message.has(MESSAGE_ID, operation.commentId())
-                ).insert(var()
-                        .rel(ADMIRER, $person).rel(LIKE, $message).isa(LIKES)
-                        .has(CREATION_DATE, fromDate(operation.creationDate()))
-                ).execute();
+                                $person.has(PERSON_ID, operation.personId()),
+                                $message.has(MESSAGE_ID, operation.commentId())
+                        ).insert(var()
+                                .rel(ADMIRER, $person).rel(LIKE, $message).isa(LIKES)
+                                .has(CREATION_DATE, fromDate(operation.creationDate()))
+                        ).toList();
 
                 graph.commit();
 
@@ -275,7 +275,7 @@ public class GraknUpdateQueryHandlers {
 
                 insert.add(var().rel(MODERATOR, $mod).rel(MODERATED, $forum).isa(HAS_MODERATOR));
 
-                graph.graql().match(match.build()).insert(insert.build()).execute();
+                graph.graql().match(match.build()).insert(insert.build()).toList();
                 graph.commit();
 
                 reporter.report(0, LdbcNoResult.INSTANCE, operation);
@@ -298,12 +298,12 @@ public class GraknUpdateQueryHandlers {
             try (GraknTx graph = session.open(GraknTxType.WRITE)) {
 
                 graph.graql().match(
-                        $forum.has(FORUM_ID, operation.forumId()),
-                        $person.has(PERSON_ID, operation.personId())
-                ).insert(var()
-                        .rel(MEMBER, $person).rel(GROUP, $forum).isa(HAS_MEMBER)
-                        .has(JOIN_DATE, fromDate(operation.joinDate()))
-                ).execute();
+                                $forum.has(FORUM_ID, operation.forumId()),
+                                $person.has(PERSON_ID, operation.personId())
+                        ).insert(var()
+                                .rel(MEMBER, $person).rel(GROUP, $forum).isa(HAS_MEMBER)
+                                .has(JOIN_DATE, fromDate(operation.joinDate()))
+                        ).toList();
 
                 graph.commit();
 
@@ -361,7 +361,7 @@ public class GraknUpdateQueryHandlers {
                         var().rel(CONTAINED, $post).rel(CONTAINER, $forum).isa(CONTAINER_OF)
                 );
 
-                graph.graql().match(match.build()).insert(insert.build()).execute();
+                graph.graql().match(match.build()).insert(insert.build()).toList();
                 graph.commit();
 
                 reporter.report(0, LdbcNoResult.INSTANCE, operation);
@@ -413,7 +413,7 @@ public class GraknUpdateQueryHandlers {
                         var().rel(REPLY, $comment).rel(ORIGINAL, $original).isa(REPLY_OF)
                 );
 
-                graph.graql().match(match.build()).insert(insert.build()).execute();
+                graph.graql().match(match.build()).insert(insert.build()).toList();
 
                 graph.commit();
 
@@ -439,12 +439,12 @@ public class GraknUpdateQueryHandlers {
                 Var person2 = var("person2");
 
                 graph.graql().match(
-                        person1.has(PERSON_ID, operation.person1Id()),
-                        person2.has(PERSON_ID, operation.person2Id())
-                ).insert(var()
-                        .rel(FRIEND, person1).rel(FRIEND, person2).isa(KNOWS)
-                        .has(CREATION_DATE, fromDate(operation.creationDate()))
-                ).execute();
+                                person1.has(PERSON_ID, operation.person1Id()),
+                                person2.has(PERSON_ID, operation.person2Id())
+                        ).insert(var()
+                                .rel(FRIEND, person1).rel(FRIEND, person2).isa(KNOWS)
+                                .has(CREATION_DATE, fromDate(operation.creationDate()))
+                        ).toList();
 
                 graph.commit();
 


### PR DESCRIPTION
# Why is this PR needed?

The main reason is related to gRPC. Originally, all queries over gRPC would yield streams of results.
e.g. a `GetQuery` would get a stream of `Answer`s, `compute count` would return a stream containing just one number, a `DeleteQuery` would return an empty stream...

The Python client (and any other clients we implement) cannot tell the difference between these - for example, if the Python client receives an empty stream, is that:
1. An empty stream of answers from a `get` query?
2. An indication of "nothing" such as from a `delete` query?

There's no way to say! This PR changes the behaviour such that "proper" streaming queries return a stream of responses over gRPC, while ones that return a single result actually just return one result.

# What does the PR do?

As well as the fairly simple gRPC change, this also required a big refactor of `GetQuery` and `InsertQuery` to be parameterised on `Stream<Answer>` instead of `List<Answer>`. This is actually a very simple refactor, even if it's big.

I added in a new `toList` method, since the old behaviour was still helpful.

# Does it break backwards compatibility?

Yes, since `GetQuery#execute` and `InsertQuery#execute` return a different type now! But it's not data model, so it's fine.

# List of future improvements not on this PR

None.
