### PR TITLE
[Stable] Fix problems when matching rules requiring type inference

### DIFF
--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Conjunction.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Conjunction.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graql.admin;
 
-import ai.grakn.GraknTx;
 import javax.annotation.CheckReturnValue;
 import java.util.Set;
 
@@ -35,10 +34,4 @@ public interface Conjunction<T extends PatternAdmin> extends PatternAdmin {
      */
     @CheckReturnValue
     Set<T> getPatterns();
-
-    /**
-     * @return the corresponding reasoner query
-     */
-    @CheckReturnValue
-    ReasonerQuery toReasonerQuery(GraknTx tx);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/PatternAdmin.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.admin;
 
+import ai.grakn.GraknTx;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
 
@@ -90,6 +91,12 @@ public interface PatternAdmin extends Pattern {
     default Conjunction<?> asConjunction() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * @return the corresponding reasoner query
+     */
+    @CheckReturnValue
+    ReasonerQuery toReasonerQuery(GraknTx tx);
 
     /**
      * @return this {@link PatternAdmin} as a {@link VarPatternAdmin}, if it is one.

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
@@ -51,7 +51,6 @@ public interface ReasonerQuery{
     @CheckReturnValue
     GraknTx tx();
 
-
     /**
      * validate the query wrt transaction it is defined in
      */

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
@@ -69,6 +69,13 @@ public interface ReasonerQuery{
     Set<Atomic> getAtoms();
 
     /**
+     *
+     * @return
+     */
+    @CheckReturnValue
+    Conjunction<PatternAdmin> getPattern();
+
+    /**
      * @param type the class of {@link Atomic} to return
      * @param <T> the type of {@link Atomic} to return
      * @return stream of atoms of specified type defined in this query

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractPattern.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/AbstractPattern.java
@@ -18,9 +18,16 @@
 
 package ai.grakn.graql.internal.pattern;
 
+import ai.grakn.GraknTx;
 import ai.grakn.graql.Graql;
 import ai.grakn.graql.Pattern;
+import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.PatternAdmin;
+import ai.grakn.graql.admin.ReasonerQuery;
+import ai.grakn.graql.admin.VarPatternAdmin;
+import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
+import ai.grakn.kb.internal.EmbeddedGraknTx;
+import com.google.common.collect.Iterables;
 
 /**
  * The abstract implementation of {@link PatternAdmin}.
@@ -39,5 +46,12 @@ public abstract class AbstractPattern implements PatternAdmin {
     @Override
     public final Pattern or(Pattern pattern) {
         return Graql.or(this, pattern);
+    }
+
+    @Override
+    public ReasonerQuery toReasonerQuery(GraknTx tx){
+        Conjunction<VarPatternAdmin> pattern = Iterables.getOnlyElement(getDisjunctiveNormalForm().getPatterns());
+        // TODO: This cast is unsafe - this method should accept an `EmbeddedGraknTx`
+        return ReasonerQueries.create(pattern, (EmbeddedGraknTx<?>) tx);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/ConjunctionImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/ConjunctionImpl.java
@@ -18,18 +18,13 @@
 
 package ai.grakn.graql.internal.pattern;
 
-import ai.grakn.GraknTx;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
 import ai.grakn.graql.admin.PatternAdmin;
-import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
-import ai.grakn.graql.internal.reasoner.query.ReasonerQueries;
-import ai.grakn.kb.internal.EmbeddedGraknTx;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 
 import java.util.List;
@@ -78,13 +73,6 @@ abstract class ConjunctionImpl<T extends PatternAdmin> extends AbstractPattern i
     @Override
     public Conjunction<?> asConjunction() {
         return this;
-    }
-
-    @Override
-    public ReasonerQuery toReasonerQuery(GraknTx tx){
-        Conjunction<VarPatternAdmin> pattern = Iterables.getOnlyElement(getDisjunctiveNormalForm().getPatterns());
-        // TODO: This cast is unsafe - this method should accept an `EmbeddedGraknTx`
-        return ReasonerQueries.create(pattern, (EmbeddedGraknTx<?>) tx);
     }
 
     private static <U extends PatternAdmin> Conjunction<U> fromConjunctions(List<Conjunction<U>> conjunctions) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/DisjunctionImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/pattern/DisjunctionImpl.java
@@ -18,10 +18,12 @@
 
 package ai.grakn.graql.internal.pattern;
 
+import ai.grakn.GraknTx;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Conjunction;
 import ai.grakn.graql.admin.Disjunction;
 import ai.grakn.graql.admin.PatternAdmin;
+import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -61,6 +63,11 @@ abstract class DisjunctionImpl<T extends PatternAdmin> extends AbstractPattern i
     @Override
     public Disjunction<?> asDisjunction() {
         return this;
+    }
+
+    @Override
+    public ReasonerQuery toReasonerQuery(GraknTx tx){
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -229,6 +229,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     @Override
     public void checkValid() { getAtoms().forEach(Atomic::checkValid);}
 
+    @Override
     public Conjunction<PatternAdmin> getPattern() {
         return Patterns.conjunction(
                 getAtoms().stream()

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
@@ -23,7 +23,6 @@ import ai.grakn.concept.Rule;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
-import ai.grakn.kb.internal.EmbeddedGraknTx;
 import ai.grakn.util.Schema;
 import com.google.common.base.Equivalence;
 
@@ -71,15 +70,7 @@ public class RuleUtils {
     public static Stream<Rule> getRulesWithType(SchemaConcept type, boolean direct, GraknTx graph){
         if (type == null) return getRules(graph);
         Set<SchemaConcept> parentTypes = direct? Sets.newHashSet(type) : type.subs().collect(Collectors.toSet());
-        Stream<Rule> typedRules = parentTypes.stream().flatMap(SchemaConcept::getRulesOfConclusion);
-
-        Stream<Rule> untypedRules = getRules(graph)
-                .filter(r -> !r.getConclusionTypes().findFirst().isPresent())
-                .filter(r -> {
-                    SchemaConcept headType = new InferenceRule(r, (EmbeddedGraknTx<?>) graph).getHead().getAtom().getSchemaConcept();
-                    return parentTypes.stream().anyMatch(t -> t.equals(headType));
-                });
-        return Stream.concat(typedRules, untypedRules);
+        return parentTypes.stream().flatMap(SchemaConcept::getRulesOfConclusion);
     }
 
     /**

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicTest.java
@@ -73,6 +73,9 @@ public class AtomicTest {
     public static final SampleKBContext ruleApplicabilitySet = SampleKBContext.load("ruleApplicabilityTest.gql");
 
     @ClassRule
+    public static final SampleKBContext relationHierarchySet = SampleKBContext.load("relationHierarchyTest.gql");
+
+    @ClassRule
     public static final SampleKBContext resourceApplicabilitySet = SampleKBContext.load("resourceApplicabilityTest.gql");
 
     @ClassRule
@@ -601,6 +604,32 @@ public class AtomicTest {
                 RuleUtils.getRules(graph).count(),
                 relation.getApplicableRules().count()
         );
+    }
+
+    @Test
+    public void testRuleApplicability_hierarchicRelations(){
+        EmbeddedGraknTx<?> graph = relationHierarchySet.tx();
+        Atom alpha = ReasonerQueries.atomic(conjunction("{$x isa alpha;}", graph), graph).getAtom();
+        Atom beta = ReasonerQueries.atomic(conjunction("{$x isa beta;}", graph), graph).getAtom();
+        Atom gamma = ReasonerQueries.atomic(conjunction("{$x isa gamma;}", graph), graph).getAtom();
+        Atom delta = ReasonerQueries.atomic(conjunction("{$x isa delta;}", graph), graph).getAtom();
+        Atom eps = ReasonerQueries.atomic(conjunction("{$x isa epsilon;}", graph), graph).getAtom();
+        Atom zeta = ReasonerQueries.atomic(conjunction("{$x isa zeta;}", graph), graph).getAtom();
+        Atom directBeta = ReasonerQueries.atomic(conjunction("{$x isa! beta;}", graph), graph).getAtom();
+        Atom directDelta = ReasonerQueries.atomic(conjunction("{$x isa! delta;}", graph), graph).getAtom();
+        Atom directEps = ReasonerQueries.atomic(conjunction("{$x isa! epsilon;}", graph), graph).getAtom();
+        Atom directZeta = ReasonerQueries.atomic(conjunction("{$x isa! zeta;}", graph), graph).getAtom();
+
+        assertEquals(RuleUtils.getRules(graph).count(), alpha.getApplicableRules().count());
+        assertEquals(beta.getSchemaConcept().subs().count(), beta.getApplicableRules().count());
+        assertEquals(gamma.getSchemaConcept().subs().count(), gamma.getApplicableRules().count());
+        assertEquals(delta.getSchemaConcept().subs().count(), delta.getApplicableRules().count());
+        assertEquals(eps.getSchemaConcept().subs().count(), eps.getApplicableRules().count());
+        assertEquals(zeta.getSchemaConcept().subs().count(), zeta.getApplicableRules().count());
+        assertEquals(1, directBeta.getApplicableRules().count());
+        assertEquals(1, directDelta.getApplicableRules().count());
+        assertEquals(1, directEps.getApplicableRules().count());
+        assertEquals(1, directZeta.getApplicableRules().count());
     }
 
     @Test

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/ValidateGlobalRules.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/ValidateGlobalRules.java
@@ -313,7 +313,7 @@ class ValidateGlobalRules {
     /**
      * @param graph graph used to ensure the rule head is valid
      * @param rule the rule to be validated
-     * @return Error messages if the rule head is invalid - is not a single-atom conjunction, doesn't contain illegal atomics and is ontologically valid
+     * @return Error messages if the rule head is invalid - is not a single-atom conjunction, contains illegal atomics or is ontologically invalid
      */
     private static Set<String> validateRuleHead(GraknTx graph, Rule rule) {
         Set<String> errors = new HashSet<>();

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RuleImpl.java
@@ -46,8 +46,8 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
 
     private RuleImpl(VertexElement vertexElement, Rule type, Pattern when, Pattern then) {
         super(vertexElement, type);
-        vertex().propertyImmutable(Schema.VertexProperty.RULE_WHEN, when, getWhen(), Pattern::toString);
-        vertex().propertyImmutable(Schema.VertexProperty.RULE_THEN, then, getThen(), Pattern::toString);
+        vertex().propertyImmutable(Schema.VertexProperty.RULE_WHEN, when.admin().toReasonerQuery(vertex().tx()).getPattern(), getWhen(), Pattern::toString);
+        vertex().propertyImmutable(Schema.VertexProperty.RULE_THEN, then.admin().toReasonerQuery(vertex().tx()).getPattern(), getThen(), Pattern::toString);
     }
 
     public static RuleImpl get(VertexElement vertexElement){

--- a/grakn-test-tools/src/main/graql/relationHierarchyTest.gql
+++ b/grakn-test-tools/src/main/graql/relationHierarchyTest.gql
@@ -1,0 +1,111 @@
+define
+
+#Roles
+
+alphaRole sub role;
+betaRole sub alphaRole;
+gammaRole sub alphaRole;
+deltaRole sub betaRole;
+epsilonRole sub betaRole;
+zetaRole sub deltaRole;
+
+#Entities
+
+alphaEntity sub entity
+    plays alphaRole;
+
+betaEntity sub entity
+    plays betaRole;
+
+gammaEntity sub entity
+    plays gammaRole;
+
+deltaEntity sub entity
+    plays deltaRole;
+
+epsilonEntity sub entity
+    plays epsilonRole;
+
+zetaEntity sub entity
+    plays zetaRole;
+
+
+# Relation hierarchy
+#
+#            relation
+#               |
+#             alpha
+#           /       \
+#        beta        gamma
+#        /  \
+#   delta    eps
+#     |
+#    zeta
+
+#Relations
+
+alpha sub relationship
+    relates alphaRole;
+
+beta sub alpha
+    relates betaRole;
+
+gamma sub alpha
+    relates gammaRole;
+
+delta sub beta
+    relates deltaRole;
+
+epsilon sub beta
+    relates epsilonRole;
+
+zeta sub delta
+    relates zetaRole;
+
+alphaRule sub rule
+    when {
+    	$x isa alphaEntity;
+    }
+    then {
+    	(alphaRole: $x) isa alpha;
+    };
+
+betaRule sub rule
+    when {
+    	$x isa betaEntity;
+    }
+    then {
+    	(betaRole: $x) isa beta;
+    };
+
+gammaRule sub rule
+    when {
+    	$x isa gammaEntity;
+    }
+    then {
+    	(gammaRole: $x);
+    };
+
+deltaRule sub rule
+    when {
+    	$x isa deltaEntity;
+    }
+    then {
+    	(deltaRole: $x);
+    };
+
+epsRule sub rule
+    when {
+    	$x isa epsilonEntity;
+    }
+    then {
+    	(epsilonRole: $x);
+    };
+
+zetaRule sub rule
+    when {
+    	$x isa zetaEntity;
+    }
+    then {
+    	(zetaRole: $x);
+    };


### PR DESCRIPTION
# Why is this PR needed?
Because type inference wasn't triggered for rule heads, rules requiring type inference might be omitted.
# What does the PR do?
Ensures rules requiring type inference are correctly matched.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.