### PR TITLE
exit docs deployment immediately after error

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,10 @@ After you are done making changes, run the deployment server with ```node ./depl
 You can access the site on `http://127.0.0.1:3003/`
 
 If everything works, create a new PR against grakn [stable branch](https://github.com/graknlabs/grakn/tree/stable).
-Once the PR has been merged run the `deploy.sh` script inside `/docs`.
+Once the PR has been merged run the following:
+```
+cd docs && ./deploy.sh
+```
 The script deploys the application to our heroku server. Make sure you have the correct git credentials.
 
 > If deploying from some other branch make sure to edit `deploy.sh` file to branch off accordingly.

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
+
 set -e
+
+function error {
+    echo "The script failed with an error. Please remember to remove the temporary remote and branch which was created:"
+    echo "git remote remove grakn-docs-origin"
+    echo "git branch -D docs-deploy-temp"
+}
+
+trap error ERR
 
 echo "Checking out temporary branch from stable"
 git remote add grakn-docs-origin git@github.com:graknlabs/grakn.git

--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 echo "Checking out temporary branch from stable"
 git remote add grakn-docs-origin git@github.com:graknlabs/grakn.git
 git fetch grakn-docs-origin


### PR DESCRIPTION
# Why is this PR needed?
`./docs/deploy.sh` would execute until the end regardless, even when the docs actually failed to get built by `rake build`.

When that happens, this will cause the script to push an empty directory into Heroku, and basically bring the online docs down.

# What does the PR do?
1. Add a `set -e` in `deploy.sh`, so it stops the deployment if there's a failure in one of the step.
2. Add a minor formatting change in the docs to make the deploy command more visible

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A