### PR TITLE
Configuration settings bug

### DIFF
--- a/workbase/src/renderer/components/shared/Preferences.vue
+++ b/workbase/src/renderer/components/shared/Preferences.vue
@@ -17,7 +17,6 @@
                     <h1 class="connection-label port">Port:</h1>
                     <input class="input" type="number" v-model="serverPort">
                     <loading-button v-on:clicked="testConnection" :text="connectionTest" className="btn test-btn" :loading="connectionTest === 'testing'"></loading-button>
-                    <!-- <button @click="testConnection" :class="connectionTest" class="btn test-btn" :disabled="(connectionTest !== 'Test')? true : false">{{connectionTest}}</button> -->
                 </div>
             </div>
 

--- a/workbase/src/renderer/components/shared/Preferences.vue
+++ b/workbase/src/renderer/components/shared/Preferences.vue
@@ -16,7 +16,8 @@
                     <input class="input" v-model="serverHost">
                     <h1 class="connection-label port">Port:</h1>
                     <input class="input" type="number" v-model="serverPort">
-                    <button @click="testConnection" :class="connectionTest" class="btn test-btn" :disabled="(connectionTest !== 'Test')? true : false">{{connectionTest}}</button>
+                    <loading-button v-on:clicked="testConnection" :text="connectionTest" className="btn test-btn" :loading="connectionTest === 'testing'"></loading-button>
+                    <!-- <button @click="testConnection" :class="connectionTest" class="btn test-btn" :disabled="(connectionTest !== 'Test')? true : false">{{connectionTest}}</button> -->
                 </div>
             </div>
 
@@ -219,6 +220,7 @@ export default {
   },
   methods: {
     testConnection() {
+      this.connectionTest = 'testing';
       this.$store.dispatch('initGrakn');
     },
     addNewKeyspace() {


### PR DESCRIPTION
# Why is this PR needed?
Closes: #4707
When the host is changed as follows: 127.0.0.1 -> 127.0.0.12
The server takes time to check if grakn is running resulting in the test button text to remain as 'Test'

# What does the PR do?
Replaces the test button with a loading button so it waits on the isGraknRunning flag to be set when the host is changed.

# Does it break backwards compatibility?
No 

# List of future improvements not on this PR
Have an API endpoint to see if Grakn is running