### PR TITLE
[Stable] Equivalence overhaul and update

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -44,7 +44,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -224,26 +223,6 @@ public abstract class Atom extends AtomicBase {
      * @return value variable name
      */
     public abstract Var getPredicateVariable();
-
-    /**
-     * @param var variable of interest
-     * @return id predicate referring to prescribed variable
-     */
-    @Nullable
-    public IdPredicate getIdPredicate(Var var){
-        return getPredicate(var, IdPredicate.class);
-    }
-
-    /**
-     * @param var variable the predicate refers to
-     * @param type predicate type
-     * @param <T> predicate type generic
-     * @return specific predicate referring to provided variable
-     */
-    @Nullable
-    public <T extends Predicate> T getPredicate(Var var, Class<T> type){
-        return getPredicates(type).filter(p -> p.getVarName().equals(var)).findFirst().orElse(null);
-    }
 
     public abstract Stream<Predicate> getInnerPredicates();
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicBase.java
@@ -24,6 +24,7 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.internal.query.QueryAnswer;
+import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.Predicate;
 import ai.grakn.kb.internal.EmbeddedGraknTx;
 import ai.grakn.util.ErrorMessage;
@@ -32,6 +33,7 @@ import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -72,6 +74,26 @@ public abstract class AtomicBase implements Atomic {
      */
     public <T extends Predicate> Stream<T> getPredicates(Class<T> type) {
         return getParentQuery().getAtoms(type).filter(atom -> !Sets.intersection(this.getVarNames(), atom.getVarNames()).isEmpty());
+    }
+
+    /**
+     * @param var variable of interest
+     * @return id predicate referring to prescribed variable
+     */
+    @Nullable
+    public IdPredicate getIdPredicate(Var var){
+        return getPredicate(var, IdPredicate.class);
+    }
+
+    /**
+     * @param var variable the predicate refers to
+     * @param type predicate type
+     * @param <T> predicate type generic
+     * @return specific predicate referring to provided variable
+     */
+    @Nullable
+    public <T extends Predicate> T getPredicate(Var var, Class<T> type){
+        return getPredicates(type).filter(p -> p.getVarName().equals(var)).findFirst().orElse(null);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
@@ -1,0 +1,79 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/agpl.txt>.
+ */
+
+package ai.grakn.graql.internal.reasoner.atom;
+
+import ai.grakn.graql.admin.Atomic;
+import com.google.common.base.Equivalence;
+
+
+/**
+ *
+ * <p>
+ * Static class defining different equivalence comparisons for atomics({@link Atomic}):
+ *
+ * - alpha equivalence - two atomics are alpha-equivalent if they are equal up to the choice of free variables
+ *
+ * - structural equivalence - two atomics are structurally equivalent if they are equal up to the choice of free variables and partial substitutions (id predicates {@link ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate})
+ *
+ * </p>
+ *
+ * @author Kasper Piskorski
+ *
+ */
+public abstract class AtomicEquivalence extends Equivalence<Atomic> {
+
+    public final static Equivalence<Atomic> Equality = new AtomicEquivalence(){
+
+        @Override
+        protected boolean doEquivalent(Atomic a, Atomic b) {
+            return a.equals(b);
+        }
+
+        @Override
+        protected int doHash(Atomic a) {
+            return a.hashCode();
+        }
+    };
+
+    public final static Equivalence<Atomic> AlphaEquivalence = new AtomicEquivalence(){
+
+        @Override
+        protected boolean doEquivalent(Atomic a, Atomic b) {
+            return a.isAlphaEquivalent(b);
+        }
+
+        @Override
+        protected int doHash(Atomic a) {
+            return a.alphaEquivalenceHashCode();
+        }
+    };
+
+    public final static Equivalence<Atomic> StructuralEquivalence = new AtomicEquivalence(){
+
+        @Override
+        protected boolean doEquivalent(Atomic a, Atomic b) {
+            return a.isStructurallyEquivalent(b);
+        }
+
+        @Override
+        protected int doHash(Atomic a) {
+            return a.structuralEquivalenceHashCode();
+        }
+    };
+}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
@@ -19,7 +19,12 @@
 package ai.grakn.graql.internal.reasoner.atom;
 
 import ai.grakn.graql.admin.Atomic;
+import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
 import com.google.common.base.Equivalence;
+import java.util.Collection;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
 
 
 /**
@@ -37,6 +42,22 @@ import com.google.common.base.Equivalence;
  *
  */
 public abstract class AtomicEquivalence extends Equivalence<Atomic> {
+
+    public static <B extends Atomic, S extends B> boolean equivalence(Collection<S> a1, Collection<S> a2, Equivalence<B> equiv){
+        return ReasonerUtils.isEquivalentCollection(a1, a2, equiv);
+    }
+
+    public static <B extends Atomic, S extends B> int equivalenceHash(Stream<S> atoms, Equivalence<B> equiv){
+        int hashCode = 1;
+        SortedSet<Integer> hashes = new TreeSet<>();
+        atoms.forEach(atom -> hashes.add(equiv.hash(atom)));
+        for (Integer hash : hashes) hashCode = hashCode * 37 + hash;
+        return hashCode;
+    }
+
+    public static <B extends Atomic, S extends B> int equivalenceHash(Collection<S> atoms, Equivalence<B> equiv){
+        return equivalenceHash(atoms.stream(), equiv);
+    }
 
     public final static Equivalence<Atomic> Equality = new AtomicEquivalence(){
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/AtomicEquivalence.java
@@ -30,11 +30,19 @@ import java.util.stream.Stream;
 /**
  *
  * <p>
- * Static class defining different equivalence comparisons for atomics({@link Atomic}):
+ * Static class defining different equivalence comparisons for {@link Atomic}s :
  *
- * - alpha equivalence - two atomics are alpha-equivalent if they are equal up to the choice of free variables
+ * - Equality: two {@link Atomic}s are equal if they are equal including all their corresponding variables.
  *
- * - structural equivalence - two atomics are structurally equivalent if they are equal up to the choice of free variables and partial substitutions (id predicates {@link ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate})
+ * - Alpha-equivalence: two {@link Atomic}s are alpha-equivalent if they are equal up to the choice of free variables.
+ *
+ * - Structural equivalence:
+ * Two atomics are structurally equivalent if they are equal up to the choice of free variables and partial substitutions (id predicates {@link ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate}).
+ * Hence:
+ * - any two IdPredicates are structurally equivalent
+ * - structural equivalence check on queries is done by looking at {@link Atom}s. As a result:
+ *   * connected predicates are assessed together with atoms they are connected to
+ *   * dangling predicates are ignored
  *
  * </p>
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
@@ -97,7 +97,7 @@ public abstract class Binary extends Atom {
         return  (this.isUserDefined() == that.isUserDefined())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeId(), that.getTypeId())
-                && this.hasEquivalentPredicatesWith(that);
+                && this.predicateBindingsAlphaEquivalent(that);
     }
 
     @Override
@@ -115,7 +115,7 @@ public abstract class Binary extends Atom {
         return  (this.isUserDefined() == that.isUserDefined())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeId(), that.getTypeId())
-                && this.predicateBindingsAreEquivalent(that);
+                && this.predicateBindingsStructurallyEquivalent(that);
     }
 
     @Override
@@ -123,7 +123,7 @@ public abstract class Binary extends Atom {
         return alphaEquivalenceHashCode();
     }
 
-    boolean hasEquivalentPredicatesWith(Binary atom) {
+    boolean predicateBindingsAlphaEquivalent(Binary atom) {
         //check if there is a substitution for varName
         IdPredicate thisVarPredicate = this.getIdPredicate(getVarName());
         IdPredicate varPredicate = atom.getIdPredicate(atom.getVarName());
@@ -134,7 +134,7 @@ public abstract class Binary extends Atom {
                 && (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && thisTypePredicate.isAlphaEquivalent(typePredicate));
     }
 
-    boolean predicateBindingsAreEquivalent(Binary atom) {
+    boolean predicateBindingsStructurallyEquivalent(Binary atom) {
         //check if there is a substitution for varName
         IdPredicate thisVarPredicate = this.getIdPredicate(getVarName());
         IdPredicate varPredicate = atom.getIdPredicate(atom.getVarName());

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/Binary.java
@@ -23,15 +23,19 @@ import ai.grakn.concept.SchemaConcept;
 import ai.grakn.exception.GraqlQueryException;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
+import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.admin.PatternAdmin;
 import ai.grakn.graql.admin.Unifier;
 import ai.grakn.graql.internal.pattern.Patterns;
 import ai.grakn.graql.internal.pattern.property.IsaExplicitProperty;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.atom.AtomicEquivalence;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 
+import ai.grakn.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.Predicate;
+import com.google.common.base.Equivalence;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -97,7 +101,7 @@ public abstract class Binary extends Atom {
         return  (this.isUserDefined() == that.isUserDefined())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeId(), that.getTypeId())
-                && this.predicateBindingsAlphaEquivalent(that);
+                && this.predicateBindingsEquivalent(that, AtomicEquivalence.AlphaEquivalence);
     }
 
     @Override
@@ -115,7 +119,7 @@ public abstract class Binary extends Atom {
         return  (this.isUserDefined() == that.isUserDefined())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeId(), that.getTypeId())
-                && this.predicateBindingsStructurallyEquivalent(that);
+                && this.predicateBindingsEquivalent(that, AtomicEquivalence.StructuralEquivalence);
     }
 
     @Override
@@ -123,26 +127,24 @@ public abstract class Binary extends Atom {
         return alphaEquivalenceHashCode();
     }
 
-    boolean predicateBindingsAlphaEquivalent(Binary atom) {
+    boolean predicateBindingsEquivalent(Binary that, Equivalence<Atomic> equiv) {
         //check if there is a substitution for varName
-        IdPredicate thisVarPredicate = this.getIdPredicate(getVarName());
-        IdPredicate varPredicate = atom.getIdPredicate(atom.getVarName());
+        IdPredicate thisVarPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate varPredicate = that.getIdPredicate(that.getVarName());
+
+        NeqPredicate thisVarNeqPredicate = this.getPredicate(this.getVarName(), NeqPredicate.class);
+        NeqPredicate varNeqPredicate = that.getPredicate(that.getVarName(), NeqPredicate.class);
 
         IdPredicate thisTypePredicate = this.getTypePredicate();
-        IdPredicate typePredicate = atom.getTypePredicate();
-        return ((thisVarPredicate == null && varPredicate == null || thisVarPredicate != null && thisVarPredicate.isAlphaEquivalent(varPredicate)))
-                && (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && thisTypePredicate.isAlphaEquivalent(typePredicate));
-    }
+        IdPredicate typePredicate = that.getTypePredicate();
 
-    boolean predicateBindingsStructurallyEquivalent(Binary atom) {
-        //check if there is a substitution for varName
-        IdPredicate thisVarPredicate = this.getIdPredicate(getVarName());
-        IdPredicate varPredicate = atom.getIdPredicate(atom.getVarName());
+        NeqPredicate thisTypeNeqPredicate = this.getPredicate(this.getPredicateVariable(), NeqPredicate.class);
+        NeqPredicate typeNeqPredicate = that.getPredicate(that.getPredicateVariable(), NeqPredicate.class);
 
-        IdPredicate thisTypePredicate = this.getTypePredicate();
-        IdPredicate typePredicate = atom.getTypePredicate();
-        return (thisVarPredicate == null) == (varPredicate == null)
-                && (thisTypePredicate == null) == (typePredicate == null);
+        return ((thisVarPredicate == null && varPredicate == null || thisVarPredicate != null && equiv.equivalent(thisVarPredicate, varPredicate)))
+                && (thisVarNeqPredicate == null && varNeqPredicate == null || thisVarNeqPredicate != null && equiv.equivalent(thisVarNeqPredicate, varNeqPredicate))
+                && (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && equiv.equivalent(thisTypePredicate, typePredicate))
+                && (thisTypeNeqPredicate == null && typeNeqPredicate == null || thisTypeNeqPredicate != null && equiv.equivalent(thisTypeNeqPredicate, typeNeqPredicate));
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -49,6 +49,7 @@ import ai.grakn.graql.internal.reasoner.MultiUnifierImpl;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.UnifierType;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.atom.AtomicEquivalence;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.Predicate;
@@ -64,13 +65,13 @@ import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import com.google.auto.value.AutoValue;
 import com.google.auto.value.extension.memoized.Memoized;
+import com.google.common.base.Equivalence;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
@@ -309,7 +310,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
 
     private boolean predicateBindingsEquivalent(RelationshipAtom atom,
                                                 BiFunction<String, String, Boolean> conceptComparison,
-                                                BiFunction<NeqPredicate, NeqPredicate, Boolean> neqComparison) {
+                                                Equivalence<Atomic> equiv) {
         Multimap<Role, String> thisIdMap = this.getRoleConceptIdMap();
         Multimap<Role, String> thatIdMap = atom.getRoleConceptIdMap();
 
@@ -318,15 +319,15 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return thisIdMap.keySet().equals(thatIdMap.keySet())
                 && thisIdMap.keySet().stream().allMatch(k -> ReasonerUtils.isEquivalentCollection(thisIdMap.get(k), thatIdMap.get(k), conceptComparison))
                 && thisNeqMap.keySet().equals(thatNeqMap.keySet())
-                && thisNeqMap.keySet().stream().allMatch(k -> ReasonerUtils.isEquivalentCollection(thisNeqMap.get(k), thatNeqMap.get(k), neqComparison));
+                && thisNeqMap.keySet().stream().allMatch(k -> ReasonerUtils.isEquivalentCollection(thisNeqMap.get(k), thatNeqMap.get(k), equiv));
     }
 
     private boolean predicateBindingsAlphaEquivalent(RelationshipAtom atom) {
-        return predicateBindingsEquivalent(atom, String::equals, Atomic::isAlphaEquivalent);
+        return predicateBindingsEquivalent(atom, String::equals, AtomicEquivalence.AlphaEquivalence);
     }
 
     private boolean predicateBindingsStructurallyEquivalent(RelationshipAtom atom) {
-        return predicateBindingsEquivalent(atom, (a, b) -> true, Atomic::isStructurallyEquivalent);
+        return predicateBindingsEquivalent(atom, (a, b) -> true, AtomicEquivalence.StructuralEquivalence);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -166,27 +166,16 @@ public abstract class ResourceAtom extends Binary{
     }
 
     @Override
-    boolean predicateBindingsAlphaEquivalent(Binary at) {
-        if (!(at instanceof ResourceAtom && super.predicateBindingsAlphaEquivalent(at))) return false;
+    boolean predicateBindingsEquivalent(Binary at, Equivalence<Atomic> equiv) {
+        if (!(at instanceof ResourceAtom && super.predicateBindingsEquivalent(at, equiv))) return false;
 
         ResourceAtom that = (ResourceAtom) at;
-        if (!multiPredicateEquivalent(that, AtomicEquivalence.AlphaEquivalence)) return false;
+        if (!multiPredicateEquivalent(that, equiv)) return false;
 
-        IdPredicate thisPredicate = this.getIdPredicate(getPredicateVariable());
+        IdPredicate thisPredicate = this.getIdPredicate(this.getPredicateVariable());
         IdPredicate predicate = that.getIdPredicate(that.getPredicateVariable());
-        return thisPredicate == null && predicate == null || thisPredicate != null && thisPredicate.isAlphaEquivalent(predicate);
-    }
 
-    @Override
-    boolean predicateBindingsStructurallyEquivalent(Binary at) {
-        if (!(at instanceof ResourceAtom && super.predicateBindingsStructurallyEquivalent(at))) return false;
-
-        ResourceAtom that = (ResourceAtom) at;
-        if (!multiPredicateEquivalent(that, AtomicEquivalence.StructuralEquivalence)) return false;
-
-        IdPredicate thisPredicate = this.getIdPredicate(getPredicateVariable());
-        IdPredicate predicate = that.getIdPredicate(that.getPredicateVariable());
-        return (thisPredicate == null) == (predicate == null);
+        return thisPredicate == null && predicate == null || thisPredicate != null && equiv.equivalent(thisPredicate, predicate);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -42,10 +42,12 @@ import ai.grakn.graql.internal.pattern.property.HasAttributeProperty;
 import ai.grakn.graql.internal.query.QueryAnswer;
 import ai.grakn.graql.internal.reasoner.UnifierImpl;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.atom.AtomicEquivalence;
 import ai.grakn.graql.internal.reasoner.atom.predicate.IdPredicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.Predicate;
 import ai.grakn.graql.internal.reasoner.atom.predicate.ValuePredicate;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
+import ai.grakn.graql.internal.reasoner.utils.ReasonerUtils;
 import ai.grakn.kb.internal.concept.AttributeImpl;
 import ai.grakn.kb.internal.concept.AttributeTypeImpl;
 import ai.grakn.kb.internal.concept.EntityImpl;
@@ -53,12 +55,11 @@ import ai.grakn.kb.internal.concept.RelationshipImpl;
 import ai.grakn.util.ErrorMessage;
 import ai.grakn.util.Schema;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Equivalence;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import com.google.common.collect.Iterables;
-import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.stream.Stream;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -142,7 +143,11 @@ public abstract class ResourceAtom extends Binary{
         ResourceAtom a2 = (ResourceAtom) obj;
         return Objects.equals(this.getTypeId(), a2.getTypeId())
                 && this.getVarName().equals(a2.getVarName())
-                && this.hasMultiPredicateEquivalentWith(a2);
+                && this.multiPredicateEquivalent(a2, AtomicEquivalence.Equality);
+    }
+
+    private boolean multiPredicateEquivalent(ResourceAtom that, Equivalence<Atomic> equiv){
+        return ReasonerUtils.isEquivalentCollection(this.getMultiPredicate(), that.getMultiPredicate(), equiv);
     }
 
     @Override
@@ -156,52 +161,31 @@ public abstract class ResourceAtom extends Binary{
     public int alphaEquivalenceHashCode() {
         int hashCode = 1;
         hashCode = hashCode * 37 + (this.getTypeId() != null? this.getTypeId().hashCode() : 0);
-        hashCode = hashCode * 37 + this.multiPredicateEquivalenceHashCode();
-        return hashCode;
-    }
-
-    private boolean hasMultiPredicateEquivalentWith(ResourceAtom atom){
-        if(this.getMultiPredicate().size() != atom.getMultiPredicate().size()) return false;
-        for (ValuePredicate vp : getMultiPredicate()) {
-            Iterator<ValuePredicate> objIt = atom.getMultiPredicate().iterator();
-            boolean predicateHasEquivalent = false;
-            while (objIt.hasNext() && !predicateHasEquivalent) {
-                predicateHasEquivalent = vp.isAlphaEquivalent(objIt.next());
-            }
-            if (!predicateHasEquivalent) return false;
-        }
-        return true;
-    }
-
-    private int multiPredicateEquivalenceHashCode(){
-        int hashCode = 0;
-        SortedSet<Integer> hashes = new TreeSet<>();
-        getMultiPredicate().forEach(atom -> hashes.add(atom.alphaEquivalenceHashCode()));
-        for (Integer hash : hashes) hashCode = hashCode * 37 + hash;
+        hashCode = hashCode * 37 + AtomicEquivalence.equivalenceHash(this.getMultiPredicate(), AtomicEquivalence.AlphaEquivalence);
         return hashCode;
     }
 
     @Override
-    boolean hasEquivalentPredicatesWith(Binary at) {
-        if (!(at instanceof ResourceAtom && super.hasEquivalentPredicatesWith(at))) return false;
+    boolean predicateBindingsAlphaEquivalent(Binary at) {
+        if (!(at instanceof ResourceAtom && super.predicateBindingsAlphaEquivalent(at))) return false;
 
-        ResourceAtom atom = (ResourceAtom) at;
-        if (!hasMultiPredicateEquivalentWith(atom)) return false;
+        ResourceAtom that = (ResourceAtom) at;
+        if (!multiPredicateEquivalent(that, AtomicEquivalence.AlphaEquivalence)) return false;
 
         IdPredicate thisPredicate = this.getIdPredicate(getPredicateVariable());
-        IdPredicate predicate = atom.getIdPredicate(atom.getPredicateVariable());
+        IdPredicate predicate = that.getIdPredicate(that.getPredicateVariable());
         return thisPredicate == null && predicate == null || thisPredicate != null && thisPredicate.isAlphaEquivalent(predicate);
     }
 
     @Override
-    boolean predicateBindingsAreEquivalent(Binary at) {
-        if (!(at instanceof ResourceAtom && super.predicateBindingsAreEquivalent(at))) return false;
+    boolean predicateBindingsStructurallyEquivalent(Binary at) {
+        if (!(at instanceof ResourceAtom && super.predicateBindingsStructurallyEquivalent(at))) return false;
 
-        ResourceAtom atom = (ResourceAtom) at;
-        if (!hasMultiPredicateEquivalentWith(atom)) return false;
+        ResourceAtom that = (ResourceAtom) at;
+        if (!multiPredicateEquivalent(that, AtomicEquivalence.StructuralEquivalence)) return false;
 
         IdPredicate thisPredicate = this.getIdPredicate(getPredicateVariable());
-        IdPredicate predicate = atom.getIdPredicate(atom.getPredicateVariable());
+        IdPredicate predicate = that.getIdPredicate(that.getPredicateVariable());
         return (thisPredicate == null) == (predicate == null);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/IdPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/IdPredicate.java
@@ -80,6 +80,18 @@ public abstract class IdPredicate extends Predicate<ConceptId>{
     }
 
     @Override
+    public boolean isStructurallyEquivalent(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        return true;
+    }
+
+    @Override
+    public int structuralEquivalenceHashCode() {
+        return 1;
+    }
+
+    @Override
     public Atomic copy(ReasonerQuery parent){
         return create(this, parent);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
@@ -63,10 +63,41 @@ public abstract class NeqPredicate extends Predicate<Var> {
     }
 
     @Override
+    public boolean isAlphaEquivalent(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        NeqPredicate that = (NeqPredicate) obj;
+
+        //check bindings
+        IdPredicate thisPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate thatPredicate = that.getIdPredicate(that.getVarName());
+        IdPredicate thisRefPredicate = this.getIdPredicate(this.getPredicate());
+        IdPredicate thatRefPredicate = that.getIdPredicate(that.getPredicate());
+        return ( (thisPredicate == null) ? (thisPredicate == thatPredicate) : thisPredicate.isAlphaEquivalent(thatPredicate) )
+                && ( (thisRefPredicate == null) ? (thisRefPredicate == thatRefPredicate) : thisRefPredicate.isAlphaEquivalent(thatRefPredicate) );
+    }
+
+    @Override
+    public int alphaEquivalenceHashCode() {
+        int hashCode = 1;
+        IdPredicate idPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate refIdPredicate = this.getIdPredicate(this.getPredicate());
+        hashCode = hashCode * 37 + (idPredicate != null? idPredicate.alphaEquivalenceHashCode() : 0);
+        hashCode = hashCode * 37 + (refIdPredicate != null? refIdPredicate.alphaEquivalenceHashCode() : 0);
+        return hashCode;
+    }
+
+    @Override
     public Atomic copy(ReasonerQuery parent) { return create(this, parent);}
 
     @Override
-    public String toString(){ return "[" + getVarName() + "!=" + getReferenceVarName() + "]";}
+    public String toString(){
+        IdPredicate idPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate refIdPredicate = this.getIdPredicate(this.getPredicate());
+        return "[" + getVarName() + "!=" + getPredicate() + "]" +
+                (idPredicate != null? idPredicate : "" ) +
+                (refIdPredicate != null? refIdPredicate : "");
+    }
 
     @Override
     public String getPredicateValue() {
@@ -76,7 +107,7 @@ public abstract class NeqPredicate extends Predicate<Var> {
     @Override
     public Set<Var> getVarNames(){
         Set<Var> vars = super.getVarNames();
-        vars.add(getReferenceVarName());
+        vars.add(getPredicate());
         return vars;
     }
 
@@ -86,11 +117,7 @@ public abstract class NeqPredicate extends Predicate<Var> {
      */
     public boolean isSatisfied(Answer sub) {
         return !sub.containsVar(getVarName())
-                || !sub.containsVar(getReferenceVarName())
-                || !sub.get(getVarName()).equals(sub.get(getReferenceVarName()));
-    }
-
-    private Var getReferenceVarName(){
-        return getPredicate();
+                || !sub.containsVar(getPredicate())
+                || !sub.get(getVarName()).equals(sub.get(getPredicate()));
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/predicate/NeqPredicate.java
@@ -26,8 +26,10 @@ import ai.grakn.graql.admin.ReasonerQuery;
 import ai.grakn.graql.admin.VarPatternAdmin;
 import ai.grakn.graql.internal.pattern.property.NeqProperty;
 
+import ai.grakn.graql.internal.reasoner.atom.AtomicEquivalence;
 import ai.grakn.graql.internal.reasoner.utils.IgnoreHashEquals;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Equivalence;
 import java.util.Set;
 
 /**
@@ -62,29 +64,48 @@ public abstract class NeqPredicate extends Predicate<Var> {
         return pattern.admin().getProperties(NeqProperty.class).iterator().next().var().var();
     }
 
+    private boolean predicateBindingsEquivalent(NeqPredicate that, Equivalence<Atomic> equiv){
+        IdPredicate thisPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate thatPredicate = that.getIdPredicate(that.getVarName());
+        IdPredicate thisRefPredicate = this.getIdPredicate(this.getPredicate());
+        IdPredicate thatRefPredicate = that.getIdPredicate(that.getPredicate());
+        return ( (thisPredicate == null) ? (thisPredicate == thatPredicate) : equiv.equivalent(thisPredicate, thatPredicate) )
+                && ( (thisRefPredicate == null) ? (thisRefPredicate == thatRefPredicate) : equiv.equivalent(thisRefPredicate, thatRefPredicate) );
+    }
+
+    private int bindingHash(Equivalence<Atomic> equiv){
+        int hashCode = 1;
+        IdPredicate idPredicate = this.getIdPredicate(this.getVarName());
+        IdPredicate refIdPredicate = this.getIdPredicate(this.getPredicate());
+        hashCode = hashCode * 37 + (idPredicate != null? equiv.hash(idPredicate) : 0);
+        hashCode = hashCode * 37 + (refIdPredicate != null? equiv.hash(refIdPredicate) : 0);
+        return hashCode;
+    }
+
     @Override
     public boolean isAlphaEquivalent(Object obj){
         if (obj == null || this.getClass() != obj.getClass()) return false;
         if (obj == this) return true;
         NeqPredicate that = (NeqPredicate) obj;
-
-        //check bindings
-        IdPredicate thisPredicate = this.getIdPredicate(this.getVarName());
-        IdPredicate thatPredicate = that.getIdPredicate(that.getVarName());
-        IdPredicate thisRefPredicate = this.getIdPredicate(this.getPredicate());
-        IdPredicate thatRefPredicate = that.getIdPredicate(that.getPredicate());
-        return ( (thisPredicate == null) ? (thisPredicate == thatPredicate) : thisPredicate.isAlphaEquivalent(thatPredicate) )
-                && ( (thisRefPredicate == null) ? (thisRefPredicate == thatRefPredicate) : thisRefPredicate.isAlphaEquivalent(thatRefPredicate) );
+        return predicateBindingsEquivalent(that, AtomicEquivalence.AlphaEquivalence);
     }
 
     @Override
     public int alphaEquivalenceHashCode() {
-        int hashCode = 1;
-        IdPredicate idPredicate = this.getIdPredicate(this.getVarName());
-        IdPredicate refIdPredicate = this.getIdPredicate(this.getPredicate());
-        hashCode = hashCode * 37 + (idPredicate != null? idPredicate.alphaEquivalenceHashCode() : 0);
-        hashCode = hashCode * 37 + (refIdPredicate != null? refIdPredicate.alphaEquivalenceHashCode() : 0);
-        return hashCode;
+        return bindingHash(AtomicEquivalence.AlphaEquivalence);
+    }
+
+    @Override
+    public boolean isStructurallyEquivalent(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        NeqPredicate that = (NeqPredicate) obj;
+        return predicateBindingsEquivalent(that, AtomicEquivalence.StructuralEquivalence);
+    }
+
+    @Override
+    public int structuralEquivalenceHashCode() {
+        return bindingHash(AtomicEquivalence.StructuralEquivalence);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryEquivalence.java
@@ -31,9 +31,11 @@ import java.util.stream.Collectors;
  * <p>
  * Static class defining different equivalence comparisons for reasoner queries ({@link ReasonerQuery}):
  *
- * - alpha equivalence - two queries are alpha-equivalent if they are equal up to the choice of free variables
+ * - Equality - two queries are equal if they contain the same {@link Atomic}s of which all corresponding pairs are equal.
  *
- * - structural equivalence - two queries are structurally equivalent if they are equal up to the choice of free variables and partial substitutions (id predicates)
+ * - Alpha equivalence - two queries are alpha-equivalent if they are equal up to the choice of free variables.
+ *
+ * - Structural equivalence - two queries are structurally equivalent if they are equal up to the choice of free variables and partial substitutions (id predicates).
  *
  * </p>
  *

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
@@ -21,7 +21,9 @@ package ai.grakn.graql.internal.reasoner.rule;
 import ai.grakn.GraknTx;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.SchemaConcept;
+import ai.grakn.graql.admin.Atomic;
 import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.atom.AtomicEquivalence;
 import ai.grakn.graql.internal.reasoner.query.ReasonerQueryImpl;
 import ai.grakn.util.Schema;
 import com.google.common.base.Equivalence;
@@ -117,12 +119,7 @@ public class RuleUtils {
      * @return all rules that are reachable from the entry types
      */
     public static Set<InferenceRule> getDependentRules(ReasonerQueryImpl query){
-        final Equivalence<Atom> equivalence = new Equivalence<Atom>(){
-            @Override
-            protected boolean doEquivalent(Atom a1, Atom a2) {return a1.isAlphaEquivalent(a2);}
-            @Override
-            protected int doHash(Atom a) {return a.alphaEquivalenceHashCode();}
-        };
+        final Equivalence<Atomic> equivalence = AtomicEquivalence.AlphaEquivalence;
 
         Set<InferenceRule> rules = new HashSet<>();
         Set<Equivalence.Wrapper<Atom>> visitedAtoms = new HashSet<>();

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -854,63 +854,59 @@ public class AtomicQueryTest {
     public void testEquivalence_TypesWithSubstitution(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String query = "{$y isa baseRoleEntity;}";
-
         String query2 = "{$x isa baseRoleEntity; $x id 'X';}";
         String query2b = "{$r isa baseRoleEntity; $r id 'X';}";
         String query2c = "{$e isa $t;$t label baseRoleEntity;$e id 'X';}";
-
-        String query3 = "{$a isa baseRoleEntity; $b id 'X';}";
-        String query4 = "{$z isa baseRoleEntity; $z id 'Y';}";
+        String query3s2 = "{$z isa baseRoleEntity; $z id 'Y';}";
+        String query4s1 = "{$a isa baseRoleEntity; $b id 'X';}";
         String query5 = "{$e isa baseRoleEntity ; $e != $f;}";
         String query6 = "{$e isa baseRoleEntity ; $e != $f; $f id 'X';}";
-
         String query7 = "{$e isa entity ; $e id 'X';}";
 
-        queryEquivalence(query2, query4, false, true, graph);
-
-        queryEquivalence(query3, query5, false, true, false, graph);
 
         queryEquivalence(query, query2, false, graph);
-        queryEquivalence(query, query3, false, true, false, graph);
-        queryEquivalence(query, query4, false, graph);
         queryEquivalence(query, query2b, false, graph);
         queryEquivalence(query, query2c, false, graph);
+        queryEquivalence(query, query3s2, false, graph);
+        queryEquivalence(query, query4s1, false, true, true, graph);
+        queryEquivalence(query, query5, false, graph);
+        queryEquivalence(query, query6, false, graph);
         queryEquivalence(query, query7, false, graph);
 
         queryEquivalence(query2, query2b, true, graph);
         queryEquivalence(query2, query2c, true, graph);
-        queryEquivalence(query2, query3, false, graph);
-
+        queryEquivalence(query2, query3s2, false, true, graph);
+        queryEquivalence(query2, query4s1, false, graph);
         queryEquivalence(query2, query5, false, graph);
         queryEquivalence(query2, query6, false, graph);
         queryEquivalence(query2, query7, false, graph);
 
-        queryEquivalence(query3, query4, false, graph);
-        queryEquivalence(query3, query2b, false, graph);
-        queryEquivalence(query3, query2c, false, graph);
-        queryEquivalence(query3, query4, false, graph);
-
-        queryEquivalence(query3, query6, false, graph);
-        queryEquivalence(query3, query7, false, graph);
-
-        queryEquivalence(query4, query2b, false, true, graph);
-        queryEquivalence(query4, query2c, false, true, graph);
-        queryEquivalence(query4, query5, false, graph);
-        queryEquivalence(query4, query6, false, graph);
-        queryEquivalence(query4, query7, false, graph);
-
         queryEquivalence(query2b, query2c, true, graph);
-        queryEquivalence(query2b, query3, false, graph);
-        queryEquivalence(query2b, query4, false, graph);
+        queryEquivalence(query2b, query3s2, false, true, graph);
+        queryEquivalence(query2b, query4s1, false, graph);
         queryEquivalence(query2b, query5, false, graph);
         queryEquivalence(query2b, query6, false, graph);
         queryEquivalence(query2b, query7, false, graph);
 
-        queryEquivalence(query2c, query3, false, graph);
-        queryEquivalence(query2c, query4, false, graph);
+        queryEquivalence(query2c, query3s2, false, true, graph);
+        queryEquivalence(query2c, query4s1, false, graph);
         queryEquivalence(query2c, query5, false, graph);
         queryEquivalence(query2c, query6, false, graph);
         queryEquivalence(query2c, query7, false, graph);
+
+        queryEquivalence(query3s2, query4s1, false, graph);
+        queryEquivalence(query3s2, query5, false, graph);
+        queryEquivalence(query3s2, query6, false, graph);
+        queryEquivalence(query3s2, query7, false, graph);
+
+        queryEquivalence(query4s1, query5, false,  graph);
+        queryEquivalence(query4s1, query6, false, graph);
+        queryEquivalence(query4s1, query7, false, graph);
+
+        queryEquivalence(query5, query6, false, graph);
+        queryEquivalence(query5, query7, false, graph);
+
+        queryEquivalence(query6, query7, false, graph);
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -991,59 +991,52 @@ public class AtomicQueryTest {
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String query = "{$z has resource $u;$a >23; $a <27;}";
         String query2 = "{$x isa baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
+        String query2b = "{$a isa baseRoleEntity;$a has resource $p;$p <27;$p >23;}";
+        String query2c = "{$x isa baseRoleEntity, has resource $a;$a >23; $a <27;}";
+        String query2d = "{$x isa $type;$type label baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
         String query3 = "{$e isa baseRoleEntity;$e has resource > 23;}";
-
-        String query4 = "{$p isa baseRoleEntity;$p has resource $a;$a >23;}";
-        String query5 = "{$x isa baseRoleEntity;$x has resource $y;$y >27;$y <23;}";
-        String query6 = "{$a isa baseRoleEntity;$a has resource $p;$p <27;$p >23;}";
-        String query7 = "{$x isa baseRoleEntity, has resource $a;$a >23; $a <27;}";
-        String query8 = "{$x isa baseRoleEntity, has resource $z1;$z1 >23; $z2 <27;}";
-
-        String query9 = "{$x isa $type;$type label baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
+        String query3b = "{$p isa baseRoleEntity;$p has resource $a;$a >23;}";
+        String query4 = "{$x isa baseRoleEntity;$x has resource $y;$y >27;$y <23;}";
+        String query5 = "{$x isa baseRoleEntity, has resource $z1;$z1 >23; $z2 <27;}";
 
         queryEquivalence(query, query2, false, graph);
+        queryEquivalence(query, query2b, false, graph);
+        queryEquivalence(query, query2c, false, graph);
+        queryEquivalence(query, query2d, false, graph);
         queryEquivalence(query, query3, false, graph);
+        queryEquivalence(query, query3b, false, graph);
         queryEquivalence(query, query4, false, graph);
         queryEquivalence(query, query5, false, graph);
-        queryEquivalence(query, query6, false, graph);
-        queryEquivalence(query, query7, false, graph);
-        queryEquivalence(query, query8, false, graph);
-        queryEquivalence(query, query9, false, graph);
 
+        queryEquivalence(query2, query2b, true, graph);
+        queryEquivalence(query2, query2c, true, graph);
+        queryEquivalence(query2, query2d, true, graph);
         queryEquivalence(query2, query3, false, graph);
+        queryEquivalence(query2, query3b, false, graph);
         queryEquivalence(query2, query4, false, graph);
         queryEquivalence(query2, query5, false, graph);
-        queryEquivalence(query2, query6, true, graph);
-        queryEquivalence(query2, query7, true, graph);
-        queryEquivalence(query2, query8, false, graph);
-        queryEquivalence(query2, query9, true, graph);
 
-        queryEquivalence(query3, query4, true, graph);
-        queryEquivalence(query3, query5, false, graph);
-        queryEquivalence(query3, query6, false, graph);
-        queryEquivalence(query3, query7, false, graph);
+        queryEquivalence(query2b, query2c, true, graph);
+        queryEquivalence(query2b, query2d, true, graph);
+        queryEquivalence(query2b, query3, false, graph);
+        queryEquivalence(query2b, query3b, false, graph);
+        queryEquivalence(query2b, query4, false, graph);
+        queryEquivalence(query2b, query5, false, graph);
 
-        queryEquivalence(query3, query8, false, true, false, graph);
+        queryEquivalence(query2c, query2d, true, graph);
+        queryEquivalence(query2c, query3, false, graph);
+        queryEquivalence(query2c, query3b, false, graph);
+        queryEquivalence(query2c, query4, false, graph);
+        queryEquivalence(query2c, query5, false, graph);
 
-        queryEquivalence(query3, query9, false, graph);
+        queryEquivalence(query3, query3b, true, graph);
+        queryEquivalence(query3, query4, false, graph);
+        queryEquivalence(query3, query5, false, true, true, graph);
+
+        queryEquivalence(query3b, query4, false, graph);
+        queryEquivalence(query3b, query5, false, true, true, graph);
 
         queryEquivalence(query4, query5, false, graph);
-        queryEquivalence(query4, query6, false, graph);
-        queryEquivalence(query4, query7, false, graph);
-        queryEquivalence(query4, query8, false, true, false, graph);
-        queryEquivalence(query4, query9, false, graph);
-
-        queryEquivalence(query5, query6, false, graph);
-        queryEquivalence(query5, query7, false, graph);
-        queryEquivalence(query5, query8, false, graph);
-        queryEquivalence(query5, query9, false, graph);
-
-        queryEquivalence(query6, query7, true, graph);
-        queryEquivalence(query6, query8, false, graph);
-        queryEquivalence(query6, query9, true, graph);
-
-        queryEquivalence(query7, query8, false, graph);
-        queryEquivalence(query7, query9, true, graph);
     }
 
     @Test //tests alpha-equivalence of resource atoms with different predicates
@@ -1052,22 +1045,22 @@ public class AtomicQueryTest {
         String query = "{$x has resource $r;$r > 1099;}";
         String query2 = "{$x has resource $r;$r < 1099;}";
         String query3 = "{$x has resource $r;$r == 1099;}";
-        String query4 = "{$x has resource $r;$r '1099';}";
-        String query5 = "{$x has resource $r;$r > $var;}";
+        String query3b = "{$x has resource $r;$r '1099';}";
+        String query4 = "{$x has resource $r;$r > $var;}";
 
         queryEquivalence(query, query2, false, graph);
         queryEquivalence(query, query3, false, graph);
+        queryEquivalence(query, query3b, false, graph);
         queryEquivalence(query, query4, false, graph);
-        queryEquivalence(query, query5, false, graph);
 
         queryEquivalence(query2, query3, false, graph);
+        queryEquivalence(query2, query3b, false, graph);
         queryEquivalence(query2, query4, false, graph);
-        queryEquivalence(query2, query5, false, graph);
 
-        queryEquivalence(query3, query4, true, graph);
-        queryEquivalence(query3, query5, false, graph);
+        queryEquivalence(query3, query3b, true, graph);
+        queryEquivalence(query3, query4, false, graph);
 
-        queryEquivalence(query4, query5, false, graph);
+        queryEquivalence(query3b, query4, false, graph);
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -10,10 +10,10 @@
  * Grakn is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
+ * GNU General Public License for more details.
  *
- * You should have received a copy of the GNU Affero General Public License
- * along with Grakn. If not, see <http://www.gnu.org/licenses/agpl.txt>.
+ * You should have received a copy of the GNU General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/gpl.txt>.
  */
 
 package ai.grakn.graql.internal.reasoner;
@@ -146,7 +146,7 @@ public class AtomicQueryTest {
         Concept secondEntity = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa entity2; get;").execute()).get("x");
         Concept resource = Iterables.getOnlyElement(qb.<GetQuery>parse("match $x isa resource; get;").execute()).get("x");
 
-        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r 'inferred';$x id " + firstEntity.id().getValue() + ";}", graph), graph);
+        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{$x has resource $r;$r == 'inferred';$x id " + firstEntity.id().getValue() + ";}", graph), graph);
         String reuseResourcePatternString =
                 "{" +
                         "$x has resource $r;" +
@@ -765,12 +765,12 @@ public class AtomicQueryTest {
      */
 
     @Test
-    public void testAlphaEquivalence_DifferentIsaVariants(){
+    public void testEquivalence_DifferentIsaVariants(){
         testEquivalence_DifferentTypeVariants(unificationTestSet.tx(), "isa", "baseRoleEntity", "subRoleEntity");
     }
 
     @Test
-    public void testAlphaEquivalence_DifferentSubVariants(){
+    public void testEquivalence_DifferentSubVariants(){
         testEquivalence_DifferentTypeVariants(unificationTestSet.tx(), "sub", "baseRoleEntity", "role1");
     }
 
@@ -854,39 +854,63 @@ public class AtomicQueryTest {
     public void testEquivalence_TypesWithSubstitution(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String query = "{$y isa baseRoleEntity;}";
+
         String query2 = "{$x isa baseRoleEntity; $x id 'X';}";
+        String query2b = "{$r isa baseRoleEntity; $r id 'X';}";
+        String query2c = "{$e isa $t;$t label baseRoleEntity;$e id 'X';}";
+
         String query3 = "{$a isa baseRoleEntity; $b id 'X';}";
         String query4 = "{$z isa baseRoleEntity; $z id 'Y';}";
-        String query5 = "{$r isa baseRoleEntity; $r id 'X';}";
-        String query6 = "{$e isa $t;$t label baseRoleEntity;$e id 'X';}";
+        String query5 = "{$e isa baseRoleEntity ; $e != $f;}";
+        String query6 = "{$e isa baseRoleEntity ; $e != $f; $f id 'X';}";
+
         String query7 = "{$e isa entity ; $e id 'X';}";
+
+        queryEquivalence(query2, query4, false, true, graph);
+
+        queryEquivalence(query3, query5, false, true, false, graph);
 
         queryEquivalence(query, query2, false, graph);
         queryEquivalence(query, query3, false, true, false, graph);
         queryEquivalence(query, query4, false, graph);
-        queryEquivalence(query, query5, false, graph);
-        queryEquivalence(query, query6, false, graph);
+        queryEquivalence(query, query2b, false, graph);
+        queryEquivalence(query, query2c, false, graph);
         queryEquivalence(query, query7, false, graph);
 
+        queryEquivalence(query2, query2b, true, graph);
+        queryEquivalence(query2, query2c, true, graph);
         queryEquivalence(query2, query3, false, graph);
-        queryEquivalence(query2, query4, false, true, graph);
-        queryEquivalence(query2, query5, true, graph);
-        queryEquivalence(query2, query6, true, graph);
+
+        queryEquivalence(query2, query5, false, graph);
+        queryEquivalence(query2, query6, false, graph);
         queryEquivalence(query2, query7, false, graph);
 
         queryEquivalence(query3, query4, false, graph);
-        queryEquivalence(query3, query5, false, graph);
+        queryEquivalence(query3, query2b, false, graph);
+        queryEquivalence(query3, query2c, false, graph);
+        queryEquivalence(query3, query4, false, graph);
+
         queryEquivalence(query3, query6, false, graph);
         queryEquivalence(query3, query7, false, graph);
 
-        queryEquivalence(query4, query5, false, true, graph);
-        queryEquivalence(query4, query6, false, true, graph);
+        queryEquivalence(query4, query2b, false, true, graph);
+        queryEquivalence(query4, query2c, false, true, graph);
+        queryEquivalence(query4, query5, false, graph);
+        queryEquivalence(query4, query6, false, graph);
         queryEquivalence(query4, query7, false, graph);
 
-        queryEquivalence(query5, query6, true, graph);
-        queryEquivalence(query5, query7, false, graph);
+        queryEquivalence(query2b, query2c, true, graph);
+        queryEquivalence(query2b, query3, false, graph);
+        queryEquivalence(query2b, query4, false, graph);
+        queryEquivalence(query2b, query5, false, graph);
+        queryEquivalence(query2b, query6, false, graph);
+        queryEquivalence(query2b, query7, false, graph);
 
-        queryEquivalence(query6, query7, false, graph);
+        queryEquivalence(query2c, query3, false, graph);
+        queryEquivalence(query2c, query4, false, graph);
+        queryEquivalence(query2c, query5, false, graph);
+        queryEquivalence(query2c, query6, false, graph);
+        queryEquivalence(query2c, query7, false, graph);
     }
 
     @Test
@@ -913,28 +937,53 @@ public class AtomicQueryTest {
         String query3 = "{$z has resource $u; $z id 'Y';}";
 
         String query4 = "{$y has resource $r;$r id 'X';}";
-        String query5 = "{$r has resource $x;$x id 'X';}";
-        String query6 = "{$y has resource $x;$x id 'Y';}";
+        String query4b = "{$r has resource $x;$x id 'X';}";
+        String query5 = "{$y has resource $x;$x id 'Y';}";
+
+        String query6 = "{$y has resource $x;$x != $x2;}";
+        String query7 = "{$y has resource $x;$x != $x2; $x2 id 'Y';}";
+        String query8 = "{$y has resource $x;$y != $y2;}";
+        String query9 = "{$y has resource $x;$y != $y2; $y2 id 'Y';}";
 
         queryEquivalence(query, query2, false, graph);
         queryEquivalence(query, query3, false, graph);
         queryEquivalence(query, query4, false, graph);
+        queryEquivalence(query, query4b, false, graph);
         queryEquivalence(query, query5, false, graph);
         queryEquivalence(query, query6, false, graph);
+        queryEquivalence(query, query7, false, graph);
+        queryEquivalence(query, query8, false, graph);
+        queryEquivalence(query, query9, false, graph);
 
         queryEquivalence(query2, query3, false, false, true, graph);
         queryEquivalence(query2, query4, false, graph);
+        queryEquivalence(query2, query4b, false, graph);
         queryEquivalence(query2, query5, false, graph);
         queryEquivalence(query2, query6, false, graph);
+        queryEquivalence(query2, query7, false, graph);
+        queryEquivalence(query2, query8, false, graph);
+        queryEquivalence(query2, query9, false, graph);
 
         queryEquivalence(query3, query4, false, graph);
+        queryEquivalence(query3, query4b, false, graph);
         queryEquivalence(query3, query5, false, graph);
         queryEquivalence(query3, query6, false, graph);
+        queryEquivalence(query3, query7, false, graph);
+        queryEquivalence(query3, query8, false, graph);
+        queryEquivalence(query3, query9, false, graph);
 
-        queryEquivalence(query4, query5, true, graph);
-        queryEquivalence(query4, query6, false, false, true, graph);
+        queryEquivalence(query4, query4b, true, graph);
+        queryEquivalence(query4, query5, false, false, true, graph);
+        queryEquivalence(query4, query6, false, graph);
+        queryEquivalence(query4, query7, false, graph);
+        queryEquivalence(query4, query8, false, graph);
+        queryEquivalence(query4, query9, false, graph);
 
-        queryEquivalence(query5, query6, false, false, true, graph);
+        queryEquivalence(query4b, query5, false, false, true, graph);
+        queryEquivalence(query4b, query6, false, graph);
+        queryEquivalence(query4b, query7, false, graph);
+        queryEquivalence(query4b, query8, false, graph);
+        queryEquivalence(query4b, query9, false, graph);
     }
 
     @Test //tests alpha-equivalence of queries with resources with multi predicate
@@ -943,11 +992,13 @@ public class AtomicQueryTest {
         String query = "{$z has resource $u;$a >23; $a <27;}";
         String query2 = "{$x isa baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
         String query3 = "{$e isa baseRoleEntity;$e has resource > 23;}";
+
         String query4 = "{$p isa baseRoleEntity;$p has resource $a;$a >23;}";
         String query5 = "{$x isa baseRoleEntity;$x has resource $y;$y >27;$y <23;}";
         String query6 = "{$a isa baseRoleEntity;$a has resource $p;$p <27;$p >23;}";
         String query7 = "{$x isa baseRoleEntity, has resource $a;$a >23; $a <27;}";
         String query8 = "{$x isa baseRoleEntity, has resource $z1;$z1 >23; $z2 <27;}";
+
         String query9 = "{$x isa $type;$type label baseRoleEntity;$x has resource $a;$a >23; $a <27;}";
 
         queryEquivalence(query, query2, false, graph);
@@ -971,7 +1022,9 @@ public class AtomicQueryTest {
         queryEquivalence(query3, query5, false, graph);
         queryEquivalence(query3, query6, false, graph);
         queryEquivalence(query3, query7, false, graph);
+
         queryEquivalence(query3, query8, false, true, false, graph);
+
         queryEquivalence(query3, query9, false, graph);
 
         queryEquivalence(query4, query5, false, graph);
@@ -1104,34 +1157,62 @@ public class AtomicQueryTest {
     public void testEquivalence_RelationsWithSubstitution(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String query = "{(role: $x, role: $y);$x id 'V666';}";
-        String query2 = "{(role: $x, role: $y);$y id 'V666';}";
-        String query3 = "{(role: $x, role: $y);$x id 'V666';$y id 'V667';}";
-        String query4 = "{(role: $x, role: $y);$y id 'V666';$x id 'V667';}";
-        String query5 = "{(role1: $x, role2: $y);$x id 'V666';$y id 'V667';}";
-        String query6 = "{(role1: $x, role2: $y);$y id 'V666';$x id 'V667';}";
+        String queryb = "{(role: $x, role: $y);$y id 'V666';}";
+
+        String query2 = "{(role: $x, role: $y);$x != $y;}";
+        String query3 = "{(role: $x, role: $y);$x != $y;$y id 'V667';}";
+
+        String query4 = "{(role: $x, role: $y);$x id 'V666';$y id 'V667';}";
+        String query4b = "{(role: $x, role: $y);$y id 'V666';$x id 'V667';}";
+
         String query7 = "{(role: $x, role: $y);$x id 'V666';$y id 'V666';}";
 
-        queryEquivalence(query, query2, true, true, graph);
-        queryEquivalence(query, query3, false, false, graph);
+        String query5 = "{(role1: $x, role2: $y);$x id 'V666';$y id 'V667';}";
+        String query6 = "{(role1: $x, role2: $y);$y id 'V666';$x id 'V667';}";
+
+
+        queryEquivalence(query4, query7, false, true, graph);
+
+        queryEquivalence(query3, query4, false, false, graph);
+
+        queryEquivalence(query, queryb, true, true, graph);
+        queryEquivalence(query, query2, false, graph);
+        queryEquivalence(query, query3, false, graph);
         queryEquivalence(query, query4, false, false, graph);
+        queryEquivalence(query, query4b, false, false, graph);
         queryEquivalence(query, query5, false, false, graph);
         queryEquivalence(query, query6, false, false, graph);
         queryEquivalence(query, query7, false, false, graph);
 
-        queryEquivalence(query2, query3, false, false, graph);
+        queryEquivalence(queryb, query2, false, graph);
+        queryEquivalence(queryb, query3, false, graph);
+        queryEquivalence(queryb, query4, false, false, graph);
+        queryEquivalence(queryb, query4b, false, false, graph);
+        queryEquivalence(queryb, query5, false, false, graph);
+        queryEquivalence(queryb, query6, false, false, graph);
+        queryEquivalence(queryb, query7, false, false, graph);
+
         queryEquivalence(query2, query4, false, false, graph);
+        queryEquivalence(query2, query4b, false, false, graph);
         queryEquivalence(query2, query5, false, false, graph);
         queryEquivalence(query2, query6, false, false, graph);
         queryEquivalence(query2, query7, false, false, graph);
 
-        queryEquivalence(query3, query4, true, true, graph);
+
+        queryEquivalence(query3, query4b, false, false, graph);
         queryEquivalence(query3, query5, false, false, graph);
         queryEquivalence(query3, query6, false, false, graph);
-        queryEquivalence(query3, query7, false, true, graph);
+        queryEquivalence(query3, query7, false, false, graph);
 
+        queryEquivalence(query4, query4b, true, true, graph);
         queryEquivalence(query4, query5, false, false, graph);
         queryEquivalence(query4, query6, false, false, graph);
-        queryEquivalence(query4, query7, false, true, graph);
+
+
+
+        queryEquivalence(query4b, query5, false, false, graph);
+        queryEquivalence(query4b, query6, false, false, graph);
+        queryEquivalence(query4b, query7, false, true, graph);
 
         queryEquivalence(query5, query6, false, true, graph);
         queryEquivalence(query5, query7, false, false, graph);
@@ -1146,28 +1227,76 @@ public class AtomicQueryTest {
         String query2 = "{(role1: $x, role2: $y);$x id 'V667';}";
         String query3 = "{(role1: $x, role2: $y);$y id 'V666';}";
         String query4 = "{(role1: $x, role2: $y);$y id 'V667';}";
-        String query5 = "{(role1: $x, role2: $y);$x id 'V666';$y id 'V667';}";
-        String query6 = "{(role1: $x, role2: $y);$y id 'V666';$x id 'V667';}";
+
+        String query5 = "{(role1: $x, role2: $y);$x != $y;}";
+        String query6 = "{(role1: $x, role2: $y);$x != $x2;}";
+        String query7 = "{(role1: $x, role2: $y);$x != $x2;$x2 id 'V667';}";
+
+        String query8 = "{(role1: $x, role2: $y);$x id 'V666';$y id 'V667';}";
+        String query9 = "{(role1: $x, role2: $y);$y id 'V666';$x id 'V667';}";
 
         queryEquivalence(query, query2, false, true, graph);
-        queryEquivalence(query, query3, false, false, graph);
-        queryEquivalence(query, query4, false, false, graph);
-        queryEquivalence(query, query5, false, false, graph);
-        queryEquivalence(query, query6, false, false, graph);
+        queryEquivalence(query, query3, false, graph);
+        queryEquivalence(query, query4, false, graph);
+        queryEquivalence(query, query5, false, graph);
+        queryEquivalence(query, query6, false, graph);
+        queryEquivalence(query, query7, false, graph);
+        queryEquivalence(query, query8, false, graph);
+        queryEquivalence(query, query9, false, graph);
 
         queryEquivalence(query2, query3, false, false, graph);
         queryEquivalence(query2, query4, false, false, graph);
-        queryEquivalence(query2, query5, false, false, graph);
-        queryEquivalence(query2, query6, false, false, graph);
+        queryEquivalence(query2, query8, false, false, graph);
+        queryEquivalence(query2, query9, false, false, graph);
 
         queryEquivalence(query3, query4, false, true, graph);
-        queryEquivalence(query3, query5, false, false, graph);
-        queryEquivalence(query3, query6, false, false, graph);
+        queryEquivalence(query3, query8, false, false, graph);
+        queryEquivalence(query3, query9, false, false, graph);
 
-        queryEquivalence(query4, query5, false, false, graph);
-        queryEquivalence(query4, query6, false, false, graph);
+        queryEquivalence(query4, query8, false, false, graph);
+        queryEquivalence(query4, query9, false, false, graph);
 
-        queryEquivalence(query5, query6, false, true, graph);
+        queryEquivalence(query8, query9, false, true, graph);
+    }
+
+    @Test
+    public void testEquivalence_RelationsWithVariableAndSubstitution(){
+        EmbeddedGraknTx<?> graph = unificationTestSet.tx();
+        String query = "{$r (role1: $x);$x id 'V666';}";
+        String query2 = "{$a (role1: $x);$x id 'V667';}";
+        String query3 = "{$b (role2: $y);$y id 'V666';}";
+        String query4 = "{$c (role1: $a);$a != $b;}";
+        String query4b = "{$r (role1: $x);$x != $y;}";
+        String query5 = "{$e (role1: $a);$a != $b;$b id 'V666';}";
+        String query5b = "{$r (role1: $x);$x != $y;$y id 'V666';}";
+
+
+        queryEquivalence(query, query2, false, true, graph);
+        queryEquivalence(query, query3, false, graph);
+        queryEquivalence(query, query4, false, graph);
+        queryEquivalence(query, query4b, false, graph);
+        queryEquivalence(query, query5, false, graph);
+        queryEquivalence(query, query5b, false, graph);
+
+        queryEquivalence(query2, query3, false, graph);
+        queryEquivalence(query2, query4, false, graph);
+        queryEquivalence(query2, query4b, false, graph);
+        queryEquivalence(query2, query5, false, graph);
+        queryEquivalence(query2, query5b, false, graph);
+
+        queryEquivalence(query3, query4, false, graph);
+        queryEquivalence(query3, query4b, false, graph);
+        queryEquivalence(query3, query5, false, graph);
+        queryEquivalence(query3, query5b, false, graph);
+
+        queryEquivalence(query4, query4b, true, graph);
+        queryEquivalence(query4, query5, false, graph);
+        queryEquivalence(query4, query5b, false, graph);
+
+        queryEquivalence(query4b, query5, false, graph);
+        queryEquivalence(query4b, query5b, false, graph);
+
+        queryEquivalence(query5, query5b, true, graph);
     }
 
     private Concept getConceptByResourceValue(EmbeddedGraknTx<?> graph, String id){
@@ -1189,11 +1318,8 @@ public class AtomicQueryTest {
     private void queryEquivalence(String patternA, String patternB, boolean queryExpectation, boolean atomExpectation, boolean structuralExpectation, EmbeddedGraknTx<?> graph){
         ReasonerAtomicQuery a = ReasonerQueries.atomic(conjunction(patternA, graph), graph);
         ReasonerAtomicQuery b = ReasonerQueries.atomic(conjunction(patternB, graph), graph);
-        queryEquivalence(a, b, queryExpectation, ReasonerQueryEquivalence.AlphaEquivalence);
-        queryEquivalence(a, b, structuralExpectation, ReasonerQueryEquivalence.StructuralEquivalence);
-        atomicEquivalence(a.getAtom(), b.getAtom(), atomExpectation);
+        queryEquivalence(a, b, queryExpectation, atomExpectation, structuralExpectation);
     }
-
 
     private void queryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, boolean atomExpectation, boolean structuralExpectation){
         queryEquivalence(a, b, queryExpectation, ReasonerQueryEquivalence.AlphaEquivalence);
@@ -1216,16 +1342,16 @@ public class AtomicQueryTest {
     }
 
     private void singleQueryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, Equivalence<ReasonerQuery> equiv){
-        assertEquals("Query: " + a.toString() + " =? " + b.toString(), equiv.equivalent(a, b), queryExpectation);
+        assertEquals("Query: " + a.toString() + " =? " + b.toString(), queryExpectation, equiv.equivalent(a, b));
 
         //check hash additionally if need to be equal
         if (queryExpectation) {
-            assertEquals(a.toString() + " hash=? " + b.toString(), equiv.hash(a) == equiv.hash(b), true);
+            assertEquals(a.toString() + " hash=? " + b.toString(), true, equiv.hash(a) == equiv.hash(b));
         }
     }
 
     private void singleAtomicEquivalence(Atomic a, Atomic b, boolean expectation){
-        assertEquals("Atom: " + a.toString() + " =? " + b.toString(), a.isAlphaEquivalent(b), expectation);
+        assertEquals("Atom: " + a.toString() + " =? " + b.toString(), expectation,  a.isAlphaEquivalent(b));
 
         //check hash additionally if need to be equal
         if (expectation) {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/AtomicQueryTest.java
@@ -50,9 +50,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -83,28 +81,23 @@ public class AtomicQueryTest {
     @ClassRule
     public static final SampleKBContext unificationWithTypesSet = SampleKBContext.load("unificationWithTypesTest.gql");
 
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @BeforeClass
     public static void setUpClass() {
         assumeTrue(GraknTestUtil.usingTinker());
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void testWhenConstructingNonAtomicQuery_ExceptionIsThrown() {
         EmbeddedGraknTx<?> graph = geoKB.tx();
         String patternString = "{$x isa university;$y isa country;($x, $y) isa is-located-in;($y, $z) isa is-located-in;}";
         Conjunction<VarPatternAdmin> pattern = conjunction(patternString, graph);
-        exception.expect(GraqlQueryException.class);
         ReasonerAtomicQuery atomicQuery = ReasonerQueries.atomic(pattern, graph);
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void testWhenCreatingQueryWithNonexistentType_ExceptionIsThrown(){
         EmbeddedGraknTx<?> graph = unificationTestSet.tx();
         String patternString = "{$x isa someType;}";
-        exception.expect(GraqlQueryException.class);
         ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(patternString, graph), graph);
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryValidityTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/QueryValidityTest.java
@@ -25,18 +25,13 @@ import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.util.GraknTestUtil;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeTrue;
 
 public class QueryValidityTest {
-
-    @Rule
-    public final ExpectedException expectedException = ExpectedException.none();
 
     @ClassRule
     public static final SampleKBContext testContext = SampleKBContext.load("ruleApplicabilityTest.gql");
@@ -80,11 +75,10 @@ public class QueryValidityTest {
         assertThat(qb.<GetQuery>parse(queryString3).execute(), empty());
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForInexistentEntityTypeLabel_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x isa polok; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 
@@ -95,27 +89,24 @@ public class QueryValidityTest {
         assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForMismatchedResourceTypeLabel_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match $x has binary $r; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForInexistentRelationTypeLabel_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa jakas-relacja; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForMismatchedRelationTypeLabel_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match ($x, $y) isa name; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 
@@ -126,19 +117,17 @@ public class QueryValidityTest {
         assertThat(qb.<GetQuery>parse(queryString).execute(), empty());
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForRelationWithNonRoleRoles_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match (entity: $x, entity: $y) isa relationship; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 
-    @Test
+    @Test (expected = GraqlQueryException.class)
     public void whenQueryingForRelationWithNonExistentRoles_Throws() throws GraqlQueryException{
         QueryBuilder qb = testContext.tx().graql().infer(true);
         String queryString = "match (rola: $x, rola: $y) isa relationship; get;";
-        expectedException.expect(GraqlQueryException.class);
         qb.<GetQuery>parse(queryString).execute();
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -74,7 +74,7 @@ public class ResolutionPlanTest {
         EmbeddedGraknTx<?> testTx = testContext.tx();
         String queryString = "{" +
                 "$x isa someEntity;" +
-                "$y isa resource;$y val 'value';" +
+                "$y isa resource;$y 'value';" +
                 "$z isa relation;" +
                 "}";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString, testTx), testTx);


### PR DESCRIPTION
# Why is this PR needed?
Fixes some issues with assessing equivalence in the presence of neq predicates.
# What does the PR do?
* Introduces `AtomicEquivalence` class to contain different equivalence variants for `Atomic`s. 
* Connects with `ReasonerQueryEquivalence`.
* Simplifies equivalence checks in atoms by employing the above facilities.
* Introduces comparison of predicate bindings including bindings via neq predicates.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.