### PR TITLE
update docs/deply-master.sh to have correct app name

### DIFF
--- a/docs/deploy-master.sh
+++ b/docs/deploy-master.sh
@@ -29,11 +29,11 @@ git add --force -- _jekyll _site
 git commit -m "Updating dev.grakn.ai"
 
 echo
-echo "Pushing website to git@heroku.com:dev-grakn.git"
+echo "Pushing website to git@heroku.com:grakn-web-dev.git"
 echo "..."
 # we will just push the git tree for just the docs repo, by doing `git subtree split --prefix docs ...` from the root directory
 cd ../
-git push git@heroku.com:dev-grakn.git `git subtree split --prefix docs graknlabs-docs-temp-branch`:master --force
+git push git@heroku.com:grakn-web-dev.git `git subtree split --prefix docs graknlabs-docs-temp-branch`:master --force
 
 echo
 echo "Removing up temporary branch graknlabs-docs-temp-branch"


### PR DESCRIPTION
# Why is this PR needed?
To deploy docs to the correct Heroku app.

# What does the PR do?
Updates `deploy-master.sh` to contain the correct Heroku app name for docs: `grakn-web-dev`

# Does it break backwards compatibility?
no

# List of future improvements not on this PR
In case the deploy fails, the temporary branch and remote that was created, is not removed by `deploy-master.sh`. Instead instructions are given that they need to be removed if they exist. It makes sense to remove them in the `error` block. I haven't made this change, because there may be a reason for not doing this, that I'm not aware of.
