### PR TITLE
Fixed DeleteQuery to work remotely, and with arbitrary number of Vars and repeating Concepts in Answers

### DIFF
--- a/docs/pages/docs/04-querying-data/aggregate-queries.md
+++ b/docs/pages/docs/04-querying-data/aggregate-queries.md
@@ -140,7 +140,7 @@ Find the minimum of the given attribute variable.
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="shell4">
 <pre class="language-graql"> <code>
-match $x isa person, has firstname $n; aggregate min $n;
+match $x isa person, has age $a; aggregate min $a;
 </code>
 </pre>
 </div>

--- a/grakn-core/src/main/java/ai/grakn/graql/Match.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/Match.java
@@ -38,7 +38,7 @@ import java.util.Set;
  */
 public interface Match extends Streamable<Answer> {
     /**
-     * Get all {@link Var}s mentioned in the query
+     * Construct a get query with all all {@link Var}s mentioned in the query
      */
     @CheckReturnValue
     GetQuery get();
@@ -79,6 +79,12 @@ public interface Match extends Streamable<Answer> {
     InsertQuery insert(Collection<? extends VarPattern> vars);
 
     /**
+     * Construct a delete query with all all {@link Var}s mentioned in the query
+     */
+    @CheckReturnValue
+    DeleteQuery delete();
+
+    /**
      * @param vars an array of variables to delete for each result of this {@link Match}
      * @return a delete query that will delete the given variables for each result of this {@link Match}
      */
@@ -90,14 +96,14 @@ public interface Match extends Streamable<Answer> {
      * @return a delete query that will delete the given variables for each result of this {@link Match}
      */
     @CheckReturnValue
-    DeleteQuery delete(Var... vars);
+    DeleteQuery delete(Var var, Var... vars);
 
     /**
      * @param vars a collection of variables to delete for each result of this {@link Match}
      * @return a delete query that will delete the given variables for each result of this {@link Match}
      */
     @CheckReturnValue
-    DeleteQuery delete(Collection<? extends Var> vars);
+    DeleteQuery delete(Set<Var> vars);
 
     /**
      * Order the results by degree in ascending order

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/DeleteQueryAdmin.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/DeleteQueryAdmin.java
@@ -23,7 +23,7 @@ import ai.grakn.graql.Match;
 import ai.grakn.graql.Var;
 
 import javax.annotation.CheckReturnValue;
-import java.util.Collection;
+import java.util.Set;
 
 /**
  * Admin class for inspecting and manipulating a DeleteQuery
@@ -41,5 +41,5 @@ public interface DeleteQueryAdmin extends DeleteQuery {
      * Get the {@link Var}s to delete on each result of {@link #match()}.
      */
     @CheckReturnValue
-    Collection<? extends Var> vars();
+    Set<Var> vars();
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
@@ -45,7 +45,6 @@ import ai.grakn.util.CommonUtil;
 import ai.grakn.util.GraqlSyntax;
 import ai.grakn.util.StringUtil;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -176,8 +175,9 @@ class GraqlConstructor extends GraqlBaseVisitor {
 
     @Override
     public DeleteQuery visitDeleteQuery(GraqlParser.DeleteQueryContext ctx) {
-        Set<Var> vars = ctx.variables() != null ? visitVariables(ctx.variables()) : ImmutableSet.of();
-        return visitMatchPart(ctx.matchPart()).delete(vars);
+        Match match = visitMatchPart(ctx.matchPart());
+        if (ctx.variables() != null) return match.delete(visitVariables(ctx.variables()));
+        else return match.delete();
     }
 
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/GraqlConstructor.java
@@ -176,7 +176,7 @@ class GraqlConstructor extends GraqlBaseVisitor {
 
     @Override
     public DeleteQuery visitDeleteQuery(GraqlParser.DeleteQueryContext ctx) {
-        Collection<Var> vars = ctx.variables() != null ? visitVariables(ctx.variables()) : ImmutableSet.of();
+        Set<Var> vars = ctx.variables() != null ? visitVariables(ctx.variables()) : ImmutableSet.of();
         return visitMatchPart(ctx.matchPart()).delete(vars);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
@@ -136,7 +136,7 @@ class StringPrinter extends Printer<StringBuilder> {
 
         builder.append("{");
         collection.stream().findFirst().ifPresent(item -> builder.append(build(item)));
-        collection.stream().skip(1).forEach(item -> builder.append(",").append(build(item)));
+        collection.stream().skip(1).forEach(item -> builder.append(",\n").append(build(item)));
         builder.append("}");
 
         return builder;
@@ -151,8 +151,10 @@ class StringPrinter extends Printer<StringBuilder> {
     public StringBuilder queryAnswer(Answer answer) {
         StringBuilder builder = new StringBuilder();
 
-        if (answer.isEmpty()) builder.append("{}");
-        else answer.forEach((name, concept) -> builder.append(name).append(" ").append(concept(concept)).append("; "));
+//        if (answer.isEmpty()) builder.append("{}");
+        builder.append("{");
+        answer.forEach((name, concept) -> builder.append(name).append(" ").append(concept(concept)).append("; "));
+        builder.append("}");
 
         return builder;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
@@ -150,13 +150,9 @@ class StringPrinter extends Printer<StringBuilder> {
     @Override
     public StringBuilder queryAnswer(Answer answer) {
         StringBuilder builder = new StringBuilder();
-
-//        if (answer.isEmpty()) builder.append("{}");
-        builder.append("{");
         answer.forEach((name, concept) -> builder.append(name).append(" ").append(concept(concept)).append("; "));
-        builder.append("}");
 
-        return builder;
+        return new StringBuilder("{" + builder.toString().trim() + "}");
     }
 
     //TODO: implement StringPrinter for ComputeAnswer properly!

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
@@ -27,7 +27,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Collection;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.joining;

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
@@ -65,7 +65,7 @@ abstract class DeleteQueryImpl extends AbstractQuery<Void, Void> implements Dele
 
     @Override
     public DeleteQuery withTx(GraknTx tx) {
-        return Queries.delete(vars(), match().withTx(tx));
+        return Queries.delete(match().withTx(tx).admin(), vars());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/DeleteQueryImpl.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.joining;
+
 /**
  * A {@link DeleteQuery} that will execute deletions for every result of a {@link Match}
  *
@@ -74,7 +76,12 @@ abstract class DeleteQueryImpl extends AbstractQuery<Void, Void> implements Dele
 
     @Override
     public String toString() {
-        return match() + " delete " + vars().stream().map(v -> v + ";").collect(Collectors.joining("\n")).trim();
+        StringBuilder query = new StringBuilder();
+        query.append(match()).append(" ").append("delete");
+        if(!vars().isEmpty()) query.append(" ").append(vars().stream().map(Var::toString).collect(joining(", ")).trim());
+        query.append(";");
+
+        return query.toString();
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/GetQueryImpl.java
@@ -49,7 +49,7 @@ public abstract class GetQueryImpl extends AbstractQuery<List<Answer>, Answer> i
 
     @Override
     public GetQuery withTx(GraknTx tx) {
-        return Queries.get(vars(), match().withTx(tx).admin());
+        return Queries.get(match().withTx(tx).admin(), vars());
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/InsertQueryImpl.java
@@ -67,9 +67,9 @@ abstract class InsertQueryImpl extends AbstractQuery<List<Answer>, Answer> imple
     @Override
     public final InsertQuery withTx(GraknTx tx) {
         if (match() != null) {
-            return Queries.insert(varPatterns(), match().withTx(tx).admin());
+            return Queries.insert(match().withTx(tx).admin(), varPatterns());
         } else {
-            return Queries.insert(varPatterns(), tx);
+            return Queries.insert(tx, varPatterns());
         }
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/Queries.java
@@ -44,7 +44,33 @@ public class Queries {
     private Queries() {
     }
 
-    public static GetQuery get(ImmutableSet<Var> vars, MatchAdmin match) {
+    public static GetQuery get(MatchAdmin match, ImmutableSet<Var> vars) {
+        validateMatchVars(match, vars);
+        return GetQueryImpl.of(match, vars);
+    }
+
+    public static InsertQueryAdmin insert(GraknTx tx, Collection<VarPatternAdmin> vars) {
+        return InsertQueryImpl.create(vars, null, tx);
+    }
+
+    /**
+     * @param match the {@link Match} to insert for each result
+     * @param varPattern  a collection of Vars to insert
+     */
+    public static InsertQueryAdmin insert(MatchAdmin match, Collection<VarPatternAdmin> varPattern) {
+        return InsertQueryImpl.create(varPattern, match, match.tx());
+    }
+
+    public static DeleteQueryAdmin delete(MatchAdmin match, Set<Var> vars) {
+        validateMatchVars(match, vars);
+        return DeleteQueryImpl.of(vars, match);
+    }
+
+    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<T> aggregate) {
+        return AggregateQueryImpl.of(match, aggregate);
+    }
+
+    private static void validateMatchVars(MatchAdmin match, Set<Var> vars) {
         Set<Var> selectedVars = match.getSelectedNames();
 
         for (Var var : vars) {
@@ -52,27 +78,5 @@ public class Queries {
                 throw GraqlQueryException.varNotInQuery(var);
             }
         }
-
-        return GetQueryImpl.of(match, vars);
-    }
-
-    public static InsertQueryAdmin insert(Collection<VarPatternAdmin> vars, GraknTx tx) {
-        return InsertQueryImpl.create(vars, null, tx);
-    }
-
-    /**
-     * @param vars  a collection of Vars to insert
-     * @param match the {@link Match} to insert for each result
-     */
-    public static InsertQueryAdmin insert(Collection<VarPatternAdmin> vars, MatchAdmin match) {
-        return InsertQueryImpl.create(vars, match, match.tx());
-    }
-
-    public static DeleteQueryAdmin delete(Collection<? extends Var> vars, Match match) {
-        return DeleteQueryImpl.of(vars, match);
-    }
-
-    public static <T> AggregateQuery<T> aggregate(MatchAdmin match, Aggregate<T> aggregate) {
-        return AggregateQueryImpl.of(match, aggregate);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
@@ -208,6 +208,9 @@ public class QueryAnswer implements Answer {
 
     @Override
     public Answer project(Set<Var> vars) {
+        for (Var var : vars) {
+            if (!map.containsKey(var)) throw GraqlQueryException.varNotInQuery(var);
+        }
         return new QueryAnswer(
                 this.entrySet().stream()
                         .filter(e -> vars.contains(e.getKey()))

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryAnswer.java
@@ -208,9 +208,6 @@ public class QueryAnswer implements Answer {
 
     @Override
     public Answer project(Set<Var> vars) {
-        for (Var var : vars) {
-            if (!map.containsKey(var)) throw GraqlQueryException.varNotInQuery(var);
-        }
         return new QueryAnswer(
                 this.entrySet().stream()
                         .filter(e -> vars.contains(e.getKey()))

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/QueryBuilderImpl.java
@@ -114,7 +114,7 @@ public class QueryBuilderImpl implements QueryBuilder {
     @Override
     public InsertQuery insert(Collection<? extends VarPattern> vars) {
         ImmutableList<VarPatternAdmin> varAdmins = ImmutableList.copyOf(AdminConverter.getVarAdmins(vars));
-        return Queries.insert(varAdmins, tx);
+        return Queries.insert(tx, varAdmins);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/aggregate/MinAggregate.java
@@ -50,7 +50,7 @@ class MinAggregate extends AbstractAggregate<Number> {
         Object value = result.get(varName).asAttribute().value();
 
         if (value instanceof Number) return (Number) value;
-        else throw new RuntimeException("Invalid attempt to compare non-Numbers in Max Aggregate function");
+        else throw new RuntimeException("Invalid attempt to compare non-Numbers in Min Aggregate function");
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
@@ -116,8 +116,9 @@ abstract class AbstractMatch implements MatchAdmin {
 
     @Override
     public GetQuery get(Set<Var> vars) {
-        if (vars.isEmpty()) return get();
-        else return Queries.get(ImmutableSet.copyOf(vars), this);
+        if (vars.isEmpty()) vars = getPattern().commonVars();
+
+        return Queries.get(ImmutableSet.copyOf(vars), this);
     }
 
     @Override
@@ -151,8 +152,9 @@ abstract class AbstractMatch implements MatchAdmin {
 
     @Override
     public final DeleteQuery delete(Set<Var> vars) {
-        if (vars.isEmpty()) return delete();
-        else return Queries.delete(vars, this);
+        if (vars.isEmpty()) vars = getPattern().commonVars();
+
+        return Queries.delete(vars, this);
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/AbstractMatch.java
@@ -118,7 +118,7 @@ abstract class AbstractMatch implements MatchAdmin {
     public GetQuery get(Set<Var> vars) {
         if (vars.isEmpty()) vars = getPattern().commonVars();
 
-        return Queries.get(ImmutableSet.copyOf(vars), this);
+        return Queries.get(this, ImmutableSet.copyOf(vars));
     }
 
     @Override
@@ -129,7 +129,7 @@ abstract class AbstractMatch implements MatchAdmin {
     @Override
     public final InsertQuery insert(Collection<? extends VarPattern> vars) {
         ImmutableMultiset<VarPatternAdmin> varAdmins = ImmutableMultiset.copyOf(AdminConverter.getVarAdmins(vars));
-        return Queries.insert(varAdmins, admin());
+        return Queries.insert(admin(), varAdmins);
     }
 
     @Override
@@ -154,7 +154,7 @@ abstract class AbstractMatch implements MatchAdmin {
     public final DeleteQuery delete(Set<Var> vars) {
         if (vars.isEmpty()) vars = getPattern().commonVars();
 
-        return Queries.delete(vars, this);
+        return Queries.delete(this, vars);
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/printer/StringPrinterTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/printer/StringPrinterTest.java
@@ -88,7 +88,7 @@ public class StringPrinterTest {
 
         String result = printer.toString(match.iterator().next());
 
-        assertEquals("$x val \"Godfather\" isa title;", result.trim());
+        assertEquals("{$x val \"Godfather\" isa title;}", result.trim());
     }
 
     @Test

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
@@ -497,7 +497,7 @@ public class ServerRPCIT {
     @Test
     public void whenExecutingDeleteQueries_ConceptsAreDeleted() {
         try (Grakn.Transaction tx = remoteSession.transaction(GraknTxType.WRITE)) {
-            DeleteQuery deleteQuery = tx.graql().match(var().rel("x").rel("y").isa("has-genre")).delete("x", "y");
+            DeleteQuery deleteQuery = tx.graql().match(var("g").rel("x").rel("y").isa("has-genre")).delete("x", "y");
             deleteQuery.execute();
             assertTrue(tx.graql().match(var().rel("x").rel("y").isa("has-genre")).get("x", "y").execute().isEmpty());
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
@@ -38,6 +38,7 @@ import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
 import ai.grakn.graql.AggregateQuery;
 import ai.grakn.graql.ComputeQuery;
+import ai.grakn.graql.DeleteQuery;
 import ai.grakn.graql.GetQuery;
 import ai.grakn.graql.QueryBuilder;
 import ai.grakn.graql.Var;
@@ -429,7 +430,7 @@ public class ServerRPCIT {
     }
 
     @Test
-    public void whenPerformingAggregateQueries_theResultsAreCorrect() {
+    public void whenExecutingAggregateQueries_theResultsAreCorrect() {
         try (Grakn.Transaction tx = remoteSession.transaction(GraknTxType.BATCH.WRITE)) {
             EntityType person = tx.putEntityType("person");
             AttributeType name = tx.putAttributeType("name", DataType.STRING);
@@ -491,6 +492,19 @@ public class ServerRPCIT {
 //                    assertTrue(answer.get("x").asEntity().attributes(name).collect(toSet()).contains(attribute));
 //                });
 //            });
+        }
+    }
+
+    @Test
+    public void whenExecutingDeleteQueries_ConceptsAreDeleted() {
+        try (Grakn.Transaction tx = remoteSession.transaction(GraknTxType.WRITE)) {
+            DeleteQuery deleteQuery = tx.graql().match(var().rel("x").rel("y").isa("has-genre")).delete("x", "y");
+            deleteQuery.execute();
+            assertTrue(tx.graql().match(var().rel("x").rel("y").isa("has-genre")).get("x", "y").execute().isEmpty());
+
+            deleteQuery = tx.graql().match(var("x").isa("person")).delete();
+            deleteQuery.execute();
+            assertTrue(tx.graql().match(var("x").isa("person")).get().execute().isEmpty());
         }
     }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/engine/ServerRPCIT.java
@@ -75,7 +75,6 @@ import java.util.stream.Stream;
 
 import static ai.grakn.graql.Graql.ask;
 import static ai.grakn.graql.Graql.count;
-import static ai.grakn.graql.Graql.group;
 import static ai.grakn.graql.Graql.label;
 import static ai.grakn.graql.Graql.max;
 import static ai.grakn.graql.Graql.mean;


### PR DESCRIPTION
# Why is this PR needed?

There are 2 problems solved in this PR:

## 1. Fixed DeleteQuery.toString() to produce the write query syntax
`DeleteQuery.toString()` was being silly and produced a messed up string representation of the query. This caused remote executions of `DeleteQuery` over GRPC (e.g. Grakn Console) to fail in two ways:
1. When there are no variables provided (e.g. `delete;`), it removes the semicolon `;` from the end.
2. When there are more than one delete variables (e.g. `delete $x, $y;`) it replaces the comma with `;\n`.

## 2. Fixed DeleteQuery to work on answers with repeating concepts, given any combination of Vars.
1. `DeleteQuery` did not handle `match` results correctly, such as projecting results onto the `var`s that the user asked for, and filter the `match` results to be distinct.
2. `Match` interface did not provide a way to create DeleteQuery with no vars (`delete()`) where the default behaviour is to delete all found concepts.

# What does the PR do?

1. Fix the `DeleteQuery.toString()` method to produce the right query
2. Fix Graql query interfaces (`Match` and `Delete`) to properly take in `var`s for all scenarios.
3. Fix `TinkerQueryExecutor` to handle `DeleteQuery` correctly.
2. Add tests in `ServerRPCIT` for now (it will be moved in the future)