### PR TITLE
Ensure correct propagation of attribute relation hierarchies

### DIFF
--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
@@ -192,6 +192,16 @@ public class ReasoningTest {
         List<ConceptMap> baseResourceSubs = qb.<GetQuery>parse("match $x sub baseResource; get;").execute();
         List<ConceptMap> baseResourceRelationSubs = qb.<GetQuery>parse("match $x sub @has-baseResource; get;").execute();
         assertEquals(baseResourceSubs.size(), baseResourceRelationSubs.size());
+
+        assertEquals(
+                Sets.newHashSet(
+                        tx.getAttributeType("extendedResource"),
+                        tx.getAttributeType("anotherExtendedResource"),
+                        tx.getAttributeType("furtherExtendedResource"),
+                        tx.getAttributeType("simpleResource")
+                ),
+                tx.getEntityType("genericEntity").attributes().collect(toSet())
+        );
     }
 
     @Test

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
@@ -188,6 +188,10 @@ public class ReasoningTest {
 
         assertEquals(attributeSubs.size(), attributeRelationSubs.size());
         assertTrue(attributeRelationSubs.stream().map(ans -> ans.get("x")).map(Concept::asRelationshipType).allMatch(relTypes::contains));
+
+        List<ConceptMap> baseResourceSubs = qb.<GetQuery>parse("match $x sub baseResource; get;").execute();
+        List<ConceptMap> baseResourceRelationSubs = qb.<GetQuery>parse("match $x sub @has-baseResource; get;").execute();
+        assertEquals(baseResourceSubs.size(), baseResourceRelationSubs.size());
     }
 
     @Test

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
@@ -413,7 +413,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         //attributeType plays valueRole;
         ((AttributeTypeImpl) attributeType).play(valueRole, false);
 
-        updateAttributeRelationHierarchy(attributeType, has, hasOwner, hasValue, ownerRole, valueRole, relationshipType);
+        updateAttributeRelationHierarchy(attributeType, has, hasValue, hasOwner, ownerRole, valueRole, relationshipType);
 
         return getThis();
     }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
@@ -369,7 +369,27 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         return getThis();
     }
 
+    private void updateAttributeRelationHierarchy(AttributeType attributeType, Schema.ImplicitType has, Schema.ImplicitType hasValue, Schema.ImplicitType hasOwner,
+                                     Role ownerRole, Role valueRole, RelationshipType relationshipType){
+        AttributeType attributeTypeSuper = attributeType.sup();
+        Label superLabel = attributeTypeSuper.label();
+        Role ownerRoleSuper = vertex().tx().putRoleTypeImplicit(hasOwner.getLabel(superLabel));
+        Role valueRoleSuper = vertex().tx().putRoleTypeImplicit(hasValue.getLabel(superLabel));
+        RelationshipType relationshipTypeSuper = vertex().tx().putRelationTypeImplicit(has.getLabel(superLabel)).
+                relates(ownerRoleSuper).relates(valueRoleSuper);
 
+        //Create the super type edges from sub role/relations to super roles/relation
+        ownerRole.sup(ownerRoleSuper);
+        valueRole.sup(valueRoleSuper);
+        relationshipType.sup(relationshipTypeSuper);
+
+        if (!Schema.MetaSchema.ATTRIBUTE.getLabel().equals(superLabel)) {
+            //Make sure the supertype attribute is linked with the role as well
+            ((AttributeTypeImpl) attributeTypeSuper).plays(valueRoleSuper);
+            updateAttributeRelationHierarchy(attributeTypeSuper, has, hasValue, hasOwner, ownerRoleSuper, valueRoleSuper, relationshipTypeSuper);
+        }
+
+    }
     /**
      * Creates a relation type which allows this type and a {@link ai.grakn.concept.Attribute} type to be linked.
      * @param attributeType The {@link AttributeType} which instances of this type should be allowed to play.
@@ -393,34 +413,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         //attributeType plays valueRole;
         ((AttributeTypeImpl) attributeType).play(valueRole, false);
 
-        //Link with full sub structure of relation resources
-        AttributeType attributeTypeSuper = attributeType.sup();
-        while(attributeTypeSuper != null) {
-            Label superLabel = attributeTypeSuper.label();
-
-            Role ownerRoleSuper = vertex().tx().putRoleTypeImplicit(hasOwner.getLabel(superLabel));
-            Role valueRoleSuper = vertex().tx().putRoleTypeImplicit(hasValue.getLabel(superLabel));
-            RelationshipType relationshipTypeSuper = vertex().tx().putRelationTypeImplicit(has.getLabel(superLabel)).
-                    relates(ownerRoleSuper).relates(valueRoleSuper);
-
-            //Create the super type edges from sub role/relations to super roles/relation
-            ownerRole.sup(ownerRoleSuper);
-            valueRole.sup(valueRoleSuper);
-            relationshipType.sup(relationshipTypeSuper);
-
-            if (!Schema.MetaSchema.ATTRIBUTE.getLabel().equals(superLabel)) {
-                //Make sure the supertype attribute is linked with the role as well
-                ((AttributeTypeImpl) attributeTypeSuper).plays(valueRoleSuper);
-                attributeTypeSuper = attributeTypeSuper.sup();
-
-                //reset the current resource relation
-                ownerRole = ownerRoleSuper;
-                valueRole = valueRoleSuper;
-                relationshipType = relationshipTypeSuper;
-            } else {
-                attributeTypeSuper = null;
-            }
-        }
+        updateAttributeRelationHierarchy(attributeType, has, hasOwner, hasValue, ownerRole, valueRole, relationshipType);
 
         return getThis();
     }

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTypeTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/concept/EntityTypeTest.java
@@ -257,11 +257,12 @@ public class EntityTypeTest extends TxTestBase {
         Label superLabel = Label.of("Super Attribute Type");
         Label label = Label.of("Attribute Type");
 
-        AttributeType rtSuper = tx.putAttributeType(superLabel, AttributeType.DataType.STRING);
-        AttributeType rt = tx.putAttributeType(label, AttributeType.DataType.STRING).sup(rtSuper);
+        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.DataType.STRING);
+        AttributeType attributeType = tx.putAttributeType(label, AttributeType.DataType.STRING).sup(superAttributeType);
+        AttributeType metaType = tx.getMetaAttributeType();
 
-        entityType1.has(rtSuper);
-        entityType2.has(rt);
+        entityType1.has(superAttributeType);
+        entityType2.has(attributeType);
 
         //Check role types are only built explicitly
         assertThat(entityType1.playing().collect(toSet()),
@@ -271,17 +272,64 @@ public class EntityTypeTest extends TxTestBase {
                 containsInAnyOrder(tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(label).getValue())));
 
         //Check Implicit Types Follow SUB Structure
-        RelationshipType rtSuperRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(rtSuper.label()));
-        Role rtSuperRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(rtSuper.label()));
-        Role rtSuperRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(rtSuper.label()));
+        RelationshipType superRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()));
+        Role superRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(superAttributeType.label()));
+        Role superRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(superAttributeType.label()));
 
-        RelationshipType rtRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(rt.label()));
-        Role reRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(rt.label()));
-        Role reRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(rt.label()));
+        RelationshipType relation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(attributeType.label()));
+        Role roleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(attributeType.label()));
+        Role roleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(attributeType.label()));
 
-        assertEquals(rtSuperRoleOwner, reRoleOwner.sup());
-        assertEquals(rtSuperRoleValue, reRoleValue.sup());
-        assertEquals(rtSuperRelation, rtRelation.sup());
+        RelationshipType metaRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(metaType.label()));
+        Role metaRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(metaType.label()));
+        Role metaRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(metaType.label()));
+
+        assertEquals(superRoleOwner, roleOwner.sup());
+        assertEquals(superRoleValue, roleValue.sup());
+        assertEquals(superRelation, relation.sup());
+
+        assertEquals(metaRoleOwner, superRoleOwner.sup());
+        assertEquals(metaRoleValue, superRoleValue.sup());
+        assertEquals(metaRelation, superRelation.sup());
+    }
+
+    @Test
+    public void whenAddingResourceWithAbstractSuperTypeToEntityType_EnsureImplicitStructureFollowsSubTypes(){
+        EntityType entityType = tx.putEntityType("Entity Type");
+
+        Label superLabel = Label.of("Abstract Super Attribute Type");
+        Label label = Label.of("Attribute Type");
+
+        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.DataType.STRING);
+        AttributeType attributeType = tx.putAttributeType(label, AttributeType.DataType.STRING).sup(superAttributeType);
+        AttributeType metaType = tx.getMetaAttributeType();
+
+        entityType.has(attributeType);
+
+        //Check role types are only built explicitly
+        assertThat(entityType.playing().collect(toSet()),
+                containsInAnyOrder(tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(label).getValue())));
+
+        //Check Implicit Types Follow SUB Structure
+        RelationshipType superRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()));
+        Role superRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(superAttributeType.label()));
+        Role superRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(superAttributeType.label()));
+
+        RelationshipType relation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(attributeType.label()));
+        Role roleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(attributeType.label()));
+        Role roleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(attributeType.label()));
+
+        RelationshipType metaRelation = tx.getSchemaConcept(Schema.ImplicitType.HAS.getLabel(metaType.label()));
+        Role metaRoleOwner = tx.getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(metaType.label()));
+        Role metaRoleValue = tx.getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(metaType.label()));
+
+        assertEquals(superRoleOwner, roleOwner.sup());
+        assertEquals(superRoleValue, roleValue.sup());
+        assertEquals(superRelation, relation.sup());
+
+        assertEquals(metaRoleOwner, superRoleOwner.sup());
+        assertEquals(metaRoleValue, superRoleValue.sup());
+        assertEquals(metaRelation, superRelation.sup());
     }
 
     @Test

--- a/grakn-test-tools/src/main/graql/resourceHierarchy.gql
+++ b/grakn-test-tools/src/main/graql/resourceHierarchy.gql
@@ -1,7 +1,6 @@
 define
 
 genericEntity sub entity
-    has baseResource
     has extendedResource
     has anotherExtendedResource
     has furtherExtendedResource


### PR DESCRIPTION
# Why is this PR needed?
To make sure the hierarchies of attributes relations reflect hierarchies of their corresponding attributes. This is needed to ensure `has` traversals have necessary information when abstract attributes are part of attribute hierarchy.
# What does the PR do?
When performing a `has`, all links from the input `attributeType` attribute relation up to the `{has, key}-attribute` relation are added.
# Does it break backwards compatibility?
**YES**. 

Similarly to https://github.com/graknlabs/grakn/pull/2942,
With naive migration from previous versions, the schema will be lacking some attribute relations which may lead to empty responses from has queries. The missing attribute relations can be added manually however.
# List of future improvements not on this PR
None.