### PR TITLE
Fix issue with rule rewriting for type atoms

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -307,23 +307,19 @@ public abstract class Atom extends AtomicBase {
      */
     public Set<Atom> rewriteToAtoms(){ return Sets.newHashSet(this);}
 
-    public abstract Atom rewriteWithTypeVariable();
-
     /**
      * rewrites the atom to user-defined type variable
      * @param parentAtom parent atom that triggers rewrite
      * @return rewritten atom
      */
-    protected Atom rewriteWithTypeVariable(Atom parentAtom){
-        if (this.getPredicateVariable().isUserDefinedName() || !parentAtom.getPredicateVariable().isUserDefinedName()) return this;
-        return rewriteWithTypeVariable();
+    public Atom rewriteWithTypeVariable(Atom parentAtom){
+        if (parentAtom.getPredicateVariable().isUserDefinedName()
+                && !this.getPredicateVariable().isUserDefinedName()
+                && this.getClass() == parentAtom.getClass() ){
+            return rewriteWithTypeVariable();
+        }
+        return this;
     }
-
-    /**
-     * rewrites the atom to one with user defined relation variable
-     * @return rewritten atom
-     */
-    public Atom rewriteWithRelationVariable(){ return this;}
 
     /**
      * rewrites the atom to one with suitably user-defined names depending on provided parent
@@ -331,6 +327,15 @@ public abstract class Atom extends AtomicBase {
      * @return rewritten atom
      */
     public abstract Atom rewriteToUserDefined(Atom parentAtom);
+
+
+    public abstract Atom rewriteWithTypeVariable();
+
+    /**
+     * rewrites the atom to one with user defined relation variable
+     * @return rewritten atom
+     */
+    public Atom rewriteWithRelationVariable(){ return this;}
 
     /**
      * @param parentAtom atom to be unified with

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/IsaAtom.java
@@ -223,8 +223,6 @@ public abstract class IsaAtom extends IsaAtomBase {
 
     @Override
     public Atom rewriteToUserDefined(Atom parentAtom) {
-        return parentAtom.getPredicateVariable().isUserDefinedName()?
-                rewriteWithTypeVariable() :
-                this;
+        return this.rewriteWithTypeVariable(parentAtom);
     }
 }

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -1005,8 +1005,6 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return Stream.of(substitution.merge(relationSub));
     }
 
-
-
     /**
      * if any {@link Role} variable of the parent is user defined rewrite ALL {@link Role} variables to user defined (otherwise unification is problematic)
      * @param parentAtom parent atom that triggers rewrite

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -339,8 +339,8 @@ public abstract class ResourceAtom extends Binary{
      * @return rewritten atom
      */
     private ResourceAtom rewriteWithRelationVariable(Atom parentAtom){
-        if (!parentAtom.isResource() || !((ResourceAtom) parentAtom).getRelationVariable().isUserDefinedName()) return this;
-        return rewriteWithRelationVariable();
+        if (parentAtom.isResource() && ((ResourceAtom) parentAtom).getRelationVariable().isUserDefinedName()) return rewriteWithRelationVariable();
+        return this;
     }
 
     @Override

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/AtomicState.java
@@ -77,7 +77,9 @@ class AtomicState extends QueryState<ReasonerAtomicQuery>{
         ConceptMap baseAnswer = state.getSubstitution();
         InferenceRule rule = state.getRule();
         Unifier unifier = state.getUnifier();
-        if (rule == null) answer = state.getSubstitution();
+        if (rule == null){
+            answer = baseAnswer.merge(query.getSubstitution());
+        }
         else{
             answer = rule.requiresMaterialisation(query.getAtom()) ?
                     materialisedAnswer(baseAnswer, rule, unifier) :

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
@@ -49,7 +49,7 @@ public class OntologicalQueryTest {
     @Rule
     public final SampleKBContext matchingTypesContext = SampleKBContext.load("matchingTypesTest.gql");
 
-    @Test @Ignore("to be fixed soon - flaky")
+    @Test
     public void instancePairsRelatedToSameTypeOfEntity(){
         GraknTx tx = matchingTypesContext.tx();
         String basePattern = "$x isa service;" +


### PR DESCRIPTION
# Why is this PR needed?
Body atoms were only rewritten if they were relations leading to possible ambiguities and invalid cache entries.
# What does the PR do?
Cleans up the rule rewrite code and includes other types of atoms.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.