### PR TITLE
Update Java API docs to 1.3.0

### DIFF
--- a/docs/pages/docs/08-java-library/advanced.md
+++ b/docs/pages/docs/08-java-library/advanced.md
@@ -19,15 +19,16 @@ The following would result in an exception because the first transaction `tx1` w
 
 <!-- Ignored because this is designed to crash! -->
 ```java-test-ignore
-tx1 = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
-tx2 = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
+Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn.Transaction tx1 = session.transaction(GraknTxType.WRITE)
+Grakn.Transaction tx2 = session.transaction(GraknTxType.WRITE)
 ```
 
 If you require multiple transactions open at the same time then you must do this on different threads. This is best illustrated with an example. Let's say that you wish to create 100 entities of a specific type concurrently.  The following will achieve that:
 
 <!-- Ignored because it contains a Java lambda, which Groovy doesn't support -->
 ```java-test-ignore
-GraknSession session = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
 Set<Future> futures = new HashSet<>();
 ExecutorService pool = Executors.newFixedThreadPool(10);
 

--- a/docs/pages/docs/08-java-library/advanced.md
+++ b/docs/pages/docs/08-java-library/advanced.md
@@ -33,14 +33,14 @@ Set<Future> futures = new HashSet<>();
 ExecutorService pool = Executors.newFixedThreadPool(10);
 
 //Create sample schema
-GraknTx tx = session.open(GraknTxType.WRITE);
+Grakn.Transaction tx = session.open(GraknTxType.WRITE);
 EntityType entityType = tx.putEntityType("Some Entity Type");
 tx.commit();
 
 //Load the data concurrently
 for(int i = 0; i < 100; i ++){
     futures.add(pool.submit(() -> {
-        GraknTx innerTx = session.open(GraknTxType.WRITE);
+        Grakn.Transaction innerTx = session.open(GraknTxType.WRITE);
         entityType.addEntity();
         innerTx.commit();
     }));

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -26,7 +26,8 @@ First we need a knowledge graph. For this example we will just use an
 [in-memory knowledge graph](./setup#initialising-a-transaction-on-the-knowledge-base):
 
 ```java-test-ignore
-Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).transaction(GraknTxType.WRITE);
+Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 ```
 
 We need to define our constructs before we can use them. We will begin by defining our attribute types since they are used everywhere. In Graql, they were defined as follows:
@@ -160,7 +161,8 @@ insert $x isa person has firstname "John";
 Now the equivalent Core API:    
 
 ```java-test-ignore
-tx = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).transaction(GraknTxType.WRITE);
+Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 
 Attribute johnName = firstname.putAttribute("John"); //Create the attribute
 person.create().has(johnName); //Link it to an entity

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -14,9 +14,9 @@ To get set up to use this API, please read through our [Setup Guide](../get-star
 
 ## Core API
 
-On this page we will focus primarily on the methods provided by the `GraknTx` interface which is used by all knowledge graph mutation operations executed by Graql statements. If you are primarily interested in mutating the knowledge graph, as well as doing simple concept lookups the `GraknTx` interface will be sufficient.
+On this page we will focus primarily on the methods provided by the `Grakn.Transaction` interface which is used by all knowledge graph mutation operations executed by Graql statements. If you are primarily interested in mutating the knowledge graph, as well as doing simple concept lookups the `Grakn.Transaction` interface will be sufficient.
 
-It is also possible to interact with the knowledge graph using a Core API to form Graql queries via `GraknTx.graql()`, which is discussed separately [here](./graql-api), and is best suited for advanced querying.
+It is also possible to interact with the knowledge graph using a Core API to form Graql queries via `Grakn.Transaction::graql()`, which is discussed separately [here](./graql-api), and is best suited for advanced querying.
 
 ## Building a Schema with the Core API
 
@@ -274,7 +274,7 @@ Pattern rule2when = and(
 Pattern rule2then = var().rel("ancestor", "p").rel("descendant", "d").isa("Ancestor");
 ```
 
-If we have a specific `GraknTx tx` already defined, we can use the Graql pattern parser:
+If we have a specific `Grakn.Transaction tx` already defined, we can use the Graql pattern parser:
 
 ```java-test-ignore
 rule1when = and(tx.graql().parser().parsePatterns("(parent: $p, child: $c) isa Parent;"));

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -26,7 +26,7 @@ First we need a knowledge graph. For this example we will just use an
 [in-memory knowledge graph](./setup#initialising-a-transaction-on-the-knowledge-base):
 
 ```java-test-ignore
-GraknTx tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
+Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).transaction(GraknTxType.WRITE);
 ```
 
 We need to define our constructs before we can use them. We will begin by defining our attribute types since they are used everywhere. In Graql, they were defined as follows:
@@ -160,7 +160,7 @@ insert $x isa person has firstname "John";
 Now the equivalent Core API:    
 
 ```java-test-ignore
-tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
+tx = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).transaction(GraknTxType.WRITE);
 
 Attribute johnName = firstname.putAttribute("John"); //Create the attribute
 person.create().has(johnName); //Link it to an entity

--- a/docs/pages/docs/08-java-library/graql-api.md
+++ b/docs/pages/docs/08-java-library/graql-api.md
@@ -10,29 +10,14 @@ folder: docs
 
 As well as the Graql shell, users can also construct and execute Graql queries programmatically in Java. The Java Graql API expresses the concepts and functionality of the Graql language in the syntax of Java. It is useful if you want to make queries using Java, without having to construct a string containing the appropriate Graql expression.
 
-To use the API, add the following to your `pom.xml`:
-
-```xml
-<dependency>
-  <groupId>ai.grakn</groupId>
-  <artifactId>grakn-graql</artifactId>
-  <version>${grakn.version}</version>
-</dependency>
-```
-
-and add the following to your imports.
+To use the API, add the following to your imports:
 
 ```java-test-ignore
 import ai.grakn.graql.QueryBuilder;
+import static ai.grakn.graql.Graql.*;
 ```
 
 ## QueryBuilder
-
-`Graql` contains several useful static methods such as `var` and `eq`, so it's recommended that you use a static import:
-
-```java-test-ignore
-import static ai.grakn.graql.Graql.*;
-```
 
 A `QueryBuilder` is constructed from a `GraknTx`:
 

--- a/docs/pages/docs/08-java-library/graql-api.md
+++ b/docs/pages/docs/08-java-library/graql-api.md
@@ -16,7 +16,7 @@ To use the API, add the following to your `pom.xml`:
 <dependency>
   <groupId>ai.grakn</groupId>
   <artifactId>grakn-graql</artifactId>
-  <version>1.2.0</version>
+  <version>${grakn.version}</version>
 </dependency>
 ```
 
@@ -37,7 +37,9 @@ import static ai.grakn.graql.Graql.*;
 A `QueryBuilder` is constructed from a `GraknTx`:
 
 ```java-test-ignore
-GraknTx tx = RemoteGrakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn")).open(GraknTxType.WRITE);
+Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
+
 QueryBuilder qb = tx.graql();
 ```
 

--- a/docs/pages/docs/08-java-library/loader-api.md
+++ b/docs/pages/docs/08-java-library/loader-api.md
@@ -9,22 +9,13 @@ folder: docs
 ---
 
 
-The Grakn loader is a Java client for loading large quantities of data into a Grakn knowledge graph using multithreaded batch loading. The loader client operates by sending requests to the Grakn REST Tasks endpoint and polling for the status of submitted tasks, so the user no longer needs to implement these REST transactions. The loader client additionally provides a number of useful features, including batching insert queries, blocking, and callback on batch execution status. Configuration options allow the user to finely-tune batch loading settings.
+The Grakn loader is a Java API for loading large quantities of data into a Grakn knowledge graph using multithreaded batch loading. The loader client operates by sending requests to the Grakn REST Tasks endpoint and polling for the status of submitted tasks, so the user no longer needs to implement these REST transactions. The loader client additionally provides a number of useful features, including batching insert queries, blocking, and callback on batch execution status. Configuration options allow the user to finely-tune batch loading settings.
 
 It is possible for batches of insert queries to fail upon insertion. By default, the client will not log the status of the batch execution. The user can specify a callback function to operate on the result of the batch operation and print and accumulate status information.
 
 If you are using the [Graql shell](../get-started/graql-console), batch loading is available using the `-b` option.
 
-To use the loader client API, add the following to your pom.xml:
-
-```xml
-<dependency>
-    <groupId>ai.grakn</groupId>
-    <artifactId>client-java</artifactId>
-    <version>${grakn.version}</version>
-</dependency>
-```
- and add the following to your imports:
+To use the loader client API, add the following to your imports:
 
 ```
 import ai.grakn.client.BatchExecutorClient;

--- a/docs/pages/docs/08-java-library/loader-api.md
+++ b/docs/pages/docs/08-java-library/loader-api.md
@@ -13,15 +13,15 @@ The Grakn loader is a Java API for loading large quantities of data into a Grakn
 
 It is possible for batches of insert queries to fail upon insertion. By default, the client will not log the status of the batch execution. The user can specify a callback function to operate on the result of the batch operation and print and accumulate status information.
 
-If you are using the [Graql shell](../get-started/graql-console), batch loading is available using the `-b` option.
+{% include note.html content="If you are using the [Graql shell](../get-started/graql-console), batch loading is available using the `-b` option." %}
 
 To use the loader client API, add the following to your imports:
 
-```
+```java
 import ai.grakn.client.BatchExecutorClient;
 ```
 
-# Basic Usage
+## Basic Usage
 
 The loader client can be instantiated by giving the engine URI.
 
@@ -38,8 +38,6 @@ for(int i = 0; i < 100; i++){
     loader.add(insert, keyspace);
 }
 ```
-
-## Close
 
 The loader should be closed as follows
 

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -19,11 +19,15 @@ All applications which use **Grakn 1.3.0** will require the `client-java` depend
   </repository>
 </repositories>
 
+<properties>
+    <grakn.version>1.3.0</grakn.version>
+</properties>
+
 <dependencies>
   <dependency>
     <groupId>ai.grakn</groupId>
     <artifactId>client-java</artifactId>
-    <version>1.3.0</version>
+    <version>${grakn.version}</version>
   </dependency>
 </dependencies>
 ```
@@ -41,11 +45,15 @@ Alternatively, applications which are still using **Grakn 1.2.0** will instead r
   </repository>
 </repositories>
 
+<properties>
+    <grakn.version>1.2.0</grakn.version>
+</properties>
+
 <dependencies>
   <dependency>
     <groupId>ai.grakn</groupId>
     <artifactId>grakn-client</artifactId>
-    <version>1.2.0</version>
+    <version>${grakn.version}</version>
   </dependency>
 </dependencies>
 ```

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -10,9 +10,27 @@ folder: docs
 
 ## Basic Setup
 
-This section will discuss how to start developing with Grakn using the Java API.
-All Grakn applications require the following Maven dependency:
+This section will discuss how to develop an application with Grakn, using the Java API.
+All applications which use **Grakn 1.3.0** will require the `client-java` dependency to be declared on the `pom.xml` of your application.
 
+```xml
+<repositories>
+  <repository>
+    <id>releases</id>
+    <url>https://oss.sonatype.org/content/repositories/releases</url>
+  </repository>
+</repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>ai.grakn</groupId>
+    <artifactId>client-java</artifactId>
+    <version>1.3.0</version>
+  </dependency>
+</dependencies>
+```
+
+Alternatively, applications which are still using **Grakn 1.2.0** will instead require the `grakn-client` dependency.
 ```xml
 <repositories>
   <repository>
@@ -28,29 +46,17 @@ All Grakn applications require the following Maven dependency:
 <dependencies>
   <dependency>
     <groupId>ai.grakn</groupId>
-    <artifactId>client-java</artifactId>
+    <artifactId>grakn-client</artifactId>
     <version>1.2.0</version>
   </dependency>
 </dependencies>
 ```
 
-This dependency will give you access to the Core API as well as an in-memory knowledge graph, which serves as a toy knowledge graph, should you wish to use the stack without having to have an instance of the Grakn server running.
-
-## Server Dependent Setup
-
-If you require persistence and would like to access the entirety of the Grakn stack, then it is vital to have an instance of engine running.  
-Please see the [Setup Guide](../get-started/setup-guide) on more details on how to set up a Grakn server.
-
-Here are some links to guides for adding external jars using different IDEs:
-
-- [IntelliJ](https://www.jetbrains.com/help/idea/2016.1/configuring-module-dependencies-and-libraries.html)
-- [Eclipse](http://www.tutorialspoint.com/eclipse/eclipse_java_build_path.htm)
-- [Netbeans](http://oopbook.com/java-classpath-2/classpath-in-netbeans/)
-
+Please be noted that most of the materials in the documentation will use the syntax of Grakn 1.3.0.
 
 ## Connecting to Grakn
 
-{% include note.html content="Before proceeding, make sure that Grakn has already been started. Otherwise, refer to the [Setup guide](./docs/get-started/setup-guide#install-graknai)." %}
+{% include note.html content="Before proceeding, make sure that the Grakn database has already been started. Otherwise, refer to the [Setup guide](./docs/get-started/setup-guide#install-graknai) on how to install and start Grakn properly." %}
 
 First, make sure to import the following classes:
 ```java-test-ignore


### PR DESCRIPTION
# Why is this PR needed?
Update Java API docs so that it complies with the API in Grakn 1.3.0.

# What does the PR do?
- Updates session and transaction docs
- Removed irrelevant docs

# Does it break backward compatibility?
No. Rather, this documentation *explains* the non-backward compatible changes in 1.3.0.

# List of future improvements not on this PR
N/A