### PR TITLE
[Workbase] - Delete fav query bug

### DIFF
--- a/workbase/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
+++ b/workbase/src/renderer/components/Visualiser/TopBar/FavQueries/FavQueriesList.vue
@@ -160,13 +160,14 @@
       },
       removeFavQuery(index, queryName) {
         FavQueriesSettings.removeFavQuery(queryName, this.currentKeyspace);
-        this.favQueries.splice(index, 1);
+        this.$emit('refresh-queries');
+        this.codeMirror[index].toTextArea(); // Remove codemirror instance
         this.$notifyInfo(`Query ${queryName} has been deleted from favourite queries.`, 'bottom-right');
       },
       renderQueries() {
         const savedQueries = this.$refs.favQuery;
         savedQueries.forEach((queryInput) => {
-          if (queryInput.style.display !== 'none') {
+          if (queryInput.style.display !== 'none') { // Do not re-render inputs which already have been converted to code mirrors
             const cm = GraqlCodeMirror.getCodeMirror(queryInput);
             cm.setValue(this.favQueries[parseInt(queryInput.value, 10)].value);
             cm.setOption('readOnly', 'nocursor');

--- a/workbase/src/renderer/store/actions.js
+++ b/workbase/src/renderer/store/actions.js
@@ -3,7 +3,7 @@ import EngineSettings from '@/components/EngineSettings';
 
 export const loadKeyspaces = async (context) => {
   try {
-    const resp = await context.state.grakn.keyspace.retrieve();
+    const resp = await context.state.grakn.keyspaces().retrieve();
     context.commit('setIsGraknRunning', true);
     context.commit('setKeyspaces', resp);
   } catch (e) {


### PR DESCRIPTION
# Why is this PR needed?
Code mirror instance to deleted query was not being removed

# What does the PR do?
Remove code mirror instance for every query that is deleted

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
1) Refactor renderQueries 
2) Replace code mirror with custom input with simple text highlighter