### PR TITLE
Simplify the CI workflow - test-unit and test-integration jobs no longer depend on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,17 +36,6 @@ references:
       attach_workspace:
         at: ~/grakn
 
-    start_grakn_server: &start_grakn_server
-      run: nohup grakn-dist/target/grakn-core-test/grakn server start
-
-    save_test_results: &save_test_results
-      run:
-        name: Save test results
-        command: |
-          mkdir -p ~/grakn-surefire-reports/
-          find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/grakn-surefire-reports/ \;
-        when: always
-
 jobs:
   build:
     machine: true
@@ -68,35 +57,25 @@ jobs:
     machine: true
     working_directory: ~/grakn
     steps:
+      - checkout
       - *prepare_apt_repositories
       - *install_yarn_and_unzip
       - *install_node
       - *install_bazel
-      - *attach_grakn_workspace
       - run: bazel test //grakn-graql/... --test_output=errors
       - run: bazel test //server/... --test_output=errors
       - run: bazel test //client-java/... --test_output=errors
-      - *save_test_results
-      - store_artifacts:
-          path: ~/grakn-surefire-reports/
-      - store_test_results:
-          path: ~/grakn-surefire-reports/
 
   test-integration:
     machine: true
     working_directory: ~/grakn
     steps:
-    - *prepare_apt_repositories
-    - *install_yarn_and_unzip
-    - *install_node
-    - *install_bazel
-    - *attach_grakn_workspace
-    - run: bazel test //test-integration/... --test_output=errors
-    - *save_test_results
-    - store_artifacts:
-        path: ~/grakn-surefire-reports/
-    - store_test_results:
-        path: ~/grakn-surefire-reports/
+      - checkout
+      - *prepare_apt_repositories
+      - *install_yarn_and_unzip
+      - *install_node
+      - *install_bazel
+      - run: bazel test //test-integration/... --test_output=errors
 
   test-end-to-end:
     machine: true
@@ -106,11 +85,6 @@ jobs:
       - *install_bazel
       - run: bazel build //:distribution --sandbox_debug
       - run: bazel test //test-end-to-end:test-end-to-end --test_output=streamed --spawn_strategy=standalone
-      - *save_test_results
-      - store_artifacts:
-          path: ~/grakn-surefire-reports/
-      - store_test_results:
-          path: ~/grakn-surefire-reports/
 
   client-nodejs-e2e:
       machine: true
@@ -246,12 +220,8 @@ workflows:
           filters:
             tags:
               ignore: /.*/
-      - test-unit:
-          requires:
-            - build
-      - test-integration:
-          requires:
-          - build
+      - test-unit
+      - test-integration
       - test-end-to-end
       - client-nodejs-e2e
       - client-python-e2e


### PR DESCRIPTION
# Why is this PR needed?
Simplify the CI workflow - `test-unit` and `test-integration` jobs no longer depend on `build`. They `checkout` the code and build it themselves instead. In Bazel, the artifact that got built resides in a sandboxed environment which is hard to copy over using the attach workspace functionality.

# What does the PR do?
1. `test-unit` and `test-integration` no longer depend on `build`. They do `checkout` instead.
2. remove `start_grakn_server` 
3. remove `store_artifacts`, `save_test_results `, and `store_test_results` as they are for saving JUnit test results which we no longer use

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A