### PR TITLE
Bug: Match.get(Var var) will crash on RemoteGraknSession

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/Match.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Match.java
@@ -19,14 +19,12 @@
 package ai.grakn.graql;
 
 import ai.grakn.GraknTx;
-import ai.grakn.concept.Concept;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.MatchAdmin;
 
 import javax.annotation.CheckReturnValue;
 import java.util.Collection;
 import java.util.Set;
-import java.util.stream.Stream;
 
 /**
  * a part of a query used for finding data in a knowledge base that matches the given patterns.
@@ -39,21 +37,6 @@ import java.util.stream.Stream;
  * @author Felix Chapman
  */
 public interface Match extends Streamable<Answer> {
-
-    /**
-     * @param var a variable to get
-     * @return a stream of concepts
-     */
-    @CheckReturnValue
-    Stream<Concept> get(String var);
-
-    /**
-     * @param var a variable to get
-     * @return a stream of concepts
-     */
-    @CheckReturnValue
-    Stream<Concept> get(Var var);
-
     /**
      * Get all {@link Var}s mentioned in the query
      */

--- a/grakn-engine/src/test/java/ai/grakn/engine/printer/JacksonPrinterTest.java
+++ b/grakn-engine/src/test/java/ai/grakn/engine/printer/JacksonPrinterTest.java
@@ -49,7 +49,8 @@ public class JacksonPrinterTest {
 
     @Test
     public void whenGraqlQueryResultsInConcept_EnsureConceptWrapperIsReturned() throws JsonProcessingException {
-        ai.grakn.concept.Concept concept = rule.tx().graql().match(var("x").isa("person")).get("x").iterator().next();
+        ai.grakn.concept.Concept concept = rule.tx().graql().match(var("x").isa("person")).get("x")
+                .stream().map(ans -> ans.get("x")).iterator().next();
         Concept conceptWrapper = ConceptBuilder.build(concept);
         assertWrappersMatch(conceptWrapper, concept);
     }
@@ -57,7 +58,8 @@ public class JacksonPrinterTest {
     @Test
     public void whenGraqlQueryResultsInConcepts_EnsureConceptsAreWrappedAndReturned() throws JsonProcessingException {
         Set<ai.grakn.concept.Concept> concepts = rule.tx().graql().
-                match(var("x").isa("person")).get("x").collect(Collectors.toSet());
+                match(var("x").isa("person")).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         List<Concept> conceptsWrapper = concepts.stream().map(ConceptBuilder::<Concept>build).collect(Collectors.toList());
         assertWrappersMatch(conceptsWrapper, concepts);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/analytics/Utility.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/analytics/Utility.java
@@ -129,6 +129,7 @@ public class Utility {
                     var("y").id(conceptId2),
                     var("z").rel(var("x")).rel(var("y")))
                     .get("z")
+                    .stream().map(answer -> answer.get("z"))
                     .findFirst();
             if (firstConcept.isPresent()) {
                 return firstConcept.get().getId();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
@@ -19,8 +19,6 @@
 package ai.grakn.graql.internal.query.match;
 
 import ai.grakn.GraknTx;
-import ai.grakn.concept.Concept;
-import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.DeleteQuery;
@@ -97,21 +95,6 @@ abstract class AbstractMatch implements MatchAdmin {
     @Override
     public final <S> AggregateQuery<S> aggregate(Aggregate<? super Answer, S> aggregate) {
         return Queries.aggregate(admin(), aggregate);
-    }
-
-    @Override
-    public final Stream<Concept> get(String var) {
-        return get(Graql.var(var));
-    }
-
-    @Override
-    public final Stream<Concept> get(Var var) {
-        return stream().map(result -> {
-            if (!result.containsVar(var)) {
-                throw GraqlQueryException.varNotInQuery(var);
-            }
-            return result.get(var);
-        });
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/printer/StringPrinterTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/printer/StringPrinterTest.java
@@ -68,7 +68,7 @@ public class StringPrinterTest {
 
         Match match = rule.tx().graql().match(var("r").isa("has-cluster"));
 
-        Relationship relationship = match.get("r").iterator().next().asRelationship();
+        Relationship relationship = match.get("r").stream().map(ans -> ans.get("r").asRelationship()).findFirst().get();
         long numRolePlayers = relationship.rolePlayers().count();
         long numCommas = numRolePlayers - 1;
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DefineQueryTest.java
@@ -200,7 +200,7 @@ public class DefineQueryTest {
 
         // We checked count ahead of time
         //noinspection OptionalGetWithoutIsPresent
-        EntityType newType = typeQuery.get("n").findFirst().get().asEntityType();
+        EntityType newType = typeQuery.get("n").stream().map(ans -> ans.get("n")).findFirst().get().asEntityType();
 
         assertTrue(newType.plays().anyMatch(role -> role.equals(movies.tx().getRole(roleTypeLabel))));
 
@@ -271,7 +271,8 @@ public class DefineQueryTest {
         qb.define(label("greeting").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING).regex("hello|good day")).execute();
 
         Match match = qb.match(var("x").label("greeting"));
-        assertEquals("hello|good day", match.get("x").findFirst().get().asAttributeType().getRegex());
+        assertEquals("hello|good day", match.get("x")
+                .stream().map(ans -> ans.get("x")).findFirst().get().asAttributeType().getRegex());
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DeleteQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/DeleteQueryTest.java
@@ -126,7 +126,7 @@ public class DeleteQueryTest {
 
     @Test
     public void testDeleteAllRolePlayers() {
-        ConceptId id = kurtzCastRelation.get("a").findFirst().get().getId();
+        ConceptId id = kurtzCastRelation.get("a").stream().map(ans -> ans.get("a")).findFirst().get().getId();
         Match relation = qb.match(var().id(id));
 
         assertExists(kurtz);
@@ -161,7 +161,7 @@ public class DeleteQueryTest {
         ConceptId id = qb.match(
                 x.has("title", "Godfather"),
                 var("a").rel(x).rel(y).isa(Schema.ImplicitType.HAS.getLabel("tmdb-vote-count").getValue())
-        ).get("a").findFirst().get().getId();
+        ).get("a").stream().map(ans -> ans.get("a")).findFirst().get().getId();
 
         assertExists(qb, var().has("title", "Godfather"));
         assertExists(qb, var().id(id));

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
@@ -464,7 +464,8 @@ public class InsertQueryTest {
 
     @Test
     public void testInsertResourceOnExistingId() {
-        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x").findAny().get().getId();
+        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
         qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).execute();
@@ -473,7 +474,8 @@ public class InsertQueryTest {
 
     @Test
     public void testInsertResourceOnExistingIdWithType() {
-        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x").findAny().get().getId();
+        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
         qb.insert(var().id(apocalypseNow).isa("movie").has("title", "Apocalypse Maybe Tomorrow")).execute();
@@ -482,7 +484,8 @@ public class InsertQueryTest {
 
     @Test
     public void testInsertResourceOnExistingResourceId() {
-        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x").findAny().get().getId();
+        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
         qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).execute();
@@ -491,7 +494,8 @@ public class InsertQueryTest {
 
     @Test
     public void testInsertResourceOnExistingResourceIdWithType() {
-        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x").findAny().get().getId();
+        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().getId();
 
         assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
         qb.insert(var().id(apocalypseNow).isa("title").has("title", "Apocalypse Maybe Tomorrow")).execute();

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryErrorTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/QueryErrorTest.java
@@ -208,15 +208,11 @@ public class QueryErrorTest {
 
     @Test
     public void testGetNonExistentVariable() {
-        Match match = qb.match(var("x").isa("movie"));
-
-        Stream<Concept> concepts = match.get("y");
-
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(Graql.var("y")));
 
-        //noinspection ResultOfMethodCallIgnored
-        concepts.count();
+        Match match = qb.match(var("x").isa("movie"));
+        Stream<Concept> concepts = match.get("y").stream().map(ans -> ans.get("y"));
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
@@ -655,7 +655,8 @@ public class MatchTest {
         ).execute();
 
         Stream.of(a, b, c, d, e, f).forEach(type -> {
-            Set<Concept> graqlPlays = qb.match(Graql.label(type).plays(x)).get(x).collect(Collectors.toSet());
+            Set<Concept> graqlPlays = qb.match(Graql.label(type).plays(x)).get(x).stream()
+                                        .map(answer -> answer.get(x)).collect(Collectors.toSet());
             Collection<Role> graphAPIPlays;
 
             SchemaConcept schemaConcept = tx.getSchemaConcept(type);
@@ -669,7 +670,8 @@ public class MatchTest {
         });
 
         Stream.of(d, e, f).forEach(type -> {
-            Set<Concept> graqlPlayedBy = qb.match(x.plays(Graql.label(type))).get(x).collect(toSet());
+            Set<Concept> graqlPlayedBy = qb.match(x.plays(Graql.label(type))).get(x).stream()
+                                           .map(answer -> answer.get(x)).collect(Collectors.toSet());
             Collection<Type> graphAPIPlayedBy = tx.<Role>getSchemaConcept(type).playedByTypes().collect(toSet());
 
             assertEquals(graqlPlayedBy, graphAPIPlayedBy);
@@ -801,7 +803,7 @@ public class MatchTest {
         Thing godfather = movieKB.tx().getAttributeType("title").getAttribute("Godfather").owner();
         Set<Attribute<?>> expected = godfather.attributes().collect(toSet());
 
-        Set<Attribute<?>> results = match.get(x).map(Concept::asAttribute).collect(toSet());
+        Set<Attribute<?>> results = match.get(x).stream().map(answer -> answer.get(x).asAttribute()).collect(toSet());
 
         assertEquals(expected, results);
     }
@@ -972,7 +974,7 @@ public class MatchTest {
     public void whenQueryingForAnImplicitRelationById_TheRelationIsReturned() {
         Match match = qb.match(var("x").isa(label(Schema.ImplicitType.HAS.getLabel("name"))));
 
-        Relationship relationship = match.get("x").findAny().get().asRelationship();
+        Relationship relationship = match.get("x").stream().map(answer -> answer.get("x").asRelationship()).findAny().get();
 
         Match queryById = qb.match(var("x").id(relationship.getId()));
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/pattern/PatternTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/pattern/PatternTest.java
@@ -162,23 +162,27 @@ public class PatternTest {
                 var("x").isa("movie"),
                 var("y1").isa("genre").has("name", "crime"),
                 var().isa("has-genre").rel(var("x")).rel(var("y1")));
-        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x").collect(Collectors.toSet());
+        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(resultSet1.isEmpty());
 
         Set<VarPattern> varSet11 = Sets.newHashSet(var("x"));
         varSet11.addAll(varSet1);
-        Set<Concept> resultSet11 = tx.graql().match(varSet11).get("x").collect(Collectors.toSet());
+        Set<Concept> resultSet11 = tx.graql().match(varSet11).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertEquals(resultSet11, resultSet1);
 
         varSet11.add(var("z"));
-        resultSet11 = tx.graql().match(varSet11).get("x").collect(Collectors.toSet());
+        resultSet11 = tx.graql().match(varSet11).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertEquals(resultSet11, resultSet1);
 
         Set<VarPattern> varSet2 = Sets.newHashSet(
                 var("x").isa("movie"),
                 var("y2").isa("person").has("name", "Marlon Brando"),
                 var().isa("has-cast").rel(var("x")).rel(var("y2")));
-        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x").collect(Collectors.toSet());
+        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(resultSet1.isEmpty());
 
         Set<VarPattern> varSet3 = Sets.newHashSet(
@@ -187,16 +191,18 @@ public class PatternTest {
                 var().isa("has-genre").rel(var("x")).rel(var("y")),
                 var("y2").isa("person").has("name", "Marlon Brando"),
                 var().isa("has-cast").rel(var("x")).rel(var("y2")));
-        Set<Concept> conj = tx.graql().match(varSet3).get("x").collect(Collectors.toSet());
+        Set<Concept> conj = tx.graql().match(varSet3).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(conj.isEmpty());
 
         resultSet2.retainAll(resultSet1);
         assertEquals(resultSet2, conj);
 
-        conj = tx.graql().match(and(varSet3)).get("x").collect(Collectors.toSet());
+        conj = tx.graql().match(and(varSet3)).get("x").stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertEquals(resultSet2, conj);
 
-        conj = tx.graql().match(or(var("x"), var("x"))).get("x").collect(Collectors.toSet());
+        conj = tx.graql().match(or(var("x"), var("x"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertTrue(conj.size() > 1);
     }
 
@@ -220,14 +226,16 @@ public class PatternTest {
                 var("x").isa("movie"),
                 var("y1").isa("genre").has("name", "crime"),
                 var().isa("has-genre").rel(var("x")).rel(var("y1")));
-        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x").collect(Collectors.toSet());
+        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(resultSet1.isEmpty());
 
         Set<VarPattern> varSet2 = Sets.newHashSet(
                 var("x").isa("movie"),
                 var("y2").isa("person").has("name", "Marlon Brando"),
                 var().isa("has-cast").rel(var("x")).rel(var("y2")));
-        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x").collect(Collectors.toSet());
+        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(resultSet1.isEmpty());
 
         Set<Pattern> varSet3 = Sets.newHashSet(
@@ -235,13 +243,15 @@ public class PatternTest {
                 or(var("y").isa("genre").has("name", "crime"),
                         var("y").isa("person").has("name", "Marlon Brando")),
                 var().rel(var("x")).rel(var("y")));
-        Set<Concept> conj = tx.graql().match(varSet3).get("x").collect(Collectors.toSet());
+        Set<Concept> conj = tx.graql().match(varSet3).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(conj.isEmpty());
 
         resultSet2.addAll(resultSet1);
         assertEquals(resultSet2, conj);
 
-        conj = tx.graql().match(or(var("x"), var("x"))).get("x").collect(Collectors.toSet());
+        conj = tx.graql().match(or(var("x"), var("x"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertTrue(conj.size() > 1);
     }
 
@@ -264,12 +274,14 @@ public class PatternTest {
         assertExists(tx.graql(), var().isa("movie").has("title", "Godfather"));
         Set<Concept> result1 = tx.graql().match(
                 var("x").isa("movie").has("title", var("y")),
-                var("y").val(neq("Godfather"))).get("x").collect(Collectors.toSet());
+                var("y").val(neq("Godfather"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(result1.isEmpty());
 
         Set<Concept> result2 = tx.graql().match(
                 var("x").isa("movie").has("title", var("y")),
-                var("y")).get("x").collect(Collectors.toSet());
+                var("y")).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
         assertFalse(result2.isEmpty());
 
         result2.removeAll(result1);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
@@ -1387,7 +1387,8 @@ public class AtomicTest {
     }
 
     private Concept getConcept(EmbeddedGraknTx<?> graph, String typeName, Object val){
-        return graph.graql().match(var("x").has(typeName, val).admin()).get("x").findAny().orElse(null);
+        return graph.graql().match(var("x").has(typeName, val).admin()).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().orElse(null);
     }
 
     private Multimap<Role, Var> roleSetMap(Multimap<Role, Var> roleVarMap) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ExplanationTest.java
@@ -357,7 +357,8 @@ public class ExplanationTest {
     }
 
     private static Concept getConcept(GraknTx graph, String typeLabel, Object val){
-        return graph.graql().match(var("x").has(typeLabel, val)).get("x").findAny().orElse(null);
+        return graph.graql().match(var("x").has(typeLabel, val)).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().orElse(null);
     }
 
     private Answer findAnswer(Answer a, List<Answer> list){

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryTest.java
@@ -284,6 +284,7 @@ public class QueryTest {
     }
 
     private static Concept getConcept(EmbeddedGraknTx<?> graph, String typeLabel, Object val){
-        return graph.graql().match(Graql.var("x").has(typeLabel, val).admin()).get("x").findAny().get();
+        return graph.graql().match(Graql.var("x").has(typeLabel, val).admin()).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get();
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -186,7 +186,8 @@ public class ResolutionPlanTest {
     @Test
     public void makeSureOptimalOrderPickedWhenResourcesWithSubstitutionsArePresent() {
         EmbeddedGraknTx<?> testTx = testContext.tx();
-        Concept concept = testTx.graql().match(var("x").isa("baseEntity")).get("x").findAny().orElse(null);
+        Concept concept = testTx.graql().match(var("x").isa("baseEntity")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().orElse(null);
         String basePatternString =
                 "(role1:$x, role2: $y) isa relation;" +
                 "$x has resource 'this';" +

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GeoInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/GeoInferenceTest.java
@@ -355,6 +355,7 @@ public class GeoInferenceTest {
     }
 
     private Concept getConcept(GraknTx graph, String typeName, Object val){
-        return graph.graql().match(Graql.var("x").has(typeName, val).admin()).get("x").findAny().orElse(null);
+        return graph.graql().match(Graql.var("x").has(typeName, val).admin()).get("x")
+                .stream().map(answer -> answer.get("x")).findAny().orElse(null);
     }
 }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/RecursiveInferenceTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/inference/RecursiveInferenceTest.java
@@ -507,6 +507,7 @@ public class RecursiveInferenceTest {
     }
 
     private Concept getConcept(GraknTx graph, String typeName, Object val){
-        return graph.graql().match(Graql.var("x").has(typeName, val).admin()).get("x").findAny().orElse(null);
+        return graph.graql().match(Graql.var("x").has(typeName, val).admin()).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().orElse(null);
     }
 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/GrpcServerIT.java
@@ -38,6 +38,8 @@ import ai.grakn.concept.Type;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.ComputeQuery;
 import ai.grakn.graql.GetQuery;
+import ai.grakn.graql.QueryBuilder;
+import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.remote.RemoteGrakn;
 import ai.grakn.test.kbs.MovieKB;
@@ -56,6 +58,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -662,6 +665,32 @@ public class GrpcServerIT {
             exception.expectMessage(GraqlQueryException.labelNotFound(Label.of("not-a-thing")).getMessage());
 
             query.execute();
+        }
+    }
+
+    @Test
+    public void whenPerformingAMatchGetQuery_TheResultsAreCorrect(){
+        try (GraknTx tx = remoteSession.open(GraknTxType.WRITE)) {
+            //Graql.match(var("x").isa("company")).get(var("x"), var("y"));
+
+            EntityType company = tx.putEntityType("company-123");
+            company.addEntity();
+            company.addEntity();
+
+            EntityType person = tx.putEntityType("person-123");
+            person.addEntity();
+            person.addEntity();
+            person.addEntity();
+
+            QueryBuilder qb = tx.graql();
+            Var x = var("x");
+            Var y = var("y");
+
+            Collection<Answer> result = qb.match(x.isa("company-123"), y.isa("person-123")).get(x, y).execute();
+            assertEquals(6, result.size());
+
+            result = qb.match(x.isa("company-123")).get(x).execute();
+            assertEquals(2, result.size());
         }
     }
 }


### PR DESCRIPTION
# Why is this PR needed?

For some reason, we have 2 (odd) `Match.get(var)` behaviours:
1. `Match.get(Var var)`, which takes a single `Var` and returns `Stream<Concept>`, and
2. `Match.get(Var var, Var.. vars)`, which takes one or more `Var` and returns `Stream<Answer>`.

The critical issue is that: although the (2) `Match.get(Var var, Var.. vars)` (plural) executes fine over GRPC, the (1)`Match.get(var)` (singular) does not. It forces the `match` clause to execute an internal `AbstractMatch.stream()` which forces a cast of `RemoteGraknTx` into `EmbeddedGraknTx` (see MatchTx.java:51). This causes the query to crash as it hits a casting exception.

# What does the PR do?

While it's possible to try and fix the underlying casting issue, we're better off fixing the odd API issue. I.e. Just remove the singular (1)`Match.get(var)`, as we already have the plural (2) `Match.get(Var var, Var.. vars)` covering all cases.

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

Note that the `ai.grakn.graql.internal.query.match` is way too convoluted to serve such a simple thing. The whole package will be simplified in future refactors.