### PR TITLE
added back maven.grakn.ai nexus snapshot

### DIFF
--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -16,6 +16,10 @@ All Grakn applications require the following Maven dependency:
 ```xml
 <repositories>
   <repository>
+    <id>snapshots</id>
+    <url>http://maven.grakn.ai/nexus/content/repositories/snapshots/</url>
+  </repository>
+  <repository>
     <id>releases</id>
     <url>https://oss.sonatype.org/content/repositories/releases</url>
   </repository>


### PR DESCRIPTION
# Why is this PR needed?
The Java API version 1.2.0 and below depends on tinkerpop 3.2.5-grakn-SNAPSHOT

# What does the PR do?
added back maven.grakn.ai nexus snapshot which hosts tinkerpop 3.2.5-grakn-SNAPSHOT

# Does it break backward compatibility?
No

# List of future improvements not on this PR
N/A