### PR TITLE
[Workbase] - Close display settings panel when keyspace is changed

### DIFF
--- a/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
@@ -53,8 +53,6 @@
 
 <script>
   import { Chrome } from 'vue-color';
-  import * as React from 'react';
-  import { Button } from '@blueprintjs/core';
 
   import { TOGGLE_COLOUR, TOGGLE_LABEL } from '@/components/shared/StoresActions';
   import NodeSettings from './DisplaySettings';
@@ -70,7 +68,6 @@
         showTypeList: false,
         types: [],
         currentType: null,
-        typesBtn: null,
         nodeAttributes: [],
         currentTypeSavedAttributes: [],
         attributesLoaded: false,
@@ -78,9 +75,6 @@
           hex: '#563891',
         },
       };
-    },
-    created() {
-      this.renderButton();
     },
     computed: {
       metaTypeInstances() {
@@ -99,23 +93,21 @@
       },
     },
     watch: {
-      async showConceptDisplayContent(open) {
+      showConceptDisplayContent(open) {
         if (open) {
+          this.attributesLoaded = false;
           this.loadMetaTypes();
-          await this.loadAttributeTypes();
+          this.loadAttributeTypes();
           this.loadColour();
         }
       },
       currentType() {
-        this.renderButton();
+        this.attributesLoaded = false;
         this.loadAttributeTypes();
         this.loadColour();
       },
-      async currentKeyspace() {
-        this.loadMetaTypes();
-        this.renderButton();
-        await this.loadAttributeTypes();
-        this.loadColour();
+      currentKeyspace() {
+        this.showConceptDisplayContent = false;
       },
       node(node) {
         if (node) this.currentType = node.type;
@@ -140,6 +132,7 @@
       loadMetaTypes() {
         if (this.metaTypeInstances.entities || this.metaTypeInstances.attributes || this.metaTypeInstances.relationships) {
           this.types = this.metaTypeInstances.entities.concat(this.metaTypeInstances.attributes, this.metaTypeInstances.relationships);
+
           this.currentType = this.types[0];
           this.showConceptDisplayContent = true;
         } else { this.showConceptDisplayContent = false; }
@@ -162,14 +155,6 @@
       selectType(type) {
         this.showTypeList = false;
         this.currentType = type;
-      },
-      renderButton() {
-        this.typesBtn = React.createElement(Button, {
-          text: this.currentType,
-          className: 'vue-button attribute-btn',
-          key: this.currentType,
-          rightIcon: 'caret-down',
-        });
       },
       setTypeColour(col) {
         if (NodeSettings.getTypeColours(this.currentType) !== col) {

--- a/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
@@ -130,8 +130,8 @@
         this.attributesLoaded = true;
       },
       loadMetaTypes() {
-        if (this.metaTypeInstances.entities || this.metaTypeInstances.attributes || this.metaTypeInstances.relationships) {
-          this.types = this.metaTypeInstances.entities.concat(this.metaTypeInstances.attributes, this.metaTypeInstances.relationships);
+        if (this.metaTypeInstances.entities || this.metaTypeInstances.attributes) {
+          this.types = this.metaTypeInstances.entities.concat(this.metaTypeInstances.attributes);
 
           this.currentType = this.types[0];
           this.showConceptDisplayContent = true;


### PR DESCRIPTION
# Why is this PR needed?
Attributes were not being loaded when keyspace was changed.

# What does the PR do?
1) Close the display settings panel when keyspace is changed so when the user toggles the panel the metatypes and attributes are loaded one after the other.

2) Remove unused blueprint button

3) Remove relationships from type list since relationship nodes have no label

# Does it break backwards compatibility?
no

# List of future improvements not on this PR
N/A