### PR TITLE
Stream console prints in GraqlShell

### DIFF
--- a/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
+++ b/grakn-graql-shell/src/main/java/ai/grakn/graql/shell/GraqlShell.java
@@ -228,12 +228,15 @@ public class GraqlShell implements AutoCloseable {
                     .parser()
                     .parseList(queryString);
 
-            Iterable<String> results = () -> queries
-                    .flatMap(query -> printer.toStream(query.stream())).iterator();
+            Stream<String> results = queries.flatMap(query -> printer.toStream(query.stream()));
 
-            for (String result : results) {
-                console.println(result);
-            }
+            results.forEach(result -> {
+                try {
+                    console.println(result);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            });
         });
 
         // Flush the console so the output is all displayed before the next command


### PR DESCRIPTION
# Why is this PR needed?

Console printing in GraqlShell does not properly stream outputs.

# What does the PR do?

Instead of calling `.iterator()` on a `.flatMap(...)` (which already returns a stream), we just call `results.forEach(...)` where `results` is a `stream` returned by `.flatMap(...)`.

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

None.