### PR TITLE
add attribute types to defined schema concepts

### DIFF
--- a/workbase/src/renderer/components/shared/StoresActions.js
+++ b/workbase/src/renderer/components/shared/StoresActions.js
@@ -23,6 +23,8 @@ export const UPDATE_NODES_COLOUR = 'update-nodes-colour';
 export const DELETE_SELECTED_NODES = 'delete-selected-nodes';
 export const LOAD_NEIGHBOURS = 'load-neighbours';
 export const LOAD_ATTRIBUTES = 'load-attributes';
+export const ADD_ATTRIBUTE_TYPE = 'add-attribute-types';
+
 
 // Common actions shared by the two canvas stores (SchemaDesign && DataManagement)
 export const UPDATE_METATYPE_INSTANCES = 'update-metatype-instances';


### PR DESCRIPTION
# Why is this PR needed?
Allow user to add attribute types to already defined schema concepts

# What does the PR do?
Add UI/UX/Implementation to add attribute types to already defined schema concepts

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A