### PR TITLE
Expand resolution plan tests and add repeats

### DIFF
--- a/grakn-graql/src/test/java/ai/grakn/util/Repeat.java
+++ b/grakn-graql/src/test/java/ai/grakn/util/Repeat.java
@@ -1,0 +1,36 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ai.grakn.util;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+/**
+ * Repeat annotation to be applied at the test method level to indicate how many times the test method shall be executed.
+ * Used in conjunction with {@link RepeatRule}.
+ *
+ */
+@Retention( RetentionPolicy.RUNTIME )
+@Target(METHOD)
+public @interface Repeat {
+    int times();
+}

--- a/grakn-graql/src/test/java/ai/grakn/util/RepeatRule.java
+++ b/grakn-graql/src/test/java/ai/grakn/util/RepeatRule.java
@@ -1,0 +1,59 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package ai.grakn.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Repeat rule for {@link Repeat} annotation.
+ *
+ */
+public class RepeatRule implements TestRule {
+
+    private static class RepeatStatement extends Statement {
+
+        private final int times;
+        private final Statement statement;
+
+        private RepeatStatement(int times, Statement statement) {
+            this.times = times;
+            this.statement = statement;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            for( int i = 0; i < times; i++ ) {
+                statement.evaluate();
+            }
+        }
+    }
+
+    @Override
+    public Statement apply(Statement statement, Description description) {
+        Statement result = statement;
+        Repeat repeat = description.getAnnotation(Repeat.class);
+        if( repeat != null ) {
+            int times = repeat.times();
+            result = new RepeatStatement(times, statement);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
# Why is this PR needed?
To add more test cases for the resolution planner and introduce test repeats - to catch non-deterministic failures.
# What does the PR do?
The above.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.