### PR TITLE
Allow deploying Grakn Core maven artifact versioned by git commit id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -954,16 +954,6 @@
         </dependency>
     </dependencies>
 
-    <distributionManagement>
-      <snapshotRepository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-      </snapshotRepository>
-      <repository>
-        <id>ossrh</id>
-        <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-      </repository>
-    </distributionManagement>
     <repositories>
         <!--Snapshot repository for 3rd party libraries -->
         <repository>
@@ -1103,17 +1093,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.7</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>2.19.1</version>
@@ -1225,13 +1204,7 @@
 
     <profiles>
         <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
+            <id>grakn-releases</id>
             <build>
                 <plugins>
                     <plugin>
@@ -1267,28 +1240,39 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.7</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>graknRepo</id>
-            <activation>
-                <property>
-                    <name>graknRepo</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-              <skip.deploy.dist>false</skip.deploy.dist>
-            </properties>
             <distributionManagement>
                 <snapshotRepository>
-                    <id>snapshots</id>
-                    <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
                 </snapshotRepository>
                 <repository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>grakn-snapshots</id>
+            <properties>
+                <skip.deploy.dist>false</skip.deploy.dist>
+            </properties>
+            <distributionManagement>
+                <repository>
                     <id>releases</id>
-                    <url>https://maven.grakn.ai/content/repositories/releases/</url>
+                    <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
                 </repository>
             </distributionManagement>
         </profile>


### PR DESCRIPTION
# Why is this PR needed?
Solving the issue of KGMS depending on Grakn Core artifact which is a SNAPSHOT version. This often causes the build to break if a newer SNAPSHOT is pushed to the maven repository.

With this PR, Grakn Core will be deployed to a snapshot repository which is versioned by commit id instead (ie., `v1.1.0-174-g3b30ebaa7c5605bb1b28d27aacd3b6f410aad9da`).

# What does the PR do?
Refactor the `pom.xml` to introduce 2 profiles, `grakn-releases` and `grakn-snapshots`. The one which will be used by KGMS is `grakn-snapshots`.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Automate the deployment of new artifacts