### PR TITLE
Explanation fixes

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.graql.admin;
 
+import com.google.common.base.Equivalence;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import javax.annotation.CheckReturnValue;
 
@@ -58,7 +60,7 @@ public interface AnswerExplanation {
      * @return answers this explanation is dependent on
      */
     @CheckReturnValue
-    ImmutableSet<Answer> getAnswers();
+    ImmutableList<Answer> getAnswers();
 
     /**
      *

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/AnswerExplanation.java
@@ -18,9 +18,7 @@
 
 package ai.grakn.graql.admin;
 
-import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import javax.annotation.CheckReturnValue;
 
 /**

--- a/grakn-engine/src/main/java/ai/grakn/engine/controller/response/ExplanationBuilder.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/controller/response/ExplanationBuilder.java
@@ -47,12 +47,13 @@ public class ExplanationBuilder {
             ai.grakn.graql.admin.Answer inferredAnswer = new QueryAnswer();
 
             if (expl.isLookupExplanation()){
-                ReasonerAtomicQuery rewrittenQuery = ReasonerQueries.atomic(atom.rewriteWithRelationVariable());
+                ReasonerAtomicQuery rewrittenQuery = ReasonerQueries.atomic(atom.isResource()? atom : atom.rewriteWithRelationVariable());
                 inferredAnswer = ReasonerQueries.atomic(rewrittenQuery, answer).getQuery().stream()
                         .findFirst().orElse(new QueryAnswer());
             } else if (expl.isRuleExplanation()) {
                 Atom headAtom = ((RuleExplanation) expl).getRule().getHead().getAtom();
-                ReasonerAtomicQuery rewrittenQuery = ReasonerQueries.atomic(headAtom.rewriteWithRelationVariable());
+                ReasonerAtomicQuery rewrittenQuery = ReasonerQueries.atomic(headAtom.isResource()? headAtom : headAtom.rewriteWithRelationVariable());
+
                 inferredAnswer = headAtom.getMultiUnifier(atom, UnifierType.RULE).stream()
                         .map(Unifier::inverse)
                         .flatMap(unifier -> rewrittenQuery.materialise(answer.unify(unifier)))

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/LabelFragment.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/gremlin/fragment/LabelFragment.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graql.internal.gremlin.fragment;
 
-import ai.grakn.GraknTx;
 import ai.grakn.concept.Label;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.graql.Var;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
@@ -42,7 +42,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -189,11 +190,11 @@ public class QueryAnswer implements Answer {
         );
     }
 
-    public AnswerExplanation mergeExplanation(Answer toMerge) {
-        Set<Answer> partialAnswers = new HashSet<>();
-        if (this.getExplanation().isJoinExplanation()) this.getExplanation().getAnswers().forEach(partialAnswers::add);
+    private AnswerExplanation mergeExplanation(Answer toMerge) {
+        List<Answer> partialAnswers = new ArrayList<>();
+        if (this.getExplanation().isJoinExplanation()) partialAnswers.addAll(this.getExplanation().getAnswers());
         else partialAnswers.add(this);
-        if (toMerge.getExplanation().isJoinExplanation()) toMerge.getExplanation().getAnswers().forEach(partialAnswers::add);
+        if (toMerge.getExplanation().isJoinExplanation()) partialAnswers.addAll(toMerge.getExplanation().getAnswers());
         else partialAnswers.add(toMerge);
         return new JoinExplanation(partialAnswers);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/Explanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/Explanation.java
@@ -22,11 +22,8 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/Explanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/Explanation.java
@@ -21,8 +21,11 @@ package ai.grakn.graql.internal.reasoner.explanation;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -37,19 +40,19 @@ import java.util.Set;
 public class Explanation implements AnswerExplanation {
 
     private final ReasonerQuery query;
-    private final ImmutableSet<Answer> answers;
+    private final ImmutableList<Answer> answers;
 
     public Explanation(){
         this.query = null;
-        this.answers = ImmutableSet.of();}
-    Explanation(ReasonerQuery q, Set<Answer> ans){
+        this.answers = ImmutableList.of();}
+    Explanation(ReasonerQuery q, List<Answer> ans){
         this.query = q;
-        this.answers = ImmutableSet.copyOf(ans);
+        this.answers = ImmutableList.copyOf(ans);
     }
     Explanation(ReasonerQuery q){
-        this(q, new HashSet<>());
+        this(q, new ArrayList<>());
     }
-    Explanation(Set<Answer> ans){
+    Explanation(List<Answer> ans){
         this(null, ans);
     }
 
@@ -64,7 +67,7 @@ public class Explanation implements AnswerExplanation {
     }
 
     @Override
-    public ImmutableSet<Answer> getAnswers(){ return answers;}
+    public ImmutableList<Answer> getAnswers(){ return answers;}
 
     @Override
     public boolean isLookupExplanation(){ return false;}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/JoinExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/JoinExplanation.java
@@ -22,7 +22,9 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
+import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
 import com.google.common.collect.Sets;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -37,19 +39,19 @@ import java.util.stream.Collectors;
  */
 public class JoinExplanation extends Explanation {
 
-    public JoinExplanation(Set<Answer> answers){ super(answers);}
+    public JoinExplanation(List<Answer> answers){ super(answers);}
     public JoinExplanation(ReasonerQueryImpl q, Answer mergedAnswer){
         super(q, q.selectAtoms().stream()
                 .map(at -> at.inferTypes(mergedAnswer.project(at.getVarNames())))
                 .map(ReasonerQueries::atomic)
                 .map(aq -> mergedAnswer.project(aq.getVarNames()).explain(new LookupExplanation(aq)))
-                .collect(Collectors.toSet())
+                .collect(Collectors.toList())
         );
     }
 
     @Override
     public AnswerExplanation childOf(Answer ans) {
-        return new JoinExplanation(Sets.union(this.getAnswers(), ans.getExplanation().getAnswers()));
+        return new JoinExplanation(ReasonerUtils.listUnion(this.getAnswers(), ans.getExplanation().getAnswers()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/JoinExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/JoinExplanation.java
@@ -23,9 +23,7 @@ import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
-import com.google.common.collect.Sets;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/LookupExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/LookupExplanation.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.internal.reasoner.explanation;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -35,7 +36,7 @@ import java.util.Set;
 public class LookupExplanation extends Explanation {
 
     public LookupExplanation(ReasonerQuery q){ super(q);}
-    private LookupExplanation(ReasonerQuery q, Set<Answer> answers){
+    private LookupExplanation(ReasonerQuery q, List<Answer> answers){
         super(q, answers);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/LookupExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/LookupExplanation.java
@@ -22,7 +22,6 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
 import java.util.List;
-import java.util.Set;
 
 /**
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/RuleExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/RuleExplanation.java
@@ -23,10 +23,8 @@ import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
 import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
-import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 /**
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/RuleExplanation.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/explanation/RuleExplanation.java
@@ -22,8 +22,10 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.AnswerExplanation;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
+import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
 import com.google.common.collect.Sets;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -43,7 +45,7 @@ public class RuleExplanation extends Explanation {
         super(q);
         this.rule = rl;
     }
-    private RuleExplanation(ReasonerQuery q, Set<Answer> answers, InferenceRule rl){
+    private RuleExplanation(ReasonerQuery q, List<Answer> answers, InferenceRule rl){
         super(q, answers);
         this.rule = rl;
     }
@@ -56,7 +58,11 @@ public class RuleExplanation extends Explanation {
     @Override
     public AnswerExplanation childOf(Answer ans) {
         AnswerExplanation explanation = ans.getExplanation();
-        return new RuleExplanation(getQuery(), Sets.union(this.getAnswers(), explanation.isLookupExplanation()? Collections.singleton(ans) : explanation.getAnswers()) , getRule());
+        return new RuleExplanation(getQuery(),
+                ReasonerUtils.listUnion(this.getAnswers(), explanation.isLookupExplanation()?
+                        Collections.singletonList(ans) :
+                        explanation.getAnswers()),
+                getRule());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
@@ -68,6 +68,19 @@ public abstract class ReasonerQueryEquivalence extends Equivalence<ReasonerQuery
         return query.getAtoms(Atom.class).anyMatch(atom2 -> equivalenceFunction.apply(atom, atom2));
     }
 
+    public final static Equivalence<ReasonerQuery> Equality = new ReasonerQueryEquivalence(){
+
+        @Override
+        protected boolean doEquivalent(ReasonerQuery q1, ReasonerQuery q2) {
+            return equivalence(q1, q2, Atomic::equals);
+        }
+
+        @Override
+        protected int doHash(ReasonerQuery q) {
+            return equivalenceHash(q, Atomic.class, Atomic::hashCode);
+        }
+    };
+
     public final static Equivalence<ReasonerQuery> AlphaEquivalence = new ReasonerQueryEquivalence(){
 
         @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
@@ -68,19 +68,6 @@ public abstract class ReasonerQueryEquivalence extends Equivalence<ReasonerQuery
         return query.getAtoms(Atom.class).anyMatch(atom2 -> equivalenceFunction.apply(atom, atom2));
     }
 
-    public final static Equivalence<ReasonerQuery> Equality = new ReasonerQueryEquivalence(){
-
-        @Override
-        protected boolean doEquivalent(ReasonerQuery q1, ReasonerQuery q2) {
-            return equivalence(q1, q2, Atomic::equals);
-        }
-
-        @Override
-        protected int doHash(ReasonerQuery q) {
-            return equivalenceHash(q, Atomic.class, Atomic::hashCode);
-        }
-    };
-
     public final static Equivalence<ReasonerQuery> AlphaEquivalence = new ReasonerQueryEquivalence(){
 
         @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -310,5 +311,11 @@ public class ReasonerUtils {
         ArrayList<T> list = new ArrayList<>(a);
         b.forEach(list::remove);
         return list;
+    }
+
+    public static <T> List<T> listUnion(List<T> a, List<T> b){
+        List<T> union = new ArrayList<>(a);
+        union.addAll(b);
+        return union;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/utils/ReasonerUtils.java
@@ -313,6 +313,13 @@ public class ReasonerUtils {
         return list;
     }
 
+    /**
+     *
+     * @param a union left operand
+     * @param b union right operand
+     * @param <T> list type
+     * @return new list being a union of the two operands
+     */
     public static <T> List<T> listUnion(List<T> a, List<T> b){
         List<T> union = new ArrayList<>(a);
         union.addAll(b);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
@@ -31,6 +31,7 @@ import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.test.kbs.GenealogyKB;
 import ai.grakn.test.kbs.GeoKB;
 import ai.grakn.util.GraknTestUtil;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -312,7 +313,7 @@ public class ExplanationTest {
     }
 
     private void checkAnswerConnectedness(Answer answer){
-        ImmutableSet<Answer> answers = answer.getExplanation().getAnswers();
+        ImmutableList<Answer> answers = answer.getExplanation().getAnswers();
         answers.forEach(a -> {
             assertTrue("Disconnected answer in explanation",
                     answers.stream()

--- a/grakn-test-tools/src/main/graql/explanationTest.gql
+++ b/grakn-test-tools/src/main/graql/explanationTest.gql
@@ -7,22 +7,18 @@ role2 sub role;
 
 #Entities
 
-entity1 sub entity
+genericEntity sub entity
     has name
     plays role1
     plays role2;
 
 #Relations
 
-relation1 sub relationship
+baseRelation sub relationship
     relates role1
     relates role2;
 
-relation2 sub relationship
-    relates role1
-    relates role2;
-
-relation3 sub relationship
+anotherBaseRelation sub relationship
     relates role1
     relates role2;
 
@@ -34,109 +30,31 @@ inferredRelation sub relationship
 
 "name" sub attribute, datatype string;
 
-insert
-
-$a1 isa entity1, has name "a1";
-$a2 isa entity1, has name "a2";
-$b isa entity1, has name "b";
-$c isa entity1, has name "c";
-
-(role1:$a1, role2:$c) isa relation2;
-(role1:$a2, role2:$c) isa relation2;
-(role1:$a1, role2:$b) isa relation1;
-(role1:$a2, role2:$b) isa relation1;
-(role1:$b, role2:$c) isa inferredRelation;
-
-
-define
-
 rule-1 sub rule
     when {
-    	(role1: $x, role2: $y) isa relation1;
+    	(role1: $x, role2: $y) isa baseRelation;
     	($y, $z) isa inferredRelation;
-    	($z, $u) isa relation2;
-    	($u, $v) isa relation1;
+    	($z, $u) isa anotherBaseRelation;
+    	($u, $v) isa baseRelation;
     	(role1: $v, role2: $w) isa inferredRelation;
     }
     then {
     	(role1: $x, role2: $w) isa inferredRelation;
     };
 
-object sub role;
-subject sub role;
-location sub role;
-place sub role;
-operated sub role;
-operator sub role;
-owned sub role;
-owner sub role;
-
-geo-location sub entity
-    plays location
-    plays subject;
-
-asset sub entity
-    plays place
-    plays owned
-    plays operated;
-
-company sub entity
-    plays operator
-    plays owner
-    plays subject;
-
-factor sub entity
-    has value
-    plays object;
-
-carried-relation sub relationship
-    relates object
-    relates subject;
-
-coordinates sub relationship
-    relates location
-    relates place;
-
-operates sub relationship
-    relates operated
-    relates operator;
-
-owns sub relationship
-    relates owned
-    relates owner;
-
-value sub attribute, datatype string;
-
-carryRelation sub rule
-when {
-  $geo isa geo-location;
-  $asset isa asset;
-  $company isa company;
-  (object: $obj, subject: $geo) isa carried-relation;
-  (location: $geo, place: $asset) isa coordinates;
-  (operated: $asset, operator: $company) isa operates;
-}
-then {
-  (object: $obj, subject: $company) isa carried-relation;
-};
-
-assetOperator sub rule
-when {
-  $a isa company;
-  $b isa asset;
-  (owner: $a, owned: $b) isa owns;
-}
-then {
-  (operator: $a, operated: $b) isa operates;
-};
-
 insert
 
-$fac isa factor, has value 'high';
-$geo isa geo-location;
-$asset isa asset;
-$company isa company;
-(object: $fac, subject: $geo) isa carried-relation;
-(location: $geo, place: $asset) isa coordinates;
-(owned: $asset, owner: $company) isa owns;
+$a1 isa genericEntity, has name "a1";
+$a2 isa genericEntity, has name "a2";
+$b isa genericEntity, has name "b";
+$c isa genericEntity, has name "c";
+
+(role1:$a1, role2:$c) isa anotherBaseRelation;
+(role1:$a2, role2:$c) isa anotherBaseRelation;
+(role1:$a1, role2:$b) isa baseRelation;
+(role1:$a2, role2:$b) isa baseRelation;
+(role1:$b, role2:$c) isa inferredRelation;
+
+
+
 

--- a/grakn-test-tools/src/main/graql/explanationTest2.gql
+++ b/grakn-test-tools/src/main/graql/explanationTest2.gql
@@ -1,0 +1,79 @@
+define
+
+object sub role;
+subject sub role;
+location sub role;
+place sub role;
+operated sub role;
+operator sub role;
+owned sub role;
+owner sub role;
+
+geo-location sub entity
+    plays location
+    plays subject;
+
+asset sub entity
+    plays place
+    plays owned
+    plays operated;
+
+company sub entity
+    plays operator
+    plays owner
+    plays subject;
+
+factor sub entity
+    has value
+    plays object;
+
+carried-relation sub relationship
+    relates object
+    relates subject;
+
+coordinates sub relationship
+    relates location
+    relates place;
+
+operates sub relationship
+    relates operated
+    relates operator;
+
+owns sub relationship
+    relates owned
+    relates owner;
+
+value sub attribute, datatype string;
+
+carryRelation sub rule
+when {
+  $geo isa geo-location;
+  $asset isa asset;
+  $company isa company;
+  (object: $obj, subject: $geo) isa carried-relation;
+  (location: $geo, place: $asset) isa coordinates;
+  (operated: $asset, operator: $company) isa operates;
+}
+then {
+  (object: $obj, subject: $company) isa carried-relation;
+};
+
+assetOperator sub rule
+when {
+  $a isa company;
+  $b isa asset;
+  (owner: $a, owned: $b) isa owns;
+}
+then {
+  (operator: $a, operated: $b) isa operates;
+};
+
+insert
+
+$fac isa factor, has value 'high';
+$geo isa geo-location;
+$asset isa asset;
+$company isa company;
+(object: $fac, subject: $geo) isa carried-relation;
+(location: $geo, place: $asset) isa coordinates;
+(owned: $asset, owner: $company) isa owns;

--- a/grakn-test-tools/src/main/graql/explanationTest3.gql
+++ b/grakn-test-tools/src/main/graql/explanationTest3.gql
@@ -1,0 +1,39 @@
+define
+
+column sub entity
+    plays tagged
+    plays linked-column;
+
+tag sub entity
+    has tag-type
+    plays tagger;
+
+tagging sub relationship
+    relates tagged
+    relates tagger;
+
+same-tag-column-link sub relationship
+    relates linked-column;
+
+tag-type sub attribute, datatype string;
+
+same-tag-column-linking sub rule,
+when {
+	$col1 isa column;
+	$col2 isa column;
+	$tag isa tag, has tag-type "dimension";
+	(tagged: $col1, tagger: $tag) isa tagging;
+	(tagged: $col2, tagger: $tag) isa tagging;
+	$col1 != $col2;
+},
+then {
+	(linked-column: $col1, linked-column: $col2) isa same-tag-column-link;
+};
+
+insert
+
+$col1 isa column;
+$col2 isa column;
+$tag isa tag, has tag-type "dimension";
+(tagged: $col1, tagger: $tag) isa tagging;
+(tagged: $col2, tagger: $tag) isa tagging;


### PR DESCRIPTION
# Why is this PR needed?
Fixes issues:
- not differentiating partial answers if they come from two equivalent queries
- visualising implicit attribute relations when not asked to

# What does the PR do?
Switch to list storage in explanations instead of a set. Adds an extra condition when building concepts for visualisation.

# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.