### PR TITLE
Bootup refactor + various bootup fixes

### DIFF
--- a/grakn-bootup/pom.xml
+++ b/grakn-bootup/pom.xml
@@ -67,5 +67,9 @@
             <groupId>org.zeroturnaround</groupId>
             <artifactId>zt-exec</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.auto.value</groupId>
+            <artifactId>auto-value</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/grakn-bootup/pom.xml
+++ b/grakn-bootup/pom.xml
@@ -43,8 +43,6 @@
             <groupId>ai.grakn</groupId>
             <artifactId>grakn-graql-shell</artifactId>
         </dependency>
-
-        <!--Migrations-->
         <dependency>
             <groupId>ai.grakn</groupId>
             <artifactId>migration-sql</artifactId>
@@ -64,6 +62,10 @@
         <dependency>
             <groupId>ai.grakn</groupId>
             <artifactId>migration-export</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.zeroturnaround</groupId>
+            <artifactId>zt-exec</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/AbstractProcessHandler.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/AbstractProcessHandler.java
@@ -143,7 +143,7 @@ public abstract class AbstractProcessHandler {
         return operatingSystem.output.trim().equals("Darwin") ? osx : linux;
     }
 
-    public boolean processIsRunning(Path pidFile) {
+    public boolean isProcessRunning(Path pidFile) {
         boolean isRunning = false;
         String processPid;
         if (pidFile.toFile().exists()) {
@@ -168,7 +168,7 @@ public abstract class AbstractProcessHandler {
     public void stopProgram(Path pidFile, String programName) {
         System.out.print("Stopping "+programName+"...");
         System.out.flush();
-        boolean programIsRunning = processIsRunning(pidFile);
+        boolean programIsRunning = isProcessRunning(pidFile);
         if(!programIsRunning) {
             System.out.println("NOT RUNNING");
         } else {
@@ -185,7 +185,7 @@ public abstract class AbstractProcessHandler {
     }
 
     public void processStatus(Path storagePid, String name) {
-        if (processIsRunning(storagePid)) {
+        if (isProcessRunning(storagePid)) {
             System.out.println(name+": RUNNING");
         } else {
             System.out.println(name+": NOT RUNNING");

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/AbstractProcessHandler.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/AbstractProcessHandler.java
@@ -33,7 +33,7 @@ import java.util.Optional;
  */
 public abstract class AbstractProcessHandler {
 
-    public static final long WAIT_INTERVAL_S=2;
+    public static final long WAIT_INTERVAL_SECOND = 2;
     public static final String SH = "/bin/sh";
 
     public OutputCommand executeAndWait(String[] cmdarray, String[] envp, File dir) {
@@ -118,7 +118,7 @@ public abstract class AbstractProcessHandler {
             outputCommand = kill(pid,"0");
 
             try {
-                Thread.sleep(WAIT_INTERVAL_S * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 // DO NOTHING
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupException.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupException.java
@@ -22,5 +22,5 @@ package ai.grakn.bootup;
  *
  * @author Michele Orsi
  */
-public class ProcessNotStartedException extends RuntimeException {
+public class BootupException extends RuntimeException {
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FileUtils;
 import org.zeroturnaround.exec.ProcessExecutor;
 import org.zeroturnaround.exec.ProcessResult;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -49,8 +50,9 @@ public class BootupProcessExecutor {
 
     public BootupProcessResult executeAndWait(List<String> command, File workingDirectory) {
         try {
-            ProcessResult result = new ProcessExecutor().readOutput(true).directory(workingDirectory).command(command).execute();
-            return BootupProcessResult.create(result.outputUTF8(), "", result.getExitValue());
+            ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+            ProcessResult result = new ProcessExecutor().readOutput(true).redirectError(stderr).directory(workingDirectory).command(command).execute();
+            return BootupProcessResult.create(result.outputUTF8(), stderr.toString(StandardCharsets.UTF_8.name()), result.getExitValue());
         }
         catch (IOException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
@@ -31,10 +31,10 @@ import java.util.Optional;
  *
  * @author Michele Orsi
  */
-public abstract class AbstractProcessHandler {
+public class BootupProcessExecutor {
 
-    public static final long WAIT_INTERVAL_SECOND = 2;
-    public static final String SH = "/bin/sh";
+    public final long WAIT_INTERVAL_SECOND = 2;
+    public final String SH = "/bin/sh";
 
     public OutputCommand executeAndWait(String[] cmdarray, String[] envp, File dir) {
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
@@ -41,8 +41,8 @@ import java.util.concurrent.TimeoutException;
  */
 public class BootupProcessExecutor {
 
-    public final long WAIT_INTERVAL_SECOND = 2;
-    public final String SH = "/bin/sh";
+    public static final long WAIT_INTERVAL_SECOND = 2;
+    public static final String SH = "/bin/sh";
 
     public CompletableFuture<BootupProcessResult> executeAsync(List<String> command, File workingDirectory) {
         return CompletableFuture.supplyAsync(() -> executeAndWait(command, workingDirectory));

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessExecutor.java
@@ -154,7 +154,7 @@ public class BootupProcessExecutor {
 
     void stopProcess(Path pidFile) {
         int pid = retrievePid(pidFile);
-        if (pid <0 ) return;
+        if (pid < 0 ) return;
         kill(pid);
         waitUntilStopped(pidFile, pid);
     }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessResult.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/BootupProcessResult.java
@@ -18,20 +18,25 @@
 
 package ai.grakn.bootup;
 
+import com.google.auto.value.AutoValue;
+
 /**
  *
+ * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  */
-public class OutputCommand {
-    public final String output;
-    public final int exitStatus;
 
-    public OutputCommand(String output, int exitStatus) {
-        this.output = output;
-        this.exitStatus = exitStatus;
+@AutoValue
+public abstract class BootupProcessResult {
+    public static BootupProcessResult create(String stdout, String stderr, int exitCode) {
+        return new AutoValue_BootupProcessResult(stdout, stderr, exitCode);
     }
 
-    public boolean succes() {
-        return exitStatus==0;
+    public boolean success() {
+        return exitCode() == 0;
     }
+
+    public abstract String stdout();
+    public abstract String stderr();
+    public abstract int exitCode();
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -59,8 +59,6 @@ public class EngineBootup {
     private static final Path ENGINE_PIDFILE = Paths.get(File.separator,"tmp","grakn-engine.pid");
     private static final String JAVA_OPTS = Optional.ofNullable(GraknSystemProperty.ENGINE_JAVAOPTS.value()).orElse("");
 
-    protected static Class ENGINE_MAIN_CLASS = Grakn.class; // this needs to be overridable as KGMS needs to supply a different class name
-
     protected final Path graknHome;
     protected final Path graknPropertiesPath;
     private final GraknConfig graknProperties;
@@ -72,6 +70,13 @@ public class EngineBootup {
         this.graknHome = graknHome;
         this.graknPropertiesPath = graknPropertiesPath;
         this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
+    }
+
+    /**
+     * @return the main class of Engine. In KGMS, this method will be overriden to return a different class.
+     */
+    public Class getEngineMainClass() {
+        return Grakn.class;
     }
 
     public void startIfNotRunning() {
@@ -92,7 +97,7 @@ public class EngineBootup {
     }
 
     public void statusVerbose() {
-        System.out.println(DISPLAY_NAME + " pid = '"+ bootupProcessExecutor.getPidFromFile(ENGINE_PIDFILE).orElse("")+"' (from "+ ENGINE_PIDFILE +"), '"+ bootupProcessExecutor.getPidFromPsOf(ENGINE_MAIN_CLASS.getName()) +"' (from ps -ef)");
+        System.out.println(DISPLAY_NAME + " pid = '"+ bootupProcessExecutor.getPidFromFile(ENGINE_PIDFILE).orElse("")+"' (from "+ ENGINE_PIDFILE +"), '"+ bootupProcessExecutor.getPidFromPsOf(getEngineMainClass().getName()) +"' (from ps -ef)");
     }
 
     public void clean() {
@@ -123,7 +128,7 @@ public class EngineBootup {
                 " -Dgrakn.dir=" + graknHome.toString().replace(" ", "\\ ") +
                 " -Dgrakn.conf="+ graknPropertiesPath.toString().replace(" ", "\\ ") +
                 " -Dgrakn.pidfile=" + ENGINE_PIDFILE.toString().replace(" ", "\\ ") +
-                " " + ENGINE_MAIN_CLASS.getName());
+                " " + getEngineMainClass().getName());
 
         System.out.print("Starting " + DISPLAY_NAME + "...");
         System.out.flush();

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -167,7 +167,7 @@ public class EngineBootup {
         System.out.println("FAILED!");
         System.err.println("Unable to start " + DISPLAY_NAME + ".");
         System.err.println(errorMessage);
-        throw new ProcessNotStartedException();
+        throw new BootupException();
 
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -74,7 +74,7 @@ public class EngineBootup {
     }
 
     /**
-     * @return the main class of Engine. In KGMS, this method will be overriden to return a different class.
+     * @return the main class of Engine. In KGMS, this method will be overridden to return a different class.
      */
     public Class getEngineMainClass() {
         return Grakn.class;

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -126,10 +126,10 @@ public class EngineBootup {
         System.out.print("Starting " + DISPLAY_NAME + "...");
         System.out.flush();
 
-        CompletableFuture<OutputCommand> startEngine = bootupProcessExecutor.executeAsync(startEngineCmd_EscapeWhitespace, graknHome.toFile())
+        CompletableFuture<BootupProcessResult> startEngine = bootupProcessExecutor.executeAsync(startEngineCmd_EscapeWhitespace, graknHome.toFile())
                 .whenComplete((result, ex) -> {
-                    if (result.exitStatus != 0) {
-                        throw new RuntimeException(ErrorMessage.UNABLE_TO_START_GRAKN.getMessage() + ". Engine exited with status " + result.exitStatus);
+                    if (result.exitCode() != 0) {
+                        throw new RuntimeException(ErrorMessage.UNABLE_TO_START_GRAKN.getMessage() + ". Engine exited with status " + result.exitCode());
                     }
                 });
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -25,7 +25,6 @@ import ai.grakn.engine.GraknConfig;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.REST;
 import ai.grakn.util.SimpleURI;
-import sun.rmi.runtime.Log;
 
 import javax.ws.rs.core.UriBuilder;
 import java.io.File;
@@ -45,6 +44,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static ai.grakn.bootup.BootupProcessExecutor.WAIT_INTERVAL_SECOND;
 
 /**
  * A class responsible for managing the Engine process,
@@ -150,7 +151,7 @@ public class EngineBootup {
                 return;
             }
             try {
-                Thread.sleep(bootupProcessExecutor.WAIT_INTERVAL_SECOND * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineBootup.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  */
-public class EngineProcess extends AbstractProcessHandler {
+public class EngineBootup extends AbstractProcessHandler {
     private static final String DISPLAY_NAME = "Engine";
     private static final long ENGINE_STARTUP_TIMEOUT_S = 300;
     private static final Path ENGINE_PIDFILE = Paths.get(File.separator,"tmp","grakn-engine.pid");
@@ -65,7 +65,7 @@ public class EngineProcess extends AbstractProcessHandler {
     protected final Path graknPropertiesPath;
     private final GraknConfig graknProperties;
 
-    public EngineProcess(Path graknHome, Path graknPropertiesPath) {
+    public EngineBootup(Path graknHome, Path graknPropertiesPath) {
         this.graknHome = graknHome;
         this.graknPropertiesPath = graknPropertiesPath;
         this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -69,7 +69,7 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     public void start() {
-        boolean graknIsRunning = processIsRunning(ENGINE_PID);
+        boolean graknIsRunning = isProcessRunning(ENGINE_PID);
         if(graknIsRunning) {
             System.out.println(COMPONENT_NAME + " is already running");
         } else {
@@ -115,7 +115,7 @@ public class EngineProcess extends AbstractProcessHandler {
             String host = graknConfig.getProperty(GraknConfigKey.SERVER_HOST_NAME);
             int port = graknConfig.getProperty(GraknConfigKey.SERVER_PORT);
 
-            if(processIsRunning(ENGINE_PID) && graknCheckIfReady(host,port, REST.WebPath.STATUS)) {
+            if(isProcessRunning(ENGINE_PID) && graknCheckIfReady(host,port, REST.WebPath.STATUS)) {
                 System.out.println("SUCCESS");
                 return;
             }
@@ -182,6 +182,6 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     public boolean isRunning() {
-        return processIsRunning(ENGINE_PID);
+        return isProcessRunning(ENGINE_PID);
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -50,12 +50,11 @@ import java.util.stream.Stream;
  * @author Michele Orsi
  */
 public class EngineProcess extends AbstractProcessHandler {
-    private static final String COMPONENT_NAME = "Engine";
-    private static final String GRAKN_NAME = "Grakn";
-    private static final long GRAKN_STARTUP_TIMEOUT_S = 300;
-    public static final Path ENGINE_PID = Paths.get(File.separator,"tmp","grakn-engine.pid");
-    public static final String javaOpts = Optional.ofNullable(GraknSystemProperty.ENGINE_JAVAOPTS.value()).orElse("");
-    private static final Logger LOG = LoggerFactory.getLogger(EngineProcess.class);
+    private static final String DISPLAY_NAME = "Engine";
+    private static final long ENGINE_STARTUP_TIMEOUT_S = 300;
+    private static final Path ENGINE_PIDFILE = Paths.get(File.separator,"tmp","grakn-engine.pid");
+    private static final String JAVA_OPTS = Optional.ofNullable(GraknSystemProperty.ENGINE_JAVAOPTS.value()).orElse("");
+    private static Class ENGINE_MAIN_CLASS = Grakn.class;
 
     protected final Path graknHome;
     protected final Path graknPropertiesPath;
@@ -67,14 +66,10 @@ public class EngineProcess extends AbstractProcessHandler {
         this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
     }
 
-    protected Class graknClass() {
-        return Grakn.class;
-    }
-
     public void startIfNotRunning() {
-        boolean graknIsRunning = isProcessRunning(ENGINE_PID);
+        boolean graknIsRunning = isProcessRunning(ENGINE_PIDFILE);
         if(graknIsRunning) {
-            System.out.println(COMPONENT_NAME + " is already running");
+            System.out.println(DISPLAY_NAME + " is already running");
         } else {
             start();
         }
@@ -85,31 +80,28 @@ public class EngineProcess extends AbstractProcessHandler {
         File folder = new File(home + File.separator+"services"+File.separator+"lib"); // services/lib folder
         File[] values = folder.listFiles(jarFiles);
         if(values==null) {
-            throw new RuntimeException("No libraries found: cannot run " + COMPONENT_NAME);
+            throw new RuntimeException("No libraries found: cannot run " + DISPLAY_NAME);
         }
         Stream<File> jars = Stream.of(values);
-        File conf = new File(home + File.separator+"conf"+File.separator); // /conf
-        File graknLogback = new File(home + File.separator+"services"+File.separator+"grakn"+File.separator + "server"+File.separator); // services/grakn/server lib
-        return ":"+Stream.concat(jars, Stream.of(conf, graknLogback))
+        File conf = home.resolve("conf").toFile(); // $GRAKN_HOME/conf
+        File graknLogback = Paths.get(home.toAbsolutePath().toString(), "services", "grakn", "server").toFile(); // $GRAKN_HOME/services/grakn/server lib
+        String classPath = ":"+Stream.concat(jars, Stream.of(conf, graknLogback))
                 .filter(f -> !f.getName().contains("slf4j-log4j12"))
                 .map(File::getAbsolutePath)
                 .sorted() // we need to sort otherwise it doesn't load logback configuration properly
                 .collect(Collectors.joining(":"));
+        return classPath;
     }
 
     private void start() {
-        System.out.print("Starting " + COMPONENT_NAME + "...");
+        System.out.print("Starting " + DISPLAY_NAME + "...");
         System.out.flush();
 
         String command = commandToRun();
-        LOG.debug(command);
-        executeAndWait(new String[]{
-                "/bin/sh",
-                "-c",
-                command}, null, null);
+        executeAndWait(new String[]{ "/bin/sh", "-c", command }, null, null);
 
         LocalDateTime init = LocalDateTime.now();
-        LocalDateTime timeout = init.plusSeconds(GRAKN_STARTUP_TIMEOUT_S);
+        LocalDateTime timeout = init.plusSeconds(ENGINE_STARTUP_TIMEOUT_S);
 
         while(LocalDateTime.now().isBefore(timeout)) {
             System.out.print(".");
@@ -118,25 +110,25 @@ public class EngineProcess extends AbstractProcessHandler {
             String host = graknProperties.getProperty(GraknConfigKey.SERVER_HOST_NAME);
             int port = graknProperties.getProperty(GraknConfigKey.SERVER_PORT);
 
-            if(isProcessRunning(ENGINE_PID) && graknCheckIfReady(host,port, REST.WebPath.STATUS)) {
+            if(isProcessRunning(ENGINE_PIDFILE) && graknCheckIfReady(host,port, REST.WebPath.STATUS)) {
                 System.out.println("SUCCESS");
                 return;
             }
             try {
-                Thread.sleep(WAIT_INTERVAL_S * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
         }
 
         System.out.println("FAILED!");
-        System.out.println("Unable to start " + COMPONENT_NAME);
+        System.out.println("Unable to start " + DISPLAY_NAME);
         throw new ProcessNotStartedException();
     }
 
     protected String commandToRun() {
-        String cmd = "java " + javaOpts + " -cp " + getClassPathFrom(graknHome) + " -Dgrakn.dir=" + graknHome +
-                " -Dgrakn.conf="+ graknPropertiesPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
+        String cmd = "java " + JAVA_OPTS + " -cp " + getClassPathFrom(graknHome) + " -Dgrakn.dir=" + graknHome +
+                " -Dgrakn.conf="+ graknPropertiesPath + " -Dgrakn.pidfile=" + ENGINE_PIDFILE.toString() + " " + ENGINE_MAIN_CLASS.getName() + " > /dev/null 2>&1 &";
 
         return cmd;
     }
@@ -157,19 +149,19 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     public void stop() {
-        stopProgram(ENGINE_PID, COMPONENT_NAME);
+        stopProgram(ENGINE_PIDFILE, DISPLAY_NAME);
     }
 
     public void status() {
-        processStatus(ENGINE_PID, COMPONENT_NAME);
+        processStatus(ENGINE_PIDFILE, DISPLAY_NAME);
     }
 
     public void statusVerbose() {
-        System.out.println(COMPONENT_NAME + " pid = '"+ getPidFromFile(ENGINE_PID).orElse("")+"' (from "+ ENGINE_PID +"), '"+ getPidFromPsOf(graknClass().getName()) +"' (from ps -ef)");
+        System.out.println(DISPLAY_NAME + " pid = '"+ getPidFromFile(ENGINE_PIDFILE).orElse("")+"' (from "+ ENGINE_PIDFILE +"), '"+ getPidFromPsOf(ENGINE_MAIN_CLASS.getName()) +"' (from ps -ef)");
     }
 
     public void clean() {
-        System.out.print("Cleaning "+GRAKN_NAME+"...");
+        System.out.print("Cleaning "+DISPLAY_NAME+"...");
         System.out.flush();
         Path rootPath = graknHome.resolve("logs");
         try (Stream<Path> files = Files.walk(rootPath)) {
@@ -180,11 +172,11 @@ public class EngineProcess extends AbstractProcessHandler {
             System.out.println("SUCCESS");
         } catch (IOException e) {
             System.out.println("FAILED!");
-            System.out.println("Unable to clean "+GRAKN_NAME);
+            System.out.println("Unable to clean "+DISPLAY_NAME);
         }
     }
 
     public boolean isRunning() {
-        return isProcessRunning(ENGINE_PID);
+        return isProcessRunning(ENGINE_PIDFILE);
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -71,12 +71,12 @@ public class EngineProcess extends AbstractProcessHandler {
         return Grakn.class;
     }
 
-    public void start() {
+    public void startIfNotRunning() {
         boolean graknIsRunning = isProcessRunning(ENGINE_PID);
         if(graknIsRunning) {
             System.out.println(COMPONENT_NAME + " is already running");
         } else {
-            graknStartProcess();
+            start();
         }
     }
 
@@ -97,7 +97,7 @@ public class EngineProcess extends AbstractProcessHandler {
                 .collect(Collectors.joining(":"));
     }
 
-    private void graknStartProcess() {
+    private void start() {
         System.out.print("Starting " + COMPONENT_NAME + "...");
         System.out.flush();
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/EngineProcess.java
@@ -43,7 +43,10 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
+ * A class responsible for managing the Engine process,
+ * including starting, stopping, and performing status checks
  *
+ * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  */
 public class EngineProcess extends AbstractProcessHandler {
@@ -54,14 +57,14 @@ public class EngineProcess extends AbstractProcessHandler {
     public static final String javaOpts = Optional.ofNullable(GraknSystemProperty.ENGINE_JAVAOPTS.value()).orElse("");
     private static final Logger LOG = LoggerFactory.getLogger(EngineProcess.class);
 
-    protected final Path homePath;
-    protected final Path configPath;
-    private final GraknConfig graknConfig;
+    protected final Path graknHome;
+    protected final Path graknPropertiesPath;
+    private final GraknConfig graknProperties;
 
-    public EngineProcess(Path homePath, Path configPath) {
-        this.homePath = homePath;
-        this.configPath = configPath;
-        this.graknConfig = GraknConfig.read(configPath.toFile());
+    public EngineProcess(Path graknHome, Path graknPropertiesPath) {
+        this.graknHome = graknHome;
+        this.graknPropertiesPath = graknPropertiesPath;
+        this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
     }
 
     protected Class graknClass() {
@@ -112,8 +115,8 @@ public class EngineProcess extends AbstractProcessHandler {
             System.out.print(".");
             System.out.flush();
 
-            String host = graknConfig.getProperty(GraknConfigKey.SERVER_HOST_NAME);
-            int port = graknConfig.getProperty(GraknConfigKey.SERVER_PORT);
+            String host = graknProperties.getProperty(GraknConfigKey.SERVER_HOST_NAME);
+            int port = graknProperties.getProperty(GraknConfigKey.SERVER_PORT);
 
             if(isProcessRunning(ENGINE_PID) && graknCheckIfReady(host,port, REST.WebPath.STATUS)) {
                 System.out.println("SUCCESS");
@@ -132,8 +135,8 @@ public class EngineProcess extends AbstractProcessHandler {
     }
 
     protected String commandToRun() {
-        String cmd = "java " + javaOpts + " -cp " + getClassPathFrom(homePath) + " -Dgrakn.dir=" + homePath +
-                " -Dgrakn.conf="+ configPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
+        String cmd = "java " + javaOpts + " -cp " + getClassPathFrom(graknHome) + " -Dgrakn.dir=" + graknHome +
+                " -Dgrakn.conf="+ graknPropertiesPath + " -Dgrakn.pidfile=" + ENGINE_PID.toString() + " " + graknClass().getName() + " > /dev/null 2>&1 &";
 
         return cmd;
     }
@@ -168,12 +171,12 @@ public class EngineProcess extends AbstractProcessHandler {
     public void clean() {
         System.out.print("Cleaning "+GRAKN_NAME+"...");
         System.out.flush();
-        Path rootPath = homePath.resolve("logs");
+        Path rootPath = graknHome.resolve("logs");
         try (Stream<Path> files = Files.walk(rootPath)) {
             files.sorted(Comparator.reverseOrder())
                     .map(Path::toFile)
                     .forEach(File::delete);
-            Files.createDirectories(homePath.resolve("logs"));
+            Files.createDirectories(graknHome.resolve("logs"));
             System.out.println("SUCCESS");
         } catch (IOException e) {
             System.out.println("FAILED!");

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -176,21 +176,21 @@ public class GraknBootup {
         switch (arg) {
             case ENGINE:
                 try {
-                    engineProcess.start();
+                    engineProcess.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
                 break;
             case QUEUE:
                 try {
-                    queueProcess.start();
+                    queueProcess.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
                 break;
             case STORAGE:
                 try {
-                    storageProcess.start();
+                    storageProcess.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
@@ -198,9 +198,9 @@ public class GraknBootup {
             default:
                 try {
                     ConfigProcessor.updateProcessConfigs();
-                    storageProcess.start();
-                    queueProcess.start();
-                    engineProcess.start();
+                    storageProcess.startIfNotRunning();
+                    queueProcess.startIfNotRunning();
+                    engineProcess.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     System.out.println("Please run 'grakn server status' or check the logs located under 'logs' directory.");
                 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -45,12 +45,12 @@ public class GraknBootup {
     private static final String QUEUE = "queue";
     private static final String STORAGE = "storage";
 
-    private final StorageProcess storageProcess;
+    private final StorageBootup storageBootup;
     private final QueueProcess queueProcess;
     private final EngineProcess engineProcess;
 
-    private GraknBootup(StorageProcess storageProcess, QueueProcess queueProcess, EngineProcess engineProcess) {
-        this.storageProcess = storageProcess;
+    private GraknBootup(StorageBootup storageBootup, QueueProcess queueProcess, EngineProcess engineProcess) {
+        this.storageBootup = storageBootup;
         this.queueProcess = queueProcess;
         this.engineProcess = engineProcess;
     }
@@ -98,7 +98,7 @@ public class GraknBootup {
 
     private static GraknBootup newGraknBootup(Path graknHome, Path configPath) {
         return new GraknBootup(
-                new StorageProcess(graknHome, configPath),
+                new StorageBootup(graknHome, configPath),
                 new QueueProcess(graknHome),
                 new EngineProcess(graknHome, configPath));
     }
@@ -163,12 +163,12 @@ public class GraknBootup {
                 queueProcess.stop();
                 break;
             case STORAGE:
-                storageProcess.stop();
+                storageBootup.stop();
                 break;
             default:
                 engineProcess.stop();
                 queueProcess.stop();
-                storageProcess.stop();
+                storageBootup.stop();
         }
     }
 
@@ -190,7 +190,7 @@ public class GraknBootup {
                 break;
             case STORAGE:
                 try {
-                    storageProcess.startIfNotRunning();
+                    storageBootup.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
@@ -198,7 +198,7 @@ public class GraknBootup {
             default:
                 try {
                     ConfigProcessor.updateProcessConfigs();
-                    storageProcess.startIfNotRunning();
+                    storageBootup.startIfNotRunning();
                     queueProcess.startIfNotRunning();
                     engineProcess.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
@@ -222,13 +222,13 @@ public class GraknBootup {
     }
 
     private void serverStatus(String verboseFlag) {
-        storageProcess.status();
+        storageBootup.status();
         queueProcess.status();
         engineProcess.status();
 
         if(verboseFlag.equals("--verbose")) {
             System.out.println("======== Failure Diagnostics ========");
-            storageProcess.statusVerbose();
+            storageBootup.statusVerbose();
             queueProcess.statusVerbose();
             engineProcess.statusVerbose();
         }
@@ -252,7 +252,7 @@ public class GraknBootup {
     }
 
     private void clean() {
-        boolean storage = storageProcess.isRunning();
+        boolean storage = storageBootup.isRunning();
         boolean queue = queueProcess.isRunning();
         boolean grakn = engineProcess.isRunning();
         if(storage || queue || grakn) {
@@ -266,7 +266,7 @@ public class GraknBootup {
             System.out.println("Response '" + response + "' did not equal 'y' or 'Y'.  Canceling clean operation.");
             return;
         }
-        storageProcess.clean();
+        storageBootup.clean();
         queueProcess.clean();
         engineProcess.clean();
     }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -96,11 +96,11 @@ public class GraknBootup {
         }
     }
 
-    private static GraknBootup newGraknBootup(Path homePathFolder, Path configPath) {
+    private static GraknBootup newGraknBootup(Path graknHome, Path configPath) {
         return new GraknBootup(
-                new StorageProcess(homePathFolder, configPath),
-                new QueueProcess(homePathFolder),
-                new EngineProcess(homePathFolder, configPath));
+                new StorageProcess(graknHome, configPath),
+                new QueueProcess(graknHome),
+                new EngineProcess(graknHome, configPath));
     }
 
     private static void printAscii() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -176,21 +176,21 @@ public class GraknBootup {
             case ENGINE:
                 try {
                     engineBootup.startIfNotRunning();
-                } catch (ProcessNotStartedException e) {
+                } catch (BootupException e) {
                     // DO NOTHING
                 }
                 break;
             case QUEUE:
                 try {
                     queueBootup.startIfNotRunning();
-                } catch (ProcessNotStartedException e) {
+                } catch (BootupException e) {
                     // DO NOTHING
                 }
                 break;
             case STORAGE:
                 try {
                     storageBootup.startIfNotRunning();
-                } catch (ProcessNotStartedException e) {
+                } catch (BootupException e) {
                     // DO NOTHING
                 }
                 break;
@@ -200,7 +200,7 @@ public class GraknBootup {
                     storageBootup.startIfNotRunning();
                     queueBootup.startIfNotRunning();
                     engineBootup.startIfNotRunning();
-                } catch (ProcessNotStartedException e) {
+                } catch (BootupException e) {
                     System.out.println("Please run 'grakn server status' or check the logs located under 'logs' directory.");
                 }
         }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/GraknBootup.java
@@ -46,13 +46,13 @@ public class GraknBootup {
     private static final String STORAGE = "storage";
 
     private final StorageBootup storageBootup;
-    private final QueueProcess queueProcess;
-    private final EngineProcess engineProcess;
+    private final QueueBootup queueBootup;
+    private final EngineBootup engineBootup;
 
-    private GraknBootup(StorageBootup storageBootup, QueueProcess queueProcess, EngineProcess engineProcess) {
+    private GraknBootup(StorageBootup storageBootup, QueueBootup queueBootup, EngineBootup engineBootup) {
         this.storageBootup = storageBootup;
-        this.queueProcess = queueProcess;
-        this.engineProcess = engineProcess;
+        this.queueBootup = queueBootup;
+        this.engineBootup = engineBootup;
     }
 
     /**
@@ -99,8 +99,8 @@ public class GraknBootup {
     private static GraknBootup newGraknBootup(Path graknHome, Path configPath) {
         return new GraknBootup(
                 new StorageBootup(graknHome, configPath),
-                new QueueProcess(graknHome),
-                new EngineProcess(graknHome, configPath));
+                new QueueBootup(graknHome),
+                new EngineBootup(graknHome, configPath));
     }
 
     private static void printAscii() {
@@ -157,17 +157,17 @@ public class GraknBootup {
     private void serverStop(String arg) {
         switch (arg) {
             case ENGINE:
-                engineProcess.stop();
+                engineBootup.stop();
                 break;
             case QUEUE:
-                queueProcess.stop();
+                queueBootup.stop();
                 break;
             case STORAGE:
                 storageBootup.stop();
                 break;
             default:
-                engineProcess.stop();
-                queueProcess.stop();
+                engineBootup.stop();
+                queueBootup.stop();
                 storageBootup.stop();
         }
     }
@@ -176,14 +176,14 @@ public class GraknBootup {
         switch (arg) {
             case ENGINE:
                 try {
-                    engineProcess.startIfNotRunning();
+                    engineBootup.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
                 break;
             case QUEUE:
                 try {
-                    queueProcess.startIfNotRunning();
+                    queueBootup.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     // DO NOTHING
                 }
@@ -199,8 +199,8 @@ public class GraknBootup {
                 try {
                     ConfigProcessor.updateProcessConfigs();
                     storageBootup.startIfNotRunning();
-                    queueProcess.startIfNotRunning();
-                    engineProcess.startIfNotRunning();
+                    queueBootup.startIfNotRunning();
+                    engineBootup.startIfNotRunning();
                 } catch (ProcessNotStartedException e) {
                     System.out.println("Please run 'grakn server status' or check the logs located under 'logs' directory.");
                 }
@@ -223,14 +223,14 @@ public class GraknBootup {
 
     private void serverStatus(String verboseFlag) {
         storageBootup.status();
-        queueProcess.status();
-        engineProcess.status();
+        queueBootup.status();
+        engineBootup.status();
 
         if(verboseFlag.equals("--verbose")) {
             System.out.println("======== Failure Diagnostics ========");
             storageBootup.statusVerbose();
-            queueProcess.statusVerbose();
-            engineProcess.statusVerbose();
+            queueBootup.statusVerbose();
+            engineBootup.statusVerbose();
         }
     }
 
@@ -253,8 +253,8 @@ public class GraknBootup {
 
     private void clean() {
         boolean storage = storageBootup.isRunning();
-        boolean queue = queueProcess.isRunning();
-        boolean grakn = engineProcess.isRunning();
+        boolean queue = queueBootup.isRunning();
+        boolean grakn = engineBootup.isRunning();
         if(storage || queue || grakn) {
             System.out.println("Grakn is still running! Please do a shutdown with 'grakn server stop' before performing a cleanup.");
             return;
@@ -267,8 +267,8 @@ public class GraknBootup {
             return;
         }
         storageBootup.clean();
-        queueProcess.clean();
-        engineProcess.clean();
+        queueBootup.clean();
+        engineBootup.clean();
     }
 }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -128,7 +128,7 @@ public class QueueBootup {
         String errorMessage = "Process exited with code " + startQueue.exitCode() + ": '" + startQueue.stderr() + "'";
         System.out.println("FAILED!");
         System.err.println("Unable to start " + DISPLAY_NAME + ". " + errorMessage);
-        throw new ProcessNotStartedException();
+        throw new BootupException();
     }
 
     private void queueStopProcess() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -31,8 +31,11 @@ import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 
 /**
- * A class responsible for managing the Queue process,
- * including starting, stopping, status checks, and cleaning the Queue data
+ * A class responsible for managing the bootup-related process for the Queue component, including
+ * starting and stopping, performing status checks, and cleaning the data.
+ *
+ * The PID file for the Storage component is managed internally by Cassandra and not by this class. This means that
+ * you will not find any code which creates or deletes the PID file for the Storage component.
  *
  * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -20,15 +20,12 @@ package ai.grakn.bootup;
 
 import ai.grakn.GraknConfigKey;
 import ai.grakn.engine.GraknConfig;
-import org.zeroturnaround.exec.ProcessExecutor;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.concurrent.TimeoutException;
 
 /**
  * A class responsible for managing the bootup-related process for the Queue component, including
@@ -145,8 +142,8 @@ public class QueueBootup {
     }
 
     private String selectCommand(String osx, String linux) {
-        OutputCommand operatingSystem = bootupProcessExecutor.executeAndWait(Arrays.asList(bootupProcessExecutor.SH, "-c", "uname"), null);
-        return operatingSystem.output.trim().equals("Darwin") ? osx : linux;
+        BootupProcessResult operatingSystem = bootupProcessExecutor.executeAndWait(Arrays.asList(bootupProcessExecutor.SH, "-c", "uname"), null);
+        return operatingSystem.stdout().trim().equals("Darwin") ? osx : linux;
     }
 
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -103,7 +103,7 @@ public class QueueBootup {
         System.out.print("Starting "+ DISPLAY_NAME +"...");
         System.out.flush();
 
-        bootupProcessExecutor.executeAndWait(Arrays.asList(QUEUE_SERVER_BIN.toString(), QUEUE_CONFIG_PATH.toString()), graknHome.toFile());
+        BootupProcessResult startQueue = bootupProcessExecutor.executeAndWait(Arrays.asList(QUEUE_SERVER_BIN.toString(), QUEUE_CONFIG_PATH.toString()), graknHome.toFile());
 
         LocalDateTime timeout = LocalDateTime.now().plusSeconds(QUEUE_STARTUP_TIMEOUT_SECOND);
 
@@ -122,8 +122,9 @@ public class QueueBootup {
             }
         }
 
+        String errorMessage = "Process exited with code " + startQueue.exitCode() + ". Error message: " + startQueue.stderr();
         System.out.println("FAILED!");
-        System.out.println("Unable to start "+ DISPLAY_NAME);
+        System.out.println("Unable to start " + DISPLAY_NAME + ": " + errorMessage);
         throw new ProcessNotStartedException();
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeoutException;
  * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  */
-public class QueueProcess extends AbstractProcessHandler {
+public class QueueBootup extends AbstractProcessHandler {
     private static final String DISPLAY_NAME = "Queue";
     private static final String QUEUE_PROCESS_NAME = "redis-server";
     private static final long QUEUE_STARTUP_TIMEOUT_SECOND = 10;
@@ -47,7 +47,7 @@ public class QueueProcess extends AbstractProcessHandler {
 
     private final Path graknHome;
 
-    public QueueProcess(Path graknHome) {
+    public QueueBootup(Path graknHome) {
         this.graknHome = graknHome;
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -27,6 +27,9 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 
+import static ai.grakn.bootup.BootupProcessExecutor.SH;
+import static ai.grakn.bootup.BootupProcessExecutor.WAIT_INTERVAL_SECOND;
+
 /**
  * A class responsible for managing the bootup-related process for the Queue component, including
  * starting and stopping, performing status checks, and cleaning the data.
@@ -116,7 +119,7 @@ public class QueueBootup {
                 return;
             }
             try {
-                Thread.sleep(bootupProcessExecutor.WAIT_INTERVAL_SECOND * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -143,7 +146,7 @@ public class QueueBootup {
     }
 
     private String selectCommand(String osx, String linux) {
-        BootupProcessResult operatingSystem = bootupProcessExecutor.executeAndWait(Arrays.asList(bootupProcessExecutor.SH, "-c", "uname"), null);
+        BootupProcessResult operatingSystem = bootupProcessExecutor.executeAndWait(Arrays.asList(SH, "-c", "uname"), null);
         return operatingSystem.stdout().trim().equals("Darwin") ? osx : linux;
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -56,8 +56,8 @@ public class QueueBootup {
         this.graknHome = graknHome;
         this.bootupProcessExecutor = bootupProcessExecutor;
 
-        QUEUE_SERVER_BIN = Paths.get("services", "redis", bootupProcessExecutor.selectCommand("redis-server-osx", "redis-server-linux"));
-        QUEUE_CLI_BIN = Paths.get("services", "redis", bootupProcessExecutor.selectCommand("redis-cli-osx", "redis-cli-linux"));
+        QUEUE_SERVER_BIN = Paths.get("services", "redis", selectCommand("redis-server-osx", "redis-server-linux"));
+        QUEUE_CLI_BIN = Paths.get("services", "redis", selectCommand("redis-cli-osx", "redis-cli-linux"));
     }
 
     public void startIfNotRunning() {
@@ -143,4 +143,11 @@ public class QueueBootup {
         Path fileLocation = graknHome.resolve(QUEUE_CONFIG_PATH);
         return GraknConfig.read(fileLocation.toFile()).getProperty(GraknConfigKey.REDIS_BIND);
     }
+
+    private String selectCommand(String osx, String linux) {
+        OutputCommand operatingSystem = bootupProcessExecutor.executeAndWait(Arrays.asList(bootupProcessExecutor.SH, "-c", "uname"), null);
+        return operatingSystem.output.trim().equals("Darwin") ? osx : linux;
+    }
+
+
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueBootup.java
@@ -122,9 +122,9 @@ public class QueueBootup {
             }
         }
 
-        String errorMessage = "Process exited with code " + startQueue.exitCode() + ". Error message: " + startQueue.stderr();
+        String errorMessage = "Process exited with code " + startQueue.exitCode() + ": '" + startQueue.stderr() + "'";
         System.out.println("FAILED!");
-        System.out.println("Unable to start " + DISPLAY_NAME + ": " + errorMessage);
+        System.err.println("Unable to start " + DISPLAY_NAME + ". " + errorMessage);
         throw new ProcessNotStartedException();
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -47,15 +47,15 @@ public class QueueProcess extends AbstractProcessHandler {
         this.graknHome = graknHome;
     }
 
-    public void start() {
+    public void startIfNotRunning() {
         boolean queueRunning = isProcessRunning(QUEUE_PIDFILE);
         if(queueRunning) {
             System.out.println(DISPLAY_NAME +" is already running");
         } else {
-            queueStartProcess();
+            start();
         }
     }
-    private void queueStartProcess() {
+    private void start() {
         System.out.print("Starting "+ DISPLAY_NAME +"...");
         System.out.flush();
 
@@ -124,7 +124,7 @@ public class QueueProcess extends AbstractProcessHandler {
     public void clean() {
         System.out.print("Cleaning "+ DISPLAY_NAME +"...");
         System.out.flush();
-        start();
+        startIfNotRunning();
 
         executeAndWait(new String[]{
                 SH,

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -126,7 +126,7 @@ public class QueueProcess extends AbstractProcessHandler {
         System.out.print("Cleaning "+ DISPLAY_NAME +"...");
         System.out.flush();
         startIfNotRunning();
-        executeAndWait(new String[]{ SH, "-c", graknHome.resolve(QUEUE_CLI_BIN) + " flushall" },null,null);
+        redisCliClean();
         stop();
         System.out.println("SUCCESS");
     }
@@ -169,5 +169,20 @@ public class QueueProcess extends AbstractProcessHandler {
         }
     }
 
-    // TODO: redis clean
+    /**
+     * Executes the following command:
+     * ./services/redis/redis-cli-osx flushall
+     */
+    private void redisCliClean() {
+        try {
+            new ProcessExecutor()
+                    .readOutput(true)
+                    .directory(graknHome.toFile())
+                    .command(QUEUE_CLI_BIN.toString(), "flushall")
+                    .execute();
+        }
+        catch (IOException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -77,7 +77,7 @@ public class QueueProcess extends AbstractProcessHandler {
                 return;
             }
             try {
-                Thread.sleep(WAIT_INTERVAL_S * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -45,7 +45,7 @@ public class QueueProcess extends AbstractProcessHandler {
     }
 
     public void start() {
-        boolean queueRunning = processIsRunning(QUEUE_PID);
+        boolean queueRunning = isProcessRunning(QUEUE_PID);
         if(queueRunning) {
             System.out.println(COMPONENT_NAME +" is already running");
         } else {
@@ -73,7 +73,7 @@ public class QueueProcess extends AbstractProcessHandler {
             System.out.print(".");
             System.out.flush();
 
-            if(processIsRunning(QUEUE_PID)) {
+            if(isProcessRunning(QUEUE_PID)) {
                 System.out.println("SUCCESS");
                 return;
             }
@@ -92,7 +92,7 @@ public class QueueProcess extends AbstractProcessHandler {
     public void stop() {
         System.out.print("Stopping "+ COMPONENT_NAME +"...");
         System.out.flush();
-        boolean queueIsRunning = processIsRunning(QUEUE_PID);
+        boolean queueIsRunning = isProcessRunning(QUEUE_PID);
         if(!queueIsRunning) {
             System.out.println("NOT RUNNING");
         } else {
@@ -144,6 +144,6 @@ public class QueueProcess extends AbstractProcessHandler {
     }
 
     public boolean isRunning() {
-        return processIsRunning(QUEUE_PID);
+        return isProcessRunning(QUEUE_PID);
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/QueueProcess.java
@@ -27,7 +27,10 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 
 /**
+ * A class responsible for managing the Queue process,
+ * including starting, stopping, status checks, and cleaning the Queue data
  *
+ * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  */
 public class QueueProcess extends AbstractProcessHandler {
@@ -38,10 +41,10 @@ public class QueueProcess extends AbstractProcessHandler {
 
     private static final String COMPONENT_NAME = "Queue";
 
-    private final Path homePath;
+    private final Path graknHome;
 
-    public QueueProcess(Path homePath) {
-        this.homePath = homePath;
+    public QueueProcess(Path graknHome) {
+        this.graknHome = graknHome;
     }
 
     public void start() {
@@ -63,8 +66,8 @@ public class QueueProcess extends AbstractProcessHandler {
         executeAndWait(new String[]{
                 SH,
                 "-c",
-                homePath +"/services/redis/"+queueBin+" "+ homePath + CONFIG_LOCATION
-        },null,homePath.toFile());
+                graknHome +"/services/redis/"+queueBin+" "+ graknHome + CONFIG_LOCATION
+        },null, graknHome.toFile());
 
         LocalDateTime init = LocalDateTime.now();
         LocalDateTime timeout = init.plusSeconds(QUEUE_STARTUP_TIMEOUT_S);
@@ -109,14 +112,14 @@ public class QueueProcess extends AbstractProcessHandler {
         executeAndWait(new String[]{
                 SH,
                 "-c",
-                homePath + "/services/redis/" + queueBin + " -h " + host + " shutdown"
+                graknHome + "/services/redis/" + queueBin + " -h " + host + " shutdown"
         }, null, null);
 
         waitUntilStopped(QUEUE_PID,pid);
     }
 
     private String getHostFromConfig() {
-        Path fileLocation = Paths.get(homePath.toString(), CONFIG_LOCATION);
+        Path fileLocation = Paths.get(graknHome.toString(), CONFIG_LOCATION);
         return GraknConfig.read(fileLocation.toFile()).getProperty(GraknConfigKey.REDIS_BIND);
     }
 
@@ -137,7 +140,7 @@ public class QueueProcess extends AbstractProcessHandler {
         executeAndWait(new String[]{
                 SH,
                 "-c",
-                homePath.resolve(Paths.get("services", "redis", queueBin))+" flushall"
+                graknHome.resolve(Paths.get("services", "redis", queueBin))+" flushall"
         },null,null);
         stop();
         System.out.println("SUCCESS");

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -130,26 +130,26 @@ public class StorageBootup {
         List<String> storageCmd_EscapeWhitespace = storageCmd.stream().map(string -> string.replace(" ", "\\ ")).collect(Collectors.toList());
 
         // services/cassandra/nodetool statusthrift 2>/dev/null | tr -d '\n\r'
-        List<String> nodetoolCmd_EscapeWhitespace = Arrays.asList(bootupProcessExecutor.SH, "-c",
+        List<String> isStorageRunningCmd_EscapeWhitespace = Arrays.asList(bootupProcessExecutor.SH, "-c",
                 NODETOOL_BIN.toString().replace(" ", "\\ ") + " statusthrift | tr -d '\n\r'");
 
-        System.out.print("Starting " + DISPLAY_NAME +"...");
+        System.out.print("Starting " + DISPLAY_NAME + "...");
         System.out.flush();
 
         OutputCommand startStorage = bootupProcessExecutor.executeAndWait(storageCmd_EscapeWhitespace, graknHome.toFile());
 
-        LocalDateTime init = LocalDateTime.now();
-        LocalDateTime timeout = init.plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
-
-        while(LocalDateTime.now().isBefore(timeout) && startStorage.exitStatus < 1) {
+        LocalDateTime timeout = LocalDateTime.now().plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
+        while(LocalDateTime.now().isBefore(timeout) && startStorage.exitStatus == 0) {
             System.out.print(".");
             System.out.flush();
 
-            OutputCommand storageStatus = bootupProcessExecutor.executeAndWait(nodetoolCmd_EscapeWhitespace, graknHome.toFile());
-            if(storageStatus.output.trim().equals("running")) {
+            OutputCommand isStorageRunning = bootupProcessExecutor.executeAndWait(isStorageRunningCmd_EscapeWhitespace, graknHome.toFile());
+
+            if(isStorageRunning.output.trim().equals("running")) {
                 System.out.println("SUCCESS");
                 return;
             }
+            
             try {
                 Thread.sleep(bootupProcessExecutor.WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -152,9 +152,10 @@ public class StorageBootup {
             }
         }
 
-        String errorMessage = "Process exited with code " + startStorage.exitCode() + ". Error message: " + startStorage.stderr();
+        String errorMessage = "Process exited with code " + startStorage.exitCode() + ": '" + startStorage.stderr() + "'";
         System.out.println("FAILED!");
-        System.out.println("Unable to start " + DISPLAY_NAME + ": " + errorMessage);
+        System.err.println("Unable to start " + DISPLAY_NAME + ". ");
+        System.err.println(errorMessage);
         throw new ProcessNotStartedException();
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -21,11 +21,7 @@ package ai.grakn.bootup;
 import ai.grakn.GraknConfigKey;
 import ai.grakn.engine.GraknConfig;
 import org.apache.commons.io.FileUtils;
-import org.zeroturnaround.exec.ProcessExecutor;
-import org.zeroturnaround.exec.ProcessResult;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -35,7 +31,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -83,7 +78,7 @@ public class StorageBootup {
     }
 
    public void stop() {
-       bootupProcessExecutor.stopProgram(STORAGE_PIDFILE, DISPLAY_NAME);
+       bootupProcessExecutor.stopProcessIfRunning(STORAGE_PIDFILE, DISPLAY_NAME);
     }
 
     public void status() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static ai.grakn.bootup.BootupProcessExecutor.SH;
+import static ai.grakn.bootup.BootupProcessExecutor.WAIT_INTERVAL_SECOND;
+
 /**
  * A class responsible for managing the bootup-related process for the Storage component, including
  * starting and stopping, performing status checks, and cleaning the data.
@@ -125,7 +128,7 @@ public class StorageBootup {
         List<String> storageCmd_EscapeWhitespace = storageCmd.stream().map(string -> string.replace(" ", "\\ ")).collect(Collectors.toList());
 
         // services/cassandra/nodetool statusthrift 2>/dev/null | tr -d '\n\r'
-        List<String> isStorageRunningCmd_EscapeWhitespace = Arrays.asList(bootupProcessExecutor.SH, "-c",
+        List<String> isStorageRunningCmd_EscapeWhitespace = Arrays.asList(SH, "-c",
                 NODETOOL_BIN.toString().replace(" ", "\\ ") + " statusthrift | tr -d '\n\r'");
 
         System.out.print("Starting " + DISPLAY_NAME + "...");
@@ -146,7 +149,7 @@ public class StorageBootup {
             }
 
             try {
-                Thread.sleep(bootupProcessExecutor.WAIT_INTERVAL_SECOND * 1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -117,10 +117,10 @@ public class StorageBootup {
     /**
      * Attempt to start Storage and perform periodic polling until it is ready. The readiness check is performed with nodetool.
      *
-     * A {@link ProcessNotStartedException} will be thrown if Storage does not start after a timeout specified
+     * A {@link BootupException} will be thrown if Storage does not start after a timeout specified
      * in the 'WAIT_INTERVAL_SECOND' field.
      *
-     * @throws ProcessNotStartedException
+     * @throws BootupException
      */
     private void start() {
         // services/cassandra/cassandra -p <storage-pidfile> -l <storage-logdir>
@@ -159,7 +159,7 @@ public class StorageBootup {
         System.out.println("FAILED!");
         System.err.println("Unable to start " + DISPLAY_NAME + ". ");
         System.err.println(errorMessage);
-        throw new ProcessNotStartedException();
+        throw new BootupException();
     }
 
     private Path getStorageLogPathFromGraknProperties() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -131,16 +131,16 @@ public class StorageBootup {
         System.out.print("Starting " + DISPLAY_NAME + "...");
         System.out.flush();
 
-        OutputCommand startStorage = bootupProcessExecutor.executeAndWait(storageCmd_EscapeWhitespace, graknHome.toFile());
+        BootupProcessResult startStorage = bootupProcessExecutor.executeAndWait(storageCmd_EscapeWhitespace, graknHome.toFile());
 
         LocalDateTime timeout = LocalDateTime.now().plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
-        while(LocalDateTime.now().isBefore(timeout) && startStorage.exitStatus == 0) {
+        while(LocalDateTime.now().isBefore(timeout) && startStorage.exitCode() == 0) {
             System.out.print(".");
             System.out.flush();
 
-            OutputCommand isStorageRunning = bootupProcessExecutor.executeAndWait(isStorageRunningCmd_EscapeWhitespace, graknHome.toFile());
+            BootupProcessResult isStorageRunning = bootupProcessExecutor.executeAndWait(isStorageRunningCmd_EscapeWhitespace, graknHome.toFile());
 
-            if(isStorageRunning.output.trim().equals("running")) {
+            if(isStorageRunning.stdout().trim().equals("running")) {
                 System.out.println("SUCCESS");
                 return;
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -149,7 +149,7 @@ public class StorageBootup {
                 System.out.println("SUCCESS");
                 return;
             }
-            
+
             try {
                 Thread.sleep(bootupProcessExecutor.WAIT_INTERVAL_SECOND * 1000);
             } catch (InterruptedException e) {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageBootup.java
@@ -151,8 +151,10 @@ public class StorageBootup {
                 Thread.currentThread().interrupt();
             }
         }
+
+        String errorMessage = "Process exited with code " + startStorage.exitCode() + ". Error message: " + startStorage.stderr();
         System.out.println("FAILED!");
-        System.out.println("Unable to start " + DISPLAY_NAME);
+        System.out.println("Unable to start " + DISPLAY_NAME + ": " + errorMessage);
         throw new ProcessNotStartedException();
     }
 

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -52,7 +52,7 @@ public class StorageProcess extends AbstractProcessHandler {
     }
 
     public void start() {
-        boolean storageIsRunning = processIsRunning(STORAGE_PID);
+        boolean storageIsRunning = isProcessRunning(STORAGE_PID);
         if(storageIsRunning) {
             System.out.println(COMPONENT_NAME +" is already running");
         } else {
@@ -142,6 +142,6 @@ public class StorageProcess extends AbstractProcessHandler {
     }
 
     public boolean isRunning() {
-        return processIsRunning(STORAGE_PID);
+        return isProcessRunning(STORAGE_PID);
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -62,11 +62,8 @@ public class StorageProcess extends AbstractProcessHandler {
         }
     }
 
-    private Path getStorageLogPath(){
-        //make the path absolute to avoid cassandra confusion
-        String logDirString = graknProperties.getProperty(GraknConfigKey.LOG_DIR);
-        Path logDirPath = Paths.get(graknProperties.getProperty(GraknConfigKey.LOG_DIR));
-        return logDirPath.isAbsolute() ? logDirPath : Paths.get(graknHome.toString(), logDirString);
+    private Path getStorageLogPathFromGraknProperties(){
+        return Paths.get(graknProperties.getProperty(GraknConfigKey.LOG_DIR));
     }
 
     private void start() {
@@ -84,7 +81,7 @@ public class StorageProcess extends AbstractProcessHandler {
                 "-c",
                 graknHome.resolve(STORAGE_BIN)
                         + " -p " + STORAGE_PIDFILE
-                        + " -l " + getStorageLogPath()
+                        + " -l " + getStorageLogPathFromGraknProperties().toAbsolutePath()
         }, null, null);
         LocalDateTime init = LocalDateTime.now();
         LocalDateTime timeout = init.plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
@@ -122,7 +119,8 @@ public class StorageProcess extends AbstractProcessHandler {
     }
 
     public void statusVerbose() {
-        System.out.println(DISPLAY_NAME +" pid = '"+ getPidFromFile(STORAGE_PIDFILE).orElse("")+"' (from "+ STORAGE_PIDFILE +"), '"+ getPidFromPsOf(STORAGE_PROCESS_NAME) +"' (from ps -ef)");
+        System.out.println(DISPLAY_NAME +" pid = '"+ getPidFromFile(STORAGE_PIDFILE).orElse("") +
+                "' (from "+ STORAGE_PIDFILE +"), '"+ getPidFromPsOf(STORAGE_PROCESS_NAME) +"' (from ps -ef)");
     }
 
     public void clean() {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -42,6 +42,7 @@ public class StorageProcess extends AbstractProcessHandler {
     private static final long STORAGE_STARTUP_TIMEOUT_SECOND = 60;
     private static final Path STORAGE_PIDFILE = Paths.get(File.separator,"tmp","grakn-storage.pid");
     private static final Path STORAGE_BIN = Paths.get("services", "cassandra", "cassandra");
+    private static final Path NODETOOL_BIN = Paths.get("services", "cassandra", "nodetool");
     private static final Path STORAGE_DATA = Paths.get("db", "cassandra");
 
     private final Path graknHome;
@@ -95,7 +96,7 @@ public class StorageProcess extends AbstractProcessHandler {
             OutputCommand storageStatus = executeAndWait(new String[]{
                     SH,
                     "-c",
-                    graknHome + "/services/cassandra/nodetool statusthrift 2>/dev/null | tr -d '\n\r'"
+                    graknHome.resolve(NODETOOL_BIN) + " statusthrift 2>/dev/null | tr -d '\n\r'"
             },null,null);
             if(storageStatus.output.trim().equals("running")) {
                 System.out.println("SUCCESS");

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -100,7 +100,7 @@ public class StorageProcess extends AbstractProcessHandler {
                 return;
             }
             try {
-                Thread.sleep(WAIT_INTERVAL_S *1000);
+                Thread.sleep(WAIT_INTERVAL_SECOND *1000);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -146,6 +146,10 @@ public class StorageProcess extends AbstractProcessHandler {
         return isProcessRunning(STORAGE_PIDFILE);
     }
 
+    /**
+     * Executes the following command:
+     *   services/cassandra/cassandra -p <storage-pidfile> -l <storage-logdir>
+     */
     private OutputCommand startStorage() {
         try {
             List<String> storageCmd_EscapeWhitespace = Arrays.asList(STORAGE_BIN.toString(), "-p", STORAGE_PIDFILE.toString(),
@@ -168,6 +172,10 @@ public class StorageProcess extends AbstractProcessHandler {
         }
     }
 
+    /**
+     * Executes the following command:
+     *   services/cassandra/nodetool statusthrift 2>/dev/null | tr -d '\n\r'
+     */
     private OutputCommand nodetoolCheckIfStorageIsStarted() {
         try {
             String nodetoolCmd_EscapeWhitespace = NODETOOL_BIN.toString().replace(" ", "\\ ");

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/StorageProcess.java
@@ -53,12 +53,12 @@ public class StorageProcess extends AbstractProcessHandler {
         this.graknProperties = GraknConfig.read(graknPropertiesPath.toFile());
     }
 
-    public void start() {
+    public void startIfNotRunning() {
         boolean storageIsRunning = isProcessRunning(STORAGE_PIDFILE);
         if(storageIsRunning) {
             System.out.println(DISPLAY_NAME +" is already running");
         } else {
-            storageStartProcess();
+            start();
         }
     }
 
@@ -69,7 +69,7 @@ public class StorageProcess extends AbstractProcessHandler {
         return logDirPath.isAbsolute() ? logDirPath : Paths.get(graknHome.toString(), logDirString);
     }
 
-    private void storageStartProcess() {
+    private void start() {
         System.out.print("Starting "+ DISPLAY_NAME +"...");
         System.out.flush();
         if(STORAGE_PIDFILE.toFile().exists()) {

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/config/QueueConfig.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/config/QueueConfig.java
@@ -98,8 +98,8 @@ public class QueueConfig extends ProcessConfig<List<Object>>{
         String dbDir = config.getProperty(GraknConfigKey.DATA_DIR);
 
         ImmutableMap<String, List<Object>> dirParams = ImmutableMap.of(
-                DB_DIR_CONFIG_KEY, Collections.singletonList(dbDir + DATA_SUBDIR),
-                LOG_DIR_CONFIG_KEY, Collections.singletonList(getAbsoluteLogPath(config))
+                DB_DIR_CONFIG_KEY, Collections.singletonList("\"" + dbDir + DATA_SUBDIR + "\""),
+                LOG_DIR_CONFIG_KEY, Collections.singletonList("\"" + getAbsoluteLogPath(config) + "\"")
         );
         return new QueueConfig(this.updateParamsFromMap(dirParams));
     }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/graknengine/Grakn.java
@@ -34,10 +34,11 @@ import java.util.Optional;
 
 /**
  *
- * Main class invoked by bash scripting.
+ * Main class invoked by the 'grakn' bash script.
  *
- * NOTE: The class name is shown when a user is running the 'jps' command. Therefore please keep the class name "Grakn".
+ * NOTE: Please keep the class name "Grakn" as it is shown when a user is running the 'ps' or 'jps' command.
  *
+ * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
  *
  */
@@ -47,7 +48,7 @@ public class Grakn {
 
     /**
      *
-     * Invocation from class 'GraknProcess' in grakn-dist project
+     * Invocation from class '{@link ai.grakn.bootup.GraknBootup}'
      *
      * @param args
      */

--- a/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
+++ b/grakn-core/src/main/java/ai/grakn/util/ErrorMessage.java
@@ -33,6 +33,7 @@ public enum ErrorMessage {
     GRAKN_PIDFILE_SYSTEM_PROPERTY_UNDEFINED("Unable to find the Java system property 'grakn.pidfile'. Don't forget to specify -Dgrakn.pidfile=/path/to/grakn.pid"),
     UNSUPPORTED_JAVA_VERSION("Unsupported Java version [%s] found. Grakn needs Java 1.8 in order to run."),
     UNABLE_TO_START_GRAKN("Unable to start Grakn"),
+    UNABLE_TO_START_ENGINE_JAR_NOT_FOUND("Unable to start Engine, No JAR files found! Please re-download the Grakn distribution."),
     UNABLE_TO_GET_GRAKN_HOME_FOLDER("Unable to find Grakn home folder"),
     UNABLE_TO_GET_GRAKN_CONFIG_FOLDER("Unable to find Grakn config folder"),
     UNCAUGHT_EXCEPTION("Uncaught exception at thread [%s]"),

--- a/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2E.java
+++ b/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2E.java
@@ -114,7 +114,7 @@ public class DistributionE2E {
         String output = commandExecutor
                 .redirectInput(new ByteArrayInputStream(userInput.getBytes(StandardCharsets.UTF_8)))
                 .command("./grakn", "server", "clean").execute().outputUTF8();
-        assertThat(output, allOf(containsString("Cleaning Storage...SUCCESS"), containsString("Cleaning Grakn...SUCCESS")));
+        assertThat(output, allOf(containsString("Cleaning Storage...SUCCESS"), containsString("Cleaning Engine...SUCCESS")));
     }
 
     /**

--- a/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
+++ b/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
@@ -18,7 +18,7 @@ public class DistributionE2EConstants {
     public static final Path GRAKN_BASE_DIRECTORY = Paths.get(System.getProperty("main.basedir"));
     public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), ZIP_FILENAME);
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "grakn-dist-" + GraknVersion.VERSION);
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-dist-" + GraknVersion.VERSION);
 
     public static void assertGraknRunning() {
         assertThat("assertGraknRunning() failed because /tmp/grakn-engine.pid is not found", Paths.get("/tmp/grakn-engine.pid").toFile().exists(), equalTo(true));
@@ -41,6 +41,6 @@ public class DistributionE2EConstants {
     public static void unzipGrakn() throws IOException, InterruptedException, TimeoutException {
         new ProcessExecutor()
                 .directory(GRAKN_TARGET_DIRECTORY.toFile())
-                .command("unzip", ZIP_FULLPATH.toString()).execute();
+                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.getParent().toString()).execute();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -908,6 +908,12 @@
                 <groupId>org.zeroturnaround</groupId>
                 <artifactId>zt-exec</artifactId>
                 <version>${zt-exec.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
# Why is this PR needed?
Stabilising Grakn's bootup process. Cleaning up bootup module.

# What does the PR do?
1. Fixes issue https://github.com/graknlabs/grakn/issues/2812
2. Fixes issue https://github.com/graknlabs/grakn/issues/2824
3. Fixes issue https://github.com/graknlabs/grakn/issues/2834
4. Cleaning up `grakn-bootup` module:

Renaming the following classes:
  - `EngineProcess` -> `EngineBootup` (since it is a class responsible for booting up Engine)
  - `QueueProcess` -> `QueueBootup` (since it is a class responsible for booting up Queue)
  - `StorageProcess` -> `StorageBootup` (since it is a class responsible for booting up Storage)
  - `OutputCommand` -> `BootupProcessResult` (a class for storing the result of a bootup process)
  - `ProcessNotStartedException` -> `BootupException` (an exception thrown if bootup fails for some reason)
  - `AbstractProcessHandler` -> `BootupProcessExecutor` (a helper for invoking operating system commands)

The `BootupProcessExecutor` is now injected in a DI style in order to increase testability. In the future we can test the bootup functionality purely with unit test if we inject a mock `BootupProcessExecutor`

Using `zt-exec` for spawning processes. It has a fluent API and therefore easier to use compared to the clunky `java.lang.Process`.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
perhaps `grakn-bootup` should be moved to `grakn-engine`