### PR TITLE
Getting rid of self hosted maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1244,18 +1244,6 @@
                 </repository>
             </distributionManagement>
         </profile>
-        <profile>
-            <id>internal-releases</id>
-            <properties>
-                <skip.deploy.dist>false</skip.deploy.dist>
-            </properties>
-            <distributionManagement>
-                <repository>
-                    <id>internal-releases</id>
-                    <url>https://maven.grakn.ai/content/repositories/internal-releases/</url>
-                </repository>
-            </distributionManagement>
-        </profile>
     </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -938,11 +938,11 @@
         <!--Snapshot repository for 3rd party libraries -->
         <repository>
             <id>snapshots</id>
-            <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <repository>
             <id>releases</id>
-            <url>https://maven.grakn.ai/content/repositories/releases/</url>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
# Why is this PR needed?
The repository maven.grakn.ai is no more.

# What does the PR do?
Point to oss.sonatype instead of maven.grakn.ai

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
SNB depends on `com.ldbc.driver.jeeves` version `0.3-SNAPSHOT`, which must be built (ie., `mvn install`) from https://github.com/ldbc/ldbc_snb_driver.

At the moment we can get away even without building it prior to running the SNB test, since we happen to already have it in CircleCI cache, but this must be solved in the future.

The work has been logged in a [TP ticket](https://work.grakn.ai/entity/20315-solve-snb-dependencies-to-comldbcdriverjeeves03-snapshot).