### PR TITLE
Numerical Aggregate Fix

### DIFF
--- a/client-java/src/main/java/ai/grakn/client/executor/RemoteQueryExecutor.java
+++ b/client-java/src/main/java/ai/grakn/client/executor/RemoteQueryExecutor.java
@@ -31,6 +31,7 @@ import ai.grakn.graql.admin.Answer;
 import ai.grakn.client.Grakn;
 import com.google.common.collect.Iterators;
 
+import java.util.Iterator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -76,7 +77,9 @@ public final class RemoteQueryExecutor implements QueryExecutor {
 
     @Override
     public <T> T run(AggregateQuery<T> query) {
-        return (T) Iterators.getOnlyElement(tx.query(query));
+        Iterator iterator = tx.query(query);
+        if (iterator.hasNext()) return (T) Iterators.getOnlyElement(iterator);
+        else return null;
     }
 
 

--- a/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
@@ -18,24 +18,25 @@
 
 package ai.grakn.graql;
 
+import ai.grakn.graql.admin.Answer;
+
 import javax.annotation.CheckReturnValue;
 import java.util.stream.Stream;
 
 /**
  * An aggregate operation to perform on a query.
- * @param <T> the type of the query to perform the aggregate operation on
- * @param <S> the type of the result of the aggregate operation
+ * @param <T> the type of the result of the aggregate operation
  *
  * @author Felix Chapman
  */
-public interface Aggregate<T, S> {
+public interface Aggregate<T> {
     /**
      * The function to apply to the stream of results to produce the aggregate result.
      * @param stream a stream of query results
      * @return the result of the aggregate operation
      */
     @CheckReturnValue
-    S apply(Stream<? extends T> stream);
+    T apply(Stream<? extends Answer> stream);
 
     /**
      * Return a {@link NamedAggregate}. This is used when operating on a query with multiple aggregates.
@@ -43,5 +44,5 @@ public interface Aggregate<T, S> {
      * @return a new named aggregate
      */
     @CheckReturnValue
-    NamedAggregate<S> as(String name);
+    NamedAggregate<T> as(String name);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Aggregate.java
@@ -43,5 +43,5 @@ public interface Aggregate<T, S> {
      * @return a new named aggregate
      */
     @CheckReturnValue
-    NamedAggregate<T, S> as(String name);
+    NamedAggregate<S> as(String name);
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/AggregateQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/AggregateQuery.java
@@ -19,7 +19,6 @@
 package ai.grakn.graql;
 
 import ai.grakn.GraknTx;
-import ai.grakn.graql.admin.Answer;
 
 import javax.annotation.Nullable;
 
@@ -44,5 +43,5 @@ public interface AggregateQuery<T> extends Query<T> {
     /**
      * Get the {@link Aggregate} that will be executed against the results of the {@link #match()}.
      */
-    Aggregate<Answer, T> aggregate();
+    Aggregate<T> aggregate();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/AggregateQuery.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/AggregateQuery.java
@@ -44,5 +44,5 @@ public interface AggregateQuery<T> extends Query<T> {
     /**
      * Get the {@link Aggregate} that will be executed against the results of the {@link #match()}.
      */
-    Aggregate<? super Answer, T> aggregate();
+    Aggregate<Answer, T> aggregate();
 }

--- a/grakn-core/src/main/java/ai/grakn/graql/Match.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Match.java
@@ -156,11 +156,11 @@ public interface Match extends Streamable<Answer> {
     /**
      * Aggregate results of a query.
      * @param aggregate the aggregate operation to apply
-     * @param <S> the type of the aggregate result
+     * @param <T> the type of the aggregate result
      * @return a query that will yield the aggregate result
      */
     @CheckReturnValue
-    <S> AggregateQuery<S> aggregate(Aggregate<Answer, S> aggregate);
+    <T> AggregateQuery<T> aggregate(Aggregate<T> aggregate);
 
     /**
      * @return admin instance for inspecting and manipulating this query

--- a/grakn-core/src/main/java/ai/grakn/graql/Match.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Match.java
@@ -160,7 +160,7 @@ public interface Match extends Streamable<Answer> {
      * @return a query that will yield the aggregate result
      */
     @CheckReturnValue
-    <S> AggregateQuery<S> aggregate(Aggregate<? super Answer, S> aggregate);
+    <S> AggregateQuery<S> aggregate(Aggregate<Answer, S> aggregate);
 
     /**
      * @return admin instance for inspecting and manipulating this query

--- a/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
@@ -18,22 +18,23 @@
 
 package ai.grakn.graql;
 
+import ai.grakn.graql.admin.Answer;
+
 import javax.annotation.CheckReturnValue;
 
 /**
  * An aggregate operation with an associated name. Used when combining aggregates using the 'select' aggregate.
- * @param <T> the type of the query to perform the aggregate operation on
- * @param <S> the type of the result of the aggregate operation
+ * @param <T> the type of the result of the aggregate operation
  *
  * @author Felix Chapman
  */
-public interface NamedAggregate<T, S> {
+public interface NamedAggregate<T> {
     /**
      * Get the aggregate this named aggregate represents.
      * @return the aggregate this named aggregate represents
      */
     @CheckReturnValue
-    Aggregate<T, S> getAggregate();
+    Aggregate<Answer, T> getAggregate();
 
     /**
      * Get the name of this aggregate.

--- a/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/NamedAggregate.java
@@ -18,8 +18,6 @@
 
 package ai.grakn.graql;
 
-import ai.grakn.graql.admin.Answer;
-
 import javax.annotation.CheckReturnValue;
 
 /**
@@ -34,7 +32,7 @@ public interface NamedAggregate<T> {
      * @return the aggregate this named aggregate represents
      */
     @CheckReturnValue
-    Aggregate<Answer, T> getAggregate();
+    Aggregate<T> getAggregate();
 
     /**
      * Get the name of this aggregate.

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
@@ -68,7 +68,7 @@ public class ResponseBuilder {
                     .build();
         }
 
-        static SessionProto.Transaction.Res queryIterator(@Nullable int iteratorId) {
+        static SessionProto.Transaction.Res queryIterator(int iteratorId) {
             SessionProto.Transaction.Query.Iter.Builder iterator = SessionProto.Transaction.Query.Iter.newBuilder();
             if (iteratorId == -1) {
                 iterator.setNull(ConceptProto.Null.getDefaultInstance());

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
@@ -370,7 +370,7 @@ public class ResponseBuilder {
         }
     }
 
-    public static StatusRuntimeException exception(RuntimeException e) {
+    public static StatusRuntimeException exception(Throwable e) {
 
         if (e instanceof GraknException) {
             GraknException ge = (GraknException) e;

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/SessionService.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/SessionService.java
@@ -117,7 +117,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             try {
                 submit(() -> handleRequest(request));
             } catch (RuntimeException e) {
-                close(ResponseBuilder.exception(e));
+                close(e);
             }
         }
 
@@ -188,7 +188,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             if (!terminated.getAndSet(true)) {
                 if (error != null) {
                     LOG.error("Runtime Exception in RPC TransactionListener: ", error);
-                    responseSender.onError(error);
+                    responseSender.onError(ResponseBuilder.exception(error));
                 } else {
                     responseSender.onCompleted();
                 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -268,7 +268,7 @@ public class Graql {
      * @param var the variable to find the maximum of
      */
     @CheckReturnValue
-    public static <T extends Comparable<T>> Aggregate<Optional<T>> max(String var) {
+    public static Aggregate<Number> max(String var) {
         return Aggregates.max(Graql.var(var));
     }
 
@@ -277,7 +277,7 @@ public class Graql {
      * @param var the variable to find the maximum of
      */
     @CheckReturnValue
-    public static <T extends Comparable<T>> Aggregate<Optional<T>> min(String var) {
+    public static Aggregate<Number> min(String var) {
         return Aggregates.min(Graql.var(var));
     }
 
@@ -286,7 +286,7 @@ public class Graql {
      * @param var the variable to find the mean of
      */
     @CheckReturnValue
-    public static Aggregate<Optional<Double>> mean(String var) {
+    public static Aggregate<Number> mean(String var) {
         return Aggregates.mean(Graql.var(var));
     }
 
@@ -295,7 +295,7 @@ public class Graql {
      * @param var the variable to find the median of
      */
     @CheckReturnValue
-    public static Aggregate<Optional<Number>> median(String var) {
+    public static Aggregate<Number> median(String var) {
         return Aggregates.median(Graql.var(var));
     }
 
@@ -304,7 +304,7 @@ public class Graql {
      * @param var the variable to find the standard deviation of
      */
     @CheckReturnValue
-    public static Aggregate<Optional<Double>> std(String var) {
+    public static Aggregate<Number> std(String var) {
         return Aggregates.std(Graql.var(var));
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -243,7 +243,7 @@ public class Graql {
      * Create an aggregate that will check if there are any results
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Boolean> ask() {
+    public static Aggregate<Boolean> ask() {
         return Aggregates.ask();
     }
 
@@ -251,7 +251,7 @@ public class Graql {
      * Create an aggregate that will count the results of a query.
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Long> count() {
+    public static Aggregate<Long> count() {
         return Aggregates.count();
     }
 
@@ -259,7 +259,7 @@ public class Graql {
      * Create an aggregate that will sum the values of a variable.
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Number> sum(String var) {
+    public static Aggregate<Number> sum(String var) {
         return Aggregates.sum(Graql.var(var));
     }
 
@@ -268,7 +268,7 @@ public class Graql {
      * @param var the variable to find the maximum of
      */
     @CheckReturnValue
-    public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> max(String var) {
+    public static <T extends Comparable<T>> Aggregate<Optional<T>> max(String var) {
         return Aggregates.max(Graql.var(var));
     }
 
@@ -277,7 +277,7 @@ public class Graql {
      * @param var the variable to find the maximum of
      */
     @CheckReturnValue
-    public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> min(String var) {
+    public static <T extends Comparable<T>> Aggregate<Optional<T>> min(String var) {
         return Aggregates.min(Graql.var(var));
     }
 
@@ -286,7 +286,7 @@ public class Graql {
      * @param var the variable to find the mean of
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Optional<Double>> mean(String var) {
+    public static Aggregate<Optional<Double>> mean(String var) {
         return Aggregates.mean(Graql.var(var));
     }
 
@@ -295,7 +295,7 @@ public class Graql {
      * @param var the variable to find the median of
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Optional<Number>> median(String var) {
+    public static Aggregate<Optional<Number>> median(String var) {
         return Aggregates.median(Graql.var(var));
     }
 
@@ -304,7 +304,7 @@ public class Graql {
      * @param var the variable to find the standard deviation of
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Optional<Double>> std(String var) {
+    public static Aggregate<Optional<Double>> std(String var) {
         return Aggregates.std(Graql.var(var));
     }
 
@@ -313,7 +313,7 @@ public class Graql {
      * @param var the variable to group results by
      */
     @CheckReturnValue
-    public static Aggregate<Answer, Map<Concept, List<Answer>>> group(String var) {
+    public static Aggregate<Map<Concept, List<Answer>>> group(String var) {
         return group(var, Aggregates.list());
     }
 
@@ -324,8 +324,8 @@ public class Graql {
      * @param <T> the type the aggregate returns
      */
     @CheckReturnValue
-    public static <T> Aggregate<Answer, Map<Concept, T>> group(
-            String var, Aggregate<? super Answer, T> aggregate) {
+    public static <T> Aggregate<Map<Concept, T>> group(
+            String var, Aggregate<T> aggregate) {
         return Aggregates.group(Graql.var(var), aggregate);
     }
 
@@ -336,7 +336,7 @@ public class Graql {
      */
     @CheckReturnValue
     @SafeVarargs
-    public static <T> Aggregate<Answer, Map<String, T>> select(NamedAggregate<? extends T>... aggregates) {
+    public static <T> Aggregate<Map<String, T>> select(NamedAggregate<? extends T>... aggregates) {
         return select(ImmutableSet.copyOf(aggregates));
     }
 
@@ -346,7 +346,7 @@ public class Graql {
      * @param <T> the type that each aggregate returns
      */
     @CheckReturnValue
-    public static <T> Aggregate<Answer, Map<String, T>> select(Set<NamedAggregate<? extends T>> aggregates) {
+    public static <T> Aggregate<Map<String, T>> select(Set<NamedAggregate<? extends T>> aggregates) {
         return Aggregates.select(ImmutableSet.copyOf(aggregates));
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -243,7 +243,7 @@ public class Graql {
      * Create an aggregate that will check if there are any results
      */
     @CheckReturnValue
-    public static Aggregate<Object, Boolean> ask() {
+    public static Aggregate<Answer, Boolean> ask() {
         return Aggregates.ask();
     }
 
@@ -251,7 +251,7 @@ public class Graql {
      * Create an aggregate that will count the results of a query.
      */
     @CheckReturnValue
-    public static Aggregate<Object, Long> count() {
+    public static Aggregate<Answer, Long> count() {
         return Aggregates.count();
     }
 
@@ -332,23 +332,21 @@ public class Graql {
     /**
      * Create an aggregate that will collect together several named aggregates into a map.
      * @param aggregates the aggregates to join together
-     * @param <S> the type that the query returns
      * @param <T> the type that each aggregate returns
      */
     @CheckReturnValue
     @SafeVarargs
-    public static <S, T> Aggregate<S, Map<String, T>> select(NamedAggregate<? super S, ? extends T>... aggregates) {
+    public static <T> Aggregate<Answer, Map<String, T>> select(NamedAggregate<? extends T>... aggregates) {
         return select(ImmutableSet.copyOf(aggregates));
     }
 
     /**
      * Create an aggregate that will collect together several named aggregates into a map.
      * @param aggregates the aggregates to join together
-     * @param <S> the type that the query returns
      * @param <T> the type that each aggregate returns
      */
     @CheckReturnValue
-    public static <S, T> Aggregate<S, Map<String, T>> select(Set<NamedAggregate<? super S, ? extends T>> aggregates) {
+    public static <T> Aggregate<Answer, Map<String, T>> select(Set<NamedAggregate<? extends T>> aggregates) {
         return Aggregates.select(ImmutableSet.copyOf(aggregates));
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/Graql.java
@@ -38,7 +38,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 
 import static ai.grakn.util.GraqlSyntax.Compute.Method;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
@@ -39,7 +39,6 @@ import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.ValuePredicate;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarPattern;
-import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.internal.antlr.GraqlBaseVisitor;
 import ai.grakn.graql.internal.antlr.GraqlParser;
 import ai.grakn.util.CommonUtil;
@@ -194,7 +193,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Aggregate<?, ?> visitCustomAgg(GraqlParser.CustomAggContext ctx) {
+    public Aggregate<?> visitCustomAgg(GraqlParser.CustomAggContext ctx) {
         String name = visitIdentifier(ctx.identifier());
         Function<List<Object>, Aggregate> aggregateMethod = aggregateMethods.get(name);
 
@@ -208,7 +207,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Aggregate<?, ? extends Map<String, ?>> visitSelectAgg(GraqlParser.SelectAggContext ctx) {
+    public Aggregate<? extends Map<String, ?>> visitSelectAgg(GraqlParser.SelectAggContext ctx) {
         Set aggregates = ctx.namedAgg().stream().map(this::visitNamedAgg).collect(toSet());
 
         // We can't handle cases when the aggregate types are wrong, because the user can provide custom aggregates
@@ -221,7 +220,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Aggregate<Answer, ?> visitAggregateArgument(GraqlParser.AggregateArgumentContext ctx) {
+    public Aggregate<?> visitAggregateArgument(GraqlParser.AggregateArgumentContext ctx) {
         return visitAggregate(ctx.aggregate());
     }
 
@@ -540,7 +539,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
         return (Match) visit(ctx);
     }
 
-    private Aggregate<Answer, ?> visitAggregate(GraqlParser.AggregateContext ctx) {
+    private Aggregate<?> visitAggregate(GraqlParser.AggregateContext ctx) {
         return (Aggregate) visit(ctx);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
@@ -39,6 +39,7 @@ import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.ValuePredicate;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.VarPattern;
+import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.internal.antlr.GraqlBaseVisitor;
 import ai.grakn.graql.internal.antlr.GraqlParser;
 import ai.grakn.util.CommonUtil;
@@ -220,12 +221,12 @@ class GraqlConstructor extends GraqlBaseVisitor {
     }
 
     @Override
-    public Aggregate<?, ?> visitAggregateArgument(GraqlParser.AggregateArgumentContext ctx) {
+    public Aggregate<Answer, ?> visitAggregateArgument(GraqlParser.AggregateArgumentContext ctx) {
         return visitAggregate(ctx.aggregate());
     }
 
     @Override
-    public NamedAggregate<?, ?> visitNamedAgg(GraqlParser.NamedAggContext ctx) {
+    public NamedAggregate<?> visitNamedAgg(GraqlParser.NamedAggContext ctx) {
         String name = visitIdentifier(ctx.identifier());
         return visitAggregate(ctx.aggregate()).as(name);
     }
@@ -539,7 +540,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
         return (Match) visit(ctx);
     }
 
-    private Aggregate<?, ?> visitAggregate(GraqlParser.AggregateContext ctx) {
+    private Aggregate<Answer, ?> visitAggregate(GraqlParser.AggregateContext ctx) {
         return (Aggregate) visit(ctx);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
@@ -177,8 +177,6 @@ class StringPrinter extends Printer<StringBuilder> {
         else if (computeAnswer.getPaths().isPresent()) {
             builder.append(collection(computeAnswer.getPaths().get()));
         }
-        //TODO: remove
-        System.out.println("BUILDER: " + builder.toString());
 
         return builder;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
@@ -32,7 +32,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 abstract class AggregateQueryImpl<T> extends AbstractExecutableQuery<T> implements AggregateQuery<T> {
 
-    public static <T> AggregateQueryImpl<T> of(Match match, Aggregate<? super Answer, T> aggregate) {
+    public static <T> AggregateQueryImpl<T> of(Match match, Aggregate<Answer, T> aggregate) {
         return new AutoValue_AggregateQueryImpl<>(match, aggregate);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/AggregateQueryImpl.java
@@ -22,7 +22,6 @@ import ai.grakn.GraknTx;
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.Match;
-import ai.grakn.graql.admin.Answer;
 import com.google.auto.value.AutoValue;
 
 /**
@@ -32,7 +31,7 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 abstract class AggregateQueryImpl<T> extends AbstractExecutableQuery<T> implements AggregateQuery<T> {
 
-    public static <T> AggregateQueryImpl<T> of(Match match, Aggregate<Answer, T> aggregate) {
+    public static <T> AggregateQueryImpl<T> of(Match match, Aggregate<T> aggregate) {
         return new AutoValue_AggregateQueryImpl<>(match, aggregate);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
@@ -73,7 +73,7 @@ public class Queries {
         return DeleteQueryImpl.of(vars, match);
     }
 
-    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<? super Answer, T> aggregate) {
+    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<Answer, T> aggregate) {
         return AggregateQueryImpl.of(match, aggregate);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
@@ -25,7 +25,6 @@ import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
-import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.DeleteQueryAdmin;
 import ai.grakn.graql.admin.InsertQueryAdmin;
 import ai.grakn.graql.admin.MatchAdmin;
@@ -73,7 +72,7 @@ public class Queries {
         return DeleteQueryImpl.of(vars, match);
     }
 
-    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<Answer, T> aggregate) {
+    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<T> aggregate) {
         return AggregateQueryImpl.of(match, aggregate);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
@@ -20,7 +20,6 @@ package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.NamedAggregate;
-import ai.grakn.graql.admin.Answer;
 
 /**
  * Abstract implementation of an {@link Aggregate}, providing an implementation of the {@link Aggregate#as(String)}}
@@ -30,7 +29,7 @@ import ai.grakn.graql.admin.Answer;
  *
  * @author Felix Chapman
  */
-public abstract class AbstractAggregate<S> implements Aggregate<Answer, S> {
+public abstract class AbstractAggregate<S> implements Aggregate<S> {
 
     @Override
     public final NamedAggregate<S> as(String name) {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
@@ -38,6 +38,9 @@ public abstract class AbstractAggregate<S> implements Aggregate<S> {
         return new NamedAggregateImpl<>(this, name);
     }
 
+    /**
+     * A Comparator class to compare the 2 numbers only if they have the same primitive type.
+     */
     public static class NumberPrimitiveTypeComparator implements Comparator<Number> {
 
         @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
@@ -20,20 +20,20 @@ package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.NamedAggregate;
+import ai.grakn.graql.admin.Answer;
 
 /**
  * Abstract implementation of an {@link Aggregate}, providing an implementation of the {@link Aggregate#as(String)}}
  * method.
  *
- * @param <T> The input type to the aggregate.
  * @param <S> The result type of the aggregate.
  *
  * @author Felix Chapman
  */
-public abstract class AbstractAggregate<T, S> implements Aggregate<T, S> {
+public abstract class AbstractAggregate<S> implements Aggregate<Answer, S> {
 
     @Override
-    public final NamedAggregate<T, S> as(String name) {
+    public final NamedAggregate<S> as(String name) {
         return new NamedAggregateImpl<>(this, name);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AbstractAggregate.java
@@ -21,6 +21,8 @@ package ai.grakn.graql.internal.query.aggregate;
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.NamedAggregate;
 
+import java.util.Comparator;
+
 /**
  * Abstract implementation of an {@link Aggregate}, providing an implementation of the {@link Aggregate#as(String)}}
  * method.
@@ -34,5 +36,17 @@ public abstract class AbstractAggregate<S> implements Aggregate<S> {
     @Override
     public final NamedAggregate<S> as(String name) {
         return new NamedAggregateImpl<>(this, name);
+    }
+
+    public static class NumberPrimitiveTypeComparator implements Comparator<Number> {
+
+        @Override
+        public int compare(Number a, Number b) {
+            if (((Object) a).getClass().equals(((Object) b).getClass()) && a instanceof Comparable) {
+                return ((Comparable) a).compareTo(b);
+            }
+
+            throw new RuntimeException("Invalid attempt to compare non-comparable primitive type of Numbers in Aggregate function");
+        }
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
@@ -28,7 +28,6 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * Factory for making {@link Aggregate} implementations.
@@ -42,7 +41,7 @@ public class Aggregates {
     /**
      * Aggregate that finds mean of a {@link Match}.
      */
-    public static Aggregate<Optional<Double>> mean(Var varName) {
+    public static Aggregate<Number> mean(Var varName) {
         return new MeanAggregate(varName);
     }
 
@@ -88,29 +87,29 @@ public class Aggregates {
     /**
      * Aggregate that finds maximum of a {@link Match}.
      */
-    public static <T extends Comparable<T>> Aggregate<Optional<T>> max(Var varName) {
-        return new MaxAggregate<>(varName);
+    public static Aggregate<Number> max(Var varName) {
+        return new MaxAggregate(varName);
     }
 
     /**
      * Aggregate that finds median of a {@link Match}.
      */
-    public static Aggregate<Optional<Number>> median(Var varName) {
+    public static Aggregate<Number> median(Var varName) {
         return new MedianAggregate(varName);
     }
 
     /**
      * Aggregate that finds the unbiased sample standard deviation of a {@link Match}
      */
-    public static Aggregate<Optional<Double>> std(Var varName) {
+    public static Aggregate<Number> std(Var varName) {
         return new StdAggregate(varName);
     }
 
     /**
      * Aggregate that finds minimum of a {@link Match}.
      */
-    public static <T extends Comparable<T>> Aggregate<Optional<T>> min(Var varName) {
-        return new MinAggregate<>(varName);
+    public static Aggregate<Number> min(Var varName) {
+        return new MinAggregate(varName);
     }
 
     /**

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
@@ -42,21 +42,21 @@ public class Aggregates {
     /**
      * Aggregate that finds mean of a {@link Match}.
      */
-    public static Aggregate<Answer, Optional<Double>> mean(Var varName) {
+    public static Aggregate<Optional<Double>> mean(Var varName) {
         return new MeanAggregate(varName);
     }
 
     /**
      * Aggregate that counts results of a {@link Match}.
      */
-    public static Aggregate<Answer, Long> count() {
+    public static Aggregate<Long> count() {
         return new CountAggregate();
     }
 
     /**
      * Aggregate that checks if there are any results
      */
-    public static Aggregate<Answer,Boolean> ask() {
+    public static Aggregate<Boolean> ask() {
         return AskAggregate.get();
     }
 
@@ -64,7 +64,7 @@ public class Aggregates {
      * Aggregate that groups results of a {@link Match} by variable name
      * @param varName the variable name to group results by
      */
-    public static Aggregate<Answer, Map<Concept, List<Answer>>> group(Var varName) {
+    public static Aggregate<Map<Concept, List<Answer>>> group(Var varName) {
         return group(varName, list());
     }
 
@@ -72,8 +72,8 @@ public class Aggregates {
      * Aggregate that groups results of a {@link Match} by variable name, applying an aggregate to each group.
      * @param <T> the type of each group
      */
-    public static <T> Aggregate<Answer, Map<Concept, T>> group(
-            Var varName, Aggregate<? super Answer, T> innerAggregate
+    public static <T> Aggregate<Map<Concept, T>> group(
+            Var varName, Aggregate<T> innerAggregate
     ) {
         return new GroupAggregate<>(varName, innerAggregate);
     }
@@ -81,35 +81,35 @@ public class Aggregates {
     /**
      * An aggregate that changes {@link Match} results into a list.
      */
-    public static Aggregate<Answer, List<Answer>> list() {
+    public static Aggregate<List<Answer>> list() {
         return new ListAggregate();
     }
 
     /**
      * Aggregate that finds maximum of a {@link Match}.
      */
-    public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> max(Var varName) {
+    public static <T extends Comparable<T>> Aggregate<Optional<T>> max(Var varName) {
         return new MaxAggregate<>(varName);
     }
 
     /**
      * Aggregate that finds median of a {@link Match}.
      */
-    public static Aggregate<Answer, Optional<Number>> median(Var varName) {
+    public static Aggregate<Optional<Number>> median(Var varName) {
         return new MedianAggregate(varName);
     }
 
     /**
      * Aggregate that finds the unbiased sample standard deviation of a {@link Match}
      */
-    public static Aggregate<Answer, Optional<Double>> std(Var varName) {
+    public static Aggregate<Optional<Double>> std(Var varName) {
         return new StdAggregate(varName);
     }
 
     /**
      * Aggregate that finds minimum of a {@link Match}.
      */
-    public static <T extends Comparable<T>> Aggregate<Answer, Optional<T>> min(Var varName) {
+    public static <T extends Comparable<T>> Aggregate<Optional<T>> min(Var varName) {
         return new MinAggregate<>(varName);
     }
 
@@ -117,7 +117,7 @@ public class Aggregates {
      * An aggregate that combines several aggregates together into a map (where keys are the names of the aggregates)
      * @param <T> the type of the aggregate results
      */
-    public static <T> Aggregate<Answer, Map<String, T>> select(
+    public static <T> Aggregate<Map<String, T>> select(
             ImmutableSet<NamedAggregate<? extends T>> aggregates
     ) {
         return new SelectAggregate<>(aggregates);
@@ -126,7 +126,7 @@ public class Aggregates {
     /**
      * Aggregate that sums results of a {@link Match}.
      */
-    public static Aggregate<Answer, Number> sum(Var varName) {
+    public static Aggregate<Number> sum(Var varName) {
         return new SumAggregate(varName);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/Aggregates.java
@@ -49,14 +49,14 @@ public class Aggregates {
     /**
      * Aggregate that counts results of a {@link Match}.
      */
-    public static Aggregate<Object, Long> count() {
+    public static Aggregate<Answer, Long> count() {
         return new CountAggregate();
     }
 
     /**
      * Aggregate that checks if there are any results
      */
-    public static Aggregate<Object,Boolean> ask() {
+    public static Aggregate<Answer,Boolean> ask() {
         return AskAggregate.get();
     }
 
@@ -80,10 +80,9 @@ public class Aggregates {
 
     /**
      * An aggregate that changes {@link Match} results into a list.
-     * @param <T> the type of the results of the {@link Match}
      */
-    public static <T> Aggregate<T, List<T>> list() {
-        return new ListAggregate<>();
+    public static Aggregate<Answer, List<Answer>> list() {
+        return new ListAggregate();
     }
 
     /**
@@ -116,11 +115,10 @@ public class Aggregates {
 
     /**
      * An aggregate that combines several aggregates together into a map (where keys are the names of the aggregates)
-     * @param <S> the type of the {@link Match} results
      * @param <T> the type of the aggregate results
      */
-    public static <S, T> Aggregate<S, Map<String, T>> select(
-            ImmutableSet<NamedAggregate<? super S, ? extends T>> aggregates
+    public static <T> Aggregate<Answer, Map<String, T>> select(
+            ImmutableSet<NamedAggregate<? extends T>> aggregates
     ) {
         return new SelectAggregate<>(aggregates);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AskAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/AskAggregate.java
@@ -18,6 +18,8 @@
 
 package ai.grakn.graql.internal.query.aggregate;
 
+import ai.grakn.graql.admin.Answer;
+
 import java.util.stream.Stream;
 
 /**
@@ -25,7 +27,7 @@ import java.util.stream.Stream;
  *
  * @author Felix Chapman
  */
-public class AskAggregate extends AbstractAggregate<Object,Boolean> {
+public class AskAggregate extends AbstractAggregate<Boolean> {
 
     private static final AskAggregate INSTANCE = new AskAggregate();
 
@@ -37,7 +39,7 @@ public class AskAggregate extends AbstractAggregate<Object,Boolean> {
     }
 
     @Override
-    public Boolean apply(Stream<?> stream) {
+    public Boolean apply(Stream<? extends Answer> stream) {
         return stream.findAny().isPresent();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/CountAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/CountAggregate.java
@@ -19,15 +19,16 @@
 package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Match;
+import ai.grakn.graql.admin.Answer;
 
 import java.util.stream.Stream;
 
 /**
  * Aggregate that counts results of a {@link Match}.
  */
-class CountAggregate extends AbstractAggregate<Object, Long> {
+class CountAggregate extends AbstractAggregate<Long> {
     @Override
-    public Long apply(Stream<?> stream) {
+    public Long apply(Stream<? extends Answer> stream) {
         return stream.count();
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/GroupAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/GroupAggregate.java
@@ -41,9 +41,9 @@ import static java.util.stream.Collectors.toList;
 class GroupAggregate<T> extends AbstractAggregate<Map<Concept, T>> {
 
     private final Var varName;
-    private final Aggregate<? super Answer, T> innerAggregate;
+    private final Aggregate<T> innerAggregate;
 
-    GroupAggregate(Var varName, Aggregate<? super Answer, T> innerAggregate) {
+    GroupAggregate(Var varName, Aggregate<T> innerAggregate) {
         this.varName = varName;
         this.innerAggregate = innerAggregate;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/GroupAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/GroupAggregate.java
@@ -38,7 +38,7 @@ import static java.util.stream.Collectors.toList;
  * Aggregate that groups results of a {@link Match} by variable name, applying an aggregate to each group.
  * @param <T> the type of each group
  */
-class GroupAggregate<T> extends AbstractAggregate<Answer, Map<Concept, T>> {
+class GroupAggregate<T> extends AbstractAggregate<Map<Concept, T>> {
 
     private final Var varName;
     private final Aggregate<? super Answer, T> innerAggregate;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/ListAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/ListAggregate.java
@@ -19,6 +19,7 @@
 package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Match;
+import ai.grakn.graql.admin.Answer;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,12 +27,11 @@ import java.util.stream.Stream;
 
 /**
  * An aggregate that changes {@link Match} results into a list.
- * @param <T> the type of the results of the {@link Match}
  */
-class ListAggregate<T> extends AbstractAggregate<T, List<T>> {
+class ListAggregate extends AbstractAggregate<List<Answer>> {
 
     @Override
-    public List<T> apply(Stream<? extends T> stream) {
+    public List<Answer> apply(Stream<? extends Answer> stream) {
         return stream.collect(Collectors.toList());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MaxAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MaxAggregate.java
@@ -30,7 +30,7 @@ import static java.util.Comparator.naturalOrder;
 /**
  * Aggregate that finds maximum of a {@link Match}.
  */
-class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Answer, Optional<T>> {
+class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T>> {
 
     private final Var varName;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MaxAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MaxAggregate.java
@@ -22,15 +22,12 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 
-import java.util.Optional;
 import java.util.stream.Stream;
-
-import static java.util.Comparator.naturalOrder;
 
 /**
  * Aggregate that finds maximum of a {@link Match}.
  */
-class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T>> {
+class MaxAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
 
@@ -39,8 +36,9 @@ class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
     }
 
     @Override
-    public Optional<T> apply(Stream<? extends Answer> stream) {
-        return stream.map(this::getValue).max(naturalOrder());
+    public Number apply(Stream<? extends Answer> stream) {
+        NumberPrimitiveTypeComparator comparator = new NumberPrimitiveTypeComparator();
+        return stream.map(this::getValue).max(comparator).orElse(null);
     }
 
     @Override
@@ -48,8 +46,11 @@ class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
         return "max " + varName;
     }
 
-    private T getValue(Answer result) {
-        return result.get(varName).<T>asAttribute().value();
+    private Number getValue(Answer result) {
+        Object value = result.get(varName).asAttribute().value();
+
+        if (value instanceof Number) return (Number) value;
+        else throw new RuntimeException("Invalid attempt to compare non-Numbers in Max Aggregate function");
     }
 
     @Override
@@ -57,7 +58,7 @@ class MaxAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        MaxAggregate<?> that = (MaxAggregate<?>) o;
+        MaxAggregate that = (MaxAggregate) o;
 
         return varName.equals(that.varName);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
@@ -32,7 +32,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Aggregate that finds mean of a {@link Match}.
  */
-class MeanAggregate extends AbstractAggregate<Answer, Optional<Double>> {
+class MeanAggregate extends AbstractAggregate<Optional<Double>> {
 
     private final Var varName;
     private final CountAggregate countAggregate;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
@@ -36,7 +36,7 @@ class MeanAggregate extends AbstractAggregate<Optional<Double>> {
 
     private final Var varName;
     private final CountAggregate countAggregate;
-    private final Aggregate<Answer, Number> sumAggregate;
+    private final Aggregate<Number> sumAggregate;
 
     MeanAggregate(Var varName) {
         this.varName = varName;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
@@ -24,7 +24,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MeanAggregate.java
@@ -32,7 +32,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Aggregate that finds mean of a {@link Match}.
  */
-class MeanAggregate extends AbstractAggregate<Optional<Double>> {
+class MeanAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
     private final CountAggregate countAggregate;
@@ -45,16 +45,16 @@ class MeanAggregate extends AbstractAggregate<Optional<Double>> {
     }
 
     @Override
-    public Optional<Double> apply(Stream<? extends Answer> stream) {
+    public Number apply(Stream<? extends Answer> stream) {
         List<? extends Answer> list = stream.collect(toList());
 
         long count = countAggregate.apply(list.stream());
 
         if (count == 0) {
-            return Optional.empty();
+            return null;
         } else {
             Number sum = sumAggregate.apply(list.stream());
-            return Optional.of(sum.doubleValue() / count);
+            return sum.doubleValue() / count;
         }
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
@@ -31,7 +31,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Aggregate that finds median of a {@link Match}.
  */
-class MedianAggregate extends AbstractAggregate<Optional<Number>> {
+class MedianAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
 
@@ -40,7 +40,7 @@ class MedianAggregate extends AbstractAggregate<Optional<Number>> {
     }
 
     @Override
-    public Optional<Number> apply(Stream<? extends Answer> stream) {
+    public Number apply(Stream<? extends Answer> stream) {
         List<Number> results = stream
                 .map(result -> ((Number) result.get(varName).asAttribute().value()))
                 .sorted()
@@ -51,13 +51,13 @@ class MedianAggregate extends AbstractAggregate<Optional<Number>> {
         int halveCeiling = (int) Math.ceil((size - 1) / 2.0);
 
         if (size == 0) {
-            return Optional.empty();
+            return null;
         } else if (size % 2 == 1) {
             // Take exact middle result
-            return Optional.of(results.get(halveFloor));
+            return results.get(halveFloor);
         } else {
             // Take average of middle results
-            return Optional.of((results.get(halveFloor).doubleValue() + results.get(halveCeiling).doubleValue()) / 2);
+            return (results.get(halveFloor).doubleValue() + results.get(halveCeiling).doubleValue()) / 2;
         }
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
@@ -31,7 +31,7 @@ import static java.util.stream.Collectors.toList;
 /**
  * Aggregate that finds median of a {@link Match}.
  */
-class MedianAggregate extends AbstractAggregate<Answer, Optional<Number>> {
+class MedianAggregate extends AbstractAggregate<Optional<Number>> {
 
     private final Var varName;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MedianAggregate.java
@@ -23,7 +23,6 @@ import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
@@ -30,7 +30,7 @@ import static java.util.Comparator.naturalOrder;
 /**
  * Aggregate that finds minimum of a {@link Match}.
  */
-class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Answer, Optional<T>> {
+class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T>> {
 
     private final Var varName;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
@@ -22,15 +22,12 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 
-import java.util.Optional;
 import java.util.stream.Stream;
-
-import static java.util.Comparator.naturalOrder;
 
 /**
  * Aggregate that finds minimum of a {@link Match}.
  */
-class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T>> {
+class MinAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
 
@@ -39,8 +36,9 @@ class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
     }
 
     @Override
-    public Optional<T> apply(Stream<? extends Answer> stream) {
-        return stream.map(this::getValue).min(naturalOrder());
+    public Number apply(Stream<? extends Answer> stream) {
+        NumberPrimitiveTypeComparator comparator = new NumberPrimitiveTypeComparator();
+        return stream.map(this::getValue).min(comparator).orElse(null);
     }
 
     @Override
@@ -48,8 +46,11 @@ class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
         return "min " + varName;
     }
 
-    private T getValue(Answer result) {
-        return result.get(varName).<T>asAttribute().value();
+    private Number getValue(Answer result) {
+        Object value = result.get(varName).asAttribute().value();
+
+        if (value instanceof Number) return (Number) value;
+        else throw new RuntimeException("Invalid attempt to compare non-Numbers in Max Aggregate function");
     }
 
     @Override
@@ -57,7 +58,7 @@ class MinAggregate<T extends Comparable<T>> extends AbstractAggregate<Optional<T
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        MinAggregate<?> that = (MinAggregate<?>) o;
+        MinAggregate that = (MinAggregate) o;
 
         return varName.equals(that.varName);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/NamedAggregateImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/NamedAggregateImpl.java
@@ -20,19 +20,18 @@ package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.NamedAggregate;
-import ai.grakn.graql.admin.Answer;
 
 class NamedAggregateImpl<S> implements NamedAggregate<S> {
-    private final Aggregate<Answer, S> aggregate;
+    private final Aggregate<S> aggregate;
     private final String name;
 
-    NamedAggregateImpl(Aggregate<Answer, S> aggregate, String name) {
+    NamedAggregateImpl(Aggregate<S> aggregate, String name) {
         this.aggregate = aggregate;
         this.name = name;
     }
 
     @Override
-    public Aggregate<Answer, S> getAggregate() {
+    public Aggregate<S> getAggregate() {
         return aggregate;
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/NamedAggregateImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/NamedAggregateImpl.java
@@ -20,18 +20,19 @@ package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.NamedAggregate;
+import ai.grakn.graql.admin.Answer;
 
-class NamedAggregateImpl<T, S> implements NamedAggregate<T, S> {
-    private final Aggregate<T, S> aggregate;
+class NamedAggregateImpl<S> implements NamedAggregate<S> {
+    private final Aggregate<Answer, S> aggregate;
     private final String name;
 
-    NamedAggregateImpl(Aggregate<T, S> aggregate, String name) {
+    NamedAggregateImpl(Aggregate<Answer, S> aggregate, String name) {
         this.aggregate = aggregate;
         this.name = name;
     }
 
     @Override
-    public Aggregate<T, S> getAggregate() {
+    public Aggregate<Answer, S> getAggregate() {
         return aggregate;
     }
 
@@ -50,7 +51,7 @@ class NamedAggregateImpl<T, S> implements NamedAggregate<T, S> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        NamedAggregateImpl<?, ?> that = (NamedAggregateImpl<?, ?>) o;
+        NamedAggregateImpl<?> that = (NamedAggregateImpl<?>) o;
 
         if (!aggregate.equals(that.aggregate)) return false;
         return name.equals(that.name);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SelectAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SelectAggregate.java
@@ -18,9 +18,9 @@
 
 package ai.grakn.graql.internal.query.aggregate;
 
-import ai.grakn.graql.Match;
-import com.google.common.collect.ImmutableSet;
 import ai.grakn.graql.NamedAggregate;
+import ai.grakn.graql.admin.Answer;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,24 +32,23 @@ import static java.util.stream.Collectors.toList;
 
 /**
  * An aggregate that combines several aggregates together into a map (where keys are the names of the aggregates)
- * @param <S> the type of the {@link Match} results
  * @param <T> the type of the aggregate results
  */
-class SelectAggregate<S, T> extends AbstractAggregate<S, Map<String, T>> {
+class SelectAggregate<T> extends AbstractAggregate<Map<String, T>> {
 
-    private final ImmutableSet<NamedAggregate<? super S, ? extends T>> aggregates;
+    private final ImmutableSet<NamedAggregate<? extends T>> aggregates;
 
-    SelectAggregate(ImmutableSet<NamedAggregate<? super S, ? extends T>> aggregates) {
+    SelectAggregate(ImmutableSet<NamedAggregate<? extends T>> aggregates) {
         this.aggregates = aggregates;
     }
 
     @Override
-    public Map<String, T> apply(Stream<? extends S> stream) {
-        List<? extends S> list = stream.collect(toList());
+    public Map<String, T> apply(Stream<? extends Answer> stream) {
+        List<? extends Answer> list = stream.collect(toList());
 
         Map<String, T> map = new HashMap<>();
 
-        for (NamedAggregate<? super S, ? extends T> aggregate : aggregates) {
+        for (NamedAggregate<? extends T> aggregate : aggregates) {
             map.put(aggregate.getName(), aggregate.getAggregate().apply(list.stream()));
         }
 
@@ -66,7 +65,7 @@ class SelectAggregate<S, T> extends AbstractAggregate<S, Map<String, T>> {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
-        SelectAggregate<?, ?> that = (SelectAggregate<?, ?>) o;
+        SelectAggregate<?> that = (SelectAggregate<?>) o;
 
         return aggregates.equals(that.aggregates);
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
@@ -30,7 +30,7 @@ import static java.lang.Math.sqrt;
 /**
  * Aggregate that finds the unbiased sample standard deviation of a {@link Match}.
  */
-class StdAggregate extends AbstractAggregate<Answer, Optional<Double>> {
+class StdAggregate extends AbstractAggregate<Optional<Double>> {
 
     private final Var varName;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
@@ -30,7 +30,7 @@ import static java.lang.Math.sqrt;
 /**
  * Aggregate that finds the unbiased sample standard deviation of a {@link Match}.
  */
-class StdAggregate extends AbstractAggregate<Optional<Double>> {
+class StdAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
 
@@ -39,7 +39,7 @@ class StdAggregate extends AbstractAggregate<Optional<Double>> {
     }
 
     @Override
-    public Optional<Double> apply(Stream<? extends Answer> stream) {
+    public Number apply(Stream<? extends Answer> stream) {
         Stream<Double> numStream = stream.map(result -> result.get(varName).<Number>asAttribute().value().doubleValue());
 
         Iterable<Double> data = numStream::iterator;
@@ -59,9 +59,9 @@ class StdAggregate extends AbstractAggregate<Optional<Double>> {
         }
 
         if (n < 2) {
-            return Optional.empty();
+            return null;
         } else {
-            return Optional.of(sqrt(M2 / (double) (n - 1)));
+            return sqrt(M2 / (double) (n - 1));
         }
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/StdAggregate.java
@@ -22,7 +22,6 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 import ai.grakn.graql.admin.Answer;
 
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static java.lang.Math.sqrt;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SumAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SumAggregate.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 /**
  * Aggregate that sums results of a {@link Match}.
  */
-class SumAggregate extends AbstractAggregate<Answer, Number> {
+class SumAggregate extends AbstractAggregate<Number> {
 
     private final Var varName;
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SumAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/SumAggregate.java
@@ -37,10 +37,14 @@ class SumAggregate extends AbstractAggregate<Number> {
 
     @Override
     public Number apply(Stream<? extends Answer> stream) {
-        return stream.map(result -> (Number) result.get(varName).asAttribute().value()).reduce(0, this::add);
+        // initial value is set to null so that we can return null if there is no Answers to consume
+        return stream.map(result -> (Number) result.get(varName).asAttribute().value()).reduce(null, this::add);
     }
 
     private Number add(Number x, Number y) {
+        // if this method is called, then there is at least one number to apply SumAggregate to, thus we set x back to 0
+        if (x == null) x = 0;
+
         // This method is necessary because Number doesn't support '+' because java!
         if (x instanceof Long || y instanceof Long) {
             return x.longValue() + y.longValue();

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
@@ -93,7 +93,7 @@ abstract class AbstractMatch implements MatchAdmin {
     }
 
     @Override
-    public final <S> AggregateQuery<S> aggregate(Aggregate<? super Answer, S> aggregate) {
+    public final <S> AggregateQuery<S> aggregate(Aggregate<Answer, S> aggregate) {
         return Queries.aggregate(admin(), aggregate);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
@@ -93,7 +93,7 @@ abstract class AbstractMatch implements MatchAdmin {
     }
 
     @Override
-    public final <S> AggregateQuery<S> aggregate(Aggregate<Answer, S> aggregate) {
+    public final <S> AggregateQuery<S> aggregate(Aggregate<S> aggregate) {
         return Queries.aggregate(admin(), aggregate);
     }
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -1167,7 +1167,7 @@ public class QueryParserTest {
         assertEquals(query, parse(query).toString());
     }
 
-    class GetAny extends AbstractAggregate<Answer, Concept> {
+    class GetAny extends AbstractAggregate<Concept> {
 
         private final Var varName;
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AggregateQueryImplTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AggregateQueryImplTest.java
@@ -35,7 +35,7 @@ public class AggregateQueryImplTest {
     private final MatchAdmin match1 = Graql.match(var("x").isa("movie")).admin();
     private final MatchAdmin match2 = Graql.match(var("y").isa("movie")).admin();
 
-    private final Aggregate<Object, Long> aggregate1 = Aggregates.count();
+    private final Aggregate<Answer, Long> aggregate1 = Aggregates.count();
     private final Aggregate<Answer, Number> aggregate2 = Aggregates.sum(Graql.var("x"));
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AggregateQueryImplTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/AggregateQueryImplTest.java
@@ -21,7 +21,6 @@ package ai.grakn.graql.internal.query;
 import ai.grakn.graql.Aggregate;
 import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.Graql;
-import ai.grakn.graql.admin.Answer;
 import ai.grakn.graql.admin.MatchAdmin;
 import ai.grakn.graql.internal.query.aggregate.Aggregates;
 import org.junit.Test;
@@ -35,8 +34,8 @@ public class AggregateQueryImplTest {
     private final MatchAdmin match1 = Graql.match(var("x").isa("movie")).admin();
     private final MatchAdmin match2 = Graql.match(var("y").isa("movie")).admin();
 
-    private final Aggregate<Answer, Long> aggregate1 = Aggregates.count();
-    private final Aggregate<Answer, Number> aggregate2 = Aggregates.sum(Graql.var("x"));
+    private final Aggregate<Long> aggregate1 = Aggregates.count();
+    private final Aggregate<Number> aggregate2 = Aggregates.sum(Graql.var("x"));
 
     @Test
     public void aggregateQueriesWithTheSameMatchAndAggregatesAreEqual() {

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
@@ -31,6 +31,7 @@ import ai.grakn.test.kbs.MovieKB;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -127,12 +128,12 @@ public class AggregateTest {
     }
 
     @Test
-    public void testSumLong() {
+    public void testSum() {
         AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(sum("y"));
 
-        assertEquals(1940L, query.execute());
+        assertEquals(1940, query.execute().intValue());
     }
 
     @Test
@@ -145,70 +146,64 @@ public class AggregateTest {
     }
 
     @Test
-    public void testMaxLong() {
-        AggregateQuery<Optional<Long>> query = qb
+    public void testMaxInt() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(max("y"));
 
-        assertEquals(Optional.of(1000L), query.execute());
+        assertEquals(1000, query.execute().intValue());
     }
 
     @Test
     public void testMaxDouble() {
-        AggregateQuery<Optional<Double>> query = qb
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
                 .aggregate(max("y"));
 
-        assertEquals(Optional.of(8.6d), query.execute());
+        assertEquals(8.6d, query.execute());
     }
 
     @Test
-    public void testMaxString() {
-        AggregateQuery<Optional<String>> query = qb.match(var("x").isa("title")).aggregate(max("x"));
-        assertEquals(Optional.of("The Muppets"), query.execute());
-    }
-
-    @Test
-    public void testMinLong() {
-        AggregateQuery<Optional<Long>> query = qb
+    public void testMinInt() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(min("y"));
 
-        assertEquals(Optional.of(5L), query.execute());
+        assertEquals(5, query.execute().intValue());
     }
 
     @Test
-    public void testAverageDouble() {
-        AggregateQuery<Optional<Double>> query = qb
+    public void testMean() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
                 .aggregate(mean("y"));
 
         //noinspection OptionalGetWithoutIsPresent
-        assertEquals((8.6d + 7.6d + 8.4d + 3.1d) / 4d, query.execute().get(), 0.01d);
+        assertEquals((8.6d + 7.6d + 8.4d + 3.1d) / 4d, query.execute().doubleValue(), 0.01d);
     }
 
     @Test
-    public void testMedianLong() {
-        AggregateQuery<Optional<Number>> query = qb
+    public void testMedianInt() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(median("y"));
 
-        assertEquals(Optional.of(400L), query.execute());
+        assertEquals(400, query.execute().intValue());
     }
 
     @Test
     public void testMedianDouble() {
-        AggregateQuery<Optional<Number>> query = qb
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
                 .aggregate(median("y"));
 
         //noinspection OptionalGetWithoutIsPresent
-        assertEquals(8.0d, query.execute().get().doubleValue(), 0.01d);
+        assertEquals(8.0d, query.execute().doubleValue(), 0.01d);
     }
 
     @Test
-    public void testStdevLong() {
-        AggregateQuery<Optional<Double>> query = qb
+    public void testStdDouble1() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie").has("tmdb-vote-count", var("y")))
                 .aggregate(std("y"));
 
@@ -217,12 +212,12 @@ public class AggregateTest {
                 + pow(400d - mean, 2d) + pow(435d - mean, 2d) + pow(5d - mean, 2d)) / 4d;
         double expected = sqrt(variance);
 
-        assertEquals(expected, query.execute().get().doubleValue(), 0.01d);
+        assertEquals(expected, query.execute().doubleValue(), 0.01d);
     }
 
     @Test
-    public void testStdevDouble() {
-        AggregateQuery<Optional<Double>> query = qb
+    public void testStdDouble2() {
+        AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie").has("tmdb-vote-average", var("y")))
                 .aggregate(std("y"));
 
@@ -231,7 +226,7 @@ public class AggregateTest {
                 (pow(8.6d - mean, 2d) + pow(8.4d - mean, 2d) + pow(7.6d - mean, 2d) + pow(3.1d - mean, 2d)) / 3d;
         double expected = sqrt(variance);
 
-        assertEquals(expected, query.execute().get().doubleValue(), 0.01d);
+        assertEquals(expected, query.execute().doubleValue(), 0.01d);
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
@@ -111,7 +111,7 @@ public class AggregateTest {
     }
 
     @Test
-    public void testCountAndGroup() {
+    public void testSelectCountAndGroup() {
         AggregateQuery<Map<String, Object>> query = qb.match(var("x").isa("movie"), var().rel("x").rel("y"))
                         .aggregate(select(count().as("c"), group("x").as("g")));
 

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
@@ -18,6 +18,7 @@
 
 package ai.grakn.graql.internal.query.aggregate;
 
+import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.Concept;
 import ai.grakn.concept.Thing;
 import ai.grakn.exception.GraqlQueryException;
@@ -54,6 +55,7 @@ import static ai.grakn.util.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static java.lang.Math.pow;
 import static java.lang.Math.sqrt;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class AggregateTest {
 
@@ -128,7 +130,7 @@ public class AggregateTest {
     }
 
     @Test
-    public void testSum() {
+    public void testSumInt() {
         AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(sum("y"));
@@ -143,6 +145,16 @@ public class AggregateTest {
                 .aggregate(sum("y"));
 
         assertEquals(27.7d, query.execute().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testSumNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(sum("y"));
+
+        assertNull(query.execute());
     }
 
     @Test
@@ -164,12 +176,32 @@ public class AggregateTest {
     }
 
     @Test
+    public void testMaxNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(max("y"));
+
+        assertNull(query.execute());
+    }
+
+    @Test
     public void testMinInt() {
         AggregateQuery<Number> query = qb
                 .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
                 .aggregate(min("y"));
 
         assertEquals(5, query.execute().intValue());
+    }
+
+    @Test
+    public void testMinNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(min("y"));
+
+        assertNull(query.execute());
     }
 
     @Test
@@ -180,6 +212,16 @@ public class AggregateTest {
 
         //noinspection OptionalGetWithoutIsPresent
         assertEquals((8.6d + 7.6d + 8.4d + 3.1d) / 4d, query.execute().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testMeanNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(mean("y"));
+
+        assertNull(query.execute());
     }
 
     @Test
@@ -199,6 +241,16 @@ public class AggregateTest {
 
         //noinspection OptionalGetWithoutIsPresent
         assertEquals(8.0d, query.execute().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testMedianNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(median("y"));
+
+        assertNull(query.execute());
     }
 
     @Test
@@ -227,6 +279,16 @@ public class AggregateTest {
         double expected = sqrt(variance);
 
         assertEquals(expected, query.execute().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testStdNull() {
+        rule.tx().putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Number> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(std("y"));
+
+        assertNull(query.execute());
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/SelectAggregateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/SelectAggregateTest.java
@@ -19,6 +19,7 @@
 package ai.grakn.graql.internal.query.aggregate;
 
 import ai.grakn.graql.NamedAggregate;
+import ai.grakn.graql.admin.Answer;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 
@@ -28,16 +29,16 @@ import static org.junit.Assert.assertNotEquals;
 
 public class SelectAggregateTest {
 
-    private ImmutableSet<NamedAggregate<? super Object, ? extends Long>> set1 =
+    private ImmutableSet<NamedAggregate<? extends Long>> set1 =
             ImmutableSet.of(count().as("a"));
 
-    private ImmutableSet<NamedAggregate<? super Object, ? extends Long>> set2 =
+    private ImmutableSet<NamedAggregate<? extends Long>> set2 =
             ImmutableSet.of(count().as("l"), count().as("c"));
 
     @Test
     public void selectAggregatesContainingTheSamePropertiesAreEqual() {
-        SelectAggregate<Object, Long> aggregate1 = new SelectAggregate<>(set1);
-        SelectAggregate<Object, Long> aggregate2 = new SelectAggregate<>(set1);
+        SelectAggregate<Long> aggregate1 = new SelectAggregate<>(set1);
+        SelectAggregate<Long> aggregate2 = new SelectAggregate<>(set1);
 
         assertEquals(aggregate1, aggregate2);
         assertEquals(aggregate1.hashCode(), aggregate2.hashCode());
@@ -45,8 +46,8 @@ public class SelectAggregateTest {
 
     @Test
     public void selectAggregatesContainingDifferentPropertiesAreDifferent() {
-        SelectAggregate<Object, Long> aggregate1 = new SelectAggregate<>(set1);
-        SelectAggregate<Object, Long> aggregate2 = new SelectAggregate<>(set2);
+        SelectAggregate<Long> aggregate1 = new SelectAggregate<>(set1);
+        SelectAggregate<Long> aggregate2 = new SelectAggregate<>(set2);
 
         assertNotEquals(aggregate1, aggregate2);
     }

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/match/MatchTest.java
@@ -168,6 +168,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "unchecked"})
 public class MatchTest {
@@ -1088,6 +1089,30 @@ public class MatchTest {
     @Test(expected = Exception.class)
     public void testOrderBy8() {
         movieKB.tx().graql().match(x.isa("movie")).orderBy(x, Order.asc).stream().findAny().get();
+    }
+
+    @Test
+    public void testOrderDescendingString() {
+        Answer answer = movieKB.tx().graql().match(x.isa("movie").has("title", y)).orderBy(y, Order.desc).stream().findFirst().get();
+        assertEquals("The Muppets", answer.get(y).asAttribute().value());
+    }
+
+    @Test
+    public void testOrderAscendingString() {
+        Answer answer = movieKB.tx().graql().match(x.isa("movie").has("title", y)).orderBy(y, Order.asc).stream().findFirst().get();
+        assertEquals("Apocalypse Now", answer.get(y).asAttribute().value());
+    }
+
+    @Test
+    public void testOrderDescendingDate() {
+        Answer answer = movieKB.tx().graql().match(x.isa("movie").has("release-date", y)).orderBy(y, Order.desc).stream().findFirst().get();
+        assertEquals(LocalDateTime.of(2000, 9, 2, 0, 0), answer.get(y).asAttribute().value());
+    }
+
+    @Test
+    public void testOrderAscendingDate() {
+        Answer answer = movieKB.tx().graql().match(x.isa("movie").has("release-date", y)).orderBy(y, Order.asc).stream().findFirst().get();
+        assertEquals(LocalDateTime.of(1984, 1, 1, 0, 0), answer.get(y).asAttribute().value());
     }
 
     @Test


### PR DESCRIPTION
# Why is this PR needed?

What we mean by Numerical Aggregates are `sum`, `min`, `max`, `mean`, `median` and `std`.
1. These aggregate functions return 0 when there are no attributes to apply the calculation over. This is wrong, it should return null.
2. These aggregate functions (except for `sum`) returns optional, which does not work with GRPC (before and after the new GRPC refactor).

# What does the PR do?

1. Removed `Optional<T>` return types from aggregate functions.
2. Modify the aggregate functions to return `null` when there are no attributes to calculate over.
3. Fix `RemoteQueryExecutor.run(AggregateQuery)` to consider `null` results.
4. Add tests for `null` results in `AggregateTest`
5. Add tests for numerical aggregate functions in `ServerRPCIT`

Additionally, we also did some cleaning:
1. Removed the first Generics parameter `T` in `Aggregate<T, S>`.
2. Added tests for ordering `String`s and `Date`s in `MatchTest.java`

# Does it break backwards compatibility?

Yes. Aggregate `min` and `max` no longer apply to `String` and `Date`. This is because making the change allows us to simplify numerical aggregates, while still being able to get the same functionality of `min/max string/date` through `order string/date asc/desc`.

# List of future improvements not on this PR

This PR will be followed by another PR where we implement a proper GRPC message for Aggregate responses, and also fix the Remote `GroupAggregate` query which is currently broken too on the client side.
