### PR TITLE
[Workbase] - Do not store consecutive duplicate graql queries in history

### DIFF
--- a/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
+++ b/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlCodeMirror.js
@@ -33,8 +33,10 @@ function GraqlEditorHistory(graqlCodeMirror) {
   let graqlEditorHistory = [''];
 
   this.addToHistory = function addToHistory(query) {
-    historyIndex += 1;
-    graqlEditorHistory.push(query);
+    if (graqlEditorHistory[graqlEditorHistory.length - 1] !== query) {
+      historyIndex += 1;
+      graqlEditorHistory.push(query);
+    }
   };
 
   this.undo = function undo() {


### PR DESCRIPTION
# Why is this PR needed?
Graql editor stored consecutive duplicate queries in history

# What does the PR do?
Only add query to history if it is not the same as most recent query in history

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A