### PR TITLE
try building with experimental rules_nodejs

### DIFF
--- a/dependencies/npm/dependencies.bzl
+++ b/dependencies/npm/dependencies.bzl
@@ -19,6 +19,6 @@
 def node_dependencies():
     native.git_repository(
         name = "build_bazel_rules_nodejs",
-        remote = "https://github.com/bazelbuild/rules_nodejs.git",
-        commit = "e29c446b2f0cddfa51c307f898162f55d64d1fde",
+        remote = "https://github.com/graknlabs/rules_nodejs.git",
+        commit = "15d8a38af4ffaee9742195acf5b2cba73a86ce7a",
     )


### PR DESCRIPTION
# Why is this PR needed?

Increases performance for Node tests

# What does the PR do?

Integrates bazelbuild/rules_nodejs#405 so test run time decreases

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR

Debugging tests when ran in parallel
