### PR TITLE
Fixed docs sidebar to scroll with the page

### DIFF
--- a/docs/_jekyll/js/customscripts.js
+++ b/docs/_jekyll/js/customscripts.js
@@ -9,7 +9,7 @@ $( document ).ready(function() {
     var h = $(window).height();
     //console.log (h);
     if (h > 800) {
-        $( "#mysidebar" ).attr("class", "nav affix");
+        $( "#mysidebar" ).attr("class", "nav");
     }
     // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
     $('[data-toggle="tooltip"]').tooltip({
@@ -109,7 +109,7 @@ $( document ).ready(function() {
     //Footer Subscribe logic
     var footerSubscribeButton = $("#footer-subscribe-btn");
     var footerSubscribeInput = $("#footer-subscribe-input");
-    
+
     function validateEmail(email) {
         var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
         return re.test(email.toLowerCase());


### PR DESCRIPTION
# Why is this PR needed?

The documentation sidebar doesn't scroll with the page, which is a problem when the sidebar expands higher than the size of the screen.

# What does the PR do?

Make the sidebar scroll with the page by removing the fixed positioning.

# Does it break backwards compatibility?

# List of future improvements not on this PR
