### PR TITLE
Fix 'not executable' error for //:deploy-github-zip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - checkout
       - *install_bazel
-      - run: bazel build //:distribution --sandbox_debug
+      - run: bazel build //... --sandbox_debug
       - run: mkdir dist/ && mv bazel-genfiles/dist/* dist/
       - persist_to_workspace: #share Grakn with other jobs by putting it in the workspace
           root: ~/grakn

--- a/BUILD
+++ b/BUILD
@@ -19,10 +19,11 @@
 exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
 load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
 
-sh_binary(
+py_binary(
     name = "deploy-github-zip",
     srcs = ["@graknlabs_rules_deployment//github:deployment.py"],
-    data = [":distribution", ":VERSION", ":deployment.properties", "@ghr_osx_zip//file:file", "@ghr_linux_tar//file:file"]
+    data = [":distribution", ":VERSION", ":deployment.properties", "@ghr_osx_zip//file:file", "@ghr_linux_tar//file:file"],
+    main = "deployment.py"
 )
 
 genrule(


### PR DESCRIPTION
# Why is this PR needed?

Fixes error:
```
ERROR: /Users/haikalpribadi/Workspace/repos/graknlabs/grakn/BUILD:22:1: failed to create symbolic link 'deploy-github-zip': file 'external/graknlabs_rules_deployment/github/deployment.py' is not executable
```

# What does the PR do?

Migrates `//:deploy-github-zip` from `sh_binary` to `py_binary`

# Does it break backwards compatibility?

Nope

# List of future improvements not on this PR

—
