### PR TITLE
Trim unwanted characters from ask query response

### DIFF
--- a/grakn-dashboard/src/components/consolePage.vue
+++ b/grakn-dashboard/src/components/consolePage.vue
@@ -132,7 +132,7 @@ export default {
     shellResponse(resp, err) {
 
       // Remove unwanted characters from ask query response
-      if((resp.startsWith('[32m') && resp.endsWith('[0m')) || (resp.startsWith('[31') && resp.endsWith('[0m'))){
+      if( (resp.startsWith('[32m') || resp.startsWith('[31m')) && resp.endsWith('[0m')){
         resp = resp.slice(5,-4);
       }
 

--- a/grakn-dashboard/src/components/consolePage.vue
+++ b/grakn-dashboard/src/components/consolePage.vue
@@ -130,6 +130,12 @@ export default {
          * EngineClient callbacks
          */
     shellResponse(resp, err) {
+
+      // Remove unwanted characters from ask query response
+      if((resp.startsWith('[32m') && resp.endsWith('[0m')) || (resp.startsWith('[31') && resp.endsWith('[0m'))){
+        resp = resp.slice(5,-4);
+      }
+
       if (resp.length === 0) {
         this.state.eventHub.$emit('warning-message', 'No results were found for your query.');
       } else {


### PR DESCRIPTION
# Why is this PR needed?
- Ask query output in dashboard console has odd characters

# What does the PR do?
- Checks if the the query response contains the odd characters and trims the response string to exclude them

# Does it break backwards compatibility?
- No. 

# List of future improvements not on this PR
- Check at the back-end if the query is for the console page of the dashboard and does not send the unwanted characters along with the response.