### PR TITLE
update grakn distribution file name + add client-java-e2e into the CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,3 +360,6 @@ workflows:
       - client-python-e2e:
           requires:
             - build
+      - client-java-e2e:
+          requires:
+            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
           key: grakn-cache-m2-version-8
       - run: mvn versions:set -DnewVersion=test -DgenerateBackupPoms=false
       - run: mvn --batch-mode install -T 2.5C -DskipTests=true
-      - run: tar -xf grakn-dist/target/grakn-dist-test.tar.gz -C grakn-dist/target/
+      - run: tar -xf grakn-dist/target/grakn-core-test.tar.gz -C grakn-dist/target/
       - save_cache:
           name: Save maven m2 cache
           paths:
@@ -263,9 +263,9 @@ jobs:
       - restore_cache:
           name: Restore maven m2 cache
           key: grakn-cache-m2-version-8
-      - run: nohup grakn-dist/target/grakn-dist-test/grakn server start
-      - run: PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh
-      - run: PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-dist-test PACKAGE=./grakn-dist/target/grakn-dist-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh
+      - run: nohup grakn-dist/target/grakn-core-test/grakn server start
+      - run: PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-core-test PACKAGE=./grakn-dist/target/grakn-core-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/load.sh
+      - run: PATH=$PATH:./grakn-test/test-snb/src/main/bash:./grakn-test/test-integration/src/test/bash:./grakn-dist/target/grakn-core-test PACKAGE=./grakn-dist/target/grakn-core-test WORKSPACE=. ./grakn-test/test-snb/src/main/bash/validate.sh
 
   biomed-e2e:
     machine: true
@@ -276,9 +276,9 @@ jobs:
       - restore_cache:
           name: Restore maven m2 cache
           key: grakn-cache-m2-version-8
-      - run: nohup grakn-dist/target/grakn-dist-test/grakn server start
-      - run: PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/load.sh
-      - run: PATH=$PATH:./grakn-dist/target/grakn-dist-test ./grakn-test/test-biomed/validate.sh
+      - run: nohup grakn-dist/target/grakn-core-test/grakn server start
+      - run: PATH=$PATH:./grakn-dist/target/grakn-core-test ./grakn-test/test-biomed/load.sh
+      - run: PATH=$PATH:./grakn-dist/target/grakn-core-test ./grakn-test/test-biomed/validate.sh
 
   client-nodejs-e2e:
       machine: true
@@ -309,8 +309,8 @@ jobs:
         - run:
             name: Install yarn
             command: sudo apt-get -y install yarn
-        - run: nohup grakn-dist/target/grakn-dist-test/grakn server start
-        - run: cd grakn-dist/target/grakn-dist-test/ && ./graql console -f ./examples/basic-genealogy.gql -k gene
+        - run: nohup grakn-dist/target/grakn-core-test/grakn server start
+        - run: cd grakn-dist/target/grakn-core-test/ && ./graql console -f ./examples/basic-genealogy.gql -k gene
         - run: cd client-nodejs && yarn install && yarn run test
 
   client-python-e2e:
@@ -328,7 +328,7 @@ jobs:
         - run:
             name: Install protobuf and grpc
             command: pip install protobuf grpcio grpcio-tools --user
-        - run: nohup grakn-dist/target/grakn-dist-test/grakn server start
+        - run: nohup grakn-dist/target/grakn-core-test/grakn server start
         - run: cd client-python && make protobuf
         - run: cd client-python && python -m unittest discover ./tests/integration/ -v
 

--- a/grakn-dist/pom.xml
+++ b/grakn-dist/pom.xml
@@ -118,6 +118,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <finalName>grakn-core-${project.version}</finalName>
                     <tarLongFileMode>gnu</tarLongFileMode>
                     <descriptors>
                         <descriptor>${project.basedir}/src/dist.xml</descriptor>

--- a/grakn-test/test-client-java/src/test/java/ai/grakn/client/ClientJavaE2EConstants.java
+++ b/grakn-test/test-client-java/src/test/java/ai/grakn/client/ClientJavaE2EConstants.java
@@ -16,7 +16,7 @@ public class ClientJavaE2EConstants {
     // path of grakn zip files
     public static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     public static final Path GRAKN_BASE_DIRECTORY = Paths.get(System.getProperty("main.basedir"));
-    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
+    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), ZIP_FILENAME);
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-core-" + GraknVersion.VERSION);
 

--- a/grakn-test/test-client-java/src/test/java/ai/grakn/client/ClientJavaE2EConstants.java
+++ b/grakn-test/test-client-java/src/test/java/ai/grakn/client/ClientJavaE2EConstants.java
@@ -14,11 +14,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ClientJavaE2EConstants {
     // path of grakn zip files
-    public static final String ZIP_FILENAME = "grakn-dist-" + GraknVersion.VERSION + ".zip";
+    public static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     public static final Path GRAKN_BASE_DIRECTORY = Paths.get(System.getProperty("main.basedir"));
-    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
+    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), ZIP_FILENAME);
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-dist-" + GraknVersion.VERSION);
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-core-" + GraknVersion.VERSION);
 
     public static void assertGraknRunning() {
         assertThat("assertGraknRunning() failed because /tmp/grakn-engine.pid is not found", Paths.get("/tmp/grakn-engine.pid").toFile().exists(), equalTo(true));

--- a/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
+++ b/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
@@ -32,11 +32,11 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class DistributionE2EConstants {
     // path of grakn zip files
-    public static final String ZIP_FILENAME = "grakn-dist-" + GraknVersion.VERSION + ".zip";
+    public static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     public static final Path GRAKN_BASE_DIRECTORY = Paths.get(System.getProperty("main.basedir"));
-    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
+    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), ZIP_FILENAME);
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-dist-" + GraknVersion.VERSION);
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-core-" + GraknVersion.VERSION);
 
     public static void assertGraknRunning() {
         assertThat("assertGraknRunning() failed because /tmp/grakn-engine.pid is not found", Paths.get("/tmp/grakn-engine.pid").toFile().exists(), equalTo(true));

--- a/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
+++ b/grakn-test/test-distribution/src/test/java/ai/grakn/distribution/DistributionE2EConstants.java
@@ -34,7 +34,7 @@ public class DistributionE2EConstants {
     // path of grakn zip files
     public static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     public static final Path GRAKN_BASE_DIRECTORY = Paths.get(System.getProperty("main.basedir"));
-    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
+    public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), ZIP_FILENAME);
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution test", "grakn-core-" + GraknVersion.VERSION);
 

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
@@ -60,11 +60,11 @@ public class DistributionContext extends CompositeTestRule {
 
     public static final Logger LOG = LoggerFactory.getLogger(DistributionContext.class);
 
-    private static final String ZIP_FILENAME = "grakn-dist-" + GraknVersion.VERSION + ".zip";
+    private static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     private static final Path GRAKN_BASE_DIRECTORY = Paths.get(GraknSystemProperty.PROJECT_RELATIVE_DIR.value());
-    private static final Path TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
+    private static final Path TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
     private static final Path ZIP_FULLPATH = Paths.get(TARGET_DIRECTORY.toString(), ZIP_FILENAME);
-    private static final Path EXTRACTED_DISTRIBUTION_DIRECTORY = Paths.get(TARGET_DIRECTORY.toString(), "grakn-dist-" + GraknVersion.VERSION);
+    private static final Path EXTRACTED_DISTRIBUTION_DIRECTORY = Paths.get(TARGET_DIRECTORY.toString(), "grakn-core-" + GraknVersion.VERSION);
 
     private Process engineProcess;
     private int port = 4567;

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
@@ -62,7 +62,7 @@ public class DistributionContext extends CompositeTestRule {
 
     private static final String ZIP_FILENAME = "grakn-core-" + GraknVersion.VERSION + ".zip";
     private static final Path GRAKN_BASE_DIRECTORY = Paths.get(GraknSystemProperty.PROJECT_RELATIVE_DIR.value());
-    private static final Path TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-core", "target");
+    private static final Path TARGET_DIRECTORY = Paths.get(GRAKN_BASE_DIRECTORY.toString(), "grakn-dist", "target");
     private static final Path ZIP_FULLPATH = Paths.get(TARGET_DIRECTORY.toString(), ZIP_FILENAME);
     private static final Path EXTRACTED_DISTRIBUTION_DIRECTORY = Paths.get(TARGET_DIRECTORY.toString(), "grakn-core-" + GraknVersion.VERSION);
 


### PR DESCRIPTION
# Why is this PR needed?
The distribution file name is called `grakn-dist-$version`, which could be better. On thee other hand, we found that the `client-java-e2e` test wasn't added to the CircleCI workflow.

# What does the PR do?
- Update the distribution file name to `grakn-core-$version`, eg., `grakn-core-1.4.0`.
- Add the `client-java-e2e` to the CircelCI workflow

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A