### PR TITLE
Highlight '[', ']', 'using', and 'where' in graql queries

### DIFF
--- a/grakn-dashboard/src/components/graphPage/modules/QueryBuilder.js
+++ b/grakn-dashboard/src/components/graphPage/modules/QueryBuilder.js
@@ -35,7 +35,7 @@ export default {
   },
 
   shortestPathBuilder(nodeIds) {
-    return `compute path from "${nodeIds[0]}" to "${nodeIds[1]}";`;
+    return `compute path from "${nodeIds[0]}", to "${nodeIds[1]}";`;
   },
 
   exploreRelationshipsBuilder(nodeIds) {

--- a/grakn-dashboard/src/js/codemirrorGraql.js
+++ b/grakn-dashboard/src/js/codemirrorGraql.js
@@ -5,13 +5,13 @@ CodeMirror.defineSimpleMode('graql', {
   start: [
     { regex: /#.*/, token: 'comment' },
     { regex: /".*?"/, token: 'string' },
-    { regex: /(match|insert|delete|select|isa|sub|plays|relates|datatype|is-abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in|aggregate|label|get)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
+    { regex: /(match|insert|delete|select|isa|sub|plays|relates|datatype|is-abstract|has|value|id|of|limit|offset|order|by|compute|from|to|in|aggregate|label|get|using|where)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
       token: 'keyword' },
     { regex: /true|false/, token: 'number' },
     { regex: /\$[-a-zA-Z_0-9]+/, token: 'variable' },
     { regex: /[-a-zA-Z_][-a-zA-Z_0-9]*/, token: 'identifier' },
     { regex: /[0-9]+(\.[0-9][0-9]*)?/, token: 'number' },
-    { regex: /=|!=|>|<|>=|<=|contains|regex/, token: 'operator' },
+    { regex: /=|!=|>|<|>=|<=|\[|\]|contains|regex/, token: 'operator' },
   ],
   comment: [],
   // The meta property contains global information about the mode. It

--- a/grakn-dashboard/src/js/prismGraql.js
+++ b/grakn-dashboard/src/js/prismGraql.js
@@ -29,7 +29,7 @@ export default {
     alias: 'string',
   },
   keyword: {
-    pattern: /((?:(?![-a-zA-Z_0-9]).)|^|\s)(match|insert|delete|select|isa|sub|plays|relates|datatype|is-abstract|has|value|id|of|limit|offset|order|by|compute|aggregate|label|get)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
+    pattern: /((?:(?![-a-zA-Z_0-9]).)|^|\s)(match|insert|delete|select|isa|sub|plays|relates|datatype|is-abstract|has|value|id|of|limit|offset|order|by|compute|aggregate|label|get|using|where)(?![-a-zA-Z_0-9])/, // eslint-disable-line max-len
     alias: 'keyword',
     lookbehind: true,
   },
@@ -50,7 +50,7 @@ export default {
     alias: 'number',
   },
   operator: {
-    pattern: /=|!=|>|<|>=|<=|contains|regex/,
+    pattern: /=|!=|>|<|>=|<=|\[|\]|contains|regex/,
     alias: 'operator',
   },
 };


### PR DESCRIPTION
# Why is this PR needed?
Highlight '[', ']', 'using', and 'where' in graql queries

# What does the PR do?
Added the following characters to the patterns to match while highlighting queries and response.
[
]
using
where

# Does it break backwards compatibility?
No. 

# List of future improvements not on this PR
Currently we are using two ways to highlight text.
We can remove codemirrorGraql.js and use PrismGraql.js to highlight in all places: Graql editor, console page, and while saving the current query in addCurrentQuery.vue