### PR TITLE
Fix as syntax bug and add test

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelatesProperty.java
@@ -100,7 +100,7 @@ public abstract class RelatesProperty extends AbstractVarProperty {
 
     @Override
     public Stream<VarPatternAdmin> innerVarPatterns() {
-        return Stream.of(role());
+        return superRole() == null ? Stream.of(role()) : Stream.of(superRole(), role());
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -461,6 +461,23 @@ public class DefineQueryTest {
     }
 
     @Test
+    public void whenDefiningARelationship_SubRoleCasUseAs() {
+        qb.define(label("parentship").sub(label(RELATIONSHIP.getLabel()))
+                .relates("parent")
+                .relates("child")).execute();
+        qb.define(label("fatherhood").sub(label(RELATIONSHIP.getLabel()))
+                .relates("father", "parent")
+                .relates("son", "child")).execute();
+
+        RelationshipType marriage = movies.tx().getRelationshipType("fatherhood");
+        Role father = movies.tx().getRole("father");
+        Role son = movies.tx().getRole("son");
+        assertThat(marriage.relates().toArray(), arrayContainingInAnyOrder(father, son));
+        assertEquals(movies.tx().getRole("parent"), father.sup());
+        assertEquals(movies.tx().getRole("child"), son.sup());
+    }
+
+    @Test
     public void whenDefiningARule_SubRuleDeclarationsCanBeSkipped() {
         Pattern when = qb.parser().parsePattern("$x isa entity");
         Pattern then = qb.parser().parsePattern("$x isa entity");


### PR DESCRIPTION
# Why is this PR needed?
Because there is this annoying bug...
# What does the PR do?
Fix `as` syntax
# Does it break backwards compatibility?
No
# List of future improvements not on this PR
n/a