### PR TITLE
Add shortcut to clear graph and add delay before dimming of nodes when hovering on a node

### DIFF
--- a/workbase/src/renderer/components/CanvasVisualiser/Visualiser.js
+++ b/workbase/src/renderer/components/CanvasVisualiser/Visualiser.js
@@ -6,6 +6,7 @@ import _ from 'underscore';
 import Settings from './Settings';
 import * as eventsHandlers from './Events';
 
+
 function render(container) {
   this._nodes = new vis.DataSet([]);
   this._edges = new vis.DataSet([]);
@@ -19,7 +20,15 @@ function render(container) {
 
   this._network.on('dragEnd', params => this.onDragEnd(params));
   this._network.on('dragStart', params => this.onDragStart(params));
-  this._network.on('hoverNode', params => this.onHoverNode(params));
+
+  this._network.on('hoverNode', (params) => {
+    // Set delay between hovering on a node and the dimming of all other nodes
+    const timer = setTimeout(() => { this.onHoverNode(params); }, 1000);
+    const nodeId = params.node;
+    this._network.on('blurNode', (params) => { if (nodeId === params.node) window.clearTimeout(timer); },
+    );
+  });
+
   this._network.on('blurNode', params => this.onBlurNode(params));
   this._network.on('selectNode', params => this.onSelectNode(params));
   this._network.on('deselectNode', params => this.onDeselectNode(params));

--- a/workbase/src/renderer/components/CanvasVisualiser/Visualiser.js
+++ b/workbase/src/renderer/components/CanvasVisualiser/Visualiser.js
@@ -18,18 +18,22 @@ function render(container) {
     this._options,
   );
 
+  this.hoverTimer = null;
+
   this._network.on('dragEnd', params => this.onDragEnd(params));
   this._network.on('dragStart', params => this.onDragStart(params));
 
   this._network.on('hoverNode', (params) => {
     // Set delay between hovering on a node and the dimming of all other nodes
-    const timer = setTimeout(() => { this.onHoverNode(params); }, 1000);
-    const nodeId = params.node;
-    this._network.on('blurNode', (params) => { if (nodeId === params.node) window.clearTimeout(timer); },
-    );
+    this.hoverTimer = setTimeout(() => { this.onHoverNode(params); }, 500);
   });
 
-  this._network.on('blurNode', params => this.onBlurNode(params));
+  this._network.on('blurNode', (params) => {
+    this.onBlurNode(params);
+    // Remove hover timer if user does not hover on the node for more than 500 ms
+    window.clearTimeout(this.hoverTimer);
+  });
+
   this._network.on('selectNode', params => this.onSelectNode(params));
   this._network.on('deselectNode', params => this.onDeselectNode(params));
   this._network.on('oncontext', params => this.onContext(params));

--- a/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -217,12 +217,6 @@
     },
     created() {
       this.renderIcons();
-
-      window.addEventListener('keydown', (e) => {
-        const gKey = 71;
-        // meta key -> cmd
-        if ((e.keyCode === gKey) && e.metaKey) { this.clearGraph(); }
-      });
     },
     computed: {
       currentQuery() {

--- a/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -213,25 +213,15 @@
         dummyGraqlIcon: null,
         dummyStarIcon: null,
         showEditorToolTip: false,
-        keyMap: { 91: false, 71: false },
       };
     },
     created() {
       this.renderIcons();
 
       window.addEventListener('keydown', (e) => {
-        if (e.keyCode in this.keyMap) {
-          this.keyMap[e.keyCode] = true;
-          if (this.keyMap[91] && this.keyMap[71]) {
-            this.clearGraph();
-          }
-        }
-      });
-      window.addEventListener('keyup', (e) => {
-        if (e.keyCode in this.keyMap) {
-          this.keyMap[91] = false;
-          this.keyMap[71] = false;
-        }
+        const gKey = 71;
+        // meta key -> cmd
+        if ((e.keyCode === gKey) && e.metaKey) { this.clearGraph(); }
       });
     },
     computed: {

--- a/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -213,10 +213,26 @@
         dummyGraqlIcon: null,
         dummyStarIcon: null,
         showEditorToolTip: false,
+        keyMap: { 91: false, 71: false },
       };
     },
     created() {
       this.renderIcons();
+
+      window.addEventListener('keydown', (e) => {
+        if (e.keyCode in this.keyMap) {
+          this.keyMap[e.keyCode] = true;
+          if (this.keyMap[91] && this.keyMap[71]) {
+            this.clearGraph();
+          }
+        }
+      });
+      window.addEventListener('keyup', (e) => {
+        if (e.keyCode in this.keyMap) {
+          this.keyMap[91] = false;
+          this.keyMap[71] = false;
+        }
+      });
     },
     computed: {
       currentQuery() {

--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -13,6 +13,7 @@ import {
   RUN_CURRENT_QUERY,
   EXPLAIN_CONCEPT,
   TOGGLE_LABEL,
+  CANVAS_RESET,
   TOGGLE_COLOUR,
   LOAD_METATYPE_INSTANCES,
 } from '../shared/StoresActions';
@@ -110,6 +111,13 @@ const watch = {
       } else { // double click => load neighbours
         this.loadNeighbours(visNode, neighboursLimit);
       }
+    });
+
+    // Event listener to clear graph (cmd + g)
+    const LETTER_G_KEYCODE = 71;
+    window.addEventListener('keydown', (e) => {
+      // metaKey -> cmd
+      if ((e.keyCode === LETTER_G_KEYCODE) && e.metaKey) { this.dispatch(CANVAS_RESET); }
     });
   },
   currentKeyspace(newKs, oldKs) {

--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -18,6 +18,8 @@ import {
   LOAD_METATYPE_INSTANCES,
 } from '../shared/StoresActions';
 
+const LETTER_G_KEYCODE = 71;
+
 const actions = {
 
   async [RUN_CURRENT_QUERY]() {
@@ -114,7 +116,6 @@ const watch = {
     });
 
     // Event listener to clear graph (cmd + g)
-    const LETTER_G_KEYCODE = 71;
     window.addEventListener('keydown', (e) => {
       // metaKey -> cmd
       if ((e.keyCode === LETTER_G_KEYCODE) && e.metaKey) { this.dispatch(CANVAS_RESET); }

--- a/workbase/static/styles/style.css
+++ b/workbase/static/styles/style.css
@@ -45,7 +45,7 @@
   --red-4: #EE3E82;
   --red-5: #F16299;
 
-  --error-container-color: var(--red-1);
+  --error-container-color: var(--red-3);
 
   --font-default: #d9d9d9;
   --font-faded: #777777;


### PR DESCRIPTION
# Why is this PR needed?
Issue: #4354
1) User could only clear graph by clicking on a button
2) Hovering animation on nodes was too sensitive

# What does the PR do?
1) Allow user to clear graph by doing 'cmd' + 'g'
2) Add a 500 ms delay before dimming all other nodes when hovering on a specific node

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Modify clearing graph shortcut 