### PR TITLE
load metatypes and attribtues when display settings panel is created

### DIFF
--- a/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/SettingsTab/DisplaySettingsPanel.vue
@@ -76,6 +76,11 @@
         },
       };
     },
+    created() {
+      this.loadMetaTypes();
+      this.loadAttributeTypes();
+      this.loadColour();
+    },
     computed: {
       metaTypeInstances() {
         return this.localStore.getMetaTypeInstances();


### PR DESCRIPTION
# Why is this PR needed?
Display settings panel would not open when right bar tabs were switched 

# What does the PR do?
Load meta types and attributes when the component is created to set attribtuesLoaded to true which enables the panel

# Does it break backwards compatibility?
No 

# List of future improvements not on this PR
N/A