### PR TITLE
Make comparisons on values less ambiguous

### DIFF
--- a/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
+++ b/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
@@ -92,9 +92,9 @@ casting        : variable (':' VARIABLE)?
 
 variable       : label | VARIABLE ;
 
-predicate      : '='? value                     # predicateEq
-               | '=' VARIABLE                   # predicateVariable
-               | '!=' valueOrVar                # predicateNeq
+predicate      : '=='? value                     # predicateEq
+               | '==' VARIABLE                   # predicateVariable
+               | '!==' valueOrVar                # predicateNeq
                | '>' valueOrVar                 # predicateGt
                | '>=' valueOrVar                # predicateGte
                | '<' valueOrVar                 # predicateLt

--- a/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
+++ b/grakn-graql/src/main/antlr4/ai/grakn/graql/internal/antlr/Graql.g4
@@ -74,7 +74,7 @@ property       : 'isa' variable                     # isa
                | 'plays' variable                   # plays
                | 'id' id                            # propId
                | 'label' label                      # propLabel
-               | 'val' predicate                    # propValue
+               | 'val'? predicate                   # propValue
                | 'when' '{' patterns '}'            # propWhen
                | 'then' '{' varPatterns '}'         # propThen
                | 'has' label (resource=VARIABLE | predicate) ('via' relation=VARIABLE)? # propHas
@@ -92,9 +92,9 @@ casting        : variable (':' VARIABLE)?
 
 variable       : label | VARIABLE ;
 
-predicate      : '=='? value                     # predicateEq
-               | '==' VARIABLE                   # predicateVariable
-               | '!==' valueOrVar                # predicateNeq
+predicate      : '=='? value                    # predicateEq
+               | '==' VARIABLE                  # predicateVariable
+               | '!==' valueOrVar               # predicateNeq
                | '>' valueOrVar                 # predicateGt
                | '>=' valueOrVar                # predicateGte
                | '<' valueOrVar                 # predicateLt

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -66,6 +66,11 @@ public abstract class ValueProperty extends AbstractVarProperty implements Named
     }
 
     @Override
+    public void buildString(StringBuilder builder) {
+        builder.append(getProperty());
+    }
+
+    @Override
     public Collection<EquivalentFragmentSet> match(Var start) {
         return ImmutableSet.of(EquivalentFragmentSets.value(this, start, predicate()));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/property/ValueProperty.java
@@ -47,7 +47,7 @@ import java.util.stream.Stream;
 @AutoValue
 public abstract class ValueProperty extends AbstractVarProperty implements NamedProperty {
 
-    public static final String NAME = "val";
+    public static final String NAME = "";
 
     public static ValueProperty of(ValuePredicate predicate) {
         return new AutoValue_ValueProperty(predicate);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -20,8 +20,6 @@ package ai.grakn.graql.internal.query.predicate;
 
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 
-import ai.grakn.util.StringUtil;
-
 import java.util.Optional;
 
 class EqPredicate extends ComparatorPredicate {
@@ -51,17 +49,6 @@ class EqPredicate extends ComparatorPredicate {
     @Override
     public Optional<Object> equalsValue() {
         return value();
-    }
-
-    @Override
-    public String toString() {
-        Optional<Object> value = value();
-        if (value.isPresent()) {
-            // Omit the `=` if we're using a literal value, not a var
-            return StringUtil.valueToString(value.get());
-        } else {
-            return super.toString();
-        }
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -35,7 +35,7 @@ class EqPredicate extends ComparatorPredicate {
 
     @Override
     protected String getSymbol() {
-        return "=";
+        return "==";
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/EqPredicate.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.internal.query.predicate;
 
+import ai.grakn.util.StringUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 
 import java.util.Optional;
@@ -44,6 +45,17 @@ class EqPredicate extends ComparatorPredicate {
     @Override
     public boolean isSpecific() {
         return !getInnerVar().isPresent();
+    }
+
+    @Override
+    public String toString() {
+        Optional<Object> value = value();
+        if (value.isPresent()) {
+            // Omit the `=` if we're using a literal value, not a var
+            return StringUtil.valueToString(value.get());
+        } else {
+            return super.toString();
+        }
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/NeqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/predicate/NeqPredicate.java
@@ -31,7 +31,7 @@ class NeqPredicate extends ComparatorPredicate {
 
     @Override
     protected String getSymbol() {
-        return "!=";
+        return "!==";
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -131,7 +131,7 @@ public class QueryParserTest {
 
         GetQuery parsed = parse(
                 "match\n" +
-                        "$brando val \"Marl B\" isa person;\n" +
+                        "$brando == \"Marl B\" isa person;\n" +
                         "(actor: $brando, $char, production-with-cast: $prod);\n" +
                         "get $char, $prod;"
         );
@@ -156,8 +156,8 @@ public class QueryParserTest {
         GetQuery parsed = parse(
                 "match\n" +
                         "$x isa movie, has title $t;\n" +
-                        "$t val == \"Apocalypse Now\" or {$t val < 'Juno'; $t val > 'Godfather';} or $t val 'Spy';" +
-                        "$t val !=='Apocalypse Now'; get;\n"
+                        "$t == \"Apocalypse Now\" or {$t < 'Juno'; $t > 'Godfather';} or $t 'Spy';" +
+                        "$t !=='Apocalypse Now'; get;\n"
         );
 
         assertEquals(expected, parsed);
@@ -175,7 +175,7 @@ public class QueryParserTest {
 
         GetQuery parsed = parse(
                 "match $x isa movie, has title $t;" +
-                        "{$t val <= 'Juno'; $t val >= 'Godfather'; $t val !== 'Heat';} or $t val == 'The Muppets'; get;"
+                        "{$t <= 'Juno'; $t >= 'Godfather'; $t !== 'Heat';} or $t == 'The Muppets'; get;"
         );
 
         assertEquals(expected, parsed);
@@ -191,7 +191,7 @@ public class QueryParserTest {
 
         GetQuery parsed = parse(
                 "match ($x, $y); $y isa person, has name $n;" +
-                        "$n val contains 'ar' or $n val /^M.*$/; get;"
+                        "$n contains 'ar' or $n /^M.*$/; get;"
         );
 
         assertEquals(expected, parsed);
@@ -201,7 +201,7 @@ public class QueryParserTest {
     public void whenParsingContainsPredicateWithAVariable_ResultMatchesJavaGraql() {
         GetQuery expected = match(var("x").val(contains(var("y")))).get();
 
-        GetQuery parsed = parse("match $x val contains $y; get;");
+        GetQuery parsed = parse("match $x contains $y; get;");
 
         assertEquals(expected, parsed);
     }
@@ -210,7 +210,7 @@ public class QueryParserTest {
     public void testValueEqualsVariableQuery() {
         GetQuery expected = match(var("s1").val(var("s2"))).get();
 
-        GetQuery parsed = parse("match $s1 val == $s2; get;");
+        GetQuery parsed = parse("match $s1 == $s2; get;");
 
         assertEquals(expected, parsed);
     }
@@ -340,7 +340,7 @@ public class QueryParserTest {
                 "match" +
                         "($p: $x, $y);" +
                         "$x isa $z;" +
-                        "$y val 'crime';" +
+                        "$y == 'crime';" +
                         "$z sub production;" +
                         "has-genre relates $p; get;"
         );
@@ -359,7 +359,7 @@ public class QueryParserTest {
         ).get();
 
         GetQuery parsed = parse(
-                "match $x isa movie; { $y isa genre val 'drama'; ($x, $y); } or $x val 'The Muppets'; get;"
+                "match $x isa movie; { $y isa genre == 'drama'; ($x, $y); } or $x == 'The Muppets'; get;"
         );
 
         assertEquals(expected, parsed);
@@ -1098,27 +1098,27 @@ public class QueryParserTest {
 
     @Test
     public void regexPredicateParsesCharacterClassesCorrectly() {
-        assertEquals(match(var("x").val(regex("\\d"))).get(), parse("match $x val /\\d/; get;"));
+        assertEquals(match(var("x").val(regex("\\d"))).get(), parse("match $x /\\d/; get;"));
     }
 
     @Test
     public void regexPredicateParsesQuotesCorrectly() {
-        assertEquals(match(var("x").val(regex("\""))).get(), parse("match $x val /\"/; get;"));
+        assertEquals(match(var("x").val(regex("\""))).get(), parse("match $x /\"/; get;"));
     }
 
     @Test
     public void regexPredicateParsesBackslashesCorrectly() {
-        assertEquals(match(var("x").val(regex("\\\\"))).get(), parse("match $x val /\\\\/; get;"));
+        assertEquals(match(var("x").val(regex("\\\\"))).get(), parse("match $x /\\\\/; get;"));
     }
 
     @Test
     public void regexPredicateParsesNewlineCorrectly() {
-        assertEquals(match(var("x").val(regex("\\n"))).get(), parse("match $x val /\\n/; get;"));
+        assertEquals(match(var("x").val(regex("\\n"))).get(), parse("match $x /\\n/; get;"));
     }
 
     @Test
     public void regexPredicateParsesForwardSlashesCorrectly() {
-        assertEquals(match(var("x").val(regex("/"))).get(), parse("match $x val /\\//; get;"));
+        assertEquals(match(var("x").val(regex("/"))).get(), parse("match $x /\\//; get;"));
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -606,7 +606,7 @@ public class QueryParserTest {
 
     @Test
     public void testParseBoolean() {
-        assertEquals("insert has flag true;", parse("insert has flag true;").toString());
+        assertEquals("insert has flag == true;", parse("insert has flag true;").toString());
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -156,8 +156,8 @@ public class QueryParserTest {
         GetQuery parsed = parse(
                 "match\n" +
                         "$x isa movie, has title $t;\n" +
-                        "$t val = \"Apocalypse Now\" or {$t val < 'Juno'; $t val > 'Godfather';} or $t val 'Spy';" +
-                        "$t val !='Apocalypse Now'; get;\n"
+                        "$t val == \"Apocalypse Now\" or {$t val < 'Juno'; $t val > 'Godfather';} or $t val 'Spy';" +
+                        "$t val !=='Apocalypse Now'; get;\n"
         );
 
         assertEquals(expected, parsed);
@@ -175,7 +175,7 @@ public class QueryParserTest {
 
         GetQuery parsed = parse(
                 "match $x isa movie, has title $t;" +
-                        "{$t val <= 'Juno'; $t val >= 'Godfather'; $t val != 'Heat';} or $t val = 'The Muppets'; get;"
+                        "{$t val <= 'Juno'; $t val >= 'Godfather'; $t val !== 'Heat';} or $t val == 'The Muppets'; get;"
         );
 
         assertEquals(expected, parsed);
@@ -210,7 +210,7 @@ public class QueryParserTest {
     public void testValueEqualsVariableQuery() {
         GetQuery expected = match(var("s1").val(var("s2"))).get();
 
-        GetQuery parsed = parse("match $s1 val = $s2; get;");
+        GetQuery parsed = parse("match $s1 val == $s2; get;");
 
         assertEquals(expected, parsed);
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -606,7 +606,7 @@ public class QueryParserTest {
 
     @Test
     public void testParseBoolean() {
-        assertEquals("insert has flag == true;", parse("insert has flag true;").toString());
+        assertEquals("insert has flag true;", parse("insert has flag true;").toString());
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
@@ -125,7 +125,7 @@ public class QueryToStringTest {
 
     @Test
     public void testEscapeStrings() {
-        assertEquals("insert $x val \"hello\\nworld\";", qb.insert(var("x").val("hello\nworld")).toString());
+        assertEquals("insert $x == \"hello\\nworld\";", qb.insert(var("x").val("hello\nworld")).toString());
     }
 
     @Test
@@ -204,22 +204,22 @@ public class QueryToStringTest {
     @Test
     public void testMatchInsertToString() {
         InsertQuery query = qb.match(var("x").isa("movie")).insert(var("x").has("title", "hello"));
-        assertEquals("match $x isa movie;\ninsert $x has title \"hello\";", query.toString());
+        assertEquals("match $x isa movie;\ninsert $x has title == \"hello\";", query.toString());
     }
 
     @Test
     public void testZeroToString() {
-        assertEquals("match $x val 0.0;", qb.match(var("x").val(0.0)).toString());
+        assertEquals("match $x == 0.0;", qb.match(var("x").val(0.0)).toString());
     }
 
     @Test
     public void testExponentsToString() {
-        assertEquals("match $x val 1000000000.0;", qb.match(var("x").val(1_000_000_000.0)).toString());
+        assertEquals("match $x == 1000000000.0;", qb.match(var("x").val(1_000_000_000.0)).toString());
     }
 
     @Test
     public void testDecimalToString() {
-        assertEquals("match $x val 0.0001;", qb.match(var("x").val(0.0001)).toString());
+        assertEquals("match $x == 0.0001;", qb.match(var("x").val(0.0001)).toString());
     }
 
     @Test
@@ -233,7 +233,7 @@ public class QueryToStringTest {
     public void whenCallingToStringOnAQueryWithAContainsPredicate_ResultIsCorrect() {
         Match match = match(var("x").val(contains(var("y"))));
 
-        assertEquals("match $x val contains $y;", match.toString());
+        assertEquals("match $x contains $y;", match.toString());
     }
 
     private void assertSameResults(GetQuery query) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryToStringTest.java
@@ -125,7 +125,7 @@ public class QueryToStringTest {
 
     @Test
     public void testEscapeStrings() {
-        assertEquals("insert $x == \"hello\\nworld\";", qb.insert(var("x").val("hello\nworld")).toString());
+        assertEquals("insert $x \"hello\\nworld\";", qb.insert(var("x").val("hello\nworld")).toString());
     }
 
     @Test
@@ -204,22 +204,22 @@ public class QueryToStringTest {
     @Test
     public void testMatchInsertToString() {
         InsertQuery query = qb.match(var("x").isa("movie")).insert(var("x").has("title", "hello"));
-        assertEquals("match $x isa movie;\ninsert $x has title == \"hello\";", query.toString());
+        assertEquals("match $x isa movie;\ninsert $x has title \"hello\";", query.toString());
     }
 
     @Test
     public void testZeroToString() {
-        assertEquals("match $x == 0.0;", qb.match(var("x").val(0.0)).toString());
+        assertEquals("match $x 0.0;", qb.match(var("x").val(0.0)).toString());
     }
 
     @Test
     public void testExponentsToString() {
-        assertEquals("match $x == 1000000000.0;", qb.match(var("x").val(1_000_000_000.0)).toString());
+        assertEquals("match $x 1000000000.0;", qb.match(var("x").val(1_000_000_000.0)).toString());
     }
 
     @Test
     public void testDecimalToString() {
-        assertEquals("match $x == 0.0001;", qb.match(var("x").val(0.0001)).toString());
+        assertEquals("match $x 0.0001;", qb.match(var("x").val(0.0001)).toString());
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
@@ -273,11 +273,11 @@ public class InsertQueryTest {
     @Test
     public void whenInsertingAResourceWithMultipleValues_Throw() {
         VarPattern varPattern = var().val("123").val("456").isa("title");
-
+        
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(isOneOf(
-                GraqlQueryException.insertMultipleProperties(varPattern, "val", "123", "456").getMessage(),
-                GraqlQueryException.insertMultipleProperties(varPattern, "val", "456", "123").getMessage()
+                GraqlQueryException.insertMultipleProperties(varPattern, "", "123", "456").getMessage(),
+                GraqlQueryException.insertMultipleProperties(varPattern, "", "456", "123").getMessage()
         ));
 
         qb.insert(varPattern).execute();
@@ -438,7 +438,7 @@ public class InsertQueryTest {
     @Test
     public void whenInsertingAResourceWithoutAValue_Throw() {
         exception.expect(GraqlQueryException.class);
-        exception.expectMessage(allOf(containsString("name"), containsString("val")));
+        exception.expectMessage(allOf(containsString("name")));
         qb.insert(var("x").isa("name")).execute();
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -146,7 +146,7 @@ public class AtomicQueryTest {
         Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").execute()).get("x");
         Concept resource = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa resource; get;").execute()).get("x");
 
-        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r val 'inferred';$x id " + firstEntity.getId().getValue() + ";}", graph), graph);
+        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r 'inferred';$x id " + firstEntity.getId().getValue() + ";}", graph), graph);
         String reuseResourcePatternString =
                 "{" +
                         "$x has resource $r;" +
@@ -893,7 +893,7 @@ public class AtomicQueryTest {
     public void testEquivalence_DifferentResourceVariants(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String query = "{$x has resource 'value';}";
-        String query2 = "{$y has resource $r;$r val 'value';}";
+        String query2 = "{$y has resource $r;$r 'value';}";
         String query3 = "{$y has resource $r;}";
         String query4 = "{$y has resource 'value2';}";
 
@@ -940,15 +940,15 @@ public class AtomicQueryTest {
     @Test //tests alpha-equivalence of queries with resources with multi predicate
     public void testEquivalence_MultiPredicateResources(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
-        String query = "{$z has resource $u;$a val >23; $a val <27;}";
-        String query2 = "{$x isa baseRoleEntity;$x has resource $a;$a val >23; $a val <27;}";
+        String query = "{$z has resource $u;$a >23; $a <27;}";
+        String query2 = "{$x isa baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
         String query3 = "{$e isa baseRoleEntity;$e has resource > 23;}";
-        String query4 = "{$p isa baseRoleEntity;$p has resource $a;$a val >23;}";
-        String query5 = "{$x isa baseRoleEntity;$x has resource $y;$y val >27;$y val <23;}";
-        String query6 = "{$a isa baseRoleEntity;$a has resource $p;$p val <27;$p val >23;}";
-        String query7 = "{$x isa baseRoleEntity, has resource $a;$a val >23; $a val <27;}";
-        String query8 = "{$x isa baseRoleEntity, has resource $z1;$z1 val >23; $z2 val <27;}";
-        String query9 = "{$x isa $type;$type label baseRoleEntity;$x has resource $a;$a val >23; $a val <27;}";
+        String query4 = "{$p isa baseRoleEntity;$p has resource $a;$a >23;}";
+        String query5 = "{$x isa baseRoleEntity;$x has resource $y;$y >27;$y <23;}";
+        String query6 = "{$a isa baseRoleEntity;$a has resource $p;$p <27;$p >23;}";
+        String query7 = "{$x isa baseRoleEntity, has resource $a;$a >23; $a <27;}";
+        String query8 = "{$x isa baseRoleEntity, has resource $z1;$z1 >23; $z2 <27;}";
+        String query9 = "{$x isa $type;$type label baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
 
         queryEquivalence(query, query2, false, graph);
         queryEquivalence(query, query3, false, graph);
@@ -996,11 +996,11 @@ public class AtomicQueryTest {
     @Test //tests alpha-equivalence of resource atoms with different predicates
     public void testEquivalence_resourcesWithDifferentPredicates() {
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
-        String query = "{$x has resource $r;$r val > 1099;}";
-        String query2 = "{$x has resource $r;$r val < 1099;}";
-        String query3 = "{$x has resource $r;$r val = 1099;}";
-        String query4 = "{$x has resource $r;$r val '1099';}";
-        String query5 = "{$x has resource $r;$r val > $var;}";
+        String query = "{$x has resource $r;$r > 1099;}";
+        String query2 = "{$x has resource $r;$r < 1099;}";
+        String query3 = "{$x has resource $r;$r == 1099;}";
+        String query4 = "{$x has resource $r;$r '1099';}";
+        String query5 = "{$x has resource $r;$r > $var;}";
 
         queryEquivalence(query, query2, false, graph);
         queryEquivalence(query, query3, false, graph);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
@@ -747,8 +747,8 @@ public class AtomicTest {
         String resourceString4 = "{$x has res-double < 4.0;}";
         String resourceString5 = "{$x has res-double >= 5;}";
         String resourceString6 = "{$x has res-double <= 5;}";
-        String resourceString7 = "{$x has res-double = 3.14;}";
-        String resourceString8 = "{$x has res-double != 5;}";
+        String resourceString7 = "{$x has res-double == 3.14;}";
+        String resourceString8 = "{$x has res-double !== 5;}";
 
         Atom resource = ReasonerQueries.atomic(conjunction(resourceString, graph), graph).getAtom();
         Atom resource2 = ReasonerQueries.atomic(conjunction(resourceString2, graph), graph).getAtom();
@@ -778,8 +778,8 @@ public class AtomicTest {
         String resourceString4 = "{$x has res-long < 200;}";
         String resourceString5 = "{$x has res-long >= 130;}";
         String resourceString6 = "{$x has res-long <= 130;}";
-        String resourceString7 = "{$x has res-long = 123;}";
-        String resourceString8 = "{$x has res-long != 200;}";
+        String resourceString7 = "{$x has res-long == 123;}";
+        String resourceString8 = "{$x has res-long !== 200;}";
 
         Atom resource = ReasonerQueries.atomic(conjunction(resourceString, graph), graph).getAtom();
         Atom resource2 = ReasonerQueries.atomic(conjunction(resourceString2, graph), graph).getAtom();
@@ -859,14 +859,14 @@ public class AtomicTest {
     @Test
     public void testRuleApplicability_ReifiedResourceDouble(){
         EmbeddedGraknTx<?> graph = reifiedResourceApplicabilitySet.tx();
-        String queryString = "{$x isa res-double val > 3.0;($x, $y);}";
-        String queryString2 = "{$x isa res-double val > 4.0;($x, $y);}";
-        String queryString3 = "{$x isa res-double val < 3.0;($x, $y);}";
-        String queryString4 = "{$x isa res-double val < 4.0;($x, $y);}";
-        String queryString5 = "{$x isa res-double val >= 5;($x, $y);}";
-        String queryString6 = "{$x isa res-double val <= 5;($x, $y);}";
-        String queryString7 = "{$x isa res-double val = 3.14;($x, $y);}";
-        String queryString8 = "{$x isa res-double val != 5;($x, $y);}";
+        String queryString = "{$x isa res-double > 3.0;($x, $y);}";
+        String queryString2 = "{$x isa res-double > 4.0;($x, $y);}";
+        String queryString3 = "{$x isa res-double < 3.0;($x, $y);}";
+        String queryString4 = "{$x isa res-double < 4.0;($x, $y);}";
+        String queryString5 = "{$x isa res-double >= 5;($x, $y);}";
+        String queryString6 = "{$x isa res-double <= 5;($x, $y);}";
+        String queryString7 = "{$x isa res-double == 3.14;($x, $y);}";
+        String queryString8 = "{$x isa res-double !== 5;($x, $y);}";
 
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, graph), graph).getAtom();
         Atom atom2 = ReasonerQueries.atomic(conjunction(queryString2, graph), graph).getAtom();
@@ -890,14 +890,14 @@ public class AtomicTest {
     @Test
     public void testRuleApplicability_ReifiedResourceLong(){
         EmbeddedGraknTx<?> graph = reifiedResourceApplicabilitySet.tx();
-        String queryString = "{$x isa res-long val > 100;($x, $y);}";
-        String queryString2 = "{$x isa res-long val > 150;($x, $y);}";
-        String queryString3 = "{$x isa res-long val < 100;($x, $y);}";
-        String queryString4 = "{$x isa res-long val < 200;($x, $y);}";
-        String queryString5 = "{$x isa res-long val >= 130;($x, $y);}";
-        String queryString6 = "{$x isa res-long val <= 130;($x, $y);}";
-        String queryString7 = "{$x isa res-long val = 123;($x, $y);}";
-        String queryString8 = "{$x isa res-long val != 200;($x, $y);}";
+        String queryString = "{$x isa res-long > 100;($x, $y);}";
+        String queryString2 = "{$x isa res-long > 150;($x, $y);}";
+        String queryString3 = "{$x isa res-long < 100;($x, $y);}";
+        String queryString4 = "{$x isa res-long < 200;($x, $y);}";
+        String queryString5 = "{$x isa res-long >= 130;($x, $y);}";
+        String queryString6 = "{$x isa res-long <= 130;($x, $y);}";
+        String queryString7 = "{$x isa res-long == 123;($x, $y);}";
+        String queryString8 = "{$x isa res-long !== 200;($x, $y);}";
 
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, graph), graph).getAtom();
         Atom atom2 = ReasonerQueries.atomic(conjunction(queryString2, graph), graph).getAtom();
@@ -921,10 +921,10 @@ public class AtomicTest {
     @Test
     public void testRuleApplicability_ReifiedResourceString(){
         EmbeddedGraknTx<?> graph = reifiedResourceApplicabilitySet.tx();
-        String queryString = "{$x isa res-string val contains 'val';($x, $y);}";
-        String queryString2 = "{$x isa res-string val 'test';($x, $y);}";
-        String queryString3 = "{$x isa res-string val /.*(fast|value).*/;($x, $y);}";
-        String queryString4 = "{$x isa res-string val /.*/;($x, $y);}";
+        String queryString = "{$x isa res-string contains 'val';($x, $y);}";
+        String queryString2 = "{$x isa res-string 'test';($x, $y);}";
+        String queryString3 = "{$x isa res-string /.*(fast|value).*/;($x, $y);}";
+        String queryString4 = "{$x isa res-string /.*/;($x, $y);}";
 
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, graph), graph).getAtom();
         Atom atom2 = ReasonerQueries.atomic(conjunction(queryString2, graph), graph).getAtom();
@@ -940,8 +940,8 @@ public class AtomicTest {
     @Test
     public void testRuleApplicability_ReifiedResourceBoolean(){
         EmbeddedGraknTx<?> graph = reifiedResourceApplicabilitySet.tx();
-        String queryString = "{$x isa res-boolean val 'true';($x, $y);}";
-        String queryString2 = "{$x isa res-boolean val 'false';($x, $y);}";
+        String queryString = "{$x isa res-boolean 'true';($x, $y);}";
+        String queryString2 = "{$x isa res-boolean 'false';($x, $y);}";
 
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, graph), graph).getAtom();
         Atom atom2 = ReasonerQueries.atomic(conjunction(queryString2, graph), graph).getAtom();
@@ -1104,11 +1104,11 @@ public class AtomicTest {
     @Test
     public void testUnification_VariousResourceAtoms(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
-        String resource = "{$x has resource $r;$r val 'f';}";
-        String resource2 = "{$r has resource $x;$x val 'f';}";
+        String resource = "{$x has resource $r;$r 'f';}";
+        String resource2 = "{$r has resource $x;$x 'f';}";
         String resource3 = "{$r has resource 'f';}";
-        String resource4 = "{$x has resource $y via $r;$y val 'f';}";
-        String resource5 = "{$y has resource $r via $x;$r val 'f';}";
+        String resource4 = "{$x has resource $y via $r;$y 'f';}";
+        String resource5 = "{$y has resource $r via $x;$r 'f';}";
         exactUnification(resource, resource2, true, true, graph);
         exactUnification(resource, resource3, true, true, graph);
         exactUnification(resource2, resource3, true, true, graph);
@@ -1172,8 +1172,8 @@ public class AtomicTest {
     @Test
     public void testUnification_ResourceWithIndirectValuePredicate(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
-        String resource = "{$x has resource $r;$r val 'f';}";
-        String resource2 = "{$r has resource $x;$x val 'f';}";
+        String resource = "{$x has resource $r;$r 'f';}";
+        String resource2 = "{$r has resource $x;$x 'f';}";
         String resource3 = "{$r has resource 'f';}";
 
         ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction(resource, graph), graph);

--- a/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/kb/internal/RuleTest.java
@@ -196,7 +196,7 @@ public class RuleTest {
     public void whenAddingRuleWithIllegalAtomicInHead_ResourceWithAmbiguousPredicates_Throw() throws InvalidKBException {
         validateIllegalHead(
                 graknTx.graql().parser().parsePattern("(role1: $x, role2: $y) isa relation1"),
-                graknTx.graql().parser().parsePattern("{$x has res1 $r; $r val =10; $r val =20;}"),
+                graknTx.graql().parser().parsePattern("{$x has res1 $r; $r == 10; $r == 20;}"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_RESOURCE_WITH_AMBIGUOUS_PREDICATES
         );
     }
@@ -294,7 +294,7 @@ public class RuleTest {
         );
         validateIllegalHead(
                 graknTx.graql().parser().parsePattern("($x, $y); $x isa res1;"),
-                graknTx.graql().parser().parsePattern("$x val '100'"),
+                graknTx.graql().parser().parsePattern("$x == '100'"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalHead(
@@ -304,7 +304,7 @@ public class RuleTest {
         );
         validateIllegalRule(
                 graknTx.graql().parser().parsePattern("($x, $y); $x isa res1;"),
-                graknTx.graql().parser().parsePattern("$x val '100'"),
+                graknTx.graql().parser().parsePattern("$x == '100'"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalRule(

--- a/grakn-test-tools/src/main/graql/admission-rules.gql
+++ b/grakn-test-tools/src/main/graql/admission-rules.gql
@@ -88,7 +88,7 @@ rule-11
 when {$x isa applicant;
 $x has considerGPR 'true';
 $x has GPR >2.99;
-$x has specialHonours !='none';},
+$x has specialHonours !== 'none';},
 then {$x has admissionStatus 'full';};
 
 rule-12

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -430,7 +430,7 @@ public class GraqlShellIT {
             String value = Strings.repeat("really-", 100000) + "long-value";
 
             assertShellMatches(
-                    "define X sub " + Schema.MetaSchema.ATTRIBUTE.getLabel().getValue() + " datatype string; insert val '" + value + "' isa X;",
+                    "define X sub " + Schema.MetaSchema.ATTRIBUTE.getLabel().getValue() + " datatype string; insert isa X val '" + value + "';",
                     anything(),
                     anything(),
                     "match $x isa X; get;",
@@ -451,7 +451,7 @@ public class GraqlShellIT {
 
             // Query has a syntax error
             ShellResponse response = runShell(
-                    "insert X sub resource datatype string; value '" + value + "' isa X;\n"
+                    "define X sub attribute datatype string; insert isa X value '" + value + "' ;\n"
             );
 
             assertThat(response.err(), allOf(containsString("syntax error"), containsString(value)));


### PR DESCRIPTION
# Why is this PR needed?
To disambiguate and clean up syntax for comparing attribute values.

# What does the PR do?
* value equality and inequality syntax update:
  - `$x != $y` -> `$x !== $y`
  - `$x = $y` -> `$x == $y`
* comparisons with single equals, e. g. `$x = $y`, are not valid syntax anymore
* `val` keyword is now optional for specifying attribute values. Could remove it completely but leaving to maintain backwards compatibility. 
If we want to specify a value we can either do`$x == 'value';` or `$x 'value';`. 
# Does it break backwards compatibility?

# List of future improvements not on this PR
