### PR TITLE
[Stable] Add extra rule pruning

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/Cache.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/Cache.java
@@ -51,16 +51,17 @@ import java.util.stream.Stream;
 public abstract class Cache<Q extends ReasonerQueryImpl, T extends Iterable<Answer>>{
 
     private final Map<Q, CacheEntry<Q, T>> cache = new HashMap<>();
-    private final StructuralCache<Q> sCache;
+    private final StructuralCache<Q> sCache = new StructuralCache<>();
+    private final RuleCache ruleCache = new RuleCache();
 
-    Cache(){
-        this.sCache = new StructuralCache<>();
-    }
+    Cache(){ }
 
     /**
      * @return structural cache of this cache
      */
     StructuralCache<Q> structuralCache(){ return sCache;}
+
+    public RuleCache ruleCache(){ return ruleCache;}
 
     /**
      * @param query for which the entry is to be retrieved

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/RuleCache.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/cache/RuleCache.java
@@ -1,0 +1,51 @@
+/*
+ * Grakn - A Distributed Semantic Database
+ * Copyright (C) 2016-2018 Grakn Labs Limited
+ *
+ * Grakn is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Grakn is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Grakn. If not, see <http://www.gnu.org/licenses/agpl.txt>.
+ */
+
+package ai.grakn.graql.internal.reasoner.cache;
+
+import ai.grakn.concept.Rule;
+import ai.grakn.graql.internal.reasoner.atom.Atom;
+import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * TODO
+ */
+public class RuleCache {
+    private final Set<Rule> fruitlessRules = new HashSet<>();
+    private final Set<Rule> checkedRules = new HashSet<>();
+
+    public Stream<InferenceRule> getApplicableRules(Atom atom){
+        return atom.getApplicableRules()
+                .filter( r -> {
+                    if (fruitlessRules.contains(r.getRule())) return false;
+                    if (checkedRules.contains(r.getRule())) return true;
+                    if (r.getBody().isRuleResolvable()) return true;
+                    boolean fruitless = !r.getBody().getQuery().stream().findFirst().isPresent();
+                    if (fruitless) {
+                        fruitlessRules.add(r.getRule());
+                        return false;
+                    }
+                    checkedRules.add(r.getRule());
+                    return true;
+                });
+
+    }
+}

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -199,7 +199,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
             subGoalIterator = Collections.emptyIterator();
         } else {
             visitedSubGoals.add(this);
-            subGoalIterator = this.getRuleStream()
+            subGoalIterator = this.getRuleStream(cache)
                     .map(rulePair -> rulePair.getKey().subGoal(this.getAtom(), rulePair.getValue(), parent, visitedSubGoals, cache))
                     .iterator();
         }
@@ -209,8 +209,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     /**
      * @return stream of all rules applicable to this atomic query including permuted cases when the role types are meta roles
      */
-    private Stream<Pair<InferenceRule, Unifier>> getRuleStream(){
-        return getAtom().getApplicableRules()
+    private Stream<Pair<InferenceRule, Unifier>> getRuleStream(QueryCache<ReasonerAtomicQuery> cache){
+        return cache.ruleCache().getApplicableRules(this.getAtom())
                 .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
                 .sorted(Comparator.comparing(rt -> -rt.getKey().resolutionPriority()));
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -33,7 +33,6 @@ import ai.grakn.graql.internal.reasoner.atom.Atom;
 import ai.grakn.graql.internal.reasoner.atom.binary.TypeAtom;
 import ai.grakn.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import ai.grakn.graql.internal.reasoner.cache.QueryCache;
-import ai.grakn.graql.internal.reasoner.rule.InferenceRule;
 import ai.grakn.graql.internal.reasoner.state.AnswerState;
 import ai.grakn.graql.internal.reasoner.state.AtomicStateProducer;
 import ai.grakn.graql.internal.reasoner.state.QueryStateBase;
@@ -46,7 +45,6 @@ import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -199,20 +197,10 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
             subGoalIterator = Collections.emptyIterator();
         } else {
             visitedSubGoals.add(this);
-            subGoalIterator = this.getRuleStream(cache)
+            subGoalIterator = cache.ruleCache().getRuleStream(this.getAtom())
                     .map(rulePair -> rulePair.getKey().subGoal(this.getAtom(), rulePair.getValue(), parent, visitedSubGoals, cache))
                     .iterator();
         }
         return Iterators.concat(dbIterator, subGoalIterator);
     }
-
-    /**
-     * @return stream of all rules applicable to this atomic query including permuted cases when the role types are meta roles
-     */
-    private Stream<Pair<InferenceRule, Unifier>> getRuleStream(QueryCache<ReasonerAtomicQuery> cache){
-        return cache.ruleCache().getApplicableRules(this.getAtom())
-                .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
-                .sorted(Comparator.comparing(rt -> -rt.getKey().resolutionPriority()));
-    }
-
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -527,7 +527,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
      */
     public boolean requiresReiteration() {
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
-        return RuleUtils.subGraphIsCyclical(dependentRules, tx())
+        return RuleUtils.subGraphIsCyclical(dependentRules)
                || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
@@ -18,7 +18,6 @@
 
 package ai.grakn.graql.internal.reasoner.rule;
 
-import ai.grakn.concept.ConceptId;
 import ai.grakn.concept.Rule;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.graql.Var;
@@ -67,7 +66,7 @@ import static java.util.stream.Collectors.toSet;
 public class InferenceRule {
 
     private final EmbeddedGraknTx<?> tx;
-    private final ConceptId ruleId;
+    private final Rule rule;
     private final ReasonerQueryImpl body;
     private final ReasonerAtomicQuery head;
 
@@ -76,15 +75,15 @@ public class InferenceRule {
 
     public InferenceRule(Rule rule, EmbeddedGraknTx<?> tx){
         this.tx = tx;
-        this.ruleId = rule.id();
+        this.rule = rule;
         //TODO simplify once changes propagated to rule objects
         this.body = ReasonerQueries.create(conjunction(rule.when().admin()), tx);
         this.head = ReasonerQueries.atomic(conjunction(rule.then().admin()), tx);
     }
 
-    private InferenceRule(ReasonerAtomicQuery head, ReasonerQueryImpl body, ConceptId ruleId, EmbeddedGraknTx<?> tx){
+    private InferenceRule(ReasonerAtomicQuery head, ReasonerQueryImpl body, Rule rule, EmbeddedGraknTx<?> tx){
         this.tx = tx;
-        this.ruleId = ruleId;
+        this.rule = rule;
         this.head = head;
         this.body = body;
     }
@@ -127,7 +126,7 @@ public class InferenceRule {
         return Patterns.conjunction(vars);
     }
 
-    public ConceptId getRuleId(){ return ruleId;}
+    public Rule getRule(){ return rule;}
 
     /**
      * @return true if the rule has disconnected head, i.e. head and body do not share any variables
@@ -243,7 +242,7 @@ public class InferenceRule {
         return new InferenceRule(
                 ReasonerQueries.atomic(headAtom),
                 ReasonerQueries.create(bodyAtoms, tx),
-                ruleId,
+                rule,
                 tx
         );
     }
@@ -253,7 +252,7 @@ public class InferenceRule {
             return new InferenceRule(
                     ReasonerQueries.atomic(getHead().getAtom().toRelationshipAtom()),
                     ReasonerQueries.create(getBody().getAtoms(), tx),
-                    ruleId,
+                    rule,
                     tx
             );
         }
@@ -291,7 +290,7 @@ public class InferenceRule {
                     }).forEach(bodyRewrites::add);
 
             ReasonerQueryImpl rewrittenBody = ReasonerQueries.create(bodyRewrites, tx);
-            return new InferenceRule(rewrittenHead, rewrittenBody, ruleId, tx);
+            return new InferenceRule(rewrittenHead, rewrittenBody, rule, tx);
         }
         return this;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/InferenceRule.java
@@ -298,7 +298,7 @@ public class InferenceRule {
 
     private InferenceRule rewriteBodyAtoms(){
         if (getBody().requiresDecomposition()) {
-            return new InferenceRule(getHead(), getBody().rewrite(), ruleId, tx);
+            return new InferenceRule(getHead(), getBody().rewrite(), rule, tx);
         }
         return this;
     }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
@@ -73,12 +73,11 @@ public class RuleUtils {
 
     /**
      * @param rules set of rules of interest forming a rule subgraph
-     * @param graph of interest
      * @return true if the rule subgraph formed from provided rules contains loops
      */
-    public static boolean subGraphIsCyclical(Set<InferenceRule> rules, GraknTx graph){
+    public static boolean subGraphIsCyclical(Set<InferenceRule> rules){
         Iterator<Rule> ruleIterator = rules.stream()
-                .map(r -> graph.<Rule>getConcept(r.getRule().id()))
+                .map(InferenceRule::getRule)
                 .iterator();
         boolean cyclical = false;
         while (ruleIterator.hasNext() && !cyclical){

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/rule/RuleUtils.java
@@ -83,7 +83,7 @@ public class RuleUtils {
      */
     public static boolean subGraphIsCyclical(Set<InferenceRule> rules, GraknTx graph){
         Iterator<Rule> ruleIterator = rules.stream()
-                .map(r -> graph.<Rule>getConcept(r.getRuleId()))
+                .map(r -> graph.<Rule>getConcept(r.getRule().id()))
                 .iterator();
         boolean cyclical = false;
         while (ruleIterator.hasNext() && !cyclical){


### PR DESCRIPTION
# Why is this PR needed?
To prune rules that even though applicable, yield no answers during resolution.
# What does the PR do?
Introduces an extra rule cache so that we don't keep retrying fruitless rules like maniacs.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No?