### PR TITLE
Use distribution_* rules in place of deploy_* rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,7 +27,7 @@ build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true
 
 # The following configuration forces Bazel to execute rules which depends on pkg_rpm() locally instead of in RBE.
-# The deploy_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
+# The distribution_rpm() macro uses pkg_rpm() which uses the 'rpmbuild' binary under the hood.
 # It won't be available in some distributions and therefore can't be ran in RBE.
 # When executed, the pkg_rpm() rule will produce the "MakeRpm" Bazel actions
 # (you can look at what actions are produced when a target is executed by adding -s: bazel build -s //target:name).

--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@
 
 exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
 load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "deploy_deb", "deploy_rpm")
+load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "distribution_deb", "distribution_rpm")
 
 
 py_binary(
@@ -60,7 +60,7 @@ deploy_brew(
     version_file = "//:VERSION"
 )
 
-deploy_deb(
+distribution_deb(
     name = "deploy-deb",
     package_name = "grakn-core-bin",
     maintainer = "Grakn Labs <community@grakn.ai>",
@@ -88,7 +88,7 @@ deploy_deb(
 )
 
 
-deploy_rpm(
+distribution_rpm(
     name = "deploy-rpm",
     package_name = "grakn-core-bin",
     installation_dir = "/opt/grakn/core/",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,7 +144,7 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_rules_deployment",
     remote="https://github.com/graknlabs/deployment",
-    commit="1fd6f328d55b28ca70b047894917cb169d5f028e",
+    commit="fa9219eab886a013650af17642940df5f408252e",
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/console/BUILD
+++ b/console/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:__subpackages__"])
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "deploy_deb", "deploy_rpm")
+load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "distribution_deb", "distribution_rpm")
 
 java_library(
     name = "console",
@@ -83,7 +83,7 @@ distribution(
     output_filename = "grakn-core-console",
 )
 
-deploy_deb(
+distribution_deb(
     name = "deploy-deb",
     package_name = "grakn-core-console",
     maintainer = "Grakn Labs <community@grakn.ai>",
@@ -101,7 +101,7 @@ deploy_deb(
 )
 
 
-deploy_rpm(
+distribution_rpm(
     name = "deploy-rpm",
     package_name = "grakn-core-console",
     installation_dir = "/opt/grakn/core/console/",

--- a/server/BUILD
+++ b/server/BUILD
@@ -19,7 +19,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "deploy_deb", "deploy_rpm")
+load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "distribution_deb", "distribution_rpm")
 
 exports_files(
     glob(["conf/**", "services/**"]),
@@ -137,7 +137,7 @@ distribution(
     output_filename = "grakn-core-server",
 )
 
-deploy_deb(
+distribution_deb(
     name = "deploy-deb",
     package_name = "grakn-core-server",
     maintainer = "Grakn Labs <community@grakn.ai>",
@@ -170,7 +170,7 @@ deploy_deb(
 )
 
 
-deploy_rpm(
+distribution_rpm(
     name = "deploy-rpm",
     package_name = "grakn-core-server",
     installation_dir = "/opt/grakn/core/server/",


### PR DESCRIPTION
# Why is this PR needed?

Uses up-to-date `@graknlabs_rules_deployment`

# What does the PR do?

Replaces `deploy_(deb|rpm)` rules with `distribution_(deb|rpm)` rules so their purpose is clear

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—