### PR TITLE
Prune rules if pattern var has an id mapping

### DIFF
--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -180,7 +180,7 @@ public abstract class Atom extends AtomicBase {
     public Set<Var> getRoleExpansionVariables(){ return new HashSet<>();}
 
     private boolean isRuleApplicable(InferenceRule child) {
-        return getIdPredicate(getVarName()) == null
+        return (getIdPredicate(getVarName()) == null || child.isAppendRule())
                 && isRuleApplicableViaAtom(child.getRuleConclusionAtom());
     }
 

--- a/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
+++ b/grakn-graql/src/main/java/ai/grakn/graql/internal/reasoner/atom/Atom.java
@@ -179,8 +179,9 @@ public abstract class Atom extends AtomicBase {
      */
     public Set<Var> getRoleExpansionVariables(){ return new HashSet<>();}
 
-    protected boolean isRuleApplicable(InferenceRule child){
-        return isRuleApplicableViaAtom(child.getRuleConclusionAtom());
+    private boolean isRuleApplicable(InferenceRule child) {
+        return getIdPredicate(getVarName()) == null
+                && isRuleApplicableViaAtom(child.getRuleConclusionAtom());
     }
 
     protected abstract boolean isRuleApplicableViaAtom(Atom headAtom);


### PR DESCRIPTION
# Why is this PR needed?
Addresses #4506, #4422 

# What does the PR do?
Doesn't not apply rules if atom in question has a mapping for the pattern variable.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.