### PR TITLE
Add metadata map field to gRPC protocols

### DIFF
--- a/client-protocol/proto/Session.proto
+++ b/client-protocol/proto/Session.proto
@@ -16,6 +16,7 @@ service SessionService {
 
 message Transaction {
     message Req {
+        map<string, string> metadata = 1000;
         oneof req {
             Open.Req open_req = 1;
             Commit.Req commit_req = 2;
@@ -33,6 +34,7 @@ message Transaction {
         }
     }
     message Res {
+        map<string, string> metadata = 1000;
         oneof res {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;


### PR DESCRIPTION
# Why is this PR needed?
Profiling & KGMS credential support in Transaction.Req and Transcation.Res

# What does the PR do?
adds metadata field to our gRPC protocol

# Does it break backwards compatibility?
no

# List of future improvements not on this PR
-
