### PR TITLE
Fix incompatibilities with new Bazel version

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,0 @@
-build --distinct_host_configuration=false
-build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+build --distinct_host_configuration=false
+build --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
+build --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ references:
       run:
         name: Install bazel
         command: |
-          curl -OL https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh
-          chmod +x bazel-0.21.0-installer-linux-x86_64.sh
-          sudo ./bazel-0.21.0-installer-linux-x86_64.sh
+          curl -OL https://github.com/bazelbuild/bazel/releases/download/0.20.0/bazel-0.20.0-installer-linux-x86_64.sh
+          chmod +x bazel-0.20.0-installer-linux-x86_64.sh
+          sudo ./bazel-0.20.0-installer-linux-x86_64.sh
 
     attach_grakn_workspace: &attach_grakn_workspace
       attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ references:
       run:
         name: Install bazel
         command: |
-          curl -OL https://github.com/bazelbuild/bazel/releases/download/0.18.0/bazel-0.18.0-installer-linux-x86_64.sh
-          chmod +x bazel-0.18.0-installer-linux-x86_64.sh
-          sudo ./bazel-0.18.0-installer-linux-x86_64.sh
+          curl -OL https://github.com/bazelbuild/bazel/releases/download/0.21.0/bazel-0.21.0-installer-linux-x86_64.sh
+          chmod +x bazel-0.21.0-installer-linux-x86_64.sh
+          sudo ./bazel-0.21.0-installer-linux-x86_64.sh
 
     attach_grakn_workspace: &attach_grakn_workspace
       attach_workspace:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,6 +18,9 @@
 
 workspace(name = "grakn_core")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 
 ####################
 # Load Build Tools #
@@ -126,7 +129,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="d68bde38af6405195f5858f9a7cd8cc37dcca4e7",
+    commit="a883f333d830d8eeffaabcabc486caa263e97b8b",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -16,22 +16,24 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 def antlr_dependencies():
 
-    native.git_repository(
+    git_repository(
         name = "rules_antlr",
-        remote = "https://github.com/marcohu/rules_antlr",
-        tag = "0.1.0" # sync version with //dependencies/maven/artifacts/org/antlr
+        remote = "https://github.com/graknlabs/rules_antlr",
+        commit = "e40680fccd90b6bcf3c746f63d48a201152bb67f"
     )
 
 def grpc_dependencies():
-    native.git_repository(
+    git_repository(
         name = "com_github_grpc_grpc",
         remote = "https://github.com/graknlabs/grpc",
-        commit = "da829a5ac902ab99eef14e6aad1d8e0cd173ec64"
+        commit = "ad6b3949bdbe6d0d25522558ebe73f4044a02146"
     )
 
-    native.git_repository(
+    git_repository(
         name = "stackb_rules_proto",
         remote = "https://github.com/stackb/rules_proto",
         commit = "4c2226458203a9653ae722245cc27e8b07c383f7",

--- a/dependencies/npm/dependencies.bzl
+++ b/dependencies/npm/dependencies.bzl
@@ -16,8 +16,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 def node_dependencies():
-    native.git_repository(
+    git_repository(
         name = "build_bazel_rules_nodejs",
         remote = "https://github.com/graknlabs/rules_nodejs.git",
         commit = "5d0c6c78fc62bcffd01297350c694690fca770b8",

--- a/dependencies/pip/dependencies.bzl
+++ b/dependencies/pip/dependencies.bzl
@@ -16,10 +16,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 def python_dependencies():
-    native.git_repository(
+    git_repository(
         name = "io_bazel_rules_python",
         remote = "https://github.com/bazelbuild/rules_python.git",
         commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
-        sha256 = "8b32d2dbb0b0dca02e0410da81499eef8ff051dad167d6931a92579e3b2a1d48"
     )

--- a/dependencies/tools/BUILD
+++ b/dependencies/tools/BUILD
@@ -16,17 +16,11 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-
-java_import(
-    name = "bazel-deps-jar",
-    jars = ["@bazel_deps//file"],
-)
-
 java_binary(
     name = "bazel-deps",
     main_class = "com.github.johnynek.bazel_deps.ParseProject",
     visibility = ["//visibility:public"],
-    runtime_deps = [":bazel-deps-jar"],
+    runtime_deps = ["@bazel_deps//jar:jar"],
 )
 
 sh_binary(

--- a/dependencies/tools/dependencies.bzl
+++ b/dependencies/tools/dependencies.bzl
@@ -17,53 +17,54 @@
 #
 
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_jar")
+
 def tools_dependencies():
 
-    native.http_file(
+    http_file(
         name = "buildifier",
         executable = True,
         sha256 = "d7d41def74991a34dfd2ac8a73804ff11c514c024a901f64ab07f45a3cf0cfef",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildifier"],
     )
 
-    native.http_file(
+    http_file(
         name = "buildifier_osx",
         executable = True,
         sha256 = "3cbd708ff77f36413cfaef89cd5790a1137da5dfc3d9b3b3ca3fac669fbc298b",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildifier.osx"],
     )
 
-    native.http_file(
+    http_file(
         name = "buildozer",
         executable = True,
         sha256 = "3226cfd3ac706b48fe69fc4581c6c163ba5dfa71a752a44d3efca4ae489f1105",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildozer"],
     )
 
-    native.http_file(
+    http_file(
         name = "buildozer_osx",
         executable = True,
         sha256 = "48109a542da2ad4bf10e7df962514a58ac19a32033e2dae8e682938ed11f4775",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.11.1/buildozer.osx"],
     )
 
-    native.http_file(
+    http_file(
         name = "unused_deps",
         executable = True,
         sha256 = "59a7553f825e78bae9875e48d29e6dd09f9e80ecf40d16210c4ac95bab7ce29c",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.19.2/unused_deps"],
     )
 
-    native.http_file(
+    http_file(
         name = "unused_deps_osx",
         executable = True,
         sha256 = "e14f82cfddb9db4b18db91f438babb1b4702572aabfdbeb9b94e265c7f1c147d",
         urls = ["https://github.com/bazelbuild/buildtools/releases/download/0.19.2/unused_deps.osx"],
     )
 
-    native.http_file(
+    http_jar(
         name = "bazel_deps",
-        executable = True,
         sha256 = "43278a0042e253384543c4700021504019c1f51f3673907a1b25bb1045461c0c",
         urls = ["https://github.com/graknlabs/bazel-deps/releases/download/v0.2/grakn-bazel-deps-v0.2.jar"],
     )


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4736

# What does the PR do?

* Replaces usages of deprecated native rules, such as `http_file`, `http_jar`, `git_repository`
* Use JDK8 for building

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

—
