### PR TITLE
List keyspaces grpc

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/ServerFactory.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/ServerFactory.java
@@ -93,7 +93,7 @@ public class ServerFactory {
         // http services: spark, http controller, and gRPC server
         spark.Service sparkHttp = spark.Service.ignite();
         Collection<HttpController> httpControllers = Collections.emptyList();
-        ServerRPC rpcServerRPC = configureServerRPC(config, engineGraknTxFactory, postProcessor);
+        ServerRPC rpcServerRPC = configureServerRPC(config, engineGraknTxFactory, postProcessor, keyspaceStore);
 
         return createServer(engineId, config, status, sparkHttp, httpControllers, rpcServerRPC, engineGraknTxFactory, metricRegistry, queueSanityCheck, lockProvider, postProcessor, keyspaceStore);
     }
@@ -129,13 +129,13 @@ public class ServerFactory {
         return taskRunner;
     }
 
-    private static ServerRPC configureServerRPC(GraknConfig config, EngineGraknTxFactory engineGraknTxFactory, PostProcessor postProcessor){
+    private static ServerRPC configureServerRPC(GraknConfig config, EngineGraknTxFactory engineGraknTxFactory, PostProcessor postProcessor, KeyspaceStore keyspaceStore){
         int grpcPort = config.getProperty(GraknConfigKey.GRPC_PORT);
         OpenRequest requestOpener = new ServerOpenRequest(engineGraknTxFactory);
 
         io.grpc.Server grpcServer = ServerBuilder.forPort(grpcPort)
                 .addService(new SessionService(requestOpener, postProcessor))
-                .addService(new KeyspaceService(requestOpener))
+                .addService(new KeyspaceService(requestOpener, keyspaceStore))
                 .build();
 
         return ServerRPC.create(grpcServer);

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/EngineContext.java
@@ -310,7 +310,7 @@ public class EngineContext extends CompositeTestRule {
 
         io.grpc.Server server = ServerBuilder.forPort(0)
                 .addService(new SessionService(requestOpener, postProcessor))
-                .addService(new KeyspaceService(requestOpener))
+                .addService(new KeyspaceService(requestOpener, keyspaceStore))
                 .build();
         ServerRPC rpcServerRPC = ServerRPC.create(server);
         GraknTestUtil.allocateSparkPort(config);


### PR DESCRIPTION
# Why is this PR needed?

We don't have a way to retrieve list of keyspaces via gRPC

# What does the PR do?

Adds implementation of `retrieve` method in `KesypaceService`

# Does it break backwards compatibility?

Nah

# List of future improvements not on this PR

Add integration Java integration test once the client is updated