### PR TITLE
Rename directIsa -> isaExplicit

### DIFF
--- a/docs/pages/docs/04-querying-data/match-clause.md
+++ b/docs/pages/docs/04-querying-data/match-clause.md
@@ -25,15 +25,15 @@ A match describes a pattern to find in the knowledge graph. The results of the m
 Match instances that have the given type. In the example, find all `person` entities.
 
 <ul id="profileTabs" class="nav nav-tabs">
-    <li class="active"><a href="#shell1" data-toggle="tab">Graql</a></li>
-    <li><a href="#java1" data-toggle="tab">Java</a></li>
+    <li class="active"><a href="#shell0" data-toggle="tab">Graql</a></li>
+    <li><a href="#java0" data-toggle="tab">Java</a></li>
 </ul>
 
 <div class="tab-content">
-<div role="tabpanel" class="tab-pane active" id="shell1">
+<div role="tabpanel" class="tab-pane active" id="shell0">
 <pre class="language-graql"><code>match $x isa person; get;</code></pre>
 </div>
-<div role="tabpanel" class="tab-pane" id="java1">
+<div role="tabpanel" class="tab-pane" id="java0">
 <pre  class="language-java"><code>qb.match(var("x").isa("person")).get();</code></pre>
 </div> <!-- tab-pane -->
 </div> <!-- tab-content -->
@@ -52,7 +52,7 @@ Match entities that are direct instances of the given type. In the example, find
 <pre class="language-graql"><code>match $x isa! person; get;</code></pre>
 </div>
 <div role="tabpanel" class="tab-pane" id="java1">
-<pre  class="language-java"><code>qb.match(var("x").directIsa("person")).get();</code></pre>
+<pre  class="language-java"><code>qb.match(var("x").isaExplicit("person")).get();</code></pre>
 </div> <!-- tab-pane -->
 </div> <!-- tab-content -->
 
@@ -68,7 +68,6 @@ Match concepts that have a system id that matches the [predicate](#predicates).
 <div role="tabpanel" class="tab-pane active" id="shell2">
 <pre class="language-graql">
 <code>
-# Insert one of the system id values that were displayed from the previous query. For example:
 match $x id "1216728"; get;
 </code>
 </pre>

--- a/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/VarPattern.java
@@ -158,14 +158,14 @@ public interface VarPattern extends Pattern {
      * @return this
      */
     @CheckReturnValue
-    VarPattern directIsa(String type);
+    VarPattern isaExplicit(String type);
 
     /**
      * @param type a concept type that this variable must be an instance of directly
      * @return this
      */
     @CheckReturnValue
-    VarPattern directIsa(VarPattern type);
+    VarPattern isaExplicit(VarPattern type);
 
     /**
      * @param type a concept type id that this variable must be a kind of

--- a/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
+++ b/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
@@ -68,7 +68,7 @@ varPatterns    : (varPattern ';')+ ;
 varPattern     : VARIABLE | variable? property (','? property)* ;
 
 property       : 'isa' variable                     # isa
-               | 'isa!' variable                    # directIsa
+               | 'isa!' variable                    # isaExplicit
                | 'sub' variable                     # sub
                | 'relates' role=variable ('as' superRole=variable)? # relates
                | 'plays' variable                   # plays

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryVisitor.java
@@ -575,8 +575,8 @@ class QueryVisitor extends GraqlBaseVisitor {
     }
 
     @Override
-    public UnaryOperator<VarPattern> visitDirectIsa(GraqlParser.DirectIsaContext ctx) {
-        return var -> var.directIsa(visitVariable(ctx.variable()));
+    public UnaryOperator<VarPattern> visitIsaExplicit(GraqlParser.IsaExplicitContext ctx) {
+        return var -> var.isaExplicit(visitVariable(ctx.variable()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractVarPattern.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractVarPattern.java
@@ -34,7 +34,7 @@ import ai.grakn.graql.admin.UniqueVarProperty;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.admin.VarProperty;
 import ai.grakn.graql.internal.pattern.property.DataTypeProperty;
-import ai.grakn.graql.internal.pattern.property.DirectIsaProperty;
+import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.pattern.property.HasAttributeProperty;
 import ai.grakn.graql.internal.pattern.property.HasAttributeTypeProperty;
 import ai.grakn.graql.internal.pattern.property.IdProperty;
@@ -210,13 +210,13 @@ public abstract class AbstractVarPattern extends AbstractPattern implements VarP
     }
 
     @Override
-    public final VarPattern directIsa(String type) {
-        return directIsa(Graql.label(type));
+    public final VarPattern isaExplicit(String type) {
+        return isaExplicit(Graql.label(type));
     }
 
     @Override
-    public final VarPattern directIsa(VarPattern type) {
-        return addProperty(DirectIsaProperty.of(type.admin()));
+    public final VarPattern isaExplicit(VarPattern type) {
+        return addProperty(IsaExplicitProperty.of(type.admin()));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaExplicitProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/IsaExplicitProperty.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 
 /**
- * Represents the {@code direct-isa} property on a {@link Thing}.
+ * Represents the {@code isa-explicit} property on a {@link Thing}.
  * <p>
  * This property can be queried and inserted.
  * </p>
@@ -47,12 +47,12 @@ import java.util.Collection;
  * @author Jason Liu
  */
 @AutoValue
-public abstract class DirectIsaProperty extends AbstractIsaProperty {
+public abstract class IsaExplicitProperty extends AbstractIsaProperty {
 
     public static final String NAME = "isa!";
 
-    public static DirectIsaProperty of(VarPatternAdmin directType) {
-        return new AutoValue_DirectIsaProperty(directType);
+    public static IsaExplicitProperty of(VarPatternAdmin directType) {
+        return new AutoValue_IsaExplicitProperty(directType);
     }
 
     @Override
@@ -69,6 +69,6 @@ public abstract class DirectIsaProperty extends AbstractIsaProperty {
 
     @Override
     protected final VarPattern varPatternForAtom(Var varName, Var typeVariable) {
-        return varName.directIsa(typeVariable);
+        return varName.isaExplicit(typeVariable);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationshipProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/RelationshipProperty.java
@@ -264,8 +264,8 @@ public abstract class RelationshipProperty extends AbstractVarProperty implement
             }
         }
         ConceptId predicateId = predicate != null? predicate.getPredicate() : null;
-        relVar = isaProp instanceof DirectIsaProperty?
-                relVar.directIsa(typeVariable.asUserDefined()) :
+        relVar = isaProp instanceof IsaExplicitProperty ?
+                relVar.isaExplicit(typeVariable.asUserDefined()) :
                 relVar.isa(typeVariable.asUserDefined());
         return RelationshipAtom.create(relVar.admin(), typeVariable, predicateId, parent);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -28,7 +28,7 @@ import ai.grakn.graql.admin.MultiUnifier;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.admin.UnifierComparison;
 import ai.grakn.graql.admin.VarProperty;
-import ai.grakn.graql.internal.pattern.property.DirectIsaProperty;
+import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.MultiUnifierImpl;
 import ai.grakn.graql.internal.reasoner.atom.binary.RelationshipAtom;
@@ -152,7 +152,7 @@ public abstract class Atom extends AtomicBase {
     protected Stream<Rule> getPotentialRules(){
         return RuleUtils.getRulesWithType(
                 getSchemaConcept(),
-                getPattern().admin().getProperties(DirectIsaProperty.class).findFirst().isPresent(),
+                getPattern().admin().getProperties(IsaExplicitProperty.class).findFirst().isPresent(),
                 tx());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
@@ -26,7 +26,7 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.internal.pattern.Patterns;
-import ai.grakn.graql.internal.pattern.property.DirectIsaProperty;
+import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
@@ -86,7 +86,7 @@ public abstract class Binary extends Atom {
     }
 
     public boolean isDirect(){
-        return getPattern().admin().getProperties(DirectIsaProperty.class).findFirst().isPresent();
+        return getPattern().admin().getProperties(IsaExplicitProperty.class).findFirst().isPresent();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
@@ -30,7 +30,7 @@ import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.admin.VarProperty;
-import ai.grakn.graql.internal.pattern.property.DirectIsaProperty;
+import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.pattern.property.IsaProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
@@ -126,8 +126,8 @@ public abstract class IsaAtom extends IsaAtomBase {
         if (getPredicateVariable().isUserDefinedName()) return super.createCombinedPattern();
         return getSchemaConcept() == null?
                 getVarName().isa(getPredicateVariable()) :
-                getPattern().admin().getProperties(DirectIsaProperty.class).findFirst().isPresent()?
-                        getVarName().directIsa(getSchemaConcept().getLabel().getValue()) :
+                getPattern().admin().getProperties(IsaExplicitProperty.class).findFirst().isPresent()?
+                        getVarName().isaExplicit(getSchemaConcept().getLabel().getValue()) :
                         getVarName().isa(getSchemaConcept().getLabel().getValue()) ;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -234,7 +234,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return getSchemaConcept() == null?
                 relationPattern() :
                 isDirect()?
-                        relationPattern().directIsa(getSchemaConcept().getLabel().getValue()):
+                        relationPattern().isaExplicit(getSchemaConcept().getLabel().getValue()):
                         relationPattern().isa(getSchemaConcept().getLabel().getValue());
     }
 
@@ -741,7 +741,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         VarPattern relationPattern = relationPattern(getVarName(), inferredRelationPlayers);
         VarPatternAdmin newPattern =
                 (isDirect()?
-                        relationPattern.directIsa(getPredicateVariable()) :
+                        relationPattern.isaExplicit(getPredicateVariable()) :
                         relationPattern.isa(getPredicateVariable())
                 ).admin();
         return create(newPattern, getPredicateVariable(), getTypeId(), getParentQuery());

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/fragment/IsaExplicitTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/gremlin/fragment/IsaExplicitTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
-public class DirectIsaTest {
+public class IsaExplicitTest {
 
     private static final Var x = var("x");
     private static final Var y = var("y");
@@ -101,17 +101,17 @@ public class DirectIsaTest {
         QueryBuilder queryBuilder = tx.graql();
         InsertQuery insertQuery;
 
-        insertQuery = queryBuilder.insert(x.directIsa(thingy));
+        insertQuery = queryBuilder.insert(x.isaExplicit(thingy));
         assertEquals("insert $x isa! thingy;", insertQuery.toString());
 
         insertQuery = queryBuilder.parse("insert $x isa! thingy;");
-        assertEquals(queryBuilder.insert(x.directIsa(thingy)), insertQuery);
+        assertEquals(queryBuilder.insert(x.isaExplicit(thingy)), insertQuery);
     }
 
     @Test
-    public void whenInsertDirectIsa_InsertsADirectInstanceOfAType() {
+    public void whenInsertIsaExplicit_InsertsADirectInstanceOfAType() {
         QueryBuilder queryBuilder = tx.graql();
-        queryBuilder.insert(x.directIsa(thingy)).execute();
+        queryBuilder.insert(x.isaExplicit(thingy)).execute();
         assertEquals(1L, queryBuilder.parse("match $z isa! thingy; aggregate count;").execute());
         assertEquals(2L, queryBuilder.parse("match $z isa thingy; aggregate count;").execute());
     }
@@ -122,27 +122,27 @@ public class DirectIsaTest {
         Match matchQuery;
         GetQuery getQuery;
 
-        matchQuery = queryBuilder.match(x.directIsa(thingy1));
+        matchQuery = queryBuilder.match(x.isaExplicit(thingy1));
         assertEquals("match $x isa! thingy1;", matchQuery.toString());
 
-        matchQuery = queryBuilder.match(x.directIsa(y));
+        matchQuery = queryBuilder.match(x.isaExplicit(y));
         assertEquals("match $x isa! $y;", matchQuery.toString());
 
         getQuery = queryBuilder.parse("match $x isa! thingy1; get;");
-        assertEquals(queryBuilder.match(x.directIsa(thingy1)), getQuery.match());
+        assertEquals(queryBuilder.match(x.isaExplicit(thingy1)), getQuery.match());
 
         getQuery = queryBuilder.parse("match $x isa! $y; get;");
-        assertEquals(queryBuilder.match(x.directIsa(y)), getQuery.match());
+        assertEquals(queryBuilder.match(x.isaExplicit(y)), getQuery.match());
     }
 
     @Test
-    public void testMatchIsaAndDirectIsaReturnDifferentPlans() {
+    public void testMatchIsaAndIsaExplicitReturnDifferentPlans() {
         Pattern pattern;
         ImmutableList<Fragment> plan;
 
         // test type without subtypes
 
-        pattern = x.directIsa(thingy1);
+        pattern = x.isaExplicit(thingy1);
         plan = getPlan(pattern);
         assertEquals(2, plan.size());
         assertThat(plan, contains(
@@ -151,8 +151,8 @@ public class DirectIsaTest {
         ));
 
         pattern = and(
-                x.directIsa(thingy1),
-                y.directIsa(thingy1),
+                x.isaExplicit(thingy1),
+                y.isaExplicit(thingy1),
                 var().rel(x).rel(y).isa(related));
         plan = getPlan(pattern);
 
@@ -172,7 +172,7 @@ public class DirectIsaTest {
 
         // test type with subtypes
 
-        pattern = x.directIsa(thingy);
+        pattern = x.isaExplicit(thingy);
         plan = getPlan(pattern);
         assertEquals(2, plan.size());
         assertThat(plan, contains(
@@ -191,8 +191,8 @@ public class DirectIsaTest {
         ));
 
         pattern = and(
-                x.directIsa(thingy),
-                y.directIsa(thingy),
+                x.isaExplicit(thingy),
+                y.isaExplicit(thingy),
                 var().rel(x).rel(y).isa(related));
         plan = getPlan(pattern);
 
@@ -210,11 +210,11 @@ public class DirectIsaTest {
                 instanceOf(OutIsaFragment.class) // check the role player's type
         ));
 
-        // combine isa and direct isa
+        // combine isa and explicit isa
 
         pattern = and(
                 x.isa(thingy),
-                y.directIsa(thingy),
+                y.isaExplicit(thingy),
                 var().rel(x).rel(y).isa(related));
         plan = getPlan(pattern);
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AdminTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AdminTest.java
@@ -112,7 +112,7 @@ public class AdminTest {
         InsertQuery query = qb.match(var("x").isa("movie")).insert(var().id(ConceptId.of("123")).isa("movie"));
         assertEquals(Optional.of("match $x isa movie;"), query.admin().match().map(Object::toString));
 
-        query = qb.match(var("x").directIsa("movie")).insert(var().id(ConceptId.of("123")).isa("movie"));
+        query = qb.match(var("x").isaExplicit("movie")).insert(var().id(ConceptId.of("123")).isa("movie"));
         assertEquals(Optional.of("match $x isa! movie;"), query.admin().match().map(Object::toString));
     }
 
@@ -128,7 +128,7 @@ public class AdminTest {
         DeleteQuery query = qb.match(var("x").isa("movie")).delete("x");
         assertEquals("match $x isa movie;", query.admin().match().toString());
 
-        query = qb.match(var("x").directIsa("movie")).delete("x");
+        query = qb.match(var("x").isaExplicit("movie")).delete("x");
         assertEquals("match $x isa! movie;", query.admin().match().toString());
     }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/generator/HasAttributeProperties.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/generator/HasAttributeProperties.java
@@ -20,7 +20,7 @@ package ai.grakn.generator;
 
 import ai.grakn.concept.Label;
 import ai.grakn.graql.admin.VarPatternAdmin;
-import ai.grakn.graql.internal.pattern.property.DirectIsaProperty;
+import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.pattern.property.HasAttributeProperty;
 import ai.grakn.graql.internal.pattern.property.IsaProperty;
 
@@ -42,12 +42,12 @@ public class HasAttributeProperties extends AbstractGenerator<HasAttributeProper
         do {
             varPatternAttribute = gen(VarPatternAdmin.class);
         } while (varPatternAttribute.hasProperty(IsaProperty.class) ||
-                varPatternAttribute.hasProperty(DirectIsaProperty.class));
+                varPatternAttribute.hasProperty(IsaExplicitProperty.class));
 
         do {
             varPatternRelationship = gen(VarPatternAdmin.class);
         } while (varPatternRelationship.hasProperty(IsaProperty.class) ||
-                varPatternRelationship.hasProperty(DirectIsaProperty.class));
+                varPatternRelationship.hasProperty(IsaExplicitProperty.class));
 
 
         return HasAttributeProperty.of(gen(Label.class), varPatternAttribute, varPatternRelationship);


### PR DESCRIPTION
# Why is this PR needed?
More intuitive?
# What does the PR do?
Rename
# Does it break backwards compatibility?
For java version, yes. Graql syntax stays the same
# List of future improvements not on this PR
NA