### PR TITLE
Improve resolution logging

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchBase.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/query/match/MatchBase.java
@@ -77,8 +77,6 @@ public class MatchBase extends AbstractMatch {
         validatePattern(tx);
 
         GraqlTraversal graqlTraversal = GreedyTraversalPlan.createTraversal(pattern, tx);
-        LOG.trace("Created query plan");
-        LOG.trace(graqlTraversal.toString());
         return streamWithTraversal(this.getPattern().commonVars(), tx, graqlTraversal);
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/CumulativeState.java
@@ -63,7 +63,7 @@ public class CumulativeState extends QueryStateBase{
 
     @Override
     public String toString(){
-        return getClass() + "\n" +
+        return super.toString() +  "\n" +
                 getSubstitution() + "\n" +
                 query + "\n" +
                 subQueries.stream().map(ReasonerQueryImpl::toString).collect(Collectors.joining("\n")) + "\n";

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/QueryState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/QueryState.java
@@ -54,9 +54,7 @@ public abstract class QueryState<Q extends ReasonerQueryImpl> extends QueryState
     }
 
     @Override
-    public String toString(){
-        return getClass() + "\n" + getQuery() + "\n";
-    }
+    public String toString(){ return super.toString() + "\n" + getQuery() + "\n"; }
 
     @Override
     public ResolutionState generateSubGoal() {

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/ResolutionState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/ResolutionState.java
@@ -39,6 +39,9 @@ public abstract class ResolutionState {
         this.parentState = parent;
     }
 
+    @Override
+    public String toString(){ return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode());}
+
     /**
      * @return new sub goal generated from this state
      */

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/RuleState.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/state/RuleState.java
@@ -49,7 +49,7 @@ public class RuleState extends QueryStateBase{
 
     @Override
     public String toString(){
-        return getClass() + "\n" + rule + "\n";
+        return super.toString() + "\n" + rule + "\n";
     }
 
     @Override


### PR DESCRIPTION
# Why is this PR needed?
Logging was a bit verbose and obfuscated.
# What does the PR do?
Shortens the log entries not to include full package info.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.