### PR TITLE
[stable] academy fix: match delete queries in the insert-delete-queries.md page

### DIFF
--- a/docs/pages/academy/2-GRAQL/3-insert-delete-queries.md
+++ b/docs/pages/academy/2-GRAQL/3-insert-delete-queries.md
@@ -95,7 +95,7 @@ How do we delete things that we don’t want in the knowledge graph? With a dele
 A delete query has the same form as a get query that uses `delete` as the action keyword. There is no difference in syntax. Try this, for example:
 
 ```graql
-match $x isa company has name "Grakn"; delete;
+match $x isa company has name "Grakn"; delete $x;
 ```
 
 Did it work? No? Of course not.
@@ -115,7 +115,7 @@ Did you notice that we did not had to specify the "UK" in the above query? When 
 
 At this point you are free to run
 ```graql
-match $x isa company has name "Grakn"; delete;
+match $x isa company has name "Grakn"; delete $x;
 ```
 Then commit, and everything will be returned like it was at the beginning of this lesson.
 


### PR DESCRIPTION
# Why is this PR needed?
academy fix: match delete queries in the insert-delete-queries.md page

# What does the PR do?
Fixes [this ticket](https://work.grakn.ai/entity/20286-delete-syntax-is-outdated-in-academy): `match $x isa company has name "Grakn"; delete;` should be `match $x isa company has name "Grakn"; delete $x;`

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A