### PR TITLE
fix Maven deployment script: comment/empty lines; sanity check

### DIFF
--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -44,11 +44,6 @@ fi
 
 # awk in the next line strips out empty and comment lines
 MAVEN_URL=$(grep "maven.repository-url.$MAVEN_REPO_TYPE" <(awk '!/^#/ && /./' deployment.properties) | cut -d '=' -f 2)
-RESULTS_COUNT=$(echo $MAVEN_URL | awk '{print NF; exit}') # count lines matching patterns
-if [[ "$RESULTS_COUNT" != "1" ]]; then
-    echo "Multiple ($RESULTS_COUNT) results found for $MAVEN_REPO_TYPE; check your deployment.properties file"
-    exit 1
-fi
 
 platform=$(uname)
 

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -42,8 +42,11 @@ if [[ "$MAVEN_REPO_TYPE" != "snapshot" ]] && [[ "$MAVEN_REPO_TYPE" != "release" 
     exit 1
 fi
 
+# create a temporary file for preprocessing deployment.properties
+DEPLOYMENT_PROPERTIES_STRIPPED_FILE=$(mktemp)
 # awk in the next line strips out empty and comment lines
-MAVEN_URL=$(grep "maven.repository-url.$MAVEN_REPO_TYPE" <(awk '!/^#/ && /./' deployment.properties) | cut -d '=' -f 2)
+awk '!/^#/ && /./' deployment.properties > ${DEPLOYMENT_PROPERTIES_STRIPPED_FILE}
+MAVEN_URL=$(grep "maven.repository-url.$MAVEN_REPO_TYPE" ${DEPLOYMENT_PROPERTIES_STRIPPED_FILE} | cut -d '=' -f 2)
 
 platform=$(uname)
 

--- a/dependencies/deployment/maven/deploy.sh
+++ b/dependencies/deployment/maven/deploy.sh
@@ -42,8 +42,13 @@ if [[ "$MAVEN_REPO_TYPE" != "snapshot" ]] && [[ "$MAVEN_REPO_TYPE" != "release" 
     exit 1
 fi
 
-
-MAVEN_URL=$(grep "maven.repository-url.$MAVEN_REPO_TYPE" deployment.properties | cut -d '=' -f 2)
+# awk in the next line strips out empty and comment lines
+MAVEN_URL=$(grep "maven.repository-url.$MAVEN_REPO_TYPE" <(awk '!/^#/ && /./' deployment.properties) | cut -d '=' -f 2)
+RESULTS_COUNT=$(echo $MAVEN_URL | awk '{print NF; exit}') # count lines matching patterns
+if [[ "$RESULTS_COUNT" != "1" ]]; then
+    echo "Multiple ($RESULTS_COUNT) results found for $MAVEN_REPO_TYPE; check your deployment.properties file"
+    exit 1
+fi
 
 platform=$(uname)
 


### PR DESCRIPTION
# Why is this PR needed?
closes #4614

# What does the PR do?
`deployment.properties` now supports *non-inline* comments like this:
```
# comment
# another comment
maven.repository.snapshot=...
```

*inline* comments aren't supported and there are no plans to support it as it's difficult to do in Bash:
```
maven.repository.snapshot=... # this type of comment isn't supported
```

# Does it break backwards compatibility?
Nope

# List of future improvements not on this PR
1. More sanity checks?
2. Apply the same validation in `deploy-github-zip`'s `deployment.sh` script