### PR TITLE
ignore 2 flaky reasoning tests

### DIFF
--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/OntologicalQueryTest.java
@@ -49,6 +49,8 @@ public class OntologicalQueryTest {
     @Rule
     public final SampleKBContext matchingTypesContext = SampleKBContext.load("matchingTypesTest.gql");
 
+    //TODO flaky!
+    @Ignore
     @Test
     public void instancePairsRelatedToSameTypeOfEntity(){
         GraknTx tx = matchingTypesContext.tx();

--- a/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
+++ b/grakn-graql/src/test/java/ai/grakn/graql/internal/reasoner/ResolutionPlanTest.java
@@ -341,6 +341,8 @@ public class ResolutionPlanTest {
      *        resource $res                                                  resource $res
      *    anotherResource 'someValue'
      */
+    //TODO flaky!
+    @Ignore
     @Test
     public void exploitDBRelationsAndConnectivity_relationLinkWithEndsSharingAResource(){
         EmbeddedGraknTx<?> testTx = testContext.tx();


### PR DESCRIPTION
# Why is this PR needed?
- flaky tests
# What does the PR do?
Ignores them for now to be fixed later.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.