### PR TITLE
Fixed RemoteRelationship.rolePlayersMap()

### DIFF
--- a/client-java/src/main/java/ai/grakn/client/concept/RemoteRelationship.java
+++ b/client-java/src/main/java/ai/grakn/client/concept/RemoteRelationship.java
@@ -32,6 +32,7 @@ import com.google.auto.value.AutoValue;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -63,7 +64,7 @@ public abstract class RemoteRelationship extends RemoteThing<Relationship, Relat
             if (rolePlayerMap.containsKey(role)) {
                 rolePlayerMap.get(role).add(player);
             } else {
-                rolePlayerMap.put(role, Collections.singleton(player));
+                rolePlayerMap.put(role, new HashSet<>(Collections.singletonList(player)));
             }
         }
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -221,6 +221,26 @@ public class GraqlShellIT {
     }
 
     @Test
+    public void testMatchGetRelationship() throws Exception {
+        assertShellMatches(
+                "define name sub attribute datatype string;",
+                anything(),
+                "define marriage sub relationship, relates spouse;",
+                anything(),
+                "define person sub entity, has name, plays spouse;",
+                anything(),
+                "insert isa person has name \"Bill Gates\";",
+                anything(),
+                "insert isa person has name \"Melinda Gates\";",
+                anything(),
+                "match $husband isa person has name \"Bill Gates\"; $wife isa person has name \"Melinda Gates\"; insert (spouse: $husband, spouse: $wife) isa marriage;",
+                anything(),
+                "match $x isa marriage; get;",
+                allOf(containsString("spouse"), containsString("isa"), containsString("marriage"))
+        );
+    }
+
+    @Test
     public void testInsertQuery() throws Exception {
         assertShellMatches(
                 "define entity2 sub entity;",


### PR DESCRIPTION
# Why is this PR needed?

When we perform `match $x isa some-relationship; get;`, and `some-relationship` has multiple role players for the same role, the query will throw a null pointer exception. This is because the in the construction of the `Map<Role, Set<Thing>>`, where `Set<Thing>` represents the role players for a given `Role`, the `Set` was initialised with an IMMUTABLE set through `Collections.singleton(..)`.

# What does the PR do?

Fixed RemoteRelationship.rolePlayersMap() to be able to add multiple players to the same role.