### PR TITLE
RPMs should be built locally, without RBE

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,4 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-build:rbe --remote_local_fallback --remote_local_fallback_strategy=sandboxed --noremote_upload_local_results
+build:rbe --strategy_regexp=MakeRpm*=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,3 +25,4 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
+build:rbe --remote_local_fallback --remote_local_fallback_strategy=sandboxed --noremote_upload_local_results

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,11 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
+# TODO(vmax): replace with upstream once graknlabs/deplyment#23 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/graknlabs/deployment",
-    commit="1fd6f328d55b28ca70b047894917cb169d5f028e",
+    remote="https://github.com/vmax/graknlabs-deployment",
+    commit="86cd131aa4d775db3c84072dd1939acf306253d3",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")


### PR DESCRIPTION
# Why is this PR needed?

Needs graknlabs/deployment#23
Fixes RPM failing on RBE

# What does the PR do?

Uses new rules which include `no-remote` tag

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—
