### PR TITLE
Graql editor should only maximise when minimized

### DIFF
--- a/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
+++ b/workbase/src/renderer/components/Visualiser/TopBar/GraqlEditor/GraqlEditor.vue
@@ -270,7 +270,7 @@
         });
 
         this.codeMirror.on('focus', () => {
-          this.maximizeEditor();
+          if (this.editorMinimized) this.maximizeEditor();
         });
       });
     },


### PR DESCRIPTION
# Why is this PR needed?
Graql editor would try to maximise even if it was not minimised and would cause a movement of the editor

# What does the PR do?
Checks if graql editor is minimised before trying to maximise it.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A