### PR TITLE
Add shortcut for zooming in on workbase

### DIFF
--- a/workbase/src/main/index.js
+++ b/workbase/src/main/index.js
@@ -51,7 +51,7 @@ function buildApplicationMenu() {
         role: 'reload',
       },
       {
-        role: 'zoomin',
+        role: 'zoomin', accelerator: 'CmdOrCtrl+=',
       },
       {
         role: 'zoomout',


### PR DESCRIPTION
# Why is this PR needed?
The shortcut for Zooming into the workbase window was inconsistent with zooming out

# What does the PR do?
Add shortcut to zoom in so that the user does not have to hold shift 

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A