### PR TITLE
Fix parsing exception message

### DIFF
--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
@@ -31,22 +31,19 @@ import java.nio.file.Paths;
 import java.util.Optional;
 
 /**
- *
  * The main class of the 'grakn' command. This class is not a class responsible
  * for booting up the real command, but rather the command itself.
- *
+ * <p>
  * Please keep the class name "Grakn" as it is what will be displayed to the user.
  *
  * @author Ganeshwara Herawan Hananda
  * @author Michele Orsi
- *
  */
 public class Grakn {
 
     private static final Logger LOG = LoggerFactory.getLogger(Grakn.class);
 
     /**
-     *
      * Invocation from class '{@link ai.grakn.bootup.GraknBootup}'
      *
      * @param args
@@ -66,7 +63,7 @@ public class Grakn {
             // Start Engine
             GraknEngineServer graknEngineServer = GraknEngineServerFactory.createGraknEngineServer();
             graknEngineServer.start();
-        } catch (Exception e) {
+        } catch (RuntimeException | IOException e) {
             LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getCause()), e);
         }
     }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
@@ -66,8 +66,8 @@ public class Grakn {
             // Start Engine
             GraknEngineServer graknEngineServer = GraknEngineServerFactory.createGraknEngineServer();
             graknEngineServer.start();
-        } catch (IOException e) {
-            LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(), e);
+        } catch (Exception e) {
+            LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getCause()), e);
         }
     }
 }

--- a/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
+++ b/grakn-bootup/src/main/java/ai/grakn/bootup/Grakn.java
@@ -64,7 +64,7 @@ public class Grakn {
             GraknEngineServer graknEngineServer = GraknEngineServerFactory.createGraknEngineServer();
             graknEngineServer.start();
         } catch (RuntimeException | IOException e) {
-            LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getCause()), e);
+            LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getMessage()), e);
         }
     }
 }


### PR DESCRIPTION
# Why is this PR needed?

When exception was thrown and we were catching it in `Grakn.java`
we were getting a parsing exception of error message because no parameter was passed to
`.getMessage()`

# What does the PR do?

Add `e.getCause()` as a param to `getMessage()` to solve parsing message
Catch also  `RuntimeException` together with `IOException`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

See if there's a way to write tests for these things