### PR TITLE
Include join-explanations in gRPC answers

### DIFF
--- a/client-nodejs/tests/service/session/transaction/CommitTx.test.js
+++ b/client-nodejs/tests/service/session/transaction/CommitTx.test.js
@@ -76,6 +76,20 @@ describe('Integration test', () => {
         await localSession.close();
     });
 
+    test("explanation with join explanation", async () => {
+        const localSession = graknClient.session("gene");
+        const tx = await localSession.transaction(env.txType().WRITE);
+        const iterator = await tx.query(`match ($x, $y) isa marriage; ($y, $z) isa marriage;
+                                            $x != $z; get;`);
+        const answers = await iterator.collect();
+        expect(answers).toHaveLength(4);
+        answers.forEach(a=>{
+            expect(a.explanation).toBeDefined()
+        });
+        await tx.close()
+        await localSession.close();
+    });
+
     test("no results with infer false", async () => {
         const localSession = graknClient.session("gene");
         const tx = await localSession.transaction(env.txType().WRITE);

--- a/grakn-core/src/main/java/ai/grakn/graql/admin/Explanation.java
+++ b/grakn-core/src/main/java/ai/grakn/graql/admin/Explanation.java
@@ -21,6 +21,7 @@ package ai.grakn.graql.admin;
 import ai.grakn.graql.answer.ConceptMap;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -53,6 +54,7 @@ public interface Explanation {
     /**
      * @return query associated with this explanation
      */
+    @Nullable
     @CheckReturnValue
     ReasonerQuery getQuery();
 

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
@@ -269,7 +269,7 @@ public class ResponseBuilder {
         public static AnswerProto.Answer answer(Object object) {
             AnswerProto.Answer.Builder answer = AnswerProto.Answer.newBuilder();
 
-            if (object instanceof AnswerGroup){
+            if (object instanceof AnswerGroup) {
                 answer.setAnswerGroup(answerGroup((AnswerGroup) object));
             } else if (object instanceof ConceptMap) {
                 answer.setConceptMap(conceptMap((ConceptMap) object));
@@ -287,12 +287,11 @@ public class ResponseBuilder {
         }
 
         static AnswerProto.Explanation explanation(Explanation explanation) {
-            return AnswerProto.Explanation.newBuilder()
-                    .setPattern(explanation.getQuery().getPattern().toString())
-                    .addAllAnswers(explanation.getAnswers().stream()
-                            .map(Answer::conceptMap)
-                            .collect(Collectors.toList()))
-                    .build();
+            AnswerProto.Explanation.Builder builder = AnswerProto.Explanation.newBuilder()
+                    .addAllAnswers(explanation.getAnswers().stream().map(Answer::conceptMap)
+                            .collect(Collectors.toList()));
+            if (explanation.getQuery() != null) builder.setPattern(explanation.getQuery().getPattern().toString());
+            return builder.build();
         }
 
         static AnswerProto.AnswerGroup answerGroup(AnswerGroup<?> answer) {
@@ -301,7 +300,7 @@ public class ResponseBuilder {
                     .addAllAnswers(answer.answers().stream().map(Answer::answer).collect(Collectors.toList()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null) {
                 answerGroupProto.setExplanation(explanation(answer.explanation()));
             }
             return answerGroupProto.build();
@@ -315,7 +314,7 @@ public class ResponseBuilder {
             });
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null) {
                 conceptMapProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptMapProto.build();
@@ -326,7 +325,7 @@ public class ResponseBuilder {
             conceptListProto.setList(conceptIds(answer.list()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null) {
                 conceptListProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptListProto.build();
@@ -337,7 +336,7 @@ public class ResponseBuilder {
             conceptSetProto.setSet(conceptIds(answer.set()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null) {
                 conceptSetProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptSetProto.build();

--- a/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/rpc/ResponseBuilder.java
@@ -300,7 +300,7 @@ public class ResponseBuilder {
                     .addAllAnswers(answer.answers().stream().map(Answer::answer).collect(Collectors.toList()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 answerGroupProto.setExplanation(explanation(answer.explanation()));
             }
             return answerGroupProto.build();
@@ -314,7 +314,7 @@ public class ResponseBuilder {
             });
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 conceptMapProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptMapProto.build();
@@ -325,7 +325,7 @@ public class ResponseBuilder {
             conceptListProto.setList(conceptIds(answer.list()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 conceptListProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptListProto.build();
@@ -336,7 +336,7 @@ public class ResponseBuilder {
             conceptSetProto.setSet(conceptIds(answer.set()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 conceptSetProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptSetProto.build();
@@ -346,7 +346,7 @@ public class ResponseBuilder {
             AnswerProto.ConceptSetMeasure.Builder conceptSetMeasureProto = AnswerProto.ConceptSetMeasure.newBuilder();
             conceptSetMeasureProto.setSet(conceptIds(answer.set()));
             conceptSetMeasureProto.setMeasurement(number(answer.measurement()));
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 conceptSetMeasureProto.setExplanation(explanation(answer.explanation()));
             }
             return conceptSetMeasureProto.build();
@@ -357,7 +357,7 @@ public class ResponseBuilder {
             valueProto.setNumber(number(answer.number()));
 
             // TODO: answer.explanation should return null, rather than an instance where .getQuery() returns null
-            if (answer.explanation() != null && answer.explanation().getQuery() != null) {
+            if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 valueProto.setExplanation(explanation(answer.explanation()));
             }
             return valueProto.build();


### PR DESCRIPTION
# Why is this PR needed?

Server was not including join explanation in gRPC Answer object

# What does the PR do?

- Builds explanation even when `answer.explanation().getQuery()` is null (true for join-explanation)
- add nodejs test

# Does it break backwards compatibility?
no
# List of future improvements not on this PR

Add explanation also to Java client