### PR TITLE
Schema designer bug fixes

### DIFF
--- a/workbase/src/renderer/components/SchemaDesign/ContextMenu.vue
+++ b/workbase/src/renderer/components/SchemaDesign/ContextMenu.vue
@@ -42,13 +42,17 @@
       async deleteNode() {
         this.setContextMenu({ show: false, x: null, y: null });
 
-        const label = this.selectedNodes[0].label;
+        if (this.selectedNodes.length > 1) {
+          this.$notifyError('Cannot delete multiple schema concepts');
+        } else {
+          const label = this.selectedNodes[0].label;
 
-        this[DELETE_SCHEMA_CONCEPT](this.selectedNodes[0])
-          .then(() => {
-            this.$notifyInfo(`Schema concept, ${label}, has been deleted`);
-          })
-          .catch((e) => { this.$notifyError(e); });
+          this[DELETE_SCHEMA_CONCEPT](this.selectedNodes[0])
+            .then(() => {
+              this.$notifyInfo(`Schema concept, ${label}, has been deleted`);
+            })
+            .catch((e) => { this.$notifyError(e); });
+        }
       },
     },
   };


### PR DESCRIPTION
# Why is this PR needed?
1) Sub-typed schema concepts were connected to inherited attributes
2) User was able to add an inherited attribute when defining a sup-typed schema concept causing duplicated attributes
3) Removing an attribute of a schema concept which is sup-typing the same attribute would remove the "sub" edge as well
4) Deleting a schema concept which had subbed schema concepts produced an error
5) Deleting multiple schema concepts only deleted the first one selected

# What does the PR do?
1) Do not construct edges between schema concepts and inherited attributes
2) Highlight inherited attributes by default when defining a sup-typed schema concept
3) Check if we are removing only the "has" edge when unhasing an attribute from a schema concept
4) Refine the error message shown when deleting a subbed schema concept
5) Do not allow deleting of multiple schema concepts at once (show error)

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
1) Modularise the has and plays panels with all their functionalities in a separate component and reuse in NewEntityPanel, NewAttributePanel, and NewRelationshipPanel
2) Add tests for missing schema designer actions