### PR TITLE
Fixed aggregate count argument restriction in QueryParserImpl

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/parser/QueryParserImpl.java
@@ -105,8 +105,7 @@ public class QueryParserImpl implements QueryParser {
         registerAggregate(name, numArgs, numArgs, aggregateMethod);
     }
 
-    private void registerAggregate(
-            String name, int minArgs, int maxArgs, Function<List<Object>, Aggregate> aggregateMethod) {
+    private void registerAggregate(String name, int minArgs, int maxArgs, Function<List<Object>, Aggregate> aggregateMethod) {
         aggregateMethods.put(name, args -> {
             if (args.size() < minArgs || args.size() > maxArgs) {
                 throw GraqlQueryException.incorrectAggregateArgumentNumber(name, minArgs, maxArgs, args);
@@ -249,9 +248,10 @@ public class QueryParserImpl implements QueryParser {
 
     // Aggregate methods that include other aggregates, such as group are not necessarily safe at runtime.
     // This is unavoidable in the parser.
+    // TODO: remove this manual registration of aggregate queries and design it into the grammar
     @SuppressWarnings("unchecked")
     private void registerDefaultAggregates() {
-        registerAggregate("count", 0, args -> Graql.count());
+        registerAggregate("count", 0, Integer.MAX_VALUE, args -> Graql.count());
         registerAggregate("sum", 1, args -> Aggregates.sum((Var) args.get(0)));
         registerAggregate("max", 1, args -> Aggregates.max((Var) args.get(0)));
         registerAggregate("min", 1, args -> Aggregates.min((Var) args.get(0)));

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/parser/QueryParserTest.java
@@ -1051,14 +1051,6 @@ public class QueryParserTest {
     }
 
     @Test
-    public void whenParsingAggregateWithWrongArgumentNumber_Throw() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(ErrorMessage.AGGREGATE_ARGUMENT_NUM.getMessage("count", 0, 1));
-        //noinspection ResultOfMethodCallIgnored
-        parse("match $x isa name; aggregate count $x;");
-    }
-
-    @Test
     public void whenParsingAggregateWithWrongVariableArgumentNumber_Throw() {
         exception.expect(GraqlQueryException.class);
         exception.expectMessage(ErrorMessage.AGGREGATE_ARGUMENT_NUM.getMessage("group", "1-2", 0));

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -243,11 +243,11 @@ public class GraqlShellIT {
         assertShellMatches(
                 "define entity2 sub entity;",
                 anything(),
-                "match $x isa entity2; aggregate count;",
+                "match $x isa entity2; aggregate count $x;",
                 containsString("0"),
                 "insert $x isa entity2;",
                 anything(),
-                "match $x isa entity2; aggregate count;",
+                "match $x isa entity2; aggregate count $x;",
                 containsString("1")
         );
     }


### PR DESCRIPTION
# Why is this PR needed?

`QueryParserImpl` was restricting the number of arguments an aggregate count query can take in. This manual hard coding of the query grammar should not exist in the first place, but we can fix the range restriction for now.

# What does the PR do?

1. Change the max number of arguments an aggregate count is registered to take
2. Modify test in GraqlShellIT to catch this bug

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

Remove manual registration of aggregate queries.