### PR TITLE
Update readme for clients

### DIFF
--- a/client-java/README.md
+++ b/client-java/README.md
@@ -1,13 +1,147 @@
----
-title: Grakn Java Client
-keywords: setup, getting started, download, driver
-tags: [getting-started]
-sidebar: documentation_sidebar
-permalink: /docs/language-drivers/client-java
-folder: docs
-symlink: true
----
+# Grakn Client Java
 
-# Grakn Java Client
+## Dependencies
+The only dependency for getting started with Grakn Client Java is `Grakn >= 1.3.0` added as a dependency in your Java project.
 
-Welcome to Grakn's Java Client page. Please find the document setup documentation at: [http://dev.grakn.ai/docs/java-library/setup](http://dev.grakn.ai/docs/java-library/setup)
+### Grakn Core
+
+```xml
+<dependency>
+  <groupId>ai.grakn</groupId>
+  <artifactId>client-java</artifactId>
+  <version>1.4.3</version>
+</dependency>
+```
+
+### Grakn KGMS
+
+```xml
+<dependency>
+  <groupId>ai.grakn.kgms</groupId>
+  <artifactId>client</artifactId>
+  <version>1.4.3</version>
+</dependency>
+```
+
+## Quickstart
+First make sure, the [Grakn server](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server) is running.
+
+In the interpreter or in your source, import `grakn`.
+
+Instantiate a client and open a session.
+
+```java
+import ai.grakn.Keyspace;
+import ai.grakn.client.Grakn;
+import ai.grakn.util.SimpleURI;
+
+public class GraknQuickstart {
+    public static void main(String[] args) {
+        SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+        Keyspace keyspace = Keyspace.of("genealogy");
+        Grakn grakn = new Grakn(localGrakn);
+        Grakn.Session session = grakn.session(keyspace);
+        // session is open
+        session.close();
+        // session is closed
+    }
+}
+```
+
+As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
+
+We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users).
+
+```java
+SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+Grakn grakn = new ClientFactory(localGrakn, "<username>", "<password>").client();
+```
+
+Create transactions to use for reading and writing data.
+
+```java
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.client.Grakn;
+import ai.grakn.util.SimpleURI;
+
+public class GraknQuickstart {
+    public static void main(String[] args) {
+        SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+        Keyspace keyspace = Keyspace.of("genealogy");
+        Grakn grakn = new Grakn(localGrakn);
+        Grakn.Session session = grakn.session(keyspace);
+
+        // creating a write transaction
+        Grakn.Transaction writeTransaction = session.transaction(GraknTxType.WRITE);
+        // write transaction is open
+        // write transaction must always be committed (closed)
+        writeTransaction.commit();
+
+        // creating a read transaction
+        Grakn.Transaction readTransaction = session.transaction(GraknTxType.READ);
+        // read transaction is open
+        // read transaction must always be closed
+        readTransaction.close();
+
+        session.close();
+    }
+}
+```
+
+Running basic retrieval and insertion queries.
+
+```java
+import ai.grakn.GraknTxType;
+import ai.grakn.Keyspace;
+import ai.grakn.client.Grakn;
+import ai.grakn.graql.GetQuery;
+import ai.grakn.graql.Graql;
+import ai.grakn.graql.InsertQuery;
+import ai.grakn.graql.answer.ConceptMap;
+import ai.grakn.util.SimpleURI;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class GraknQuickstart {
+    public static void main(String[] args) {
+      SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+      Keyspace keyspace = Keyspace.of("phone_calls");
+      Grakn grakn = new Grakn(localGrakn);
+      Grakn.Session session = grakn.session(keyspace);
+
+      Grakn.Transaction writeTransaction = session.transaction(GraknTxType.WRITE);
+      InsertQuery insertQuery = Graql.insert(var("p").isa("person").has("first-name", "Elizabeth"));
+      List<ConceptMap> insertedId = insertQuery.withTx(writeTransaction).execute();
+      System.out.println("Inserted a person with ID: " + insertedId.get(0).get("p").id());
+      writeTransaction.commit();
+
+      Grakn.Transaction readTransaction = session.transaction(GraknTxType.READ);
+      GetQuery query = Graql.match(var("p").isa("person")).limit(10).get();
+      Stream<ConceptMap> answers = query.withTx(readTransaction).stream();
+      answers.forEach(answer -> System.out.println(answer.get("p").id()));
+      readTransaction.close();
+
+      session.close();
+    }
+}
+```
+
+**Remember that transactions always need to be closed. Commiting a write transaction closes it. A read transaction, however, must be explicitly clased by calling the `close()` method on it.**
+
+To view examples of running various Graql queries using the Grakn Client Java, head over to their dedicated documentation pages as listed below.
+
+- [Insert](http://dev.grakn.ai/docs/query/insert-query)
+- [Get](http://dev.grakn.ai/docs/query/get-query)
+- [Delete](http://dev.grakn.ai/docs/query/delete-query)
+- [Aggregate](http://dev.grakn.ai/docs/query/aggregate-query)
+- [Compute](http://dev.grakn.ai/docs/query/compute-query)
+
+## Client Architecture
+To learn about the mechanism that a Grakn Client uses to set up communication with keyspaces running on the Grakn Server, refer to [Grakn > Client API > Overview]((http://dev.grakn.ai/docs/client-api/overview).
+
+## API Reference
+To learn about the methods available for executing queries and retrieving their answers using Client Java, refer to [Grakn > Client API > Java > API Reference](http://dev.grakn.ai/docs/client-api/java#api-reference).
+
+## Concept API
+To learn about the methods available on the concepts retrieved as the answers to Graql queries, refer to [Grakn > Concept API > Overview](http://dev.grakn.ai/docs/concept-api/overview)

--- a/client-java/README.md
+++ b/client-java/README.md
@@ -102,26 +102,30 @@ import java.util.List;
 import java.util.stream.Stream;
 
 public class GraknQuickstart {
-    public static void main(String[] args) {
-      SimpleURI localGrakn = new SimpleURI("localhost", 48555);
-      Keyspace keyspace = Keyspace.of("phone_calls");
-      Grakn grakn = new Grakn(localGrakn);
-      Grakn.Session session = grakn.session(keyspace);
+  public static void main(String[] args) {
+    SimpleURI localGrakn = new SimpleURI("localhost", 48555);
+    Keyspace keyspace = Keyspace.of("phone_calls");
+    Grakn grakn = new Grakn(localGrakn);
+    Grakn.Session session = grakn.session(keyspace);
 
-      Grakn.Transaction writeTransaction = session.transaction(GraknTxType.WRITE);
-      InsertQuery insertQuery = Graql.insert(var("p").isa("person").has("first-name", "Elizabeth"));
-      List<ConceptMap> insertedId = insertQuery.withTx(writeTransaction).execute();
-      System.out.println("Inserted a person with ID: " + insertedId.get(0).get("p").id());
-      writeTransaction.commit();
+    // Insert a person using a WRITE transaction
+    Grakn.Transaction writeTransaction = session.transaction(GraknTxType.WRITE);
+    InsertQuery insertQuery = Graql.insert(var("p").isa("person").has("first-name", "Elizabeth"));
+    List<ConceptMap> insertedId = insertQuery.withTx(writeTransaction).execute();
+    System.out.println("Inserted a person with ID: " + insertedId.get(0).get("p").id());
+    // to persist changes, a write transaction must always be committed (closed)
+    writeTransaction.commit();
 
-      Grakn.Transaction readTransaction = session.transaction(GraknTxType.READ);
-      GetQuery query = Graql.match(var("p").isa("person")).limit(10).get();
-      Stream<ConceptMap> answers = query.withTx(readTransaction).stream();
-      answers.forEach(answer -> System.out.println(answer.get("p").id()));
-      readTransaction.close();
+    // Read the person using a READ only transaction
+    Grakn.Transaction readTransaction = session.transaction(GraknTxType.READ);
+    GetQuery query = Graql.match(var("p").isa("person")).limit(10).get();
+    Stream<ConceptMap> answers = query.withTx(readTransaction).stream();
+    answers.forEach(answer -> System.out.println(answer.get("p").id()));
 
-      session.close();
-    }
+    // a read transaction and session must always be closed
+    readTransaction.close();
+    session.close();
+  }
 }
 ```
 

--- a/client-java/README.md
+++ b/client-java/README.md
@@ -48,8 +48,6 @@ public class GraknQuickstart {
 }
 ```
 
-As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
-
 We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users).
 
 ```java

--- a/client-nodejs/README.md
+++ b/client-nodejs/README.md
@@ -81,7 +81,6 @@ async function runBasicQueries() {
   }
 
   // Or query and consume the iterator immediately collecting all the results
-  // - consume it all immediately
   answerIterator = await readTransaction.query("match $x isa person; limit 10; get;");
   const persons = await answerIterator.collectConcepts();
   persons.forEach( person => { console.log("Retrieved person with id "+ person.id) });

--- a/client-nodejs/README.md
+++ b/client-nodejs/README.md
@@ -27,8 +27,6 @@ const client = new Grakn("localhost:48555");
 const session = client.session("keyspace");
 ```
 
-As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
-
 We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users), into the initial constructor as a Javascript object.
 
 ```javascript

--- a/client-nodejs/README.md
+++ b/client-nodejs/README.md
@@ -1,377 +1,109 @@
----
-title: Grakn Node.js Client
-keywords: setup, getting started, download, driver
-tags: [getting-started]
-sidebar: documentation_sidebar
-permalink: /docs/language-drivers/client-nodejs
-folder: docs
-symlink: true
----
+# Grakn Client Node.js
 
-# Grakn Node.js Client
+## Dependencies
+Before installing the `grakn` node module, make sure the following dependencies are installed.
 
-A Node.js client for [Grakn](https://grakn.ai)
+- [Grakn >= 1.3.0](https://github.com/graknlabs/grakn/releases)
+- [Node >= 6.5.0](https://nodejs.org/en/download/)
 
-Requires Grakn 1.3.0 && Node >= 6.5.0
-
-# Installation
-
-To install the Grakn client, simply run:
-
+## Installation
 ```
 npm install grakn
 ```
 
-You will also need access to a Grakn database. Head [here](https://grakn.ai/pages/documentation/get-started/setup-guide.html) to get started with Grakn.
+## Quickstart
+First make sure, the [Grakn server](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server) is running..
 
-# Quickstart
+In your source, require `grakn`.
 
-Begin by importing Grakn:
-
-```
-const Grakn = require('grakn');
-```
-
-You can then instantiate a client, open a session, and create transactions. 
-
-> Note that new versions of Grakn client now use the default port **48555**. Port 4567 was the default port on older clients.
+```javascript
+const Grakn = require("grakn");
 ```
 
-const grakn = new Grakn('localhost:48555');
-const session = grakn.session('keyspace');
-const tx = await session.transaction(Grakn.txType.WRITE);
+Instantiate a client and open a session.
+
+```javascript
+const client = new Grakn("localhost:48555");
+const session = client.session("keyspace");
 ```
 
-Execute Graql queries:
+As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
 
+We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users), into the initial constructor as a Javascript object.
 
-```
-// Example of match query
-const resultIterator = await tx.query("match $x isa person; limit 10; get;"); // This will return an Iterator of ConceptMap Answer
-const answer = await resultIterator.next(); // Take first ConceptMap Answer
-const person = answer.map().get('x'); // Access map in Answer with answer.map() and take Concept associated to variable x from 'match $x isa person; get;'
-tx.close();
+```javascript
+const client = grakn.Grakn("localhost:48555", { "username": "<username>", "password": "<password>" });
 ```
 
-NOTE: the `query()` method almost immediately returns an iterator - this is because the actual result retrieval is done lazily every time
-`.next()` is invoked on a specific iterator
+Create transactions to use for reading and writing data.
 
-```
-// Example of insert query
-const iterator = await tx.query("insert $x isa person, has birth-date 2018-08-06;"); // Insert query returns Iterator of ConceptMap Answer containing inserted concepts
-// On Iterators of ConceptMap Answers is possible to use the collectConcept method to consume the whole iterator and obtain an array of Concepts
-const concepts = (await iterator.collectConcepts()); 
-const person = concepts[0];
-tx.commit(); // Remember to commit your changes so that they get persisted in the graph! This will also close the transaction.
-```
+```javascript
+const client = new Grakn("localhost:48555");
+const session = client.session("keyspace");
 
-# API Reference
+// creating a write transaction
+const writeTx = await session.transaction(Grakn.txType.WRITE); // write transaction is open
+// write transaction must always be committed/closed
+writeTx.commit();
 
-First create a new Grakn object with
-
-```
-// URI must be a string containing host address and gRPC port of a running Grakn instance, e.g. "localhost:48555"
-const grakn = new Grakn(URI);
+// creating a read transaction
+const readTx = await session.transaction(Grakn.txType.READ); // read transaction is open
+// read transaction must always be closed
+readTx.close();
 ```
 
-on the Grakn object the following methods are available:
+Running basic retrieval and insertion queries.
 
-**Grakn**
+```javascript
+const client = new Grakn("localhost:48555");
+const session = client.session("keyspace");
 
-| Method                                   | Return type       | Description                                          |
-| ---------------------------------------- | ----------------- | ---------------------------------------------------- |
-| `session(String keyspace)`               | *Session*         | Return a new Session bound to the specified keyspace |
-| async `keyspaces().delete(String keyspace)` | *void*            | Deletes the specified keyspace                       |
-| async `keyspaces().retrieve()`              | Array of *String* | Retrieves all available keyspaces                    |
+async function runBasicQueries() {
+  // creating a write transaction
+  const writeTransaction = await session.transaction(Grakn.txType.WRITE); // write transaction is open
+  const insertIterator = await writeTransaction.query("insert $x isa person has birth-date 2018-08-06");
+  concepts = await insertIterator.collectConcepts()
+  console.log("Inserted a person with ID: " + concepts[0].id);
+  // write transaction must always be committed (closed)
+  await writeTransaction.commit();
 
+  // creating a read transaction
+  const readTransaction = await session.transaction(Grakn.txType.READ); // read transaction is open
+  const answerIterator = await readTransaction.query("match $x isa person; limit 10; get;");
+  // retrieve the first answer
+  let aConceptMapAnswer = await answerIterator.next();
+  // get the object of variables : concepts, retrieve variable "x"
+  const person = aConceptMapAnswer.map().get("x");
+  // we can also iterate using a `for` loop
+  const somePeople = [];
 
-
-on the Session the following methods are available:
-
-**Session**
-
-| Method                            | Return type   | Description                                                                           |
-| --------------------------------- | ------------- | ------------------------------------------------------------------------------------- |
-| async `transaction(Grakn.txType)` | *Transaction* | Return a new Transaction bound to the keyspace of this session                        |
-| `close()`                         | *void*        | This must be used to correctly terminate session and close communication with server. |
-
-
-Once obtained a `Transaction` you will be able to:
-
- **Transaction**  
-
-| Method                                                       | Return type               | Description                                                                                                                                                                                    |
-| ------------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| async `query(String graqlQuery[, { infer }])`                | Iterator of *Answer*      | Executes a Graql query on the session keyspace. It's possible to specify whether to enable inference passing an object with *infer* property set to true or false. Inference is ON by default. |
-| async `commit()`                                             | *void*                    | Commit current Transaction, persisting changes in the graph. After committing, the transaction will be closed and you will need to get a new one from the session                              |
-| async `close()`                                              | *void*                    | Closes current Transaction without committing. This makes the transaction unusable.                                                                                                            |
-| async `getConcept(String conceptId)`                         | *Concept* or *null*       | Retrieves a Concept by ConceptId                                                                                                                                                               |
-| async `getSchemaConcept(String label)`                       | *SchemaConcept* or *null* | Retrieves a SchemaConcept by label                                                                                                                                                             |
-| async `getAttributesByValue(attributeValue, Grakn.dataType)` | Iterator of *Attribute*   | Get all Attributes holding the value provided, if any exists                                                                                                                                   |
-| async `putEntityType(String label)`                          | *EntityType*              | Create a new EntityType with super-type entity, or return a pre-existing EntityType with the specified label                                                                                   |
-| async `putRelationshipType(String label)`                    | *RelationshipType*        | Create a new RelationshipType with super-type relation, or return a pre-existing RelationshipType with the specified label                                                                     |
-| async `putAttributeType(String label, Grakn.dataType)`       | *AttributeType*           | Create a new AttributeType with super-type attribute, or return a pre-existing AttributeType with the specified label and DataType                                                             |
-| async `putRole(String label)`                                | *Role*                    | Create a Role, or return a pre-existing Role, with the specified label.                                                                                                                        |
-| async `putRule(String label, String when, String then)`      | *Rule*                    | Create a Rule, or return a pre-existing Rule, with the specified label                                                                                                                         |
-
-**Iterator**
-
-Some of the following Concept methods return an Iterator,
-on every iterator the following methods are available:
-
-| Method                    | Return type                 | Description                                                                                                                                                                                                                                                               |
-| ------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| async `next()`            | *IteratorElement* or *null* | Retrieves next element or returns null when no more elements are available                                                                                                                                                                                                |
-| async `collect()`         | Array of *IteratorElement*  | Consumes the iterator and collect all the elements into an array                                                                                                                                                                                                          |
-| async `collectConcepts()` | Array of *Concept*          | Consumes the iterator and return array of Concepts. **This helper is only available on Iterator containing ConceptMap Answer, returned by transaction.query().**. It is useful when one wants to work directly on Concepts without the need to traverse the result map or access the explanation. |
-
-NOTE: these iterators represent a lazy evaluation of a query or method on the Grakn server, and will be created very quickly. 
-The actual work is performed when the iterator is consumed, creating an RPC to the server to obtain the next concrete Answer or Concept.
-
-**IteratorElement**
-
-Element handled by iterators, depending on the type of iterator this can be a type of *Concept* or an *Answer*.
-
-**Answer**
-
-This object represents a query answer and it is contained in the Iterator returned by `transaction.query()` method.     
-There are **different types of Answer**, based on the type of query executed a different type of Answer will be returned:   
-
-| Query Type                           | Answer Type       |
-|--------------------------------------|-------------------|
-| `define`                               | ConceptMap        |
-| `undefine`                             | ConceptMap        |
-| `get`                                  | ConceptMap        |
-| `insert`                               | ConceptMap        |
-| `delete`                               | ConceptMap        |
-| `aggregate count/min/max/sum/mean/std` |  Value            |
-| `aggregate group`                      | AnswerGroup       |
-| `compute count/min/max/sum/mean/std`   | Value             |
-| `compute path`                         | ConceptList       |
-| `compute cluster`                      | ConceptSet        |
-| `compute centrality`                  | ConceptSetMeasure |
-
-**ConceptMap**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `map()`         | Map<*String*, *Concept*> | Returns result map in which every variable name (key) is linked to a Concept.                   |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**Value**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `number()`      | Number                   | Returns numeric value of the Answer.                                                            |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptList**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `list()`        | Array of *String*        | Returns list of Concept IDs.                                                                    |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptSet**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `set()`         | Set of *String*          | Returns a set containing Concept IDs.                                                           |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptSetMeasure**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `measurement()` | Number                   | Returns numeric value that is associated to the set of Concepts contained in the current Answer.|
-| `set()`         | Set of *String*          | Returns a set containing Concept IDs.                                                           |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**AnswerGroup**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `owner()`       | *Concept*                | Returns the Concepts which is the group owner.                                                  |
-| `answers()`     | Array of *Answer*        | Returns list of Answers that belongs to this group.                                             |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**Explanation**
-
-| Method           | Return type       | Description                                                                                 |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------- |
-| `queryPattern()` | String            | Returns a query pattern that describes how the owning answer was retrieved.                 |
-| `answers()`      | Array of *Answer* | Set of deducted/factual answers that allowed us to determine that the owning answer is true |
-
-
-
-**Concepts hierarchy**
-
-Grakn is composed of different types of Concepts, that have a specific hierarchy
-
+  while ( aConceptMapAnswer != null) {
+    // get the next `x`
+    somePeople.push(aConceptMapAnswer.map().get("x"));
+    break; // skip the iteration, we are going to try something else
+    aConceptMapAnswer = await answerIterator.next();
+  }
+  const remainingPeople = answerIterator.collectConcepts()
+  // read transaction must always be closed
+  await readTransaction.close();
+}
 ```
-                                                Concept
-                                                /       \
-                                              /           \
-                                            /               \
-                                          /                   \
-                                  SchemaConcept                    Thing
-                                  /     |    \                    /   |  \
-                                /       |     \                 /     |    \
-                              /         |      \              /       |      \
-                            Type      Rule    Role     Entity    Attribute   Relationship
-                        /     |   \
-                      /       |     \
-                    /         |       \
-            EntityType  AttributeType  RelationshipType
-```
----
 
-All Concepts are bound to the transaction that has been used to retrieve them.
-If for any reason a trasaction gets closed all the concepts bound to it won't be able to
-communicate with the database anymore, so all the methods won't work and the user will have to re-query
-for the needed concepts.
+**Remember that transactions always need to be closed. Committing a write transaction closes it. A read transaction, however, must be explicitly closed by calling the `close()` method on it.**
 
----
+To view examples of running various Graql queries using the Grakn Client Node.js, head over to their dedicated documentation pages as listed below.
 
-**Concept**
+- [Insert](http://dev.grakn.ai/docs/query/insert-query)
+- [Get](http://dev.grakn.ai/docs/query/get-query)
+- [Delete](http://dev.grakn.ai/docs/query/delete-query)
+- [Aggregate](http://dev.grakn.ai/docs/query/aggregate-query)
+- [Compute](http://dev.grakn.ai/docs/query/compute-query)
 
-These methods are available on every type of `Concept`
+## Client Architecture
+To learn about the mechanism that a Grakn Client uses to set up communication with keyspaces running on the Grakn Server, refer to [Grakn > Client API > Overview]((http://dev.grakn.ai/docs/client-api/overview).
 
-| Method                 | Return type | Description                                      |
-| ---------------------- | ----------- | ------------------------------------------------ |
-| async `delete()`       | *void*      | Delete concept                                   |
-| `isSchemaConcept()`    | *Boolean*   | Check whether this Concept is a SchemaConcept    |
-| `isType() `            | *Boolean*   | Check whether this Concept is a Type             |
-| `isThing() `           | *Boolean*   | Check whether this Concept is a Thing            |
-| `isAttributeType()`    | *Boolean*   | Check whether this Concept is an AttributeType   |
-| `isEntityType() `      | *Boolean*   | Check whether this Concept is an EntityType      |
-| `isRelationshipType()` | *Boolean*   | Check whether this Concept is a RelationshipType |
-| `isRole()`             | *Boolean*   | Check whether this Concept is a Role             |
-| `isRule()`             | *Boolean*   | Check whether this Concept is a Rule             |
-| `isAttribute()`        | *Boolean*   | Check whether this Concept is an Attribute       |
-| `isEntity()`           | *Boolean*   | Check whether this Concept is a Entity           |
-| `isRelationship()`     | *Boolean*   | Check whether this Concept is a Relationship     |
+## API Reference
+To learn about the methods available for executing queries and retrieving their answers using Client Node.js, refer to [Grakn > Client API > Node.js > API Reference](http://dev.grakn.ai/docs/client-api/nodejs#api-reference).
 
-  **Schema concept**  
-
-A `SchemaConcept` concept has all the `Concept` methods plus the following:
-
-| Method                      | Return type                 | Description                                                                                                                                                          |
-| --------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| async `label()`             | *String*                    | Get label of this SchemaConcept                                                                                                                                      |
-| async `label(String value)` | *void*                      | Set label of this SchemaConcept                                                                                                                                      |
-| async `isImplicit()`        | *Boolean*                   | Returns `true` when the SchemaConcept is implicit, i.e. when it's been created by Grakn and not explicitly by the user, `false` when explicitly created by the user. |
-| async `sup(Type)`           | *void*                      | Set direct super SchemaConcept of this SchemaConcept                                                                                                                 |
-| async `sup()`               | *SchemaConcept*  or *null*  | Get direct super SchemaConcept of this SchemaConcept                                                                                                                 |
-| async `subs()`              | Iterator of *SchemaConcept* | Get all indirect subs of this SchemaConcept.                                                                                                                         |
-| async `sups()`              | Iterator of *SchemaConcept* | Get all indirect sups of this SchemaConcept.                                                                                                                         |
-
-  **Thing**
-
- A `Thing` concept has all the `Concept` methods plus the following:
-
- | Method                               | Return type                | Description                                                                                                                                                                       |
- | ------------------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | async `isInferred()`                 | *Boolean*                  | Returns `true` if this Thing is inferred by Reasoner, `false` otherwise                                                                                                           |
- | async `type()`                       | *Type*                     | Returns a Type which is the type of this Thing. This Thing is an instance of that type.                                                                                           |
- | async `relationships(...Role)`       | Iterator of *Relationship* | Returns Relationships which this Thing takes part in, which may **optionally** be narrowed to a particular set according to the Roles you are interested in                       |
- | async `attributes(...AttributeType)` | Iterator of *Attribute*    | Returns Attributes attached to this Thing, which may **optionally** be narrowed to a particular set according to the AttributeTypes you are interested in                         |
- | async `roles()`                      | Iterator of *Role*         | Returns the Roles that this Thing is currently playing                                                                                                                            |
- | async `keys(...Attributetype)`       | Iterator of *Attribute*    | Returns a collection of Attribute attached to this Thing as a key, which may **optionally** be narrowed to a particular set according to the AttributeTypes you are interested in |
- | async `has(Attribute)`               | *void*                     | Attaches the provided Attribute to this Thing                                                                                                                                     |
- | async `unhas(Attribute)`             | *void*                     | Removes the provided Attribute from this Thing                                                                                                                                    |
-
-  **Attribute**
-
-  An `Attribute` concept has all the `Thing` methods plus the following:
-
-
- | Method             | Return type         | Description                                               |
- | ------------------ | ------------------- | --------------------------------------------------------- |
- | async `value()`    | *String*            | Get value of this Attribute                               |
- | async `owners()`   | Iterator of *Thing* | Returns the set of all Things that possess this Attribute |
-
-  **Relationship**  
-
-A `Relationship` concept has all the `Thing` methods plus the following:
-
-
-| Method                        | Return type               | Description                                                                                              |
-| ----------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| async `rolePlayersMap()`      | Map<*Role*, Set<*Thing*>> | Returns a Map that links all the Roles of this Relationship to all the Things that are playing each Role |
-| async `rolePlayers(...Role)`  | Iterator of *Thing*       | Returns a list of every Thing involved in this Relationship, optionally filtered by Roles played         |
-| async `assign(Role, Thing)`   | *void*                    | Expands this Relationship to include a new role player (Thing) which is playing a specific Role          |
-| async `unassign(Role, Thing)` | *void*                    | Removes the Thing which is playing a Role in this Relationship.                                          |  |
-
-    NB: There are no specific methods for `Entity` concept.
-
-  **Type**  
-
-A `Type` concept has all the `SchemaConcept` methods plus the following:
-
-
-| Method                       | Return type                 | Description                                                                                                                    |
-| ---------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| async `isAbstract(Boolean)`  | *void*                      | Sets the Type to be abstract - which prevents it from having any instances                                                     |
-| async `isAbstract()`         | *Boolean*                   | Returns `true` if the type is set to abstract, `false` otherwise                                                               |
-| async `playing()`            | Iterator of *Role*          | Returns all the Roles which instances of this Type can indirectly play                                                         |
-| async `plays(Role)`          | *void*                      | Add a new Role to the ones that the instances of this Type are allowed to play                                                 |
-| async `attributes()`         | Iterator of *AttributeType* | The AttributeTypes which this Type is linked with.                                                                             |
-| async `instances()`          | Iterator of *Thing*         | Get all indirect instances of this Type                                                                                        |
-| async `keys()`               | Iterator of *AttributeType* | The AttributeTypes which this Type is linked with as a key                                                                     |
-| async `key(AttributeType)`   | *void*                      | Creates an implicit RelationshipType which allows this Type and a AttributeType to be linked in a strictly one-to-one mapping. |
-| async `has(AttributeType)`   | *void*                      | Add a new AttributeType which the instances of this Type are allowed to have attached to themselves                            |
-| async `unplay(Role)`         | *void*                      | Delete a Role from the ones that the instances of this Type are allowed to play                                                |
-| async `unhas(AttributeType)` | *void*                      | Delete AttributeType from the ones that the instances of this Type are allowed to have attached to themselves                  |
-| async `unkey(AttributeType)` | *void*                      | Delete AttributeType from available keys                                                                                       |
-
-  **AttributeType**
-
-  An `AttributeType` concept has all the `Type` methods plus the following:
-
-
-  | Method                      | Return type           | Description                                                                                                                                 |
-  | --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-  | async `create(value)`       | *Attribute*           | Create new Attribute of this type with the provided value. The value provided must conform to the DataType specified for this AttributeType |
-  | async `attribute(value)`    | *Attribute* or *null* | Retrieve the Attribute with the provided value if it exists                                                                                 |
-  | async `dataType()`          | *String*              | Get the data type to which instances of the AttributeType must have                                                                         |
-  | async `regex()`             | *String* or *null*    | Retrieve the regular expression to which instances of this AttributeType must conform to, or `null` if no regular expression is set         |
-  | async `regex(String regex)` | *void*                | Set the regular expression that instances of the AttributeType must conform to                                                              |
-
-  **RelationshipType**  
-
-  A `RelationshipType` concept has all the `Type` methods plus the following:
-
- | Method                 | Return type        | Description                                                                          |
- | ---------------------- | ------------------ | ------------------------------------------------------------------------------------ |
- | async `create()`       | *Relationship*     | Creates and returns a new Relationship instance, whose direct type will be this type |
- | async `roles()`        | Iterator of *Role* | Returns a list of the RoleTypes which make up this RelationshipType                  |
- | async `relates(Role)`  | *void*             | Sets a new Role for this RelationshipType                                            |
- | async `unrelate(Role)` | *void*             | Delete a Role from this RelationshipType                                             |
-
-  **EntityType**  
-
-  An `EntityType` concept has all the `Type` methods plus the following:
-
-  | Method           | Return type | Description                                                                    |
-  | ---------------- | ----------- | ------------------------------------------------------------------------------ |
-  | async `create()` | *Entity*    | Creates and returns a new Entity instance, whose direct type will be this type |
-
-
-  **Role**  
-
-  A `Role` concept has all the `SchemaConcept` methods plus the following:
-
-| Method                  | Return type                    | Description                                                 |
-| ----------------------- | ------------------------------ | ----------------------------------------------------------- |
-| async `relationships()` | Iterator of *RelationshipType* | Returns the RelationshipTypes that this Role takes part in. |
-| async `players()`       | Iterator of *Type*             | Returns a collection of the Types that can play this Role   |
-
-  **Rule**  
-
-A `Rule` concept has all the `SchemaConcept` methods plus the following:  
-
-| Method            | Return type | Description                                                                                                |
-| ----------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| async `getWhen()` | *String*    | Retrieves the when part of this Rule. When this query is satisfied the "then" part of the rule is executed |
-| async `getThen()` | *String*    | Retrieves the then part of this Rule. This query is executed when the "when" part of the rule is satisfied |
+## Concept API
+To learn about the methods available on the concepts retrieved as the answers to Graql queries, refer to [Grakn > Concept API > Overview](http://dev.grakn.ai/docs/concept-api/overview)

--- a/client_python/README.md
+++ b/client_python/README.md
@@ -35,8 +35,6 @@ with client.session(keyspace="mykeyspace") as session:
 ## session is closed
 ```
 
-As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
-
 We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users), into the client constructor as a dictionary.
 
 ```python

--- a/client_python/README.md
+++ b/client_python/README.md
@@ -76,7 +76,7 @@ with client.session(keyspace="keyspace") as session:
     ## to persist changes, write transaction must always be committed (closed)
     write_transaction.commit()
 
-  ## Read the person using a READ only transaction:
+  ## Read the person using a READ only transaction
   with session.transaction(grakn.TxType.READ) as read_transaction:
     answer_iterator = read_transaction.query("match $x isa person; limit 10; get;")
 

--- a/client_python/README.md
+++ b/client_python/README.md
@@ -85,7 +85,6 @@ with client.session(keyspace="keyspace") as session:
       print("Retrieved person with id " + person.id)
 
   ## Or query and consume the iterator immediately collecting all the results
-  ## - consume it all immediately
   with session.transaction(grakn.TxType.READ) as read_transaction:
     answer_iterator = read_transaction.query("match $x isa person; limit 10; get;")
     persons = answer_iterator.collect_concepts()

--- a/client_python/README.md
+++ b/client_python/README.md
@@ -1,433 +1,118 @@
----
-title: Grakn Python Client
-keywords: setup, getting started, download, driver
-tags: [getting-started]
-sidebar: documentation_sidebar
-permalink: /docs/language-drivers/client-python
-folder: docs
-symlink: true
----
+# Grakn Client Python
 
-# Grakn Python Client
+## Dependencies
+Before installing the Python `grakn` package, make sure the following dependencies are installed.
 
-A Python client for [Grakn](https://grakn.ai)
+- [Grakn >= 1.3.0](https://github.com/graknlabs/grakn/releases)
+- [Python >= 2.7](https://www.python.org/downloads/)
+- [PIP package manager](https://pip.pypa.io/en/stable/installing/)
 
-Works with Grakn >=1.3.0 up to this driver version, and Python >= 3.6
-
-# Installation
-
+## Installation
+```
+pip install grakn
+```
+If multiple Python versions are available, you may wish to use
 ```
 pip3 install grakn
 ```
 
-To obtain the Grakn database itself, head [here](https://grakn.ai/pages/documentation/get-started/setup-guide.html) for the setup guide.
+## Quickstart
+First make sure, the [Grakn server](http://dev.grakn.ai/docs/running-grakn/install-and-run#start-the-grakn-server) is running.
 
-# Quickstart
+In the interpreter or in your source, import `grakn`.
 
-## Grakn client, sessions, and transactions
-
-In the interpreter or in your source, import `grakn`:
-
-```
+```python
 import grakn
 ```
 
-You can then instantiate a client, open a session, and create transactions.     
-_NOTE_: Grakn's default gRPC port is 48555 for versions >=1.3. Port 4567 (the old default REST endpoint) is deprecated for clients.
+Instantiate a client and open a session.
 
-```
-client = grakn.Grakn(uri="localhost:48555")
-session = client.session(keyspace="mykeyspace")
-tx = session.transaction(grakn.TxType.WRITE)
-```
-
-Alternatively, you can also use `with` statements, which automatically closes sessions and transactions:
-```
+```python
 client = grakn.Grakn(uri="localhost:48555")
 with client.session(keyspace="mykeyspace") as session:
-    with session.transaction(grakn.TxType.READ) as tx:
-        ...
+  ## session is open
+  pass
+## session is closed
 ```
 
-Credentials can be passed into the initial constructor as a dictionary, if you are a KGMS user:
-```
-client = grakn.Grakn(uri='localhost:48555', credentials={'username': 'xxxx', 'password': 'yyyy'})
-```
+As specified above, Grakn's default gRPC port is `48555`. The port `4567` (previously used as the default REST endpoint) is deprecated for clients.
 
-If a transaction fails (throws exception), it automatically gets closed.
-Also note that closing a transaction means that _all concept objects retrieved from that transaction are no longer queryable via internal getters/setters_.
+We can also pass the credentials, as specified when [configuring authentication via Grakn Console](http://dev.grakn.ai/docs/management/users), into the client constructor as a dictionary.
 
-For example
-```
-# obtain a tx
-tx = session.transaction(grakn.TxType.READ)
-person_type = tx.get_schema_concept("person") # creates a local Concept object with the `tx` bound internally
-print("Label of person type: {0}".format(person_type.label()) # uses interal `tx` to retrieve label from server
-tx.close()
-# the following will raise an exception, internally bound transaction is closed
-print("Label of person type: {0}".format(person_type.label())
+```python
+client = grakn.Grakn(uri="localhost:48555", credentials={"username": "<username>", "password": "<password>"})
 ```
 
-## Basic retrievals and insertions 
+Create transactions to use for reading and writing data.
 
-You can execute Graql queries and iterate through the answers as follows:
-```
-# Perform a query that returns an iterator of ConceptMap answers
-answer_iterator = tx.query("match $x isa person; limit 10; get;") 
-# Request first response
-a_concept_map_answer = next(answer_iterator) 
-# Get the dictionary of variables : concepts, retrieve variable 'x'
-person = a_concept_map_answer.map()['x']      
+```python
+client = grakn.Grakn(uri="localhost:48555")
 
-# we can also iterate using a `for` loop
-some_people = []
-for concept_map in answer_iterator:           
-    # Get 'x' again, without going through .map()
-    some_people.append(concept_map.get('x'))    
-    break 
+with client.session(keyspace="mykeyspace") as session:
+  ## creating a write transaction
+  with session.transaction(grakn.TxType.WRITE) as write_transaction:
+    ## write transaction is open
+    ## write transaction must always be committed (closed)
+    write_transaction.commit()
 
-# skip the iteration and .get('x') and extract all the concepts in one go
-remaining_people = answer_iterator.collect_concepts() 
-
-# explicit close if not using `with` statements
-tx.close()
+  ## creating a read transaction
+  with session.transaction(grakn.TxType.READ) as read_transaction:
+    ## read transaction is open
+    ## if not using a `with` statement, we must always close the read transaction like so
+    # read_transaction.close()
 ```
 
-_NOTE_: queries will return almost immediately -- this is because Grakn lazily evaluates the request on the server when
-the local iterator is consumed, not when the request is created. Each time `next(iter)` is called, the client executes a fast RPC request 
-to the server to obtain the next concrete result.
+Running basic retrieval and insertion queries.
 
-You might also want to make some insertions using `.query()`
+```python
+client = grakn.Grakn(uri="localhost:48555")
+
+with client.session(keyspace="mykeyspace") as session:
+  ## creating a write transaction
+  with session.transaction(grakn.TxType.WRITE) as write_transaction:
+    insert_iterator = write_transaction.query("insert $x isa person has birth-date 2018-08-06;")
+    concepts = insert_iterator.collect_concepts()
+    print("Inserted a person with ID: {0}".format(concepts[0].id))
+    ## write transaction must be committed (closed)
+    write_transaction.commit()
+
+  ## creating a read transaction
+  with session.transaction(grakn.TxType.READ) as read_transaction:
+    answer_iterator = read_transaction.query("match $x isa person; limit 10; get;")
+
+    ## retrieve the first answer
+    a_concept_map_answer = next(answer_iterator)
+    ## get the dictionary of variables : concepts, retrieve variable 'x'
+    person = a_concept_map_answer.map().get("x")
+
+    ## we can also iterate using a `for` loop
+    some_people = []
+
+    for answer in answer_iterator:
+      some_people.append(answer.map().get("x"))
+      break ## skip the iteration, we are going to try something else
+
+    ## extract the rest of the people in one go
+    remaining_people = answer_iterator.collect_concepts()
+
+    ## if not using a `with` statement, then we must always close the read transaction
+    # read_transaction.close()
 ```
-# Perform insert query that returns an iterator of ConceptMap of inserted concepts
-insert_iterator = tx.query("insert $x isa person, has birth-date 2018-08-06;") 
-concepts = insert_iterator.collect_concepts()
-print("Inserted a person with ID: {0}".format(concepts[0].id))
-# Don't forget to commit() to persist changes
-tx.commit()
-```
+**Remember that transactions always need to be closed. The safest way is to use the `with ...` syntax which auto-closes at the end of the `with` block. Otherwise, remember to call `transaction.close()` explicitly.**
 
-Or you can use the methods available on Concept objects, known as the Concept API:
-```
-person_type = tx.get_schema_concept("person") # retrieve the "person" schema type 
-person = person_type.create()                 # instantiate a person
-birth_date_type = tx.get_schema_concept("birth-date") " retrieve the "birth-date" schema type
-date = datetime.datetime(year=2018, month=8, day=6) # requires `import datetime`
-birth_date = birth_date_type.create(date)     # instantiate a date with a python datetime object
-person.has(birth_date)                        # attach the birth_date concept to the person concept 
-tx.commit()                                   # write changes to Grakn 
-```
+To view examples of running various Graql queries using the Grakn Client Python, head over to their dedicated documentation pages as listed below.
 
+- [Insert](http://dev.grakn.ai/docs/query/insert-query)
+- [Get](http://dev.grakn.ai/docs/query/get-query)
+- [Delete](http://dev.grakn.ai/docs/query/delete-query)
+- [Aggregate](http://dev.grakn.ai/docs/query/aggregate-query)
+- [Compute](http://dev.grakn.ai/docs/query/compute-query)
 
-# API reference
+## Client Architecture
+To learn about the mechanism that a Grakn Client uses to set up communication with keyspaces running on the Grakn Server, refer to [Grakn > Client API > Overview]((http://dev.grakn.ai/docs/client-api/overview).
 
+## API Reference
+To learn about the methods available for executing queries and retrieving their answers using Client Python, refer to [Grakn > Client API > Python > API Reference](http://dev.grakn.ai/docs/client-api/python#api-reference).
 
-First create a new Grakn object/client with
-
-```
-// URI must be a string containing host address and gRPC port of a running Grakn instance, e.g. "localhost:48555"
-client = grakn.Grakn(URI)
-```
-
-on the Grakn object the following methods are available:
-
-**Grakn**
-
-| Method                                   | Return type       | Description                                          |
-| ---------------------------------------- | ----------------- | ---------------------------------------------------- |
-| `session(String keyspace)`               | *Session*         | Return a new Session bound to the specified keyspace |
-| `keyspaces().delete(String keyspace)`      | *None*            | Deletes the specified keyspace                       |
-| `keyspaces().retrieve()`                   | List of *String*  | Retrieves all available keyspaces                    |
-
-
-
-on the Session the following methods are available:
-
-**Session**
-
-| Method                            | Return type   | Description                                                                           |
-| --------------------------------- | ------------- | ------------------------------------------------------------------------------------- |
-| `transaction(grakn.TxType)`       | *Transaction* | Return a new Transaction bound to the keyspace of this session                        |
-| `close()`                         | *None*        | This must be used to correctly terminate session and close communication with server. |
-
-
-Once obtained a `Transaction` you will be able to:
-
- **Transaction**
-
-| Method                                                       | Return type               | Description                                                                                                                                                                                    |
-| ------------------------------------------------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `query(String graql_query, infer=True)`                      | Iterator of *Answer*      | Executes a Graql query on the session keyspace. It's possible to specify whether to enable inference, which is ON by default.                                                                  |
-| `commit()`                                                   | *None*                    | Commit current Transaction, persisting changes in the graph. After committing, the transaction will be closed and you will need to get a new one from the session                              |
-| `close()`                                                    | *None*                    | Closes current Transaction without committing. This makes the transaction unusable.                                                                                                            |
-| `get_concept(String concept_id)`                             | *Concept* or *None*       | Retrieves a Concept by ConceptId                                                                                                                                                               |
-| `get_schema_concept(String label)`                           | *SchemaConcept* or *None* | Retrieves a SchemaConcept by label                                                                                                                                                             |
-| `get_attributes_by_value(attribute_value, grakn.DataType)`   | Iterator of *Attribute*   | Get all Attributes holding the value provided, if any exist                                                                                                                                    |
-| `put_entity_type(String label)`                              | *EntityType*              | Create a new EntityType with super-type entity, or return a pre-existing EntityType with the specified label                                                                                   |
-| `put_relationship_type(String label)`                        | *RelationshipType*        | Create a new RelationshipType with super-type relation, or return a pre-existing RelationshipType with the specified label                                                                     |
-| `put_attribute_type(String label, grakn.DataType)`           | *AttributeType*           | Create a new AttributeType with super-type attribute, or return a pre-existing AttributeType with the specified label and DataType                                                             |
-| `put_role(String label)`                                     | *Role*                    | Create a Role, or return a pre-existing Role, with the specified label.                                                                                                                        |
-| `put_rule(String label, String when, String then)`           | *Rule*                    | Create a Rule, or return a pre-existing Rule, with the specified label                                                                                                                         |
-
-**Iterator**
-
-Some of the following Concept methods return a python iterator, which can be converted into a list using standard constructs such as `list(iterator)`. The iterator will either return *Answer* or *Concept* objects.
-
-| Method                    | Return type                 | Description                                                                                                                                                                                                                                                               |
-| ------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `collect_concepts()`      | List of *Concept*           | Consumes the iterator and return list of Concepts. **This helper is useful on Iterator that return ConceptMap answer types**. It is useful when one wants to work directly on Concepts without the need to traverse the result map or access the explanation. |
-
-_NOTE_: these iterators represent a lazy evaluation of a query or method on the Grakn server, and will be created very quickly. The actual work
-is performed when the iterator is consumed, creating an RPC to the server to obtain the next concrete `Answer` or `Concept`.
-
-
-**Answer**
-
-This object represents a query answer and it is contained in the Iterator returned by `transaction.query()` method.     
-There are **different types of Answer**, based on the type of query executed a different type of Answer will be returned:   
-
-| Query Type                           | Answer Type       |
-|--------------------------------------|-------------------|
-| `define`                               | ConceptMap        |
-| `undefine`                             | ConceptMap        |
-| `get`                                  | ConceptMap        |
-| `insert`                               | ConceptMap        |
-| `delete`                               | ConceptMap        |
-| `aggregate count/min/max/sum/mean/std` |  Value            |
-| `aggregate group`                      | AnswerGroup       |
-| `compute count/min/max/sum/mean/std`   | Value             |
-| `compute path`                         | ConceptList       |
-| `compute cluster`                      | ConceptSet        |
-| `compute centrality`                  | ConceptSetMeasure |
-
-**ConceptMap**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `map()`         | Dict of *str* to *Concept* | Returns result dictionary in which every variable name (key) is linked to a Concept.          |
-| `explanation()` | *Explanation* or *null*    | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**Value**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `number()`      | int or float             | Returns numeric value of the Answer.                                                            |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptList**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `list()`        | Array of *String*        | Returns list of Concept IDs.                                                                    |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptSet**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `set()`         | Set of *String*          | Returns a set containing Concept IDs.                                                           |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**ConceptSetMeasure**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `measurement()` | int or float             | Returns numeric value that is associated to the set of Concepts contained in the current Answer.|
-| `set()`         | Set of *String*          | Returns a set containing Concept IDs.                                                           |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**AnswerGroup**
-
-| Method          | Return type              | Description                                                                                     |
-| --------------- | ------------------------ | ----------------------------------------------------------------------------------------------- |
-| `owner()`       | *Concept*                | Returns the Concepts which is the group owner.                                                  |
-| `answers()`     | List of *Answer*         | Returns list of Answers that belongs to this group.                                             |
-| `explanation()` | *Explanation* or *null*  | Returns an Explanation object if the current Answer contains inferred Concepts, null otherwise. |
-
-**Explanation**
-
-| Method           | Return type       | Description                                                                                 |
-| ---------------- | ----------------- | ------------------------------------------------------------------------------------------- |
-| `query_pattern()`| String            | Returns a query pattern that describes how the owning answer was retrieved.                 |
-| `answers()`      | List of *Answer*  | Set of deducted/factual answers that allowed us to determine that the owning answer is true |
-
-
-**Concepts hierarchy**
-
-Grakn is composed of different types of Concepts, that have a specific hierarchy
-
-```
-                                                Concept
-                                                /       \
-                                              /           \
-                                            /               \
-                                          /                   \
-                                  SchemaConcept                    Thing
-                                  /     |    \                    /   |  \
-                                /       |     \                 /     |    \
-                              /         |      \              /       |      \
-                            Type      Rule    Role     Entity    Attribute   Relationship
-                        /     |   \
-                      /       |     \
-                    /         |       \
-            EntityType  AttributeType  RelationshipType
-```
----
-
-All Concepts are bound to the transaction that has been used to retrieve them.
-If for any reason a trasaction gets closed all the concepts bound to it won't be able to
-communicate with the database anymore, so all the methods won't work and the user will have to re-query
-for the needed concepts.
-
-All setters return the same concept object (`self`) to facilitate chaining setters (e.g. `person.has(name).has(age)`).
-
----
-
-**Concept**
-
-These fields are accessible in every `Concept`:
-
-| Field                   | Type        | Description                                      |
-| ----------------------  | ----------- | ------------------------------------------------ |
-| `id`                    | *String*      | Delete concept                                   |
-
-These methods are available on every type of `Concept`
-
-| Method                  | Return type | Description                                      |
-| ----------------------  | ----------- | ------------------------------------------------ |
-| `delete()`              | *None*      | Delete concept                                   |
-| `is_schema_concept()`   | *Boolean*   | Check whether this Concept is a SchemaConcept    |
-| `is_type() `            | *Boolean*   | Check whether this Concept is a Type             |
-| `is_thing() `           | *Boolean*   | Check whether this Concept is a Thing            |
-| `is_attribute_type()`   | *Boolean*   | Check whether this Concept is an AttributeType   |
-| `is_entity_type() `     | *Boolean*   | Check whether this Concept is an EntityType      |
-| `is_relationship_type()`| *Boolean*   | Check whether this Concept is a RelationshipType |
-| `is_role()`             | *Boolean*   | Check whether this Concept is a Role             |
-| `is_rule()`             | *Boolean*   | Check whether this Concept is a Rule             |
-| `is_attribute()`        | *Boolean*   | Check whether this Concept is an Attribute       |
-| `is_entity()`           | *Boolean*   | Check whether this Concept is a Entity           |
-| `is_relationship()`     | *Boolean*   | Check whether this Concept is a Relationship     |
-
-  **Schema concept**
-
-A `SchemaConcept` concept has all the `Concept` methods plus the following:
-
-| Method                      | Return type                 | Description                                                                                                                                                          |
-| --------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label()`                   | *String*                    | Get label of this SchemaConcept                                                                                                                                      |
-| `label(String value)`       | *None*                      | Set label of this SchemaConcept                                                                                                                                      |
-| `is_implicit()`             | *Boolean*                   | Returns `True` when the SchemaConcept is implicit, i.e. when it's been created by Grakn and not explicitly by the user, `False` when explicitly created by the user. |
-| `sup(Type)`                 | *None*                      | Set direct super SchemaConcept of this SchemaConcept                                                                                                                 |
-| `sup()`                     | *SchemaConcept*  or *None*  | Get direct super SchemaConcept of this SchemaConcept                                                                                                                 |
-| `subs()`                    | Iterator of *SchemaConcept* | Get all indirect subs of this SchemaConcept.                                                                                                                         |
-| `sups()`                    | Iterator of *SchemaConcept* | Get all indirect sups of this SchemaConcept.                                                                                                                         |
-
-  **Thing**
-
- A `Thing` concept has all the `Concept` methods plus the following:
-
- | Method                               | Return type                | Description                                                                                                                                                                       |
- | ------------------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | `is_inferred()`                      | *Boolean*                  | Returns `True` if this Thing is inferred by Reasoner, `False` otherwise                                                                                                           |
- | `type()`                             | *Type*                     | Returns a Type which is the type of this Thing. This Thing is an instance of that type.                                                                                           |
- | `relationships(*Role)`               | Iterator of *Relationship* | Returns Relationships which this Thing takes part in, which may **optionally** be narrowed to a particular set according to the Roles you are interested in                       |
- | `attributes(*AttributeType)`         | Iterator of *Attribute*    | Returns Attributes attached to this Thing, which may **optionally** be narrowed to a particular set according to the AttributeTypes you are interested in                         |
- | `roles()`                            | Iterator of *Role*         | Returns the Roles that this Thing is currently playing                                                                                                                            |
- | `keys(*AttributeType)`               | Iterator of *Attribute*    | Returns a collection of Attribute attached to this Thing as a key, which may **optionally** be narrowed to a particular set according to the AttributeTypes you are interested in |
- | `has(Attribute)`                     | *None*                     | Attaches the provided Attribute to this Thing                                                                                                                                     |
- | `unhas(Attribute)`                   | *None*                     | Removes the provided Attribute from this Thing                                                                                                                                    |
-
-  **Attribute**
-
-  An `Attribute` concept has all the `Thing` methods plus the following:
-
-
- | Method             | Return type         | Description                                               |
- | ------------------ | ------------------- | --------------------------------------------------------- |
- | `value()`    | *String*            | Get value of this Attribute                               |
- | `owners()`   | Iterator of *Thing* | Returns the set of all Things that possess this Attribute |
-
-  **Relationship**
-
-A `Relationship` concept has all the `Thing` methods plus the following:
-
-
-| Method                        | Return type               | Description                                                                                              |
-| ----------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------- |
-| `role_players_map()`          | Dict[*Role*, set[*Thing*]]| Returns a dictionary that links all the Roles of this Relationship to all the Things that are playing each Role |
-| `role_players(*Role)`         | Iterator of *Thing*       | Returns a list of every Thing involved in this Relationship, optionally filtered by Roles played         |
-| `assign(Role, Thing)`         | *None*                    | Expands this Relationship to include a new role player (Thing) which is playing a specific Role          |
-| `unassign(Role, Thing)`       | *None*                    | Removes the Thing which is playing a Role in this Relationship.                                          |  |
-
-    NB: There are no specific methods for `Entity` concept.
-
-  **Type**
-
-A `Type` concept has all the `SchemaConcept` methods plus the following:
-
-
-| Method                       | Return type                 | Description                                                                                                                    |
-| ---------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `is_abstract(Boolean)`       | *None*                      | Sets the Type to be abstract - which prevents it from having any instances                                                     |
-| `is_abstract()`              | *Boolean*                   | Returns `True` if the type is set to abstract, `False` otherwise                                                               |
-| `playing()`                  | Iterator of *Role*          | Returns all the Roles which instances of this Type can indirectly play                                                         |
-| `plays(Role)`                | *None*                      | Add a new Role to the ones that the instances of this Type are allowed to play                                                 |
-| `attributes()`               | Iterator of *AttributeType* | The AttributeTypes which this Type is linked with.                                                                             |
-| `instances()`                | Iterator of *Thing*         | Get all indirect instances of this Type                                                                                        |
-| `keys()`                     | Iterator of *AttributeType* | The AttributeTypes which this Type is linked with as a key                                                                     |
-| `key(AttributeType)`         | *None*                      | Creates an implicit RelationshipType which allows this Type and a AttributeType to be linked in a strictly one-to-one mapping. |
-| `has(AttributeType)`         | *None*                      | Add a new AttributeType which the instances of this Type are allowed to have attached to themselves                            |
-| `unplay(Role)`               | *None*                      | Delete a Role from the ones that the instances of this Type are allowed to play                                                |
-| `unhas(AttributeType)`       | *None*                      | Delete AttributeType from the ones that the instances of this Type are allowed to have attached to themselves                  |
-| `unkey(AttributeType)`       | *None*                      | Delete AttributeType from available keys                                                                                       |
-
-  **AttributeType**
-
-  An `AttributeType` concept has all the `Type` methods plus the following:
-
-
-  | Method                      | Return type           | Description                                                                                                                                 |
-  | --------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `create(value)`             | *Attribute*           | Create new Attribute of this type with the provided value. The value provided must conform to the DataType specified for this AttributeType |
-  | `attribute(value)`          | *Attribute* or *None* | Retrieve the Attribute with the provided value if it exists                                                                                 |
-  | `data_type()`               | *Enum of Grakn.DataType*   | Get the data type to which instances of the AttributeType must have                                                                         |
-  | `regex()`                   | *String* or *None*    | Retrieve the regular expression to which instances of this AttributeType must conform to, or `None` if no regular expression is set         |
-  | `regex(String regex)`       | *None*                | Set the regular expression that instances of the AttributeType must conform to                                                              |
-
-  **RelationshipType**
-
-  A `RelationshipType` concept has all the `Type` methods plus the following:
-
- | Method                 | Return type        | Description                                                                          |
- | ---------------------- | ------------------ | ------------------------------------------------------------------------------------ |
- | `create()`             | *Relationship*     | Creates and returns a new Relationship instance, whose direct type will be this type |
- | `roles()`              | Iterator of *Role* | Returns a list of the RoleTypes which make up this RelationshipType                  |
- | `relates(Role)`        | *None*             | Sets a new Role for this RelationshipType                                            |
- | `unrelate(Role)`       | *None*             | Delete a Role from this RelationshipType                                             |
-
-  **EntityType**
-
-  An `EntityType` concept has all the `Type` methods plus the following:
-
-  | Method           | Return type | Description                                                                    |
-  | ---------------- | ----------- | ------------------------------------------------------------------------------ |
-  | `create()`       | *Entity*    | Creates and returns a new Entity instance, whose direct type will be this type |
-
-
-  **Role**
-
-  A `Role` concept has all the `SchemaConcept` methods plus the following:
-
-| Method                  | Return type                    | Description                                                 |
-| ----------------------- | ------------------------------ | ----------------------------------------------------------- |
-| `relationships()`       | Iterator of *RelationshipType* | Returns the RelationshipTypes that this Role takes part in. |
-| `players()`             | Iterator of *Type*             | Returns a collection of the Types that can play this Role   |
-
-  **Rule**
-
-A `Rule` concept has all the `SchemaConcept` methods plus the following:
-
-| Method            | Return type | Description                                                                                                |
-| ----------------- | ----------- | ---------------------------------------------------------------------------------------------------------- |
-| `get_when()`      | *String*    | Retrieves the when part of this Rule. When this query is satisfied the "then" part of the rule is executed |
-| `get_then()`      | *String*    | Retrieves the then part of this Rule. This query is executed when the "when" part of the rule is satisfied |
+## Concept API
+To learn about the methods available on the concepts retrieved as the answers to Graql queries, refer to [Grakn > Concept API > Overview](http://dev.grakn.ai/docs/concept-api/overview)


### PR DESCRIPTION
# Why is this PR needed?
To update the readme for clients Java, Node.js and Python to keep them consistent with the documentation.

# What does the PR do?
Updates the `README.MD` of each client, to provide:
- installation instructions (inc. dependencies)
- a quickstart example
- references to the examples queries in the docs
- reference to the API Reference in the docs
- reference to the Concept API in the docs

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
The minimal redundant content that exists both in the `README.MD` files and in the corresponding page in the documentation, need to stay in sync.