### PR TITLE
Node client use keyspaces() and update Docs

### DIFF
--- a/client-nodejs/README.md
+++ b/client-nodejs/README.md
@@ -55,8 +55,8 @@ on the Grakn object the following methods are available:
 | Method                                   | Return type       | Description                                          |
 | ---------------------------------------- | ----------------- | ---------------------------------------------------- |
 | `session(String keyspace)`               | *Session*         | Return a new Session bound to the specified keyspace |
-| async `keyspace.delete(String keyspace)` | *void*            | Deletes the specified keyspace                       |
-| async `keyspace.retrieve()`              | Array of *String* | Retrieves all available keyspaces                    |
+| async `keyspaces().delete(String keyspace)` | *void*            | Deletes the specified keyspace                       |
+| async `keyspaces().retrieve()`              | Array of *String* | Retrieves all available keyspaces                    |
 
 
 

--- a/client-nodejs/package.json
+++ b/client-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grakn",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Grakn Node.js Client",
   "main": "dist/Grakn.js",
   "author": "Grakn Labs",

--- a/client-nodejs/src/Grakn.js
+++ b/client-nodejs/src/Grakn.js
@@ -35,10 +35,10 @@ function Grakn(uri, credentials) {
 
     this.session = (keyspace) => new Session(uri, keyspace, credentials);
 
-    this.keyspace = {
+    this.keyspaces = ()=> ({
         delete: (keyspace) => keyspaceService.delete(keyspace),
         retrieve: () => keyspaceService.retrieve()
-    };
+    });
 }
 
 module.exports = Grakn

--- a/client-nodejs/tests/service/keyspace/Keyspace.test.js
+++ b/client-nodejs/tests/service/keyspace/Keyspace.test.js
@@ -34,11 +34,11 @@ describe("Keyspace methods", () => {
         const session = graknClient.session("retrievetest");
         const tx = await session.transaction(env.txType().WRITE);
         tx.close();
-        const keyspaces = await graknClient.keyspace.retrieve();
+        const keyspaces = await graknClient.keyspaces().retrieve();
         expect(keyspaces.length).toBeGreaterThan(0);
         expect(keyspaces.includes('retrievetest')).toBeTruthy;
-        await graknClient.keyspace.delete('retrievetest');
-        const keyspacesAfterDeletion = await graknClient.keyspace.retrieve();
+        await graknClient.keyspaces().delete('retrievetest');
+        const keyspacesAfterDeletion = await graknClient.keyspaces().retrieve();
         expect(keyspacesAfterDeletion.includes('retrievetest')).toBeFalsy();
         session.close();
     });

--- a/client-nodejs/tests/service/session/transaction/CommitTx.test.js
+++ b/client-nodejs/tests/service/session/transaction/CommitTx.test.js
@@ -29,7 +29,7 @@ beforeAll(() => {
 
 afterAll(async () => {
     await session.close();
-    graknClient.keyspace.delete("testcommit");
+    graknClient.keyspaces().delete("testcommit");
     env.tearDown();
 });
 

--- a/client-nodejs/tests/service/session/transaction/GraknTx.test.js
+++ b/client-nodejs/tests/service/session/transaction/GraknTx.test.js
@@ -114,7 +114,7 @@ describe("Transaction methods", () => {
     expect(answer.list().includes(parentshipMap.rel)).toBeTruthy();
     localTx.close();
     localSession.close();
-    env.graknClient.keyspace.delete('shortestpathks');
+    env.graknClient.keyspaces().delete('shortestpathks');
   });
 
   test("cluster connected components - Answer of conceptSet", async ()=>{
@@ -130,7 +130,7 @@ describe("Transaction methods", () => {
     expect(answer.set().has(parentshipMap.rel)).toBeTruthy();
     localTx.close();
     localSession.close();
-    env.graknClient.keyspace.delete('clusterkeyspace');
+    env.graknClient.keyspaces().delete('clusterkeyspace');
   });
 
   test("compute centrality - Answer of conceptSetMeasure", async ()=>{
@@ -145,7 +145,7 @@ describe("Transaction methods", () => {
     expect(answer.set().has(parentshipMap.parent)).toBeTruthy();
     localTx.close();
     localSession.close();
-    env.graknClient.keyspace.delete('computecentralityks');
+    env.graknClient.keyspaces().delete('computecentralityks');
   });
 
   test("compute aggregate group - Answer of answerGroup", async ()=>{
@@ -162,7 +162,7 @@ describe("Transaction methods", () => {
 
     localTx.close();
     localSession.close();
-    env.graknClient.keyspace.delete('groupks');
+    env.graknClient.keyspaces().delete('groupks');
   });
 
 

--- a/client-nodejs/tests/support/GraknTestEnvironment.js
+++ b/client-nodejs/tests/support/GraknTestEnvironment.js
@@ -41,7 +41,7 @@ module.exports = {
     sessionForKeyspace: (keyspace) => graknClient.session(keyspace),
     tearDown: async () => {
         await session.close();
-        // await graknClient.keyspace.delete(TEST_KEYSPACE);
+        // await graknClient.keyspaces().delete(TEST_KEYSPACE);
     },
     dataType: () => Grakn.dataType,
     txType: () => Grakn.txType,

--- a/docs/pages/docs/08-java-library/advanced.md
+++ b/docs/pages/docs/08-java-library/advanced.md
@@ -19,7 +19,8 @@ The following would result in an exception because the first transaction `tx1` w
 
 <!-- Ignored because this is designed to crash! -->
 ```java-test-ignore
-Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(Keyspace.of("grakn"));
 Grakn.Transaction tx1 = session.transaction(GraknTxType.WRITE)
 Grakn.Transaction tx2 = session.transaction(GraknTxType.WRITE)
 ```
@@ -28,7 +29,8 @@ If you require multiple transactions open at the same time then you must do this
 
 <!-- Ignored because it contains a Java lambda, which Groovy doesn't support -->
 ```java-test-ignore
-Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(Keyspace.of("grakn"));
 Set<Future> futures = new HashSet<>();
 ExecutorService pool = Executors.newFixedThreadPool(10);
 

--- a/docs/pages/docs/08-java-library/core-api.md
+++ b/docs/pages/docs/08-java-library/core-api.md
@@ -26,7 +26,8 @@ First we need a knowledge graph. For this example we will just use an
 [in-memory knowledge graph](./setup#initialising-a-transaction-on-the-knowledge-base):
 
 ```java-test-ignore
-Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(Keyspace.of("grakn"));
 Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 ```
 
@@ -161,7 +162,8 @@ insert $x isa person has firstname "John";
 Now the equivalent Core API:    
 
 ```java-test-ignore
-Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(Keyspace.of("grakn"));
 Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 
 Attribute johnName = firstname.putAttribute("John"); //Create the attribute

--- a/docs/pages/docs/08-java-library/graql-api.md
+++ b/docs/pages/docs/08-java-library/graql-api.md
@@ -19,10 +19,11 @@ import static ai.grakn.graql.Graql.*;
 
 ## QueryBuilder
 
-A `QueryBuilder` is constructed from a `GraknTx`:
+A `QueryBuilder` is constructed from a `Grakn.Transaction`:
 
 ```java-test-ignore
-Grakn.Session session = Grakn.session(new SimpleURI("localhost:48555"), Keyspace.of("grakn"));
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(Keyspace.of("grakn"));
 Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 
 QueryBuilder qb = tx.graql();

--- a/docs/pages/docs/08-java-library/setup.md
+++ b/docs/pages/docs/08-java-library/setup.md
@@ -9,7 +9,7 @@ folder: docs
 ---
 
 ## Declaring The Dependency In Maven
-All applications which use **Grakn 1.3.0** will require the `client-java` dependency to be declared on the `pom.xml` of your application.
+All applications will require the `client-java` dependency to be declared on the `pom.xml` of your application.
 
 ```xml
 <repositories>
@@ -32,39 +32,11 @@ All applications which use **Grakn 1.3.0** will require the `client-java` depend
 </dependencies>
 ```
 
-Alternatively, applications which are still using **Grakn 1.2.0** will instead require the `grakn-client` dependency.
-```xml
-<repositories>
-  <repository>
-    <id>snapshots</id>
-    <url>http://maven.grakn.ai/nexus/content/repositories/snapshots/</url>
-  </repository>
-  <repository>
-    <id>releases</id>
-    <url>https://oss.sonatype.org/content/repositories/releases</url>
-  </repository>
-</repositories>
-
-<properties>
-    <grakn.version>1.2.0</grakn.version>
-</properties>
-
-<dependencies>
-  <dependency>
-    <groupId>ai.grakn</groupId>
-    <artifactId>grakn-client</artifactId>
-    <version>${grakn.version}</version>
-  </dependency>
-</dependencies>
-```
-
-Please be noted that most of the materials in the documentation will use the syntax of Grakn 1.3.0.
-
 ## Opening A Session And Transaction
 
 {% include note.html content="Before proceeding, make sure that the Grakn knowledge graph has already been started. Otherwise, refer to the [Setup guide](./docs/get-started/setup-guide#install-graknai) on how to install and start Grakn properly." %}
 
-A **session** object is responsible for maintaining a connection to a specific keyspace in the knowledge graph. Opening a session is performed by invoking the `Grakn.session` method.
+A **session** object is responsible for maintaining a connection to a specific keyspace in the knowledge graph. Opening a session is performed by invoking the `session()` method on the grakn client.
 Once the session is open, you can proceed by creating a **transaction** in order to manipulate the data in the keyspace.
 
 The following snippet shows how to open a Grakn session and transaction:
@@ -79,7 +51,8 @@ public class App {
   public static void main(String[] args) {
     SimpleURI localGrakn = new SimpleURI("localhost", 48555);
     Keyspace keyspace = Keyspace.of("grakn");
-    try (Grakn.Session session = Grakn.session(localGrakn, keyspace)) {
+    Grakn grakn = new Grakn(localGrakn);
+    try (Grakn.Session session = grakn.session(keyspace)) {
       try (Grakn.Transaction transaction = session.transaction(GraknTxType.WRITE)) {
         // ...
         transaction.commit();

--- a/docs/pages/docs/11-resources/faq.md
+++ b/docs/pages/docs/11-resources/faq.md
@@ -142,8 +142,8 @@ I want to clear the knowledge graph I've been experimenting with and try somethi
 If you are using the Java API, it's a simple as:
 
 ```java-test-ignore
-tx = Grakn.session(Grakn.DEFAULT_URI, "my-knowledge-base").open(GraknTxType.WRITE);
-tx.clear();
+Grakn grakn = new Grakn(Grakn.DEFAULT_URI);
+grakn.keyspaces().delete("my-knowledge-base");
 ```
 
 If you are using the Graql shell and have not committed what you have in the knowledge graph, you can just quit the shell and restart it, and all is clean.

--- a/docs/pages/docs/12-examples/java-api-example.md
+++ b/docs/pages/docs/12-examples/java-api-example.md
@@ -14,11 +14,24 @@ This example shows how to use Java in a basic example that can be extended as a 
 All Grakn applications have the following Maven dependency:
 
 ```xml
- <dependency>
-   <groupId>ai.grakn</groupId>
-   <artifactId>client-java</artifactId>
-   <version>${project.version}</version>
-</dependency>
+<repositories>
+  <repository>
+    <id>releases</id>
+    <url>https://oss.sonatype.org/content/repositories/releases</url>
+  </repository>
+</repositories>
+
+<properties>
+    <grakn.version>1.3.0</grakn.version>
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>ai.grakn</groupId>
+    <artifactId>client-java</artifactId>
+    <version>${grakn.version}</version>
+  </dependency>
+</dependencies>
 ```
 
 ### Grakn Engine
@@ -31,9 +44,9 @@ cd [your Grakn install directory]
 ```
 
 
-## Java API: GraknTx
+## Java API: Grakn.Transaction
 
-The Java API, `GraknTx`, is a low-level API that encapsulates the [Grakn knowledge model](../knowledge-model/model). It provides Java object constructs for the Grakn ontological elements (entity types, relationship types, etc.) and data instances (entities, relationships, etc.), allowing you to build up a knowledge graph programmatically. It is also possible to perform simple concept lookups using the java API, which I’ll illustrate presently. First, let’s look at building up the knowledge graph.
+The Java API, `Grakn.Transaction`, is a low-level API that encapsulates the [Grakn knowledge model](../knowledge-model/model). It provides Java object constructs for the Grakn ontological elements (entity types, relationship types, etc.) and data instances (entities, relationships, etc.), allowing you to build up a knowledge graph programmatically. It is also possible to perform simple concept lookups using the java API, which I’ll illustrate presently. First, let’s look at building up the knowledge graph.
 
 ### Building the Schema
 
@@ -42,8 +55,9 @@ We will look at the same schema as is covered in the [Basic Schema documentation
 First we need a [knowledge graph](../java-library/setup#initialising-a-transaction-on-the-knowledge-base):
 
 ```java-test-ignore
-GraknSession session = new Grakn("localhost:48555").session(keyspace);
-GraknTx tx = session.transaction(GraknTxType.WRITE)
+Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+Grakn.Session session = grakn.session(keyspace);
+Grakn.Transaction tx = session.transaction(GraknTxType.WRITE)
 ```
 
 
@@ -156,7 +170,7 @@ for (Thing p: tx.getEntityType("person").instances()) {
 
 ## Querying the Knowledge Graph Using QueryBuilder
 
-It is also possible to interact with the knowledge graph using a separate Java API that forms Graql queries. This is via `GraknTx.graql()`, which returns a `QueryBuilder` object, discussed in the documentation. It is useful to use `QueryBuilder` if you want to make queries using Java, without having to construct a string containing the appropriate Graql expression. Taking the same query "What are the instances of type person?":
+It is also possible to interact with the knowledge graph using a separate Java API that forms Graql queries. This is via `Grakn.Transaction.graql()`, which returns a `QueryBuilder` object, discussed in the documentation. It is useful to use `QueryBuilder` if you want to make queries using Java, without having to construct a string containing the appropriate Graql expression. Taking the same query "What are the instances of type person?":
 
 ```java-test-ignore
 for (ConceptMap a: tx.graql().match(var("x").isa("person")).get().execute()) {
@@ -166,7 +180,7 @@ for (ConceptMap a: tx.graql().match(var("x").isa("person")).get().execute()) {
 
 Which leads us to the common question...
 
-## When to use GraknTx and when to use QueryBuilder?
+## When to use Grakn.Transaction and when to use QueryBuilder?
 
 **Java API**
 If you are primarily interested in mutating the knowledge graph, as well as doing simple concept lookups the Java API will be sufficient, e.g. for

--- a/docs/pages/docs/12-examples/working-with-tweets.md
+++ b/docs/pages/docs/12-examples/working-with-tweets.md
@@ -83,15 +83,27 @@ Now that you have basic project structure and `pom.xml` in place, let's start cu
 </build>
 ```
 
-Then continue to the `<dependencies>` section and make sure you have all the required dependencies, i.e., `grakn-kb`, `twitter4j-core`, and `twitter4j-stream`:
+Then continue to the `<dependencies>` section and make sure you have all the required dependencies, i.e., `client-java`, `twitter4j-core`, and `twitter4j-stream`:
 
 ```xml
+<repositories>
+ <repository>
+   <id>releases</id>
+   <url>https://oss.sonatype.org/content/repositories/releases</url>
+ </repository>
+</repositories>
+
+<properties>
+   <grakn.version>1.3.0</grakn.version>
+</properties>
+   
 <dependencies>
-    <dependency>
-        <groupId>ai.grakn</groupId>
-        <artifactId>grakn-kb</artifactId>
-        <version><Current Grakn Version></version>
-    </dependency>
+   <dependency>
+       <groupId>ai.grakn</groupId>
+       <artifactId>client-java</artifactId>
+       <version>${grakn.version}</version>
+     </dependency>
+   </dependencies>
 
     <dependency>
         <groupId>org.twitter4j</groupId>
@@ -110,15 +122,14 @@ Then continue to the `<dependencies>` section and make sure you have all the req
 ## The Main Class
 
 Let's kick things off by defining a `Main` class inside the `ai.grakn.twitterexample` package. Aside from Twitter credentials, it contains a few important Grakn settings.
-
-First, we have decided to use an **in-memory knowledge graph** for simplicity's sake — working with an in-memory knowledge graph frees us from having to set up a Grakn distribution in the local machine. The in-memory graph is not for storing data and will be lost once the program finishes execution. Second, the graph will be stored in a **keyspace** named `twitter-example`.
+The graph will be stored in a **keyspace** named `twitter-example`.
 
 <!-- A lot of these examples are not valid Groovy, so they've been ignored in tests -->
 ```java-test-ignore
 package ai.grakn.twitterexample;
 
-import ai.grakn.Grakn;
-import ai.grakn.GraknSession;
+import ai.grakn.client.Grakn;
+import ai.grakn.Grakn.Session;
 
 public class Main {
   // Twitter credentials
@@ -128,7 +139,6 @@ public class Main {
   private static final String accessTokenSecret = "...";
 
   // Grakn settings
-  private static final String implementation = Grakn.IN_MEMORY;
   private static final String keyspace = "twitter-example";
 
   public static void main(String[] args) {
@@ -137,22 +147,23 @@ public class Main {
 }
 ```
 
-We then define a `GraknSession` object in `main()`. Enclosing it in a `try-with-attribute` construct is a good practice, lest we forget closing the session by calling `session.close()`.
+We then define a `Grakn.Session` object in `main()`. Enclosing it in a `try-with-attribute` construct is a good practice, lest we forget closing the session by calling `session.close()`.
 
 ```java-test-ignore
 public static void main(String[] args) {
-  try (GraknSession session = Grakn.session(implementation, keyspace)) {
+  Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+  try (Grakn.Session session = grakn.session(keyspace)) {
     // our code will go here
   }
 }
 ```
 
-Following that, another equally important object for operating on the knowledge graph is `GraknTx`. After performing the operations we desire, we must not forget to commit. For convenience, let's define a helper method which opens a `GraknTx` in write mode, and commits it after executing the function `fn`. We will be using this function in various places throughout the tutorial.
+Following that, another equally important object for operating on the knowledge graph is `Grakn.Transaction`. After performing the operations we desire, we must not forget to commit. For convenience, let's define a helper method which opens a `GraknTx` in write mode, and commits it after executing the function `fn`. We will be using this function in various places throughout the tutorial.
 
 ```java-test-ignore
 public class GraknTweetSchemaHelper {
-  public static void withGraknTx(GraknSession session, Consumer<GraknTx> fn) {
-    GraknTx tx = session.open(GraknTxType.WRITE);
+  public static void withGraknTx(Grakn.Session session, Consumer<GraknTx> fn) {
+    Grakn.Transaction tx = session.open(GraknTxType.WRITE);
     fn.accept(tx);
     tx.commit();
   }
@@ -177,7 +188,7 @@ With that set, let's define a new method `initTweetSchema` inside `GraknTweetSch
 
 ```java-test-ignore
 public class GraknTweetSchemaHelper {
-  public static void initTweetSchema(GraknTx tx) {
+  public static void initTweetSchema(Grakn.Transaction tx) {
 
   }
 }
@@ -226,7 +237,8 @@ Now invoke the method in `main` so the schema is created at the start of the app
 
 ```java-test-ignore
 public static void main(String[] args) {
-  try (GraknSession session = Grakn.session(implememntation, keyspace)) {
+  Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+  try (Grakn.Session session = grakn.session(keyspace)) {
     withGraknTx(session, tx -> initTweetSchema(tx)); // initialize schema
   }
 }
@@ -319,7 +331,8 @@ Let's wrap up this section by adding the call to `listenToTwitterStreamAsync` in
 
 ```java-test-ignore
 public static void main(String[] args) {
-  try (GraknSession session = Grakn.session(implementation, keyspace)) {
+  Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+  try (Grakn.Session session = grakn.session(keyspace)) {
     withGraknTx(session, tx -> initTweetSchema(tx)); // initialize schema
 
     listenToTwitterStreamAsync(consumerKey, consumerSecret, accessToken, accessTokenSecret, (screenName, tweet) -> {
@@ -348,7 +361,7 @@ Let's do that with a new method. It will accept a single `String` and inserts it
 Pay attention to how we need to retrieve the `EntityTypes` and `AttributeTypes` of entity and attribute we are interested in — we need them in order to perform the actual insertion.
 
 ```java-test-ignore
-public static Entity insertTweet(GraknTx tx, String tweet) {
+public static Entity insertTweet(Grakn.Transaction tx, String tweet) {
     EntityType tweetEntityType = tx.getEntityType("tweet");
     AttributeType tweetResouceType = tx.getAttributeType("text");
 
@@ -392,7 +405,7 @@ public static Entity insertUser(GraknTx tx, String user) {
 And finally, write a function for inserting a user only if it's not yet there in the knowledge graph.
 
 ```java-test-ignore
-public static Entity insertUserIfNotExist(GraknTx tx, String screenName) {
+public static Entity insertUserIfNotExist(Grakn.Transaction tx, String screenName) {
   QueryBuilder qb = tx.graql();
   return findUser(qb, screenName).orElse(insertUser(tx, screenName));
 }
@@ -405,7 +418,7 @@ We're almost there with a complete tweet insertion functionality! There's only o
 The following function will create a relationship between the user and tweet that we specify.
 
 ```java-test-ignore
-public static Relationship insertUserTweetRelation(GraknTx tx, Entity user, Entity tweet) {
+public static Relationship insertUserTweetRelation(Grakn.Transaction tx, Entity user, Entity tweet) {
   RelationType userTweetRelationType = tx.getRelationType("user-tweet-relationship");
   RoleType postsType = tx.getRoleType("posts");
   RoleType postedByType = tx.getRoleType("posted_by");
@@ -423,7 +436,7 @@ public static Relationship insertUserTweetRelation(GraknTx tx, Entity user, Enti
 Finally, let's wrap up by defining a function of which the sole responsibility is to execute all of the methods we have defined above.
 
 ```java-test-ignore
-public static Relationship insertUserTweet(GraknTx tx, String screenName, String tweet) {
+public static Relationship insertUserTweet(Grakn.Transaction tx, String screenName, String tweet) {
   Entity tweetEntity = insertTweet(tx, tweet);
   Entity userEntity = insertUserIfNotExist(tx, screenName);
   return insertUserTweetRelation(tx, userEntity, tweetEntity);
@@ -434,7 +447,8 @@ We're done with tweet insertion functionality! Next step: querying the stored da
 
 ```java-test-ignore
 public static void main(String[] args) {
-  try (GraknSession session = Grakn.session(implementation, keyspace)) {
+  Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+  try (Grakn.Session session = grakn.session(keyspace)) {
     withGraknTx(session, tx -> initTweetSchema(tx)); // initialize schema
 
     listenToTwitterStreamAsync(consumerKey, consumerSecret, accessToken, accessTokenSecret, (screenName, tweet) -> {
@@ -537,11 +551,11 @@ public class Main {
   private static final String accessTokenSecret = "...";
 
   // Grakn settings
-  private static final String implementation = Grakn.IN_MEMORY;
   private static final String keyspace = "twitter-example";
 
   public static void main(String[] args) {
-    try (GraknSession session = Grakn.session(mplementation, keyspace)) {
+    Grakn grakn = new Grakn(new SimpleURI("localhost:48555"));
+    try (Grakn.Session session = grakn.session(keyspace)) {
       withGraknTx(session, tx -> initTweetSchema(tx)); // initialize schema
 
       listenToTwitterStreamAsync(consumerKey, consumerSecret, accessToken, accessTokenSecret, (screenName, tweet) -> {


### PR DESCRIPTION
# Why is this PR needed?

Client NodeJs was still using client.keyspace
Docs were outdated

# What does the PR do?

Introduces `client.keyspaces()` in NodeJs.

Updates docs on how to use grakn client, which it's not static anymore.

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

None