### PR TITLE
Add an "internal-release" maven repository for Grakn Core internal release (ie., for KGMS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1258,14 +1258,14 @@
             </distributionManagement>
         </profile>
         <profile>
-            <id>grakn-snapshots</id>
+            <id>internal-releases</id>
             <properties>
                 <skip.deploy.dist>false</skip.deploy.dist>
             </properties>
             <distributionManagement>
                 <repository>
-                    <id>releases</id>
-                    <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
+                    <id>internal-releases</id>
+                    <url>https://maven.grakn.ai/content/repositories/internal-releases/</url>
                 </repository>
             </distributionManagement>
         </profile>


### PR DESCRIPTION
# Why is this PR needed?
Let's not mix the repository for normal release with the internal release for KGMS's use.

# What does the PR do?
Add an "internal-release" maven repository for Grakn Core internal release.

Grakn Core release from `master` will go to this repository, and have a version number based on its commit id which will look like `v1.1.0-174-g3b30ebaa7c5605bb1b28d27aacd3b6f410aad9da`. The version is generated via `git describe --abbrev=40 head`.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A