### PR TITLE
Removed prepare_apt and install_node completely

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,5 @@
 version: 2
 references:
-    prepare_apt_repositories: &prepare_apt_repositories
-      run:
-        name: Prepare apt repositories
-        command: |
-          sudo apt-get install apt-transport-https
-          sudo apt-get update
-
-    install_node: &install_node
-      run:
-        name: Install nvm and node
-        command: |
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-          export NVM_DIR="/opt/circleci/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-          nvm install v10.5.0
-          nvm alias default v10.5.0
-          echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
-          echo "[ -s \"$NVM_DIR/nvm.sh\" ] && . \"$NVM_DIR/nvm.sh\"" >> $BASH_ENV
-
     install_bazel: &install_bazel
       run:
         name: Install bazel
@@ -118,7 +99,6 @@ jobs:
       working_directory: ~/grakn
       steps:
         - checkout
-        - *prepare_apt_repositories
         - *install_bazel
         - run: bazel run @nodejs//:npm install
         - run: bazel test //workbase:tests-unit
@@ -190,8 +170,6 @@ jobs:
     working_directory: ~/grakn
     steps:
       - checkout
-      - *prepare_apt_repositories
-      - *install_node
       - *install_bazel
       - run: echo 'export GRAKN_VERSION=$(echo ${CIRCLE_TAG} | cut -c 2-)' >> $BASH_ENV #remove 'v' from tag name and use it as Grakn Version to be released
       - run: mvn --batch-mode install -T 2.5C -DskipTests=true


### PR DESCRIPTION
# Why is this PR needed?

With the new Bazel build system, and the new architecture, we no longer need the some of the "preps" we had in CircleCI. We've removed some in a previous PR, but this PR removes 2 more "references" completely.

# What does the PR do?

1. Removed `prepare_apt_repositories`, as we use the default machines that already have the OS dependencies installed.
2. Removed `install_node` as Bazel brings its own Node.js in the dependencies

# Does it break backwards compatibility?

Nope.

# List of future improvements not on this PR

We need to Bazelize the deployment jobs in CI, @lolski @vmax @marco-scoppetta. Let's make a list of issues for them.