### PR TITLE
Java library > setup section updated to provide information about using the gRPC client

### DIFF
--- a/docs/pages/docs/08-java-library/advanced.md
+++ b/docs/pages/docs/08-java-library/advanced.md
@@ -19,8 +19,8 @@ The following would result in an exception because the first transaction `tx1` w
 
 <!-- Ignored because this is designed to crash! -->
 ```java-test-ignore
-tx1 = Grakn.session(uri, "MyKnowledgeBase").open(GraknTxType.WRITE);
-tx2 = Grakn.session(uri, "MyKnowledgeBase").open(GraknTxType.WRITE);
+tx1 = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
+tx2 = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 ```
 
 If you require multiple transactions open at the same time then you must do this on different threads. This is best illustrated with an example. Let's say that you wish to create 100 entities of a specific type concurrently.  The following will achieve that:

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -25,7 +25,7 @@ Let's see how we can build the same schema exclusively via the Core API.
 First we need a knowledge graph. For this example we will just use an
 [in-memory knowledge graph](./setup#initialising-a-transaction-on-the-knowledge-base):
 
-```java
+```java-test-ignore
 GraknTx tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 ```
 
@@ -159,7 +159,7 @@ insert $x isa person has firstname "John";
 
 Now the equivalent Core API:    
 
-```java
+```java-test-ignore
 tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 
 Attribute johnName = firstname.putAttribute("John"); //Create the attribute

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -26,7 +26,7 @@ First we need a knowledge graph. For this example we will just use an
 [in-memory knowledge graph](./setup#initialising-a-transaction-on-the-knowledge-base):
 
 ```java
-GraknTx tx = Grakn.session(Grakn.IN_MEMORY, "myknowlegdebase").open(GraknTxType.WRITE);
+GraknTx tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 ```
 
 We need to define our constructs before we can use them. We will begin by defining our attribute types since they are used everywhere. In Graql, they were defined as follows:
@@ -160,7 +160,7 @@ insert $x isa person has firstname "John";
 Now the equivalent Core API:    
 
 ```java
-tx = Grakn.session(Grakn.IN_MEMORY, "myknowlegdebase").open(GraknTxType.WRITE);
+tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 
 Attribute johnName = firstname.putAttribute("John"); //Create the attribute
 person.addEntity().attribute(johnName); //Link it to an entity

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -49,7 +49,7 @@ gender sub attribute datatype string;
 
 These same attribute types can be built with the Core API as follows:
 
-```java
+```java-test-ignore
 AttributeType identifier = tx.putAttributeType("identifier", AttributeType.DataType.STRING);
 AttributeType firstname = tx.putAttributeType("firstname", AttributeType.DataType.STRING);
 AttributeType surname = tx.putAttributeType("surname", AttributeType.DataType.STRING);
@@ -78,7 +78,7 @@ parentship sub relationship
 
 Using the Core API:
 
-```java
+```java-test-ignore
 Role spouse1 = tx.putRole("spouse1");
 Role spouse2 = tx.putRole("spouse2");
 RelationshipType marriage = tx.putRelationshipType("marriage")
@@ -116,7 +116,7 @@ person sub entity
 
 Using the Core API:
 
-```java
+```java-test-ignore
 EntityType person = tx.putEntityType("person")
                         .plays(parent)
                         .plays(child)
@@ -136,13 +136,13 @@ person.attribute(gender);
 
 Now to commit the schema using the Core API:
 
-```java
+```java-test-ignore
 tx.commit();
 ```
 
 If you do not wish to commit the schema you can revert your changes with:
 
-```java
+```java-test-ignore
 tx.abort();
 ```
 
@@ -179,7 +179,7 @@ insert
 
 With the Core API this would be:
 
-```java
+```java-test-ignore
 //Create the attributes
 johnName = firstname.putAttribute("John");
 Attribute maryName = firstname.putAttribute("Mary");
@@ -205,7 +205,7 @@ insert
 
 Now the equivalent using the Core API:
 
-```java
+```java-test-ignore
 Attribute weddingPicture = picture.putAttribute("www.LocationOfMyPicture.com");
 theMarriage.attribute(weddingPicture);
 ```
@@ -225,7 +225,7 @@ define
 
 becomes the following with the Core API:
 
-```java
+```java-test-ignore
 EntityType event = tx.putEntityType("event");
 EntityType wedding = tx.putEntityType("wedding").sup(event);
 ```
@@ -261,7 +261,7 @@ then {
 
 As there is more than one way to define Graql patterns through the API, there are several ways to construct rules. One options is through the Pattern factory:
 
-```java
+```java-test-ignore
 Pattern rule1when = var().rel("parent", "p").rel("child", "c").isa("Parent");
 Pattern rule1then = var().rel("ancestor", "p").rel("descendant", "c").isa("Ancestor");
 
@@ -274,7 +274,7 @@ Pattern rule2then = var().rel("ancestor", "p").rel("descendant", "d").isa("Ances
 
 If we have a specific `GraknTx tx` already defined, we can use the Graql pattern parser:
 
-```java
+```java-test-ignore
 rule1when = and(tx.graql().parser().parsePatterns("(parent: $p, child: $c) isa Parent;"));
 rule1then = and(tx.graql().parser().parsePatterns("(ancestor: $p, descendant: $c) isa Ancestor;"));
 
@@ -284,7 +284,7 @@ rule2then = and(tx.graql().parser().parsePatterns("(ancestor: $p, descendant: $d
 
 We conclude the rule creation with defining the rules from their constituent patterns:
 
-```java
+```java-test-ignore
 Rule rule1 = tx.putRule("R1", rule1when, rule1then);
 Rule rule2 = tx.putRule("R2", rule2when, rule2then);
 ```

--- a/docs/pages/docs/08-java-library/graql-api.md
+++ b/docs/pages/docs/08-java-library/graql-api.md
@@ -16,7 +16,7 @@ To use the API, add the following to your `pom.xml`:
 <dependency>
   <groupId>ai.grakn</groupId>
   <artifactId>grakn-graql</artifactId>
-  <version>${project.version}</version>
+  <version>1.2.0</version>
 </dependency>
 ```
 
@@ -37,7 +37,7 @@ import static ai.grakn.graql.Graql.*;
 A `QueryBuilder` is constructed from a `GraknTx`:
 
 ```java-test-ignore
-GraknTx tx = Grakn.session(Grakn.IN_MEMORY, "MyGraph").open(GraknTxType.WRITE);
+GraknTx tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
 QueryBuilder qb = tx.graql();
 ```
 

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -59,30 +59,21 @@ Here are some links to guides for adding external jars using different IDEs:
 - [Netbeans](http://oopbook.com/java-classpath-2/classpath-in-netbeans/)
 
 
-## Initialising a Transaction on The knowledge graph
+## Connecting to Grakn
 
-You can initialise an in memory knowledge graph without having the Grakn server running with:
-
-<!-- These are ignored in tests because they connect to non-existent servers -->
-```java
-GraknTx tx = Grakn.session(Grakn.IN_MEMORY, "keyspace").open(GraknTxType.WRITE);
-```    
-
-If you are running the Grakn server locally then you can initialise a knowledge graph with:
+First, make sure that Grakn is running. Otherwise, boot it up with `grakn server start`. Now, connect to Grakn with:
 
 ```java-test-ignore
-tx = Grakn.session(Grakn.DEFAULT_URI, "keyspace").open(GraknTxType.WRITE);
+GraknSession session = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+try (GraknTx tx = session.open(GraknTxType.READ)) {
+  // ...
+}
+
 ```
 
-If you are running the Grakn server remotely you must initialise the knowledge graph by providing the IP address of your server:
+A "Keyspace" uniquely identifies the knowledge graph and allows you to create different knowledge graphs.
 
-```java-test-ignore
-tx = Grakn.session("127.6.21.2", "keyspace").open(GraknTxType.WRITE);
-```
-
-The string "keyspace" uniquely identifies the knowledge graph and allows you to create different knowledge graphs.
-
-Please note that knowledge graph keyspaces are **not** case sensitive so the following two knowledge graphs are actually the same:
+Please note that keyspaces are **not** case sensitive, so the following two keyspaces are actually the same:
 
 ```java-test-ignore
     GraknTx tx1 = Grakn.session("127.6.21.2", "keyspace").open(GraknTxType.WRITE);

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -15,14 +15,14 @@ All Grakn applications require the following Maven dependency:
 
 ```xml
 <properties>
-  <grakn.version>1.1.0</grakn.version>
+  <grakn.version>1.2.0</grakn.version>
 </properties>
 
 <dependencies>
   <dependency>
     <groupId>ai.grakn</groupId>
-    <artifactId>grakn-kb</artifactId>
-    <version>${grakn.version}</version>
+    <artifactId>grakn-client</artifactId>
+    <version>1.2.0</version>
   </dependency>
 </dependencies>
 ```
@@ -33,17 +33,6 @@ This dependency will give you access to the Core API as well as an in-memory kno
 
 If you require persistence and would like to access the entirety of the Grakn stack, then it is vital to have an instance of engine running.  
 Please see the [Setup Guide](../get-started/setup-guide) on more details on how to set up a Grakn server.
-
-Depending on the configuration of the Grakn server, your Java application will require the following dependency:
-```xml   
-<dependency>
-    <groupId>ai.grakn</groupId>
-    <artifactId>grakn-factory</artifactId>
-    <version>${grakn.version}</version>
-</dependency>
-```    
-
-The JAR files you will need to develop with Grakn can be found inside the `lib` directory of the distribution zip file. All the JARs are provided with no dependencies, so using these requires you to use Maven to acquire dependencies.
 
 Alternatively, you may include a reference to the snapshot repository, which contains the third-party dependencies. Add the following to your `pom.xml`:
 


### PR DESCRIPTION
# Why is this PR needed?
We do not provide information about how to use the new gRPC client.

# What does the PR do?
Update the docs to advise the user to use the gRPC client instead of the Embedded client

# Does it break backwards compatibility?
No. Strictly, this is just docs update.

However from the user perspective, yes because they are now recommended to use the gRPC client instead of the Embedded client

# List of future improvements not on this PR
N/A