### PR TITLE
Flaky tests workaround - execute tests on a slave node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,47 +49,52 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-                script {
-                    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: 4], generateInclusions: true
-                    def numSplits = splits.size()
-                    def testTimeout = 30 + 90 / numSplits // change timeout based on how many splits we have. e.g. 1 split = 120min, 3 splits = 60min
+//                script {
+//                    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: 4], generateInclusions: true
+//                    def numSplits = splits.size()
+//                    def testTimeout = 30 + 90 / numSplits // change timeout based on how many splits we have. e.g. 1 split = 120min, 3 splits = 60min
+//
+//                    splits.eachWithIndex { split, i ->
+//                        node {
+//                            String workspace = pwd()
+//                            try {
+//                                checkout scm
+//
+//                                def mavenVerify = 'clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+//
+//                                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
+//                                /* Tell Maven to read the appropriate file. */
+//                                if (split.includes) {
+//                                    writeFile file: "${workspace}/parallel-test-includes-${i}.txt", text: split.list.join("\n")
+//                                    mavenVerify += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
+//                                } else {
+//                                    writeFile file: "${workspace}/parallel-test-excludes-${i}.txt", text: split.list.join("\n")
+//                                    mavenVerify += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
+//                                }
+//
+//                                try {
+//                                    /* Call the Maven build with tests. */
+//                                    timeout(testTimeout) {
+//                                        stage('Run Janus test profile') {
+//                                            sh 'mvn ' + mavenVerify
+//                                        }
+//                                    }
+//                                } finally {
+//                                    /* Archive the test results */
+//                                    junit "**/TEST*.xml"
+//                                }
+//                            } finally {
+//                                stage('Tear Down') {
+//                                    sh './grakn-test/test-integration/src/test/bash/tear-down.sh'
+//                                }
+//                            }
+//                        }
+//                    }
+//                }
 
-                    splits.eachWithIndex { split, i ->
-                        node {
-                            String workspace = pwd()
-                            try {
-                                checkout scm
-
-                                def mavenVerify = 'clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-
-                                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
-                                /* Tell Maven to read the appropriate file. */
-                                if (split.includes) {
-                                    writeFile file: "${workspace}/parallel-test-includes-${i}.txt", text: split.list.join("\n")
-                                    mavenVerify += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
-                                } else {
-                                    writeFile file: "${workspace}/parallel-test-excludes-${i}.txt", text: split.list.join("\n")
-                                    mavenVerify += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
-                                }
-
-                                try {
-                                    /* Call the Maven build with tests. */
-                                    timeout(testTimeout) {
-                                        stage('Run Janus test profile') {
-                                            sh 'mvn ' + mavenVerify
-                                        }
-                                    }
-                                } finally {
-                                    /* Archive the test results */
-                                    junit "**/TEST*.xml"
-                                }
-                            } finally {
-                                stage('Tear Down') {
-                                    sh './grakn-test/test-integration/src/test/bash/tear-down.sh'
-                                }
-                            }
-                        }
-                    }
+                node {
+                    checkout scm
+                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
                 }
             }
         }
@@ -149,9 +154,6 @@ pipeline {
         }
         failure {
             slackGithub "Build Failure", "danger"
-        }
-        always {
-            junit '**/TEST*.xml'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
     agent any
 
     stages {
-        stage('Build + Configure') {
+        stage('Build') {
             steps {
                 sh 'mvn versions:set -DnewVersion=test -DgenerateBackupPoms=false'
                 sh "mvn --batch-mode install -T 2.5C -DskipTests=true"
@@ -49,57 +49,9 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-//                script {
-//                    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: 4], generateInclusions: true
-//                    def numSplits = splits.size()
-//                    def testTimeout = 30 + 90 / numSplits // change timeout based on how many splits we have. e.g. 1 split = 120min, 3 splits = 60min
-//
-//                    splits.eachWithIndex { split, i ->
-//                        node {
-//                            String workspace = pwd()
-//                            try {
-//                                checkout scm
-//
-//                                def mavenVerify = 'clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-//
-//                                /* Write includesFile or excludesFile for tests.  Split record provided by splitTests. */
-//                                /* Tell Maven to read the appropriate file. */
-//                                if (split.includes) {
-//                                    writeFile file: "${workspace}/parallel-test-includes-${i}.txt", text: split.list.join("\n")
-//                                    mavenVerify += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
-//                                } else {
-//                                    writeFile file: "${workspace}/parallel-test-excludes-${i}.txt", text: split.list.join("\n")
-//                                    mavenVerify += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
-//                                }
-//
-//                                try {
-//                                    /* Call the Maven build with tests. */
-//                                    timeout(testTimeout) {
-//                                        stage('Run Janus test profile') {
-//                                            sh 'mvn ' + mavenVerify
-//                                        }
-//                                    }
-//                                } finally {
-//                                    /* Archive the test results */
-//                                    junit "**/TEST*.xml"
-//                                }
-//                            } finally {
-//                                stage('Tear Down') {
-//                                    sh './grakn-test/test-integration/src/test/bash/tear-down.sh'
-//                                }
-//                            }
-//                        }
-//                    }
-//                }
-                script {
-                    node {
-                        try {
-                            checkout scm
-                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-                        } finally {
-                            junit '**/TEST*.xml'
-                        }
-                    }
+                node {
+                    checkout scm
+                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
                 }
             }
         }
@@ -159,6 +111,9 @@ pipeline {
         }
         failure {
             slackGithub "Build Failure", "danger"
+        }
+        post {
+            junit '**/TEST*.xml'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,16 +51,16 @@ pipeline {
             steps {
                 script {
                     def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: 4], generateInclusions: true
-                    def additionalParams = ""
+                    def inclusionExclusion = ""
                     splits.eachWithIndex { split, i ->
                         if (split.includes) {
                             writeFile file: "${workspace}/parallel-test-includes-${i}.txt", text: split.list.join("\n")
-                            additionalParams += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
+                            inclusionExclusion += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
                         } else {
                             writeFile file: "${workspace}/parallel-test-excludes-${i}.txt", text: split.list.join("\n")
-                            additionalParams += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
+                            inclusionExclusion += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
                         }
-                        sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1 ' + additionalParams
+                        sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1 ' + inclusionExclusion
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                                     /* Call the Maven build with tests. */
                                     timeout(testTimeout) {
                                         stage('Run Janus test profile') {
-                                            mvn mavenVerify
+                                            sh 'mvn ' + mavenVerify
                                         }
                                     }
                                 } finally {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,13 +49,13 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-//                script {
+                script {
                     node {
                         checkout scm
 //                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
                         sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
                     }
-//                }
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
                         checkout scm
                         try {
 //                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest#testDegrees -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
                         }
                         finally {
                             junit "**/TEST*.xml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,8 +53,7 @@ pipeline {
                     node {
                         checkout scm
                         try {
-//                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest#testDegrees -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
                         }
                         finally {
                             junit "**/TEST*.xml"
@@ -76,16 +75,14 @@ pipeline {
             parallel {
                 stage('SNB') {
                     steps {
-                        sh 'echo s'
-//                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh'
-//                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh'
+                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh'
+                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh'
                     }
                 }
                 stage('Biomed') {
                     steps {
-                        sh 'echo b'
-//                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/load.sh'
-//                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/validate.sh'
+                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/load.sh'
+                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/validate.sh'
                     }
                 }
 
@@ -93,13 +90,12 @@ pipeline {
                     when { branch 'stable' }
 
                     steps {
-//                        sshagent(credentials: ['jenkins-aws-ssh']) {
-//                            sh "echo 'Running the long running instance test in ${LONG_RUNNING_INSTANCE_ADDRESS}"
-//                            sh "scp -o StrictHostKeyChecking=no grakn-dist/target/grakn-dist-test.tar.gz ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/grakn-dist.tar.gz"
-//                            sh "scp -o StrictHostKeyChecking=no scripts/repeat-query ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/"
-//                            sh "ssh -o StrictHostKeyChecking=no -l ubuntu ${LONG_RUNNING_INSTANCE_ADDRESS} 'bash -s' < scripts/start-long-running-instance.sh"
-//                        }
-                        sh 'echo l'
+                        sshagent(credentials: ['jenkins-aws-ssh']) {
+                            sh "echo 'Running the long running instance test in ${LONG_RUNNING_INSTANCE_ADDRESS}"
+                            sh "scp -o StrictHostKeyChecking=no grakn-dist/target/grakn-dist-test.tar.gz ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/grakn-dist.tar.gz"
+                            sh "scp -o StrictHostKeyChecking=no scripts/repeat-query ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/"
+                            sh "ssh -o StrictHostKeyChecking=no -l ubuntu ${LONG_RUNNING_INSTANCE_ADDRESS} 'bash -s' < scripts/start-long-running-instance.sh"
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,20 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-                sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+                script {
+                    def splits = splitTests parallelism: [$class: 'CountDrivenParallelism', size: 4], generateInclusions: true
+                    def additionalParams = ""
+                    splits.eachWithIndex { split, i ->
+                        if (split.includes) {
+                            writeFile file: "${workspace}/parallel-test-includes-${i}.txt", text: split.list.join("\n")
+                            additionalParams += " -Dsurefire.includesFile=${workspace}/parallel-test-includes-${i}.txt"
+                        } else {
+                            writeFile file: "${workspace}/parallel-test-excludes-${i}.txt", text: split.list.join("\n")
+                            additionalParams += " -Dsurefire.excludesFile=${workspace}/parallel-test-excludes-${i}.txt"
+                        }
+                        sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1 ' + additionalParams
+                    }
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,10 +91,15 @@ pipeline {
 //                        }
 //                    }
 //                }
-
-                node {
-                    checkout scm
-                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+                script {
+                    node {
+                        try {
+                            checkout scm
+                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+                        } finally {
+                            junit '**/TEST*.xml'
+                        }
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,10 +49,12 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-                node {
-                    checkout scm
+                script {
+                    node {
+                        checkout scm
 //                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                        sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,13 @@ pipeline {
                 script {
                     node {
                         checkout scm
+                        try {
 //                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
-                        sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                            sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
+                        }
+                        finally {
+                            junit "**/TEST*.xml"
+                        }
                     }
                 }
             }
@@ -71,14 +76,16 @@ pipeline {
             parallel {
                 stage('SNB') {
                     steps {
-                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh'
-                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh'
+                        sh 'echo s'
+//                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh'
+//                        sh 'PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh'
                     }
                 }
                 stage('Biomed') {
                     steps {
-                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/load.sh'
-                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/validate.sh'
+                        sh 'echo b'
+//                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/load.sh'
+//                        sh 'PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/validate.sh'
                     }
                 }
 
@@ -86,12 +93,13 @@ pipeline {
                     when { branch 'stable' }
 
                     steps {
-                        sshagent(credentials: ['jenkins-aws-ssh']) {
-                            sh "echo 'Running the long running instance test in ${LONG_RUNNING_INSTANCE_ADDRESS}"
-                            sh "scp -o StrictHostKeyChecking=no grakn-dist/target/grakn-dist-test.tar.gz ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/grakn-dist.tar.gz"
-                            sh "scp -o StrictHostKeyChecking=no scripts/repeat-query ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/"
-                            sh "ssh -o StrictHostKeyChecking=no -l ubuntu ${LONG_RUNNING_INSTANCE_ADDRESS} 'bash -s' < scripts/start-long-running-instance.sh"
-                        }
+//                        sshagent(credentials: ['jenkins-aws-ssh']) {
+//                            sh "echo 'Running the long running instance test in ${LONG_RUNNING_INSTANCE_ADDRESS}"
+//                            sh "scp -o StrictHostKeyChecking=no grakn-dist/target/grakn-dist-test.tar.gz ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/grakn-dist.tar.gz"
+//                            sh "scp -o StrictHostKeyChecking=no scripts/repeat-query ubuntu@${LONG_RUNNING_INSTANCE_ADDRESS}:~/"
+//                            sh "ssh -o StrictHostKeyChecking=no -l ubuntu ${LONG_RUNNING_INSTANCE_ADDRESS} 'bash -s' < scripts/start-long-running-instance.sh"
+//                        }
+                        sh 'echo l'
                     }
                 }
             }
@@ -114,9 +122,6 @@ pipeline {
         }
         failure {
             slackGithub "Build Failure", "danger"
-        }
-        always {
-            junit '**/TEST*.xml'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,13 +49,13 @@ pipeline {
 
         stage('Unit + IT Tests') {
             steps {
-                script {
+//                script {
                     node {
                         checkout scm
 //                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
                         sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
                     }
-                }
+//                }
             }
         }
 
@@ -115,7 +115,7 @@ pipeline {
         failure {
             slackGithub "Build Failure", "danger"
         }
-        post {
+        always {
             junit '**/TEST*.xml'
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,8 @@ pipeline {
             steps {
                 node {
                     checkout scm
-                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+//                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dsurefire.rerunFailingTestsCount=1'
+                    sh 'mvn clean verify -P janus -U -Djetty.log.level=WARNING -Djetty.log.appender=STDOUT -DMaven.test.failure.ignore=true -Dtest=ai.grakn.graql.internal.analytics.GraqlTest -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1'
                 }
             }
         }


### PR DESCRIPTION
# Why is this PR needed?
I have noticed that the tests are flakier after we simplify the Jenkinsfile.

# What does the PR do?
This PR brings back the changes from the old Jenkinsfile, which is to execute unit / integration tests on a different slave node.

It seems to help in reducing the chance of race conditions with Cassandra

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A
