### PR TITLE
Changed shell output test to be order agnostic

### DIFF
--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/graql/shell/GraqlShellIT.java
@@ -55,6 +55,7 @@ import java.util.stream.Stream;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -281,8 +282,8 @@ public class GraqlShellIT {
                 "insert $x isa person, has name \"Bob\";",
                 anything(),
                 "match $x isa person, has name $y; aggregate group $x;",
-                containsString("Alice"),
-                containsString("Bob")
+                anyOf(containsString("Alice"),containsString("Bob")),
+                anyOf(containsString("Alice"),containsString("Bob"))
         );
     }
 


### PR DESCRIPTION
# Why is this PR needed?

An aggregate group query test in GraqlShellIT tries to validate the output of a map, in which the order is not guaranteed. In the future, we should make the output order to be guaranteed, this is possible even with a map, and there is already a TP ticket for it. But for now, we can just fix the test so that it doesn't randomly fail.

# What does the PR do?

Replace the output "matchers" to check for any occurrence of map entry.

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

We should make the output order to be guaranteed.