### PR TITLE
[Stable] Improve resolution logging

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/ResolutionIterator.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/ResolutionIterator.java
@@ -55,7 +55,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
     private Answer nextAnswer = null;
     private final boolean reiterationRequired;
 
-    private static final Logger LOG = LoggerFactory.getLogger(ReasonerQueryImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ResolutionIterator.class);
 
     public ResolutionIterator(ReasonerQueryImpl q){
         this.query = q;
@@ -67,6 +67,8 @@ public class ResolutionIterator extends ReasonerQueryIterator {
         while(!states.isEmpty()) {
             ResolutionState state = states.pop();
 
+            LOG.trace("state: " + state);
+
             if (state.isAnswerState() && state.isTopState()) {
                 return state.getSubstitution();
             }
@@ -75,6 +77,8 @@ public class ResolutionIterator extends ReasonerQueryIterator {
             if (newState != null) {
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);
+            } else {
+                LOG.trace("new state: NULL");
             }
         }
         return null;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -62,8 +62,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -96,8 +94,6 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     private final ImmutableSet<Atomic> atomSet;
     private Answer substitution = null;
     private ImmutableMap<Var, Type> varTypeMap = null;
-
-    private static final Logger LOG = LoggerFactory.getLogger(ReasonerQueryImpl.class);
 
     ReasonerQueryImpl(Conjunction<VarPatternAdmin> pattern, EmbeddedGraknTx<?> tx) {
         this.tx = tx;
@@ -181,10 +177,8 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     @Override
     public String toString(){
         return "{\n\t" +
-                getAtoms(Atom.class)
-                        .map(Atomic::toString)
-                        .collect(Collectors.joining(";\n\t")) +
-                "\n}\n";
+                getAtoms(Atom.class).map(Atomic::toString).collect(Collectors.joining(";\n\t")) +
+                "\n}";
     }
 
     public ReasonerQuery copy() {
@@ -538,8 +532,6 @@ public class ReasonerQueryImpl implements ReasonerQuery {
         } else {
             dbIterator = Collections.emptyIterator();
             ResolutionQueryPlan queryPlan = new ResolutionQueryPlan(this);
-
-            LOG.trace("CQ plan:\n" + queryPlan);
             subGoalIterator = Iterators.singletonIterator(new CumulativeState(queryPlan.queries(), new QueryAnswer(), parent.getUnifier(), parent, subGoals, cache));
         }
         return Iterators.concat(dbIterator, subGoalIterator);

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -42,6 +43,7 @@ public class CumulativeState extends QueryStateBase{
 
     private final LinkedList<ReasonerQueryImpl> subQueries;
     private final Iterator<ResolutionState> feederStateIterator;
+    private final ReasonerQueryImpl query;
 
     public CumulativeState(List<ReasonerQueryImpl> qs,
                            Answer sub,
@@ -52,10 +54,19 @@ public class CumulativeState extends QueryStateBase{
         super(sub, u, parent, subGoals, cache);
         this.subQueries = new LinkedList<>(qs);
 
+        this.query = subQueries.getFirst();
         //NB: we need lazy subGoal initialisation here, otherwise they are marked as visited before visit happens
         this.feederStateIterator = !subQueries.isEmpty()?
                 subQueries.removeFirst().subGoals(sub, u, this, subGoals, cache).iterator() :
                 Collections.emptyIterator();
+    }
+
+    @Override
+    public String toString(){
+        return getClass() + "\n" +
+                getSubstitution() + "\n" +
+                query + "\n" +
+                subQueries.stream().map(ReasonerQueryImpl::toString).collect(Collectors.joining("\n")) + "\n";
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/QueryState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/QueryState.java
@@ -54,6 +54,11 @@ public abstract class QueryState<Q extends ReasonerQueryImpl> extends QueryState
     }
 
     @Override
+    public String toString(){
+        return getClass() + "\n" + getQuery() + "\n";
+    }
+
+    @Override
     public ResolutionState generateSubGoal() {
         return subGoalIterator.hasNext()? subGoalIterator.next() : null;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/RuleState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/RuleState.java
@@ -47,6 +47,10 @@ public class RuleState extends QueryStateBase{
         this.rule = rule;
     }
 
+    @Override
+    public String toString(){
+        return getClass() + "\n" + rule + "\n";
+    }
 
     @Override
     ResolutionState propagateAnswer(AnswerState state){


### PR DESCRIPTION
# Why is this PR needed?
Resolution logging only provides planning information.
# What does the PR do?
Cleanup the resolution logging so that it is more meaningful.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.