### PR TITLE
Removed <scope>test</scope> from grpc-netty

### DIFF
--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -103,7 +103,6 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>


### PR DESCRIPTION
# Why is this PR needed?

Java applications that use (and thus depend on) `client-java` does not "see" the `grpc-netty` dependency, which is required for their `Grakn.Session` to work (which is over GRPC). This is because we mistakenly scoped the `grpc-netty` dependency for just tests.

# What does the PR do?

Removed `<scope>test</scope>` from `pom.xml` of `client-java`.