### PR TITLE
Maven cleanup

### DIFF
--- a/grakn-client/pom.xml
+++ b/grakn-client/pom.xml
@@ -99,10 +99,5 @@
             <artifactId>grpc-testing</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>ai.grakn</groupId>
-            <artifactId>grakn-test-tools</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1001,6 +1001,11 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -1223,7 +1228,6 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>


### PR DESCRIPTION
# Why is this PR needed?
Cleaning up the `pom.xml` of `grakn` and `grakn-client`

# What does the PR do?
- remove a duplicate grakn-test-tool dependency
- move nexus-staging-maven-plugin to pluginManagement

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A