### PR TITLE
cleaned up .gitignore in docs to sync with stable

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,39 +1,8 @@
+_site
 .sass_cache/
-.idea/
 .jekyll-metadata
 _pdf
-.DS_Store
 *.swp
 Gemfile.lock
 *.geany
 node_modules
-
-# Mac files #
-.DS_Store
-
-# IDE files #
-.idea/
-*.iml
-*.geany
-
-# Compiled files #
-out/
-target/
-*.class
-
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
-
-# Package Files #
-*.jar
-*.war
-*.ear
-
-# Debug files #
-dep.tree
-
-# Databases #
-db/
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*


### PR DESCRIPTION
# Why is this PR needed?

.gitignore in docs does not need to repeat is already in the root folder, and it also needs to ignore _site folders for the compiled website.

# What does the PR do?

# Does it break backwards compatibility?

# List of future improvements not on this PR
