### PR TITLE
//:distribution deployment to brew

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
+load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
+
 sh_binary(
     name = "deploy-github-zip",
     srcs = ["@graknlabs_rules_deployment//github:deployment.sh"],
@@ -40,4 +43,7 @@ genrule(
     visibility = ["//visibility:public"]
 )
 
-exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
+deploy_brew(
+    name = "deploy-brew",
+    version_file = "//:VERSION"
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,7 +126,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="fc812a4cd0dddd7478437ff03bc22e6c83b13620",
+    commit="5609bd932655116e41411b8615b3c625319d81d9",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4573

# What does the PR do?

Creates `//:deploy-brew` rule which updates link to already-deployed Grakn distribution for Homebrew

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—
