### PR TITLE
Correcting faulty example in docs

### DIFF
--- a/docs/pages/docs/00-get-started/quickstart-tutorial.md
+++ b/docs/pages/docs/00-get-started/quickstart-tutorial.md
@@ -140,7 +140,7 @@ match $p isa person, has identifier $i; get;
 Find all the people who are married:
 
 ```graql
-match (spouse1: $x, spouse2: $y) isa marriage; $x has identifier $xi; $y has identifier $yi; get;
+match (spouse: $x, spouse: $y) isa marriage; $x has identifier $xi; $y has identifier $yi; get;
 ```
 
 List parent-child relationships with the names of each person:


### PR DESCRIPTION

# Why is this PR needed?
As written, query produces: INVALID_ARGUMENT: GraqlQueryException-'spouse1' is not a role type. perhaps you meant 'isa spouse1'?. Please check server logs for the stack trace.
# What does the PR do?
Query in PR does not produce error.
# Does it break backwards compatibility?

# List of future improvements not on this PR
