### PR TITLE
Fix upstream location for proto rules; closes #4684

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,15 +103,15 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", com_github_grpc_grpc_bazel_gr
 com_github_grpc_grpc_bazel_grpc_deps()
 
 # Load GRPC Java dependencies
-load("@org_pubref_rules_proto//java:deps.bzl", "java_grpc_compile")
+load("@stackb_rules_proto//java:deps.bzl", "java_grpc_compile")
 java_grpc_compile()
 
 # Load GRPC Python dependencies
-load("@org_pubref_rules_proto//python:deps.bzl", "python_grpc_compile")
+load("@stackb_rules_proto//python:deps.bzl", "python_grpc_compile")
 python_grpc_compile()
 
 # Load GRPC Node.js dependencies
-load("@org_pubref_rules_proto//node:deps.bzl", "node_grpc_compile")
+load("@stackb_rules_proto//node:deps.bzl", "node_grpc_compile")
 node_grpc_compile()
 
 

--- a/client-nodejs/BUILD
+++ b/client-nodejs/BUILD
@@ -21,7 +21,7 @@ exports_files([
     "package-lock.json"
 ])
 
-load("@org_pubref_rules_proto//node:compile.bzl", "node_grpc_compile")
+load("@stackb_rules_proto//node:node_grpc_compile.bzl", "node_grpc_compile")
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "nodejs_jest_test")
 
 

--- a/client_python/grakn/BUILD
+++ b/client_python/grakn/BUILD
@@ -1,4 +1,4 @@
-load("@org_pubref_rules_proto//python:compile.bzl", "python_grpc_compile")
+load("@stackb_rules_proto//python:python_grpc_compile.bzl", "python_grpc_compile")
 load("@io_bazel_rules_python//python:python.bzl", "py_library")
 load("@graknlabs_rules_deployment//pip:rules.bzl", "py_replace_imports")
 

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -32,7 +32,7 @@ def grpc_dependencies():
     )
 
     native.git_repository(
-        name = "org_pubref_rules_proto",
-        remote = "https://github.com/pubref/rules_proto",
-        commit = "f493ce70027f353cd6964339018163207393ba93",
+        name = "stackb_rules_proto",
+        remote = "https://github.com/stackb/rules_proto",
+        commit = "4c2226458203a9653ae722245cc27e8b07c383f7",
     )

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@org_pubref_rules_proto//java:compile.bzl", "java_grpc_compile")
+load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
 load("@graknlabs_rules_deployment//maven:rules.bzl", "deploy_maven_jar")
 
 java_grpc_compile(


### PR DESCRIPTION
# Why is this PR needed?

To keep up with upstream updates of proto rules

# What does the PR do?

Updates location of proto rules we use

# Does it break backwards compatibility?

It shouldn't

# List of future improvements not on this PR

—
