### PR TITLE
Show msg for no exisiting keyspaces

### DIFF
--- a/workbase/src/renderer/components/ManageKeyspaces/KeyspacesPage.vue
+++ b/workbase/src/renderer/components/ManageKeyspaces/KeyspacesPage.vue
@@ -9,7 +9,7 @@
           <div class="title">Keyspaces</div>
           <div class="list-container">
               <div class="ks-div noselect" v-for="ks in keyspaces" :key="ks">
-                  <div class="keyspace-label">{{ks}}</div> 
+                  <div class="left-side keyspace-label">{{ks}}</div> 
                   <div class="right-side">
                       <!-- <img @click="showSaveDialog(ks)" src="static/img/icons/icon_export_white.svg" width="19"> -->
                       <i v-bind:id="'delete-'+ks" @click="askConfirmation(ks)" class="fas fa-trash-alt"></i>

--- a/workbase/src/renderer/components/shared/KeyspacesHandler/KeyspacesHandler.vue
+++ b/workbase/src/renderer/components/shared/KeyspacesHandler/KeyspacesHandler.vue
@@ -7,6 +7,7 @@
         </div>
          <transition name="slide-fade">
             <ul id="keyspaces-list" class="keyspaces-list z-depth-3" v-show="toolTipShown === 'keyspaces'">
+                <div style="text-align:center;" v-if="keyspaces && !keyspaces.length">no available keyspace</div>
                 <li :id="ks" class="ks-key" v-for="ks in keyspaces" :key="ks" @click="setKeyspace(ks)">{{ks}}</li>
             </ul>
         </transition>  
@@ -92,7 +93,9 @@ export default {
   props: ['localStore', 'toolTipShown'],
   components: { CaretIcon },
   computed: {
-    keyspaces() { return this.$store.getters.allKeyspaces; },
+    keyspaces() {
+      return this.$store.getters.allKeyspaces;
+    },
     currentKeyspace() { return this.localStore.getCurrentKeyspace(); },
     isGraknRunning() { return this.$store.getters.isGraknRunning; },
   },

--- a/workbase/src/renderer/components/shared/KeyspacesHandler/KeyspacesHandler.vue
+++ b/workbase/src/renderer/components/shared/KeyspacesHandler/KeyspacesHandler.vue
@@ -7,7 +7,7 @@
         </div>
          <transition name="slide-fade">
             <ul id="keyspaces-list" class="keyspaces-list z-depth-3" v-show="toolTipShown === 'keyspaces'">
-                <div style="text-align:center;" v-if="keyspaces && !keyspaces.length">no available keyspace</div>
+                <div style="text-align:center;" v-if="keyspaces && !keyspaces.length">no existing keyspace</div>
                 <li :id="ks" class="ks-key" v-for="ks in keyspaces" :key="ks" @click="setKeyspace(ks)">{{ks}}</li>
             </ul>
         </transition>  

--- a/workbase/test/e2e/keyspaces.test.js
+++ b/workbase/test/e2e/keyspaces.test.js
@@ -40,7 +40,11 @@ describe('Favourite queries', () => {
     assert.equal(await app.client.getText('.toasted.primary.default'), 'New keyspace [test] successfully created!\nCLOSE');
   });
 
-  test('delete exisiting keyspace - TBD', async () => {
-    // TBD
+  test('delete exisiting keyspace', async () => {
+    app.client.click('#delete-test');
+    await sleep(1000);
+    app.client.click('.confirm');
+    await sleep(3000);
+    assert.equal(await app.client.getText('.toasted.primary.default'), 'Keyspace [test] successfully deleted\nCLOSE');
   });
 });


### PR DESCRIPTION
# Why is this PR needed?
-When user has no loaded keyspaces show message in keyspace dropdown menu

# What does the PR do?
-If keyspace array has length equal to 0, show message "no exisiting keyspace"

# Does it break backwards compatibility?
-No

# List of future improvements not on this PR
-Add link to menu to redirect to manage keyspaces page