### PR TITLE
refactor canvas event handling

### DIFF
--- a/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Attributes.vue
+++ b/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Attributes.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="wrapper">
-  <edit-bar 
-  :localStore="localStore" 
+  <edit-bar
+  :localStore="localStore"
   type="attribute"
   :typesAlreadySelected="attrTypes"
   :relatesToolTip="false"
@@ -94,10 +94,10 @@ export default {
       attrTypes: [],
     };
   },
+  created() {
+    this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
+  },
   computed: {
-    readyToRegisterEvents() {
-      return this.localStore.isInit;
-    },
     selectedNode() { return this.localStore.getSelectedNode(); },
     editingMode() {
       return this.localStore.getEditingMode();
@@ -110,9 +110,6 @@ export default {
       const types = await node.attributes();
       this.attrTypes = await Promise.all(types.map(async t => ({ label: await t.getLabel(), dataType: await t.getDataType() })));
       this.attrTypes.sort((a, b) => ((a.label > b.label) ? 1 : -1));
-    },
-    readyToRegisterEvents() {
-      this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
     },
   },
   methods: {

--- a/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Edit/ExistingList.vue
+++ b/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Edit/ExistingList.vue
@@ -42,6 +42,9 @@ export default {
       typeFilter: '',
     };
   },
+  created() {
+    this.localStore.registerCanvasEventHandler('click', () => { this.$emit('close-tool-tip'); });
+  },
   computed: {
     instances() {
       const meta = this.localStore.getMetaTypeInstances();
@@ -55,14 +58,6 @@ export default {
         .filter(type => String(type).toLowerCase().indexOf(this.typeFilter) > -1)
         .filter(type => !(this.typesAlreadySelected.map(x => x.label).includes(type)))
         .sort();
-    },
-    readyToRegisterEvents() {
-      return this.localStore.isInit;
-    },
-  },
-  watch: {
-    readyToRegisterEvents() {
-      this.localStore.registerCanvasEventHandler('click', () => { this.$emit('close-tool-tip'); });
     },
   },
   methods: {

--- a/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Plays.vue
+++ b/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Plays.vue
@@ -1,7 +1,7 @@
 <template>
 <div class="wrapper">
   <edit-bar
-    :localStore="localStore" 
+    :localStore="localStore"
     :typesAlreadySelected="playsTypes"
     :relatesToolTip="false"
     type="plays"
@@ -78,21 +78,18 @@ export default {
       playsTypes: [],
     };
   },
+  created() {
+    this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
+  },
   computed: {
     selectedNode() {
       return this.localStore.getSelectedNode();
-    },
-    readyToRegisterEvents() {
-      return this.localStore.isInit;
     },
     editingMode() {
       return this.localStore.getEditingMode();
     },
   },
   watch: {
-    readyToRegisterEvents() {
-      this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
-    },
     async selectedNode(selectedNode) {
       if (!selectedNode) { this.playsTypes = []; return; }
       const node = await this.localStore.getNode(selectedNode.id);

--- a/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Relates.vue
+++ b/workbase/src/renderer/components/SchemaDesign/RightSideBar/NodePanel/Relates.vue
@@ -79,21 +79,18 @@ export default {
       type: 'relates',
     };
   },
+  created() {
+    this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
+  },
   computed: {
     selectedNode() {
       return this.localStore.getSelectedNode();
-    },
-    readyToRegisterEvents() {
-      return this.localStore.isInit;
     },
     editingMode() {
       return this.localStore.getEditingMode();
     },
   },
   watch: {
-    readyToRegisterEvents() {
-      this.localStore.registerCanvasEventHandler('click', () => { this.isEditMode = false; });
-    },
     async selectedNode(selectedNode) {
       if (!selectedNode) { this.relatesTypes = []; return; }
       const node = await this.localStore.getNode(selectedNode.id);

--- a/workbase/src/renderer/components/SchemaDesign/SchemaDesignContent/ContextMenu.vue
+++ b/workbase/src/renderer/components/SchemaDesign/SchemaDesignContent/ContextMenu.vue
@@ -20,25 +20,20 @@ export default {
       showContextMenu: false,
     };
   },
+  created() {
+    this.localStore.registerCanvasEventHandler('oncontext', (mouseEvent) => {
+      this.repositionMenu(mouseEvent);
+      this.showContextMenu = true;
+    });
+    this.localStore.registerCanvasEventHandler('click', () => { this.showContextMenu = false; });
+    this.localStore.registerCanvasEventHandler('selectNode', () => { this.showContextMenu = false; });
+    this.localStore.registerCanvasEventHandler('deselectNode', () => { this.showContextMenu = false; });
+    this.localStore.registerCanvasEventHandler('dragStart', () => { this.showContextMenu = false; });
+  },
 
   computed: {
     selectedNode() {
       return this.localStore.getSelectedNode();
-    },
-    readyToRegisterEvents() {
-      return this.localStore.isInit;
-    },
-  },
-  watch: {
-    readyToRegisterEvents() {
-      this.localStore.registerCanvasEventHandler('oncontext', (mouseEvent) => {
-        this.repositionMenu(mouseEvent);
-        this.showContextMenu = true;
-      });
-      this.localStore.registerCanvasEventHandler('click', () => { this.showContextMenu = false; });
-      this.localStore.registerCanvasEventHandler('selectNode', () => { this.showContextMenu = false; });
-      this.localStore.registerCanvasEventHandler('deselectNode', () => { this.showContextMenu = false; });
-      this.localStore.registerCanvasEventHandler('dragStart', () => { this.showContextMenu = false; });
     },
   },
   methods: {

--- a/workbase/src/renderer/components/SchemaDesign/SchemaDesignContent/SchemaDesignContent.vue
+++ b/workbase/src/renderer/components/SchemaDesign/SchemaDesignContent/SchemaDesignContent.vue
@@ -90,10 +90,8 @@ export default {
       showRolesPanel: false,
     };
   },
-  watch: {
-    'localStore.isInit': function register() {
-      this.localStore.registerCanvasEventHandler('click', this.closePanels);
-    },
+  created() {
+    this.localStore.registerCanvasEventHandler('click', this.closePanels);
   },
   methods: {
     deleteSchemaConcept(label) { this.localStore.dispatch(DELETE_SCHEMA_CONCEPT, label); },

--- a/workbase/src/renderer/components/SchemaDesign/SchemaDesignStore.js
+++ b/workbase/src/renderer/components/SchemaDesign/SchemaDesignStore.js
@@ -192,23 +192,6 @@ const watch = {
     this.schemaHandler = new SchemaHandler(tx);
     // }
   },
-  isInit() {
-    this.registerCanvasEventHandler('dragEnd', (params) => {
-      if (!params.nodes.length) return;
-      let positionMap = storage.get('schema-node-positions');
-
-      if (positionMap) {
-        positionMap = JSON.parse(positionMap);
-      } else {
-        positionMap = {};
-        storage.set('schema-node-positions', {});
-      }
-      params.nodes.forEach((nodeId) => {
-        positionMap[nodeId] = params.pointer.canvas;
-      });
-      storage.set('schema-node-positions', JSON.stringify(positionMap));
-    });
-  },
 };
 
 
@@ -266,6 +249,23 @@ const methods = {
   },
   setEditingMode(mode) {
     this.editingMode = mode;
+  },
+  registerVueCanvasEventHandlers() {
+    this.registerCanvasEventHandler('dragEnd', (params) => {
+      if (!params.nodes.length) return;
+      let positionMap = storage.get('schema-node-positions');
+
+      if (positionMap) {
+        positionMap = JSON.parse(positionMap);
+      } else {
+        positionMap = {};
+        storage.set('schema-node-positions', {});
+      }
+      params.nodes.forEach((nodeId) => {
+        positionMap[nodeId] = params.pointer.canvas;
+      });
+      storage.set('schema-node-positions', JSON.stringify(positionMap));
+    });
   },
 };
 

--- a/workbase/src/renderer/components/Visualiser/ContextMenu.vue
+++ b/workbase/src/renderer/components/Visualiser/ContextMenu.vue
@@ -20,36 +20,31 @@
         deleteNodeText: 'Delete Node',
       };
     },
+    created() {
+      this.localStore.registerCanvasEventHandler('oncontext', (params) => {
+        // Do not show context menu when keyspace is not selected or canvasData is empty
+        if (!this.currentKeyspace || (!this.localStore.canvasData.entities && !this.localStore.canvasData.attributes && !this.localStore.canvasData.relationships)) return;
+
+        // check which menu items to enable
+        this.enableDelete = this.verifyEnableDelete();
+        this.enableExplain = this.verifyEnableExplain();
+        this.enableShortestPath = this.verifyEnableShortestPath();
+
+        this.repositionMenu(params);
+        this.showContextMenu = true;
+      });
+      this.localStore.registerCanvasEventHandler('click', () => { this.showContextMenu = false; });
+      this.localStore.registerCanvasEventHandler('selectNode', () => { this.showContextMenu = false; });
+      this.localStore.registerCanvasEventHandler('deselectNode', () => { this.showContextMenu = false; });
+      this.localStore.registerCanvasEventHandler('dragStart', () => { this.showContextMenu = false; });
+      this.localStore.registerCanvasEventHandler('zoom', () => { this.showContextMenu = false; });
+    },
     computed: {
       selectedNodes() {
         return this.localStore.getSelectedNodes();
       },
-      readyToRegisterEvents() {
-        return this.localStore.isInit;
-      },
       currentKeyspace() {
         return this.localStore.currentKeyspace;
-      },
-    },
-    watch: {
-      readyToRegisterEvents() {
-        this.localStore.registerCanvasEventHandler('oncontext', async (params) => {
-          // Do not show context menu when keyspace is not selected or canvasData is empty
-          if (!this.currentKeyspace || (!this.localStore.canvasData.nodes && !this.localStore.canvasData.edges)) return;
-
-          // check which menu items to enable
-          this.enableDelete = this.verifyEnableDelete();
-          this.enableExplain = await this.verifyEnableExplain();
-          this.enableShortestPath = this.verifyEnableShortestPath();
-
-          this.repositionMenu(params);
-          this.showContextMenu = true;
-        });
-        this.localStore.registerCanvasEventHandler('click', () => { this.showContextMenu = false; });
-        this.localStore.registerCanvasEventHandler('selectNode', () => { this.showContextMenu = false; });
-        this.localStore.registerCanvasEventHandler('deselectNode', () => { this.showContextMenu = false; });
-        this.localStore.registerCanvasEventHandler('dragStart', () => { this.showContextMenu = false; });
-        this.localStore.registerCanvasEventHandler('zoom', () => { this.showContextMenu = false; });
       },
     },
     methods: {
@@ -69,13 +64,8 @@
         this.localStore.dispatch(EXPLAIN_CONCEPT).catch((err) => { this.$notifyError(err, 'Explain Concept'); });
         this.showContextMenu = false;
       },
-      async verifyEnableExplain() {
-        if (this.selectedNodes) {
-          if (this.selectedNodes[0].isInferred) {
-            return true;
-          }
-        }
-        return false;
+      verifyEnableExplain() {
+        return (this.selectedNodes && this.selectedNodes[0].isInferred);
       },
       verifyEnableDelete() {
         if (!this.selectedNodes) {

--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -100,27 +100,6 @@ const actions = {
 };
 
 const watch = {
-  isInit() {
-    this.registerCanvasEventHandler('doubleClick', async (params) => {
-      const nodeId = params.nodes[0];
-      if (!nodeId) return;
-
-      const neighboursLimit = QuerySettings.getNeighboursLimit();
-      const visNode = this.visFacade.getNode(nodeId);
-
-      if (params.event.srcEvent.shiftKey) { // shift + double click => load attributes
-        this.loadAttributes(visNode, neighboursLimit);
-      } else { // double click => load neighbours
-        this.loadNeighbours(visNode, neighboursLimit);
-      }
-    });
-
-    // Event listener to clear graph (cmd + g)
-    window.addEventListener('keydown', (e) => {
-      // metaKey -> cmd
-      if ((e.keyCode === LETTER_G_KEYCODE) && e.metaKey) { this.dispatch(CANVAS_RESET); }
-    });
-  },
   currentKeyspace(newKs, oldKs) {
     if (newKs && newKs !== oldKs) {
       this.currentQuery = '';
@@ -205,7 +184,9 @@ const methods = {
     this.visFacade.updateNode({ id: visNode.id, offset: (visNode.offset + neighboursLimit) });
 
     const graknTx = await this.openGraknTx();
+
     const result = (await (await graknTx.query(query)).collect());
+
     if (!result.length) {
       // this.$notifyInfo('No results were found for your query!');
       this.loadingQuery = false;
@@ -288,6 +269,27 @@ const methods = {
   setCurrentQuery(query) {
     this.currentQuery = query;
   },
+  registerVueCanvasEventHandlers() {
+    this.registerCanvasEventHandler('doubleClick', (params) => {
+      const nodeId = params.nodes[0];
+      if (!nodeId) return;
+
+      const neighboursLimit = QuerySettings.getNeighboursLimit();
+      const visNode = this.visFacade.getNode(nodeId);
+
+      if (params.event.srcEvent.shiftKey) { // shift + double click => load attributes
+        this.loadAttributes(visNode, neighboursLimit);
+      } else { // double click => load neighbours
+        this.loadNeighbours(visNode, neighboursLimit);
+      }
+    });
+
+    // Event listener to clear graph (cmd + g)
+    window.addEventListener('keydown', (e) => {
+      // metaKey -> cmd
+      if ((e.keyCode === LETTER_G_KEYCODE) && e.metaKey) { this.dispatch(CANVAS_RESET); }
+    });
+  },
 };
 
 const state = {
@@ -296,6 +298,7 @@ const state = {
   explanationQuery: false,
   metaTypeInstances: {},
 };
+
 export default { create: () => new Vue({
   name: 'DataManagementStore',
   mixins: [CanvasStoreMixin.create()],

--- a/workbase/src/renderer/components/shared/CanvasStoreMixin.js
+++ b/workbase/src/renderer/components/shared/CanvasStoreMixin.js
@@ -11,7 +11,7 @@ import {
   LOAD_METATYPE_INSTANCES,
 } from './StoresActions';
 
-const eventCache = {};
+const eventCache = [];
 
 const actions = {
   async [CURRENT_KEYSPACE_CHANGED](keyspace) {
@@ -33,11 +33,6 @@ const actions = {
     // Now that the visualiser is initialised it's possible to register events on the network
     this.registerCanvasEventHandlers();
     this.registerVueCanvasEventHandlers();
-    // Register caches events
-
-    Object.keys(eventCache).forEach((x) => {
-      this.registerCanvasEventHandler(x, eventCache[x]);
-    });
   },
   [CANVAS_RESET]() {
     this.visFacade.resetCanvas();
@@ -72,6 +67,11 @@ const methods = {
     this.registerCanvasEventHandler('click', (params) => {
       if (!params.nodes.length) { this.setSelectedNodes(null); }
     });
+
+    // Register caches events
+    eventCache.forEach((x) => {
+      this.registerCanvasEventHandler(x.event, x.fn);
+    });
   },
 
   // Getters
@@ -86,7 +86,7 @@ const methods = {
   setSelectedNode(nodeId) { this.selectedNodes = (nodeId) ? [this.visFacade.getNode(nodeId)] : null; },
   registerCanvasEventHandler(event, fn) {
     if (this.visFacade) { this.visFacade.registerEventHandler(event, fn); } else {
-      eventCache[event] = fn;
+      eventCache.push({ event, fn });
     }
   },
 

--- a/workbase/src/renderer/components/shared/CanvasStoreMixin.js
+++ b/workbase/src/renderer/components/shared/CanvasStoreMixin.js
@@ -85,7 +85,7 @@ const methods = {
   setSelectedNodes(nodeIds) { this.selectedNodes = (nodeIds) ? this.visFacade.getNode(nodeIds) : null; },
   setSelectedNode(nodeId) { this.selectedNodes = (nodeId) ? [this.visFacade.getNode(nodeId)] : null; },
   registerCanvasEventHandler(event, fn) {
-    if (this.visFacade) { debugger; this.visFacade.registerEventHandler(event, fn); } else {
+    if (this.visFacade) { this.visFacade.registerEventHandler(event, fn); } else {
       eventCache[event] = fn;
     }
   },


### PR DESCRIPTION
# Why is this PR needed?
Issue - #4370

# What does the PR do?
-Remove isInit flag and replace with eventCache to keep track of unregistered events.
-Move all event registering from watchers to created in vue child components.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A