### PR TITLE
[Stable] Fix excessive possible type caching

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -132,7 +132,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return new AutoValue_RelationshipAtom(pattern.admin().var(), pattern, parent, predicateVar, predicateId, relationPlayers, roleLabels);
     }
 
-    private static RelationshipAtom create(VarPattern pattern, Var predicateVar, @Nullable ConceptId predicateId, ImmutableList<SchemaConcept> possibleTypes, ReasonerQuery parent) {
+    private static RelationshipAtom create(VarPattern pattern, Var predicateVar, @Nullable ConceptId predicateId, @Nullable ImmutableList<SchemaConcept> possibleTypes, ReasonerQuery parent) {
         RelationshipAtom atom = create(pattern, predicateVar, predicateId, parent);
         atom.possibleTypes = possibleTypes;
         return atom;
@@ -483,7 +483,8 @@ public abstract class RelationshipAtom extends IsaAtomBase {
     public RelationshipAtom addType(SchemaConcept type) {
         if (getTypeId() != null) return this;
         Pair<VarPattern, IdPredicate> typedPair = getTypedPair(type);
-        return create(typedPair.getKey(), typedPair.getValue().getVarName(), typedPair.getValue().getPredicate(), this.getPossibleTypes(), this.getParentQuery());
+        //NB: do not cache possible types
+        return create(typedPair.getKey(), typedPair.getValue().getVarName(), typedPair.getValue().getPredicate(), this.getParentQuery());
     }
 
     /**

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
@@ -102,8 +102,6 @@ public class OntologicalQueryTest {
         assertCollectionsEqual(answers, qb.infer(false).<GetQuery>parse(queryString).execute());
     }
 
-    //TODO: need to be able to transform rule head attributes to relations to correctly map attribute answers
-    @Ignore
     @Test
     public void allRolePlayerPairsAndTheirRelationType(){
         GraknTx tx = testContext.tx();
@@ -111,13 +109,22 @@ public class OntologicalQueryTest {
         String relationString = "match $x isa relationship;get;";
         String rolePlayerPairString = "match ($u, $v) isa $type; get;";
 
-        List<Answer> rolePlayerPairs = qb.<GetQuery>parse(rolePlayerPairString).execute();
-        //TODO doesn't include THING and RELATIONSHIP, with RELATIONSHIP it's 38, with THING as well it should be 57
-        assertEquals(rolePlayerPairs.size(), 25);
+        GetQuery rolePlayerQuery = qb.parse(rolePlayerPairString);
+        List<Answer> rolePlayerPairs = rolePlayerQuery.execute();
+        //TODO doesn't include THING and RELATIONSHIP
+        //25 relation variants + 2 x 3 resource relation instances
+        assertEquals(rolePlayerPairs.size(), 31);
+
+        //TODO
+        //rolePlayerPairs.forEach(ans -> assertEquals(ans.vars(), rolePlayerQuery.vars()));
 
         List<Answer> relations = qb.<GetQuery>parse(relationString).execute();
-        //one implicit, 3 x binary, 2 x ternary, 7 (3 reflexive) x reifying-relation
-        assertEquals(relations.size(), 13);
+        //one implicit,
+        //3 x binary,
+        //2 x ternary,
+        //7 (3 reflexive) x reifying-relation
+        //3 x has-description resource relation
+        assertEquals(relations.size(), 16);
     }
 
     /** HasAtom **/


### PR DESCRIPTION
# Why is this PR needed?
When specifying type of a relation atom, previous possible types were cached.
# What does the PR do?
Removes excessive caching.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.