### PR TITLE
[Workbase] Limit query for multi-line queries - bug 

### DIFF
--- a/workbase/src/renderer/components/DataManagement/DataManagementUtils.js
+++ b/workbase/src/renderer/components/DataManagement/DataManagementUtils.js
@@ -226,7 +226,7 @@ async function loadAttributes(node, limit, offset) {
 }
 
 function limitQuery(query) {
-  const getRegex = /^(.*;)\s*(get\b.*;)$/;
+  const getRegex = /^((.|\s)*;)\s*(get\b.*;)$/;
   let limitedQuery = query;
 
   // If there is no `get` the user mistyped the query
@@ -236,12 +236,11 @@ function limitQuery(query) {
     const deleteRegex = /^(.*;)\s*(delete\b.*;)$/;
     const match = getRegex.exec(query);
     limitedQuery = match[1];
-    const getPattern = match[2];
+    const getPattern = match[3];
     if (!(offsetRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} offset 0;`; }
     if (!(limitRegex.test(query)) && !(deleteRegex.test(query))) { limitedQuery = `${limitedQuery} limit ${QuerySettings.getQueryLimit()};`; }
     limitedQuery = `${limitedQuery} ${getPattern}`;
   }
-
   return limitedQuery;
 }
 

--- a/workbase/test/unit/components/DataManagement/DataManagementUtils.test.js
+++ b/workbase/test/unit/components/DataManagement/DataManagementUtils.test.js
@@ -37,6 +37,15 @@ describe('limitQuery', () => {
     const limited = DataManagementUtils.limitQuery(query);
     expect(limited).toBe(query);
   });
+  test('query containing multi-line queries', () => {
+    const query = `
+    match $x isa person; 
+    $r($x, $y); get;`;
+    const limited = DataManagementUtils.limitQuery(query);
+    expect(limited).toBe(`
+    match $x isa person; 
+    $r($x, $y); offset 0; limit 10; get;`);
+  });
 });
 
 describe('prepareNodes', () => {


### PR DESCRIPTION
# Why is this PR needed?
Queries with multi line queries were not limited

# What does the PR do?
Update the regex to match multi line queries to limit them

# Does it break backwards compatibility?
No 

# List of future improvements not on this PR
None