### PR TITLE
Error container background color update

### DIFF
--- a/workbase/static/styles/style.css
+++ b/workbase/static/styles/style.css
@@ -45,7 +45,7 @@
   --red-4: #EE3E82;
   --red-5: #F16299;
 
-  --error-container-color: var(--red-3);
+  --error-container-color: var(--red-1);
 
   --font-default: #d9d9d9;
   --font-faded: #777777;


### PR DESCRIPTION
# Why is this PR needed?
closes: #4356

# What does the PR do?
Change background color of error container

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A