### PR TITLE
Put distributions into folders in archive; fix #4758

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,8 +86,8 @@ jobs:
     - bazel_add_rbe_credential
     - run: bazel build //:distribution
     - run: unzip bazel-genfiles/grakn-core-all.zip -d bazel-genfiles/dist/
-    - run: nohup bazel-genfiles/dist/grakn server start
-    - run: bazel-genfiles/dist/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
+    - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
+    - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
     - run: bazel test //client-nodejs:test-integration --test_output=streamed
 
   client-python:
@@ -99,7 +99,7 @@ jobs:
     - bazel_add_rbe_credential
     - run: bazel build //:distribution
     - run: unzip bazel-genfiles/grakn-core-all.zip -d bazel-genfiles/dist/
-    - run: nohup bazel-genfiles/dist/grakn server start
+    - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
     - run: bazel test //client_python:test_integration --test_output=streamed
 
   common:
@@ -158,8 +158,8 @@ jobs:
     - bazel:
         command: bazel build //:distribution
     - run: unzip bazel-genfiles/grakn-core-all.zip -d bazel-genfiles/dist/
-    - run: nohup bazel-genfiles/dist/grakn server start
-    - run: bazel-genfiles/dist/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
+    - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
+    - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
     - run: Xvfb :99 &
     - run: export DISPLAY=:99
     - bazel:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,11 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
+# TODO(vmax): replace with upstream once graknlabs/deployment#16 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/graknlabs/deployment",
-    commit="93bb55dfd6784d1b4987348c1f512e076dfca0bc",
+    remote="https://github.com/vmax/graknlabs-deployment",
+    commit="9bdf6e950851af735332b616534acca950b92155",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,11 +141,10 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
-# TODO(vmax): replace with upstream once graknlabs/deployment#16 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/vmax/graknlabs-deployment",
-    commit="9bdf6e950851af735332b616534acca950b92155",
+    remote="https://github.com/graknlabs/deployment",
+    commit="784b332bfe0188989802a7e83e016be43c9e0168",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/test-end-to-end/client-java/ClientJavaE2EConstants.java
+++ b/test-end-to-end/client-java/ClientJavaE2EConstants.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class ClientJavaE2EConstants {
     public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(".").toAbsolutePath();
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "grakn-core-all.zip");
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test");
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all");
 
     public static void assertGraknRunning() {
         Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
@@ -60,7 +60,7 @@ public class ClientJavaE2EConstants {
 
     public static void unzipGrakn() throws IOException, InterruptedException, TimeoutException {
         new ProcessExecutor()
-                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.toString()).execute();
+                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.getParent().toString()).execute();
     }
 
     private static boolean isServerReady(String host, int port) {

--- a/test-end-to-end/deduplicator/AttributeDeduplicatorE2EConstants.java
+++ b/test-end-to-end/deduplicator/AttributeDeduplicatorE2EConstants.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class AttributeDeduplicatorE2EConstants {
     public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(".").toAbsolutePath();
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "grakn-core-all.zip");
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test");
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all");
 
     public static void assertGraknRunning() {
         Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
@@ -60,7 +60,7 @@ public class AttributeDeduplicatorE2EConstants {
 
     public static void unzipGrakn() throws IOException, InterruptedException, TimeoutException {
         new ProcessExecutor()
-                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.toString()).execute();
+                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.getParent().toString()).execute();
     }
 
     private static boolean isServerReady(String host, int port) {

--- a/test-end-to-end/distribution/DistributionE2EConstants.java
+++ b/test-end-to-end/distribution/DistributionE2EConstants.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class DistributionE2EConstants {
     public static final Path GRAKN_TARGET_DIRECTORY = Paths.get(".").toAbsolutePath();
     public static final Path ZIP_FULLPATH = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "grakn-core-all.zip");
-    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test");
+    public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all");
 
     public static void assertGraknIsRunning() {
         Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
@@ -58,7 +58,7 @@ public class DistributionE2EConstants {
     public static void unzipGrakn() throws IOException, InterruptedException, TimeoutException {
         System.out.println("Unzipped Grakn to: " + GRAKN_UNZIPPED_DIRECTORY.toAbsolutePath());
         new ProcessExecutor()
-                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.toString()).execute();
+                .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.getParent().toString()).execute();
     }
 
     private static boolean isServerReady(String host, int port) {


### PR DESCRIPTION
Needs graknlabs/deployment#16

# Why is this PR needed?

Fixes #4758

# What does the PR do?

Uses updated `distribution` rule which creates a folder in the archive to put distribution in.

# Does it break backwards compatibility?

With e2e tests

# List of future improvements not on this PR

—
