### PR TITLE
Update to tinkerpop 3.2.9 in order to remove dependencies on custom tinkerpop 3.2.5-grakn-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.resource.encoding>UTF-8</project.resource.encoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <tinkerpop.version>3.2.6</tinkerpop.version>
+        <tinkerpop.version>3.2.9</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <janus.version>0.2.0</janus.version>
         <guava.version>19.0</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <project.resource.encoding>UTF-8</project.resource.encoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <tinkerpop.version>3.2.5-grakn-SNAPSHOT</tinkerpop.version>
+        <tinkerpop.version>3.2.6</tinkerpop.version>
         <junit.version>4.12</junit.version>
         <janus.version>0.2.0</janus.version>
         <guava.version>19.0</guava.version>


### PR DESCRIPTION
# Why is this PR needed?
Update to tinkerpop 3.2.9 in order to remove dependencies on custom tinkerpop 3.2.5-grakn-SNAPSHOT.

The plan was to update to 3.2.6 but 3.2.9 works as well, and it is newer.

We tried to upgrade to 3.3.x but unfortunately it is not a drop in replacement.

# What does the PR do?
Update to tinkerpop 3.2.9 in order to remove dependencies on custom tinkerpop 3.2.5-grakn-SNAPSHOT.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A