### PR TITLE
Checkstyle fixes part #3

### DIFF
--- a/check-for-missing-checkstyle-rule.py
+++ b/check-for-missing-checkstyle-rule.py
@@ -27,7 +27,8 @@ import sys
 
 java_targets = set(subprocess.check_output([
     'bazel', 'query',
-    '(kind(java_library, //...) union kind(java_test, //...)) except //dependencies/...'
+    '(kind(java_library, //...) union kind(java_test, //...)) '
+    'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
 ]).split())
 
 checkstyle_targets_xml = subprocess.check_output([

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -41,17 +41,7 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-protobuf",
         "//dependencies/maven/artifacts/io/grpc:grpc-stub",
     ],
-    tags = ["maven_coordinates=grakn.core:protocol:{pom_version}"],
-)
-
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
-checkstyle_test(
- name = "protocol-java-checkstyle",
- target = ":protocol-java",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
- allow_failure = True
+    tags = ["maven_coordinates=grakn.core:protocol:{pom_version}", "checkstyle_ignore"],
 )
 
 deploy_maven_jar(

--- a/server/test/graql/query/predicate/BUILD
+++ b/server/test/graql/query/predicate/BUILD
@@ -55,5 +55,4 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  licenses = ["//config/checkstyle:licenses"],
- allow_failure = True
 )

--- a/server/test/graql/query/predicate/ComparatorPredicateTest.java
+++ b/server/test/graql/query/predicate/ComparatorPredicateTest.java
@@ -77,24 +77,24 @@ public class ComparatorPredicateTest {
         exception.expectMessage(INVALID_VALUE.getMessage(value.getClass()));
         new MyComparatorPredicate(value).persistedValue();
     }
-}
 
-class MyComparatorPredicate extends ComparatorPredicate {
+    static class MyComparatorPredicate extends ComparatorPredicate {
 
-    MyComparatorPredicate(Object value) {
-        super(value);
+        MyComparatorPredicate(Object value) {
+            super(value);
+        }
+
+        @Override
+        protected String getSymbol() {
+            return "@";
+        }
+
+        @Override
+        <V> P<V> gremlinPredicate(V value) {
+            return P.eq(value);
+        }
+
+        @Override
+        public int signum() { return 0; }
     }
-
-    @Override
-    protected String getSymbol() {
-        return "@";
-    }
-
-    @Override
-    <V> P<V> gremlinPredicate(V value) {
-        return P.eq(value);
-    }
-
-    @Override
-    public int signum() { return 0; }
 }

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -179,7 +179,6 @@ checkstyle_test(
  config = "//config/checkstyle:checkstyle.xml",
  suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
  licenses = ["//config/checkstyle:licenses"],
- allow_failure = True
 )
 
 java_test(

--- a/test-integration/graql/reasoner/query/ResolutionPlanIT.java
+++ b/test-integration/graql/reasoner/query/ResolutionPlanIT.java
@@ -724,43 +724,43 @@ public class ResolutionPlanIT {
                 .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
         return Pattern.and(vars);
     }
+
+    static class RepeatRule implements TestRule {
+
+        private static class RepeatStatement extends org.junit.runners.model.Statement {
+
+            private final int times;
+            private final org.junit.runners.model.Statement statement;
+
+            private RepeatStatement(int times, org.junit.runners.model.Statement statement) {
+                this.times = times;
+                this.statement = statement;
+            }
+
+            @Override
+            public void evaluate() throws Throwable {
+                for( int i = 0; i < times; i++ ) {
+                    statement.evaluate();
+                }
+            }
+        }
+
+        @Override
+        public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement statement, Description description) {
+            org.junit.runners.model.Statement result = statement;
+            Repeat repeat = description.getAnnotation(Repeat.class);
+            if( repeat != null ) {
+                int times = repeat.times();
+                result = new RepeatStatement(times, statement);
+            }
+            return result;
+        }
+    }
 }
 
 @Retention( RetentionPolicy.RUNTIME )
 @Target(METHOD)
 @interface Repeat {
     int times();
-}
-
-class RepeatRule implements TestRule {
-
-    private static class RepeatStatement extends org.junit.runners.model.Statement {
-
-        private final int times;
-        private final org.junit.runners.model.Statement statement;
-
-        private RepeatStatement(int times, org.junit.runners.model.Statement statement) {
-            this.times = times;
-            this.statement = statement;
-        }
-
-        @Override
-        public void evaluate() throws Throwable {
-            for( int i = 0; i < times; i++ ) {
-                statement.evaluate();
-            }
-        }
-    }
-
-    @Override
-    public org.junit.runners.model.Statement apply(org.junit.runners.model.Statement statement, Description description) {
-        org.junit.runners.model.Statement result = statement;
-        Repeat repeat = description.getAnnotation(Repeat.class);
-        if( repeat != null ) {
-            int times = repeat.times();
-            result = new RepeatStatement(times, statement);
-        }
-        return result;
-    }
 }
 


### PR DESCRIPTION
# Why is this PR needed?

Fixes the remaining `checkstyle` rules with still-enabled `allow_failure`

# What does the PR do?

* `//test-integration/graql/reasoner/query:resolution-plan-it-checkstyle`
>ResolutionPlanIT.java:735: Top-level class RepeatRule has to reside in its own source file. [OneTopLevelClass]

Fixed by making `RepeatRule` a static inner class

* `//server/test/graql/query/predicate:comparator-predicate-test-checkstyle`
>ComparatorPredicateTest.java:82: Top-level class MyComparatorPredicate has to reside in its own source file. [OneTopLevelClass]

Fixed by making `MyComparatorPredicate` a static inner class

* `//protocol:protocol-java-checkstyle`

Fixed by assigning `checkstyle_ignore` tag to `//protocol:protocol-java`, ignoring targets with that tag in `check-for-missing-checkstyle-rule.py` and removing checkstyle target altogether

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

Getting rid of `allow_failure` attribute in `checkstyle_test` altogether
