### PR TITLE
Add relationship settings to query settings panel

### DIFF
--- a/grakn-dashboard/src/components/graphPage/modules/CanvasHandler.js
+++ b/grakn-dashboard/src/components/graphPage/modules/CanvasHandler.js
@@ -136,13 +136,20 @@ function onGraphResponse(resp: string) {
   // Load relationship types' roles - this will work only if loading schema concepts i.e. relationship types
   linkRelationshipTypesToRoles(filteredNodes);
 
-  // If we have 0 edges to display (e.g. when user clicks on Types -> Relationships -> one type of relationship type)
-  // force to load relationships role players.
-  // This to avoid floating points representing relationships without any roleplayer attached to any of them
-  if (parsedResponse.edges.length === 0) {
+  // Get load Role-Players status from local storage
+  const rolePlayers = localStorage.getItem('load_role_players');
+
+  // Check if user has set loading of Role-Players
+  if(rolePlayers === "true"){
+
+    // If we have 0 edges to display (e.g. when user clicks on Types -> Relationships -> one type of relationship type)
+    // force to load relationships role players.
+    // This to avoid floating points representing relationships without any roleplayer attached to any of them
+    if (parsedResponse.edges.length === 0) {
     filterNodes(parsedResponse.nodes).filter(x => x.baseType.endsWith('RELATIONSHIP'))
       .forEach((rel) => { loadRelationshipRolePlayers(rel); });
-  }
+    }
+  }  
   visualiser.fitGraphToWindow();
 }
 
@@ -164,7 +171,11 @@ function getId(str) {
 }
 
 function loadRelationshipRolePlayers(rel) {
-  const promises = rel.roleplayers.map(x => EngineClient.request({ url: x.thing }));
+
+  // Get Limit set by user on Role-Players shown
+  const rolePlayersLimit = localStorage.getItem('role_players_limit');
+
+  const promises = rel.roleplayers.slice(0,rolePlayersLimit).map(x => EngineClient.request({ url: x.thing }));
   Promise.all(promises)
     .then((resps) => { resps.forEach((res) => { onGraphResponse(res); }); })
     .then(() => {
@@ -203,7 +214,6 @@ function loadRoleRolePlayers(role, relId) {
         });
     });
 }
-
 
 function addAttributeAndEdgeToInstance(instanceId, res) {
   onGraphResponse(res);

--- a/grakn-dashboard/src/components/graqlEditor/querySettings.vue
+++ b/grakn-dashboard/src/components/graqlEditor/querySettings.vue
@@ -18,82 +18,46 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
 
 <template>
 <div>
-    <button @click="togglePanel" class="btn btn-default console-button"><i class="fa fa-cog"></i></button>
+    <button @click="togglePanel" class="btn btn-default"><i class="fa fa-cog"></i></button>
     <transition name="fade-in">
         <div v-if="showSettings" class="dropdown-content">
-            <div class="panel-heading">
-                <h4><i class="page-header-icon fa fa-cog"></i>Query settings</h4>
-                <a @click="closeSettings"><i class="fa fa-times"></i></a>
+          <div class="panel-heading">
+              <i class="page-header-icon fa fa-cog"></i>Query settings
+              <a @click="closeSettings"><i class="page-header-close-icon fa fa-times"></i></a>
+          </div>
+          <div class="panel-body">
+            <div class="dd-item">
+                <div class="left"><input type="checkbox" v-model="freezeNodes"></div><div class="right">Lock nodes position</div>
             </div>
-            <div class="panel-body">
-              <div class="dd-item">
-                 <div class="left"><input type="checkbox" v-model="freezeNodes"></div><div class="right">Lock nodes position</div>
+            <div class="divide"></div>
+            <div class="dd-item">
+                <div class="left"><input type="checkbox" v-model="useReasoner"></div><div class="right"> Activate inference</div>
+            </div>
+            <div class="divide"></div>
+            <div class="dd-item">
+              <div class="left ">Query limit:</div><input v-model="queryLimit" type="text" class="form-control input-box" maxlength="3" size="4">
+            </div>
+            <div class="divide"></div>
+            <div class="rel-settings">
+              <button @click="toggleRelationshipSettings" class="btn rel-btn">Relationship Settings</button>
+            </div>
+            <transition name="fade-in">
+              <div v-if="showRelationshipSettings">
+                <div class="dd-item">
+                  <div class="left rp-settings"><input type="checkbox" v-model="loadRolePlayers"></div><div class="right">Autoload role players</div>
+                </div>
+                <div class="dd-item" v-if="this.loadRolePlayers">
+                  <div class="left rp-settings">Limit role players:</div><input v-model="rolePlayersLimit" type="text" class="form-control" maxlength="3" size="4">
+                </div>
               </div>
-                <div class="divide"></div>
-                <div class="dd-item">
-                   <div class="left"><input type="checkbox" v-model="useReasoner"></div><div class="right"> Activate inference</div>
-                </div>
-                <div class="divide"></div>
-                <div class="dd-item">
-                  <div class="left">Query Limit:</div><div class="right"><input v-model="queryLimit" type="text" class="form-control" maxlength="3" size="4"></div>
-                </div>
-            </div>
+            </transition>
+          </div>
         </div>
     </transition>
 </div>
 </template>
 
 <style scoped>
-
-.panel-heading {
-    padding: 5px 10px;
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 10px;
-}
-
-.divide{
-  border-bottom: 1px solid #606060;
-  min-height: 5px;
-  margin-bottom: 5px;
-}
-
-.left{
-  display: inline-flex;
-  margin-right: 5px;
-}
-.right{
-  display: inline-flex;
-  flex:1;
-}
-.fa-times{
-  cursor: pointer;
-}
-
-.page-header-icon {
-    font-size: 20px;
-    float: left;
-    margin-right: 10px;
-}
-
-.panel-body {
-    display: flex;
-    flex-direction: column;
-}
-
-.dd-item {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    flex: 1;
-    margin: 10px 5px;
-    padding-left: 7px;
-}
-
-.list-key{
-  display: inline-flex;
-  flex:1;
-}
 
 .dropdown-content {
     position: absolute;
@@ -103,6 +67,73 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
     margin-top: 5px;
     background-color: #0f0f0f;
     padding: 10px;
+}
+
+.panel-heading {
+    margin-bottom: 10px;
+    width: 200px;
+}
+
+.page-header-icon {
+    padding-right: 35px;
+    font-size: 20px;
+}
+
+.page-header-close-icon {
+    margin-left: 35px;
+    float: right;
+    cursor: pointer;
+}
+
+.panel-body {
+    display: flex;
+    flex-direction: column;
+}
+
+.dd-item {
+    display: inline;
+    margin: 10px 10px;
+    padding-left: 7px;
+}
+
+.divide {
+  border-bottom: 1px solid #606060;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.left{
+  display: inline-flex;
+  margin-right: 5px;
+}
+
+.right{
+  display: inline-flex;
+  flex:1;
+}
+
+.rel-settings{
+  text-align: center;
+}
+
+.rel-btn{
+  display: inline;
+  height: 30px;
+  padding-bottom: 35px;
+}
+
+.input-box {
+  border: 1px solid #ccc;
+  float: right;
+}
+
+.rp-settings {
+  padding-bottom: 10px;
+  padding-top: 10px;
+}
+
+input:focus { 
+    background-color: #00eca2;
 }
 
 </style>
@@ -116,8 +147,11 @@ export default {
   data() {
     return {
       useReasoner: User.getReasonerStatus(),
+      loadRolePlayers: User.getRolePlayersStatus(),
       showSettings: false,
+      showRelationshipSettings: false,
       queryLimit: User.getQueryLimit(),
+      rolePlayersLimit: User.getRolePlayersLimit(),
       freezeNodes: User.getFreezeNodes(),
       elementId:'4',
     };
@@ -131,15 +165,28 @@ export default {
     });
     this.state.eventHub.$on('show-new-navbar-element',(elementId)=>{if(elementId!=this.elementId)this.showSettings=false;});
   },
+
   mounted() {
     this.$nextTick(() => {
-
     });
   },
+
   watch: {
+
     useReasoner(newVal, oldVal) {
       User.setReasonerStatus(newVal);
     },
+
+    //Set loading of Role-Players status
+    loadRolePlayers(newVal, oldVal) {
+      User.setRolePlayersStatus(newVal);
+      if(newVal){
+        toastr.success('Role-Players will be loaded with relationships.');
+      } else {
+        toastr.success('Role-Players will not be loaded with relationships.');
+      }      
+    },
+
     freezeNodes(newVal, oldVal) {
       User.setFreezeNodes(newVal);
       if (newVal) {
@@ -150,19 +197,35 @@ export default {
         toastr.success('All nodes UNLOCKED.');
       }
     },
+
     queryLimit(newVal, oldVal) {
       User.setQueryLimit(newVal);
       if (newVal.length > 0) this.queryLimit = User.getQueryLimit();
     },
+
+    // Set Role-Players limit from relationship settings
+    rolePlayersLimit(newVal, oldVal) {
+      User.setRolePlayersLimit(newVal);
+      if (newVal.length > 0) this.rolePlayersLimit = User.getRolePlayersLimit();
+    },
   },
+
   methods: {
     closeSettings() {
       this.showSettings = false;
+      this.showRelationshipSettings = false;
     },
+
     togglePanel(){
         this.showSettings=!this.showSettings;
+        this.showRelationshipSettings = false;
         if(this.showSettings) this.state.eventHub.$emit('show-new-navbar-element',this.elementId);
-    }
+    },
+
+    toggleRelationshipSettings() {
+      this.showRelationshipSettings = !this.showRelationshipSettings;
+      if(this.showRelationshipSettings) this.state.eventHub.$emit('show-new-navbar-element',this.elementId);
+    }    
   },
 };
 </script>

--- a/grakn-dashboard/src/components/graqlEditor/querySettings.vue
+++ b/grakn-dashboard/src/components/graqlEditor/querySettings.vue
@@ -46,7 +46,7 @@ along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>. -->
                 <div class="dd-item">
                   <div class="left rp-settings"><input type="checkbox" v-model="loadRolePlayers"></div><div class="right">Autoload role players</div>
                 </div>
-                <div class="dd-item" v-if="this.loadRolePlayers">
+                <div class="dd-item">
                   <div class="left rp-settings">Limit role players:</div><input v-model="rolePlayersLimit" type="text" class="form-control" maxlength="3" size="4">
                 </div>
               </div>

--- a/grakn-dashboard/src/js/User.js
+++ b/grakn-dashboard/src/js/User.js
@@ -3,8 +3,11 @@ import EngineClient from './EngineClient';
 
 // Default constant values
 const DEFAULT_USE_REASONER = true;
+const DEFAULT_ROLE_PLAYERS = true;
 export const DEFAULT_KEYSPACE = 'grakn';
 const DEFAULT_QUERY_LIMIT = '30';
+const DEFAULT_ROLE_PLAYERS_LIMIT = '50';
+
 
 
 export default {
@@ -36,6 +39,37 @@ export default {
   setFreezeNodes(status) {
     localStorage.setItem('freeze_nodes', status);
   },
+
+    // -------------- Relationship Settings ------------ //
+
+    setRolePlayersStatus(status) {
+      localStorage.setItem('load_role_players', status);
+    },
+  
+    // @return boolean
+    getRolePlayersStatus() {
+      const rolePlayers = localStorage.getItem('load_role_players');
+      if (rolePlayers == null) {
+        this.setRolePlayersStatus(DEFAULT_ROLE_PLAYERS);
+        return DEFAULT_ROLE_PLAYERS;
+      }
+      return (rolePlayers === 'true');
+    },
+
+    setRolePlayersLimit(value) {
+      let parsedValue = parseInt(value, 10) || 0;
+      if (parsedValue < 0) parsedValue = 0;
+      localStorage.setItem('role_players_limit', parsedValue);
+    },
+
+    getRolePlayersLimit() {
+      const rolePlayersLimit = localStorage.getItem('role_players_limit');
+      if (rolePlayersLimit == null) {
+        this.setRolePlayersLimit(DEFAULT_ROLE_PLAYERS_LIMIT);
+        return DEFAULT_ROLE_PLAYERS_LIMIT;
+      }
+      return rolePlayersLimit;
+    },
 
   // ---- Current Keyspace -----//
   setCurrentKeySpace(keyspace) {


### PR DESCRIPTION
# Why is this PR needed?
Dashboard shows all role-players in a relationship. Was not user friendly.

# What does the PR do?
Add relationship settings to the query settings page to let the user choose to autoload role players and also to set a limit on the number of role players shown to the the user.

# Does it break backwards compatibility?
No.

# List of future improvements not on this PR
Have more settings for the user to have more control on what is shown on the graph page.