### PR TITLE
added missing get in example match query

### DIFF
--- a/docs/pages/docs/00-get-started/quickstart-tutorial.md
+++ b/docs/pages/docs/00-get-started/quickstart-tutorial.md
@@ -193,7 +193,7 @@ commit
 
 ## Using the Grakn Visualiser
 
-You can open the [Grakn visualiser](../visualisation-dashboard/visualiser) by navigating to [localhost:4567](http://localhost:4567) in your web browser. The visualiser allows you to make queries or simply browse the schema within the knowledge graph. The screenshot below shows a basic query (`match $x isa person; offset 0; limit 100;`) typed into the form at the top of the main pane, and visualised by pressing ">":
+You can open the [Grakn visualiser](../visualisation-dashboard/visualiser) by navigating to [localhost:4567](http://localhost:4567) in your web browser. The visualiser allows you to make queries or simply browse the schema within the knowledge graph. The screenshot below shows a basic query (`match $x isa person; offset 0; limit 100; get;`) typed into the form at the top of the main pane, and visualised by pressing ">":
 
 ![Person query](/images/match-$x-isa-person.png)
 

--- a/docs/pages/docs/00-get-started/quickstart-tutorial.md
+++ b/docs/pages/docs/00-get-started/quickstart-tutorial.md
@@ -193,7 +193,7 @@ commit
 
 ## Using the Grakn Visualiser
 
-You can open the [Grakn visualiser](../visualisation-dashboard/visualiser) by navigating to [localhost:4567](http://localhost:4567) in your web browser. The visualiser allows you to make queries or simply browse the schema within the knowledge graph. The screenshot below shows a basic query (`match $x isa person; offset 0; limit 100; get;`) typed into the form at the top of the main pane, and visualised by pressing ">":
+You can open the [Grakn visualiser](../visualisation-dashboard/visualiser) by navigating to [localhost:4567](http://localhost:4567) in your web browser. The visualiser allows you to make queries or simply browse the schema within the knowledge graph. The screenshot below shows a basic query typed into the form at the top of the main pane, and visualised by pressing ">":
 
 ![Person query](/images/match-$x-isa-person.png)
 


### PR DESCRIPTION
# Why is this PR needed?

A `get;` suffix was missing in an example query in docs

# What does the PR do?

Adds the missing `get;`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

No