### PR TITLE
Un-ignore 'target' folder created by Maven which broke 'bazel' build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ bazel-*
 # Compiled files #
 dist/
 out/
-target/
 *.class
 
 # Mobile Tools for Java (J2ME) files #


### PR DESCRIPTION
# Why is this PR needed?

Makes breaking changes introduced by Maven obvious

# What does the PR do?

Un-ignores `target` folder

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR

Nope