### PR TITLE
Set gRPC max response size to 2GB

### DIFF
--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
@@ -29,7 +29,6 @@ import ai.grakn.rpc.generated.GraknGrpc.GraknStub;
 import ai.grakn.util.SimpleURI;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 
 import static ai.grakn.grpc.GrpcUtil.GRPC_MAX_MESSAGE_SIZE_IN_BYTES;

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
@@ -41,6 +41,8 @@ import io.grpc.ManagedChannelBuilder;
  */
 public class RemoteGraknSession implements GraknSession {
 
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = 209715200; // 200MB
+
     private final Keyspace keyspace;
     private final SimpleURI uri;
     private final ManagedChannel channel;
@@ -58,7 +60,7 @@ public class RemoteGraknSession implements GraknSession {
 
     public static RemoteGraknSession create(Keyspace keyspace, SimpleURI uri){
         ManagedChannel channel =
-                ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort()).usePlaintext(true).build();
+                ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort()).maxInboundMessageSize(GRPC_MAX_MESSAGE_SIZE_IN_BYTES).usePlaintext(true).build();
 
         return create(keyspace, uri, channel);
     }

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
@@ -30,6 +30,7 @@ import ai.grakn.util.SimpleURI;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.netty.NettyChannelBuilder;
 
 /**
  * Remote implementation of {@link GraknSession} that communicates with a Grakn server using gRPC.
@@ -41,7 +42,7 @@ import io.grpc.ManagedChannelBuilder;
  */
 public class RemoteGraknSession implements GraknSession {
 
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = 209715200; // 200MB
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE;
 
     private final Keyspace keyspace;
     private final SimpleURI uri;
@@ -60,7 +61,7 @@ public class RemoteGraknSession implements GraknSession {
 
     public static RemoteGraknSession create(Keyspace keyspace, SimpleURI uri){
         ManagedChannel channel =
-                ManagedChannelBuilder.forAddress(uri.getHost(), uri.getPort()).maxInboundMessageSize(GRPC_MAX_MESSAGE_SIZE_IN_BYTES).usePlaintext(true).build();
+                NettyChannelBuilder.forAddress(uri.getHost(), uri.getPort()).maxInboundMessageSize(GRPC_MAX_MESSAGE_SIZE_IN_BYTES).usePlaintext(true).build();
 
         return create(keyspace, uri, channel);
     }

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
@@ -32,6 +32,8 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.NettyChannelBuilder;
 
+import static ai.grakn.grpc.GrpcUtil.GRPC_MAX_MESSAGE_SIZE_IN_BYTES;
+
 /**
  * Remote implementation of {@link GraknSession} that communicates with a Grakn server using gRPC.
  *
@@ -41,8 +43,6 @@ import io.grpc.netty.NettyChannelBuilder;
  * @author Felix Chapman
  */
 public class RemoteGraknSession implements GraknSession {
-
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 2 GB
 
     private final Keyspace keyspace;
     private final SimpleURI uri;

--- a/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
+++ b/grakn-client/src/main/java/ai/grakn/remote/RemoteGraknSession.java
@@ -42,7 +42,7 @@ import io.grpc.netty.NettyChannelBuilder;
  */
 public class RemoteGraknSession implements GraknSession {
 
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE;
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 2 GB
 
     private final Keyspace keyspace;
     private final SimpleURI uri;

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
@@ -43,7 +43,7 @@ import ai.grakn.factory.SystemKeyspaceSession;
 import ai.grakn.grpc.GrpcOpenRequestExecutor;
 import com.codahale.metrics.MetricRegistry;
 import io.grpc.Server;
-import io.grpc.ServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
 import spark.Service;
 
 import java.util.Collection;
@@ -55,6 +55,8 @@ import java.util.Collections;
  * @author Michele Orsi
  */
 public class GraknEngineServerFactory {
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = 209715200; // 200MB
+
     /**
      * Create a {@link GraknEngineServer} configured for Grakn Core. Grakn Queue (which is needed for post-processing and distributed locks) is implemented with Redis as the backend store
      *
@@ -132,7 +134,7 @@ public class GraknEngineServerFactory {
     private static GrpcServer configureGrpcServer(GraknConfig config, EngineGraknTxFactory engineGraknTxFactory, PostProcessor postProcessor){
         int grpcPort = config.getProperty(GraknConfigKey.GRPC_PORT);
         GrpcOpenRequestExecutor requestExecutor = new GrpcOpenRequestExecutorImpl(engineGraknTxFactory);
-        Server grpcServer = ServerBuilder.forPort(grpcPort).addService(new GrpcGraknService(requestExecutor, postProcessor)).build();
+        Server grpcServer = NettyServerBuilder.forPort(grpcPort).maxMessageSize(GRPC_MAX_MESSAGE_SIZE_IN_BYTES).addService(new GrpcGraknService(requestExecutor, postProcessor)).build();
         return GrpcServer.create(grpcServer);
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
@@ -49,14 +49,14 @@ import spark.Service;
 import java.util.Collection;
 import java.util.Collections;
 
+import static ai.grakn.grpc.GrpcUtil.GRPC_MAX_MESSAGE_SIZE_IN_BYTES;
+
 /**
  * This is a factory class which contains methods for instantiating a {@link GraknEngineServer} in different ways.
  *
  * @author Michele Orsi
  */
 public class GraknEngineServerFactory {
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 2 GB
-
     /**
      * Create a {@link GraknEngineServer} configured for Grakn Core. Grakn Queue (which is needed for post-processing and distributed locks) is implemented with Redis as the backend store
      *

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
@@ -55,7 +55,7 @@ import java.util.Collections;
  * @author Michele Orsi
  */
 public class GraknEngineServerFactory {
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 200MB
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 2 GB
 
     /**
      * Create a {@link GraknEngineServer} configured for Grakn Core. Grakn Queue (which is needed for post-processing and distributed locks) is implemented with Redis as the backend store

--- a/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/GraknEngineServerFactory.java
@@ -55,7 +55,7 @@ import java.util.Collections;
  * @author Michele Orsi
  */
 public class GraknEngineServerFactory {
-    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = 209715200; // 200MB
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 200MB
 
     /**
      * Create a {@link GraknEngineServer} configured for Grakn Core. Grakn Queue (which is needed for post-processing and distributed locks) is implemented with Redis as the backend store

--- a/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
+++ b/grakn-grpc/src/main/java/ai/grakn/grpc/GrpcUtil.java
@@ -84,9 +84,10 @@ import static java.util.stream.Collectors.toList;
  * @author Felix Chapman
  */
 public class GrpcUtil {
+    public static final int GRPC_MAX_MESSAGE_SIZE_IN_BYTES = Integer.MAX_VALUE; // 2 GB
 
     private static final GrpcConcept.Unit UNIT = GrpcConcept.Unit.getDefaultInstance();
-
+    
     static class UnknownGraknException extends GraknException {
 
         private static final long serialVersionUID = 4354432748314041017L;


### PR DESCRIPTION
# Why is this PR needed?
For some analytics query like [this one](https://work.grakn.ai/entity/20034-graql-short-compute-path-crashes-with), the response size can be as big as 50MB.

# What does the PR do?
Handle scenario such as this one by increasing the response size limit to 200MB. In order to be able to do so, we need to do it via the `NettyServerBuilder`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Sending result with a streaming approach can be considered

**We are providing the same fix in Grakn KGMS**: https://github.com/graknlabs/grakn-kgms/pull/84