### PR TITLE
Refresh panel supertypes

### DIFF
--- a/workbase/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
+++ b/workbase/src/renderer/components/SchemaDesign/LeftBar/NewAttributePanel.vue
@@ -408,6 +408,7 @@
         }
       },
       metaTypeInstances(val) {
+        this.superTypes = ['attribute', ...this.metaTypeInstances.attributes];
         this.hasAttributes = val.attributes;
       },
       async superType(val) {

--- a/workbase/src/renderer/components/SchemaDesign/LeftBar/NewEntityPanel.vue
+++ b/workbase/src/renderer/components/SchemaDesign/LeftBar/NewEntityPanel.vue
@@ -334,6 +334,7 @@
       },
       metaTypeInstances(val) {
         this.hasAttributes = val.attributes;
+        this.superTypes = ['entity', ...this.metaTypeInstances.entities];
       },
       async superType(val) {
         if (val !== 'entity') { // if sup-typing an entity do not show inherited attributes in has panel to avoid duplicated attributes

--- a/workbase/src/renderer/components/SchemaDesign/LeftBar/NewRelationshipPanel.vue
+++ b/workbase/src/renderer/components/SchemaDesign/LeftBar/NewRelationshipPanel.vue
@@ -439,6 +439,7 @@
       },
       metaTypeInstances(val) {
         this.hasAttributes = val.attributes;
+        this.superTypes = ['relationship', ...this.metaTypeInstances.relationships];
       },
       async superType(val) {
         if (val !== 'relationship') { // if super type is not 'relationship' then compute roles of supertype for inheriting and overriding


### PR DESCRIPTION
# Why is this PR needed?
Super type list was not being updated when a schema concept was deleted

# What does the PR do?
Update super types when a concept is deleted from the schema designer

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A