### PR TITLE
Make the output of deploy-maven-jar more informative, useful when troubleshooting when things don't work

### DIFF
--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -78,30 +78,30 @@ jar -fu lib-with-maven-metadata.jar META-INF/
 
 $MD5_BINARY pom.xml | awk '{print $1}' > pom.md5
 $MD5_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.md5
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi
 
 $SHA1_BINARY pom.xml | awk '{print $1}' > pom.sha1
 $SHA1_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.sha1
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi
-status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar)
-if [[ ${status} -ne 201 ]]; then
+http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar)
+if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     exit 1
 fi

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -80,12 +80,12 @@ $MD5_BINARY pom.xml | awk '{print $1}' > pom.md5
 $MD5_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.md5
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 
@@ -93,21 +93,22 @@ $SHA1_BINARY pom.xml | awk '{print $1}' > pom.sha1
 $SHA1_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.sha1
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
-    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
+    echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
+echo "Deployment complete"

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -78,13 +78,30 @@ jar -fu lib-with-maven-metadata.jar META-INF/
 
 $MD5_BINARY pom.xml | awk '{print $1}' > pom.md5
 $MD5_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.md5
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi
 
 $SHA1_BINARY pom.xml | awk '{print $1}' > pom.sha1
 $SHA1_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.sha1
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1
-
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom
-curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi
+status=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar)
+if [[ ${status} -ne 201 ]]; then
+    exit 1
+fi

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -18,6 +18,7 @@
 
 #!/usr/bin/env bash
 
+set -ex
 
 ARTIFACT="$ARTIFACT"
 COORDINATES="$COORDINATES"
@@ -77,13 +78,13 @@ jar -fu lib-with-maven-metadata.jar META-INF/
 
 $MD5_BINARY pom.xml | awk '{print $1}' > pom.md5
 $MD5_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.md5
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5
 
 $SHA1_BINARY pom.xml | awk '{print $1}' > pom.sha1
 $SHA1_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.sha1
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1
 
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom
-curl -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom
+curl -v -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -80,10 +80,12 @@ $MD5_BINARY pom.xml | awk '{print $1}' > pom.md5
 $MD5_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.md5
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.md5)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.md5 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.md5)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 
@@ -91,17 +93,21 @@ $SHA1_BINARY pom.xml | awk '{print $1}' > pom.sha1
 $SHA1_BINARY lib-with-maven-metadata.jar | awk '{print $1}' > lib.jar.sha1
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom.sha1)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib.jar.sha1 $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar.sha1)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file pom.xml $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.pom)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
 http_status_code_from_upload=$(curl --silent --output /dev/stderr --write-out "%{http_code}" -X PUT -u $MAVEN_USERNAME:$MAVEN_PASSWORD --upload-file lib-with-maven-metadata.jar $MAVEN_URL/$COORDINATES/$VERSION/$ARTIFACT-$VERSION.jar)
 if [[ ${http_status_code_from_upload} -ne 201 ]]; then
+    echo "The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -111,4 +111,4 @@ if [[ ${http_status_code_from_upload} -ne 201 ]]; then
     echo "Error: The upload failed, got HTTP status code $http_status_code_from_upload"
     exit 1
 fi
-echo "Deployment complete"
+echo "Deployment completed"


### PR DESCRIPTION
# Why is this PR needed?
Solves https://github.com/graknlabs/grakn/issues/4589

# What does the PR do?
- adding `set -ex` on `deploy.sh`. It enables verbose mode where every command is printed to STDOUT. Additionally, the script will exit immediately if an error occurred instead of continuing to run (which makes no sense). 
- Make curl output the HTTP error code to STDOUT which is used to determine if the upload process was successful, eg., so that you will be informed if fails due to not having permission to upload.

Example output of when the deployment failed due to not having permission to upload:
```
...
+++ curl --silent --output /dev/stderr --write-out '%{http_code}' -X PUT -u joshua:2OS0r63OdX4xrpBOnvST --upload-file pom.md5 http://maven.grakn.ai/nexus/content/repositories/snapshots//grakn/core/protocol/1.5.0-SNAPSHOT/protocol-1.5.0-SNAPSHOT.pom.md5
++ http_status_code_from_upload=403
++ [[ 403 -ne 201 ]]
++ echo 'Error: The upload failed, got HTTP status code 403'
Error: The upload failed, got HTTP status code 403
++ exit 1
```

And when the deployment completed:
```
++ [[ 201 -ne 201 ]]
+++ curl --silent --output /dev/stderr --write-out '%{http_code}' -X PUT -u joshua:2OS0r63OdX4xrpBOnvST --upload-file lib-with-maven-metadata.jar http://maven.grakn.ai/nexus/content/repositories/bazel-test-snapshot/grakn/core/protocol/1.5.0-SNAPSHOT/protocol-1.5.0-SNAPSHOT.jar
++ http_status_code_from_upload=201
++ [[ 201 -ne 201 ]]
++ echo 'Deployment complete'
Deployment complete
```
# Does it break backwards compatibility?

# List of future improvements not on this PR
