### PR TITLE
stop spinner if no results are found for load neighbours

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
@@ -132,7 +132,6 @@ async function prepareNodes(concepts) {
 async function loadRolePlayers(relationship, limitRolePlayers, limit, offset) {
   const nodes = [];
   const edges = [];
-
   let roleplayers = await relationship.rolePlayersMap();
   roleplayers = Array.from(roleplayers.entries());
   if (limitRolePlayers) {
@@ -214,12 +213,7 @@ async function buildFromConceptMap(result, limitRoleplayers) {
   if (QuerySettings.getRolePlayersStatus()) {
     const relationships = nodes.filter(x => x.baseType === 'RELATIONSHIP');
 
-    let roleplayers;
-    if (limitRoleplayers) {
-      roleplayers = await relationshipsRolePlayers(relationships, limitRoleplayers, QuerySettings.getNeighboursLimit());
-    } else {
-      roleplayers = await relationshipsRolePlayers(relationships, true, QuerySettings.getNeighboursLimit());
-    }
+    const roleplayers = await relationshipsRolePlayers(relationships, limitRoleplayers, QuerySettings.getNeighboursLimit());
 
 
     nodes.push(...roleplayers.nodes);

--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -199,6 +199,7 @@ const methods = {
     const result = (await (await graknTx.query(query)).collect());
     if (!result.length) {
       // this.$notifyInfo('No results were found for your query!');
+      this.loadingQuery = false;
       return;
     }
 
@@ -212,7 +213,7 @@ const methods = {
     }
 
 
-    const data = await VisualiserGraphBuilder.buildFromConceptMap(filteredResult);
+    const data = await VisualiserGraphBuilder.buildFromConceptMap(filteredResult, false);
 
     this.visFacade.addToCanvas(data);
     this.visFacade.fitGraphToWindow();


### PR DESCRIPTION
# Why is this PR needed?
isssue - #4368
Spinner would not stop if no more neighbours were found for a concept

# What does the PR do?
Sets loadingQuery to false when no results are found for neighbours

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Refactor load neighbours!