### PR TITLE
Upgrade sparkjava and jackson-databind in order to fix some security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <antlr.version>4.5</antlr.version>
         <jline.version>2.12</jline.version>
         <commons-cli.version>1.3</commons-cli.version>
-        <spark-core.version>2.5.1</spark-core.version>
+        <spark-core.version>2.7.2</spark-core.version>
         <commons-collections.version>3.2.1</commons-collections.version>
         <commons-csv.version>1.3</commons-csv.version>
         <json.version>20160212</json.version>


### PR DESCRIPTION
# Why is this PR needed?

Github reported the following security issues w.r.t sparkjava and jackson-databind:
- https://nvd.nist.gov/vuln/detail/CVE-2018-9159
- https://nvd.nist.gov/vuln/detail/CVE-2016-9177


# What does the PR do?
Upgrade sparkjava and jackson-databinnd

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A