### PR TITLE
Click and holding a node shouldn't multi select

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserCanvasEventsHandler.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserCanvasEventsHandler.js
@@ -87,5 +87,12 @@ export default {
         commit('contextMenu', { show: false, x: null, y: null });
       },
     });
+
+    commit('registerCanvasEvent', {
+      event: 'hold',
+      callback: (params) => {
+        if (params.nodes.length) { commit('selectedNodes', null); state.visFacade.getNetwork().unselectAll(); }
+      },
+    });
   },
 };


### PR DESCRIPTION
# Why is this PR needed?
Clicking and holding a node would select multiple nodes

# What does the PR do?
Catches hold event and unselects nodes

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A