### PR TITLE
Don't show ID of inferred concepts

### DIFF
--- a/grakn-dashboard/src/components/graphPage/nodePanel.vue
+++ b/grakn-dashboard/src/components/graphPage/nodePanel.vue
@@ -151,6 +151,10 @@ export default {
     },
     nodeProperties() {
       if (this.node === undefined) return {};
+      if(this.node.baseType === 'INFERRED_RELATIONSHIP') return {
+        type: this.node.type,
+        baseType: this.node.baseType,
+      }
       return {
         id: this.node.id,
         type: this.node.type,


### PR DESCRIPTION
# Why is this PR needed?
Don't show ID of inferred concepts in node panel

# What does the PR do?
In `nodePanel.vue` return object that does not contain `id` field if user selects an inferred node

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A