### PR TITLE
Explanation bug

### DIFF
--- a/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
+++ b/workbase/src/renderer/components/Visualiser/VisualiserUtils.js
@@ -57,6 +57,8 @@ export function buildExplanationQuery(answer, queryPattern) {
       // attributeQuery = `has ${queryPattern.match(/(?:has )(\w+)/)[1]} $${graqlVar};`;
     } else if (concept.isEntity()) {
       query += `$${graqlVar} id ${concept.id}; `;
+    } else if (attributeQuery && concept.isRelationship()) { // if answer has a relationship and attribute
+      attributeQuery = `$${graqlVar} id ${concept.id} ${attributeQuery}`;
     }
   });
   return { query, attributeQuery };
@@ -133,6 +135,7 @@ export function addResetGraphListener(dispatch, action) {
  */
 export function mapAnswerToExplanationQuery(answer) {
   const queryPattern = answer.explanation().queryPattern();
+  debugger;
   let query = buildExplanationQuery(answer, queryPattern).query;
   if (queryPattern.includes('has')) {
     query += `${buildExplanationQuery(answer, queryPattern).attributeQuery} get;`;

--- a/workbase/test/helpers/MockConcepts.js
+++ b/workbase/test/helpers/MockConcepts.js
@@ -164,6 +164,21 @@ function getMockAnswer3() {
 
 const getMockQueryPattern3 = '{$c id 4444; $p id 3333; $1234 (child: $c, parent: $p) isa parentship;}';
 
+
+function getMockAnswer4() {
+  return {
+    explanation: () => {},
+    map: () => {
+      const map = new Map();
+      map.set('1234', getMockAttribute());
+      map.set('5678', getMockRelationship());
+      return map;
+    },
+  };
+}
+
+const getMockQueryPattern4 = '{$r has duration $1544633775910879; $1544633775910879 < 120;}';
+
 function getMockAnswerContainingImplicitType() {
   return {
     explanation: () => {},
@@ -215,6 +230,8 @@ export default {
   getMockQueryPattern2,
   getMockAnswer3,
   getMockQueryPattern3,
+  getMockAnswer4,
+  getMockQueryPattern4,
   getMockAnswerContainingImplicitType,
   getMockAnswerContainingRelationship,
   getMockAnswerContainingEntity,

--- a/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
+++ b/workbase/test/unit/components/Visualiser/VisualiserUtils.test.js
@@ -91,6 +91,11 @@ describe('Build Explanation Query', () => {
     expect(explanationQuery.query).toBe('match $p id 3333; $c id 4444; ');
     expect(explanationQuery.attributeQuery).toBe(null);
   });
+  test('from attribute and relationship', async () => {
+    const explanationQuery = buildExplanationQuery(MockConcepts.getMockAnswer4(), MockConcepts.getMockQueryPattern4);
+    expect(explanationQuery.query).toBe('match ');
+    expect(explanationQuery.attributeQuery).toBe('$5678 id 6666 has duration $1234;');
+  });
 });
 
 describe('Filters out Answers that contain inferred concepts in their ConceptMap', () => {


### PR DESCRIPTION
# Why is this PR needed?
Explanation query builder did not handle case for when an explanation answer contained an attribute and a relationship

# What does the PR do?
Builds an explanation query for when an explanation answer contains an attribute and a relationship
Add regression test

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
Refactor explanation functions