### PR TITLE
Fix checkstyle complaints; stage #1

### DIFF
--- a/client-java/BUILD
+++ b/client-java/BUILD
@@ -60,7 +60,7 @@ checkstyle_test(
     config = "//config/checkstyle:checkstyle.xml",
     suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
     license = "//config/checkstyle:checkstyle-file-header.txt",
-    allow_failure = True
+
 )
 
 deploy_maven_jar(

--- a/client-java/test/BUILD
+++ b/client-java/test/BUILD
@@ -80,5 +80,5 @@ checkstyle_test(
     config = "//config/checkstyle:checkstyle.xml",
     suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
     license = "//config/checkstyle:checkstyle-file-header.txt",
-    allow_failure = True
+
 )

--- a/client-java/test/GraknClientIT.java
+++ b/client-java/test/GraknClientIT.java
@@ -123,7 +123,8 @@ public class GraknClientIT {
 
     @After
     public void tearDown() {
-        localSession.close(); remoteSession.close();
+        localSession.close();
+        remoteSession.close();
     }
 
     @Test

--- a/common/exception/BUILD
+++ b/common/exception/BUILD
@@ -18,5 +18,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -22,6 +22,11 @@
           "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <module name="SuppressionFilter">
+        <property name="file" value="config/checkstyle/checkstyle-suppressions.xml" />
+    </module>
 
     <!-- Use 4 spaces, not tabs -->
     <module name="FileTabCharacter">
@@ -105,9 +110,9 @@
         <module name="OneStatementPerLine"/>
 
         <!-- Require JavaDoc on types (classes, interfaces, etc.) -->
-        <module name="JavadocType">
-            <property name="scope" value="public"/>
-        </module>
+        <!--<module name="JavadocType">-->
+            <!--<property name="scope" value="public"/>-->
+        <!--</module>-->
 
     </module>
 

--- a/console/test/BUILD
+++ b/console/test/BUILD
@@ -50,5 +50,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/daemon/executor/BUILD
+++ b/daemon/executor/BUILD
@@ -48,5 +48,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/graql/java/exception/BUILD
+++ b/graql/java/exception/BUILD
@@ -31,5 +31,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/graql/java/parser/BUILD
+++ b/graql/java/parser/BUILD
@@ -40,5 +40,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -94,7 +94,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_binary(

--- a/server/src/graql/internal/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/internal/reasoner/cache/SemanticCache.java
@@ -9,7 +9,7 @@
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNSES FOR A PARTICULAR PURPOSE.  See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License

--- a/server/src/graql/parser/Parser.java
+++ b/server/src/graql/parser/Parser.java
@@ -99,8 +99,9 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser parser = parse(queryString, errorListener);
 
         GraqlParser.QueryEOFContext queryEOFContext = parser.queryEOF();
-        if (errorListener.hasErrors())
+        if (errorListener.hasErrors()) {
             throw GraqlSyntaxException.create(errorListener.toString());
+        }
 
         return (T) visitQueryEOF(queryEOFContext);
     }
@@ -111,8 +112,9 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser parser = parse(queryString, errorListener);
 
         GraqlParser.QueryListContext queryListContext = parser.queryList();
-        if (errorListener.hasErrors())
+        if (errorListener.hasErrors()) {
             throw GraqlSyntaxException.create(errorListener.toString());
+        }
 
         return (Stream<T>) visitQueryList(queryListContext);
     }
@@ -122,8 +124,9 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser parser = parse(patternsString, errorListener);
 
         GraqlParser.PatternsContext patternsContext = parser.patterns();
-        if (errorListener.hasErrors())
+        if (errorListener.hasErrors()) {
             throw GraqlSyntaxException.create(errorListener.toString());
+        }
 
         return visitPatterns(patternsContext);
     }
@@ -133,8 +136,9 @@ public class Parser extends GraqlBaseVisitor {
         GraqlParser parser = parse(patternString, errorListener);
 
         GraqlParser.PatternContext patternContext = parser.pattern();
-        if (errorListener.hasErrors())
+        if (errorListener.hasErrors()) {
             throw GraqlSyntaxException.create(errorListener.toString());
+        }
 
         return visitPattern(patternContext);
     }

--- a/server/src/graql/query/ComputeQuery.java
+++ b/server/src/graql/query/ComputeQuery.java
@@ -275,8 +275,9 @@ public class ComputeQuery<T extends Answer> implements Query {
 
     @CheckReturnValue
     public final Optional<Algorithm> using() {
-        if (ALGORITHMS_DEFAULT.containsKey(method) && algorithm == null)
+        if (ALGORITHMS_DEFAULT.containsKey(method) && algorithm == null) {
             return Optional.of(ALGORITHMS_DEFAULT.get(method));
+        }
         return Optional.ofNullable(algorithm);
     }
 

--- a/server/test/graql/internal/gremlin/BUILD
+++ b/server/test/graql/internal/gremlin/BUILD
@@ -20,7 +20,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -40,5 +40,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/internal/gremlin/fragment/BUILD
+++ b/server/test/graql/internal/gremlin/fragment/BUILD
@@ -18,7 +18,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -35,7 +35,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -56,5 +56,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/internal/gremlin/sets/BUILD
+++ b/server/test/graql/internal/gremlin/sets/BUILD
@@ -19,7 +19,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -40,5 +40,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/internal/gremlin/spanningtree/BUILD
+++ b/server/test/graql/internal/gremlin/spanningtree/BUILD
@@ -14,7 +14,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -47,5 +47,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/internal/gremlin/spanningtree/ChuLiuEdmondsTest.java
+++ b/server/test/graql/internal/gremlin/spanningtree/ChuLiuEdmondsTest.java
@@ -87,16 +87,16 @@ public class ChuLiuEdmondsTest {
     public void testGetMaxSpanningTree() {
         /*
         root    10
-    	(0) -------> (1) \
-    	 |  \       /  ^  \
-    	 |   \30   |   |20 \
-    	 |10  \    |10 |    \10
-    	 |     \   |  /      \
-    	 V  15  V  V /   20   V
-    	(3)<----- (2) -----> (4)
-    	  \-------^
-    	     40
-    	 */
+        (0) -------> (1) \
+         |  \       /  ^  \
+         |   \30   |   |20 \
+         |10  \    |10 |    \10
+         |     \   |  /      \
+         V  15  V  V /   20   V
+        (3)<----- (2) -----> (4)
+          \-------^
+             40
+         */
         double[][] weights = {
                 {NINF, 10, 30, 10, NINF},
                 {NINF, NINF, 10, NINF, 10},
@@ -108,15 +108,15 @@ public class ChuLiuEdmondsTest {
         final Weighted<Arborescence<Integer>> weightedSpanningTree = ChuLiuEdmonds.getMaxArborescence(graph, 0);
         /*
         root
-    	(0)           (1)
-    	 |             ^
-    	 |             |
-    	 |             |
-    	 |            /
-    	 V           /
-    	(3)       (2) ------> (4)
-    	  \-------^
-    	 */
+        (0)           (1)
+         |             ^
+         |             |
+         |             |
+         |            /
+         V           /
+        (3)       (2) ------> (4)
+          \-------^
+         */
         final Map<Integer, Integer> maxBranching = weightedSpanningTree.val.getParents();
         assertEquals(2, maxBranching.get(1).intValue());
         assertEquals(3, maxBranching.get(2).intValue());

--- a/server/test/graql/parser/BUILD
+++ b/server/test/graql/parser/BUILD
@@ -37,7 +37,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -58,5 +58,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/query/BUILD
+++ b/server/test/graql/query/BUILD
@@ -35,7 +35,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -54,7 +54,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -75,5 +75,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/query/pattern/BUILD
+++ b/server/test/graql/query/pattern/BUILD
@@ -33,5 +33,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/graql/query/predicate/BUILD
+++ b/server/test/graql/query/predicate/BUILD
@@ -14,7 +14,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -33,7 +33,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(

--- a/server/test/server/deduplicator/BUILD
+++ b/server/test/server/deduplicator/BUILD
@@ -36,5 +36,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/server/deduplicator/RocksDbQueueTest.java
+++ b/server/test/server/deduplicator/RocksDbQueueTest.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.server.deduplicator;
 
 import grakn.core.graql.concept.ConceptId;

--- a/server/test/server/keyspace/BUILD
+++ b/server/test/server/keyspace/BUILD
@@ -13,5 +13,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/server/test/server/util/BUILD
+++ b/server/test/server/util/BUILD
@@ -33,5 +33,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-end-to-end/client-java/BUILD
+++ b/test-end-to-end/client-java/BUILD
@@ -21,5 +21,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-end-to-end/client-java/ClientJavaE2EConstants.java
+++ b/test-end-to-end/client-java/ClientJavaE2EConstants.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.client;
 
 import grakn.core.common.config.Config;

--- a/test-end-to-end/deduplicator/AttributeDeduplicatorE2E.java
+++ b/test-end-to-end/deduplicator/AttributeDeduplicatorE2E.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.deduplicator;
 
 

--- a/test-end-to-end/deduplicator/BUILD
+++ b/test-end-to-end/deduplicator/BUILD
@@ -22,5 +22,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-end-to-end/distribution/BUILD
+++ b/test-end-to-end/distribution/BUILD
@@ -20,7 +20,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -43,5 +43,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/analytics/BUILD
+++ b/test-integration/graql/analytics/BUILD
@@ -19,7 +19,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -41,7 +41,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -62,7 +62,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -83,7 +83,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -105,7 +105,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -126,7 +126,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -148,7 +148,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -170,5 +170,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/graph/BUILD
+++ b/test-integration/graql/graph/BUILD
@@ -33,5 +33,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/internal/BUILD
+++ b/test-integration/graql/internal/BUILD
@@ -36,5 +36,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -37,7 +37,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -62,7 +62,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -85,7 +85,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -112,7 +112,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -138,7 +138,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -160,7 +160,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -183,7 +183,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -208,7 +208,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -232,5 +232,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/query/pattern/BUILD
+++ b/test-integration/graql/query/pattern/BUILD
@@ -39,5 +39,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/BUILD
+++ b/test-integration/graql/reasoner/BUILD
@@ -51,5 +51,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.atomic;
 
 import grakn.core.graql.admin.Atomic;

--- a/test-integration/graql/reasoner/atomic/AtomicRoleInferenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicRoleInferenceIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.atomic;
 
 import com.google.common.collect.HashMultimap;

--- a/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.atomic;
 
 import com.google.common.collect.HashMultimap;

--- a/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.atomic;
 
 import com.google.common.collect.HashMultimap;

--- a/test-integration/graql/reasoner/atomic/BUILD
+++ b/test-integration/graql/reasoner/atomic/BUILD
@@ -22,7 +22,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -48,7 +48,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -75,7 +75,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -101,7 +101,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -125,5 +125,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/benchmark/BUILD
+++ b/test-integration/graql/reasoner/benchmark/BUILD
@@ -26,7 +26,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -58,5 +58,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/cache/BUILD
+++ b/test-integration/graql/reasoner/cache/BUILD
@@ -19,5 +19,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/cache/RuleCacheIT.java
+++ b/test-integration/graql/reasoner/cache/RuleCacheIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.cache;
 
 import com.google.common.collect.ImmutableMap;

--- a/test-integration/graql/reasoner/graph/BUILD
+++ b/test-integration/graql/reasoner/graph/BUILD
@@ -35,7 +35,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -55,7 +55,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -80,7 +80,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -96,7 +96,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -116,7 +116,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -137,7 +137,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -201,7 +201,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -222,7 +222,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -242,7 +242,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -262,5 +262,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/pattern/BUILD
+++ b/test-integration/graql/reasoner/pattern/BUILD
@@ -12,7 +12,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -32,7 +32,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -52,7 +52,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_library(
@@ -72,5 +72,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/pattern/QueryPattern.java
+++ b/test-integration/graql/reasoner/pattern/QueryPattern.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
@@ -36,11 +36,12 @@ public abstract class QueryPattern {
 
     public static int[][] identity(int N){
         int[][] matrix = new int[N][N];
-        for(int i = 0; i < N ; i++)
-            for(int j = 0; j < N ; j++){
+        for(int i = 0; i < N ; i++) {
+            for (int j = 0; j < N; j++) {
                 if (i == j) matrix[i][j] = 1;
                 else matrix[i][j] = 0;
             }
+        }
         return matrix;
     }
 

--- a/test-integration/graql/reasoner/pattern/RelationPattern.java
+++ b/test-integration/graql/reasoner/pattern/RelationPattern.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test-integration/graql/reasoner/pattern/ResourcePattern.java
+++ b/test-integration/graql/reasoner/pattern/ResourcePattern.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test-integration/graql/reasoner/pattern/TypePattern.java
+++ b/test-integration/graql/reasoner/pattern/TypePattern.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test-integration/graql/reasoner/query/AtomicQueryIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryIT.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
@@ -257,8 +257,9 @@ public class AtomicQueryIT {
     private Concept getConceptByResourceValue(TransactionOLTP tx, String id) {
         Set<Concept> instances = tx.getAttributesByValue(id)
                 .stream().flatMap(Attribute::owners).collect(Collectors.toSet());
-        if (instances.size() != 1)
+        if (instances.size() != 1) {
             throw new IllegalStateException("Something wrong, multiple instances with given res value");
+        }
         return instances.iterator().next();
     }
 

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
@@ -815,8 +815,9 @@ public class AtomicQueryUnificationIT {
     private Concept getConceptByResourceValue(TransactionOLTP tx, String id){
         Set<Concept> instances = tx.getAttributesByValue(id)
                 .stream().flatMap(Attribute::owners).collect(Collectors.toSet());
-        if (instances.size() != 1)
+        if (instances.size() != 1) {
             throw new IllegalStateException("Something wrong, multiple instances with given res value");
+        }
         return instances.iterator().next();
     }
 

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -22,7 +22,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -48,7 +48,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -85,7 +85,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -108,7 +108,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -130,7 +130,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -154,7 +154,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -204,7 +204,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -237,5 +237,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/query/ExplanationIT.java
+++ b/test-integration/graql/reasoner/query/ExplanationIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 //package grakn.core.graql.internal.reasoner;
 //
 //import grakn.core.server.Transaction;

--- a/test-integration/graql/reasoner/query/QueryValidityIT.java
+++ b/test-integration/graql/reasoner/query/QueryValidityIT.java
@@ -71,7 +71,8 @@ public class QueryValidityIT {
 
     @AfterClass
     public static void closeSession(){
-        tx.close(); genericSchemaSession.close();
+        tx.close();
+        genericSchemaSession.close();
     }
 
 

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -10,9 +10,9 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero parent Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU Affero parent Public License
+ * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 

--- a/test-integration/graql/reasoner/query/SubsumptionIT.java
+++ b/test-integration/graql/reasoner/query/SubsumptionIT.java
@@ -10,7 +10,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/test-integration/graql/reasoner/reasoning/BUILD
+++ b/test-integration/graql/reasoner/reasoning/BUILD
@@ -20,7 +20,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -58,7 +58,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -105,7 +105,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -129,7 +129,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -154,5 +154,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/graql/reasoner/reasoning/NeqPredicateIT.java
+++ b/test-integration/graql/reasoner/reasoning/NeqPredicateIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.reasoner.reasoning;
 
 import grakn.core.graql.answer.ConceptMap;

--- a/test-integration/rule/BUILD
+++ b/test-integration/rule/BUILD
@@ -44,5 +44,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.rule;
 
 import grakn.core.common.config.Config;

--- a/test-integration/server/AttributeDeduplicatorIT.java
+++ b/test-integration/server/AttributeDeduplicatorIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.server;
 
 import grakn.core.graql.answer.ConceptMap;

--- a/test-integration/server/BUILD
+++ b/test-integration/server/BUILD
@@ -34,5 +34,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/server/kb/BUILD
+++ b/test-integration/server/kb/BUILD
@@ -20,7 +20,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -41,7 +41,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -65,5 +65,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/server/kb/concept/BUILD
+++ b/test-integration/server/kb/concept/BUILD
@@ -20,7 +20,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 java_test(
      name = "attribute-type-it",
@@ -41,7 +41,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 java_test(
      name = "concept-it",
@@ -63,7 +63,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -85,7 +85,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -109,7 +109,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -134,7 +134,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -156,7 +156,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 java_test(
      name = "role-it",
@@ -177,7 +177,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 java_test(
      name = "schema-concept-it",
@@ -200,7 +200,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 java_test(
      name = "schema-mutation-it",
@@ -223,5 +223,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )

--- a/test-integration/server/kb/structure/BUILD
+++ b/test-integration/server/kb/structure/BUILD
@@ -19,7 +19,7 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )
 
 java_test(
@@ -41,5 +41,5 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  license = "//config/checkstyle:checkstyle-file-header.txt",
- allow_failure = True
+
 )


### PR DESCRIPTION
# Why is this PR needed?

We integrated `checkstyle` but it didn't really fail if you violated style. This is first stage fixing the violations and turning off `allow_failure`

# What does the PR do?

* Actually *use* `checkstyle-suppressions.xml` to ignore license check in `client-java`
* Temporarily disable Javadoc comment check
* Add AGPL license headers where they were missing (`RegexpHeaderCheck`)
* Fix `NeedBracesCheck`, `OneStatementPerLineCheck`, `FileTabCharacterCheck`
* Specify `UTF-8` as charset so CheckStyle does not fail

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

more fixes for `checkstyle`. ideally, we won't need `allow_failure` at all