### PR TITLE
Delete relationship type bug

### DIFF
--- a/workbase/src/renderer/components/SchemaDesign/store/actions.js
+++ b/workbase/src/renderer/components/SchemaDesign/store/actions.js
@@ -357,7 +357,20 @@ export default {
           await state.schemaHandler.deletePlaysRole({ label: await player.label(), roleLabel });
         }));
 
-        await state.schemaHandler.deleteRelatesRole({ label: payload.label, roleLabel });
+        // If relationship type is suptyped and inherits a role only unrelate the role
+        // otherwise unrelate and delete role
+        const sup = await type.sup();
+        if (sup) {
+          const supLabel = await sup.label();
+          if (!META_CONCEPTS.has(supLabel)) { // check if relationship type is sub-typed or not
+            const roleSup = await role.sup();
+            const roleSupLabel = await roleSup.label();
+            if (roleSupLabel === 'role') await type.unrelate(role); // check if role is overridden or not
+            else await state.schemaHandler.deleteRelatesRole({ label: payload.label, roleLabel });
+          } else {
+            await state.schemaHandler.deleteRelatesRole({ label: payload.label, roleLabel });
+          }
+        }
       }));
     } else if (payload.baseType === 'ATTRIBUTE_TYPE') {
       const nodes = state.visFacade.getAllNodes();


### PR DESCRIPTION
# Why is this PR needed?
Deleting a sub-typed relationship was not working

# What does the PR do?
If relationship type is sup-typed and inherits a role only unrelate the role otherwise unrelate and delete the role

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A