### PR TITLE
Fixed Query.inferring() method

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/Query.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Query.java
@@ -21,7 +21,6 @@ package ai.grakn.graql;
 import ai.grakn.GraknTx;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -57,6 +56,5 @@ public interface Query<T> {
      */
     Optional<? extends GraknTx> tx();
 
-    @Nullable
     Boolean inferring();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
@@ -66,6 +66,8 @@ public interface MatchAdmin extends Match {
     @CheckReturnValue
     Set<Var> getSelectedNames();
 
-    @Nullable
+    /**
+     * @return true if query will involve / set to performing inference
+     */
     Boolean inferring();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/MatchAdmin.java
@@ -24,7 +24,6 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 
 import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
@@ -25,7 +25,6 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.admin.Answer;
 import com.google.auto.value.AutoValue;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 
 /**
@@ -65,7 +64,6 @@ abstract class AggregateQueryImpl<T> extends AbstractExecutableQuery<T> implemen
         return match().toString() + " aggregate " + aggregate().toString() + ";";
     }
 
-    @Nullable
     @Override
     public final Boolean inferring() {
         return match().admin().inferring();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DefineQueryImpl.java
@@ -63,9 +63,8 @@ abstract class DefineQueryImpl extends AbstractExecutableQuery<Answer> implement
         return "define " + varPatterns().stream().map(v -> v + ";").collect(Collectors.joining("\n")).trim();
     }
 
-    @Nullable
     @Override
     public Boolean inferring() {
-        return null;
+        return false;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
@@ -26,7 +26,6 @@ import ai.grakn.graql.admin.DeleteQueryAdmin;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -83,7 +82,6 @@ abstract class DeleteQueryImpl extends AbstractQuery<Void, Void> implements Dele
         return Stream.empty();
     }
 
-    @Nullable
     @Override
     public final Boolean inferring() {
         return match().admin().inferring();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
@@ -26,7 +26,6 @@ import ai.grakn.graql.admin.Answer;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -79,7 +78,6 @@ public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> i
         return stream().collect(Collectors.toList());
     }
 
-    @Nullable
     @Override
     public final Boolean inferring() {
         return match().admin().inferring();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -33,7 +33,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -123,9 +122,8 @@ abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> imple
         return stream().collect(Collectors.toList());
     }
 
-    @Nullable
     @Override
     public final Boolean inferring() {
-        return match().map(match -> match.admin().inferring()).orElse(null);
+        return match().map(match -> match.admin().inferring()).orElse(false);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/UndefineQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/UndefineQueryImpl.java
@@ -67,9 +67,8 @@ abstract class UndefineQueryImpl extends AbstractQuery<Void, Void> implements Un
         return Stream.empty();
     }
 
-    @Nullable
     @Override
     public Boolean inferring() {
-        return null;
+        return false;
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
@@ -74,7 +74,6 @@ abstract class MatchModifier extends AbstractMatch {
      */
     protected abstract String modifierString();
 
-    @Nullable
     @Override
     public Boolean inferring() {
         return inner.inferring();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchModifier.java
@@ -25,7 +25,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
 
-import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.Set;
 


### PR DESCRIPTION
# Why is this PR needed?

`Query.inferring()` sometimes return `null`, such as:
- when the `match` part was not present. 
- when it is a `define` and `undefine` query

That logic is wrong, it should return `false`.

# What does the PR do?

Make it return `false` rather than `null` and remove `@Nullable` annotation.

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR

None.