### PR TITLE
Keep identity and attributes panels active in the right bar

### DIFF
--- a/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/AttributesPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/AttributesPanel.vue
@@ -30,9 +30,12 @@
     props: ['localStore'],
     data() {
       return {
-        showAttributesPanel: undefined,
+        showAttributesPanel: true,
         attributes: null,
       };
+    },
+    mounted() {
+      this.loadAttributes(this.selectedNodes);
     },
     computed: {
       selectedNodes() {
@@ -51,8 +54,13 @@
     },
     watch: {
       selectedNodes(nodes) {
+        this.loadAttributes(nodes);
+      },
+    },
+    methods: {
+      loadAttributes(nodes) {
         // If no node selected: close panel and return
-        if (!nodes || nodes.length > 1) { this.showAttributesPanel = false; return; }
+        if (!nodes || nodes.length > 1) return;
 
         const attributes = nodes[0].attributes;
 
@@ -60,8 +68,6 @@
 
         this.showAttributesPanel = true;
       },
-    },
-    methods: {
       toggleContent() {
         this.showAttributesPanel = !this.showAttributesPanel;
       },

--- a/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/IdentityPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/IdentityPanel.vue
@@ -64,7 +64,7 @@
     },
     watch: {
       nodes(nodes) {
-        this.showConceptInfoContent = nodes && nodes.length === 1;
+        if (nodes && nodes.length === 1) this.showConceptInfoContent = true;
       },
     },
     methods: {

--- a/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/IdentityPanel.vue
+++ b/workbase/src/renderer/components/Visualiser/RightBar/ConceptInfoTab/IdentityPanel.vue
@@ -35,7 +35,7 @@
     props: ['localStore'],
     data() {
       return {
-        showConceptInfoContent: (this.nodes && this.nodes.length === 1),
+        showConceptInfoContent: true,
       };
     },
     computed: {


### PR DESCRIPTION
# Why is this PR needed?
Closes #4402
Identity and attributes panels would close when right bar was hidden and re-shown

# What does the PR do?
Always show panels unless user toggles them  

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A