### PR TITLE
Implement AnswerGroup printers (String, JSON, Jackson)

### DIFF
--- a/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/printer/JacksonPrinter.java
@@ -21,6 +21,7 @@ package ai.grakn.engine.printer;
 import ai.grakn.concept.Concept;
 import ai.grakn.engine.controller.response.Answer;
 import ai.grakn.engine.controller.response.ConceptBuilder;
+import ai.grakn.graql.answer.AnswerGroup;
 import ai.grakn.graql.answer.ConceptMap;
 import ai.grakn.graql.answer.ConceptSetMeasure;
 import ai.grakn.graql.internal.printer.Printer;
@@ -47,7 +48,7 @@ public class JacksonPrinter extends Printer<Object> {
     }
 
     @Override
-    public String complete(Object object) {
+    protected String complete(Object object) {
         try {
             return mapper.writeValueAsString(object);
         } catch (IOException e) {
@@ -56,12 +57,17 @@ public class JacksonPrinter extends Printer<Object> {
     }
 
     @Override
-    public Object concept(Concept concept) {
+    protected Object concept(Concept concept) {
         return ConceptBuilder.build(concept);
     }
 
     @Override
-    public Object conceptMap(ConceptMap answer) {
+    protected Object answerGroup(AnswerGroup<?> answer) {
+        return new HashMap.SimpleEntry<>(answer.owner(), build(answer.answers()));
+    }
+
+    @Override
+    protected Object conceptMap(ConceptMap answer) {
         return Answer.create(answer);
     }
 
@@ -71,17 +77,17 @@ public class JacksonPrinter extends Printer<Object> {
     }
 
     @Override
-    public Object bool(boolean bool) {
+    protected Object bool(boolean bool) {
         return bool;
     }
 
     @Override
-    public Object object(Object object) {
+    protected Object object(Object object) {
         return object;
     }
 
     @Override
-    public Object map(Map map) {
+    protected Object map(Map map) {
         Stream<Map.Entry> entries = map.<Map.Entry>entrySet().stream();
         return entries.collect(Collectors.toMap(
                 entry -> build(entry.getKey()),
@@ -90,7 +96,7 @@ public class JacksonPrinter extends Printer<Object> {
     }
 
     @Override
-    public Object collection(Collection collection) {
+    protected Object collection(Collection collection) {
         return collection.stream().map(object -> build(object)).collect(Collectors.toList());
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/JsonPrinter.java
@@ -22,6 +22,7 @@ import ai.grakn.concept.Concept;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.graql.Pattern;
 import ai.grakn.graql.Var;
+import ai.grakn.graql.answer.AnswerGroup;
 import ai.grakn.graql.answer.ConceptMap;
 import ai.grakn.graql.answer.ConceptSetMeasure;
 import ai.grakn.util.CommonUtil;
@@ -39,12 +40,12 @@ import static java.util.stream.Collectors.toList;
  */
 class JsonPrinter extends Printer<Json> {
     @Override
-    public final String complete(Json builder) {
+    protected final String complete(Json builder) {
         return builder.toString();
     }
 
     @Override
-    public Json concept(Concept concept) {
+    protected Json concept(Concept concept) {
         Json json = Json.object("id", concept.id().getValue());
 
         if (concept.isSchemaConcept()) {
@@ -76,7 +77,7 @@ class JsonPrinter extends Printer<Json> {
     }
 
     @Override
-    public final Json bool(boolean bool) {
+    protected final Json bool(boolean bool) {
         return Json.make(bool);
     }
 
@@ -86,7 +87,7 @@ class JsonPrinter extends Printer<Json> {
     }
 
     @Override
-    public final Json map(Map<?, ?> map) {
+    protected final Json map(Map<?, ?> map) {
         Json json = Json.object();
 
         map.forEach((Object key, Object value) -> {
@@ -95,6 +96,13 @@ class JsonPrinter extends Printer<Json> {
             json.set(keyString, build(value));
         });
 
+        return json;
+    }
+
+    @Override
+    protected Json answerGroup(AnswerGroup<?> answer) {
+        Json json = Json.object();
+        json.set(answer.toString(), build(answer.answers()));
         return json;
     }
 
@@ -111,7 +119,7 @@ class JsonPrinter extends Printer<Json> {
     }
 
     @Override
-    public final Json object(Object object) {
+    protected final Json object(Object object) {
         return Json.make(object);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/Printer.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/Printer.java
@@ -20,6 +20,7 @@ package ai.grakn.graql.internal.printer;
 
 import ai.grakn.concept.AttributeType;
 import ai.grakn.concept.Concept;
+import ai.grakn.graql.answer.AnswerGroup;
 import ai.grakn.graql.answer.ConceptList;
 import ai.grakn.graql.answer.ConceptMap;
 import ai.grakn.graql.answer.ConceptSet;
@@ -105,14 +106,14 @@ public abstract class Printer<Builder> {
         else if (object instanceof Collection) {
             return collection((Collection<?>) object);
         }
-        if (object instanceof Value) {
-            return value((Value) object);
-        }
-        else if (object instanceof ConceptMap) {
-            return conceptMap((ConceptMap) object);
+        else if (object instanceof AnswerGroup<?>) {
+            return answerGroup((AnswerGroup<?>) object);
         }
         else if (object instanceof ConceptList) {
             return conceptList((ConceptList) object);
+        }
+        else if (object instanceof ConceptMap) {
+            return conceptMap((ConceptMap) object);
         }
         else if (object instanceof ConceptSet) {
             if (object instanceof ConceptSetMeasure) {
@@ -121,6 +122,9 @@ public abstract class Printer<Builder> {
             else {
                 return conceptSet((ConceptSet) object);
             }
+        }
+        else if (object instanceof Value) {
+            return value((Value) object);
         }
         else if (object instanceof Map) {
             return map((Map<?, ?>) object);
@@ -174,6 +178,15 @@ public abstract class Printer<Builder> {
      */
     @CheckReturnValue
     protected abstract Builder map(Map<?, ?> map);
+
+    /**
+     * Convert any {@link AnswerGroup} into its print builder
+     *
+     * @param answer is the answer result of a Graql Compute queries
+     * @return the grouped answers as an output builder
+     */
+    @CheckReturnValue
+    protected abstract Builder answerGroup(AnswerGroup<?> answer);
 
     /**
      * Convert any {@link ConceptList} into its print builder

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/printer/StringPrinter.java
@@ -24,6 +24,7 @@ import ai.grakn.concept.Role;
 import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
+import ai.grakn.graql.answer.AnswerGroup;
 import ai.grakn.graql.answer.ConceptMap;
 import ai.grakn.graql.answer.ConceptSetMeasure;
 import ai.grakn.graql.internal.util.ANSI;
@@ -148,7 +149,17 @@ class StringPrinter extends Printer<StringBuilder> {
     }
 
     @Override
-    public StringBuilder conceptMap(ConceptMap answer) {
+    protected StringBuilder answerGroup(AnswerGroup<?> answer) {
+        StringBuilder builder = new StringBuilder();
+        return builder.append('{')
+                .append(concept(answer.owner()))
+                .append(": ")
+                .append(build(answer.answers()))
+                .append('}');
+    }
+
+    @Override
+    protected StringBuilder conceptMap(ConceptMap answer) {
         StringBuilder builder = new StringBuilder();
 
         answer.forEach((name, concept) -> builder.append(name).append(" ").append(concept(concept)).append("; "));

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -270,6 +270,23 @@ public class GraqlShellIT {
     }
 
     @Test
+    public void testAggregateGroupQuery() throws Exception {
+        assertShellMatches(
+                "define name sub attribute, datatype string;",
+                anything(),
+                "define person sub entity, has name;",
+                anything(),
+                "insert $x isa person, has name \"Alice\";",
+                anything(),
+                "insert $x isa person, has name \"Bob\";",
+                anything(),
+                "match $x isa person, has name $y; aggregate group $x;",
+                containsString("Alice"),
+                containsString("Bob")
+        );
+    }
+
+    @Test
     public void testAutocomplete() throws Exception {
         String result = runShellWithoutErrors("match $x isa \t");
 


### PR DESCRIPTION
# Why is this PR needed?

The new `AnswerGroup` data structure does not have a printer method implemented, introducing a bug in the GraqlShell when `aggregate group` query is made.

# What does the PR do?

- implement `AnswerGroup` printers for StringPrinter, JsonPrinter and JacksonPrinter
- added test in `GraqlShellIT`

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

Nope.