### PR TITLE
run //workbase:tests-e2e in local mode temporarily until we make it work with RBE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,19 +151,16 @@ jobs:
     - checkout
     - bazel_install
     - bazel_add_rbe_credential
-    - bazel:
-        command: bazel test //workbase:tests-unit --test_output=errors
+    - run: bazel test //workbase:tests-unit --test_output=errors
     - run: sudo apt install xvfb libxtst6 libxss1 libgtk2.0-0 -y
     - run: sudo apt install libnss3 libasound2 libgconf-2-4 -y
-    - bazel:
-        command: bazel build //:distribution
+    - run: bazel build //:distribution
     - run: unzip bazel-genfiles/grakn-core-all.zip -d bazel-genfiles/dist/
     - run: nohup bazel-genfiles/dist/grakn-core-all/grakn server start
     - run: bazel-genfiles/dist/grakn-core-all/grakn console -f `pwd`/test-end-to-end/test-fixtures/basic-genealogy.gql -k gene
     - run: Xvfb :99 &
     - run: export DISPLAY=:99
-    - bazel:
-        command: bazel test //workbase:tests-e2e --test_output=streamed
+    - run: bazel test //workbase:tests-e2e --test_output=streamed
 
   test-integration:
     machine: true


### PR DESCRIPTION
# Why is this PR needed?
`//workbase:tests-e2e` doesn't yet work with RBE. In order to make it work, the test needs to depend on `//:distribution` so it knows to re-run the test when the distribution is changed in any way.

# What does the PR do?
run //workbase:tests-e2e in local mode temporarily. bazel is now executed in a regular way for `//workbase:tests-e2e`:
```
run: bazel ...
```
instead of using the RBE mode:
```
bazel:
  command: bazel ...
```

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
https://github.com/graknlabs/grakn/issues/4804