### PR TITLE
[Stable] Cache possible types correctly

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -132,9 +132,16 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return new AutoValue_RelationshipAtom(pattern.admin().var(), pattern, parent, predicateVar, predicateId, relationPlayers, roleLabels);
     }
 
+    private static RelationshipAtom create(VarPattern pattern, Var predicateVar, @Nullable ConceptId predicateId, ImmutableList<Type> possibleTypes, ReasonerQuery parent) {
+        RelationshipAtom atom = create(pattern, predicateVar, predicateId, parent);
+        atom.possibleTypes = possibleTypes;
+        return atom;
+    }
+
     private static RelationshipAtom create(RelationshipAtom a, ReasonerQuery parent) {
         RelationshipAtom atom = new AutoValue_RelationshipAtom( a.getVarName(), a.getPattern(), parent, a.getPredicateVariable(), a.getTypeId(), a.getRelationPlayers(), a.getRoleLabels());
         atom.applicableRules = a.applicableRules;
+        atom.possibleTypes = a.possibleTypes;
         return atom;
     }
 
@@ -476,7 +483,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
     public RelationshipAtom addType(SchemaConcept type) {
         if (getTypeId() != null) return this;
         Pair<VarPattern, IdPredicate> typedPair = getTypedPair(type);
-        return create(typedPair.getKey(), typedPair.getValue().getVarName(), typedPair.getValue().getPredicate(), this.getParentQuery());
+        return create(typedPair.getKey(), typedPair.getValue().getVarName(), typedPair.getValue().getPredicate(), this.getPossibleTypes(), this.getParentQuery());
     }
 
     /**
@@ -528,6 +535,8 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         }
         return compatibleTypes;
     }
+    
+    private ImmutableList<Type> getPossibleTypes(){ return possibleTypes;}
 
     /**
      * infer {@link RelationshipType}s that this {@link RelationshipAtom} can potentially have
@@ -744,7 +753,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
                         relationPattern.directIsa(getPredicateVariable()) :
                         relationPattern.isa(getPredicateVariable())
                 ).admin();
-        return create(newPattern, getPredicateVariable(), getTypeId(), getParentQuery());
+        return create(newPattern, this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
     }
 
     /**
@@ -976,7 +985,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
                 relVar = relVar.rel(rp.getRolePlayer());
             }
         }
-        return create(relVar.admin(), getPredicateVariable(), getTypeId(), getParentQuery());
+        return create(relVar.admin(), this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
     }
 
     /**
@@ -1003,12 +1012,12 @@ public abstract class RelationshipAtom extends IsaAtomBase {
                 relVar = relVar.rel(c.getRolePlayer());
             }
         }
-        return create(relVar.admin(), getPredicateVariable(), getTypeId(), getParentQuery());
+        return create(relVar.admin(), this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
     }
 
     @Override
     public RelationshipAtom rewriteWithTypeVariable(){
-        return create(getPattern(), getPredicateVariable().asUserDefined(), getTypeId(), getParentQuery());
+        return create(this.getPattern(), this.getPredicateVariable().asUserDefined(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/TypeInferenceQueryTest.java
@@ -25,20 +25,25 @@ import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Type;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
+import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.Conjunction;
+import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.atom.binary.RelationshipAtom;
 import ai.grakn.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
+import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.kb.internal.EmbeddedGraknTx;
 import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.util.GraqlTestUtil;
 import ai.grakn.util.Schema;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -50,6 +55,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static ai.grakn.graql.Graql.var;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -281,6 +287,48 @@ public class TypeInferenceQueryTest {
         EmbeddedGraknTx<?> graph = testContext.tx();
         String patternString = "{($x, $y);}";
         typeInference(allRelations(graph), patternString, graph);
+    }
+
+    private <T extends Atomic> T getAtom(ReasonerQuery q, Class<T> type, Set<Var> vars){
+        return q.getAtoms(type)
+                .filter(at -> at.getVarNames().containsAll(vars))
+                .findFirst().get();
+    }
+
+    @Test
+    public void testTypeInference_conjunctiveQuery() {
+        EmbeddedGraknTx<?> graph = testContext.tx();
+        String patternString = "{" +
+                "($x, $y); $x isa anotherSingleRoleEntity;" +
+                "($y, $z); $y isa anotherTwoRoleEntity;" +
+                "($z, $w); $w isa threeRoleEntity;" +
+                "}";
+
+        ReasonerQueryImpl conjQuery = ReasonerQueries.create(conjunction(patternString, graph), graph);
+
+        //determination of possible rel types for ($y, $z) relation depends on its neighbours which should be preserved
+        //when resolving (and separating atoms) the query
+        RelationshipAtom XYatom = getAtom(conjQuery, RelationshipAtom.class, Sets.newHashSet(var("x"), var("y")));
+        RelationshipAtom YZatom = getAtom(conjQuery, RelationshipAtom.class, Sets.newHashSet(var("y"), var("z")));
+        RelationshipAtom ZWatom = getAtom(conjQuery, RelationshipAtom.class, Sets.newHashSet(var("z"), var("w")));
+        RelationshipAtom midAtom = (RelationshipAtom) ReasonerQueries.atomic(YZatom).getAtom();
+
+        assertEquals(midAtom.inferPossibleTypes(new QueryAnswer()), YZatom.inferPossibleTypes(new QueryAnswer()));
+
+        //differently prioritised options arise from using neighbour information
+        List<RelationshipType> firstTypeOption = Lists.newArrayList(
+                graph.getSchemaConcept(Label.of("twoRoleBinary")),
+                graph.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
+                graph.getSchemaConcept(Label.of("threeRoleBinary"))
+        );
+        List<RelationshipType> secondTypeOption = Lists.newArrayList(
+                graph.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
+                graph.getSchemaConcept(Label.of("twoRoleBinary")),
+                graph.getSchemaConcept(Label.of("threeRoleBinary"))
+        );
+        typeInference(secondTypeOption, XYatom.getCombinedPattern().toString(), graph);
+        typeInference(firstTypeOption, YZatom.getCombinedPattern().toString(), graph);
+        typeInference(firstTypeOption, ZWatom.getCombinedPattern().toString(), graph);
     }
 
     private void typeInference(List<RelationshipType> possibleTypes, String pattern, EmbeddedGraknTx<?> graph){

--- a/grakn-test-tools/src/main/graql/typeInferenceTest.gql
+++ b/grakn-test-tools/src/main/graql/typeInferenceTest.gql
@@ -24,11 +24,11 @@ subRole2 sub role2;
 #                     |
 #               noRoleEntity
 #              /            \                                   \
-#  singleRoleEntity(R3)   anotherSingleRoleEntity(R2)    yetAnotherSingleRoleEntity(R1)
+#  singleRoleEntity(R3)   anotherSingleRoleEntity(R2, SR2)    yetAnotherSingleRoleEntity(R1)
 #           |                   |
-#   twoRoleEntity(R4)     anotherTwoRoleEntity(R3)
+#   twoRoleEntity(+R4)     anotherTwoRoleEntity(+R3)
 #                               |
-#                         threeRoleEntity(R4)
+#                         threeRoleEntity(+R4)
 
 noRoleEntity sub entity;
 
@@ -50,14 +50,12 @@ singleRoleEntity sub noRoleEntity
 twoRoleEntity sub singleRoleEntity
     plays role4;
 
-
 #plays in twoRoleBinary, anotherTwoRoleBinary, threeRoleBinary
 anotherTwoRoleEntity sub anotherSingleRoleEntity
     plays role3;
 #plays in twoRoleBinary, anotherTwoRoleBinary, threeRoleBinary
 threeRoleEntity sub anotherTwoRoleEntity
     plays role4;
-
 
 #Relations
 


### PR DESCRIPTION
# Why is this PR needed?
Lack of caching of inferred types can lead to performance deterioration if we build atomic queries from non-atomic ones - type information is preserved in possible types.

# What does the PR do?
Restores possible type caching.

# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.