### PR TITLE
predicate binding equivalence refactor

### DIFF
--- a/server/src/graql/internal/reasoner/atom/Atom.java
+++ b/server/src/graql/internal/reasoner/atom/Atom.java
@@ -290,7 +290,7 @@ public abstract class Atom extends AtomicBase {
      * @param <T>  the type of {@link Predicate} to return
      * @return stream of all predicates (public and inner) relevant to this atom and variable
      */
-    private <T extends Predicate> Stream<T> getAllPredicates(Variable var, Class<T> type) {
+    public <T extends Predicate> Stream<T> getAllPredicates(Variable var, Class<T> type) {
         return Stream.concat(
                 getPredicates(type),
                 getInnerPredicates(type)

--- a/server/src/graql/internal/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/internal/reasoner/atom/binary/Binary.java
@@ -139,7 +139,7 @@ public abstract class Binary extends Atom {
                 && predicateBindingsEquivalent(this.getPredicateVariable(), that.getPredicateVariable(), that, equiv);
     }
 
-    boolean predicateBindingsEquivalent(Var thisVar, Var thatVar, Binary that, AtomicEquivalence equiv){
+    boolean predicateBindingsEquivalent(Variable thisVar, Variable thatVar, Binary that, AtomicEquivalence equiv){
         Set<IdPredicate> thisIdPredicate = this.getPredicates(thisVar, IdPredicate.class).collect(Collectors.toSet());
         Set<IdPredicate> idPredicate = that.getPredicates(thatVar, IdPredicate.class).collect(Collectors.toSet());
 

--- a/server/src/graql/internal/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/internal/reasoner/atom/binary/Binary.java
@@ -131,31 +131,30 @@ public abstract class Binary extends Atom {
     }
 
     boolean predicateBindingsEquivalent(Binary that, AtomicEquivalence equiv) {
-        //check if there is a substitution for varName
-        IdPredicate thisVarPredicate = this.getIdPredicate(this.getVarName());
-        IdPredicate varPredicate = that.getIdPredicate(that.getVarName());
-
-        NeqPredicate thisVarNeqPredicate = this.getPredicates(this.getVarName(), NeqPredicate.class).findFirst().orElse(null);
-        NeqPredicate varNeqPredicate = that.getPredicates(that.getVarName(), NeqPredicate.class).findFirst().orElse(null);
-
         IdPredicate thisTypePredicate = this.getTypePredicate();
         IdPredicate typePredicate = that.getTypePredicate();
 
-        NeqPredicate thisTypeNeqPredicate = this.getPredicates(this.getPredicateVariable(), NeqPredicate.class).findFirst().orElse(null);
-        NeqPredicate typeNeqPredicate = that.getPredicates(that.getPredicateVariable(), NeqPredicate.class).findFirst().orElse(null);
+        Set<IdPredicate> thisVarPredicate = this.getPredicates(this.getVarName(), IdPredicate.class).collect(Collectors.toSet());
+        Set<IdPredicate> varPredicate = that.getPredicates(that.getVarName(), IdPredicate.class).collect(Collectors.toSet());
 
-        Set<ValuePredicate> thisValuePredicate = this.getPredicates(this.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
-        Set<ValuePredicate> valuePredicate = that.getPredicates(that.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
+        Set<NeqPredicate> thisVarNeqPredicate = this.getPredicates(this.getVarName(), NeqPredicate.class).collect(Collectors.toSet());
+        Set<NeqPredicate> varNeqPredicate = that.getPredicates(that.getVarName(), NeqPredicate.class).collect(Collectors.toSet());
 
-        Set<ValuePredicate> thisTypeValuePredicate  = this.getPredicates(this.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
-        Set<ValuePredicate> typeValuePredicate = that.getPredicates(that.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
+        Set<NeqPredicate> thisTypeNeqPredicate = this.getPredicates(this.getPredicateVariable(), NeqPredicate.class).collect(Collectors.toSet());
+        Set<NeqPredicate> typeNeqPredicate = that.getPredicates(that.getPredicateVariable(), NeqPredicate.class).collect(Collectors.toSet());
 
-        return ((thisVarPredicate == null && varPredicate == null || thisVarPredicate != null && equiv.equivalent(thisVarPredicate, varPredicate)))
-                && (thisVarNeqPredicate == null && varNeqPredicate == null || thisVarNeqPredicate != null && equiv.equivalent(thisVarNeqPredicate, varNeqPredicate))
-                && (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && equiv.equivalent(thisTypePredicate, typePredicate))
-                && (thisTypeNeqPredicate == null && typeNeqPredicate == null || thisTypeNeqPredicate != null && equiv.equivalent(thisTypeNeqPredicate, typeNeqPredicate))
-                && (thisValuePredicate == null && valuePredicate == null || thisValuePredicate != null && equiv.equivalentCollection(thisValuePredicate, valuePredicate))
-                && (thisTypeValuePredicate == null && typeValuePredicate == null || thisTypeValuePredicate != null && equiv.equivalentCollection(thisTypeValuePredicate, typeValuePredicate));
+        Set<ValuePredicate> thisValuePredicate = this.getAllPredicates(this.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
+        Set<ValuePredicate> valuePredicate = that.getAllPredicates(that.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
+
+        Set<ValuePredicate> thisTypeValuePredicate  = this.getAllPredicates(this.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
+        Set<ValuePredicate> typeValuePredicate = that.getAllPredicates(that.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
+
+        return (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && equiv.equivalent(thisTypePredicate, typePredicate))
+                && equiv.equivalentCollection(thisVarPredicate, varPredicate)
+                && equiv.equivalentCollection(thisVarNeqPredicate, varNeqPredicate)
+                && equiv.equivalentCollection(thisTypeNeqPredicate, typeNeqPredicate)
+                && equiv.equivalentCollection(thisValuePredicate, valuePredicate)
+                && equiv.equivalentCollection(thisTypeValuePredicate, typeValuePredicate);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/internal/reasoner/atom/binary/Binary.java
@@ -134,27 +134,24 @@ public abstract class Binary extends Atom {
         IdPredicate thisTypePredicate = this.getTypePredicate();
         IdPredicate typePredicate = that.getTypePredicate();
 
-        Set<IdPredicate> thisVarPredicate = this.getPredicates(this.getVarName(), IdPredicate.class).collect(Collectors.toSet());
-        Set<IdPredicate> varPredicate = that.getPredicates(that.getVarName(), IdPredicate.class).collect(Collectors.toSet());
-
-        Set<NeqPredicate> thisVarNeqPredicate = this.getPredicates(this.getVarName(), NeqPredicate.class).collect(Collectors.toSet());
-        Set<NeqPredicate> varNeqPredicate = that.getPredicates(that.getVarName(), NeqPredicate.class).collect(Collectors.toSet());
-
-        Set<NeqPredicate> thisTypeNeqPredicate = this.getPredicates(this.getPredicateVariable(), NeqPredicate.class).collect(Collectors.toSet());
-        Set<NeqPredicate> typeNeqPredicate = that.getPredicates(that.getPredicateVariable(), NeqPredicate.class).collect(Collectors.toSet());
-
-        Set<ValuePredicate> thisValuePredicate = this.getAllPredicates(this.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
-        Set<ValuePredicate> valuePredicate = that.getAllPredicates(that.getVarName(), ValuePredicate.class).collect(Collectors.toSet());
-
-        Set<ValuePredicate> thisTypeValuePredicate  = this.getAllPredicates(this.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
-        Set<ValuePredicate> typeValuePredicate = that.getAllPredicates(that.getPredicateVariable(), ValuePredicate.class).collect(Collectors.toSet());
-
         return (thisTypePredicate == null && typePredicate == null || thisTypePredicate != null && equiv.equivalent(thisTypePredicate, typePredicate))
-                && equiv.equivalentCollection(thisVarPredicate, varPredicate)
-                && equiv.equivalentCollection(thisVarNeqPredicate, varNeqPredicate)
-                && equiv.equivalentCollection(thisTypeNeqPredicate, typeNeqPredicate)
+                && predicateBindingsEquivalent(this.getVarName(), that.getVarName(), that, equiv)
+                && predicateBindingsEquivalent(this.getPredicateVariable(), that.getPredicateVariable(), that, equiv);
+    }
+
+    boolean predicateBindingsEquivalent(Var thisVar, Var thatVar, Binary that, AtomicEquivalence equiv){
+        Set<IdPredicate> thisIdPredicate = this.getPredicates(thisVar, IdPredicate.class).collect(Collectors.toSet());
+        Set<IdPredicate> idPredicate = that.getPredicates(thatVar, IdPredicate.class).collect(Collectors.toSet());
+
+        Set<ValuePredicate> thisValuePredicate = this.getPredicates(thisVar, ValuePredicate.class).collect(Collectors.toSet());
+        Set<ValuePredicate> valuePredicate = that.getPredicates(thatVar, ValuePredicate.class).collect(Collectors.toSet());
+
+        Set<NeqPredicate> thisNeqPredicate = this.getPredicates(thisVar, NeqPredicate.class).collect(Collectors.toSet());
+        Set<NeqPredicate> neqPredicate = that.getPredicates(thatVar, NeqPredicate.class).collect(Collectors.toSet());
+
+        return equiv.equivalentCollection(thisIdPredicate, idPredicate)
                 && equiv.equivalentCollection(thisValuePredicate, valuePredicate)
-                && equiv.equivalentCollection(thisTypeValuePredicate, typeValuePredicate);
+                && equiv.equivalentCollection(thisNeqPredicate, neqPredicate);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -304,21 +304,13 @@ public abstract class RelationshipAtom extends IsaAtomBase {
                 && this.predicateBindingsAlphaEquivalent(that);
     }
 
-    @Memoized
     @Override
-    public int alphaEquivalenceHashCode() {
-        int equivalenceHashCode = baseHashCode();
-        SortedSet<Integer> hashes = new TreeSet<>();
-        this.getRoleTypeMap().entries().stream()
-                .sorted(Comparator.comparing(e -> e.getKey().label()))
-                .sorted(Comparator.comparing(e -> e.getValue().label()))
-                .forEach(e -> hashes.add(e.hashCode()));
-        this.getRoleConceptIdMap().entries().stream()
-                .sorted(Comparator.comparing(e -> e.getKey().label()))
-                .sorted(Comparator.comparing(Map.Entry::getValue))
-                .forEach(e -> hashes.add(e.hashCode()));
-        for (Integer hash : hashes) equivalenceHashCode = equivalenceHashCode * 37 + hash;
-        return equivalenceHashCode;
+    public boolean isStructurallyEquivalent(Object obj) {
+        if (!isBaseEquivalent(obj) || !super.isStructurallyEquivalent(obj)) return false;
+        RelationshipAtom that = (RelationshipAtom) obj;
+        // check bindings
+        return this.getRoleTypeMap(false).equals(that.getRoleTypeMap(false))
+                && this.predicateBindingsStructurallyEquivalent(that);
     }
 
     private boolean predicateBindingsEquivalent(RelationshipAtom atom,
@@ -346,13 +338,21 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return predicateBindingsEquivalent(atom, (a, b) -> true, AtomicEquivalence.StructuralEquivalence);
     }
 
+    @Memoized
     @Override
-    public boolean isStructurallyEquivalent(Object obj) {
-        if (!isBaseEquivalent(obj) || !super.isStructurallyEquivalent(obj)) return false;
-        RelationshipAtom that = (RelationshipAtom) obj;
-        // check bindings
-        return this.getRoleTypeMap(false).equals(that.getRoleTypeMap(false))
-                && this.predicateBindingsStructurallyEquivalent(that);
+    public int alphaEquivalenceHashCode() {
+        int equivalenceHashCode = baseHashCode();
+        SortedSet<Integer> hashes = new TreeSet<>();
+        this.getRoleTypeMap().entries().stream()
+                .sorted(Comparator.comparing(e -> e.getKey().label()))
+                .sorted(Comparator.comparing(e -> e.getValue().label()))
+                .forEach(e -> hashes.add(e.hashCode()));
+        this.getRoleConceptIdMap().entries().stream()
+                .sorted(Comparator.comparing(e -> e.getKey().label()))
+                .sorted(Comparator.comparing(Map.Entry::getValue))
+                .forEach(e -> hashes.add(e.hashCode()));
+        for (Integer hash : hashes) equivalenceHashCode = equivalenceHashCode * 37 + hash;
+        return equivalenceHashCode;
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -176,14 +176,8 @@ public abstract class ResourceAtom extends Binary{
     @Override
     boolean predicateBindingsEquivalent(Binary at, AtomicEquivalence equiv) {
         if (!(at instanceof ResourceAtom && super.predicateBindingsEquivalent(at, equiv))) return false;
-
         ResourceAtom that = (ResourceAtom) at;
-        if (!multiPredicateEquivalent(that, equiv)) return false;
-
-        Set<IdPredicate> thisPredicate = this.getPredicates(this.getAttributeVariable(), IdPredicate.class).collect(Collectors.toSet());
-        Set<IdPredicate> predicate = that.getPredicates(that.getAttributeVariable(), IdPredicate.class).collect(Collectors.toSet());
-
-        return equiv.equivalentCollection(thisPredicate, predicate);
+        return predicateBindingsEquivalent(this.getAttributeVariable(), that.getAttributeVariable(), that, equiv);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/atom/binary/ResourceAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/ResourceAtom.java
@@ -180,10 +180,10 @@ public abstract class ResourceAtom extends Binary{
         ResourceAtom that = (ResourceAtom) at;
         if (!multiPredicateEquivalent(that, equiv)) return false;
 
-        IdPredicate thisPredicate = this.getIdPredicate(this.getAttributeVariable());
-        IdPredicate predicate = that.getIdPredicate(that.getAttributeVariable());
+        Set<IdPredicate> thisPredicate = this.getPredicates(this.getAttributeVariable(), IdPredicate.class).collect(Collectors.toSet());
+        Set<IdPredicate> predicate = that.getPredicates(that.getAttributeVariable(), IdPredicate.class).collect(Collectors.toSet());
 
-        return thisPredicate == null && predicate == null || thisPredicate != null && equiv.equivalent(thisPredicate, predicate);
+        return equiv.equivalentCollection(thisPredicate, predicate);
     }
 
     @Override


### PR DESCRIPTION
# Why is this PR needed?
Cleaner determination of equivalence of predicate bindings plus caters for edge cases with multiple predicates present.
# What does the PR do?
- doesn't silently assume uniqueness of predicates - uses sets instead
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.