### PR TITLE
Use updated distribution rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,6 +28,7 @@ py_binary(
     main = "deployment.py"
 )
 
+
 distribution_structure(
     name = "grakn-core-bin",
     additional_files = {
@@ -38,27 +39,6 @@ distribution_structure(
     visibility = ["//server:__pkg__", "//console:__pkg__"]
 )
 
-distribution_zip(
-    name = "distribution",
-    distribution_structures = ["//:grakn-core-bin",
-                               "//server:grakn-core-server",
-                               "//console:grakn-core-console"],
-    empty_directories = [
-        "server/db/cassandra",
-        "server/db/queue"
-    ],
-    permissions = {
-        "server/services/cassandra/cassandra.yaml": "0777",
-        "server/db/cassandra": "0777",
-        "server/db/queue": "0777",
-    },
-    output_filename = "grakn-core-all",
-)
-
-deploy_brew(
-    name = "deploy-brew",
-    version_file = "//:VERSION"
-)
 
 distribution_deb(
     name = "distribution-deb",
@@ -101,4 +81,28 @@ distribution_rpm(
         "usr/local/bin/grakn": "/opt/grakn/core/grakn",
         "opt/grakn/core/logs": "/var/log/grakn/",
     },
+)
+
+
+distribution_zip(
+    name = "distribution",
+    distribution_structures = ["//:grakn-core-bin",
+                               "//server:grakn-core-server",
+                               "//console:grakn-core-console"],
+    empty_directories = [
+        "server/db/cassandra",
+        "server/db/queue"
+    ],
+    permissions = {
+        "server/services/cassandra/cassandra.yaml": "0777",
+        "server/db/cassandra": "0777",
+        "server/db/queue": "0777",
+    },
+    output_filename = "grakn-core-all",
+)
+
+
+deploy_brew(
+    name = "deploy-brew",
+    version_file = "//:VERSION"
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,11 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
+# TODO(vmax): replace with upstream once graknlabs/deployment#25 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/graknlabs/deployment",
-    commit="fa9219eab886a013650af17642940df5f408252e",
+    remote="https://github.com/vmax/graknlabs-deployment",
+    commit="27cbb7404a8c8598ce7c9a250f7ff24665551b7b"
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,11 +141,10 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
-# TODO(vmax): replace with upstream once graknlabs/deployment#25 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/vmax/graknlabs-deployment",
-    commit="27cbb7404a8c8598ce7c9a250f7ff24665551b7b"
+    remote="https://github.com/graknlabs/deployment",
+    commit="8d68b4f13fe063ed7ccd04c29ab5f91e81fba052"
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/console/BUILD
+++ b/console/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:__subpackages__"])
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "distribution_deb", "distribution_rpm")
+load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
 
 java_library(
     name = "console",
@@ -70,11 +70,21 @@ deploy_maven_jar(
     package = "console",
 )
 
-distribution(
-    name = "distribution",
+distribution_structure(
+    name="grakn-core-console",
     targets = {
         "//console:console-binary": "console/services/lib/"
     },
+    additional_files = {
+        "//server:conf/logback.xml": "console/conf/logback.xml",
+        "//server:conf/grakn.properties": "console/conf/grakn.properties",
+    },
+    visibility = ["//:__pkg__"]
+)
+
+distribution_zip(
+    name = "distribution",
+    distribution_structures = [":grakn-core-console", "//:grakn-core-bin"],
     additional_files = {
         "//:grakn": 'grakn',
         "//server:conf/logback.xml": "conf/logback.xml",
@@ -84,7 +94,7 @@ distribution(
 )
 
 distribution_deb(
-    name = "deploy-deb",
+    name = "distribution-deb",
     package_name = "grakn-core-console",
     maintainer = "Grakn Labs <community@grakn.ai>",
     description = "Grakn Core (console)",
@@ -93,8 +103,8 @@ distribution_deb(
       "openjdk-8-jre",
       "grakn-core-bin"
     ],
-    target = ":console-binary",
-    installation_dir = "/opt/grakn/core/console/",
+    distribution_structures = [":grakn-core-console"],
+    installation_dir = "/opt/grakn/core/",
     empty_dirs = [
          "opt/grakn/core/console/services/lib/",
     ],
@@ -102,12 +112,12 @@ distribution_deb(
 
 
 distribution_rpm(
-    name = "deploy-rpm",
+    name = "distribution-rpm",
     package_name = "grakn-core-console",
-    installation_dir = "/opt/grakn/core/console/",
+    installation_dir = "/opt/grakn/core/",
     version_file = "//:VERSION",
     spec_file = "//dependencies/distribution/rpm:grakn-core-console.spec",
-    target = ":console-binary",
+    distribution_structures = [":grakn-core-console"],
     empty_dirs = [
          "opt/grakn/core/console/services/lib/",
     ],

--- a/dependencies/distribution/rpm/grakn-core-bin.spec
+++ b/dependencies/distribution/rpm/grakn-core-bin.spec
@@ -5,7 +5,7 @@ Summary: Grakn Core (bin)
 URL: https://grakn.ai
 License: Apache License, v2.0
 
-Source0: {_grakn-core-bin-rpm-tar.tgz}
+Source0: {_grakn-core-bin-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
 
@@ -18,7 +18,7 @@ Grakn Core (server) - description
 
 %install
 mkdir -p %{buildroot}
-tar -xvf {_grakn-core-bin-rpm-tar.tgz} -C %{buildroot}
+tar -xvf {_grakn-core-bin-rpm-tar.tar.gz} -C %{buildroot}
 
 %files
 

--- a/dependencies/distribution/rpm/grakn-core-console.spec
+++ b/dependencies/distribution/rpm/grakn-core-console.spec
@@ -5,9 +5,10 @@ Summary: Grakn Core (console)
 URL: https://grakn.ai
 License: Apache License, v2.0
 
-Source0: {_grakn-core-console-rpm-tar.tgz}
+Source0: {_grakn-core-console-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
+Requires: grakn-core-bin
 
 %description
 Grakn Core (server) - description
@@ -18,7 +19,7 @@ Grakn Core (server) - description
 
 %install
 mkdir -p %{buildroot}
-tar -xvf {_grakn-core-console-rpm-tar.tgz} -C %{buildroot}
+tar -xvf {_grakn-core-console-rpm-tar.tar.gz} -C %{buildroot}
 
 %files
 

--- a/dependencies/distribution/rpm/grakn-core-server.spec
+++ b/dependencies/distribution/rpm/grakn-core-server.spec
@@ -5,9 +5,10 @@ Summary: Grakn Core (server)
 URL: https://grakn.ai
 License: Apache License, v2.0
 
-Source0: {_grakn-core-server-rpm-tar.tgz}
+Source0: {_grakn-core-server-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
+Requires: grakn-core-bin
 
 %description
 Grakn Core (server) - description
@@ -18,7 +19,7 @@ Grakn Core (server) - description
 
 %install
 mkdir -p %{buildroot}
-tar -xvf {_grakn-core-server-rpm-tar.tgz} -C %{buildroot}
+tar -xvf {_grakn-core-server-rpm-tar.tar.gz} -C %{buildroot}
 
 %files
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -19,7 +19,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution", "distribution_deb", "distribution_rpm")
+load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
 
 exports_files(
     glob(["conf/**", "services/**"]),
@@ -112,19 +112,25 @@ deploy_maven_jar(
     package = "server",
 )
 
-distribution(
-    name = "distribution",
+distribution_structure(
+    name="grakn-core-server",
     targets = {
         "//server:server-binary": "server/services/lib/"
     },
     additional_files = {
-     "//:grakn": 'grakn',
-     "//server:conf/logback.xml": "conf/logback.xml",
-     "//server:conf/grakn.properties": "conf/grakn.properties",
-     "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
-     "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
-     "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"
+        "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
+        "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
+        "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"
     },
+    permissions = {
+      "server/services/cassandra/cassandra.yaml": "0777",
+    },
+    visibility = ["//:__pkg__"]
+)
+
+distribution_zip(
+    name = "distribution",
+    distribution_structures = [":grakn-core-server", "//:grakn-core-bin"],
     empty_directories = [
         "server/db/cassandra",
         "server/db/queue"
@@ -138,7 +144,7 @@ distribution(
 )
 
 distribution_deb(
-    name = "deploy-deb",
+    name = "distribution-deb",
     package_name = "grakn-core-server",
     maintainer = "Grakn Labs <community@grakn.ai>",
     description = "Grakn Core (server)",
@@ -147,20 +153,14 @@ distribution_deb(
       "openjdk-8-jre",
       "grakn-core-bin"
     ],
-    target = ":server-binary",
-    installation_dir = "/opt/grakn/core/server/",
+    distribution_structures = [":grakn-core-server"],
+    installation_dir = "/opt/grakn/core/",
     empty_dirs = [
         "opt/grakn/core/server/services/lib/",
         "var/lib/grakn/db/queue",
         "var/lib/grakn/db/cassandra"
      ],
-    files = {
-        "//server:services/cassandra/cassandra.yaml": "services/cassandra/cassandra.yaml",
-        "//server:services/cassandra/logback.xml": "services/cassandra/logback.xml",
-        "//server:services/grakn/grakn-core-ascii.txt": "services/grakn/grakn-core-ascii.txt"
-    },
     permissions = {
-        "services/cassandra/cassandra.yaml": "0777",
         "var/lib/grakn/db/queue": "0777",
         "var/lib/grakn/db/cassandra": "0777",
     },
@@ -171,12 +171,12 @@ distribution_deb(
 
 
 distribution_rpm(
-    name = "deploy-rpm",
+    name = "distribution-rpm",
     package_name = "grakn-core-server",
-    installation_dir = "/opt/grakn/core/server/",
+    installation_dir = "/opt/grakn/core/",
     version_file = "//:VERSION",
     spec_file = "//dependencies/distribution/rpm:grakn-core-server.spec",
-    target = ":server-binary",
+    distribution_structures = [":grakn-core-server"],
     empty_dirs = [
         "opt/grakn/core/server/services/lib/",
         "var/lib/grakn/db/queue",


### PR DESCRIPTION
# Why is this PR needed?

Needs graknlabs/deployment#25
Uses updated `distribution_*` rules

# What does the PR do?

* Replaces old `distribution` with `distribution_structure` + `distribution_zip` which has clearer semantics
* Uses updated `distribution_deb` and `distribution_rpm` rules which depend on `distribution_structure`

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—