### PR TITLE
Readded Graql Query Integration Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
       - *install_bazel
       - run: bazel test //test-integration/server/... --test_output=errors
       - run: bazel test //test-integration/graql/internal/... --test_output=errors
+      - run: bazel test //test-integration/graql/query/... --test_output=errors
 
   test-integration-reasoner:
     machine: true

--- a/server/src/graql/query/Query.java
+++ b/server/src/graql/query/Query.java
@@ -53,7 +53,6 @@ public interface Query<T extends Answer> extends Iterable<T> {
     /**
      * @return a {@link List} of T, where T is a special type of {@link Answer}
      */
-    @CheckReturnValue
     default List<T> execute() {
         return stream().collect(Collectors.toList());
     }

--- a/server/src/graql/query/pattern/Conjunction.java
+++ b/server/src/graql/query/pattern/Conjunction.java
@@ -28,7 +28,9 @@ import grakn.core.server.session.TransactionImpl;
 
 import javax.annotation.CheckReturnValue;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -47,7 +49,7 @@ public class Conjunction<T extends Pattern> implements Pattern {
         if (patterns == null) {
             throw new NullPointerException("Null patterns");
         }
-        this.patterns = patterns;
+        this.patterns = patterns.stream().map(Objects::requireNonNull).collect(Collectors.toSet());
     }
 
     /**

--- a/server/src/graql/query/pattern/Conjunction.java
+++ b/server/src/graql/query/pattern/Conjunction.java
@@ -88,6 +88,11 @@ public class Conjunction<T extends Pattern> implements Pattern {
         return true;
     }
 
+    @Override
+    public Conjunction<?> asConjunction() {
+        return this;
+    }
+
     /**
      * @return the corresponding reasoner query
      */

--- a/server/src/graql/query/pattern/Disjunction.java
+++ b/server/src/graql/query/pattern/Disjunction.java
@@ -73,6 +73,11 @@ public class Disjunction<T extends Pattern> implements Pattern {
     }
 
     @Override
+    public Disjunction<?> asDisjunction() {
+        return this;
+    }
+
+    @Override
     public String toString() {
         return getPatterns().stream().map(Object::toString).collect(Collectors.joining(" or "));
     }

--- a/server/src/graql/query/pattern/Disjunction.java
+++ b/server/src/graql/query/pattern/Disjunction.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
 import javax.annotation.CheckReturnValue;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -36,12 +37,11 @@ public class Disjunction<T extends Pattern> implements Pattern {
 
     private final Set<T> patterns;
 
-    public Disjunction(
-            Set<T> patterns) {
+    public Disjunction(Set<T> patterns) {
         if (patterns == null) {
             throw new NullPointerException("Null patterns");
         }
-        this.patterns = patterns;
+        this.patterns = patterns.stream().map(Objects::requireNonNull).collect(Collectors.toSet());
     }
 
     /**

--- a/server/src/graql/query/pattern/Pattern.java
+++ b/server/src/graql/query/pattern/Pattern.java
@@ -151,7 +151,31 @@ public interface Pattern {
     }
 
     /**
-     * @return true if this {@link Pattern}  is a {@link Conjunction}
+     * @return this {@link Pattern} as a {@link Disjunction}, if it is one.
+     */
+    @CheckReturnValue
+    default Disjunction<?> asDisjunction() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return this {@link Pattern} as a {@link Conjunction}, if it is one.
+     */
+    @CheckReturnValue
+    default Conjunction<?> asConjunction() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @return true if this {@link Pattern} is a {@link Statement}
+     */
+    @CheckReturnValue
+    default boolean isStatement() {
+        return false;
+    }
+
+    /**
+     * @return true if this {@link Pattern} is a {@link Conjunction}
      */
     @CheckReturnValue
     default boolean isDisjunction() {
@@ -159,7 +183,7 @@ public interface Pattern {
     }
 
     /**
-     * @return true if this {@link Pattern}  is a {@link Disjunction}
+     * @return true if this {@link Pattern} is a {@link Disjunction}
      */
     @CheckReturnValue
     default boolean isConjunction() {

--- a/server/src/graql/query/pattern/Statement.java
+++ b/server/src/graql/query/pattern/Statement.java
@@ -90,6 +90,11 @@ public abstract class Statement implements Pattern {
         return this;
     }
 
+    @Override
+    public boolean isStatement() {
+        return true;
+    }
+
     /**
      * @return the name this variable represents, if it represents something with a specific name
      */

--- a/server/test/graql/query/BUILD
+++ b/server/test/graql/query/BUILD
@@ -1,3 +1,21 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 java_test(
     name = "aggregate-query-test",
     test_class = "grakn.core.graql.query.AggregateQueryTest",
@@ -34,8 +52,9 @@ java_test(
     test_class = "grakn.core.graql.query.InsertQueryTest",
     srcs = ["InsertQueryTest.java"],
     deps = [
+        "//server",
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/org/mockito:mockito-core",
-        "//server"],
+    ],
     size = "small"
 )

--- a/server/test/graql/query/pattern/BUILD
+++ b/server/test/graql/query/pattern/BUILD
@@ -1,3 +1,21 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 java_test(
     name = "pattern-impl-test",
     test_class = "grakn.core.graql.query.pattern.PatternTest",

--- a/test-integration/graql/graph/BUILD
+++ b/test-integration/graql/graph/BUILD
@@ -1,0 +1,27 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+java_library(
+    name = "movie-graph",
+    srcs = ["MovieGraph.java"],
+    visibility = ["//test-integration:__subpackages__"],
+    deps = [
+        "//server",
+
+    ],
+)

--- a/test-integration/graql/graph/MovieGraph.java
+++ b/test-integration/graql/graph/MovieGraph.java
@@ -1,0 +1,327 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.graph;
+
+import grakn.core.graql.concept.Attribute;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.EntityType;
+import grakn.core.graql.concept.Relationship;
+import grakn.core.graql.concept.RelationshipType;
+import grakn.core.graql.concept.Role;
+import grakn.core.graql.concept.Thing;
+import grakn.core.graql.internal.Schema;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class MovieGraph {
+
+    private static EntityType production, movie, person, genre, character, cluster, language;
+    private static AttributeType<String> title, gender, realName, name, provenance;
+    private static AttributeType<Long> tmdbVoteCount, runtime;
+    private static AttributeType<Double> tmdbVoteAverage;
+    private static AttributeType<LocalDateTime> releaseDate;
+    private static RelationshipType hasCast, authoredBy, directedBy, hasGenre, hasCluster;
+    private static Role productionBeingDirected, director, productionWithCast, actor, characterBeingPlayed;
+    private static Role genreOfProduction, productionWithGenre, clusterOfProduction, productionWithCluster;
+    private static Role work, author;
+
+    private static Thing godfather, theMuppets, heat, apocalypseNow, hocusPocus, spy, chineseCoffee;
+    private static Thing marlonBrando, alPacino, missPiggy, kermitTheFrog, martinSheen, robertDeNiro, judeLaw;
+    private static Thing mirandaHeart, betteMidler, sarahJessicaParker;
+    private static Thing crime, drama, war, action, comedy, family, musical, fantasy;
+    private static Thing donVitoCorleone, michaelCorleone, colonelWalterEKurtz, benjaminLWillard, ltVincentHanna;
+    private static Thing neilMcCauley, bradleyFine, nancyBArtingstall, winifred, sarah, harry;
+    private static Thing cluster0, cluster1;
+
+
+    public static void load(Session session) {
+        try (Transaction transaction = session.transaction(Transaction.Type.WRITE)) {
+            buildSchema(transaction);
+            buildInstances(transaction);
+            buildRelations();
+            buildRules(transaction);
+
+            transaction.commit();
+        }
+    }
+
+
+    private static <T> void putResource(Thing thing, AttributeType<T> attributeType, T resource) {
+        Attribute attributeInstance = attributeType.create(resource);
+        thing.has(attributeInstance);
+    }
+
+
+    private static void buildSchema(Transaction tx) {
+        work = tx.putRole("work");
+        author = tx.putRole("author");
+        authoredBy = tx.putRelationshipType("authored-by").relates(work).relates(author);
+
+        productionBeingDirected = tx.putRole("production-being-directed").sup(work);
+        director = tx.putRole("director").sup(author);
+        directedBy = tx.putRelationshipType("directed-by").sup(authoredBy)
+                .relates(productionBeingDirected).relates(director);
+
+        productionWithCast = tx.putRole("production-with-cast");
+        actor = tx.putRole("actor");
+        characterBeingPlayed = tx.putRole("character-being-played");
+        hasCast = tx.putRelationshipType("has-cast")
+                .relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
+
+        genreOfProduction = tx.putRole("genre-of-production");
+        productionWithGenre = tx.putRole("production-with-genre");
+        hasGenre = tx.putRelationshipType("has-genre")
+                .relates(genreOfProduction).relates(productionWithGenre);
+
+        clusterOfProduction = tx.putRole("cluster-of-production");
+        productionWithCluster = tx.putRole("production-with-cluster");
+        hasCluster = tx.putRelationshipType("has-cluster")
+                .relates(clusterOfProduction).relates(productionWithCluster);
+
+        title = tx.putAttributeType("title", AttributeType.DataType.STRING);
+        title.has(title);
+
+        tmdbVoteCount = tx.putAttributeType("tmdb-vote-count", AttributeType.DataType.LONG);
+        tmdbVoteAverage = tx.putAttributeType("tmdb-vote-average", AttributeType.DataType.DOUBLE);
+        releaseDate = tx.putAttributeType("release-date", AttributeType.DataType.DATE);
+        runtime = tx.putAttributeType("runtime", AttributeType.DataType.LONG);
+        gender = tx.putAttributeType("gender", AttributeType.DataType.STRING).regex("(fe)?male");
+        realName = tx.putAttributeType("real-name", AttributeType.DataType.STRING);
+        name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+
+        production = tx.putEntityType("production")
+                .plays(productionWithCluster).plays(productionBeingDirected).plays(productionWithCast)
+                .plays(productionWithGenre);
+
+        production.has(title);
+        production.has(tmdbVoteCount);
+        production.has(tmdbVoteAverage);
+        production.has(releaseDate);
+        production.has(runtime);
+
+        movie = tx.putEntityType("movie").sup(production);
+
+        tx.putEntityType("tv-show").sup(production);
+
+        person = tx.putEntityType("person")
+                .plays(director).plays(actor).plays(characterBeingPlayed);
+
+        person.has(gender);
+        person.has(name);
+        person.has(realName);
+
+        genre = tx.putEntityType("genre").plays(genreOfProduction);
+        genre.key(name);
+
+        character = tx.putEntityType("character")
+                .plays(characterBeingPlayed);
+
+        character.has(name);
+
+        tx.putEntityType("award");
+        language = tx.putEntityType("language");
+
+        language.has(name);
+
+        cluster = tx.putEntityType("cluster").plays(clusterOfProduction);
+        cluster.has(name);
+
+        tx.getType(Schema.ImplicitType.HAS.getLabel("title")).has(provenance);
+    }
+
+    private static void buildInstances(Transaction tx) {
+        godfather = movie.create();
+        putResource(godfather, title, "Godfather");
+        putResource(godfather, tmdbVoteCount, 1000L);
+        putResource(godfather, tmdbVoteAverage, 8.6);
+        putResource(godfather, releaseDate, LocalDate.of(1984, 1, 1).atStartOfDay());
+
+        theMuppets = movie.create();
+        putResource(theMuppets, title, "The Muppets");
+        putResource(theMuppets, tmdbVoteCount, 100L);
+        putResource(theMuppets, tmdbVoteAverage, 7.6);
+        putResource(theMuppets, releaseDate, LocalDate.of(1985, 2, 2).atStartOfDay());
+
+        apocalypseNow = movie.create();
+        putResource(apocalypseNow, title, "Apocalypse Now");
+        putResource(apocalypseNow, tmdbVoteCount, 400L);
+        putResource(apocalypseNow, tmdbVoteAverage, 8.4);
+
+        heat = movie.create();
+        putResource(heat, title, "Heat");
+
+        hocusPocus = movie.create();
+        putResource(hocusPocus, title, "Hocus Pocus");
+        putResource(hocusPocus, tmdbVoteCount, 435L);
+
+        spy = movie.create();
+        putResource(spy, title, "Spy");
+        putResource(spy, releaseDate, LocalDate.of(1986, 3, 3).atStartOfDay());
+
+        chineseCoffee = movie.create();
+        putResource(chineseCoffee, title, "Chinese Coffee");
+        putResource(chineseCoffee, tmdbVoteCount, 5L);
+        putResource(chineseCoffee, tmdbVoteAverage, 3.1d);
+        putResource(chineseCoffee, releaseDate, LocalDate.of(2000, 9, 2).atStartOfDay());
+
+        marlonBrando = person.create();
+        putResource(marlonBrando, name, "Marlon Brando");
+        alPacino = person.create();
+        putResource(alPacino, name, "Al Pacino");
+        missPiggy = person.create();
+        putResource(missPiggy, name, "Miss Piggy");
+        kermitTheFrog = person.create();
+        putResource(kermitTheFrog, name, "Kermit The Frog");
+        martinSheen = person.create();
+        putResource(martinSheen, name, "Martin Sheen");
+        robertDeNiro = person.create();
+        putResource(robertDeNiro, name, "Robert de Niro");
+        judeLaw = person.create();
+        putResource(judeLaw, name, "Jude Law");
+        mirandaHeart = person.create();
+        putResource(mirandaHeart, name, "Miranda Heart");
+        betteMidler = person.create();
+        putResource(betteMidler, name, "Bette Midler");
+        sarahJessicaParker = person.create();
+        putResource(sarahJessicaParker, name, "Sarah Jessica Parker");
+
+        crime = genre.create();
+        putResource(crime, name, "crime");
+        drama = genre.create();
+        putResource(drama, name, "drama");
+        war = genre.create();
+        putResource(war, name, "war");
+        action = genre.create();
+        putResource(action, name, "action");
+        comedy = genre.create();
+        putResource(comedy, name, "comedy");
+        family = genre.create();
+        putResource(family, name, "family");
+        musical = genre.create();
+        putResource(musical, name, "musical");
+        fantasy = genre.create();
+        putResource(fantasy, name, "fantasy");
+
+        donVitoCorleone = character.create();
+        putResource(donVitoCorleone, name, "Don Vito Corleone");
+        michaelCorleone = character.create();
+        putResource(michaelCorleone, name, "Michael Corleone");
+        colonelWalterEKurtz = character.create();
+        putResource(colonelWalterEKurtz, name, "Colonel Walter E. Kurtz");
+        benjaminLWillard = character.create();
+        putResource(benjaminLWillard, name, "Benjamin L. Willard");
+        ltVincentHanna = character.create();
+        putResource(ltVincentHanna, name, "Lt Vincent Hanna");
+        neilMcCauley = character.create();
+        putResource(neilMcCauley, name, "Neil McCauley");
+        bradleyFine = character.create();
+        putResource(bradleyFine, name, "Bradley Fine");
+        nancyBArtingstall = character.create();
+        putResource(nancyBArtingstall, name, "Nancy B Artingstall");
+        winifred = character.create();
+        putResource(winifred, name, "Winifred");
+        sarah = character.create();
+        putResource(sarah, name, "Sarah");
+        harry = character.create();
+        putResource(harry, name, "Harry");
+
+        cluster0 = cluster.create();
+        cluster1 = cluster.create();
+        putResource(cluster0, name, "0");
+        putResource(cluster1, name, "1");
+    }
+
+    private static void buildRelations() {
+        directedBy.create()
+                .assign(productionBeingDirected, chineseCoffee)
+                .assign(director, alPacino);
+
+        hasCast(godfather, marlonBrando, donVitoCorleone);
+        hasCast(godfather, alPacino, michaelCorleone);
+        hasCast(theMuppets, missPiggy, missPiggy);
+        hasCast(theMuppets, kermitTheFrog, kermitTheFrog);
+        hasCast(apocalypseNow, marlonBrando, colonelWalterEKurtz);
+        hasCast(apocalypseNow, martinSheen, benjaminLWillard);
+        hasCast(heat, alPacino, ltVincentHanna);
+        hasCast(heat, robertDeNiro, neilMcCauley);
+        hasCast(spy, judeLaw, bradleyFine);
+        hasCast(spy, mirandaHeart, nancyBArtingstall);
+        hasCast(hocusPocus, betteMidler, winifred);
+        hasCast(hocusPocus, sarahJessicaParker, sarah);
+        hasCast(chineseCoffee, alPacino, harry);
+
+        hasGenre(godfather, crime);
+        hasGenre(godfather, drama);
+        hasGenre(apocalypseNow, drama);
+        hasGenre(apocalypseNow, war);
+        hasGenre(heat, crime);
+        hasGenre(heat, drama);
+        hasGenre(heat, action);
+        hasGenre(theMuppets, comedy);
+        hasGenre(theMuppets, family);
+        hasGenre(theMuppets, musical);
+        hasGenre(hocusPocus, comedy);
+        hasGenre(hocusPocus, family);
+        hasGenre(hocusPocus, fantasy);
+        hasGenre(spy, comedy);
+        hasGenre(spy, family);
+        hasGenre(spy, musical);
+        hasGenre(chineseCoffee, drama);
+
+        hasCluster(cluster0, godfather, apocalypseNow, heat);
+        hasCluster(cluster1, theMuppets, hocusPocus);
+    }
+
+    private static void buildRules(Transaction tx) {
+        // These rules are totally made up for testing purposes and don't work!
+        Pattern when = tx.graql().parser().parsePattern("$x has name 'expectation-when'");
+        Pattern then = tx.graql().parser().parsePattern("$x has name 'expectation-then'");
+
+        tx.putRule("expectation-rule", when, then);
+
+        when = tx.graql().parser().parsePattern("$x has name 'materialize-when'");
+        then = tx.graql().parser().parsePattern("$x has name 'materialize-then'");
+        tx.putRule("materialize-rule", when, then);
+    }
+
+    private static void hasCast(Thing movie, Thing person, Thing character) {
+        hasCast.create()
+                .assign(productionWithCast, movie)
+                .assign(actor, person)
+                .assign(characterBeingPlayed, character);
+    }
+
+    private static void hasGenre(Thing movie, Thing genre) {
+        hasGenre.create()
+                .assign(productionWithGenre, movie)
+                .assign(genreOfProduction, genre);
+    }
+
+    private static void hasCluster(Thing cluster, Thing... movies) {
+        Relationship relationship = hasCluster.create().assign(clusterOfProduction, cluster);
+        for (Thing movie : movies) {
+            relationship.assign(productionWithCluster, movie);
+        }
+    }
+}

--- a/test-integration/graql/internal/BUILD
+++ b/test-integration/graql/internal/BUILD
@@ -1,3 +1,21 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 java_test(
     name = "isa-explicit-it",
     test_class = "grakn.core.graql.internal.IsaExplicitIT",

--- a/test-integration/graql/query/AggregateQueryIT.java
+++ b/test-integration/graql/query/AggregateQueryIT.java
@@ -1,0 +1,323 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import grakn.core.graql.answer.AnswerGroup;
+import grakn.core.graql.answer.ConceptMap;
+import grakn.core.graql.answer.Value;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.Thing;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+import static grakn.core.common.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static grakn.core.graql.query.Graql.count;
+import static grakn.core.graql.query.Graql.group;
+import static grakn.core.graql.query.Graql.max;
+import static grakn.core.graql.query.Graql.mean;
+import static grakn.core.graql.query.Graql.median;
+import static grakn.core.graql.query.Graql.min;
+import static grakn.core.graql.query.Graql.std;
+import static grakn.core.graql.query.Graql.sum;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static java.lang.Math.pow;
+import static java.lang.Math.sqrt;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AggregateQueryIT {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static GraknTestServer graknServer = new GraknTestServer();
+    private static Session session;
+    private Transaction tx;
+    private QueryBuilder qb;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testCount() {
+        List<Value> count = qb.match(var("x").isa("movie"), var("y").isa("person"), var("r").rel("x").rel("y")).aggregate(count()).execute();
+        Assert.assertEquals(14, count.get(0).number().intValue());
+
+        count = qb.match(var("x").isa("movie"), var("y").isa("person"), var().rel("x").rel("y")).aggregate(count("x")).execute();
+
+        Assert.assertEquals(7, count.get(0).number().intValue());
+    }
+
+    @Test
+    public void testGroup() {
+        AggregateQuery<AnswerGroup<ConceptMap>> groupQuery =
+                qb.match(var("x").isa("movie"), var("y").isa("person"), var().rel("x").rel("y")).aggregate(group("x"));
+
+        List<AnswerGroup<ConceptMap>> groups = groupQuery.execute();
+
+        Assert.assertEquals(7, groups.size());
+
+        groups.forEach(group -> {
+            group.answers().forEach(conceptMap -> {
+                assertEquals(group.owner(), conceptMap.get(var("x")));
+                Assert.assertEquals(tx.getEntityType("person"), conceptMap.get(var("y")).asThing().type());
+            });
+        });
+    }
+
+    @Test
+    public void testGroupCount() {
+        List<AnswerGroup<Value>> groupCount = qb.match(var("x").isa("movie"), var("r").rel("x"))
+                .aggregate(group("x", count()))
+                .execute();
+        Thing godfather = tx.getAttributeType("title").attribute("Godfather").owner();
+
+        groupCount.forEach(group -> {
+            if (group.owner().equals(godfather)) {
+                assertEquals(9, group.answers().get(0).number().intValue());
+            }
+        });
+    }
+
+    @Test
+    public void testSumInt() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
+                .aggregate(sum("y"));
+
+        assertEquals(1940, query.execute().get(0).number().intValue());
+    }
+
+    @Test
+    public void testSumDouble() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
+                .aggregate(sum("y"));
+
+        assertEquals(27.7d, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testSumNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(sum("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testMaxInt() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
+                .aggregate(max("y"));
+
+        assertEquals(1000, query.execute().get(0).number().intValue());
+    }
+
+    @Test
+    public void testMaxDouble() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
+                .aggregate(max("y"));
+
+        assertEquals(8.6d, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testMaxNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(max("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testMinInt() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
+                .aggregate(min("y"));
+
+        assertEquals(5, query.execute().get(0).number().intValue());
+    }
+
+    @Test
+    public void testMinNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(min("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testMean() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
+                .aggregate(mean("y"));
+
+        //noinspection OptionalGetWithoutIsPresent
+        assertEquals((8.6d + 7.6d + 8.4d + 3.1d) / 4d, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testMeanNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(mean("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testMedianInt() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-count"))
+                .aggregate(median("y"));
+
+        assertEquals(400, query.execute().get(0).number().intValue());
+    }
+
+    @Test
+    public void testMedianDouble() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("tmdb-vote-average"))
+                .aggregate(median("y"));
+
+        //noinspection OptionalGetWithoutIsPresent
+        assertEquals(8.0d, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testMedianNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(median("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testStdDouble1() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie").has("tmdb-vote-count", var("y")))
+                .aggregate(std("y"));
+
+        double mean = (1000d + 100d + 400d + 435d + 5d) / 5d;
+        double variance = (pow(1000d - mean, 2d) + pow(100d - mean, 2d)
+                + pow(400d - mean, 2d) + pow(435d - mean, 2d) + pow(5d - mean, 2d)) / 4d;
+        double expected = sqrt(variance);
+
+        assertEquals(expected, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testStdDouble2() {
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie").has("tmdb-vote-average", var("y")))
+                .aggregate(std("y"));
+
+        double mean = (8.6d + 8.4d + 7.6d + 3.1d) / 4d;
+        double variance =
+                (pow(8.6d - mean, 2d) + pow(8.4d - mean, 2d) + pow(7.6d - mean, 2d) + pow(3.1d - mean, 2d)) / 3d;
+        double expected = sqrt(variance);
+
+        assertEquals(expected, query.execute().get(0).number().doubleValue(), 0.01d);
+    }
+
+    @Test
+    public void testStdNull() {
+        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        AggregateQuery<Value> query = qb
+                .match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random"))
+                .aggregate(std("y"));
+
+        assertTrue(query.execute().isEmpty());
+    }
+
+    @Test
+    public void testEmptyMatchCount() {
+        assertEquals(0L, tx.graql().match(var().isa("runtime")).aggregate(count()).execute().get(0).number().longValue());
+        tx.graql().match(var()).aggregate(count()).execute();
+    }
+
+    @Test(expected = Exception.class) // TODO: Would help if the error message is more specific
+    public void testVarsNotExist() {
+        tx.graql().match(var("x").isa("movie")).aggregate(min("y")).execute();
+        System.out.println(tx.graql().match(var("x").isa("movie")).aggregate(min("x")).execute());
+    }
+
+    @Test(expected = Exception.class)
+    public void testMinOnEntity() {
+        tx.graql().match(var("x")).aggregate(min("x")).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void testIncorrectResourceDataType() {
+        tx.graql().match(var("x").isa("movie").has("title", var("y")))
+                .aggregate(sum("y")).execute();
+    }
+
+    @Test
+    public void whenGroupVarIsNotInQuery_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(var("z")));
+        tx.graql().match(var("x").isa("movie").has("title", var("y"))).aggregate(group("z", count())).execute();
+    }
+}

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -50,3 +50,19 @@ java_test(
     ],
     size = "medium"
 )
+
+java_test(
+    name = "query-error-it",
+    test_class = "grakn.core.graql.query.QueryErrorIT",
+    srcs = ["QueryErrorIT.java"],
+    deps = [
+        "//common",
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+
+    ],
+    size = "medium"
+)

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -17,6 +17,20 @@
 #
 
 java_test(
+    name = "delete-query-it",
+    test_class = "grakn.core.graql.query.DeleteQueryIT",
+    srcs = ["DeleteQueryIT.java"],
+    deps = [
+        "//common",
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+    ],
+    size = "medium"
+)
+
+java_test(
     name = "insert-query-it",
     test_class = "grakn.core.graql.query.InsertQueryIT",
     srcs = ["InsertQueryIT.java"],

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -136,3 +136,18 @@ java_test(
     ],
     size = "medium"
 )
+
+java_test(
+    name = "query-planner-it",
+    test_class = "grakn.core.graql.query.QueryPlannerIT",
+    srcs = ["QueryPlannerIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+
+        "//dependencies/maven/artifacts/com/google/guava:guava",
+
+    ],
+    size = "medium"
+)

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -33,3 +33,20 @@ java_test(
     ],
     size = "medium"
 )
+
+java_test(
+    name = "undefine-query-it",
+    test_class = "grakn.core.graql.query.UndefineQueryIT",
+    srcs = ["UndefineQueryIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+
+        "//dependencies/maven/artifacts/com/google/guava:guava",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+
+    ],
+    size = "medium"
+)

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -95,6 +95,20 @@ java_test(
 )
 
 java_test(
+    name = "query-admin-it",
+    test_class = "grakn.core.graql.query.QueryAdminIT",
+    srcs = ["QueryAdminIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+
+        "//dependencies/maven/artifacts/com/google/guava:guava",
+    ],
+    size = "medium"
+)
+
+java_test(
     name = "query-error-it",
     test_class = "grakn.core.graql.query.QueryErrorIT",
     srcs = ["QueryErrorIT.java"],

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -1,0 +1,35 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+java_test(
+    name = "insert-query-it",
+    test_class = "grakn.core.graql.query.InsertQueryIT",
+    srcs = ["InsertQueryIT.java"],
+    deps = [
+        "//common",
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+
+        "//dependencies/maven/artifacts/com/google/guava:guava",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+
+    ],
+    size = "medium"
+)

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -17,6 +17,19 @@
 #
 
 java_test(
+    name = "aggregate-query-it",
+    test_class = "grakn.core.graql.query.AggregateQueryIT",
+    srcs = ["AggregateQueryIT.java"],
+    deps = [
+        "//common",
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+    ],
+    size = "medium"
+)
+
+java_test(
     name = "define-query-it",
     test_class = "grakn.core.graql.query.DefineQueryIT",
     srcs = ["DefineQueryIT.java"],

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -17,6 +17,22 @@
 #
 
 java_test(
+    name = "define-query-it",
+    test_class = "grakn.core.graql.query.DefineQueryIT",
+    srcs = ["DefineQueryIT.java"],
+    deps = [
+        "//common",
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+    ],
+    size = "medium"
+)
+
+java_test(
     name = "delete-query-it",
     test_class = "grakn.core.graql.query.DeleteQueryIT",
     srcs = ["DeleteQueryIT.java"],

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -52,6 +52,19 @@ java_test(
 )
 
 java_test(
+    name = "query-builder-it",
+    test_class = "grakn.core.graql.query.QueryBuilderIT",
+    srcs = ["QueryBuilderIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+    ],
+    size = "medium"
+)
+
+java_test(
     name = "query-error-it",
     test_class = "grakn.core.graql.query.QueryErrorIT",
     srcs = ["QueryErrorIT.java"],

--- a/test-integration/graql/query/DefineQueryIT.java
+++ b/test-integration/graql/query/DefineQueryIT.java
@@ -1,0 +1,553 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import grakn.core.common.exception.ErrorMessage;
+import grakn.core.common.exception.GraknException;
+import grakn.core.graql.answer.ConceptMap;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.ConceptId;
+import grakn.core.graql.concept.EntityType;
+import grakn.core.graql.concept.Label;
+import grakn.core.graql.concept.RelationshipType;
+import grakn.core.graql.concept.Role;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.internal.Schema;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.graql.query.pattern.Statement;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.graql.query.pattern.property.HasAttributeProperty;
+import grakn.core.graql.query.pattern.property.IsaProperty;
+import grakn.core.graql.query.pattern.property.ValueProperty;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import grakn.core.server.exception.InvalidKBException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static grakn.core.graql.concept.AttributeType.DataType.BOOLEAN;
+import static grakn.core.graql.internal.Schema.ImplicitType.HAS;
+import static grakn.core.graql.internal.Schema.ImplicitType.HAS_OWNER;
+import static grakn.core.graql.internal.Schema.ImplicitType.HAS_VALUE;
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY;
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY_OWNER;
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY_VALUE;
+import static grakn.core.graql.internal.Schema.MetaSchema.ENTITY;
+import static grakn.core.graql.internal.Schema.MetaSchema.RELATIONSHIP;
+import static grakn.core.graql.internal.Schema.MetaSchema.ROLE;
+import static grakn.core.graql.internal.Schema.MetaSchema.RULE;
+import static grakn.core.graql.query.Graql.parse;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static grakn.core.util.GraqlTestUtil.assertNotExists;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class DefineQueryIT {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+    public static Session session;
+    private Transaction tx;
+    private QueryBuilder qb;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testDefineSub() {
+        assertDefine(var("x").label("cool-movie").sub("movie"));
+    }
+
+    @Test
+    public void testDefineSchema() {
+        qb.define(
+                label("pokemon").sub(Schema.MetaSchema.ENTITY.getLabel().getValue()),
+                label("evolution").sub(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue()),
+                label("evolves-from").sub(Schema.MetaSchema.ROLE.getLabel().getValue()),
+                label("evolves-to").sub(Schema.MetaSchema.ROLE.getLabel().getValue()),
+                label("evolution").relates("evolves-from").relates("evolves-to"),
+                label("pokemon").plays("evolves-from").plays("evolves-to").has("name")
+        ).execute();
+
+        assertExists(qb, label("pokemon").sub(ENTITY.getLabel().getValue()));
+        assertExists(qb, label("evolution").sub(RELATIONSHIP.getLabel().getValue()));
+        assertExists(qb, label("evolves-from").sub(ROLE.getLabel().getValue()));
+        assertExists(qb, label("evolves-to").sub(ROLE.getLabel().getValue()));
+        assertExists(qb, label("evolution").relates("evolves-from").relates("evolves-to"));
+        assertExists(qb, label("pokemon").plays("evolves-from").plays("evolves-to"));
+    }
+
+    @Test
+    public void testDefineIsAbstract() {
+        qb.define(
+                label("concrete-type").sub(Schema.MetaSchema.ENTITY.getLabel().getValue()),
+                label("abstract-type").isAbstract().sub(Schema.MetaSchema.ENTITY.getLabel().getValue())
+        ).execute();
+
+        assertNotExists(qb, label("concrete-type").isAbstract());
+        assertExists(qb, label("abstract-type").isAbstract());
+    }
+
+    @Test
+    public void testDefineDataType() {
+        qb.define(
+                label("my-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.LONG)
+        ).execute();
+
+        Match match = qb.match(var("x").label("my-type"));
+        AttributeType.DataType datatype = match.iterator().next().get("x").asAttributeType().dataType();
+
+        Assert.assertEquals(AttributeType.DataType.LONG, datatype);
+    }
+
+    @Test
+    public void testDefineSubResourceType() {
+        qb.define(
+                label("my-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING),
+                label("sub-type").sub("my-type")
+        ).execute();
+
+        Match match = qb.match(var("x").label("sub-type"));
+        AttributeType.DataType datatype = match.iterator().next().get("x").asAttributeType().dataType();
+
+        Assert.assertEquals(AttributeType.DataType.STRING, datatype);
+    }
+
+    @Test
+    public void testDefineSubRole() {
+        qb.define(
+                label("marriage").sub(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue()).relates("spouse1").relates("spouse2"),
+                label("spouse").sub(Schema.MetaSchema.ROLE.getLabel().getValue()),
+                label("spouse1").sub("spouse"),
+                label("spouse2").sub("spouse")
+        ).execute();
+
+        assertExists(qb, label("spouse1"));
+    }
+
+    @Test
+    public void testReferenceByVariableNameAndTypeLabel() {
+        qb.define(
+                var("abc").sub("entity"),
+                var("abc").label("123"),
+                label("123").plays("actor"),
+                var("abc").plays("director")
+        ).execute();
+
+        assertExists(qb, label("123").sub("entity"));
+        assertExists(qb, label("123").plays("actor"));
+        assertExists(qb, label("123").plays("director"));
+    }
+
+    @Test
+    public void testDefineReferenceByName() {
+        String roleTypeLabel = HAS_OWNER.getLabel("title").getValue();
+        qb.define(
+                label("new-type").sub(Schema.MetaSchema.ENTITY.getLabel().getValue()),
+                label("new-type").plays(roleTypeLabel)
+        ).execute();
+
+        qb.insert(var("x").isa("new-type")).execute();
+
+        Match typeQuery = qb.match(var("n").label("new-type"));
+
+        assertEquals(1, typeQuery.stream().count());
+
+        // We checked count ahead of time
+        //noinspection OptionalGetWithoutIsPresent
+        EntityType newType = typeQuery.get("n").stream().map(ans -> ans.get("n")).findFirst().get().asEntityType();
+
+        assertTrue(newType.playing().anyMatch(role -> role.equals(tx.getRole(roleTypeLabel))));
+
+        assertExists(qb, var().isa("new-type"));
+    }
+
+    @Test
+    public void testHas() {
+        String resourceType = "a-new-resource-type";
+
+        qb.define(
+                label("a-new-type").sub("entity").has(resourceType),
+                label(resourceType).sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING),
+                label("an-unconnected-resource-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.LONG)
+        ).execute();
+
+        // Make sure a-new-type can have the given resource type, but not other resource types
+        assertExists(qb, label("a-new-type").sub("entity").has(resourceType));
+        assertNotExists(qb, label("a-new-type").has("title"));
+        assertNotExists(qb, label("movie").has(resourceType));
+        assertNotExists(qb, label("a-new-type").has("an-unconnected-resource-type"));
+
+        Statement hasResource = label(HAS.getLabel(resourceType));
+        Statement hasResourceOwner = label(HAS_OWNER.getLabel(resourceType));
+        Statement hasResourceValue = label(HAS_VALUE.getLabel(resourceType));
+
+        // Make sure the expected ontology elements are created
+        assertExists(qb, hasResource.sub(RELATIONSHIP.getLabel().getValue()));
+        assertExists(qb, hasResourceOwner.sub(ROLE.getLabel().getValue()));
+        assertExists(qb, hasResourceValue.sub(ROLE.getLabel().getValue()));
+        assertExists(qb, hasResource.relates(hasResourceOwner));
+        assertExists(qb, hasResource.relates(hasResourceValue));
+        assertExists(qb, label("a-new-type").plays(hasResourceOwner));
+        assertExists(qb, label(resourceType).plays(hasResourceValue));
+    }
+
+    @Test
+    public void testKey() {
+        String resourceType = "a-new-resource-type";
+
+        qb.define(
+                label("a-new-type").sub("entity").key(resourceType),
+                label(resourceType).sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
+        ).execute();
+
+        // Make sure a-new-type can have the given resource type as a key or otherwise
+        assertExists(qb, label("a-new-type").sub("entity").key(resourceType));
+        assertExists(qb, label("a-new-type").sub("entity").has(resourceType));
+        assertNotExists(qb, label("a-new-type").sub("entity").key("title"));
+        assertNotExists(qb, label("movie").sub("entity").key(resourceType));
+
+        Statement key = label(KEY.getLabel(resourceType));
+        Statement keyOwner = label(KEY_OWNER.getLabel(resourceType));
+        Statement keyValue = label(KEY_VALUE.getLabel(resourceType));
+
+        // Make sure the expected ontology elements are created
+        assertExists(qb, key.sub(RELATIONSHIP.getLabel().getValue()));
+        assertExists(qb, keyOwner.sub(ROLE.getLabel().getValue()));
+        assertExists(qb, keyValue.sub(ROLE.getLabel().getValue()));
+        assertExists(qb, key.relates(keyOwner));
+        assertExists(qb, key.relates(keyValue));
+        assertExists(qb, label("a-new-type").plays(keyOwner));
+        assertExists(qb, label(resourceType).plays(keyValue));
+    }
+
+    @Test
+    public void testResourceTypeRegex() {
+        qb.define(label("greeting").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING).regex("hello|good day")).execute();
+
+        Match match = qb.match(var("x").label("greeting"));
+        assertEquals("hello|good day", match.get("x")
+                .stream().map(ans -> ans.get("x")).findFirst().get().asAttributeType().regex());
+    }
+
+    @Test
+    public void whenExecutingADefineQuery_ResultContainsAllInsertedVars() {
+        Variable type = var("type");
+        Variable type2 = var("type2");
+
+        // Note that two variables refer to the same type. They should both be in the result
+        DefineQuery query = qb.define(type.label("my-type").sub("entity"), type2.label("my-type"));
+
+        ConceptMap result = query.execute().get(0);
+        assertThat(result.vars(), containsInAnyOrder(type, type2));
+        assertEquals(result.get(type), result.get(type2));
+    }
+
+    @Test
+    public void whenChangingTheSuperOfAnExistingConcept_ApplyTheChange() {
+        EntityType newType = tx.putEntityType("a-new-type");
+        EntityType movie = tx.getEntityType("movie");
+
+        qb.define(label("a-new-type").sub("movie")).execute();
+
+        assertEquals(movie, newType.sup());
+    }
+
+    @Test
+    public void whenDefiningARule_TheRuleIsInTheKB() {
+        Pattern when = qb.parser().parsePattern("$x isa entity");
+        Pattern then = qb.parser().parsePattern("$x isa entity");
+        Statement vars = label("my-rule").sub(label(RULE.getLabel())).when(when).then(then);
+        qb.define(vars).execute();
+
+        assertNotNull(tx.getRule("my-rule"));
+    }
+
+    @Test
+    public void testErrorResourceTypeWithoutDataType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(
+                allOf(containsString("my-resource"), containsString("datatype"), containsString("resource"))
+        );
+        qb.define(label("my-resource").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue())).execute();
+    }
+
+    @Test
+    public void testErrorRecursiveType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("thingy"), containsString("itself")));
+        qb.define(label("thingy").sub("thingy")).execute();
+    }
+
+    @Test
+    public void whenDefiningAnOntologyConceptWithoutALabel_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("entity"), containsString("label")));
+        qb.define(var().sub("entity")).execute();
+    }
+
+    @Test
+    public void testErrorWhenNonExistentResource() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("nothing");
+        qb.define(label("blah this").sub("entity").has("nothing")).execute();
+    }
+
+    @Test
+    public void whenDefiningMetaType_Throw() {
+        exception.expect(InvalidKBException.class);
+        exception.expectMessage(ErrorMessage.INSERT_METATYPE.getMessage("my-metatype", Schema.MetaSchema.THING.getLabel().getValue()));
+        qb.define(label("my-metatype").sub(Schema.MetaSchema.THING.getLabel().getValue())).execute();
+    }
+
+    @Test
+    public void whenSpecifyingExistingTypeWithIncorrectDataType_Throw() {
+        AttributeType name = tx.getAttributeType("name");
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(
+                GraqlQueryException.insertPropertyOnExistingConcept("datatype", BOOLEAN, name).getMessage()
+        );
+
+        tx.graql().define(label("name").datatype(BOOLEAN)).execute();
+    }
+
+    @Test
+    public void whenSpecifyingDataTypeOnAnEntityType_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(
+                allOf(containsString("unexpected property"), containsString("datatype"), containsString("my-type"))
+        );
+
+        tx.graql().define(label("my-type").sub("entity").datatype(BOOLEAN)).execute();
+    }
+
+    @Test
+    public void whenDefiningRuleWithoutWhen_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("rule"), containsString("movie"), containsString("when")));
+        qb.define(label("a-rule").sub(label(RULE.getLabel())).then(var("x").isa("movie"))).execute();
+    }
+
+    @Test
+    public void whenDefiningRuleWithoutThen_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("rule"), containsString("movie"), containsString("then")));
+        qb.define(label("a-rule").sub(label(RULE.getLabel())).when(var("x").isa("movie"))).execute();
+    }
+
+    @Test
+    public void whenDefiningANonRuleWithAWhenPattern_Throw() {
+        Statement rule = label("yes").sub(label(ENTITY.getLabel())).when(var("x"));
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(anyOf(
+                // Either we see "entity" and an unexpected "when"...
+                allOf(containsString("unexpected property"), containsString("when")),
+                // ...or we see "when" and don't find the expected "then"
+                containsString(GraqlQueryException.insertNoExpectedProperty("then", rule).getMessage()))
+        );
+
+        qb.define(rule).execute();
+    }
+
+    @Test
+    public void whenDefiningANonRuleWithAThenPattern_Throw() {
+        Statement rule = label("covfefe").sub(label(ENTITY.getLabel())).then(var("x"));
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(anyOf(
+                // Either we see "entity" and an unexpected "when"...
+                allOf(containsString("unexpected property"), containsString("then")),
+                // ...or we see "when" and don't find the expected "then"
+                containsString(GraqlQueryException.insertNoExpectedProperty("when", rule).getMessage()))
+        );
+
+        qb.define(rule).execute();
+    }
+
+    @Test
+    public void whenDefiningAThing_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.defineUnsupportedProperty(IsaProperty.NAME).getMessage());
+
+        qb.define(var("x").isa("movie")).execute();
+    }
+
+    @Test
+    public void whenModifyingAThingInADefineQuery_Throw() {
+        ConceptId id = tx.getEntityType("movie").instances().iterator().next().id();
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(anyOf(
+                is(GraqlQueryException.defineUnsupportedProperty(HasAttributeProperty.NAME).getMessage()),
+                is(GraqlQueryException.defineUnsupportedProperty(ValueProperty.NAME).getMessage())
+        ));
+
+        qb.define(var().id(id).has("title", "Bob")).execute();
+    }
+
+    @Test
+    public void whenSpecifyingLabelOfAnExistingConcept_LabelIsChanged() {
+        tx.putEntityType("a-new-type");
+
+        EntityType type = tx.getEntityType("a-new-type");
+        Label newLabel = Label.of("a-new-new-type");
+
+        qb.define(label(newLabel).id(type.id())).execute();
+
+        assertEquals(newLabel, type.label());
+    }
+
+    @Test
+    public void whenCallingToStringOfDefineQuery_ReturnCorrectRepresentation() {
+        String queryString = "define label my-entity sub entity;";
+        DefineQuery defineQuery = parse(queryString);
+        assertEquals(queryString, defineQuery.toString());
+    }
+
+    @Test
+    public void whenDefiningARelationship_SubRoleDeclarationsCanBeSkipped() {
+        qb.define(label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife")).execute();
+
+        RelationshipType marriage = tx.getRelationshipType("marriage");
+        Role husband = tx.getRole("husband");
+        Role wife = tx.getRole("wife");
+        assertThat(marriage.roles().toArray(), arrayContainingInAnyOrder(husband, wife));
+    }
+
+    @Test
+    public void whenDefiningARelationship_SubRoleCasUseAs() {
+        qb.define(label("parentship").sub(label(RELATIONSHIP.getLabel()))
+                          .relates("parent")
+                          .relates("child")).execute();
+        qb.define(label("fatherhood").sub(label(RELATIONSHIP.getLabel()))
+                          .relates("father", "parent")
+                          .relates("son", "child")).execute();
+
+        RelationshipType marriage = tx.getRelationshipType("fatherhood");
+        Role father = tx.getRole("father");
+        Role son = tx.getRole("son");
+        assertThat(marriage.roles().toArray(), arrayContainingInAnyOrder(father, son));
+        assertEquals(tx.getRole("parent"), father.sup());
+        assertEquals(tx.getRole("child"), son.sup());
+    }
+
+    @Test
+    public void whenDefiningARule_SubRuleDeclarationsCanBeSkipped() {
+        Pattern when = qb.parser().parsePattern("$x isa entity");
+        Pattern then = qb.parser().parsePattern("$x isa entity");
+        Statement vars = label("my-rule").when(when).then(then);
+        qb.define(vars).execute();
+
+        assertNotNull(tx.getRule("my-rule"));
+    }
+
+    @Test
+    public void whenDefiningARelationship_SubRoleDeclarationsCanBeSkipped_EvenWhenRoleInReferredToInOtherContexts() {
+        qb.define(
+                label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife"),
+                label("person").plays("husband").plays("wife")
+        ).execute();
+
+        RelationshipType marriage = tx.getRelationshipType("marriage");
+        EntityType person = tx.getEntityType("person");
+        Role husband = tx.getRole("husband");
+        Role wife = tx.getRole("wife");
+        assertThat(marriage.roles().toArray(), arrayContainingInAnyOrder(husband, wife));
+        assertThat(person.playing().toArray(), hasItemInArray(wife));
+        assertThat(person.playing().toArray(), hasItemInArray(husband));
+    }
+
+    @Test
+    public void whenDefiningARelationshipWithNonRoles_Throw() {
+        exception.expect(GraknException.class);
+
+        qb.define(
+                label("marriage").sub(label(RELATIONSHIP.getLabel())).relates("husband").relates("wife"),
+                label("wife").sub(label(ENTITY.getLabel()))
+        ).execute();
+    }
+
+    private void assertDefine(Statement... vars) {
+        // Make sure vars don't exist
+        for (Statement var : vars) {
+            assertNotExists(qb, var);
+        }
+
+        // Define all vars
+        qb.define(vars).execute();
+
+        // Make sure all vars exist
+        for (Statement var : vars) {
+            assertExists(qb, var);
+        }
+
+        // Undefine all vars
+        qb.undefine(vars).execute();
+
+        // Make sure vars don't exist
+        for (Statement var : vars) {
+            assertNotExists(qb, var);
+        }
+    }
+}

--- a/test-integration/graql/query/DeleteQueryIT.java
+++ b/test-integration/graql/query/DeleteQueryIT.java
@@ -1,0 +1,257 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import grakn.core.graql.concept.ConceptId;
+import grakn.core.graql.concept.SchemaConcept;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.internal.Schema;
+import grakn.core.graql.query.pattern.Statement;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+
+import static grakn.core.common.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static grakn.core.util.GraqlTestUtil.assertNotExists;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class DeleteQueryIT {
+
+    public static final Statement ENTITY = label(Schema.MetaSchema.ENTITY.getLabel());
+    public static final Variable x = var("x");
+    public static final Variable y = var("y");
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+    public static Session session;
+    public Transaction tx;
+    public QueryBuilder qb;
+
+    @Rule
+    public  final ExpectedException exception = ExpectedException.none();
+
+    private Match kurtz;
+    private Match marlonBrando;
+    private Match apocalypseNow;
+    private Match kurtzCastRelation;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+
+        kurtz = qb.match(x.has("name", "Colonel Walter E. Kurtz"));
+        marlonBrando = qb.match(x.has("name", "Marlon Brando"));
+        apocalypseNow = qb.match(x.has("title", "Apocalypse Now"));
+        kurtzCastRelation =
+                qb.match(var("a").rel("character-being-played", var().has("name", "Colonel Walter E. Kurtz")));
+    }
+
+    @After
+    public void closeTransaction(){
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testDeleteMultiple() {
+        qb.define(label("fake-type").sub(ENTITY)).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+
+        assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
+
+        qb.match(x.isa("fake-type")).delete(x).execute();
+
+        assertNotExists(qb, var().isa("fake-type"));
+    }
+
+    @Test
+    public void testDeleteEntity() {
+
+        assertExists(qb, var().has("title", "Godfather"));
+        assertExists(qb, x.has("title", "Godfather"), var().rel(x).rel(y).isa("has-cast"));
+        assertExists(qb, var().has("name", "Don Vito Corleone"));
+
+        qb.match(x.has("title", "Godfather")).delete(x).execute();
+
+        assertNotExists(qb, var().has("title", "Godfather"));
+        assertNotExists(qb, x.has("title", "Godfather"), var().rel(x).rel(y).isa("has-cast"));
+        assertExists(qb, var().has("name", "Don Vito Corleone"));
+    }
+
+    @Test
+    public void testDeleteRelation() {
+        assertExists(kurtz);
+        assertExists(marlonBrando);
+        assertExists(apocalypseNow);
+        assertExists(kurtzCastRelation);
+
+        kurtzCastRelation.delete("a").execute();
+
+        assertExists(kurtz);
+        assertExists(marlonBrando);
+        assertExists(apocalypseNow);
+        assertNotExists(kurtzCastRelation);
+    }
+
+    @Test
+    public void testDeleteAllRolePlayers() {
+        ConceptId id = kurtzCastRelation.get("a").stream().map(ans -> ans.get("a")).findFirst().get().id();
+        Match relation = qb.match(var().id(id));
+
+        assertExists(kurtz);
+        assertExists(marlonBrando);
+        assertExists(apocalypseNow);
+        assertExists(relation);
+
+        kurtz.delete(x).execute();
+
+        assertNotExists(kurtz);
+        assertExists(marlonBrando);
+        assertExists(apocalypseNow);
+        assertExists(relation);
+
+        marlonBrando.delete(x).execute();
+
+        assertNotExists(kurtz);
+        assertNotExists(marlonBrando);
+        assertExists(apocalypseNow);
+        assertExists(relation);
+
+        apocalypseNow.delete(x).execute();
+
+        assertNotExists(kurtz);
+        assertNotExists(marlonBrando);
+        assertNotExists(apocalypseNow);
+        assertNotExists(relation);
+    }
+
+    @Test
+    public void whenDeletingAResource_TheResourceAndImplicitRelationsAreDeleted() {
+        ConceptId id = qb.match(
+                x.has("title", "Godfather"),
+                var("a").rel(x).rel(y).isa(Schema.ImplicitType.HAS.getLabel("tmdb-vote-count").getValue())
+        ).get("a").stream().map(ans -> ans.get("a")).findFirst().get().id();
+
+        assertExists(qb, var().has("title", "Godfather"));
+        assertExists(qb, var().id(id));
+        assertExists(qb, var().val(1000L).isa("tmdb-vote-count"));
+
+        qb.match(x.val(1000L).isa("tmdb-vote-count")).delete(x).execute();
+
+        assertExists(qb, var().has("title", "Godfather"));
+        assertNotExists(qb, var().id(id));
+        assertNotExists(qb, var().val(1000L).isa("tmdb-vote-count"));
+    }
+
+    @Test
+    public void afterDeletingAllInstances_TheTypeCanBeUndefined() {
+        Match movie = qb.match(x.isa("movie"));
+
+        assertNotNull(tx.getEntityType("movie"));
+        assertExists(movie);
+
+        movie.delete(x).execute();
+
+        assertNotNull(tx.getEntityType("movie"));
+        assertNotExists(movie);
+
+        qb.undefine(label("movie").sub("production")).execute();
+
+        assertNull(tx.getEntityType("movie"));
+    }
+
+    @Test
+    public void whenDeletingMultipleVariables_AllVariablesGetDeleted() {
+        qb.define(label("fake-type").sub(ENTITY)).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+
+        assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
+
+        qb.match(x.isa("fake-type"), y.isa("fake-type"), x.neq(y)).limit(1).delete(x, y).execute();
+
+        assertNotExists(qb, var().isa("fake-type"));
+    }
+
+    @Test
+    public void whenDeletingWithNoArguments_AllVariablesGetDeleted() {
+        qb.define(label("fake-type").sub(Schema.MetaSchema.ENTITY.getLabel().getValue())).execute();
+        qb.insert(x.isa("fake-type"), y.isa("fake-type")).execute();
+
+        assertEquals(2, qb.match(x.isa("fake-type")).stream().count());
+
+        qb.match(x.isa("fake-type"), y.isa("fake-type"), x.neq(y)).limit(1).delete().execute();
+
+        assertNotExists(qb, var().isa("fake-type"));
+    }
+
+    @Test
+    public void whenDeletingAVariableNotInTheQuery_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(y));
+        tx.graql().match(x.isa("movie")).delete(y).execute();
+    }
+
+    @Test
+    public void whenDeletingASchemaConcept_Throw() {
+        SchemaConcept newType = qb.define(x.label("new-type").sub(ENTITY)).execute().get(0).get(x).asSchemaConcept();
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.deleteSchemaConcept(newType).getMessage());
+        qb.match(x.label("new-type")).delete(x).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void deleteVarNameNullSet() {
+        tx.graql().match(var()).delete(null).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void whenDeleteIsPassedNull_Throw() {
+        tx.graql().match(var()).delete((String) null).execute();
+    }
+
+}

--- a/test-integration/graql/query/InsertQueryIT.java
+++ b/test-integration/graql/query/InsertQueryIT.java
@@ -1,0 +1,656 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Sets;
+import grakn.core.graql.answer.ConceptMap;
+import grakn.core.graql.concept.Attribute;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.Concept;
+import grakn.core.graql.concept.ConceptId;
+import grakn.core.graql.concept.Entity;
+import grakn.core.graql.concept.EntityType;
+import grakn.core.graql.concept.Label;
+import grakn.core.graql.concept.Relationship;
+import grakn.core.graql.concept.Role;
+import grakn.core.graql.concept.Thing;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.internal.Schema;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.graql.query.pattern.Statement;
+import grakn.core.graql.query.pattern.StatementImpl;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.graql.query.pattern.property.IsaProperty;
+import grakn.core.graql.query.pattern.property.PlaysProperty;
+import grakn.core.graql.query.pattern.property.SubProperty;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import grakn.core.server.exception.InvalidKBException;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static grakn.core.common.exception.ErrorMessage.NO_PATTERNS;
+import static grakn.core.graql.internal.Schema.MetaSchema.ENTITY;
+import static grakn.core.graql.query.Graql.gt;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static grakn.core.util.GraqlTestUtil.assertNotExists;
+import static java.util.stream.Collectors.toSet;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.isOneOf;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+@SuppressWarnings("OptionalGetWithoutIsPresent")
+public class InsertQueryIT {
+
+
+    private static final Variable w = var("w");
+    private static final Variable x = var("x");
+    private static final Variable y = var("y");
+    private static final Variable z = var("z");
+
+    private static final Label title = Label.of("title");
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+
+    public static Session session;
+
+    private Transaction tx;
+    private QueryBuilder qb;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testInsertId() {
+        assertInsert(var("x").has("name", "abc").isa("genre"));
+    }
+
+    @Test
+    public void testInsertValue() {
+        assertInsert(var("x").val(LocalDateTime.of(1992, 10, 7, 13, 14, 15)).isa("release-date"));
+    }
+
+    @Test
+    public void testInsertIsa() {
+        assertInsert(var("x").has("title", "Titanic").isa("movie"));
+    }
+
+    @Test
+    public void testInsertMultiple() {
+        assertInsert(
+                var("x").has("name", "123").isa("person"),
+                var("y").val(123L).isa("runtime"),
+                var("z").isa("language")
+        );
+    }
+
+    @Test
+    public void testInsertResource() {
+        assertInsert(var("x").isa("movie").has("title", "Gladiator").has("runtime", 100L));
+    }
+
+    @Test
+    public void testInsertName() {
+        assertInsert(var("x").isa("movie").has("title", "Hello"));
+    }
+
+    @Test
+    public void testInsertRelation() {
+        Statement rel = var("r").isa("has-genre").rel("genre-of-production", "x").rel("production-with-genre", "y");
+        Statement x = var("x").has("title", "Godfather").isa("movie");
+        Statement y = var("y").has("name", "comedy").isa("genre");
+        Statement[] vars = new Statement[]{rel, x, y};
+        Pattern[] patterns = new Pattern[]{rel, x, y};
+
+        assertNotExists(qb.match(patterns));
+
+        qb.insert(vars).execute();
+        assertExists(qb, patterns);
+
+        qb.match(patterns).delete("r").execute();
+        assertNotExists(qb, patterns);
+    }
+
+    @Test
+    public void testInsertSameVarName() {
+        qb.insert(var("x").has("title", "SW"), var("x").has("title", "Star Wars").isa("movie")).execute();
+
+        assertExists(qb, var().isa("movie").has("title", "SW"));
+        assertExists(qb, var().isa("movie").has("title", "Star Wars"));
+        assertExists(qb, var().isa("movie").has("title", "SW").has("title", "Star Wars"));
+    }
+
+    @Test
+    public void testInsertRepeat() {
+        Statement language = var("x").has("name", "123").isa("language");
+        InsertQuery query = qb.insert(language);
+
+        assertEquals(0, qb.match(language).stream().count());
+        query.execute();
+        assertEquals(1, qb.match(language).stream().count());
+        query.execute();
+        assertEquals(2, qb.match(language).stream().count());
+        query.execute();
+        assertEquals(3, qb.match(language).stream().count());
+
+        qb.match(language).delete("x").execute();
+        assertEquals(0, qb.match(language).stream().count());
+    }
+
+    @Test
+    public void testMatchInsertQuery() {
+        Statement language1 = var().isa("language").has("name", "123");
+        Statement language2 = var().isa("language").has("name", "456");
+
+        qb.insert(language1, language2).execute();
+        assertExists(qb, language1);
+        assertExists(qb, language2);
+
+        qb.match(var("x").isa("language")).insert(var("x").has("name", "HELLO")).execute();
+        assertExists(qb, var().isa("language").has("name", "123").has("name", "HELLO"));
+        assertExists(qb, var().isa("language").has("name", "456").has("name", "HELLO"));
+
+        qb.match(var("x").isa("language")).delete("x").execute();
+        assertNotExists(qb, language1);
+        assertNotExists(qb, language2);
+    }
+
+    @Test
+    public void testIterateInsertResults() {
+        InsertQuery insert = qb.insert(
+                var("x").has("name", "123").isa("person"),
+                var("z").has("name", "xyz").isa("language")
+        );
+
+        Set<ConceptMap> results = insert.stream().collect(toSet());
+        assertEquals(1, results.size());
+        ConceptMap result = results.iterator().next();
+        assertEquals(ImmutableSet.of(var("x"), var("z")), result.vars());
+        assertThat(result.concepts(), Matchers.everyItem(notNullValue(Concept.class)));
+    }
+
+    @Test
+    public void testMatchInsertShouldInsertDataEvenWhenResultsAreNotCollected() {
+        Statement language1 = var().isa("language").has("name", "123");
+        Statement language2 = var().isa("language").has("name", "456");
+
+        qb.insert(language1, language2).execute();
+        assertExists(qb, language1);
+        assertExists(qb, language2);
+
+        InsertQuery query = qb.match(var("x").isa("language")).insert(var("x").has("name", "HELLO"));
+        query.stream();
+
+        assertExists(qb, var().isa("language").has("name", "123").has("name", "HELLO"));
+        assertExists(qb, var().isa("language").has("name", "456").has("name", "HELLO"));
+    }
+
+    @Test
+    public void testErrorWhenInsertWithPredicate() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("predicate");
+        qb.insert(var().id(ConceptId.of("123")).val(gt(3))).execute();
+    }
+
+    @Test
+    public void testErrorWhenInsertWithMultipleIds() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("id"), containsString("123"), containsString("456")));
+        qb.insert(var().id(ConceptId.of("123")).id(ConceptId.of("456")).isa("movie")).execute();
+    }
+
+    @Test
+    public void whenInsertingAResourceWithMultipleValues_Throw() {
+        Statement varPattern = var().val("123").val("456").isa("title");
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(isOneOf(
+                GraqlQueryException.insertMultipleProperties(varPattern, "", "123", "456").getMessage(),
+                GraqlQueryException.insertMultipleProperties(varPattern, "", "456", "123").getMessage()
+        ));
+
+        qb.insert(varPattern).execute();
+    }
+
+    @Test
+    public void testErrorWhenSubRelation() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.insertUnsupportedProperty("sub").getMessage());
+        qb.insert(
+                var().sub("has-genre").rel("genre-of-production", "x").rel("production-with-genre", "y"),
+                var("x").id(ConceptId.of("Godfather")).isa("movie"),
+                var("y").id(ConceptId.of("comedy")).isa("genre")
+        ).execute();
+    }
+
+    @Test
+    public void testInsertRepeatType() {
+        assertInsert(var("x").has("title", "WOW A TITLE").isa("movie").isa("movie"));
+    }
+
+    @Test
+    public void testKeyCorrectUsage() throws InvalidKBException {
+        qb.define(
+                label("a-new-type").sub("entity").key("a-new-resource-type"),
+                label("a-new-resource-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
+        ).execute();
+
+        qb.insert(var().isa("a-new-type").has("a-new-resource-type", "hello")).execute();
+    }
+
+    @Test
+    public void whenInsertingAThingWithTwoKeyResources_Throw() throws InvalidKBException {
+        qb.define(
+                label("a-new-type").sub("entity").key("a-new-attribute-type"),
+                label("a-new-attribute-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
+        ).execute();
+
+        qb.insert(
+                var().isa("a-new-type").has("a-new-attribute-type", "hello").has("a-new-attribute-type", "goodbye")
+        ).execute();
+
+        exception.expect(InvalidKBException.class);
+        tx.commit();
+    }
+
+    @Ignore // TODO: Un-ignore this when constraints are designed and implemented
+    @Test
+    public void testKeyUniqueValue() throws InvalidKBException {
+        qb.define(
+                label("a-new-type").sub("entity").key("a-new-resource-type"),
+                label("a-new-resource-type")
+                        .sub(label(Schema.MetaSchema.ATTRIBUTE.getLabel()))
+                        .datatype(AttributeType.DataType.STRING)
+        ).execute();
+
+        qb.insert(
+                var("x").isa("a-new-type").has("a-new-resource-type", "hello"),
+                var("y").isa("a-new-type").has("a-new-resource-type", "hello")
+        ).execute();
+
+        exception.expect(InvalidKBException.class);
+        tx.commit();
+    }
+
+    @Test
+    public void testKeyRequiredOwner() throws InvalidKBException {
+        qb.define(
+                label("a-new-type").sub("entity").key("a-new-resource-type"),
+                label("a-new-resource-type").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
+        ).execute();
+
+        qb.insert(var().isa("a-new-type")).execute();
+
+        exception.expect(InvalidKBException.class);
+        tx.commit();
+    }
+
+    @Test
+    public void whenExecutingAnInsertQuery_ResultContainsAllInsertedVars() {
+        Variable x = var("x");
+        Variable type = var("type");
+
+        // Note that two variables refer to the same type. They should both be in the result
+        InsertQuery query = qb.insert(x.isa(type), type.label("movie"));
+
+        ConceptMap result = Iterables.getOnlyElement(query);
+        assertThat(result.vars(), containsInAnyOrder(x, type));
+        assertEquals(result.get(type), result.get(x).asEntity().type());
+        assertEquals(result.get(type).asType().label(), Label.of("movie"));
+    }
+
+    @Test
+    public void whenAddingAnAttributeRelationshipWithProvenance_TheAttributeAndProvenanceAreAdded() {
+        InsertQuery query = qb.insert(
+                y.has("provenance", z.val("Someone told me")),
+                w.isa("movie").has(title, x.val("My Movie"), y)
+        );
+
+        ConceptMap answer = Iterables.getOnlyElement(query.execute());
+
+        Entity movie = answer.get(w).asEntity();
+        Attribute<String> theTitle = answer.get(x).asAttribute();
+        Relationship hasTitle = answer.get(y).asRelationship();
+        Attribute<String> provenance = answer.get(z).asAttribute();
+
+        assertThat(hasTitle.rolePlayers().toArray(), arrayContainingInAnyOrder(movie, theTitle));
+        assertThat(hasTitle.attributes().toArray(), arrayContaining(provenance));
+    }
+
+    @Test
+    public void whenAddingProvenanceToAnExistingRelationship_TheProvenanceIsAdded() {
+        InsertQuery query = qb
+                .match(w.isa("movie").has(title, x.val("The Muppets"), y))
+                .insert(x, w, y.has("provenance", z.val("Someone told me")));
+
+        ConceptMap answer = Iterables.getOnlyElement(query.execute());
+
+        Entity movie = answer.get(w).asEntity();
+        Attribute<String> theTitle = answer.get(x).asAttribute();
+        Relationship hasTitle = answer.get(y).asRelationship();
+        Attribute<String> provenance = answer.get(z).asAttribute();
+
+        assertThat(hasTitle.rolePlayers().toArray(), arrayContainingInAnyOrder(movie, theTitle));
+        assertThat(hasTitle.attributes().toArray(), arrayContaining(provenance));
+    }
+
+    @Test
+    public void testErrorWhenInsertRelationWithEmptyRolePlayer() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(
+                allOf(containsString("$y"), containsString("id"), containsString("isa"), containsString("sub"))
+        );
+        qb.insert(
+                var().rel("genre-of-production", "x").rel("production-with-genre", "y").isa("has-genre"),
+                var("x").isa("genre").has("name", "drama")
+        ).execute();
+    }
+
+    @Test
+    public void testErrorWhenAddingInstanceOfConcept() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(
+                allOf(containsString("meta-type"), containsString("my-thing"), containsString(Schema.MetaSchema.THING.getLabel().getValue()))
+        );
+        qb.insert(var("my-thing").isa(Schema.MetaSchema.THING.getLabel().getValue())).execute();
+    }
+
+    @Test
+    public void whenInsertingAResourceWithoutAValue_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("name")));
+        qb.insert(var("x").isa("name")).execute();
+    }
+
+    @Test
+    public void whenInsertingAnInstanceWithALabel_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("label"), containsString("abc")));
+        qb.insert(label("abc").isa("movie")).execute();
+    }
+
+    @Test
+    public void whenInsertingAResourceWithALabel_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("label"), containsString("bobby")));
+        qb.insert(label("bobby").val("bob").isa("name")).execute();
+    }
+
+    @Test
+    public void testInsertDuplicatePattern() {
+        qb.insert(var().isa("person").has("name", "a name"), var().isa("person").has("name", "a name")).execute();
+        assertEquals(2, qb.match(x.has("name", "a name")).stream().count());
+    }
+
+    @Test
+    public void testInsertResourceOnExistingId() {
+        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().id();
+
+        assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow")).execute();
+        assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+    }
+
+    @Test
+    public void testInsertResourceOnExistingIdWithType() {
+        ConceptId apocalypseNow = qb.match(var("x").has("title", "Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().id();
+
+        assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+        qb.insert(var().id(apocalypseNow).isa("movie").has("title", "Apocalypse Maybe Tomorrow")).execute();
+        assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+    }
+
+    @Test
+    public void testInsertResourceOnExistingResourceId() {
+        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().id();
+
+        assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Not Right Now"));
+        qb.insert(var().id(apocalypseNow).has("title", "Apocalypse Not Right Now")).execute();
+        assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Not Right Now"));
+    }
+
+    @Test
+    public void testInsertResourceOnExistingResourceIdWithType() {
+        ConceptId apocalypseNow = qb.match(var("x").val("Apocalypse Now")).get("x")
+                .stream().map(ans -> ans.get("x")).findAny().get().id();
+
+        assertNotExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+        qb.insert(var().id(apocalypseNow).isa("title").has("title", "Apocalypse Maybe Tomorrow")).execute();
+        assertExists(qb, var().id(apocalypseNow).has("title", "Apocalypse Maybe Tomorrow"));
+    }
+
+    @Test
+    public void testInsertInstanceWithoutType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("isa")));
+        qb.insert(var().has("name", "Bob")).execute();
+    }
+
+    @Test
+    public void whenInsertingMultipleRolePlayers_BothRolePlayersAreAdded() {
+        List<ConceptMap> results = qb.match(
+                var("g").has("title", "Godfather"),
+                var("m").has("title", "The Muppets")
+        ).insert(
+                var("c").isa("cluster").has("name", "2"),
+                var("r").rel("cluster-of-production", "c").rel("production-with-cluster", "g").rel("production-with-cluster", "m").isa("has-cluster")
+        ).execute();
+
+        Thing cluster = results.get(0).get("c").asThing();
+        Thing godfather = results.get(0).get("g").asThing();
+        Thing muppets = results.get(0).get("m").asThing();
+        Relationship relationship = results.get(0).get("r").asRelationship();
+
+        Role clusterOfProduction = tx.getRole("cluster-of-production");
+        Role productionWithCluster = tx.getRole("production-with-cluster");
+
+        assertEquals(relationship.rolePlayers().collect(toSet()), ImmutableSet.of(cluster, godfather, muppets));
+        assertEquals(relationship.rolePlayers(clusterOfProduction).collect(toSet()), ImmutableSet.of(cluster));
+        assertEquals(relationship.rolePlayers(productionWithCluster).collect(toSet()), ImmutableSet.of(godfather, muppets));
+    }
+
+    @Test
+    public void whenInsertingWithAMatch_ProjectMatchResultsOnVariablesInTheInsert() {
+        qb.define(
+                label("maybe-friends").relates("friend").sub("relationship"),
+                label("person").plays("friend")
+        ).execute();
+
+        InsertQuery query = qb.match(
+                var().rel("actor", x).rel("production-with-cast", z),
+                var().rel("actor", y).rel("production-with-cast", z)
+        ).insert(
+                w.rel("friend", x).rel("friend", y).isa("maybe-friends")
+        );
+
+        List<ConceptMap> answers = query.execute();
+
+        for (ConceptMap answer : answers) {
+            assertThat(
+                    "Should contain only variables mentioned in the insert (so excludes `$z`)",
+                    answer.vars(),
+                    containsInAnyOrder(x, y, w)
+            );
+        }
+
+        assertEquals("Should contain only distinct results", answers.size(), Sets.newHashSet(answers).size());
+    }
+
+    @Test(expected = Exception.class)
+    public void matchInsertNullVar() {
+        tx.graql().match(var("x").isa("movie")).insert((Statement) null).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void matchInsertNullCollection() {
+        tx.graql().match(var("x").isa("movie")).insert((Collection<? extends Statement>) null).execute();
+    }
+
+    @Test
+    public void whenMatchInsertingAnEmptyPattern_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(NO_PATTERNS.getMessage());
+        tx.graql().match(var()).insert(Collections.EMPTY_SET).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void insertNullVar() {
+        tx.graql().insert((Statement) null).execute();
+    }
+
+    @Test(expected = Exception.class)
+    public void insertNullCollection() {
+        tx.graql().insert((Collection<? extends Statement>) null).execute();
+    }
+
+    @Test
+    public void whenInsertingAnEmptyPattern_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(NO_PATTERNS.getMessage());
+        tx.graql().insert(Collections.EMPTY_SET).execute();
+    }
+
+    @Test
+    public void whenSettingTwoTypes_Throw() {
+        EntityType movie = tx.getEntityType("movie");
+        EntityType person = tx.getEntityType("person");
+
+        // We have to construct it this way because you can't have two `isa`s normally
+        // TODO: less bad way?
+        Statement varPattern = new StatementImpl(
+                var("x"),
+                ImmutableSet.of(new IsaProperty(label("movie")), new IsaProperty(label("person")))
+        );
+
+        // We don't know in what order the message will be
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(isOneOf(
+                GraqlQueryException.insertMultipleProperties(varPattern, "isa", movie, person).getMessage(),
+                GraqlQueryException.insertMultipleProperties(varPattern, "isa", person, movie).getMessage()
+        ));
+
+        tx.graql().insert(var("x").isa("movie"), var("x").isa("person")).execute();
+    }
+
+    @Test
+    public void whenSpecifyingExistingConceptIdWithIncorrectType_Throw() {
+        EntityType movie = tx.getEntityType("movie");
+        EntityType person = tx.getEntityType("person");
+
+        Concept aMovie = movie.instances().iterator().next();
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.insertPropertyOnExistingConcept("isa", person, aMovie).getMessage());
+
+        tx.graql().insert(var("x").id(aMovie.id()).isa("person")).execute();
+    }
+
+    @Test
+    public void whenInsertingASchemaConcept_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(SubProperty.NAME).getMessage());
+
+        qb.insert(label("new-type").sub(label(ENTITY.getLabel()))).execute();
+    }
+
+    @Test
+    public void whenModifyingASchemaConceptInAnInsertQuery_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(PlaysProperty.NAME).getMessage());
+
+        qb.insert(label("movie").plays("actor")).execute();
+    }
+
+    private void assertInsert(Statement... vars) {
+        // Make sure vars don't exist
+        for (Statement var : vars) {
+            assertNotExists(qb, var);
+        }
+
+        // Insert all vars
+        qb.insert(vars).execute();
+
+        // Make sure all vars exist
+        for (Statement var : vars) {
+            assertExists(qb, var);
+        }
+
+        // Delete all vars
+        for (Statement var : vars) {
+            qb.match(var).delete(var.var()).execute();
+        }
+
+        // Make sure vars don't exist
+        for (Statement var : vars) {
+            assertNotExists(qb, var);
+        }
+    }
+}

--- a/test-integration/graql/query/InsertQueryIT.java
+++ b/test-integration/graql/query/InsertQueryIT.java
@@ -84,7 +84,6 @@ import static org.junit.Assert.assertThat;
 @SuppressWarnings("OptionalGetWithoutIsPresent")
 public class InsertQueryIT {
 
-
     private static final Variable w = var("w");
     private static final Variable x = var("x");
     private static final Variable y = var("y");

--- a/test-integration/graql/query/QueryAdminIT.java
+++ b/test-integration/graql/query/QueryAdminIT.java
@@ -1,0 +1,169 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import com.google.common.collect.Sets;
+import grakn.core.graql.concept.ConceptId;
+import grakn.core.graql.concept.Label;
+import grakn.core.graql.concept.SchemaConcept;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.query.pattern.Conjunction;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class QueryAdminIT {
+
+    @ClassRule
+    public static GraknTestServer graknServer = new GraknTestServer();
+    private static Session session;
+    private Transaction tx;
+    private QueryBuilder qb;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testGetTypesInQuery() {
+        Match match = qb.match(
+                var("x").isa(label("movie").sub("production")).has("tmdb-vote-count", 400),
+                var("y").isa("character"),
+                var().rel("production-with-cast", "x").rel("y").isa("has-cast")
+        );
+
+        Set<SchemaConcept> types = Stream.of(
+                "movie", "production", "tmdb-vote-count", "character", "production-with-cast", "has-cast"
+        ).map(t -> tx.<SchemaConcept>getSchemaConcept(Label.of(t))).collect(toSet());
+
+        assertEquals(types, match.admin().getSchemaConcepts());
+    }
+
+    @Test
+    public void testDefaultGetSelectedNamesInQuery() {
+        Match match = qb.match(var("x").isa(var("y")));
+
+        assertEquals(Sets.newHashSet(var("x"), var("y")), match.admin().getSelectedNames());
+    }
+
+    @Test
+    public void testGetPatternInQuery() {
+        Match match = qb.match(var("x").isa("movie"), var("x").val("Bob"));
+
+        Conjunction<Pattern> conjunction = match.admin().getPattern();
+        assertNotNull(conjunction);
+
+        Set<Pattern> patterns = conjunction.getPatterns();
+        assertEquals(2, patterns.size());
+    }
+
+    @Test
+    public void testMutateMatch() {
+        Match match = qb.match(var("x").isa("movie"));
+
+        Conjunction<Pattern> pattern = match.admin().getPattern();
+        pattern.getPatterns().add(var("x").has("title", "Spy"));
+
+        assertEquals(1, match.stream().count());
+    }
+
+    @Test
+    public void testInsertQueryMatchPatternEmpty() {
+        InsertQuery query = qb.insert(var().id(ConceptId.of("123")).isa("movie"));
+        assertNull(query.admin().match());
+    }
+
+    @Test
+    public void testInsertQueryWithMatch() {
+        InsertQuery query = qb.match(var("x").isa("movie")).insert(var().id(ConceptId.of("123")).isa("movie"));
+        assertEquals("match $x isa movie;", query.admin().match().toString());
+
+        query = qb.match(var("x").isaExplicit("movie")).insert(var().id(ConceptId.of("123")).isa("movie"));
+        assertEquals("match $x isa! movie;", query.admin().match().toString());
+    }
+
+    @Test
+    public void testInsertQueryGetVars() {
+        InsertQuery query = qb.insert(var().id(ConceptId.of("123")).isa("movie"), var().id(ConceptId.of("123")).val("Hi"));
+        // Should not merge variables
+        assertEquals(2, query.admin().statements().size());
+    }
+
+    @Test
+    public void testDeleteQueryPattern() {
+        DeleteQuery query = qb.match(var("x").isa("movie")).delete("x");
+        assertEquals("match $x isa movie;", query.admin().match().toString());
+
+        query = qb.match(var("x").isaExplicit("movie")).delete("x");
+        assertEquals("match $x isa! movie;", query.admin().match().toString());
+    }
+
+    @Test
+    public void testInsertQueryGetTypes() {
+        InsertQuery query = qb.insert(var("x").isa("person").has("name", var("y")), var().rel("actor", "x").isa("has-cast"));
+        Set<SchemaConcept> types = Stream.of("person", "name", "actor", "has-cast").map(t -> tx.<SchemaConcept>getSchemaConcept(Label.of(t))).collect(toSet());
+        assertEquals(types, query.admin().getSchemaConcepts());
+    }
+
+    @Test
+    public void testMatchInsertQueryGetTypes() {
+        InsertQuery query = qb.match(var("y").isa("movie"))
+                .insert(var("x").isa("person").has("name", var("z")), var().rel("actor", "x").isa("has-cast"));
+
+        Set<SchemaConcept> types =
+                Stream.of("movie", "person", "name", "actor", "has-cast").map(t -> tx.<SchemaConcept>getSchemaConcept(Label.of(t))).collect(toSet());
+
+        assertEquals(types, query.admin().getSchemaConcepts());
+    }
+}

--- a/test-integration/graql/query/QueryBuilderIT.java
+++ b/test-integration/graql/query/QueryBuilderIT.java
@@ -1,0 +1,157 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import grakn.core.graql.concept.ConceptId;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static grakn.core.graql.query.Graql.insert;
+import static grakn.core.graql.query.Graql.match;
+import static grakn.core.graql.query.Graql.undefine;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static grakn.core.util.GraqlTestUtil.assertNotExists;
+
+public class QueryBuilderIT {
+
+    private static final Variable x = var("x");
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+    private static Session session;
+    private Transaction tx;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void whenBuildingInsertQueryWithGraphLast_ItExecutes() {
+        assertNotExists(tx, var().has("title", "a-movie"));
+        InsertQuery query = insert(var().has("title", "a-movie").isa("movie")).withTx(tx);
+        query.execute();
+        assertExists(tx, var().has("title", "a-movie"));
+    }
+
+    @Test
+    public void whenBuildingDeleteQueryWithGraphLast_ItExecutes() {
+        // Insert some data to delete
+        tx.graql().insert(var().has("title", "123").isa("movie")).execute();
+
+        assertExists(tx, var().has("title", "123"));
+
+        DeleteQuery query = match(x.has("title", "123")).delete(x).withTx(tx);
+        query.execute();
+
+        assertNotExists(tx, var().has("title", "123"));
+    }
+
+    @Test
+    public void whenBuildingUndefineQueryWithGraphLast_ItExecutes() {
+        tx.graql().define(label("yes").sub("entity")).execute();
+
+        UndefineQuery query = undefine(label("yes").sub("entity")).withTx(tx);
+        query.execute();
+        assertNotExists(tx, label("yes").sub("entity"));
+    }
+
+    @Test
+    public void whenBuildingMatchInsertQueryWithGraphLast_ItExecutes() {
+        assertNotExists(tx, var().has("title", "a-movie"));
+        InsertQuery query =
+                match(x.label("movie")).
+                        insert(var().has("title", "a-movie").isa("movie")).withTx(tx);
+        query.execute();
+        assertExists(tx, var().has("title", "a-movie"));
+    }
+
+    @Test
+    public void whenExecutingAMatchWithoutAGraph_Throw() {
+        Match match = match(x.isa("movie"));
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("graph");
+        //noinspection ResultOfMethodCallIgnored
+        match.iterator();
+    }
+
+    @Test
+    public void whenExecutingAnInsertQueryWithoutAGraph_Throw() {
+        InsertQuery query = insert(var().id(ConceptId.of("another-movie")).isa("movie"));
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("graph");
+        query.execute();
+    }
+
+    @Test
+    public void whenExecutingADeleteQueryWithoutAGraph_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("graph");
+        match(x.isa("movie")).delete(x).execute();
+    }
+
+    @Test
+    public void whenGraphIsProvidedAndQueryExecutedWithNonexistentType_Throw() {
+        Match match = match(x.isa("not-a-thing"));
+        exception.expect(GraqlQueryException.class);
+        //noinspection ResultOfMethodCallIgnored
+        match.withTx(tx).stream();
+    }
+
+    @Test
+    public void whenGraphIsProvidedTwice_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("graph");
+        //noinspection ResultOfMethodCallIgnored
+        tx.graql().match(x.isa("movie")).withTx(tx).stream();
+    }
+}

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -1,0 +1,255 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import grakn.core.common.exception.ErrorMessage;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.Concept;
+import grakn.core.graql.concept.Label;
+import grakn.core.graql.concept.Thing;
+import grakn.core.graql.concept.Type;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.internal.Schema;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import grakn.core.server.exception.InvalidKBException;
+import grakn.core.server.exception.TransactionException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.stream.Stream;
+
+import static grakn.core.common.exception.ErrorMessage.INVALID_VALUE;
+import static grakn.core.common.exception.ErrorMessage.NO_PATTERNS;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.StringContains.containsString;
+
+public class QueryErrorIT {
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+    private static Session session;
+    private Transaction tx;
+    private QueryBuilder qb;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testErrorNonExistentConceptType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("film");
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("x").isa("film")).stream();
+    }
+
+    @Test
+    public void testErrorNotARole() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("role"), containsString("person"), containsString("isa person")));
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("x").isa("movie"), var().rel("person", "y").rel("x")).stream();
+    }
+
+    @Test
+    public void testErrorNonExistentResourceType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage("thingy");
+        qb.match(var("x").has("thingy", "value")).delete("x").execute();
+    }
+
+    @Test
+    public void whenMatchingWildcardHas_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.noLabelSpecifiedForHas(var("x")).getMessage());
+        qb.match(label("thing").has(var("x"))).get().execute();
+    }
+
+    @Test
+    public void whenMatchingHasWithNonExistentType_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.labelNotFound(Label.of("heffalump")).getMessage());
+        qb.match(var("x").has("heffalump", "foo")).get().execute();
+    }
+
+    @Test
+    public void testErrorNotARelation() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(
+                containsString("relation"), containsString("movie"), containsString("separate"), containsString(";")));
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var().isa("movie").rel("x").rel("y")).stream();
+    }
+
+    @Test
+    public void testErrorInvalidNonExistentRole() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(ErrorMessage.NOT_A_ROLE_TYPE.getMessage("character-in-production", "character-in-production"));
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var().isa("has-cast").rel("character-in-production", "x")).stream();
+    }
+
+    @Test
+    public void testErrorMultipleIsa() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(
+                containsString("abc"), containsString("isa"), containsString("person"), containsString("has-cast")
+        ));
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("abc").isa("person").isa("has-cast"));
+    }
+
+    @Test
+    public void whenSpecifyingMultipleSubs_ThrowIncludingInformationAboutTheConceptAndBothSupers() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(
+                containsString("abc"), containsString("sub"), containsString("person"), containsString("has-cast")
+        ));
+        qb.define(label("abc").sub("person"), label("abc").sub("has-cast")).execute();
+    }
+
+    @Test
+    public void testErrorHasGenreQuery() {
+        // 'has genre' is not allowed because genre is an entity type
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage("genre"));
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("x").isa("movie").has("genre", "Drama")).stream();
+    }
+
+    @Test
+    public void testExceptionWhenNoPatternsProvided() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(NO_PATTERNS.getMessage());
+        //noinspection ResultOfMethodCallIgnored
+        qb.match();
+    }
+
+    @Test
+    public void testExceptionWhenNullValue() {
+        exception.expect(NullPointerException.class);
+        //noinspection ResultOfMethodCallIgnored
+        var("x").val(null);
+    }
+
+    @Test
+    public void testExceptionWhenNoHasResourceRelation() throws InvalidKBException {
+        // Create a fresh graph, with no has between person and name
+        Session newSession = graknServer.sessionWithNewKeyspace();
+        try (Transaction newTx = newSession.transaction(Transaction.Type.WRITE)) {
+            QueryBuilder emptyQb = newTx.graql();
+            emptyQb.define(
+                    label("person").sub("entity"),
+                    label("name").sub(Schema.MetaSchema.ATTRIBUTE.getLabel().getValue()).datatype(AttributeType.DataType.STRING)
+            ).execute();
+
+            exception.expect(TransactionException.class);
+            exception.expectMessage(allOf(
+                    containsString("person"),
+                    containsString("name")
+            ));
+            emptyQb.insert(var().isa("person").has("name", "Bob")).execute();
+        }
+    }
+
+    @Test
+    public void testExceptionInstanceOfRoleType() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.cannotGetInstancesOfNonType(Label.of("actor")).getMessage());
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("x").isa("actor")).stream();
+    }
+
+    @Test
+    public void testExceptionInstanceOfRule() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.cannotGetInstancesOfNonType(Label.of("rule")).getMessage());
+        //noinspection ResultOfMethodCallIgnored
+        qb.match(var("x").isa("rule")).stream();
+    }
+
+    @Test
+    public void testAdditionalSemicolon() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(allOf(containsString("id"), containsString("plays product-type")));
+        qb.parse(
+                "define " +
+                        "tag-group sub role; product-type sub role;" +
+                        "category sub entity, plays tag-group; plays product-type;"
+        ).execute();
+    }
+
+    @Test
+    public void testGetNonExistentVariable() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(var("y")));
+
+        Match match = qb.match(var("x").isa("movie"));
+        Stream<Concept> concepts = match.get("y").stream().map(ans -> ans.get("y"));
+    }
+
+    @Test
+    public void whenUsingInvalidResourceValue_Throw() {
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(INVALID_VALUE.getMessage(qb.getClass()));
+        qb.match(var("x").val(qb));
+    }
+
+    @Test
+    public void whenTryingToSetExistingInstanceType_Throw() {
+        Thing movie = tx.getEntityType("movie").instances().iterator().next();
+        Type person = tx.getEntityType("person");
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(containsString("person"));
+
+        qb.match(var("x").id(movie.id())).insert(var("x").isa(label(person.label()))).execute();
+    }
+}

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -1,0 +1,451 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import com.google.common.collect.ImmutableList;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.Entity;
+import grakn.core.graql.concept.EntityType;
+import grakn.core.graql.concept.RelationshipType;
+import grakn.core.graql.concept.Role;
+import grakn.core.graql.internal.gremlin.GreedyTraversalPlan;
+import grakn.core.graql.internal.gremlin.fragment.Fragment;
+import grakn.core.graql.internal.gremlin.fragment.InIsaFragment;
+import grakn.core.graql.internal.gremlin.fragment.LabelFragment;
+import grakn.core.graql.internal.gremlin.fragment.NeqFragment;
+import grakn.core.graql.internal.gremlin.fragment.OutIsaFragment;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import grakn.core.server.session.TransactionImpl;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import static grakn.core.graql.query.pattern.Pattern.and;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QueryPlannerIT {
+
+    private static final Variable x = var("x");
+    private static final Variable y = var("y");
+    private static final Variable z = var("z");
+
+    private static final Variable superType = var("superType");
+    private static final Variable subType = var("subType");
+
+    private static final String thingy = "thingy";
+    private static final String thingy0 = "thingy0";
+    private static final String thingy1 = "thingy1";
+    private static final String thingy2 = "thingy2";
+    private static final String thingy3 = "thingy3";
+    private static final String thingy4 = "thingy4";
+    private static final String related = "related";
+    private static final String veryRelated = "veryRelated";
+    private static final String sameAsRelated = "sameAsRelated";
+
+    private static final String resourceType = "resourceType";
+
+    @ClassRule
+    public static GraknTestServer graknServer = new GraknTestServer();
+    private static Session session;
+    private Transaction tx;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        Transaction graph = session.transaction(Transaction.Type.WRITE);
+
+        EntityType entityType0 = graph.putEntityType(thingy0);
+        EntityType entityType1 = graph.putEntityType(thingy1);
+        EntityType entityType2 = graph.putEntityType(thingy2);
+        EntityType entityType3 = graph.putEntityType(thingy3);
+        EntityType entityType4 = graph.putEntityType(thingy4);
+
+        AttributeType<String> attributeType = graph.putAttributeType(resourceType, AttributeType.DataType.STRING);
+        entityType4.has(attributeType);
+
+        EntityType superType1 = graph.putEntityType(thingy);
+        entityType0.sup(superType1);
+        entityType1.sup(superType1);
+
+        Role role1 = graph.putRole("role1");
+        Role role2 = graph.putRole("role2");
+        Role role3 = graph.putRole("role3");
+        superType1.plays(role1).plays(role2).plays(role3);
+        entityType2.plays(role1).plays(role2).plays(role3);
+        entityType3.plays(role1).plays(role2).plays(role3);
+        RelationshipType relationshipType1 = graph.putRelationshipType(related)
+                .relates(role1).relates(role2).relates(role3);
+        graph.putRelationshipType(sameAsRelated)
+                .relates(role1).relates(role2).relates(role3);
+
+        Role role4 = graph.putRole("role4");
+        Role role5 = graph.putRole("role5");
+        entityType1.plays(role4).plays(role5);
+        entityType2.plays(role4).plays(role5);
+        entityType4.plays(role4);
+        graph.putRelationshipType(veryRelated)
+                .relates(role4).relates(role5);
+
+        Entity entity1 = entityType1.create();
+        Entity entity2 = entityType2.create();
+        Entity entity3 = entityType3.create();
+        relationshipType1.create()
+                .assign(role1, entity1)
+                .assign(role2, entity2)
+                .assign(role3, entity3);
+
+        graph.commit();
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void inferUniqueRelationshipType() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(2L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(2L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        pattern = and(
+                x.isa(thingy2),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+
+        // Relationship type can now be inferred, so one more relationship type label
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        // Should start from the inferred relationship type, instead of role players
+        String relationship = plan.get(3).start().name();
+        assertNotEquals(relationship, x.name());
+        assertNotEquals(relationship, y.name());
+    }
+
+    @Test
+    public void inferRelationshipTypeWithMoreThan2Roles() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                z.isa(thingy4),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        // Relationship type can now be inferred, so one more relationship type label
+        assertEquals(4L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(4L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+    }
+
+    @Test
+    public void inferRelationshipTypeWithARolePlayerWithNoType() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(2L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        pattern = and(
+                y.isa(thingy2),
+                z.isa(thingy4),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        // Relationship type can now be inferred, so one more relationship type label
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(3L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+    }
+
+    @Test
+    public void inferRelationshipTypeWhereRolePlayedBySuperType() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(2L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                z.isa(thingy4),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        // Relationship type can now be inferred, so one more relationship type label
+        assertEquals(4L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(4L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+    }
+
+    @Test
+    public void inferRelationshipTypeWhereAVarHasTwoTypes() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy),
+                x.isa(thingy1),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+
+        plan = getPlan(pattern);
+        // Relationship type can now be inferred, so one more relationship type label plus existing 3 labels
+        assertEquals(4L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(4L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+
+        // Should start from the inferred relationship type, instead of role players
+        String relationship = plan.get(4).start().name();
+        assertNotEquals(relationship, x.name());
+        assertNotEquals(relationship, y.name());
+    }
+
+    @Test
+    public void inferRelationshipTypeWhereAVarHasIncorrectTypes() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(veryRelated),
+                x.isa(thingy2),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(3L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+
+        pattern = and(
+                x.isa(veryRelated),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(2L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        assertEquals(2L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+    }
+
+    @Test
+    public void avoidImplicitTypes() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy2),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        String relationship = plan.get(4).start().name();
+
+        // should start from relationship
+        assertNotEquals(relationship, x.name());
+        assertNotEquals(relationship, y.name());
+
+        pattern = and(
+                x.isa(resourceType),
+                y.isa(thingy4),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(3L, plan.stream().filter(LabelFragment.class::isInstance).count());
+        relationship = plan.get(4).start().name();
+
+        // should start from a role player
+        assertTrue(relationship.equals(x.name()) || relationship.equals(y.name()));
+        assertTrue(plan.get(5) instanceof OutIsaFragment);
+    }
+
+    @Test
+    public void sameLabelFragmentShouldNotBeAddedTwice() {
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy2),
+                y.isa(thingy4),
+                z.isa(thingy2),
+                var().rel(x).rel(y),
+                var().rel(z).rel(y));
+        plan = getPlan(pattern);
+
+        // 2 thingy2 label, 1 thingy4, 1 inferred relationship label
+        assertEquals(4L, plan.stream().filter(LabelFragment.class::isInstance).count());
+
+        // 5 isa fragments: x, y, z, relationship between x and y, relationship between z and y
+        assertEquals(5L, plan.stream()
+                .filter(fragment -> fragment instanceof OutIsaFragment || fragment instanceof InIsaFragment).count());
+    }
+
+    @Test
+    public void shardCountIsUsed() {
+        // force the concept to get a new shard
+        // shards of thing = 2 (thing = 1 and thing itself)
+        // thing 2 = 4, thing3 = 7
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy2).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy2).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy2).id());
+
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy3).id());
+
+        Pattern pattern;
+        ImmutableList<Fragment> plan;
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(x, plan.get(3).end());
+        assertEquals(3L, plan.stream().filter(fragment -> fragment instanceof NeqFragment).count());
+
+        //TODO: should uncomment the following after updating cost of out-isa fragment
+//        varName = plan.get(7).end().value();
+//        assertEquals(y.value(), varName);
+//
+//        varName = plan.get(11).end().value();
+//        assertEquals(y.value(), varName);
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(x, plan.get(3).end());
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(x, plan.get(4).end());
+
+        pattern = and(
+                x.isa(superType),
+                superType.label(thingy),
+                y.isa(thingy2),
+                subType.sub(superType),
+                z.isa(subType),
+                var().rel(x).rel(y));
+        plan = getPlan(pattern);
+        assertEquals(z, plan.get(4).end());
+
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy1).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy1).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy).id());
+        // now thing = 5, thing1 = 3
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(y, plan.get(3).end());
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(x, plan.get(3).end());
+
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy1).id());
+        ((TransactionImpl<?>) tx).shard(tx.getEntityType(thingy1).id());
+        // now thing = 7, thing1 = 5
+
+        pattern = and(
+                x.isa(thingy),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(y, plan.get(3).end());
+
+        pattern = and(
+                x.isa(thingy1),
+                y.isa(thingy2),
+                z.isa(thingy3),
+                var().rel(x).rel(y).rel(z));
+        plan = getPlan(pattern);
+        assertEquals(y, plan.get(3).end());
+    }
+
+    private ImmutableList<Fragment> getPlan(Pattern pattern) {
+        return GreedyTraversalPlan.createTraversal(pattern, ((TransactionImpl<?>) tx)).fragments().iterator().next();
+    }
+}

--- a/test-integration/graql/query/UndefineQueryIT.java
+++ b/test-integration/graql/query/UndefineQueryIT.java
@@ -1,0 +1,351 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query;
+
+import com.google.common.collect.ImmutableList;
+import grakn.core.graql.concept.AttributeType;
+import grakn.core.graql.concept.Concept;
+import grakn.core.graql.concept.EntityType;
+import grakn.core.graql.concept.Label;
+import grakn.core.graql.concept.RelationshipType;
+import grakn.core.graql.concept.Role;
+import grakn.core.graql.concept.Type;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.internal.Schema;
+import grakn.core.graql.query.pattern.Pattern;
+import grakn.core.graql.query.pattern.Statement;
+import grakn.core.graql.query.pattern.Variable;
+import grakn.core.graql.query.pattern.property.IsaProperty;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import grakn.core.server.exception.TransactionException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collection;
+
+import static grakn.core.graql.concept.AttributeType.DataType.INTEGER;
+import static grakn.core.graql.concept.AttributeType.DataType.STRING;
+import static grakn.core.graql.query.pattern.Pattern.label;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class UndefineQueryIT {
+
+    private static final Statement THING = Pattern.label(Schema.MetaSchema.THING.getLabel());
+    private static final Statement ENTITY = Pattern.label(Schema.MetaSchema.ENTITY.getLabel());
+    private static final Statement RELATIONSHIP = Pattern.label(Schema.MetaSchema.RELATIONSHIP.getLabel());
+    private static final Statement ATTRIBUTE = Pattern.label(Schema.MetaSchema.ATTRIBUTE.getLabel());
+    private static final Statement ROLE = Pattern.label(Schema.MetaSchema.ROLE.getLabel());
+    private static final Label NEW_TYPE = Label.of("new-type");
+    private static final Variable x = var("x");
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+
+    public static Session session;
+
+    private QueryBuilder qb;
+    private Transaction tx;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+        qb = tx.graql();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void whenUndefiningDataType_DoNothing() {
+        qb.undefine(label("name").datatype(STRING)).execute();
+
+        assertEquals(STRING, tx.getAttributeType("name").dataType());
+    }
+
+    @Test
+    public void whenUndefiningHas_TheHasLinkIsDeleted() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).has("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).attributes().toArray(), hasItemInArray(tx.getAttributeType("name")));
+
+        qb.undefine(label(NEW_TYPE).has("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).attributes().toArray(), not(hasItemInArray(tx.getAttributeType("name"))));
+    }
+
+    @Test
+    public void whenUndefiningHasWhichDoesntExist_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).has("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).attributes().toArray(), hasItemInArray(tx.getAttributeType("name")));
+
+        qb.undefine(label(NEW_TYPE).has("title")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).attributes().toArray(), hasItemInArray(tx.getAttributeType("name")));
+    }
+
+    @Test
+    public void whenUndefiningKey_TheKeyLinkIsDeleted() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).key("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).keys().toArray(), hasItemInArray(tx.getAttributeType("name")));
+
+        qb.undefine(label(NEW_TYPE).key("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).keys().toArray(), not(hasItemInArray(tx.getAttributeType("name"))));
+    }
+
+    @Test
+    public void whenUndefiningKeyWhichDoesntExist_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).key("name")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).keys().toArray(), hasItemInArray(tx.getAttributeType("name")));
+
+        qb.undefine(label(NEW_TYPE).key("title")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).keys().toArray(), hasItemInArray(tx.getAttributeType("name")));
+    }
+
+    @Test
+    public void whenUndefiningById_TheSchemaConceptIsDeleted() {
+        Type newType = qb.define(x.label(NEW_TYPE).sub(ENTITY)).execute().get(0).get(x).asType();
+
+        assertNotNull(tx.getType(NEW_TYPE));
+
+        qb.undefine(var().id(newType.id()).sub(ENTITY)).execute();
+
+        assertNull(tx.getType(NEW_TYPE));
+    }
+
+    @Test
+    public void whenUndefiningIsAbstract_TheTypeIsNoLongerAbstract() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).isAbstract()).execute();
+
+        assertTrue(tx.getType(NEW_TYPE).isAbstract());
+
+        qb.undefine(label(NEW_TYPE).isAbstract()).execute();
+
+        assertFalse(tx.getType(NEW_TYPE).isAbstract());
+    }
+
+    @Test
+    public void whenUndefiningIsAbstractOnNonAbstractType_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ENTITY)).execute();
+
+        assertFalse(tx.getType(NEW_TYPE).isAbstract());
+
+        qb.undefine(label(NEW_TYPE).isAbstract()).execute();
+
+        assertFalse(tx.getType(NEW_TYPE).isAbstract());
+    }
+
+    @Test
+    public void whenUndefiningPlays_TheTypeNoLongerPlaysTheRole() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).plays("actor")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).playing().toArray(), hasItemInArray(tx.getRole("actor")));
+
+        qb.undefine(label(NEW_TYPE).plays("actor")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).playing().toArray(), not(hasItemInArray(tx.getRole("actor"))));
+    }
+
+    @Test
+    public void whenUndefiningPlaysWhichDoesntExist_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ENTITY).plays("production-with-cast")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).playing().toArray(), hasItemInArray(tx.getRole("production-with-cast")));
+
+        qb.undefine(label(NEW_TYPE).plays("actor")).execute();
+
+        assertThat(tx.getType(NEW_TYPE).playing().toArray(), hasItemInArray(tx.getRole("production-with-cast")));
+    }
+
+    @Test
+    public void whenUndefiningRegexProperty_TheAttributeTypeHasNoRegex() {
+        qb.define(label(NEW_TYPE).sub(ATTRIBUTE).datatype(STRING).regex("abc")).execute();
+
+        assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
+
+        qb.undefine(label(NEW_TYPE).regex("abc")).execute();
+
+        assertNull(tx.<AttributeType>getType(NEW_TYPE).regex());
+    }
+
+    @Test
+    public void whenUndefiningRegexPropertyWithWrongRegex_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ATTRIBUTE).datatype(STRING).regex("abc")).execute();
+
+        assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
+
+        qb.undefine(label(NEW_TYPE).regex("xyz")).execute();
+
+        assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
+    }
+
+    @Test
+    public void whenUndefiningRelatesProperty_TheRelationshipTypeNoLongerRelatesTheRole() {
+        qb.define(label(NEW_TYPE).sub(RELATIONSHIP).relates("actor")).execute();
+
+        assertThat(tx.<RelationshipType>getType(NEW_TYPE).roles().toArray(), hasItemInArray(tx.getRole("actor")));
+
+        qb.undefine(label(NEW_TYPE).relates("actor")).execute();
+
+        assertThat(tx.<RelationshipType>getType(NEW_TYPE).roles().toArray(), not(hasItemInArray(tx.getRole("actor"))));
+    }
+
+    @Test
+    public void whenUndefiningSub_TheSchemaConceptIsDeleted() {
+        qb.define(label(NEW_TYPE).sub(ENTITY)).execute();
+
+        assertNotNull(tx.getType(NEW_TYPE));
+
+        qb.undefine(label(NEW_TYPE).sub(ENTITY)).execute();
+
+        assertNull(tx.getType(NEW_TYPE));
+    }
+
+    @Test
+    public void whenUndefiningSubWhichDoesntExist_DoNothing() {
+        qb.define(label(NEW_TYPE).sub(ENTITY)).execute();
+
+        assertNotNull(tx.getType(NEW_TYPE));
+
+        qb.undefine(label(NEW_TYPE).sub(THING)).execute();
+
+        assertNotNull(tx.getType(NEW_TYPE));
+    }
+
+    @Test
+    public void whenUndefiningComplexSchema_TheEntireSchemaIsRemoved() {
+        Collection<Statement> schema = ImmutableList.of(
+                label("pokemon").sub(ENTITY).has("pokedex-no").plays("ancestor").plays("descendant"),
+                label("pokedex-no").sub(ATTRIBUTE).datatype(INTEGER),
+                label("evolution").sub(RELATIONSHIP).relates("ancestor").relates("descendant"),
+                label("ancestor").sub(ROLE),
+                label("descendant").sub(ROLE)
+        );
+
+        qb.define(schema).execute();
+
+        EntityType pokemon = tx.getEntityType("pokemon");
+        RelationshipType evolution = tx.getRelationshipType("evolution");
+        AttributeType<Long> pokedexNo = tx.getAttributeType("pokedex-no");
+        Role ancestor = tx.getRole("ancestor");
+        Role descendant = tx.getRole("descendant");
+
+        assertThat(pokemon.attributes().toArray(), arrayContaining(pokedexNo));
+        assertThat(evolution.roles().toArray(), arrayContainingInAnyOrder(ancestor, descendant));
+        assertThat(pokemon.playing().filter(r -> !r.isImplicit()).toArray(), arrayContainingInAnyOrder(ancestor, descendant));
+
+        qb.undefine(schema).execute();
+
+        assertNull(tx.getEntityType("pokemon"));
+        assertNull(tx.getEntityType("evolution"));
+        assertNull(tx.getAttributeType("pokedex-no"));
+        assertNull(tx.getRole("ancestor"));
+        assertNull(tx.getRole("descendant"));
+    }
+
+    @Test
+    public void whenUndefiningATypeWithInstances_Throw() {
+        assertExists(qb, x.label("movie").sub("entity"));
+        assertExists(qb, x.isa("movie"));
+
+        exception.expect(TransactionException.class);
+        exception.expectMessage(allOf(containsString("movie"), containsString("delet")));
+        qb.undefine(label("movie").sub("production")).execute();
+    }
+
+    @Test
+    public void whenUndefiningASuperConcept_Throw() {
+        assertExists(qb, x.label("production").sub("entity"));
+
+        exception.expect(TransactionException.class);
+        exception.expectMessage(allOf(containsString("production"), containsString("delet")));
+        qb.undefine(label("production").sub(ENTITY)).execute();
+    }
+
+    @Test
+    public void whenUndefiningARoleWithPlayers_Throw() {
+        assertExists(qb, x.label("actor"));
+
+        exception.expect(TransactionException.class);
+        exception.expectMessage(allOf(containsString("actor"), containsString("delet")));
+        qb.undefine(label("actor").sub(ROLE)).execute();
+    }
+
+    @Test
+    public void whenUndefiningAnInstanceProperty_Throw() {
+        Concept movie = qb.insert(x.isa("movie")).execute().get(0).get(x);
+
+        exception.expect(GraqlQueryException.class);
+        exception.expectMessage(GraqlQueryException.defineUnsupportedProperty(IsaProperty.NAME).getMessage());
+
+        qb.undefine(var().id(movie.id()).isa("movie")).execute();
+    }
+
+    @Test
+    public void whenGettingResultsString_ResultIsEmptyAndQueryExecutes() {
+        qb.define(label(NEW_TYPE).sub(ENTITY)).execute();
+        Type newType = tx.getType(NEW_TYPE);
+        assertNotNull(newType);
+
+        qb.undefine(label(NEW_TYPE).sub(ENTITY)).execute();
+        assertNull(tx.getType(NEW_TYPE));
+    }
+}

--- a/test-integration/graql/query/pattern/BUILD
+++ b/test-integration/graql/query/pattern/BUILD
@@ -1,0 +1,33 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+java_test(
+    name = "pattern-it",
+    test_class = "grakn.core.graql.query.pattern.PatternIT",
+    srcs = ["PatternIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/graql/graph:movie-graph",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
+
+        "//dependencies/maven/artifacts/com/google/guava:guava",
+
+    ],
+    size = "medium"
+)

--- a/test-integration/graql/query/pattern/PatternIT.java
+++ b/test-integration/graql/query/pattern/PatternIT.java
@@ -115,20 +115,23 @@ public class PatternIT {
         assertEquals(conjunction, conjunction.asConjunction());
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testConjunctionAsVar() {
+        exception.expect(UnsupportedOperationException.class);
         //noinspection ResultOfMethodCallIgnored
         and(var("x").isa("movie"), var("x").isa("person")).asStatement();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testDisjunctionAsConjunction() {
+        exception.expect(UnsupportedOperationException.class);
         //noinspection ResultOfMethodCallIgnored
         or(var("x").isa("movie"), var("x").isa("person")).asConjunction();
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testVarAsDisjunction() {
+        exception.expect(UnsupportedOperationException.class);
         //noinspection ResultOfMethodCallIgnored
         var("x").isa("movie").asDisjunction();
     }
@@ -232,15 +235,17 @@ public class PatternIT {
         assertTrue(conj.size() > 1);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void whenConjunctionPassedNull_Throw() {
+        exception.expect(Exception.class);
         Set<Statement> varSet = null;
         //noinspection ResultOfMethodCallIgnored,ConstantConditions
         and(varSet);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void whenConjunctionPassedVarAndNull_Throw() {
+        exception.expect(Exception.class);
         Statement var = null;
         //noinspection ResultOfMethodCallIgnored,ConstantConditions
         and(var(), var);
@@ -281,15 +286,17 @@ public class PatternIT {
         assertTrue(conj.size() > 1);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void whenDisjunctionPassedNull_Throw() {
+        exception.expect(Exception.class);
         Set<Statement> varSet = null;
         //noinspection ResultOfMethodCallIgnored,ConstantConditions
         or(varSet);
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void whenDisjunctionPassedVarAndNull_Throw() {
+        exception.expect(Exception.class);
         Statement var = null;
         //noinspection ResultOfMethodCallIgnored,ConstantConditions
         or(var(), var);
@@ -314,8 +321,9 @@ public class PatternIT {
         assertEquals(1, result2.size());
     }
 
-    @Test(expected = Exception.class)
+    @Test
     public void whenNegationPassedNull_Throw() {
+        exception.expect(Exception.class);
         Statement var = null;
         //noinspection ConstantConditions,ResultOfMethodCallIgnored
         neq(var);

--- a/test-integration/graql/query/pattern/PatternIT.java
+++ b/test-integration/graql/query/pattern/PatternIT.java
@@ -1,0 +1,333 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.query.pattern;
+
+import com.google.common.collect.Sets;
+import grakn.core.graql.concept.Concept;
+import grakn.core.graql.graph.MovieGraph;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
+import grakn.core.server.Transaction;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static grakn.core.graql.query.Graql.neq;
+import static grakn.core.graql.query.pattern.Pattern.and;
+import static grakn.core.graql.query.pattern.Pattern.or;
+import static grakn.core.graql.query.pattern.Pattern.var;
+import static grakn.core.util.GraqlTestUtil.assertExists;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("CheckReturnValue")
+public class PatternIT {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+
+    private static Session session;
+    private Transaction tx;
+
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+        MovieGraph.load(session);
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.transaction(Transaction.Type.WRITE);
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void testStatement() {
+        Pattern x = var("x");
+
+        assertTrue(x.isStatement());
+        assertFalse(x.isDisjunction());
+        assertFalse(x.isConjunction());
+
+        assertEquals(x, x.asStatement());
+    }
+
+    @Test
+    public void testSimpleDisjunction() {
+        Pattern disjunction = or();
+
+        assertFalse(disjunction.isStatement());
+        assertTrue(disjunction.isDisjunction());
+        assertFalse(disjunction.isConjunction());
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals(disjunction, disjunction.asDisjunction());
+    }
+
+    @Test
+    public void testSimpleConjunction() {
+        Pattern conjunction = and();
+
+        assertFalse(conjunction.isStatement());
+        assertFalse(conjunction.isDisjunction());
+        assertTrue(conjunction.isConjunction());
+
+        //noinspection AssertEqualsBetweenInconvertibleTypes
+        assertEquals(conjunction, conjunction.asConjunction());
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testConjunctionAsVar() {
+        //noinspection ResultOfMethodCallIgnored
+        and(var("x").isa("movie"), var("x").isa("person")).asStatement();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDisjunctionAsConjunction() {
+        //noinspection ResultOfMethodCallIgnored
+        or(var("x").isa("movie"), var("x").isa("person")).asConjunction();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testVarAsDisjunction() {
+        //noinspection ResultOfMethodCallIgnored
+        var("x").isa("movie").asDisjunction();
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    public void testValidVarNames() {
+        var("123");
+        var("___");
+        var("---");
+        var("xxx");
+        var("_1");
+        var("1a");
+        var("-1");
+    }
+
+    @Test
+    public void whenCreatingAVarWithAnInvalidName_Throw() {
+        assertExceptionThrown(Pattern::var, "");
+        assertExceptionThrown(Pattern::var, " ");
+        assertExceptionThrown(Pattern::var, "!!!");
+        assertExceptionThrown(Pattern::var, "a b");
+        assertExceptionThrown(Pattern::var, "");
+        assertExceptionThrown(Pattern::var, "\"");
+        assertExceptionThrown(Pattern::var, "\"\"");
+        assertExceptionThrown(Pattern::var, "'");
+        assertExceptionThrown(Pattern::var, "''");
+    }
+
+    @Test
+    public void testVarEquals() {
+        Statement var1;
+        Statement var2;
+
+        var1 = var();
+        var2 = var();
+        assertTrue(var1.equals(var1));
+        assertFalse(var1.equals(var2));
+
+        var1 = var("x");
+        var2 = var("y");
+        assertTrue(var1.equals(var1));
+        assertFalse(var1.equals(var2));
+
+        var1 = var("x").isa("movie");
+        var2 = var("x").isa("movie");
+        assertTrue(var1.equals(var2));
+
+        var1 = var("x").isa("movie").has("title", "abc");
+        var2 = var("x").has("title", "abc").isa("movie");
+        assertTrue(var1.equals(var2));
+    }
+
+    @Test
+    public void testConjunction() {
+        Set<Statement> varSet1 = Sets.newHashSet(
+                var("x").isa("movie"),
+                var("y1").isa("genre").has("name", "crime"),
+                var().isa("has-genre").rel(var("x")).rel(var("y1")));
+        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(resultSet1.isEmpty());
+
+        Set<Statement> varSet11 = Sets.newHashSet(var("x"));
+        varSet11.addAll(varSet1);
+        Set<Concept> resultSet11 = tx.graql().match(varSet11).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertEquals(resultSet11, resultSet1);
+
+        varSet11.add(var("z"));
+        resultSet11 = tx.graql().match(varSet11).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertEquals(resultSet11, resultSet1);
+
+        Set<Statement> varSet2 = Sets.newHashSet(
+                var("x").isa("movie"),
+                var("y2").isa("person").has("name", "Marlon Brando"),
+                var().isa("has-cast").rel(var("x")).rel(var("y2")));
+        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(resultSet1.isEmpty());
+
+        Set<Statement> varSet3 = Sets.newHashSet(
+                var("x").isa("movie"),
+                var("y").isa("genre").has("name", "crime"),
+                var().isa("has-genre").rel(var("x")).rel(var("y")),
+                var("y2").isa("person").has("name", "Marlon Brando"),
+                var().isa("has-cast").rel(var("x")).rel(var("y2")));
+        Set<Concept> conj = tx.graql().match(varSet3).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(conj.isEmpty());
+
+        resultSet2.retainAll(resultSet1);
+        assertEquals(resultSet2, conj);
+
+        conj = tx.graql().match(and(varSet3)).get("x").stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertEquals(resultSet2, conj);
+
+        conj = tx.graql().match(or(var("x"), var("x"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertTrue(conj.size() > 1);
+    }
+
+    @Test(expected = Exception.class)
+    public void whenConjunctionPassedNull_Throw() {
+        Set<Statement> varSet = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
+        and(varSet);
+    }
+
+    @Test(expected = Exception.class)
+    public void whenConjunctionPassedVarAndNull_Throw() {
+        Statement var = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
+        and(var(), var);
+    }
+
+    @Test
+    public void testDisjunction() {
+        Set<Statement> varSet1 = Sets.newHashSet(
+                var("x").isa("movie"),
+                var("y1").isa("genre").has("name", "crime"),
+                var().isa("has-genre").rel(var("x")).rel(var("y1")));
+        Set<Concept> resultSet1 = tx.graql().match(varSet1).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(resultSet1.isEmpty());
+
+        Set<Statement> varSet2 = Sets.newHashSet(
+                var("x").isa("movie"),
+                var("y2").isa("person").has("name", "Marlon Brando"),
+                var().isa("has-cast").rel(var("x")).rel(var("y2")));
+        Set<Concept> resultSet2 = tx.graql().match(varSet2).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(resultSet1.isEmpty());
+
+        Set<Pattern> varSet3 = Sets.newHashSet(
+                var("x").isa("movie"),
+                or(var("y").isa("genre").has("name", "crime"),
+                        var("y").isa("person").has("name", "Marlon Brando")),
+                var().rel(var("x")).rel(var("y")));
+        Set<Concept> conj = tx.graql().match(varSet3).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(conj.isEmpty());
+
+        resultSet2.addAll(resultSet1);
+        assertEquals(resultSet2, conj);
+
+        conj = tx.graql().match(or(var("x"), var("x"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertTrue(conj.size() > 1);
+    }
+
+    @Test(expected = Exception.class)
+    public void whenDisjunctionPassedNull_Throw() {
+        Set<Statement> varSet = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
+        or(varSet);
+    }
+
+    @Test(expected = Exception.class)
+    public void whenDisjunctionPassedVarAndNull_Throw() {
+        Statement var = null;
+        //noinspection ResultOfMethodCallIgnored,ConstantConditions
+        or(var(), var);
+    }
+
+    @Test
+    public void testNegation() {
+        assertExists(tx.graql(), var().isa("movie").has("title", "Godfather"));
+        Set<Concept> result1 = tx.graql().match(
+                var("x").isa("movie").has("title", var("y")),
+                var("y").val(neq("Godfather"))).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(result1.isEmpty());
+
+        Set<Concept> result2 = tx.graql().match(
+                var("x").isa("movie").has("title", var("y")),
+                var("y")).get("x")
+                .stream().map(ans -> ans.get("x")).collect(Collectors.toSet());
+        assertFalse(result2.isEmpty());
+
+        result2.removeAll(result1);
+        assertEquals(1, result2.size());
+    }
+
+    @Test(expected = Exception.class)
+    public void whenNegationPassedNull_Throw() {
+        Statement var = null;
+        //noinspection ConstantConditions,ResultOfMethodCallIgnored
+        neq(var);
+    }
+
+    private void assertExceptionThrown(Consumer<String> consumer, String varName) {
+        boolean exceptionThrown = false;
+        try {
+            consumer.accept(varName);
+        } catch (Exception e) {
+            exceptionThrown = true;
+        }
+        assertTrue(exceptionThrown);
+    }
+}

--- a/test-integration/graql/reasoner/graph/BUILD
+++ b/test-integration/graql/reasoner/graph/BUILD
@@ -1,3 +1,21 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
 java_library(
     name = "diagonal-graph",
     srcs = ["DiagonalGraph.java"],

--- a/test-integration/server/kb/concept/BUILD
+++ b/test-integration/server/kb/concept/BUILD
@@ -60,7 +60,7 @@ java_test(
          "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core"
      ],
      classpath_resources = ["//test-integration/resources:logback-test"],
-     size = "medium"
+     size = "large"
 )
 java_test(
      name = "relationship-it",


### PR DESCRIPTION
# Why is this PR needed?

When we rearchitected Grakn's module structure and migrated the build system to Bazel (PR #4459), we had to remove lots of tests temporarily and incrementally bring them back. We still have one last batch of tests to bring back: Graql query integration tests, which is useful to have in place as we refactor Graql (issue #4456)

# What does the PR do?

Readded Graql query tests (closes #4653). These tests were previously considered to be unit tests, but they are effectively integration tests.
- `grakn.core.graql.query.InsertQueryIT`
- `grakn.core.graql.query.UndefineQueryIT`
- `grakn.core.graql.query.QuerryErrorIT`
- `grakn.core.graql.query.QueryBuilderIT`
- `grakn.core.graql.query.DeleteQueryIT`
- `grakn.core.graql.query.DefineQueryIT`
- `grakn.core.graql.query.pattern.PatternIT`
- `grakn.core.graql.query.QueryAdminIT`
- `grakn.core.graql.query.AggregateQueryIT`
- `grakn.core.graql.query.QueryPlannerIT`