### PR TITLE
client_python deployment to PyPI

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="31112a8f2d3d9bc04d8c6117ac4f0dc752ab45d5",
+    commit="45891bf94fd9ffc118a44295a6f1446e470f7ab8",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -122,7 +122,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="45891bf94fd9ffc118a44295a6f1446e470f7ab8",
+    commit="acc2b7baf4ab93a02dd49123d3adab4dc6989ce8",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -19,23 +19,69 @@
 
 load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
+load("@graknlabs_rules_deployment//pip:rules.bzl", "deploy_pip")
 
 
 py_library(
     name = "client_python",
-    srcs = glob([
-        "grakn/__init__.py",
-        "grakn/exception/*.py",
-        "grakn/service/**/*.py"
-    ]),
+    srcs = [
+        "//client_python/grakn:__init__.py",
+        "//client_python/grakn:service/Keyspace/KeyspaceService.py",
+        "//client_python/grakn:service/Session/TransactionService.py",
+        "//client_python/grakn:service/Session/util/enums.py",
+        "//client_python/grakn:service/Session/util/RequestBuilder.py",
+        "//client_python/grakn:service/Session/util/ResponseReader.py",
+        "//client_python/grakn:service/Session/Concept/ConceptFactory.py",
+        "//client_python/grakn:service/Session/Concept/BaseTypeMapping.py",
+        "//client_python/grakn:service/Session/Concept/Concept.py",
+        "//client_python/grakn:exception/GraknError.py",
+    ],
     deps = [
-        "//protocol:protocol_python",
+        "//client_python/grakn:protocol_python",
         requirement("protobuf"),
         requirement("grpcio"),
         requirement("six"),
-        requirement("enum34")
+        requirement("enum34"),
+        # Only needed for deployment
+        requirement("twine"),
+        requirement("setuptools"),
+        requirement("wheel"),
     ]
 )
+
+deploy_pip(
+    name = "deploy-pip",
+    package_name = "grakn",
+    version_file = "//:VERSION",
+    classifiers = [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "Environment :: Console",
+        "Topic :: Database :: Front-Ends"
+    ],
+    url = "https://github.com/graknlabs/grakn/tree/master/client-python",
+    author = "Grakn Labs",
+    author_email = "community@grakn.ai",
+    license = "Apache-2.0",
+    install_requires=['grpcio==1.16.0', 'protobuf==3.6.1', 'six==1.11.0', 'enum34==1.1.6'],
+    keywords = ["grakn", "database", "graph", "knowledgebase", "knowledge-engineering"],
+    deployment_properties = "//:deployment.properties",
+    description = "A Python client for Grakn.",
+    long_description_file = "//client_python:README.md",
+    target = ":client_python"
+)
+
 
 py_test(
     name = "test_concept",
@@ -47,7 +93,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "../protocol/protocol_python_src"]
+    imports = ["."]
 )
 
 py_test(
@@ -60,7 +106,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "../protocol/protocol_python_src"]
+    imports = ["."]
 )
 
 py_test(
@@ -73,7 +119,7 @@ py_test(
         ":client_python",
         requirement("forbiddenfruit")
     ],
-    imports = [".", "../protocol/protocol_python_src"]
+    imports = ["."]
 )
 
 test_suite(

--- a/client_python/grakn/BUILD
+++ b/client_python/grakn/BUILD
@@ -30,8 +30,6 @@ python_grpc_compile(
 py_replace_imports(
     name = "rpc",
     src = ":rpc_raw",
-    original_name = "rpc_raw",
-    output_name = "rpc",
     original_package = "protocol",
     output_package = "grakn.rpc.protocol"
 )

--- a/client_python/grakn/BUILD
+++ b/client_python/grakn/BUILD
@@ -1,0 +1,43 @@
+load("@org_pubref_rules_proto//python:compile.bzl", "python_grpc_compile")
+load("@io_bazel_rules_python//python:python.bzl", "py_library")
+load("@graknlabs_rules_deployment//pip:rules.bzl", "py_replace_imports")
+
+
+exports_files([
+    "__init__.py",
+    "service/Keyspace/KeyspaceService.py",
+    "service/Session/TransactionService.py",
+    "service/Session/util/enums.py",
+    "service/Session/util/RequestBuilder.py",
+    "service/Session/util/ResponseReader.py",
+    "service/Session/Concept/ConceptFactory.py",
+    "service/Session/Concept/BaseTypeMapping.py",
+    "service/Session/Concept/Concept.py",
+    "exception/GraknError.py"
+])
+
+python_grpc_compile(
+    name = "rpc_raw",
+    deps = [
+        "//protocol/session:session-proto",
+        "//protocol/session:answer-proto",
+        "//protocol/session:concept-proto",
+        "//protocol/keyspace:keyspace-proto",
+    ],
+     visibility = ["//visibility:public"]
+)
+
+py_replace_imports(
+    name = "rpc",
+    src = ":rpc_raw",
+    original_name = "rpc_raw",
+    output_name = "rpc",
+    original_package = "protocol",
+    output_package = "grakn.rpc.protocol"
+)
+
+py_library(
+    name = "protocol_python",
+    srcs = [":rpc"],
+    visibility = ["//visibility:public"]
+)

--- a/client_python/grakn/__init__.py
+++ b/client_python/grakn/__init__.py
@@ -21,7 +21,7 @@ import grpc
 from grakn.service.Session.util.enums import TxType, DataType
 from grakn.service.Keyspace.KeyspaceService import KeyspaceService
 from grakn.service.Session.TransactionService import TransactionService
-from protocol.session.Session_pb2_grpc import SessionServiceStub
+from grakn.rpc.protocol.session.Session_pb2_grpc import SessionServiceStub
 from grakn.exception.GraknError import GraknError
 
 class Grakn(object):

--- a/client_python/grakn/service/Keyspace/KeyspaceService.py
+++ b/client_python/grakn/service/Keyspace/KeyspaceService.py
@@ -18,8 +18,8 @@
 #
 
 import grpc
-from protocol.keyspace.Keyspace_pb2_grpc import KeyspaceServiceStub
-import protocol.keyspace.Keyspace_pb2 as keyspace_messages
+from grakn.rpc.protocol.keyspace.Keyspace_pb2_grpc import KeyspaceServiceStub
+import grakn.rpc.protocol.keyspace.Keyspace_pb2 as keyspace_messages
 
 class KeyspaceService(object):
 

--- a/client_python/grakn/service/Session/Concept/BaseTypeMapping.py
+++ b/client_python/grakn/service/Session/Concept/BaseTypeMapping.py
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-import protocol.session.Concept_pb2 as ConceptMessages
+import grakn.rpc.protocol.session.Concept_pb2 as ConceptMessages
 
 
 # base type constant names 

--- a/client_python/grakn/service/Session/util/RequestBuilder.py
+++ b/client_python/grakn/service/Session/util/RequestBuilder.py
@@ -18,8 +18,8 @@
 #
 from datetime import datetime
 
-import protocol.session.Session_pb2 as transaction_messages
-import protocol.session.Concept_pb2 as concept_messages
+import grakn.rpc.protocol.session.Session_pb2 as transaction_messages
+import grakn.rpc.protocol.session.Concept_pb2 as concept_messages
 from grakn.service.Session.util import enums
 from grakn.service.Session.Concept import BaseTypeMapping
 

--- a/client_python/grakn/service/Session/util/enums.py
+++ b/client_python/grakn/service/Session/util/enums.py
@@ -18,8 +18,8 @@
 #
 
 from enum import Enum
-import protocol.session.Session_pb2 as SessionMessages
-import protocol.session.Concept_pb2 as ConceptMessages
+import grakn.rpc.protocol.session.Session_pb2 as SessionMessages
+import grakn.rpc.protocol.session.Concept_pb2 as ConceptMessages
 
 
 class TxType(Enum):

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -3,3 +3,7 @@ protobuf==3.6.1
 six==1.11.0
 forbiddenfruit==0.1.2
 enum34==1.1.6
+# Deployment-only dependencies
+setuptools>=38.6.0 # for supporting Markdown
+wheel==0.32.3 # for supporting bdist_wheel
+twine==1.12.1 # for uploading the package

--- a/deployment.properties
+++ b/deployment.properties
@@ -19,3 +19,5 @@
 github.repository=grakn
 maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/snapshots/
 maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/releases/
+pip.repository-url.pypi=https://pypi.org/legacy/
+pip.repository-url.test=https://test.pypi.org/legacy/

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -50,29 +50,3 @@ deploy_maven_jar(
     version_file = "//:VERSION",
     deployment_properties = "//:deployment.properties",
 )
-
-
-load("@org_pubref_rules_proto//python:compile.bzl", "python_grpc_compile")
-load("@io_bazel_rules_python//python:python.bzl", "py_library")
-load("@pypi_dependencies//:requirements.bzl", "requirement")
-
-python_grpc_compile(
-    name = "protocol_python_src",
-    deps = [
-        "//protocol/session:session-proto",
-        "//protocol/session:answer-proto",
-        "//protocol/session:concept-proto",
-        "//protocol/keyspace:keyspace-proto",
-    ]
-)
-
-py_library(
-    name = "protocol_python",
-    srcs = [":protocol_python_src"],
-    deps = [
-        requirement("protobuf"),
-        requirement("grpcio"),
-        requirement("six"),
-        requirement("enum34")
-    ]
-)


### PR DESCRIPTION
# Why is this PR needed?

So we able to deploy `client_python` to PyPI; closes #4502

# What does the PR do?

Adds `//client_python:deploy-pip` target to run

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR

—
