### PR TITLE
Encapsulated Grakn's RPC library into //protocol

### DIFF
--- a/client-java/BUILD
+++ b/client-java/BUILD
@@ -26,7 +26,7 @@ java_library(
     deps = [
         # Grakn Core dependencies
         "//grakn-graql:grakn-graql",
-        "//protocol:rpc-java",
+        "//protocol:protocol-java",
 
         # External dependencies
         "//dependencies/maven/artifacts/com/google/auto/value:auto-value",
@@ -63,7 +63,7 @@ java_test(
     deps = [
         ":client-java",
         "//grakn-graql:grakn-graql",
-        "//protocol:rpc-java",
+        "//protocol:protocol-java",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//dependencies/maven/artifacts/org/mockito:mockito-core",
         "//dependencies/maven/artifacts/io/grpc:grpc-testing",

--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -17,29 +17,19 @@
 #
 
 
-load("@org_pubref_rules_proto//python:compile.bzl", "python_grpc_compile")
 load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
 
 
-python_grpc_compile(
-    name = "client_python_proto",
-    deps = [
-        "//protocol/session:session-proto",
-        "//protocol/session:answer-proto",
-        "//protocol/session:concept-proto",
-        "//protocol/keyspace:keyspace-proto",
-    ]
-)
-
 py_library(
     name = "client_python",
-    srcs = [":client_python_proto"] + glob([
+    srcs = glob([
         "grakn/__init__.py",
         "grakn/exception/*.py",
         "grakn/service/**/*.py"
     ]),
     deps = [
+        "//protocol:protocol_python",
         requirement("protobuf"),
         requirement("grpcio"),
         requirement("six"),
@@ -57,7 +47,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "./client_python_proto"]
+    imports = [".", "../protocol/protocol_python_src"]
 )
 
 py_test(
@@ -70,7 +60,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "./client_python_proto"]
+    imports = [".", "../protocol/protocol_python_src"]
 )
 
 py_test(
@@ -83,7 +73,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "./client_python_proto"]
+    imports = [".", "../protocol/protocol_python_src"]
 )
 
 test_suite(

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -22,7 +22,7 @@ load("@org_pubref_rules_proto//java:compile.bzl", "java_grpc_compile")
 load("//dependencies/deployment/maven:rules.bzl", "deploy_maven_jar")
 
 java_grpc_compile(
-    name = "rpc-java-proto",
+    name = "protocol-java-src",
     deps = [
         "//protocol/session:session-proto",
         "//protocol/session:answer-proto",
@@ -32,8 +32,8 @@ java_grpc_compile(
 )
 
 java_library(
-    name = "rpc-java",
-    srcs = [":rpc-java-proto"],
+    name = "protocol-java",
+    srcs = [":protocol-java-src"],
     deps = [
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/com/google/protobuf:protobuf-java",
@@ -46,6 +46,32 @@ java_library(
 
 deploy_maven_jar(
     name = "deploy-maven-jar",
-    targets = [":rpc-java"],
+    targets = [":protocol-java"],
     version_file = "//:VERSION",
+)
+
+
+load("@org_pubref_rules_proto//python:compile.bzl", "python_grpc_compile")
+load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@pypi_dependencies//:requirements.bzl", "requirement")
+
+python_grpc_compile(
+    name = "protocol_python_src",
+    deps = [
+        "//protocol/session:session-proto",
+        "//protocol/session:answer-proto",
+        "//protocol/session:concept-proto",
+        "//protocol/keyspace:keyspace-proto",
+    ]
+)
+
+py_library(
+    name = "protocol_python",
+    srcs = [":protocol_python_src"],
+    deps = [
+        requirement("protobuf"),
+        requirement("grpcio"),
+        requirement("six"),
+        requirement("enum34")
+    ]
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -24,7 +24,7 @@ java_library(
     deps = [
         # Grakn Core dependencies
         "//grakn-graql:grakn-graql",
-        "//protocol:rpc-java",
+        "//protocol:protocol-java",
 
         # External dependencies
         "//dependencies/maven/artifacts/com/fasterxml/jackson/core:jackson-core",

--- a/server/test/rpc/BUILD
+++ b/server/test/rpc/BUILD
@@ -8,7 +8,7 @@ java_test(
         "//server",
         "//grakn-graql",
         "//client-java",
-        "//protocol:rpc-java",
+        "//protocol:protocol-java",
         "//dependencies/maven/artifacts/io/grpc:grpc-core",
         "//dependencies/maven/artifacts/commons-io:commons-io",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",


### PR DESCRIPTION
# Why is this PR needed?

Right now we build the protocol libraries in each client driver packages. However, it would make more sense that they get encapsulated in the `//protocol` package, as it becomes more reusable.

# What does the PR do?

1. move the build of java src to `//protocol:protocol-java-src` and java lib`//protocol:protocol-java`
2. we add `deploy-maven-jar` to for `//protocol:rpc-java-proto`
1. move the build of python src to `//protocol:protocol_python_src` and python lib`//protocol:protocol_python`

# Does it break backwards compatibility?

No.

# List of future improvements not on this PR
We'll need @vmax's help on issue #4566.