### PR TITLE
spawn MakeRpm actions locally

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,4 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-build:rbe --strategy_regexp=MakeRpm*=local
+build:rbe --strategy_regexp=//:deploy-rpm,//:server:deploy-rpm,//console:deploy-rpm=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,6 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-build:rbe --strategy_regexp=console/deploy-rpm,server/deploy-rpm,deploy-rpm=local
+build:rbe --strategy_regexp=console/deploy-rpm=local
+build:rbe --strategy_regexp=server/deploy-rpm=local
+build:rbe --strategy_regexp=deploy-rpm=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,3 +25,4 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
+build:rbe --strategy_regexp=MakeRpm*=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,10 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-build:rbe --strategy_regexp=console/deploy-rpm=local
-build:rbe --strategy_regexp=server/deploy-rpm=local
-build:rbe --strategy_regexp=deploy-rpm=local
+# The following configurations force Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
+# The deploy_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
+# It won't be available in some distributions and therefore can't be ran in RBE.
+# When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions
+# (you can look at what actions are produced when a target is executed by adding -s: bazel build -s //target:name).
+# Here we configure Bazel to execute "MakeRpm" actions locally:
+build:rbe --strategy_regexp=MakeRpm=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,4 +25,4 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-build:rbe --strategy_regexp=//:deploy-rpm,//:server:deploy-rpm,//console:deploy-rpm=local
+build:rbe --strategy_regexp=console/deploy-rpm,server/deploy-rpm,deploy-rpm=local

--- a/.bazelrc
+++ b/.bazelrc
@@ -25,7 +25,8 @@ build:rbe --genrule_strategy=remote
 build:rbe --define=EXECUTOR=remote
 build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
-# The following configurations force Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
+
+# The following configuration forces Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
 # The deploy_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
 # It won't be available in some distributions and therefore can't be ran in RBE.
 # When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions


### PR DESCRIPTION
# Why is this PR needed?

Fixes `console`, `server` and `build` steps on CI where we build RPMs

# What does the PR do?

Avoids executing `MakeRpm` action on RBE

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—
