### PR TITLE
Add pre-commit check for unwanted code

### DIFF
--- a/workbase/package.json
+++ b/workbase/package.json
@@ -161,7 +161,7 @@
   },
   "husky": {
       "hooks": {
-        "pre-commit": "lint-staged $$ grep -E -r 'debugger|console' src/"
+        "pre-commit": "lint-staged $$ grep -E -r 'debugger' src/"
       }
    },
    "lint-staged": {

--- a/workbase/package.json
+++ b/workbase/package.json
@@ -161,7 +161,7 @@
   },
   "husky": {
       "hooks": {
-        "pre-commit": "lint-staged $$ grep -E -r 'debugger' src/"
+        "pre-commit": "lint-staged && grep -E -r 'debugger|console.log' src/"
       }
    },
    "lint-staged": {

--- a/workbase/package.json
+++ b/workbase/package.json
@@ -126,7 +126,9 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
     "html-webpack-plugin": "^2.30.1",
+    "husky": "^1.1.2",
     "jest": "^23.0.0",
+    "lint-staged": "^7.3.0",
     "multispinner": "^0.2.1",
     "node-loader": "^0.6.0",
     "node-sass": "^4.9.2",
@@ -156,5 +158,14 @@
     "moduleNameMapper": {
       "@/(.*)$": "<rootDir>/src/renderer/$1"
     }
-  }
+  },
+  "husky": {
+      "hooks": {
+        "pre-commit": "lint-staged $$ grep -e -r 'debugger|console' src/"
+      }
+   },
+   "lint-staged": {
+      "*.js": ["eslint --fix", "git add"],
+      "*.vue": ["eslint --fix", "git add"]
+   }
 }

--- a/workbase/package.json
+++ b/workbase/package.json
@@ -161,7 +161,7 @@
   },
   "husky": {
       "hooks": {
-        "pre-commit": "lint-staged $$ grep -e -r 'debugger|console' src/"
+        "pre-commit": "lint-staged $$ grep -E -r 'debugger|console' src/"
       }
    },
    "lint-staged": {

--- a/workbase/src/renderer/components/Visualiser/ContextMenu.vue
+++ b/workbase/src/renderer/components/Visualiser/ContextMenu.vue
@@ -15,6 +15,8 @@
     computed: {
       ...mapGetters(['selectedNodes', 'currentKeyspace', 'contextMenu']),
       enableDelete() {
+        debugger;
+        console.log('test');
         return (this.selectedNodes);
       },
       enableExplain() {

--- a/workbase/src/renderer/components/Visualiser/ContextMenu.vue
+++ b/workbase/src/renderer/components/Visualiser/ContextMenu.vue
@@ -15,8 +15,6 @@
     computed: {
       ...mapGetters(['selectedNodes', 'currentKeyspace', 'contextMenu']),
       enableDelete() {
-        debugger;
-        console.log('test');
         return (this.selectedNodes);
       },
       enableExplain() {


### PR DESCRIPTION
# Why is this PR needed?
So that the developer does not commit:
1) un-eslinted files
2) debugger
3) console.log()

# What does the PR do?
1) Import husky and lint-stager to check code before committing 
2) Will only display the files where debugger and console.log are present (Currently will not stop the commit) 

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Replace debugger and console check with a hook to not allow commit to go through if they exist in the code.