### PR TITLE
Fix catastrophic backtracking of evil regex

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -22,7 +22,7 @@ function getNeighboursQuery(node, neighboursLimit) {
 }
 
 export function limitQuery(query) {
-  const getRegex = /^((.|\s)*;)\s*(get\b.*;)$/;
+  const getRegex = /^((.|\n)*;)\s*(get\s*.\w*;)/;
   let limitedQuery = query;
 
   // If there is no `get` the user mistyped the query

--- a/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -22,7 +22,7 @@ function getNeighboursQuery(node, neighboursLimit) {
 }
 
 export function limitQuery(query) {
-  const getRegex = /^((.|\n)*;)\s*(get\s*.\w*;)/;
+  const getRegex = /^((.|\n)*;)\s*(get;|get\s*.\w*;)/;
   let limitedQuery = query;
 
   // If there is no `get` the user mistyped the query

--- a/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -46,6 +46,21 @@ describe('limit Query', () => {
     match $x isa person;
     $r($x, $y); offset 0; limit 10; get;`);
   });
+  test('query containing multi-line get query', () => {
+    const query = `
+    match $x isa person;
+    get    
+         $x;`;
+    const limited = limitQuery(query);
+    expect(limited).toBe(`
+    match $x isa person; offset 0; limit 10; get    
+         $x;`);
+  });
+  test('query without get', () => {
+    const query = 'match $x isa person;';
+    const limited = limitQuery(query);
+    expect(limited).toBe('match $x isa person;');
+  });
 });
 
 describe('Compute Attributes', () => {


### PR DESCRIPTION
# Why is this PR needed?
Catastrophic backtracking in the get Regex was causing workbase to crash

# What does the PR do?
1) Replace `(.|\s)* with (.|\n)*`
2) Update regex to match multi-line get query e.g. 
```
match $x isa person; get $x;
```

# Does it break backwards compatibility?
No 

# List of future improvements not on this PR
No