### PR TITLE
Fix a race condition in a test

### DIFF
--- a/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/rpc/GrpcServerTest.java
@@ -224,7 +224,7 @@ public class GrpcServerTest {
     }
 
     @Test
-    public void whenOpeningTwoTransactions_TransactionsAreOpenedInDifferentThreads() {
+    public void whenOpeningTwoTransactions_TransactionsAreOpenedInDifferentThreads() throws InterruptedException {
         List<Thread> threads = new ArrayList<>();
 
         when(txFactory.tx(MYKS, GraknTxType.WRITE)).thenAnswer(invocation -> {
@@ -238,6 +238,9 @@ public class GrpcServerTest {
         ) {
             tx1.send(openRequest(MYKS, GraknTxType.WRITE));
             tx2.send(openRequest(MYKS, GraknTxType.WRITE));
+
+            tx1.receive();
+            tx2.receive();
         }
 
         assertNotEquals(threads.get(0), threads.get(1));


### PR DESCRIPTION
# Why is this PR needed?

The race condition caused a random failure!

# What does the PR do?

Fixes the race condition, by making sure we get a response from the gRPC server before checking that it did the right thing.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.
