### PR TITLE
Version and license options for server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
+exports_files(["grakn", "VERSION", "deployment.properties", "LICENSE"], visibility = ["//visibility:public"])
 load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
 
 py_binary(
@@ -29,6 +29,7 @@ py_binary(
 genrule(
     name = "distribution",
     srcs = [
+        "//:LICENSE",
         "//:grakn",
         "//console:console-binary_deploy.jar",
         "//server:conf/logback.xml",
@@ -39,7 +40,7 @@ genrule(
         "//server:services/grakn/grakn-core-ascii.txt",
     ],
     outs = ["//:dist/grakn-core-all.zip"],
-    cmd = "$(location distribution.sh) $(location //:dist/grakn-core-all.zip) $(location //:grakn) $(location //server:services/grakn/grakn-core-ascii.txt) $(location //console:console-binary_deploy.jar) $(location //server:server-binary_deploy.jar) $(location //server:conf/grakn.properties) $(location //server:conf/logback.xml) $(location //server:services/cassandra/logback.xml) $(location //server:services/cassandra/cassandra.yaml)",
+    cmd = "$(location distribution.sh) $(location //:dist/grakn-core-all.zip) $(location //:grakn) $(location //server:services/grakn/grakn-core-ascii.txt) $(location //console:console-binary_deploy.jar) $(location //server:server-binary_deploy.jar) $(location //server:conf/grakn.properties) $(location //server:conf/logback.xml) $(location //server:services/cassandra/logback.xml) $(location //server:services/cassandra/cassandra.yaml) $(location //:LICENSE)",
     tools = ["distribution.sh"],
     visibility = ["//visibility:public"]
 )

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -35,6 +35,7 @@ public enum ErrorMessage {
     UNABLE_TO_START_SERVER_JAR_NOT_FOUND("Unable to start Server, No JAR files found! Please re-download the Grakn distribution."),
     UNABLE_TO_GET_GRAKN_HOME_FOLDER("Unable to find Grakn home folder"),
     UNABLE_TO_GET_GRAKN_CONFIG_FOLDER("Unable to find Grakn config folder"),
+    UNABLE_TO_GET_GRAKN_LICENSE("Unable to find Grakn license"),
     UNCAUGHT_EXCEPTION("Uncaught exception at thread [%s]"),
     PID_ALREADY_EXISTS("Pid file already exists: '[%s]'. Overwriting..."),
     COULD_NOT_GET_PID("Couldn't get the PID of Grakn Server. Received '%s'"),

--- a/console/GraknConsole.java
+++ b/console/GraknConsole.java
@@ -22,7 +22,6 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import grakn.core.client.Grakn;
 import grakn.core.common.exception.ErrorMessage;
-import grakn.core.common.util.GraknVersion;
 import io.grpc.Status;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -57,7 +56,6 @@ public class GraknConsole {
     private static final String URI = "r";
     private static final String NO_INFER = "n";
     private static final String HELP = "h";
-    private static final String VERSION = "v";
 
     private final Options options = getOptions();
     private final CommandLine commandLine;
@@ -89,7 +87,6 @@ public class GraknConsole {
         options.addOption(URI, "address", true, "Grakn Server address");
         options.addOption(NO_INFER, "no_infer", false, "do not perform inference on results");
         options.addOption(HELP, "help", false, "print usage message");
-        options.addOption(VERSION, "version", false, "print version");
 
         return options;
     }
@@ -98,10 +95,6 @@ public class GraknConsole {
         // Print usage guidelines for Grakn Console
         if (commandLine.hasOption(HELP) || !commandLine.getArgList().isEmpty()) {
             printHelp(printOut);
-        }
-        // Print Grakn Console version
-        else if (commandLine.hasOption(VERSION)) {
-            printOut.println(GraknVersion.VERSION);
         }
         // Start a Console Session to load some Graql file(s)
         else if (commandLine.hasOption(FILE)) {

--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -102,6 +102,9 @@ public class GraknDaemon {
         if (!graknProperties.toFile().exists()) {
             throw new RuntimeException(ErrorMessage.UNABLE_TO_GET_GRAKN_CONFIG_FOLDER.getMessage());
         }
+        if (!graknHome.resolve("LICENSE").toFile().exists()) {
+            throw new RuntimeException(ErrorMessage.UNABLE_TO_GET_GRAKN_LICENSE.getMessage());
+        }
     }
 
     private static void printGraknLogo() {
@@ -130,8 +133,11 @@ public class GraknDaemon {
             case "server":
                 server(action, option);
                 break;
-            case "version":
+            case "--version":
                 version();
+                break;
+            case "--license":
+                license();
                 break;
             default:
                 help();
@@ -215,13 +221,26 @@ public class GraknDaemon {
         System.out.println(GraknVersion.VERSION);
     }
 
+    private void license() {
+        try {
+            System.out.println(new String(Files.readAllBytes(Paths.get(".", "LICENSE")), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            // shouldn't happen because we checked license existence on bootup
+            // if it did, rethrow as runtime exception
+            throw new RuntimeException(e);
+        }
+    }
+
     private void help() {
-        System.out.println("Usage: grakn COMMAND\n" +
+        System.out.println("Usage: grakn <COMMAND|OPTION>\n" +
                                    "\n" +
                                    "COMMAND:\n" +
                                    "server     Manage Grakn components\n" +
-                                   "version    Print Grakn version\n" +
                                    "help       Print this message\n" +
+                                   "\n" +
+                                   "OPTION:\n" +
+                                   "--version    Print Grakn version\n" +
+                                   "--license    Print Grakn license\n" +
                                    "\n" +
                                    "Tips:\n" +
                                    "- Start Grakn with 'grakn server start'\n" +

--- a/distribution.sh
+++ b/distribution.sh
@@ -16,6 +16,7 @@ server_grakn_properties="$6"
 server_logback_xml="$7"
 server_storage_yaml="$8"
 server_storage_logback_xml="$9"
+license="${10}"
 
 # configurations
 base_dir="grakn-core-all"
@@ -46,6 +47,7 @@ echo
 # 3. copying files into the respective locations
 echo "--- copying files into the respective locations ---"
 cp "$script" "$base_dir"
+cp "$license" "$base_dir"
 cp "$console_jar" "$base_dir/$services_dir/$services_dir_lib"
 cp "$server_grakn_properties" "$base_dir/$conf_dir"
 cp "$server_logback_xml" "$base_dir/$conf_dir"

--- a/grakn
+++ b/grakn
@@ -39,6 +39,14 @@ exit_if_java_not_found() {
   fi
 }
 
+print_arguments() {
+    # First argument to function is a header
+    echo $1
+    echo "  Server:          grakn server [--help]"
+    echo "  Console:         grakn console [--help]"
+    echo "  Version:         grakn --version"
+    echo "  License:         grakn --license"
+}
 # =============================================
 # main routine
 # =============================================
@@ -49,10 +57,7 @@ pushd "$GRAKN_HOME" > /dev/null
 exit_if_java_not_found
 
 if [ -z "$1" ]; then
-    echo "Missing argument. Possible commands are:"
-    echo "  Server:          grakn server [--help]"
-    echo "  Console:         grakn console [--help]"
-    echo "  Version:         grakn version"
+    print_arguments "Missing argument. Possible commands and options are:"
 elif [ "$1" = "console" ]; then
     if [ -f "${GRAKN_HOME}/${CONSOLE_JAR_FILENAME}" ]; then
         CLASSPATH="${GRAKN_HOME}/${CONSOLE_JAR_FILENAME}:${GRAKN_HOME}/conf/"
@@ -61,7 +66,7 @@ elif [ "$1" = "console" ]; then
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."
     fi
-elif [ "$1" = "server" ] || [ "$1" = "version" ]; then
+elif [ "$1" = "server" ] || [ "$1" = "--version" ] || [ "$1" = "--license" ]; then
     if [ -f "${GRAKN_HOME}/${SERVER_JAR_FILENAME}" ]; then
         CLASSPATH="./${SERVER_JAR_FILENAME}:./conf/"
         java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.daemon.GraknDaemon $@
@@ -70,10 +75,7 @@ elif [ "$1" = "server" ] || [ "$1" = "version" ]; then
         echo "You may want to install Grakn Core Server or Grakn Core (all)."
     fi
 else
-    echo "Invalid argument: $1. Possible commands are: "
-    echo "  Server:          grakn server [--help]"
-    echo "  Console:         grakn console [--help]"
-    echo "  Version:         grakn version"
+    print_arguments "Invalid argument: $1. Possible commands and options are: "
 fi
 
 exit_code=$?

--- a/grakn.bat
+++ b/grakn.bat
@@ -35,20 +35,22 @@ if "%1" == "" goto missingargument
 
 if "%1" == "console" goto startconsole
 
-if "%1" == "server" goto startserver
+if "%1" == "server" || "%1" == "--version" || "%1" == "--license" goto startserver
 
-echo   Invalid argument: %1. Possible commands are:
-echo   Server:          grakn server [--help]
-echo   Console:         grakn console [--help]
+call :printarguments "Invalid argument: %1. Possible commands are:"
 goto exiterror
 
 :missingargument
 
- echo   Missing argument. Possible commands are:
+call :printarguments "Missing argument. Possible commands are:"
+goto exiterror
+
+:printarguments
+ echo %~1
  echo   Server:          grakn server [--help]
  echo   Console:         grakn console [--help]
-
-goto exiterror
+ echo   Version:         grakn --version
+ echo   License:         grakn --license
 
 :startconsole
 


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4698

# What does the PR do?

* Removes version (`-v`) as option of `console`
* Adds `--version` and `--license` as options to `server`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Testing this on Windows (`grakn.bat`) — I wrote the script 'blindfolded'