### PR TITLE
Set maximum width of canvas nodes

### DIFF
--- a/workbase/src/renderer/components/Visualiser/Style.js
+++ b/workbase/src/renderer/components/Visualiser/Style.js
@@ -176,6 +176,7 @@ function computeNodeStyle(node) {
       x: 2,
       y: 2,
     },
+    widthConstraint: { maximum: 600 },
   };
 }
 


### PR DESCRIPTION
# Why is this PR needed?
closes #4305
Long labels would hinder visibility of nodes

# What does the PR do?
Restrict the maximum width of a node

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Truncate long strings?