### PR TITLE
[Stable] Make sure indirect isas are not lost when planning

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
@@ -91,7 +91,7 @@ public abstract class IsaAtom extends IsaAtomBase {
     }
 
     @Override
-    public Class<? extends VarProperty> getVarPropertyClass() { return IsaProperty.class;}
+    public Class<? extends VarProperty> getVarPropertyClass() { return isDirect()? DirectIsaProperty.class : IsaProperty.class;}
 
     //NB: overriding as these require a derived property
     @Override
@@ -126,7 +126,7 @@ public abstract class IsaAtom extends IsaAtomBase {
         if (getPredicateVariable().isUserDefinedName()) return super.createCombinedPattern();
         return getSchemaConcept() == null?
                 getVarName().isa(getPredicateVariable()) :
-                getPattern().admin().getProperties(DirectIsaProperty.class).findFirst().isPresent()?
+                isDirect()?
                         getVarName().directIsa(getSchemaConcept().getLabel().getValue()) :
                         getVarName().isa(getSchemaConcept().getLabel().getValue()) ;
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -184,6 +184,21 @@ public class ResolutionPlanTest {
     }
 
     @Test
+    public void makeSureIndirectTypeAtomsAreNotLostWhenPlanning(){
+        EmbeddedGraknTx<?> testTx = testContext.tx();
+        String queryString = "{" +
+                "$x isa baseEntity;" +
+                "$y isa baseEntity;" +
+                "(role1:$x, role2: $xx) isa anotherRelation;$xx isa! $type;" +
+                "(role1:$y, role2: $yy) isa anotherRelation;$yy isa! $type;" +
+                "$y != $x;" +
+                "}";
+        ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString, testTx), testTx);
+        ImmutableList<Atom> plan = new ResolutionPlan(query).plan();
+        assertTrue(plan.containsAll(query.selectAtoms()));
+    }
+
+    @Test
     public void makeSureOptimalOrderPickedWhenResourcesWithSubstitutionsArePresent() {
         EmbeddedGraknTx<?> testTx = testContext.tx();
         Concept concept = testTx.graql().match(var("x").isa("baseEntity")).get("x").findAny().orElse(null);

--- a/grakn-test-tools/src/main/graql/resolution-plan-test.gql
+++ b/grakn-test-tools/src/main/graql/resolution-plan-test.gql
@@ -22,6 +22,10 @@ relation sub relationship
     relates role1
     relates role2;
 
+derivedRelation sub relationship
+    relates role1
+    relates role2;
+
 anotherRelation sub relationship
     relates role1
     relates role2;
@@ -32,6 +36,13 @@ yetAnotherRelation sub relationship
 
 resource sub attribute datatype string;
 anotherResource sub attribute datatype string;
+
+simple-rule
+when {
+(role1: $x, role2: $y) isa relation;
+(role1: $y, role2: $z) isa relation;},
+then {
+(role1: $x, role2: $z) isa derivedRelation;};
 
 insert
 


### PR DESCRIPTION
# Why is this PR needed?
Indirect isa atoms could get omitted when planning.
# What does the PR do?
Makes sure correct var property mapping exists.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.