### PR TITLE
Change maven.grakn.ai URL from test to the real one

### DIFF
--- a/deployment.properties
+++ b/deployment.properties
@@ -17,5 +17,5 @@
 #
 
 github.repository=grakn
-maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/bazel-test-snapshot
-maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/bazel-test-release
+maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/snapshots/
+maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/releases/


### PR DESCRIPTION
# Why is this PR needed?
Revert `http://maven.grakn.ai/nexus/content/repositories/bazel-test-snapshot` to `http://maven.grakn.ai/nexus/content/repositories/snapshots/` in `deployment.properties`.

# What does the PR do?
-

# Does it break backwards compatibility?
nope

# List of future improvements not on this PR
