### PR TITLE
Update The Java API docs

### DIFF
--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -46,7 +46,20 @@ Here are some links to guides for adding external jars using different IDEs:
 
 ## Connecting to Grakn
 
-First, make sure that Grakn is running. Otherwise, boot it up with `grakn server start`. Now, connect to Grakn with:
+{% include note.html content="Before proceeding, make sure that Grakn has already been started. Otherwise, refer to the [Setup guide](./docs/get-started/setup-guide#install-graknai)." %}
+
+First, make sure to import the following classes:
+```java-test-ignore
+import ai.grakn.GraknSession;
+import ai.grakn.GraknTx;
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.remote.RemoteGrakn;
+import ai.grakn.util.SimpleURI;
+```
+
+
+Now, connect to Grakn with:
 
 ```java-test-ignore
 GraknSession session = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -18,6 +18,13 @@ All Grakn applications require the following Maven dependency:
   <grakn.version>1.2.0</grakn.version>
 </properties>
 
+<repositories>
+  <repository>
+    <id>releases</id>
+    <url>https://oss.sonatype.org/content/repositories/releases</url>
+  </repository>
+</repositories>
+
 <dependencies>
   <dependency>
     <groupId>ai.grakn</groupId>

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -14,10 +14,6 @@ This section will discuss how to start developing with Grakn using the Java API.
 All Grakn applications require the following Maven dependency:
 
 ```xml
-<properties>
-  <grakn.version>1.2.0</grakn.version>
-</properties>
-
 <repositories>
   <repository>
     <id>releases</id>

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -34,24 +34,6 @@ This dependency will give you access to the Core API as well as an in-memory kno
 If you require persistence and would like to access the entirety of the Grakn stack, then it is vital to have an instance of engine running.  
 Please see the [Setup Guide](../get-started/setup-guide) on more details on how to set up a Grakn server.
 
-Alternatively, you may include a reference to the snapshot repository, which contains the third-party dependencies. Add the following to your `pom.xml`:
-
-```xml
-<repositories>
-  <!--Snapshot repository for 3rd party libraries -->
-  <repository>
-    <id>grakn-development-snapshots</id>
-    <url>https://maven.grakn.ai/content/repositories/snapshots/</url>
-    <releases>
-      <enabled>false</enabled>
-    </releases>
-    <snapshots>
-      <enabled>true</enabled>
-    </snapshots>
-  </repository>
-</repositories>
-```
-
 Here are some links to guides for adding external jars using different IDEs:
 
 - [IntelliJ](https://www.jetbrains.com/help/idea/2016.1/configuring-module-dependencies-and-libraries.html)


### PR DESCRIPTION
# Why is this PR needed?
Update the Java API docs

# What does the PR do?
1. Add import statements to be more user friendly.
2. Replace a reference to maven.grakn.ai with a reference to oss.sonatype.org
3. Remove an unused Java properties from the tutorial

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A