### PR TITLE
Fix AtomicQueryUnificationIT flakey test

### DIFF
--- a/test-integration/test/graql/reasoner/atomic-query/AtomicQueryUnificationIT.java
+++ b/test-integration/test/graql/reasoner/atomic-query/AtomicQueryUnificationIT.java
@@ -3,6 +3,10 @@
 
 package grakn.core.graql.internal.reasoner;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import grakn.core.GraknSession;
 import grakn.core.GraknTx;
 import grakn.core.GraknTxType;
@@ -30,11 +34,6 @@ import grakn.core.graql.internal.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.internal.reasoner.unifier.UnifierType;
 import grakn.core.kb.internal.EmbeddedGraknTx;
 import grakn.core.test.rule.ConcurrentGraknServer;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;


### PR DESCRIPTION
# Why is this PR needed?

`AtomicQueryUnificationIT` sometimes fail because an `entity` iterator may return the results in different order at different runs. Additionally, the transactions that are opened in every test method are not automatically closed when the test fails, which results in other test methods facing transaction clashes as found in issue #4582.

# What does the PR do?

1. Fix `loadContext()` to retrieve entities always in the same order at every run.
2. Open transactions in an auto-closable `try{ }` block for every test method (closes #4582)

# Does it break backwards compatibility?

Nope.