### PR TITLE
Bugfix for java.lang.RuntimeException: Couldn’t get PID of Grakn. Received '

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/pid/GraknPidFileStore.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/pid/GraknPidFileStore.java
@@ -19,6 +19,8 @@
 package ai.grakn.bootup.graknengine.pid;
 
 import ai.grakn.util.ErrorMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +35,8 @@ import java.nio.file.Path;
  *
  */
 public class GraknPidFileStore implements GraknPidStore {
+    private static final Logger LOG = LoggerFactory.getLogger(GraknPidFileStore.class);
+
     private final Path pidFilePath;
 
     public GraknPidFileStore(Path pidFilePath) {
@@ -50,15 +54,14 @@ public class GraknPidFileStore implements GraknPidStore {
     }
 
     private void attemptToWritePidFile(long pid, Path pidFilePath) {
-        if (!pidFilePath.toFile().exists()) {
-            String pidString = Long.toString(pid);
-            try {
-                Files.write(pidFilePath, pidString.getBytes(StandardCharsets.UTF_8));
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        } else {
-            throw new GraknPidException(ErrorMessage.PID_ALREADY_EXISTS.getMessage(pidFilePath.toString()));
+        if (pidFilePath.toFile().exists()) {
+            LOG.warn(ErrorMessage.PID_ALREADY_EXISTS.getMessage(pidFilePath.toString()));
+        }
+        String pidString = Long.toString(pid);
+        try {
+            Files.write(pidFilePath, pidString.getBytes(StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/pid/UnixGraknPidRetriever.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/pid/UnixGraknPidRetriever.java
@@ -18,10 +18,7 @@
 
 package ai.grakn.bootup.graknengine.pid;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
+import java.lang.management.ManagementFactory;
 
 /**
  *
@@ -32,36 +29,13 @@ import java.nio.charset.StandardCharsets;
  */
 
 public class UnixGraknPidRetriever implements GraknPidRetriever {
-    public static final String psEfCommand = "ps -ef | ps -ef | grep \"ai.grakn.bootup.graknengine.Grakn\" | grep -v grep | awk '{print $2}'";
     public long getPid() {
-        StringBuilder outputS = new StringBuilder();
-        int exitValue = 1;
-
-        Process p;
-        try {
-            p = Runtime.getRuntime().exec(new String[] { "/bin/sh", "-c", psEfCommand }, null, null);
-            p.waitFor();
-            exitValue = p.exitValue();
-
-            if (exitValue == 0) {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))){
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        outputS.append(line).append("\n");
-                    }
-                }
-            } else {
-                throw new RuntimeException("a non-zero exit code '" + exitValue + "'returned by the command '" + psEfCommand + "'");
-            }
-        } catch (InterruptedException | IOException e) {
-            // DO NOTHING
-        }
-
-        String pidString = outputS.toString().trim();
+        String[] pidAndHostnameString = ManagementFactory.getRuntimeMXBean().getName().split("@");
+        String pidString = pidAndHostnameString[0];
         try {
             return Long.parseLong(pidString);
         } catch (NumberFormatException e) {
-            throw new RuntimeException("Couldn't get PID of Grakn. Received '" + pidString);
+            throw new RuntimeException("Couldn't get the PID of Grakn Engine. Received '" + pidString + "'");
         }
     }
 }

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -190,7 +190,7 @@ public enum ErrorMessage {
     UNSUPPORTED_CONTENT_TYPE("Unsupported Content-Type [%s] requested"),
     CANNOT_DELETE_KEYSPACE("Could not delete keyspace [%s]"),
 
-    PID_ALREADY_EXISTS("pid file already exists: '[%s]'."),
+    PID_ALREADY_EXISTS("Pid file already exists: '[%s]'. Overwriting..."),
 
     //--------------------------------------------- Reasoner Errors -----------------------------------------------
     NON_ATOMIC_QUERY("Addressed query is not atomic: [%s]."),


### PR DESCRIPTION
# Why is this PR needed?
Addresses issue https://github.com/graknlabs/grakn/issues/2811

# What does the PR do?
1. Replace `ps -ef | grep` with `ManagementFactory.getRuntimeMXBean().getName()`
2. If an Engine PID file is left but the process isn't running we know that it is a left-over PID file which can safely be overwritten.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A