### PR TITLE
Attach explanation to nodes when loading neighbours

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserGraphBuilder.js
@@ -3,7 +3,7 @@ import NodeSettings from './RightBar/SettingsTab/DisplaySettings';
 import QuerySettings from './RightBar/SettingsTab/QuerySettings';
 
 // Map graql variables and explanations to each concept
-async function attachExplanation(result) {
+function attachExplanation(result) {
   return result.map((x) => {
     const exp = x.explanation();
     const key = x.map().keys().next().value;
@@ -195,7 +195,7 @@ async function constructEdges(result) {
 }
 
 async function buildFromConceptMap(result, autoLoadRolePlayers, limitRoleplayers) {
-  const nodes = await prepareNodes(await attachExplanation(result));
+  const nodes = await prepareNodes(attachExplanation(result));
   const edges = await constructEdges(result);
 
   // Check if auto-load role players is selected
@@ -232,4 +232,5 @@ export default {
   buildFromConceptList,
   prepareNodes,
   relationshipsRolePlayers,
+  attachExplanation,
 };

--- a/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -113,7 +113,7 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe(JSON.stringify(MockConcepts.getMockEntity1()));
+    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
     expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"3333","to":"0000","label":"isa"}');
   });
   test('entity', async () => {
@@ -124,8 +124,8 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(2);
     expect(neighboursData.edges).toHaveLength(2);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe(JSON.stringify(MockConcepts.getMockRelationship()));
-    expect(JSON.stringify(neighboursData.nodes[1])).toBe(JSON.stringify(MockConcepts.getMockEntity2()));
+    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"RELATIONSHIP","id":"6666","explanation":"mockExplanation","offset":0,"graqlVar":"r"}');
+    expect(JSON.stringify(neighboursData.nodes[1])).toBe('{"baseType":"ENTITY","id":"4444","explanation":"mockExplanation","graqlVar":"r"}');
     expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"6666","to":"3333","label":"son"}');
     expect(JSON.stringify(neighboursData.edges[1])).toBe('{"from":"6666","to":"4444","label":"father"}');
   });
@@ -137,7 +137,7 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe(JSON.stringify(MockConcepts.getMockEntity1()));
+    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
     expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"3333","to":"5555","label":"has"}');
   });
   test('relationship', async () => {
@@ -149,7 +149,7 @@ describe('Get neighbours data', () => {
 
     expect(neighboursData.nodes).toHaveLength(1);
     expect(neighboursData.edges).toHaveLength(1);
-    expect(JSON.stringify(neighboursData.nodes[0])).toBe(JSON.stringify(MockConcepts.getMockEntity1()));
+    expect(JSON.stringify(neighboursData.nodes[0])).toBe('{"baseType":"ENTITY","id":"3333","offset":0,"graqlVar":"x"}');
     expect(JSON.stringify(neighboursData.edges[0])).toBe('{"from":"6666","to":"3333","label":"son"}');
   });
 });


### PR DESCRIPTION
# Why is this PR needed?
Closes: #4655 

# What does the PR do?
1) When neighbours are loaded from a concept, attach its explanation on it.
2) Refactor
# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A