### PR TITLE
V1.4.2

### DIFF
--- a/client-java/pom.xml
+++ b/client-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-core/pom.xml
+++ b/grakn-core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-dashboard/pom.xml
+++ b/grakn-dashboard/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-dist/pom.xml
+++ b/grakn-dist/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>grakn-test-profiles</artifactId>
         <relativePath>../grakn-test-profiles</relativePath>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-engine/pom.xml
+++ b/grakn-engine/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>grakn-test-profiles</artifactId>
         <relativePath>../grakn-test-profiles</relativePath>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-factory/pom.xml
+++ b/grakn-factory/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-graql-shell/pom.xml
+++ b/grakn-graql-shell/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-graql/pom.xml
+++ b/grakn-graql/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>grakn-test-profiles</artifactId>
         <relativePath>../grakn-test-profiles</relativePath>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-kb/pom.xml
+++ b/grakn-kb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-migration/base/pom.xml
+++ b/grakn-migration/base/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-migration/csv/pom.xml
+++ b/grakn-migration/csv/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-migration/export/pom.xml
+++ b/grakn-migration/export/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-migration/json/pom.xml
+++ b/grakn-migration/json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-migration/pom.xml
+++ b/grakn-migration/pom.xml
@@ -23,7 +23,7 @@
   <parent>
       <artifactId>grakn</artifactId>
       <groupId>ai.grakn</groupId>
-      <version>1.4.0</version>
+      <version>1.4.2</version>
   </parent>
   <packaging>pom</packaging>
   <modules>

--- a/grakn-migration/sql/pom.xml
+++ b/grakn-migration/sql/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-migration/xml/pom.xml
+++ b/grakn-migration/xml/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-migration</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
 
     <dependencies>

--- a/grakn-test-profiles/pom.xml
+++ b/grakn-test-profiles/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test-tools/pom.xml
+++ b/grakn-test-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test/pom.xml
+++ b/grakn-test/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>grakn-test-profiles</artifactId>
         <relativePath>../grakn-test-profiles</relativePath>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test/test-client-java/pom.xml
+++ b/grakn-test/test-client-java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-test</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test/test-distribution/pom.xml
+++ b/grakn-test/test-distribution/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-test</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test/test-integration/pom.xml
+++ b/grakn-test/test-integration/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-test</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/grakn-test/test-snb/pom.xml
+++ b/grakn-test/test-snb/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>grakn-test</artifactId>
         <groupId>ai.grakn</groupId>
-        <version>1.4.0</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <auto-value.version>1.4.1</auto-value.version>
         <main.basedir>${project.basedir}</main.basedir>
         <grpc.version>1.15.0</grpc.version>
-        <netty-all.version>4.1.27.Final</netty-all.version>
+        <netty-all.version>4.1.30.Final</netty-all.version>
         <google-bigtable.version>0.9.5.1</google-bigtable.version>
         <netty-ssl.version>2.0.14.Final</netty-ssl.version>
         <apache-http-core.version>4.4.6</apache-http-core.version>
@@ -105,7 +105,7 @@
         <zt-exec.version>1.10</zt-exec.version>
         <jackson.version>2.9.2</jackson.version>
         <skip.deploy.dist>false</skip.deploy.dist>
-        <astyanax.version>3.10.1</astyanax.version>
+        <astyanax.version>3.10.2</astyanax.version>
         <rocksdbjni.version>5.14.2</rocksdbjni.version>
     </properties>
 
@@ -322,6 +322,10 @@
                 <version>${tinkerpop.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.fasterxml.jackson.module</groupId>
                         <artifactId>jackson-module-scala_2.10</artifactId>
                     </exclusion>
@@ -352,6 +356,10 @@
                 <artifactId>hadoop-gremlin</artifactId>
                 <version>${tinkerpop.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>javax.servlet</groupId>
                         <artifactId>javax.servlet-api</artifactId>
@@ -553,6 +561,10 @@
                 <version>${spark.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.fasterxml.jackson.module</groupId>
                         <artifactId>jackson-module-scala_2.10</artifactId>
                     </exclusion>
@@ -751,6 +763,21 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
+                <version>${netty-all.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>${netty-all.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty-all.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
                 <version>${netty-all.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <groupId>ai.grakn</groupId>
     <artifactId>grakn</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.4.2</version>
     <name>Grakn</name>
     <description>The Knowledge Graph</description>
     <url>https://grakn.ai</url>
@@ -180,12 +180,12 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-core</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-kb</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>javax.servlet</artifactId>
@@ -200,7 +200,7 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-graql</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>slf4j-api</artifactId>
@@ -211,7 +211,7 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-factory</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.eclipse.jetty.orbit</groupId>
@@ -235,7 +235,7 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>client-java</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -246,7 +246,7 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-engine</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.slf4j</groupId>
@@ -257,37 +257,37 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-graql-shell</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-base</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-sql</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-xml</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-csv</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-json</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>migration-export</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
             </dependency>
 
             <dependency>
@@ -882,7 +882,7 @@
             <dependency>
                 <groupId>ai.grakn</groupId>
                 <artifactId>grakn-test-tools</artifactId>
-                <version>1.4.0</version>
+                <version>1.4.2</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
# Why is this PR needed?
To fix https://github.com/graknlabs/grakn/issues/4381

# What does the PR do?
Fix https://github.com/graknlabs/grakn/issues/4381 by excluding netty in favor of netty-all

Additionally,  upgrade astyanax to 3.10.2 and netty-all to 4.1.30.Final

The fix has been manually confirmed to work on:
- Ubuntu 14.04, 16.04, and 18.04 on AWS
- Mac OS X (High Sierra 10.13.4)
- Windows 10

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Need to have full control over Grakn dependencies so we won't experience this kind of issue again. 