### PR TITLE
Temporarily reduce the size of chained rules to not hit GRPC limit

### DIFF
--- a/test-integration/test/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/test/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -252,7 +252,7 @@ public class BenchmarkBigIT {
      */
     @Test
     public void testRandomSetLinearTransitivity()  {
-        final int N = 2000;
+        final int N = 200;
         final int limit = 100;
         System.out.println(new Object(){}.getClass().getEnclosingMethod().getName());
         loadTransitivityData(N);


### PR DESCRIPTION
# Why is this PR needed?

This bug is caused by issue #4545 where explanation objects should be returned as a stream.

# What does the PR do?

Temporarily reduce the size of chained rules to not hit GRPC limit.
