### PR TITLE
Query AnswerExplanation RPC response builder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+sudo: required
+dist: trusty
+language: java
+jdk:
+  - openjdk8
+
+cache:
+  directories:
+  - $HOME/.m2
+  - grakn-dashboard/node_modules
+  - grakn-engine/npm
+
+addons:
+  sonarcloud:
+    organization: "grakn-labs"
+    branches:
+      - master
+      - stable
+
+env:
+  # Split tests into grakn-test and everything else
+  - TESTS=**/*Test* MODULE=grakn-test/test-integration
+  - TESTS=**/*IT*   MODULE=grakn-test/test-integration
+  - TESTS=**/*Test* MODULE=!grakn-test/test-integration
+  - TESTS=**/*IT*   MODULE=!grakn-test/test-integration
+
+notifications:
+  slack: grakn:RbxoPzX267spGT4cgmoGLMpT
+  email: false
+
+install: mvn install -T 2.5C -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - mvn test --projects "$MODULE" -Dtest=$TESTS -DfailIfNoTests=false -Dsurefire.rerunFailingTestsCount=1 jacoco:report
+        - bash <(curl -s https://codecov.io/bash)
+    - stage: deploy
+      if: type IN (push, cron, api)
+      script:
+        - mvn sonar:sonar
+before_install:
+  - npm config set registry http://registry.npmjs.org/

--- a/client-protocol/proto/Answer.proto
+++ b/client-protocol/proto/Answer.proto
@@ -19,6 +19,12 @@ message Answer {
 
 message QueryAnswer {
     map<string, Concept> queryAnswer = 1;
+    Explanation explanation = 2;
+}
+
+message Explanation {
+    string queryPattern = 1;
+    repeated QueryAnswer queryAnswer = 2;
 }
 
 message ComputeAnswer {

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Answer.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Answer.java
@@ -80,7 +80,7 @@ public interface Answer {
     @CheckReturnValue
     int size();
 
-    void forEach(BiConsumer<? super Var, ? super Concept> consumer);
+    void forEach(BiConsumer<Var, Concept> consumer);
 
     /**
      * perform an answer merge without explanation

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/ReasonerQuery.java
@@ -70,6 +70,11 @@ public interface ReasonerQuery{
     Set<Atomic> getAtoms();
 
     /**
+     * @return the conjunction pattern that represent this query
+     */
+    Conjunction<PatternAdmin> getPattern();
+
+    /**
      * @param type the class of {@link Atomic} to return
      * @param <T> the type of {@link Atomic} to return
      * @return stream of atoms of specified type defined in this query

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
@@ -142,7 +142,7 @@ public class QueryAnswer implements Answer {
     public int size(){ return map.size();}
 
     @Override
-    public void forEach(BiConsumer<? super Var, ? super Concept> consumer) {
+    public void forEach(BiConsumer<Var, Concept> consumer) {
         map.forEach(consumer);
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -22,6 +22,7 @@ import ai.grakn.concept.Attribute;
 import ai.grakn.concept.Concept;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.GetQuery;
+import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
@@ -95,7 +96,7 @@ public class AtomicQueryTest {
     public void testWhenConstructingNonAtomicQuery_ExceptionIsThrown() {
         EmbeddedGraknTx<?> graph = geoKB.tx();
         String patternString = "{$x isa university;$y isa country;($x, $y) isa is-located-in;($y, $z) isa is-located-in;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
         exception.expect(GraqlQueryException.class);
         ReasonerAtomicQuery atomicQuery = ReasonerQueries.atomic(pattern, graph);
     }
@@ -105,7 +106,7 @@ public class AtomicQueryTest {
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String patternString = "{$x isa someType;}";
         exception.expect(GraqlQueryException.class);
-        ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(patternString, graph), graph);
+        ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(patternString), graph);
     }
 
     @Test
@@ -116,7 +117,7 @@ public class AtomicQueryTest {
         assertTrue(!qb.<GetQuery>parse(explicitQuery).iterator().hasNext());
 
         String patternString = "{(geo-entity: $x, entity-location: $y) isa is-located-in;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
         List<Answer> answers = new ArrayList<>();
 
         answers.add(new QueryAnswer(
@@ -134,7 +135,7 @@ public class AtomicQueryTest {
     @Test
     public void testWhenMaterialisingEntity_MaterialisedInformationIsCorrectlyFlaggedAsInferred(){
         EmbeddedGraknTx<?> graph = materialisationTestSet.tx();
-        ReasonerAtomicQuery entityQuery = ReasonerQueries.atomic(conjunction("$x isa newEntity", graph), graph);
+        ReasonerAtomicQuery entityQuery = ReasonerQueries.atomic(conjunction("$x isa newEntity"), graph);
         assertEquals(entityQuery.materialise(new QueryAnswer()).findFirst().orElse(null).get("x").asEntity().isInferred(), true);
     }
 
@@ -146,7 +147,7 @@ public class AtomicQueryTest {
         Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").execute()).get("x");
         Concept resource = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa resource; get;").execute()).get("x");
 
-        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r 'inferred';$x id " + firstEntity.id().getValue() + ";}", graph), graph);
+        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r 'inferred';$x id " + firstEntity.id().getValue() + ";}"), graph);
         String reuseResourcePatternString =
                 "{" +
                         "$x has resource $r;" +
@@ -154,7 +155,7 @@ public class AtomicQueryTest {
                         "$r id " + resource.id().getValue() + ";" +
                         "}";
 
-        ReasonerAtomicQuery reuseResourceQuery = ReasonerQueries.atomic(conjunction(reuseResourcePatternString, graph), graph);
+        ReasonerAtomicQuery reuseResourceQuery = ReasonerQueries.atomic(conjunction(reuseResourcePatternString), graph);
 
         assertEquals(resourceQuery.materialise(new QueryAnswer()).findFirst().orElse(null).get("r").asAttribute().isInferred(), true);
 
@@ -186,7 +187,7 @@ public class AtomicQueryTest {
                         "$x id " + firstEntity.id().getValue() + ";" +
                         "$y id " + secondEntity.id().getValue() + ";" +
                         "}"
-                , graph),
+                ),
                 graph
         );
 
@@ -197,7 +198,7 @@ public class AtomicQueryTest {
     public void testWhenCopying_TheCopyIsAlphaEquivalent(){
         EmbeddedGraknTx<?> graph = geoKB.tx();
         String patternString = "{($x, $y) isa is-located-in;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
         ReasonerAtomicQuery atomicQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery copy = ReasonerQueries.atomic(atomicQuery);
         assertEquals(atomicQuery, copy);
@@ -237,7 +238,7 @@ public class AtomicQueryTest {
         EmbeddedGraknTx<?> graph = unificationWithTypesSet.tx();
         String patternString = "{$x1 isa twoRoleEntity;$x2 isa twoRoleEntity2;($x1, $x2) isa binary;}";
 
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern, graph);
         Unifier unifier = childQuery.getMultiUnifier(parentQuery).getUnifier();
@@ -267,8 +268,8 @@ public class AtomicQueryTest {
         String basePatternString = "{($x1, $x2) isa binary;}";
         String basePatternString2 = "{($y1, $y2) isa binary;}";
 
-        ReasonerAtomicQuery xbaseQuery = ReasonerQueries.atomic(conjunction(basePatternString, graph), graph);
-        ReasonerAtomicQuery ybaseQuery = ReasonerQueries.atomic(conjunction(basePatternString2, graph), graph);
+        ReasonerAtomicQuery xbaseQuery = ReasonerQueries.atomic(conjunction(basePatternString), graph);
+        ReasonerAtomicQuery ybaseQuery = ReasonerQueries.atomic(conjunction(basePatternString2), graph);
 
         Answer xAnswer = new QueryAnswer(ImmutableMap.of(var("x1"), x1, var("x2"), x2));
         Answer flippedXAnswer = new QueryAnswer(ImmutableMap.of(var("x1"), x2, var("x2"), x1));
@@ -309,8 +310,8 @@ public class AtomicQueryTest {
         EmbeddedGraknTx<?> graph =  unificationWithTypesSet.tx();
         String patternString = "{$x1 isa twoRoleEntity;($x1, $x2) isa binary;}";
         String patternString2 = "{$y1 isa twoRoleEntity;($y1, $y2) isa binary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
 
@@ -327,8 +328,8 @@ public class AtomicQueryTest {
         EmbeddedGraknTx<?> graph =  unificationWithTypesSet.tx();
         String patternString = "{$x1 isa twoRoleEntity;$x2 isa twoRoleEntity2;($x1, $x2) isa binary;}";
         String patternString2 = "{$y1 isa twoRoleEntity;$y2 isa twoRoleEntity2;($y1, $y2) isa binary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
 
@@ -348,11 +349,11 @@ public class AtomicQueryTest {
         String childString2 = "{(role1: $u, role2: $v, role2: $q) isa ternary;}";
         String childString3 = "{(role1: $u, role1: $v, role2: $q) isa ternary;}";
         String childString4 = "{(role1: $u, role1: $u, role2: $q) isa ternary;}";
-        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString, graph);
-        Conjunction<VarPatternAdmin> childPattern = conjunction(childString, graph);
-        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2, graph);
-        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3, graph);
-        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4, graph);
+        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString);
+        Conjunction<VarPatternAdmin> childPattern = conjunction(childString);
+        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2);
+        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3);
+        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(parentPattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(childPattern, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(childPattern2, graph);
@@ -396,11 +397,11 @@ public class AtomicQueryTest {
         String childString2 = "{(role1: $u, role2: $v, role2: $q) isa ternary;}";
         String childString3 = "{(role1: $u, role1: $v, role2: $q) isa ternary;}";
         String childString4 = "{(role1: $u, role1: $u, role2: $q) isa ternary;}";
-        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString, graph);
-        Conjunction<VarPatternAdmin> childPattern = conjunction(childString, graph);
-        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2, graph);
-        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3, graph);
-        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4, graph);
+        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString);
+        Conjunction<VarPatternAdmin> childPattern = conjunction(childString);
+        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2);
+        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3);
+        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(parentPattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(childPattern, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(childPattern2, graph);
@@ -474,11 +475,11 @@ public class AtomicQueryTest {
         String childString2 = "{(role1: $u, role2: $v, role2: $q) isa ternary;}";
         String childString3 = "{(role1: $u, role1: $v, role2: $q) isa ternary;}";
         String childString4 = "{(role1: $u, role1: $u, role2: $q) isa ternary;}";
-        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString, graph);
-        Conjunction<VarPatternAdmin> childPattern = conjunction(childString, graph);
-        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2, graph);
-        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3, graph);
-        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4, graph);
+        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString);
+        Conjunction<VarPatternAdmin> childPattern = conjunction(childString);
+        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2);
+        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3);
+        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(parentPattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(childPattern, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(childPattern2, graph);
@@ -515,11 +516,11 @@ public class AtomicQueryTest {
         String childString2 = "{(role1: $u, role2: $v, role2: $q) isa ternary;}";
         String childString3 = "{(role1: $u, role1: $v, role2: $q) isa ternary;}";
         String childString4 = "{(role1: $u, role1: $u, role2: $q) isa ternary;}";
-        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString, graph);
-        Conjunction<VarPatternAdmin> childPattern = conjunction(childString, graph);
-        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2, graph);
-        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3, graph);
-        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4, graph);
+        Conjunction<VarPatternAdmin> parentPattern = conjunction(parentString);
+        Conjunction<VarPatternAdmin> childPattern = conjunction(childString);
+        Conjunction<VarPatternAdmin> childPattern2 = conjunction(childString2);
+        Conjunction<VarPatternAdmin> childPattern3 = conjunction(childString3);
+        Conjunction<VarPatternAdmin> childPattern4 = conjunction(childString4);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(parentPattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(childPattern, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(childPattern2, graph);
@@ -572,9 +573,9 @@ public class AtomicQueryTest {
         String patternString = "{$x1 isa threeRoleEntity;$x3 isa threeRoleEntity3;($x1, $x2, $x3) isa ternary;}";
         String patternString2 = "{$y3 isa threeRoleEntity3;$y1 isa threeRoleEntity;($y2, $y3, $y1) isa ternary;}";
         String patternString3 = "{$y3 isa threeRoleEntity3;$y2 isa threeRoleEntity2;$y1 isa threeRoleEntity;(role2: $y2, role3: $y3, role1: $y1) isa ternary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2, graph);
-        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2);
+        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(pattern3, graph);
@@ -596,9 +597,9 @@ public class AtomicQueryTest {
         String patternString = "{$x1 isa threeRoleEntity;$x3 isa threeRoleEntity3;($x1, $x2, $x3) isa ternary;}";
         String patternString2 = "{$y3 isa threeRoleEntity3;$y1 isa threeRoleEntity;($y2, $y3, $y1) isa ternary;}";
         String patternString3 = "{$y3 isa threeRoleEntity3;$y2 isa threeRoleEntity2;$y1 isa threeRoleEntity;(role2: $y2, role3: $y3, role1: $y1) isa ternary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2, graph);
-        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2);
+        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(pattern3, graph);
@@ -620,9 +621,9 @@ public class AtomicQueryTest {
         String patternString = "{$x1 isa threeRoleEntity;$x2 isa threeRoleEntity2; $x3 isa threeRoleEntity3;($x1, $x2, $x3) isa ternary;}";
         String patternString2 = "{$y3 isa threeRoleEntity3;$y2 isa threeRoleEntity2;$y1 isa threeRoleEntity;($y2, $y3, $y1) isa ternary;}";
         String patternString3 = "{$y3 isa threeRoleEntity3;$y2 isa threeRoleEntity2;$y1 isa threeRoleEntity;(role2: $y2, role3: $y3, role1: $y1) isa ternary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2, graph);
-        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(patternString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(patternString2);
+        Conjunction<VarPatternAdmin> pattern3 = conjunction(patternString3);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(pattern3, graph);
@@ -645,9 +646,9 @@ public class AtomicQueryTest {
 
         String childString = "{$y1 isa threeRoleEntity;$y2 isa subThreeRoleEntity;$y3 isa subSubThreeRoleEntity;($y2, $y3, $y1) isa ternary;}";
         String childString2 = "{$y1 isa threeRoleEntity;$y2 isa subThreeRoleEntity;$y3 isa subSubThreeRoleEntity;(role2: $y2, role3: $y3, role1: $y1) isa ternary;}";
-        Conjunction<VarPatternAdmin> pattern = conjunction(parentString, graph);
-        Conjunction<VarPatternAdmin> pattern2 = conjunction(childString, graph);
-        Conjunction<VarPatternAdmin> pattern3 = conjunction(childString2, graph);
+        Conjunction<VarPatternAdmin> pattern = conjunction(parentString);
+        Conjunction<VarPatternAdmin> pattern2 = conjunction(childString);
+        Conjunction<VarPatternAdmin> pattern3 = conjunction(childString2);
         ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(pattern, graph);
         ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(pattern2, graph);
         ReasonerAtomicQuery childQuery2 = ReasonerQueries.atomic(pattern3, graph);
@@ -1185,8 +1186,8 @@ public class AtomicQueryTest {
     }
 
     private void queryEquivalence(String patternA, String patternB, boolean queryExpectation, boolean atomExpectation, boolean structuralExpectation, EmbeddedGraknTx<?> graph){
-        ReasonerAtomicQuery a = ReasonerQueries.atomic(conjunction(patternA, graph), graph);
-        ReasonerAtomicQuery b = ReasonerQueries.atomic(conjunction(patternB, graph), graph);
+        ReasonerAtomicQuery a = ReasonerQueries.atomic(conjunction(patternA), graph);
+        ReasonerAtomicQuery b = ReasonerQueries.atomic(conjunction(patternB), graph);
         queryEquivalence(a, b, queryExpectation, ReasonerQueryEquivalence.AlphaEquivalence);
         queryEquivalence(a, b, structuralExpectation, ReasonerQueryEquivalence.StructuralEquivalence);
         atomicEquivalence(a.getAtom(), b.getAtom(), atomExpectation);
@@ -1293,8 +1294,8 @@ public class AtomicQueryTest {
 
     private void queryUnification(String parentPatternString, String childPatternString, boolean checkInverse, boolean checkEquality, boolean ignoreTypes, EmbeddedGraknTx<?> graph){
         queryUnification(
-                ReasonerQueries.atomic(conjunction(parentPatternString, graph), graph),
-                ReasonerQueries.atomic(conjunction(childPatternString, graph), graph),
+                ReasonerQueries.atomic(conjunction(parentPatternString), graph),
+                ReasonerQueries.atomic(conjunction(childPatternString), graph),
                 checkInverse,
                 checkEquality,
                 ignoreTypes);
@@ -1307,8 +1308,8 @@ public class AtomicQueryTest {
         return Patterns.conjunction(vars);
     }
 
-    private Conjunction<VarPatternAdmin> conjunction(String patternString, EmbeddedGraknTx<?> graph){
-        Set<VarPatternAdmin> vars = graph.graql().parser().parsePattern(patternString).admin()
+    private Conjunction<VarPatternAdmin> conjunction(String patternString){
+        Set<VarPatternAdmin> vars = Graql.parser().parsePattern(patternString).admin()
                 .getDisjunctiveNormalForm().getPatterns()
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Patterns.conjunction(vars);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -66,7 +66,7 @@ public class ResolutionPlanTest {
         EmbeddedGraknTx<?> testTx = testContext.tx();
         String queryString = "{" +
                 "$x isa someEntity;" +
-                "$y isa resource;$y val 'value';" +
+                "$y isa resource; $y 'value';" +
                 "$z isa relation;" +
                 "}";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString, testTx), testTx);


### PR DESCRIPTION
# Why is this PR needed?

Currently, Grakn RPC SessionService doesn't embed the AnswerExplanation inside Query Answer object. Thus, queries over the remote Grakn client does not have access to reasoner's query explanation.

# What does the PR do?

Build the AnswerExplanation message into the Query Answer response. Any of the remote Grakn clients can now read the explanation from the Answer message.

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

We will need to implement the reader of this RPC message on the client side, starting with Java and JS.
