### PR TITLE
Update executor service name used by attribute deduplicator daemon

### DIFF
--- a/server/src/deduplicator/AttributeDeduplicatorDaemon.java
+++ b/server/src/deduplicator/AttributeDeduplicatorDaemon.java
@@ -63,7 +63,7 @@ public class AttributeDeduplicatorDaemon {
     private static final int QUEUE_GET_BATCH_MAX = 1000;
     private static final Path queueDataDirRelative = Paths.get("queue"); // path to the queue storage location, relative to the data directory
 
-    private ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("attribute-deduplicator-daemon-%d").build());
+    private ExecutorService executorServiceForDaemon = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("attribute-deduplicator-daemon-%d").build());
 
     private EngineGraknTxFactory txFactory;
     private RocksDbQueue queue;
@@ -132,7 +132,7 @@ public class AttributeDeduplicatorDaemon {
             }
             LOG.info("startDeduplicationDaemon() - attribute de-duplicator daemon stopped");
             return null;
-        }, executorService);
+        }, executorServiceForDaemon);
 
         daemon.exceptionally(e -> {
             LOG.error("An unhandled exception has occurred in the attribute de-duplicator daemon. ", e);

--- a/server/src/deduplicator/AttributeDeduplicatorDaemon.java
+++ b/server/src/deduplicator/AttributeDeduplicatorDaemon.java
@@ -26,6 +26,7 @@ import ai.grakn.core.server.deduplicator.queue.Attribute;
 import ai.grakn.core.server.deduplicator.queue.RocksDbQueue;
 import ai.grakn.core.server.factory.EngineGraknTxFactory;
 import ai.grakn.kb.internal.EmbeddedGraknTx;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import static ai.grakn.core.server.deduplicator.AttributeDeduplicator.deduplicate;
@@ -59,6 +62,8 @@ public class AttributeDeduplicatorDaemon {
     private static Logger LOG = LoggerFactory.getLogger(AttributeDeduplicatorDaemon.class);
     private static final int QUEUE_GET_BATCH_MAX = 1000;
     private static final Path queueDataDirRelative = Paths.get("queue"); // path to the queue storage location, relative to the data directory
+
+    private ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("attribute-deduplicator-daemon-%d").build());
 
     private EngineGraknTxFactory txFactory;
     private RocksDbQueue queue;
@@ -127,7 +132,7 @@ public class AttributeDeduplicatorDaemon {
             }
             LOG.info("startDeduplicationDaemon() - attribute de-duplicator daemon stopped");
             return null;
-        });
+        }, executorService);
 
         daemon.exceptionally(e -> {
             LOG.error("An unhandled exception has occurred in the attribute de-duplicator daemon. ", e);


### PR DESCRIPTION
# Why is this PR needed?

It is hard to see which thread is running the attribute deduplicator daemon. We need to improve the thread dump information.

# What does the PR do?

1. Created a named executor service where the threads will be assigned names with the following format: `attribute-deduplicator-daemon-%d`.
2. In practice, this means that the attribute deduplicator daemon thread will run on a thread named "attribute-deduplicator-daemon-1", which is easier to spot when debugging.
3. Add a new executor service used by the attribute deduplicator daemon

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A