### PR TITLE
fix owl error message

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Graql.java
@@ -29,6 +29,7 @@ import ai.grakn.migration.export.Main;
 import ai.grakn.migration.json.JsonMigrator;
 import ai.grakn.migration.sql.SQLMigrator;
 import ai.grakn.migration.xml.XmlMigrator;
+import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.GraknVersion;
 import com.google.common.base.StandardSystemProperty;
 import org.apache.commons.cli.ParseException;
@@ -103,7 +104,7 @@ public class Graql {
                 JsonMigrator.main(valuesFrom(args, 1));
                 break;
             case "owl":
-                System.out.println("Owl migration not supported anymore");
+                System.err.println(ErrorMessage.OWL_NOT_SUPPORTED.getMessage());
                 break;
             case "export":
                 Main.main(valuesFrom(args, 1));

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -143,6 +143,9 @@ public enum ErrorMessage {
             "Cannot produce graph"),
     COULD_NOT_REACH_ENGINE("Could not reach Grakn engine at [%s]"),
 
+    //--------------------------------------------- Migration Errors -----------------------------------------------
+    OWL_NOT_SUPPORTED("Owl migration is not supported anymore"),
+
     //--------------------------------------------- Graql Errors -----------------------------------------------
     NO_TX("no graph provided"),
 


### PR DESCRIPTION
# Why is this PR needed?
Fix grammar error and centralise the error message into `GraknUtil.ErrorMessage`.

# What does the PR do?
1. Centralise error message into `GraknUtil.ErrorMessage`.
2. Fix minor grammar error.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A