### PR TITLE
add the github pull request template back

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Why is this PR needed?
+
+# What does the PR do?
+
+# Does it break backwards compatibility?
+
+# List of future improvements not on this PR


### PR DESCRIPTION
# Why is this PR needed?
Because the pr template (previously under `docs/`) was accidentally removed.

# What does the PR do?
Adding the pr template back, under the `.github` directory.

# Does it break backwards compatibility?
No.

# List of future improvements not on this PR
We can add any Github related files such as issue templates under the same `.github` directory.