### PR TITLE
change font of canvas and graql editor to Lekton

### DIFF
--- a/workbase/src/renderer/components/DataManagement/Style.js
+++ b/workbase/src/renderer/components/DataManagement/Style.js
@@ -118,7 +118,7 @@ function nodeFont() {
     color: '#ffffff',
     dimmedColor: 'rgba(32, 161, 148, 0.5)',
     size: 15,
-    face: 'Geogrotesque-Ultralight',
+    face: 'Lekton',
   };
 }
 

--- a/workbase/static/styles/style.css
+++ b/workbase/static/styles/style.css
@@ -18,7 +18,6 @@ time, mark, audio, video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
   vertical-align: baseline; }
 
 ul {


### PR DESCRIPTION
# Why is this PR needed?
Graql editor and canvas fonts were inconsistent

# What does the PR do?
update fonts for canvas and Graql editor to Lekton.
(I tried Ubuntu, but Lekton looks much better)

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
No