### PR TITLE
[Stable] Fix issues with neq complements and predicates

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -197,22 +197,6 @@ public abstract class Atom extends AtomicBase {
     public abstract Var getPredicateVariable();
 
     /**
-     * @return set of predicates relevant to this atom
-     */
-    public Stream<Predicate> getPredicates() {
-        return getPredicates(Predicate.class);
-    }
-
-    /**
-     * @param type the class of {@link Predicate} to return
-     * @param <T> the type of {@link Predicate} to return
-     * @return stream of predicates relevant to this atom
-     */
-    public <T extends Predicate> Stream<T> getPredicates(Class<T> type) {
-        return getParentQuery().getAtoms(type).filter(atom -> !Sets.intersection(this.getVarNames(), atom.getVarNames()).isEmpty());
-    }
-
-    /**
      * @param var variable of interest
      * @return id predicate referring to prescribed variable
      */
@@ -268,7 +252,10 @@ public abstract class Atom extends AtomicBase {
      */
     public Stream<Atomic> getNonSelectableConstraints() {
         return Stream.concat(
-                getPredicates(),
+                Stream.concat(
+                        getPredicates(),
+                        getPredicates().flatMap(AtomicBase::getPredicates)
+                ),
                 getTypeConstraints().filter(at -> !at.isSelectable())
                 );
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicBase.java
@@ -24,12 +24,14 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.internal.query.QueryAnswer;
+import ai.grakn.graql.internal.reasoner.atom.predicate.Predicate;
 import ai.grakn.kb.internal.EmbeddedGraknTx;
 import ai.grakn.util.ErrorMessage;
 import com.google.common.collect.Sets;
 
 import java.util.Collections;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  *
@@ -55,6 +57,22 @@ public abstract class AtomicBase implements Atomic {
     boolean containsVar(Var name){ return getVarNames().contains(name);}
 
     public boolean isUserDefined(){ return getVarName().isUserDefinedName();}
+
+    /**
+     * @return set of predicates relevant to this atomic
+     */
+    public Stream<Predicate> getPredicates() {
+        return getPredicates(Predicate.class);
+    }
+
+    /**
+     * @param type the class of {@link Predicate} to return
+     * @param <T> the type of {@link Predicate} to return
+     * @return stream of predicates relevant to this atomic
+     */
+    public <T extends Predicate> Stream<T> getPredicates(Class<T> type) {
+        return getParentQuery().getAtoms(type).filter(atom -> !Sets.intersection(this.getVarNames(), atom.getVarNames()).isEmpty());
+    }
 
     @Override
     public Set<Var> getVarNames(){

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
@@ -47,7 +47,6 @@ public abstract class NeqPredicate extends Predicate<Var> {
     //need to have it explicitly here cause autovalue gets confused with the generic
     public abstract Var getPredicate();
 
-
     public static NeqPredicate create(VarPattern pattern, ReasonerQuery parent) {
         return new AutoValue_NeqPredicate(pattern.admin().var(), pattern, parent, extractPredicate(pattern));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -424,7 +424,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
         return orderedSelection;
     }
 
-    /**
+    /** Does id predicates -> answer conversion
      * @return substitution obtained from all id predicates (including internal) in the query
      */
     public Answer getSubstitution(){

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/NeqComplementState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/NeqComplementState.java
@@ -57,17 +57,17 @@ public class NeqComplementState extends AtomicState {
 
     private final Set<NeqPredicate> predicates;
 
-    public NeqComplementState(ReasonerAtomicQuery q,
-                              Answer sub,
-                              Unifier u,
-                              QueryStateBase parent,
-                              Set<ReasonerAtomicQuery> subGoals,
-                              QueryCache<ReasonerAtomicQuery> cache) {
+    NeqComplementState(ReasonerAtomicQuery q,
+                       Answer sub,
+                       Unifier u,
+                       QueryStateBase parent,
+                       Set<ReasonerAtomicQuery> subGoals,
+                       QueryCache<ReasonerAtomicQuery> cache) {
         super(q, sub, u, parent, subGoals, cache);
 
         ReasonerAtomicQuery complementQuery = ReasonerQueries.atomic(q.positive(), sub);
         this.predicates = q.getAtoms(NeqPredicate.class).collect(Collectors.toSet());
-        this.predicateSub = sub.project(predicates.stream().flatMap(p -> p.getVarNames().stream()).collect(Collectors.toSet()));
+        this.predicateSub = sub.project(this.predicates.stream().flatMap(p -> p.getVarNames().stream()).collect(Collectors.toSet()));
 
         complementState = complementQuery.subGoal(sub, u, this, subGoals, cache);
     }

--- a/grakn-test-tools/src/main/graql/matchingTypesTest.gql
+++ b/grakn-test-tools/src/main/graql/matchingTypesTest.gql
@@ -1,0 +1,45 @@
+define
+
+service sub entity
+    plays owner;
+capability-type sub entity
+    plays capability;
+capabilityOne sub capability-type;
+capabilityTwo sub capability-type;
+
+has-capability sub relationship
+    relates owner
+    relates capability;
+
+dummy-rule sub rule
+when {
+   $x isa capabilityOne;
+}
+then {
+   $x isa capability-type;
+};
+
+dummy-rule2 sub rule
+when {
+   $x isa capabilityTwo;
+}
+then {
+   $x isa capability-type;
+};
+
+insert
+
+$s1 isa service;
+$s2 isa service;
+$s3 isa service;
+$s4 isa service;
+
+$c1 isa capabilityOne;
+$c1prime isa capabilityOne;
+$c2 isa capabilityTwo;
+$c2prime isa capabilityTwo;
+
+(owner: $s1, capability: $c1) isa has-capability;
+(owner: $s2, capability: $c1prime) isa has-capability;
+(owner: $s3, capability: $c2) isa has-capability;
+(owner: $s4, capability: $c2prime) isa has-capability;


### PR DESCRIPTION
# Why is this PR needed?
Fixes some inconsistencies when dealing with neq predicates.
# What does the PR do?
Ensures resolution plans are validated correctly and partial substitutions are propagated correctly within queries with neq predicates.

# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
None.