### PR TITLE
Show roleplayers of sub-typed relationships

### DIFF
--- a/workbase/src/renderer/components/SchemaDesign/store/actions.js
+++ b/workbase/src/renderer/components/SchemaDesign/store/actions.js
@@ -89,12 +89,9 @@ export default {
       .filter(x => x.label !== 'relationship');
     // Find nodes that are subconcepts of existing types - these nodes will only have isa edges
     const subConcepts = await computeSubConcepts(nodes);
-    const subConceptsIds = new Set(subConcepts.nodes.map(n => n.id));
 
-    const relNodes = nodes.filter(x => !subConceptsIds.has(x.id));
-
-    // Draw all edges from relationships to roleplayers only on concepts that don't subtype a custom type
-    const relEdges = await relationshipTypesOutboundEdges(relNodes);
+    // Draw all edges from relationships to roleplayers
+    const relEdges = await relationshipTypesOutboundEdges(nodes);
 
     graknTx.close();
 


### PR DESCRIPTION
# Why is this PR needed?
Roleplayers of sub-typed relationships where not being visualised on the schema designer

# What does the PR do?
Does not filter subconcepts when building relationship type outbound edges

# Does it break backwards compatibility?
no

# List of future improvements not on this PR
N/A