### PR TITLE
Explain concept when the rule contains conjunctions

### DIFF
--- a/workbase/src/renderer/components/Visualiser/store/actions.js
+++ b/workbase/src/renderer/components/Visualiser/store/actions.js
@@ -157,7 +157,15 @@ export default {
     }
   },
   async [EXPLAIN_CONCEPT]({ state, dispatch, getters, commit }) {
-    const queries = getters.selectedNode.explanation.answers().map(answer => mapAnswerToExplanationQuery(answer));
+    const explanation = getters.selectedNode.explanation;
+
+    let queries;
+    // If the explanation is formed from a conjuction inside a rule, go one step deeper to access the actual explanation
+    if (!explanation.queryPattern().length) {
+      queries = explanation.answers().map(answer => answer.explanation().answers().map(answer => mapAnswerToExplanationQuery(answer))).flatMap(x => x);
+    } else {
+      queries = getters.selectedNode.explanation.answers().map(answer => mapAnswerToExplanationQuery(answer));
+    }
     queries.forEach(async (query) => {
       commit('loadingQuery', true);
       const graknTx = await dispatch(OPEN_GRAKN_TX);


### PR DESCRIPTION
# Why is this PR needed?
Explanation was not working for concepts where the rule included a conjunction. 

# What does the PR do?
Whenever a conjunction is in a rule, the query pattern of the explanation for that concept is empty so we can obtain the actual explanation queries by going one step deeper in the explanation.

This is done by using the explanations of the answers of the explanation for the concept.

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Import a keyspace to include such an explanation and then write an integration test to test this.