### PR TITLE
match-insert queries need to execute inserts before it streams results

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/executor/QueryExecutorImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/executor/QueryExecutorImpl.java
@@ -46,6 +46,7 @@ import java.util.stream.Stream;
 
 import static ai.grakn.util.CommonUtil.toImmutableList;
 import static ai.grakn.util.CommonUtil.toImmutableSet;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 /**
@@ -90,7 +91,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         Set<Var> projectedVars = Sets.intersection(varsInMatch, varsInInsert);
 
         Stream<ConceptMap> answers = match.get(projectedVars).stream();
-        return answers.map(answer -> QueryOperationExecutor.insertAll(varPatterns, tx, answer));
+        return answers.map(answer -> QueryOperationExecutor.insertAll(varPatterns, tx, answer)).collect(toList()).stream();
     }
 
     @Override

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/query/InsertQueryTest.java
@@ -58,7 +58,6 @@ import org.junit.rules.ExpectedException;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -78,10 +77,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -222,7 +218,7 @@ public class InsertQueryTest {
     }
 
     @Test
-    public void testIterateMatchInsertResults() {
+    public void testMatchInsertShouldInsertDataEvenWhenResultsAreNotCollected() {
         VarPattern language1 = var().isa("language").has("name", "123");
         VarPattern language2 = var().isa("language").has("name", "456");
 
@@ -231,29 +227,10 @@ public class InsertQueryTest {
         assertExists(qb, language2);
 
         InsertQuery query = qb.match(var("x").isa("language")).insert(var("x").has("name", "HELLO"));
-        Iterator<ConceptMap> results = query.iterator();
+        query.stream();
 
-        assertNotExists(qb, var().isa("language").has("name", "123").has("name", "HELLO"));
-        assertNotExists(qb, var().isa("language").has("name", "456").has("name", "HELLO"));
-
-        ConceptMap result1 = results.next();
-        assertEquals(ImmutableSet.of(var("x")), result1.vars());
-
-        boolean query123 = qb.match(var().isa("language").has("name", "123").has("name", "HELLO")).iterator().hasNext();
-        boolean query456 = qb.match(var().isa("language").has("name", "456").has("name", "HELLO")).iterator().hasNext();
-
-        //Check if one of the matches have had the insert executed correctly
-        boolean oneExists = query123 != query456;
-        assertTrue("A match insert was not executed correctly for only one match", oneExists);
-
-        //Check that both are inserted correctly
-        ConceptMap result2 = results.next();
-        assertEquals(ImmutableSet.of(var("x")), result1.vars());
         assertExists(qb, var().isa("language").has("name", "123").has("name", "HELLO"));
         assertExists(qb, var().isa("language").has("name", "456").has("name", "HELLO"));
-        assertFalse(results.hasNext());
-
-        assertNotEquals(result1.get("x"), result2.get("x"));
     }
 
     @Test


### PR DESCRIPTION
# Why is this PR needed?

At the moment, `match-insert` queries does not perform the data insertion when you call the `.stream()`, because the stream hasn't been executed. Although this is programmatically correct, it is semantically wrong with regards to the expected behaviour of the query. The expected behaviour of `match-insert` `.stream()` is that the data insertion has been performed, but the results are yet to be streamed.

# What does the PR do?

We `.collect()` the answers of the current `match-insert` stream into a list so that the insertion is performed, but then we return the `.stream()` of the answer list again.

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR
None.