### PR TITLE
Load Roleplayers should not be reset

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -265,7 +265,7 @@ const methods = {
     this.currentQuery = query;
   },
   registerVueCanvasEventHandlers() {
-    this.registerCanvasEventHandler('doubleClick', async (params) => {
+    this.registerCanvasEventHandler('doubleClick', (params) => {
       const nodeId = params.nodes[0];
       if (!nodeId) return;
 
@@ -279,8 +279,9 @@ const methods = {
         const saveLoadRolePlayersState = QuerySettings.getRolePlayersStatus();
         QuerySettings.setRolePlayersStatus(true);
 
-        await this.loadNeighbours(visNode, neighboursLimit);
-        QuerySettings.setRolePlayersStatus(saveLoadRolePlayersState);
+        this.loadNeighbours(visNode, neighboursLimit).then(() => {
+          QuerySettings.setRolePlayersStatus(saveLoadRolePlayersState);
+        });
       }
     });
 

--- a/workbase/src/renderer/components/Visualiser/VisualiserStore.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserStore.js
@@ -176,9 +176,6 @@ const methods = {
     }
   },
   async loadNeighbours(visNode, neighboursLimit) {
-    const saveloadRolePlayersState = QuerySettings.getRolePlayersStatus();
-
-    QuerySettings.setRolePlayersStatus(true);
     const query = VisualiserUtils.getNeighboursQuery(visNode, neighboursLimit);
     this.loadingQuery = true;
     this.visFacade.updateNode({ id: visNode.id, offset: (visNode.offset + neighboursLimit) });
@@ -198,10 +195,9 @@ const methods = {
     if (result.length !== filteredResult.length) {
       const offsetDiff = result.length - filteredResult.length;
       visNode.offset += QuerySettings.getNeighboursLimit();
-      this.loadNeighbours(visNode, offsetDiff);
+      await this.loadNeighbours(visNode, offsetDiff);
       if (!filteredResult.length) return;
     }
-
 
     const data = await VisualiserGraphBuilder.buildFromConceptMap(filteredResult, false);
 
@@ -239,7 +235,6 @@ const methods = {
     }
     this.visFacade.addToCanvas({ nodes: data.nodes, edges });
     this.updateCanvasData();
-    QuerySettings.setRolePlayersStatus(saveloadRolePlayersState);
   },
 
   // getters
@@ -270,7 +265,7 @@ const methods = {
     this.currentQuery = query;
   },
   registerVueCanvasEventHandlers() {
-    this.registerCanvasEventHandler('doubleClick', (params) => {
+    this.registerCanvasEventHandler('doubleClick', async (params) => {
       const nodeId = params.nodes[0];
       if (!nodeId) return;
 
@@ -280,7 +275,12 @@ const methods = {
       if (params.event.srcEvent.shiftKey) { // shift + double click => load attributes
         this.loadAttributes(visNode, neighboursLimit);
       } else { // double click => load neighbours
-        this.loadNeighbours(visNode, neighboursLimit);
+        // save state of RoleplayersStatus, force it to true and reset it after loading neighbours
+        const saveLoadRolePlayersState = QuerySettings.getRolePlayersStatus();
+        QuerySettings.setRolePlayersStatus(true);
+
+        await this.loadNeighbours(visNode, neighboursLimit);
+        QuerySettings.setRolePlayersStatus(saveLoadRolePlayersState);
       }
     });
 


### PR DESCRIPTION
# Why is this PR needed?
Issue - #4382
Load Roleplayers was not being reset when loading of neighbours

# What does the PR do?
Moves the resetting of the Load Roleplayers flag outside the function to avoid overriding it by the recursive calls to loadNeighbours()

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A