### PR TITLE
Improve the m2 cache handling from using CI cache to workflow. Fix failing test caused by an invalid CI cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,14 @@ references:
     restore_m2_cache: &restore_m2_cache
       restore_cache:
         name: Restore maven m2 cache
-        key: grakn-cache-m2-version-8
+        key: grakn-cache-m2-version-9
 
     save_m2_cache: &save_m2_cache
       save_cache:
         name: Save maven m2 cache
         paths:
           - ~/.m2
-        key: grakn-cache-m2-version-8
+        key: grakn-cache-m2-version-9
 
     list_unit_tests: &list_unit_tests
       run:
@@ -75,9 +75,10 @@ jobs:
       - *install_node
       - *restore_m2_cache
       - run: mvn versions:set -DnewVersion=test -DgenerateBackupPoms=false # sets version to be `test` so that we can refer to zip using always grakn-core-test
-      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
+      - run: mvn --batch-mode package dependency:go-offline -T 2.5C -DskipTests=true
       - run: tar -xf grakn-dist/target/grakn-core-test.tar.gz -C grakn-dist/target/
       - *save_m2_cache
+      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - persist_to_workspace: #share Grakn with other jobs by putting it in the workspace
           root: ~/grakn
           paths:
@@ -287,10 +288,11 @@ jobs:
       - *install_node
       - *restore_m2_cache
       - run: echo 'export GRAKN_VERSION=$(echo ${CIRCLE_TAG} | cut -c 2-)' >> $BASH_ENV #remove 'v' from tag name and use it as Grakn Version to be released
-      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
+      - run: mvn --batch-mode package dependency:go-offline -T 2.5C -DskipTests=true
       - run: mkdir ~/grakn/artifacts
       - run: mv grakn-dist/target/grakn-core-${GRAKN_VERSION}.zip ~/grakn/artifacts
       - *save_m2_cache
+      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - persist_to_workspace: #share Grakn with other jobs by putting it in the workspace
           root: ~/grakn
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,14 +31,14 @@ references:
     restore_m2_cache: &restore_m2_cache
       restore_cache:
         name: Restore maven m2 cache
-        key: grakn-cache-m2-version-9
+        key: grakn-cache-m2-version-8
 
     save_m2_cache: &save_m2_cache
       save_cache:
         name: Save maven m2 cache
         paths:
           - ~/.m2
-        key: grakn-cache-m2-version-9
+        key: grakn-cache-m2-version-8
 
     list_unit_tests: &list_unit_tests
       run:
@@ -75,10 +75,9 @@ jobs:
       - *install_node
       - *restore_m2_cache
       - run: mvn versions:set -DnewVersion=test -DgenerateBackupPoms=false # sets version to be `test` so that we can refer to zip using always grakn-core-test
-      - run: mvn --batch-mode package dependency:go-offline -T 2.5C -DskipTests=true
+      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - run: tar -xf grakn-dist/target/grakn-core-test.tar.gz -C grakn-dist/target/
       - *save_m2_cache
-      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - persist_to_workspace: #share Grakn with other jobs by putting it in the workspace
           root: ~/grakn
           paths:
@@ -288,11 +287,10 @@ jobs:
       - *install_node
       - *restore_m2_cache
       - run: echo 'export GRAKN_VERSION=$(echo ${CIRCLE_TAG} | cut -c 2-)' >> $BASH_ENV #remove 'v' from tag name and use it as Grakn Version to be released
-      - run: mvn --batch-mode package dependency:go-offline -T 2.5C -DskipTests=true
+      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - run: mkdir ~/grakn/artifacts
       - run: mv grakn-dist/target/grakn-core-${GRAKN_VERSION}.zip ~/grakn/artifacts
       - *save_m2_cache
-      - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - persist_to_workspace: #share Grakn with other jobs by putting it in the workspace
           root: ~/grakn
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,16 +29,21 @@ references:
         at: ~/grakn
 
     restore_m2_cache: &restore_m2_cache
-      restore_cache:
+      run:
         name: Restore maven m2 cache
-        key: grakn-cache-m2-version-8
+        command: |
+          du -shc ~/grakn/m2
+          rm -r ~/.m2
+          mv ~/grakn/m2 ~/.m2
+          du -shc ~/.m2
 
     save_m2_cache: &save_m2_cache
-      save_cache:
+      run:
         name: Save maven m2 cache
-        paths:
-          - ~/.m2
-        key: grakn-cache-m2-version-8
+        command: |
+          du -shc ~/.m2
+          cp -r ~/.m2 ~/grakn/m2
+          du -shc ~/grakn/m2
 
     list_unit_tests: &list_unit_tests
       run:
@@ -73,7 +78,6 @@ jobs:
       - *prepare_apt_repositories
       - *install_yarn_and_maven
       - *install_node
-      - *restore_m2_cache
       - run: mvn versions:set -DnewVersion=test -DgenerateBackupPoms=false # sets version to be `test` so that we can refer to zip using always grakn-core-test
       - run: mvn --batch-mode install -T 2.5C -DskipTests=true
       - run: tar -xf grakn-dist/target/grakn-core-test.tar.gz -C grakn-dist/target/

--- a/grakn-engine/src/main/java/ai/grakn/engine/attribute/deduplicator/AttributeDeduplicatorDaemon.java
+++ b/grakn-engine/src/main/java/ai/grakn/engine/attribute/deduplicator/AttributeDeduplicatorDaemon.java
@@ -87,7 +87,7 @@ public class AttributeDeduplicatorDaemon {
      */
     public void markForDeduplication(Keyspace keyspace, String index, ConceptId conceptId) {
         Attribute attribute = Attribute.create(keyspace, index, conceptId);
-        LOG.debug("insert(" + attribute + ")");
+        LOG.trace("insert(" + attribute + ")");
         queue.insert(attribute);
     }
 
@@ -105,7 +105,7 @@ public class AttributeDeduplicatorDaemon {
                 try {
                     List<Attribute> attributes = queue.read(QUEUE_GET_BATCH_MAX);
 
-                    LOG.debug("starting a new batch to process these new attributes: " + attributes);
+                    LOG.trace("starting a new batch to process these new attributes: " + attributes);
 
                     // group the attributes into a set of unique (keyspace -> value) pair
                     Set<KeyspaceIndexPair> uniqueKeyValuePairs = attributes.stream()
@@ -117,7 +117,7 @@ public class AttributeDeduplicatorDaemon {
                         deduplicate(txFactory, keyspaceIndexPair);
                     }
 
-                    LOG.debug("new attributes processed.");
+                    LOG.trace("new attributes processed.");
 
                     queue.ack(attributes);
                 }

--- a/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
+++ b/grakn-test/test-integration/src/test/java/ai/grakn/test/rule/DistributionContext.java
@@ -68,7 +68,6 @@ public class DistributionContext extends CompositeTestRule {
 
     private Process engineProcess;
     private int port = 4567;
-    private boolean inheritIO = true;
     private final SessionContext session = SessionContext.create();
 
     // prevent initialization with the default constructor
@@ -77,11 +76,6 @@ public class DistributionContext extends CompositeTestRule {
 
     public static DistributionContext create(){
         return new DistributionContext();
-    }
-
-    public DistributionContext inheritIO(boolean inheritIO) {
-        this.inheritIO = inheritIO;
-        return this;
     }
 
     public SimpleURI uri(){
@@ -155,7 +149,7 @@ public class DistributionContext extends CompositeTestRule {
 
         // Start process
         ProcessBuilder processBuilder = new ProcessBuilder(commands);
-        if (inheritIO) processBuilder.inheritIO();
+        processBuilder.inheritIO();
         return processBuilder.start();
     }
 


### PR DESCRIPTION
# Why is this PR needed?
A test is failing due to bad handling of dependencies where some Grakn dependencies with snapshot versions (ie., `grakn-core x.x.x-SNAPSHOT) got incorrectly cached into the CircleCI cache.

# What does the PR do?
Switch the caching approach where we combine the cache together with the build, in the CircleCI workspace. This approach is simpler as well since we now only use CircleCI workspace instead of CircleCI caching AND workspace. This way, we don't have to deal with issues such as when to invalidate the cache based on checksum.

Bonus:
1. Set the deduplicator daemon log level to trace from debug
2. Removed an unused function in the DistributionContext

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A