### PR TITLE
Fix bazel future-version incompatibilities

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,7 +129,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="a883f333d830d8eeffaabcabc486caa263e97b8b",
+    commit="4b66b2594933feea6511ffce60cf78e1325245c1",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")
@@ -139,7 +139,7 @@ dependencies_for_github_deployment()
 git_repository(
     name="com_github_google_bazel_common",
     remote="https://github.com/graknlabs/bazel-common",
-    commit="2e1a2025f2bd381116855c1bcfc14c99fd81aed3",
+    commit="f8bd0545c40cd19958eb284d097501242631bacd",
 )
 
 load("@com_github_google_bazel_common//:workspace_defs.bzl", "google_common_workspace_rules")

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -23,18 +23,18 @@ def antlr_dependencies():
     git_repository(
         name = "rules_antlr",
         remote = "https://github.com/graknlabs/rules_antlr",
-        commit = "e40680fccd90b6bcf3c746f63d48a201152bb67f"
+        commit = "a802065dc12736d1360946c4bc689c8c8fe0c25f"
     )
 
 def grpc_dependencies():
     git_repository(
         name = "com_github_grpc_grpc",
         remote = "https://github.com/graknlabs/grpc",
-        commit = "ad6b3949bdbe6d0d25522558ebe73f4044a02146"
+        commit = "6accbdaccb906f59be846fe11450f662562beef9"
     )
 
     git_repository(
         name = "stackb_rules_proto",
-        remote = "https://github.com/stackb/rules_proto",
-        commit = "4c2226458203a9653ae722245cc27e8b07c383f7",
+        remote = "https://github.com/graknlabs/rules_proto",
+        commit = "a8c7677d94c6eae84e123008ab656139f2530161",
     )

--- a/dependencies/maven/rules.bzl
+++ b/dependencies/maven/rules.bzl
@@ -182,7 +182,7 @@ def _transitive_maven_dependencies(_target, ctx):
     tags = []
 
     if MavenInfo in _target:
-        for x in _target[MavenInfo].maven_dependencies:
+        for x in _target[MavenInfo].maven_dependencies.to_list():
             tags.append(x)
 
     for dep in getattr(ctx.rule.attr, "jars", []):

--- a/dependencies/pip/dependencies.bzl
+++ b/dependencies/pip/dependencies.bzl
@@ -22,5 +22,5 @@ def python_dependencies():
     git_repository(
         name = "io_bazel_rules_python",
         remote = "https://github.com/bazelbuild/rules_python.git",
-        commit = "8b5d0683a7d878b28fffe464779c8a53659fc645",
+        commit = "e6399b601e2f72f74e5aa635993d69166784dde1",
     )

--- a/dependencies/tools/checkstyle/checkstyle.bzl
+++ b/dependencies/tools/checkstyle/checkstyle.bzl
@@ -70,7 +70,7 @@ def collect_sources_impl(target, ctx):
     files = []
     if hasattr(ctx.rule.attr, 'srcs'):
         for src in ctx.rule.attr.srcs:
-            for f in src.files:
+            for f in src.files.to_list():
                 if f.extension == 'java':
                     files.append(f)
     return [JavaSourceFiles(files = files)]
@@ -166,8 +166,7 @@ checkstyle_test = rule(
             doc = "Successfully finish the test even if checkstyle failed"
         ),
         "_checkstyle_py_template": attr.label(
-             allow_files = True,
-             single_file = True,
+             allow_single_file=True,
              default = "//dependencies/tools/checkstyle/templates:checkstyle.py"
         ),
         "_classpath": attr.label_list(default=[


### PR DESCRIPTION
# Why is this PR needed?

Fixes a lot of [Backwards Compatibility](https://docs.bazel.build/versions/master/skylark/backward-compatibility.html) issues prematurely

# What does the PR do?

Links to updated versions of third-party rules

0. [V] `graknlabs/deployment` => adapted to new changes, pls merge: https://github.com/graknlabs/deployment/pull/10
1. [] `protocolbuffers/protobuf` => patched `v3.6.1` with changes to make it work with latest bazel (used in `grpc/grpc`), we have to wait until official `3.7.0` release []()
2. [] `rules_proto` => PR to upstream: https://github.com/stackb/rules_proto/pull/29
3. [] `bazel_common` => adapted to new changes, PR to upstream: https://github.com/google/bazel-common/pull/45
4. [] `grpc/grpc` => adapted to new changes, PR to upstream: https://github.com/grpc/grpc/pull/17590
5. [] `rules_antlr` => adapted to new changes, PR to upstream: https://github.com/marcohu/rules_antlr/pull/4
6. [V] `bazelbuild/rules_python` => upgraded the version to latest `master`
7. [V] adapted `checkstyle_rule` in `grakn` to `depset` not being iterable

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Upgrading `bazel` to `0.21` on CI