### PR TITLE
Fix fetching attributes and attribute owners with the core api

### DIFF
--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
@@ -209,12 +209,6 @@ public class ReasoningTest {
         EmbeddedGraknTx<?> tx = resourceOwnership.tx();
         QueryBuilder qb = tx.graql().infer(true);
 
-        /**
-         * $step isa step;
-         $module isa module;
-
-         */
-
         String attributeName = "name";
         String queryString = "match $x has " + attributeName + " $y; get;";
 
@@ -228,6 +222,7 @@ public class ReasoningTest {
         List<ConceptMap> answers = qb.<GetQuery>parse(queryString).execute();
 
         tx.getMetaEntityType().instances().forEach(entity -> assertThat(entity.attributes().collect(toSet()), empty()));
+        tx.admin().getAttributeType("name").instances().forEach(attribute -> assertThat(attribute.owners().collect(toSet()), empty()));
 
         assertThat(answers, empty());
         assertCollectionsEqual(implicitAnswers, answers);

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ReasoningTest.java
@@ -209,6 +209,12 @@ public class ReasoningTest {
         EmbeddedGraknTx<?> tx = resourceOwnership.tx();
         QueryBuilder qb = tx.graql().infer(true);
 
+        /**
+         * $step isa step;
+         $module isa module;
+
+         */
+
         String attributeName = "name";
         String queryString = "match $x has " + attributeName + " $y; get;";
 
@@ -220,6 +226,8 @@ public class ReasoningTest {
 
         List<ConceptMap> implicitAnswers = qb.<GetQuery>parse(implicitQueryString).execute();
         List<ConceptMap> answers = qb.<GetQuery>parse(queryString).execute();
+
+        tx.getMetaEntityType().instances().forEach(entity -> assertThat(entity.attributes().collect(toSet()), empty()));
 
         assertThat(answers, empty());
         assertCollectionsEqual(implicitAnswers, answers);

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
@@ -27,6 +27,7 @@ import ai.grakn.concept.LabelId;
 import ai.grakn.concept.Relationship;
 import ai.grakn.concept.RelationshipType;
 import ai.grakn.concept.Role;
+import ai.grakn.concept.SchemaConcept;
 import ai.grakn.concept.Thing;
 import ai.grakn.concept.Type;
 import ai.grakn.exception.GraknTxOperationException;
@@ -48,8 +49,10 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static ai.grakn.util.Schema.EdgeProperty.RELATIONSHIP_TYPE_LABEL_ID;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * <p>
@@ -121,7 +124,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
             Role role = casting.getRole();
             relationship.unassign(role, this);
             return relationship;
-        }).collect(Collectors.toSet());
+        }).collect(toSet());
 
         vertex().tx().txCache().removedInstance(type().id());
         deleteNode();
@@ -146,14 +149,14 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
 
     @Override
     public Stream<Attribute<?>> attributes(AttributeType... attributeTypes) {
-        Set<ConceptId> attributeTypesIds = Arrays.stream(attributeTypes).map(Concept::id).collect(Collectors.toSet());
+        Set<ConceptId> attributeTypesIds = Arrays.stream(attributeTypes).map(Concept::id).collect(toSet());
         return attributes(getShortcutNeighbours(), attributeTypesIds);
     }
 
     @Override
     public Stream<Attribute<?>> keys(AttributeType... attributeTypes){
-        Set<ConceptId> attributeTypesIds = Arrays.stream(attributeTypes).map(Concept::id).collect(Collectors.toSet());
-        Set<ConceptId> keyTypeIds = type().keys().map(Concept::id).collect(Collectors.toSet());
+        Set<ConceptId> attributeTypesIds = Arrays.stream(attributeTypes).map(Concept::id).collect(toSet());
+        Set<ConceptId> keyTypeIds = type().keys().map(Concept::id).collect(toSet());
 
         if(!attributeTypesIds.isEmpty()){
             keyTypeIds = Sets.intersection(attributeTypesIds, keyTypeIds);
@@ -193,13 +196,35 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
                 map(edge -> Casting.withThing(edge, this));
     }
 
-    <X extends Thing> Stream<X> getShortcutNeighbours(){
-        GraphTraversal<Object, Vertex> shortcutTraversal = __.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
-                as("edge").
-                outV().
-                outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
-                where(P.neq("edge")).
-                inV();
+    <X extends Thing> Stream<X> getShortcutNeighbours(AttributeType... attributeTypes){
+        Set<AttributeType> completeAttributeTypes = new HashSet<>(Arrays.asList(attributeTypes));
+        if (completeAttributeTypes.isEmpty()) completeAttributeTypes.add(vertex().tx().getMetaAttributeType());
+
+        Set<Integer> typeIds = completeAttributeTypes.stream()
+                .flatMap(t -> (Stream<AttributeType>) t.subs())
+                .map(SchemaConcept::label)
+                .map(Schema.ImplicitType.HAS::getLabel)
+                .map(label -> vertex().tx().convertToId(label))
+                .filter(id -> !id.equals(LabelId.invalid()))
+                .map(LabelId::getValue)
+                .collect(toSet());
+
+        GraphTraversal<Object, Vertex> shortcutTraversal = !typeIds.isEmpty()?
+                __.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
+                        as("edge").
+                        has(RELATIONSHIP_TYPE_LABEL_ID.name(), P.within(typeIds)).
+                        outV().
+                        outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
+                        has(RELATIONSHIP_TYPE_LABEL_ID.name(), P.within(typeIds)).
+                        where(P.neq("edge")).
+                        inV()
+                :
+                __.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
+                        as("edge").
+                        outV().
+                        outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
+                        where(P.neq("edge")).
+                        inV();
 
         GraphTraversal<Object, Vertex> attributeEdgeTraversal = __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()).inV();
 
@@ -227,7 +252,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         if(roles.length == 0){
             traversal.in(Schema.EdgeLabel.ROLE_PLAYER.getLabel());
         } else {
-            Set<Integer> roleTypesIds = Arrays.stream(roles).map(r -> r.labelId().getValue()).collect(Collectors.toSet());
+            Set<Integer> roleTypesIds = Arrays.stream(roles).map(r -> r.labelId().getValue()).collect(toSet());
             traversal.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
                     has(Schema.EdgeProperty.ROLE_LABEL_ID.name(), P.within(roleTypesIds)).outV();
         }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/ThingImpl.java
@@ -203,12 +203,16 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         Set<Integer> typeIds = completeAttributeTypes.stream()
                 .flatMap(t -> (Stream<AttributeType>) t.subs())
                 .map(SchemaConcept::label)
-                .map(Schema.ImplicitType.HAS::getLabel)
+                .flatMap(label -> Stream.of(
+                        Schema.ImplicitType.HAS.getLabel(label),
+                        Schema.ImplicitType.KEY.getLabel(label))
+                )
                 .map(label -> vertex().tx().convertToId(label))
                 .filter(id -> !id.equals(LabelId.invalid()))
                 .map(LabelId::getValue)
                 .collect(toSet());
 
+        //NB: need extra check cause it seems valid types can still produce invalid ids
         GraphTraversal<Object, Vertex> shortcutTraversal = !typeIds.isEmpty()?
                 __.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
                         as("edge").

--- a/grakn-kb/src/test/java/ai/grakn/kb/internal/PostProcessingTest.java
+++ b/grakn-kb/src/test/java/ai/grakn/kb/internal/PostProcessingTest.java
@@ -150,8 +150,8 @@ public class PostProcessingTest extends TxTestBase {
         }
 
         assertNotNull(foundR1);
-        assertThat(foundR1.owners().collect(toSet()), containsInAnyOrder(e1, e2, e3));
         assertEquals(6, tx.admin().getMetaRelationType().instances().count());
+        assertThat(foundR1.owners().collect(toSet()), containsInAnyOrder(e2, e3));
     }
 
     private void addEdgeRelation(Entity entity, Attribute<?> attribute) {


### PR DESCRIPTION
# Why is this PR needed?
Fixes same problem as https://github.com/graknlabs/grakn/pull/2942 but at the core API level.

# What does the PR do?
Introduces relation type information into the traversal fetching attributes/owners.

# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.