### PR TITLE
Change how gRPC handles single and void queries

### DIFF
--- a/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
+++ b/grakn-client/src/test/java/ai/grakn/remote/RemoteGraknTxTest.java
@@ -208,7 +208,7 @@ public class RemoteGraknTxTest {
         TxResponse response =
                 TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("true")).build();
 
-        server.setResponseSequence(GrpcUtil.execQueryRequest(query), response);
+        server.setResponse(GrpcUtil.execQueryRequest(query), response);
 
         try (GraknTx tx = RemoteGraknTx.create(session, GrpcUtil.openRequest(KEYSPACE, GraknTxType.WRITE))) {
             verify(server.requests()).onNext(any()); // The open request

--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -32,10 +32,12 @@ import ai.grakn.exception.GraknException;
 import ai.grakn.exception.GraknTxOperationException;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.exception.GraqlSyntaxException;
+import ai.grakn.graql.DeleteQuery;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.admin.Answer;
+import ai.grakn.graql.analytics.CountQuery;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.grpc.ConceptMethod;
 import ai.grakn.grpc.ConceptMethods;
@@ -155,7 +157,7 @@ public class GrpcServerTest {
         when(qb.parse(QUERY)).thenReturn(query);
         when(qb.infer(anyBoolean())).thenReturn(qb);
 
-        when(query.results(any())).thenAnswer(params -> Stream.of(QueryResult.getDefaultInstance()));
+        when(query.execute()).thenAnswer(params -> Stream.of(new QueryAnswer()));
     }
 
     @After
@@ -288,8 +290,8 @@ public class GrpcServerTest {
             tx.send(execQueryRequest(QUERY, null));
         }
 
-        ai.grakn.graql.Query<?> query = tx.graql().parse(QUERY);
-        verify(query).results(any());
+        GetQuery query = tx.graql().parse(QUERY);
+        verify(query).stream();
     }
 
     @Test
@@ -309,8 +311,6 @@ public class GrpcServerTest {
                 new QueryAnswer(ImmutableMap.of(Graql.var("y"), conceptY))
         );
 
-        // TODO: reduce wtf
-        when(query.results(any())).thenAnswer(params -> query.stream().map(params.<GrpcConverter>getArgument(0)::convert));
         when(query.stream()).thenAnswer(params -> answers.stream());
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
@@ -365,9 +365,6 @@ public class GrpcServerTest {
                 new QueryAnswer(ImmutableMap.of(Graql.var("y"), conceptY))
         );
 
-        // TODO: reduce wtf
-        when(query.results(any())).thenAnswer(params -> query.stream().map(params.<GrpcConverter>getArgument(0)::convert));
-
         // Produce an endless stream of results - this means if the behaviour is not lazy this will never terminate
         when(query.stream()).thenAnswer(params -> Stream.generate(answers::stream).flatMap(Function.identity()));
 
@@ -389,6 +386,44 @@ public class GrpcServerTest {
             TxResponse response = tx.receive().ok();
 
             assertEquals(doneResponse(), response);
+        }
+    }
+
+    @Test
+    public void whenExecutingAQueryRemotelyThatReturnsOneResult_ReturnOneResult() throws InterruptedException {
+        String COUNT_QUERY = "compute count;";
+        CountQuery countQuery = mock(CountQuery.class);
+        when(tx.graql().parse(COUNT_QUERY)).thenReturn(countQuery);
+
+        when(countQuery.execute()).thenReturn(100L);
+
+        try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
+            tx.receive();
+
+            tx.send(execQueryRequest(COUNT_QUERY, null));
+
+            TxResponse expected =
+                    TxResponse.newBuilder().setQueryResult(QueryResult.newBuilder().setOtherResult("100")).build();
+
+            assertEquals(expected, tx.receive().ok());
+        }
+    }
+
+    @Test
+    public void whenExecutingAQueryRemotelyWithNoResult_ReturnDone() throws InterruptedException {
+        String DELETE_QUERY = "match $x isa person; delete $x";
+        DeleteQuery deleteQuery = mock(DeleteQuery.class);
+        when(tx.graql().parse(DELETE_QUERY)).thenReturn(deleteQuery);
+
+        when(deleteQuery.execute()).thenReturn(null);
+
+        try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
+            tx.send(openRequest(MYKS, GraknTxType.WRITE));
+            tx.receive();
+
+            tx.send(execQueryRequest(DELETE_QUERY, null));
+            assertEquals(GrpcUtil.doneResponse(), tx.receive().ok());
         }
     }
 
@@ -702,7 +737,7 @@ public class GrpcServerTest {
         String message = "your query is dumb";
         GraknException error = GraqlQueryException.create(message);
 
-        when(query.results(any())).thenThrow(error);
+        when(query.stream()).thenThrow(error);
 
         try (TxGrpcCommunicator tx = TxGrpcCommunicator.create(stub)) {
             tx.send(openRequest(MYKS, GraknTxType.WRITE));


### PR DESCRIPTION
# Why is this PR needed?

The main reason is related to gRPC. Originally, all queries over gRPC would yield streams of results.
e.g. a `GetQuery` would get a stream of `Answer`s, `compute count` would return a stream containing just one number, a `DeleteQuery` would return an empty stream...

The Python client (and any other clients we implement) cannot tell the difference between these - for example, if the Python client receives an empty stream, is that:
1. An empty stream of answers from a `get` query?
2. An indication of "nothing" such as from a `delete` query?

There's no way to say! This PR changes the behaviour such that "proper" streaming queries return a stream of responses over gRPC, while ones that return a single result actually just return one result.

# What does the PR do?

I made the gRPC change to hackily check if the query in question is `instanceof Streamable`. 

In [my previous attempt](https://github.com/graknlabs/grakn/pull/2733), I took a different approach involving changing the generics. I thought this would be more correct, but it lead to way more hacks than I expected!

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

It seems like maybe we need two generics on the `Query` class - one for a "lazy" result and another for a "strict" result:

```
interface Query<Lazy, Strict> {
    Lazy lazyExecute();
    Strict strictExecute();
}

class DeleteQuery extends Query<Void, Void> {}

class CountQuery extends Query<Long, Long> {}

class GetQuery extends Query<Stream<Answer>, List<Answer>> {}
```

...but this is a pretty significantly breaking change (in terms of the Java API).