### PR TITLE
Integrate checkstyle for Java sources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,14 @@ references:
         at: ~/grakn
 
 jobs:
+  lint:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - checkout
+      - *install_bazel
+      - run: python ./verify.py
+
   build:
     machine: true
     working_directory: ~/grakn
@@ -228,21 +236,52 @@ workflows:
   version: 2
   grakn-core-ci:
     jobs:
-      - build
-      - client-java
-      - client-nodejs
-      - client-python
-      - common
-      - console
-      - graql
-      - server
-      - workbase
-      - test-integration
-      - test-integration-reasoner
-      - test-integration-reasoner-general
-      - test-integration-reasoner-components
-      - test-integration-analytics
-      - test-end-to-end
+      - lint
+      - build:
+          requires:
+            - lint
+      - client-java:
+          requires:
+            - lint
+      - client-nodejs:
+        requires:
+            - lint
+      - client-python:
+          requires:
+            - lint
+      - common:
+          requires:
+            - lint
+      - console:
+          requires:
+            - lint
+      - graql:
+          requires:
+            - lint
+      - server:
+          requires:
+            - lint
+      - workbase:
+          requires:
+            - lint
+      - test-integration:
+          requires:
+            - lint
+      - test-integration-reasoner:
+          requires:
+            - lint
+      - test-integration-reasoner-general:
+          requires:
+            - lint
+      - test-integration-reasoner-components:
+          requires:
+            - lint
+      - test-integration-analytics:
+          requires:
+            - lint
+      - test-end-to-end:
+          requires:
+            - lint
 
   build-and-deploy:
     jobs:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,3 +144,6 @@ git_repository(
 
 load("@com_github_google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")
 google_common_workspace_rules()
+
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_repositories")
+checkstyle_repositories()

--- a/config/checkstyle/BUILD
+++ b/config/checkstyle/BUILD
@@ -1,0 +1,5 @@
+exports_files([
+    "checkstyle-file-header.txt",
+    "checkstyle-suppressions.xml",
+    "checkstyle.xml",
+])

--- a/config/checkstyle/checkstyle-file-header.txt
+++ b/config/checkstyle/checkstyle-file-header.txt
@@ -1,0 +1,16 @@
+^\W*
+^\W*GRAKN.AI - THE KNOWLEDGE GRAPH$
+^\W*Copyright \(C\) 2018 Grakn Labs Ltd$
+^\W*$
+^\W*This program is free software: you can redistribute it and/or modify$
+^\W*it under the terms of the GNU Affero General Public License as$
+^\W*published by the Free Software Foundation, either version 3 of the$
+^\W*License, or \(at your option\) any later version.$
+^\W*$
+^\W*This program is distributed in the hope that it will be useful,$
+^\W*but WITHOUT ANY WARRANTY; without even the implied warranty of$
+^\W*MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the$
+^\W*GNU Affero General Public License for more details.$
+^\W*$
+^\W*You should have received a copy of the GNU Affero General Public License$
+^\W*along with this program.  If not, see <https://www.gnu.org/licenses/>.$

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<!--
+  ~ GRAKN.AI - THE KNOWLEDGE GRAPH
+  ~ Copyright (C) 2018 Grakn Labs Ltd
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+    <suppress checks="RegexpHeader"
+              files="client-java/*"/>
+</suppressions>

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<!--
+  ~ GRAKN.AI - THE KNOWLEDGE GRAPH
+  ~ Copyright (C) 2018 Grakn Labs Ltd
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <!-- Use 4 spaces, not tabs -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <!-- Make sure every source file has the license at the top -->
+    <module name="RegexpHeader">
+        <property name="headerFile" value="config/checkstyle/checkstyle-file-header.txt"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <module name="TreeWalker">
+
+        <!-- Java filename must match name of outer class -->
+        <module name="OuterTypeFilename"/>
+
+        <!-- Use \n, \b etc. instead of octal or unicode escape (e.g. \012) -->
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+
+        <!-- Disallow unicode escapes, except control or non-printable chars -->
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+
+        <!-- Avoid wildcard star imports -->
+        <module name="AvoidStarImport"/>
+
+        <!-- Only one top-level class per file -->
+        <module name="OneTopLevelClass"/>
+
+        <!-- No line-wrapping on import and package statements, e.g.
+        ```
+        import long.import.
+            .on.many.Lines;
+        ```
+        -->
+        <module name="NoLineWrap"/>
+
+        <!-- No empty blocks allowed -->
+        <module name="EmptyBlock"/>
+
+        <!-- In some cases, empty blocks are allowed with a comment inside, e.g.
+        This is bad:
+        ```
+        try {
+            doThing();
+        } catch (MyException ex) {}
+        ```
+        This is fine:
+        ```
+        try {
+            doThing();
+        } catch (MyException ex) {
+            // I'm ignoring this for a good reason, I promise!
+        }
+        ```
+        -->
+        <module name="EmptyBlock">
+            <property name="option" value="text"/>
+            <property name="tokens" value="LITERAL_CATCH, LITERAL_CASE, LITERAL_DEFAULT, ARRAY_INIT"/>
+        </module>
+
+        <!-- No multi-line statements without braces, e.g.
+        ```
+        if (youDoThis)
+            maven.willGetAngry();
+        ```
+        -->
+        <module name="NeedBraces">
+            <property name="allowSingleLineStatement" value="true"/>
+        </module>
+
+        <!-- Allow only one statement per line -->
+        <module name="OneStatementPerLine"/>
+
+        <!-- Require JavaDoc on types (classes, interfaces, etc.) -->
+        <module name="JavadocType">
+            <property name="scope" value="public"/>
+        </module>
+
+    </module>
+
+</module>

--- a/dependencies/tools/checkstyle/checkstyle.bzl
+++ b/dependencies/tools/checkstyle/checkstyle.bzl
@@ -1,0 +1,192 @@
+def checkstyle_repositories(
+    omit = [],
+    versions = {
+      "antlr_antlr": "2.7.7",
+      "org_antlr_antlr4_runtime": "4.5.1-1",
+      "com_puppycrawl_tools_checkstyle": "8.15",
+      "commons_beanutils_commons_beanutils": "1.9.3",
+      "info_picocli_picocli": "3.8.2",
+      "commons_collections_commons_collections": "3.2.2",
+      "com_google_guava_guava23": "23.0",
+      "org_slf4j_slf4j_api": "1.7.7",
+      "org_slf4j_slf4j_jcl": "1.7.7",
+    }
+):
+  if not "antlr_antlr" in omit:
+    native.maven_jar(
+        name = "antlr_antlr",
+        artifact = "antlr:antlr:" + versions["antlr_antlr"],
+    )
+  if not "org_antlr_antlr4_runtime" in omit:
+    native.maven_jar(
+        name = "org_antlr_antlr4_runtime",
+        artifact = "org.antlr:antlr4-runtime:" + versions["org_antlr_antlr4_runtime"],
+    )
+  if not "com_puppycrawl_tools_checkstyle" in omit:
+    native.maven_jar(
+        name = "com_puppycrawl_tools_checkstyle",
+        artifact = "com.puppycrawl.tools:checkstyle:" + versions["com_puppycrawl_tools_checkstyle"],
+    )
+  if not "commons_beanutils_commons_beanutils" in omit:
+    native.maven_jar(
+        name = "commons_beanutils_commons_beanutils",
+        artifact = "commons-beanutils:commons-beanutils:" + versions["commons_beanutils_commons_beanutils"],
+    )
+  if not "info_picocli_picocli" in omit:
+    native.maven_jar(
+        name = "info_picocli_picocli",
+        artifact = "info.picocli:picocli:" + versions["info_picocli_picocli"],
+    )
+  if not "commons_collections_commons_collections" in omit:
+    native.maven_jar(
+        name = "commons_collections_commons_collections",
+        artifact = "commons-collections:commons-collections:" + versions["commons_collections_commons_collections"],
+    )
+  if not "com_google_guava_guava23" in omit:
+    native.maven_jar(
+        name = "com_google_guava_guava23",
+        artifact = "com.google.guava:guava:" + versions["com_google_guava_guava23"],
+    )
+  if not "org_slf4j_slf4j_api" in omit:
+    native.maven_jar(
+        name = "org_slf4j_slf4j_api",
+        artifact = "org.slf4j:slf4j-api:" + versions["org_slf4j_slf4j_api"],
+    )
+  if not "org_slf4j_slf4j_jcl" in omit:
+    native.maven_jar(
+        name = "org_slf4j_slf4j_jcl",
+        artifact = "org.slf4j:jcl-over-slf4j:" + versions["org_slf4j_slf4j_jcl"],
+    )
+
+
+JavaSourceFiles = provider(
+    fields = {
+        'files' : 'java source files'
+    }
+)
+
+
+def collect_sources_impl(target, ctx):
+    files = []
+    if hasattr(ctx.rule.attr, 'srcs'):
+        for src in ctx.rule.attr.srcs:
+            for f in src.files:
+                if f.extension == 'java':
+                    files.append(f)
+    # Get the counts from our dependencies.
+    for dep in ctx.rule.attr.deps:
+        files = files + dep[JavaSourceFiles].files
+    return [JavaSourceFiles(files = files)]
+
+
+collect_sources = aspect(
+    implementation = collect_sources_impl,
+    attr_aspects = ['deps']
+)
+
+
+def _checkstyle_test_impl(ctx):
+    if "{}-checkstyle".format(ctx.attr.target.label.name) != ctx.attr.name:
+        fail("target should follow `{java_library target name}-checkstyle` pattern")
+    properties = ctx.file.properties
+    suppressions = ctx.file.suppressions
+    opts = ctx.attr.opts
+    sopts = ctx.attr.string_opts
+
+    classpath = ":".join([file.path for file in ctx.files._classpath])
+
+    args = ""
+    inputs = []
+    if ctx.file.config:
+      args += " -c %s" % ctx.file.config.path
+      inputs.append(ctx.file.config)
+    if properties:
+      args += " -p %s" % properties.path
+      inputs.append(properties)
+    if suppressions:
+      inputs.append(suppressions)
+
+    cmd = " ".join(
+        ["java -cp %s com.puppycrawl.tools.checkstyle.Main" % classpath] +
+        [args] +
+        ["--%s" % x for x in opts] +
+        ["--%s %s" % (k, sopts[k]) for k in sopts] +
+        [file.path for file in ctx.attr.target[JavaSourceFiles].files]
+    )
+
+    ctx.actions.expand_template(
+        template = ctx.file._checkstyle_py_template,
+        output = ctx.outputs.checkstyle_script,
+        substitutions = {
+            "{command}" : cmd,
+            "{allow_failure}": str(int(ctx.attr.allow_failure)),
+        },
+        is_executable = True,
+    )
+
+    files = [ctx.outputs.checkstyle_script, ctx.file.license] + ctx.attr.target[JavaSourceFiles].files + ctx.files._classpath + inputs
+    runfiles = ctx.runfiles(
+        files = files,
+        collect_data = True
+    )
+    return DefaultInfo(
+        executable = ctx.outputs.checkstyle_script,
+        files = depset(files),
+        runfiles = runfiles,
+    )
+
+checkstyle_test = rule(
+    implementation = _checkstyle_test_impl,
+    test = True,
+    attrs = {
+        "config": attr.label(
+            allow_single_file=True,
+            doc = "A checkstyle configuration file"
+        ),
+        "suppressions": attr.label(
+            allow_single_file=True,
+            doc = "A checkstyle suppressions file"
+        ),
+        "license": attr.label(
+            allow_single_file=True,
+            doc = "A license file that can be used with the checkstyle license target"
+        ),
+        "properties": attr.label(
+            allow_single_file=True,
+            doc = "A properties file to be used"
+        ),
+        "opts": attr.string_list(
+            doc = "Options to be passed on the command line that have no argument"
+        ),
+        "string_opts": attr.string_dict(
+            doc = "Options to be passed on the command line that have an argument"
+        ),
+        "target": attr.label(
+            doc = "The java_library target to check sources on",
+            aspects = [collect_sources]
+        ),
+        "allow_failure": attr.bool(
+            default = False,
+            doc = "Successfully finish the test even if checkstyle failed"
+        ),
+        "_checkstyle_py_template": attr.label(
+             allow_files = True,
+             single_file = True,
+             default = "//dependencies/tools/checkstyle/templates:checkstyle.py"
+        ),
+        "_classpath": attr.label_list(default=[
+            Label("@com_puppycrawl_tools_checkstyle//jar"),
+            Label("@commons_beanutils_commons_beanutils//jar"),
+            Label("@info_picocli_picocli//jar"),
+            Label("@commons_collections_commons_collections//jar"),
+            Label("@org_slf4j_slf4j_api//jar"),
+            Label("@org_slf4j_slf4j_jcl//jar"),
+            Label("@antlr_antlr//jar"),
+            Label("@org_antlr_antlr4_runtime//jar"),
+            Label("@com_google_guava_guava23//jar"),
+        ]),
+    },
+    outputs = {
+        "checkstyle_script": "%{name}.py",
+    },
+)

--- a/dependencies/tools/checkstyle/templates/BUILD
+++ b/dependencies/tools/checkstyle/templates/BUILD
@@ -1,0 +1,1 @@
+exports_files(["checkstyle.py"])

--- a/dependencies/tools/checkstyle/templates/checkstyle.py
+++ b/dependencies/tools/checkstyle/templates/checkstyle.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import sys
+import subprocess
+
+COMMAND = '{command}'
+ALLOW_FAILURE = bool(int('{allow_failure}'))
+
+exit_code = subprocess.call(COMMAND.split(' '))
+sys.exit(0 if ALLOW_FAILURE else exit_code)

--- a/verify.py
+++ b/verify.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+from pprint import pprint
+import subprocess
+import sys
+
+
+java_targets = set(subprocess.check_output([
+    'bazel', 'query',
+    '(kind(java_library, //...) + kind(jarjar_library, //...) + kind(java_test, //...)) except //dependencies/...'
+]).split())
+
+checkstyle_targets = set(map(lambda x: x.rstrip('-checkstyle'), subprocess.check_output([
+    'bazel', 'query', 'kind(checkstyle_test, //...)'
+]).split()))
+
+java_target_with_no_checkstyle = java_targets - checkstyle_targets
+
+if java_target_with_no_checkstyle:
+    print('Java targets with no attached checkstyle_test rule')
+    pprint(java_target_with_no_checkstyle)
+    sys.exit(1)


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4692

# What does the PR do?

Adds `checkstyle_rule` to verify Java sources with [`CheckStyle`](http://checkstyle.sourceforge.net/).
Original source from [here](https://stackoverflow.com/questions/49074677/what-is-the-best-way-to-invoke-checkstyle-from-within-bazel), modernized

Rule can be used like this:

```
checkstyle_test(
    name = "checkstyle",
    srcs = glob(["**/*.java"]),
    config = "//config/checkstyle:checkstyle.xml",
    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
    license = "//config/checkstyle:checkstyle-file-header.txt",
    allow_failure = True
)
```

Also, this PR brings back CheckStyle configs which were removed in #4620

# Does it break backwards compatibility?

No due to adding `allow_failure`

# List of future improvements not on this PR

Turning off `allow_failure` for all targets:

`bazel query 'kind(checkstyle_test, //...)' `

and fixing its complaints