### PR TITLE
WIP - refactor how TypeImpl.addInstance() and TypeImpl.putInstance() are used

### DIFF
--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/AttributeTypeImpl.java
@@ -27,6 +27,7 @@ import ai.grakn.util.Schema;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.BiFunction;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -130,6 +131,28 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
 
         return putInstance(Schema.BaseType.ATTRIBUTE, () -> attribute(value), instanceBuilder, isInferred);
     }
+
+    /**
+     * Utility method used to create or find an instance of this type
+     *
+     * @param instanceBaseType The base type of the instances of this type
+     * @param finder The method to find the instrance if it already exists
+     * @param producer The factory method to produce the instance if it doesn't exist
+     * @return A new or already existing instance
+     */
+    private Attribute<D> putInstance(Schema.BaseType instanceBaseType, Supplier<Attribute<D>> finder, BiFunction<VertexElement, AttributeType<D>, Attribute<D>> producer, boolean isInferred) {
+        Attribute<D> instance = finder.get();
+        if(instance == null) {
+            instance = addInstance(instanceBaseType, producer, isInferred);
+        } else {
+            if(isInferred && !instance.isInferred()){
+                throw GraknTxOperationException.nonInferredThingExists(instance);
+            }
+        }
+        return instance;
+    }
+
+
 
     /**
      * Checks if all the regex's of the types of this resource conforms to the value provided.

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/EntityTypeImpl.java
@@ -56,11 +56,11 @@ public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements Enti
 
     @Override
     public Entity create() {
-        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), false, true);
+        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), false);
     }
 
     public Entity addEntityInferred() {
-        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true, true);
+        return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true);
     }
 
     public static EntityTypeImpl from(EntityType entityType){

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/RelationshipTypeImpl.java
@@ -77,7 +77,7 @@ public class RelationshipTypeImpl extends TypeImpl<RelationshipType, Relationshi
 
     public Relationship addRelationship(boolean isInferred) {
         Relationship relationship = addInstance(Schema.BaseType.RELATIONSHIP,
-                (vertex, type) -> vertex().tx().factory().buildRelation(vertex, type), isInferred, true);
+                (vertex, type) -> vertex().tx().factory().buildRelation(vertex, type), isInferred);
         vertex().tx().txCache().addNewRelationship(relationship);
         return relationship;
     }

--- a/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
+++ b/grakn-kb/src/main/java/ai/grakn/kb/internal/concept/TypeImpl.java
@@ -87,37 +87,14 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
     }
 
     /**
-     * Utility method used to create or find an instance of this type
-     *
-     * @param instanceBaseType The base type of the instances of this type
-     * @param finder The method to find the instrance if it already exists
-     * @param producer The factory method to produce the instance if it doesn't exist
-     * @return A new or already existing instance
-     */
-    V putInstance(Schema.BaseType instanceBaseType, Supplier<V> finder, BiFunction<VertexElement, T, V> producer, boolean isInferred) {
-        preCheckForInstanceCreation();
-
-        V instance = finder.get();
-        if(instance == null) {
-            instance = addInstance(instanceBaseType, producer, isInferred, false);
-        } else {
-            if(isInferred && !instance.isInferred()){
-                throw GraknTxOperationException.nonInferredThingExists(instance);
-            }
-        }
-        return instance;
-    }
-
-    /**
      * Utility method used to create an instance of this type
      *
      * @param instanceBaseType The base type of the instances of this type
      * @param producer The factory method to produce the instance
-     * @param checkNeeded indicates if a check is necessary before adding the instance
      * @return A new instance
      */
-    V addInstance(Schema.BaseType instanceBaseType, BiFunction<VertexElement, T, V> producer, boolean isInferred, boolean checkNeeded){
-        if(checkNeeded) preCheckForInstanceCreation();
+    V addInstance(Schema.BaseType instanceBaseType, BiFunction<VertexElement, T, V> producer, boolean isInferred){
+        preCheckForInstanceCreation();
 
         if(isAbstract()) throw GraknTxOperationException.addingInstancesToAbstractType(this);
 
@@ -370,7 +347,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
     }
 
     private void updateAttributeRelationHierarchy(AttributeType attributeType, Schema.ImplicitType has, Schema.ImplicitType hasValue, Schema.ImplicitType hasOwner,
-                                     Role ownerRole, Role valueRole, RelationshipType relationshipType){
+                                                  Role ownerRole, Role valueRole, RelationshipType relationshipType){
         AttributeType attributeTypeSuper = attributeType.sup();
         Label superLabel = attributeTypeSuper.label();
         Role ownerRoleSuper = vertex().tx().putRoleTypeImplicit(hasOwner.getLabel(superLabel));


### PR DESCRIPTION
# Why is this PR needed?
This is needed in order to start https://github.com/graknlabs/grakn/issues/4437.

The method `TypeImpl::putInstance` is only used by `AttributeTypeImpl`. The logic is quite tied to how an `Attribute` instance should be created. Therefore, let's move it to `AttributeTypeImpl`

# What does the PR do?
- Move `TypeImpl::putInstance` to `AttributeTypeImpl::putInstance`.

Additionally,
- There was a `preCheckForInstanceCreation()` which can optionally be enabled via an argument `checkNeeded`. However, it is enabled all the time anyway, so let's make it mandatory to make the code simpler.
- There was a small optimisation in how `preCheckForInstanceCreation` is called before `finder.get()` in `putInstance`, which is removed:
  - We don't know how much performance improvement it improves in practice
  - They add a small complexity to the code flow

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A
