### PR TITLE
Workaround for GRPC restriction of boolean defaulting to FALSE

### DIFF
--- a/client-java/src/main/java/ai/grakn/client/rpc/RequestBuilder.java
+++ b/client-java/src/main/java/ai/grakn/client/rpc/RequestBuilder.java
@@ -83,10 +83,14 @@ public class RequestBuilder {
             return query(query.toString(), query.inferring());
         }
 
+        public static SessionProto.Transaction.Req query(String queryString) {
+            return query(queryString, true);
+        }
+
         public static SessionProto.Transaction.Req query(String queryString, boolean infer) {
             SessionProto.Transaction.Query.Req request = SessionProto.Transaction.Query.Req.newBuilder()
                     .setQuery(queryString)
-                    .setInfer(infer)
+                    .setInfer(infer ? SessionProto.Transaction.Query.INFER.TRUE : SessionProto.Transaction.Query.INFER.FALSE)
                     .build();
             return SessionProto.Transaction.Req.newBuilder().setQueryReq(request).build();
         }

--- a/client-protocol/proto/Session.proto
+++ b/client-protocol/proto/Session.proto
@@ -90,7 +90,9 @@ message Transaction {
     message Query {
         message Req {
             string query = 1;
-            bool infer = 2; // If this is not present, leave at server default.
+            INFER infer = 2;
+            // We cannot use bool for `infer` because GRPC's default value for bool is FALSE
+            // We use enum INFER instead, because the default value is index 0 (TRUE)
         }
         message Iter {
             oneof iter {
@@ -100,6 +102,11 @@ message Transaction {
             message Res {
                 Answer answer = 1;
             }
+        }
+        enum INFER {
+            TRUE = 0;
+            FALSE = 1;
+            // The default value of this enum is 0 (TRUE)
         }
     }
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/SessionService.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/SessionService.java
@@ -229,7 +229,9 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
         }
 
         private void query(SessionProto.Transaction.Query.Req request) {
-            Query<?> query = tx().graql().infer(request.getInfer()).parse(request.getQuery());
+            Query<?> query = tx().graql()
+                    .infer(request.getInfer().equals(Transaction.Query.INFER.TRUE))
+                    .parse(request.getQuery());
 
             Stream<Transaction.Res> responseStream;
             int iteratorId;

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/aggregate/AggregateTest.java
@@ -27,19 +27,17 @@ import ai.grakn.graql.Graql;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.admin.Answer;
 import ai.grakn.matcher.MovieMatchers;
-import ai.grakn.test.rule.SampleKBContext;
 import ai.grakn.test.kbs.MovieKB;
+import ai.grakn.test.rule.SampleKBContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static ai.grakn.graql.Graql.count;
 import static ai.grakn.graql.Graql.group;


### PR DESCRIPTION
# Why is this PR needed?

GRPC sets the default value of booleans to `FALSE`, when a field is not set by a user. This is an issue for one of our fields in `SessionProto` : `Transaction.Query.Req.infer` which determines whether a query will perform inference or not. Graql (on the server) expects to perform inference (`infer=true`) as the default behaviour if the user has not set the parameter to `false`. However, if GRPC always set `infer=false` when the user doesn't set it, then this misleads the server to think that the user has set it to `false`.

# What does the PR do?

Make the `Transaction.Query.Req.infer` in `SessionProto` to be defined as `enum INFER { TRUE=0; FALSE=1 }`. GRPC sets default values of enums to be the first index, and thus `TRUE` will be the default.