### PR TITLE
Adding maven deploy rule for //util package

### DIFF
--- a/util/BUILD
+++ b/util/BUILD
@@ -17,6 +17,7 @@
 #
 
 package(default_visibility = ["//visibility:public"])
+load("//dependencies/deployment/maven:rules.bzl", "deploy_maven_jar")
 
 java_library(
     name = "util",
@@ -31,6 +32,13 @@ java_library(
         "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",
         "//dependencies/maven/artifacts/ch/qos/logback:logback-core",
     ],
+    tags = ["maven_coordinates=grakn.core:util:{pom_version}"],
+)
+
+deploy_maven_jar(
+    name = "deploy-maven-jar",
+    targets = [":util"],
+    version_file = "//:VERSION",
 )
 
 java_test(


### PR DESCRIPTION
# Why is this PR needed?
Primarily exposes SimpleURI, which is required by consumers of client-java currently.

# What does the PR do?
Adds a maven deployment rule to //util for external use (such as by consumers of client-java)

# Does it break backwards compatibility?
no

# List of future improvements not on this PR