### PR TITLE
Support multiple targets in checkstyle_test; fix #4767

### DIFF
--- a/check-for-missing-checkstyle-rule.py
+++ b/check-for-missing-checkstyle-rule.py
@@ -19,28 +19,44 @@
 #
 
 from __future__ import print_function
+from itertools import chain
+import os
 from pprint import pprint
 from xml.etree import ElementTree
 import subprocess
 import sys
 
 
-java_targets = set(subprocess.check_output([
+def check_output_discarding_stderr(*args, **kwargs):
+    with open(os.devnull, 'w') as devnull:
+        return subprocess.check_output(*args, stderr=devnull, **kwargs)
+
+
+print('Checking if there are any source files not covered by checkstyle...')
+
+java_targets = set(check_output_discarding_stderr([
     'bazel', 'query',
     '(kind(java_library, //...) union kind(java_test, //...)) '
     'except //dependencies/... except attr("tags", "checkstyle_ignore", //...)'
 ]).split())
 
-checkstyle_targets_xml = subprocess.check_output([
+checkstyle_targets_xml = check_output_discarding_stderr([
     'bazel', 'query', 'kind(checkstyle_test, //...)', '--output', 'xml'
 ])
 checkstyle_targets_tree = ElementTree.fromstring(checkstyle_targets_xml)
 checkstyle_targets = set(map(lambda x: x.get('value'),
-                             checkstyle_targets_tree.findall(".//label[@name='target'][@value]")))
+                             chain(
+                                 checkstyle_targets_tree.findall(".//label[@name='target'][@value]"),
+                                 checkstyle_targets_tree.findall(".//list[@name='targets']//label[@value]"),
+                             )))
 
 java_targets_with_no_checkstyle = java_targets - checkstyle_targets
+target_count = len(java_targets_with_no_checkstyle)
 
 if java_targets_with_no_checkstyle:
-    print('Java targets with no attached checkstyle_test rule')
-    pprint(java_targets_with_no_checkstyle)
+    print('ERROR: Found %d bazel targets which are not covered by a `checkstyle_test`:' % target_count)
+    for i, target_label in enumerate(java_targets_with_no_checkstyle, start=1):
+        print('%d: %s' % (i, target_label))
     sys.exit(1)
+else:
+    print('SUCCESS: Every source code is covered by a `checkstyle_test`!')


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4767

# What does the PR do?

* Adds `targets` attribute to `checkstyle_test` while still supporting *both* new `targets` and old `target`
* Adds support for `targets`-covered Java targets to `check-for-missing-checkstyle-rule.py`
* Makes messages in `check-for-missing-checkstyle-rule.py` more user-friendly

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

* Introducing naming convention for `checkstyle_test` targets with multiple packages (`checkstyle`?) (`package-name-checkstyle`?)
* Merging several `-checkstyle` targets in one package into one
* Removing support for `target` (attribute for checking single target)
