### PR TITLE
Integrate RPM deployment

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,6 +19,7 @@
 exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
 load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
 load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
 
 
 py_binary(
@@ -83,6 +84,11 @@ distribution_rpm(
     },
 )
 
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":distribution-rpm",
+    deployment_properties = "//:deployment.properties",
+)
 
 distribution_zip(
     name = "distribution",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,11 +141,10 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
-# TODO(vmax): use upstream repo once graknlabs/deployment#28 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/vmax/graknlabs-deployment",
-    commit="bbce6ccc5af5de25df292521f1e54d2f71c73621"
+    remote="https://github.com/graknlabs/deployment",
+    commit="dec2175bb857485c033c816cc31bdc845c82f045"
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,10 +141,11 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
+# TODO(vmax): use upstream repo once graknlabs/deployment#28 is merged
 git_repository(
     name="graknlabs_rules_deployment",
-    remote="https://github.com/graknlabs/deployment",
-    commit="8d68b4f13fe063ed7ccd04c29ab5f91e81fba052"
+    remote="https://github.com/vmax/graknlabs-deployment",
+    commit="bbce6ccc5af5de25df292521f1e54d2f71c73621"
 )
 
 load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/console/BUILD
+++ b/console/BUILD
@@ -19,6 +19,7 @@
 package(default_visibility = ["//visibility:__subpackages__"])
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
 load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
 
 java_library(
     name = "console",
@@ -121,6 +122,12 @@ distribution_rpm(
     empty_dirs = [
          "opt/grakn/core/console/services/lib/",
     ],
+)
+
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":distribution-rpm",
+    deployment_properties = "//:deployment.properties",
 )
 
 test_suite(

--- a/deployment.properties
+++ b/deployment.properties
@@ -23,3 +23,4 @@ pip.repository-url.pypi=https://pypi.org/legacy/
 pip.repository-url.test=https://test.pypi.org/legacy/
 npm.repository-url=https://registry.npmjs.org/
 maven.packages=common,server,console,protocol,client-java
+rpm.repository-url.test=http://35.241.137.92/nexus/repository/temp/

--- a/server/BUILD
+++ b/server/BUILD
@@ -20,6 +20,7 @@ package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
 load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
 
 exports_files(
     glob(["conf/**", "services/**"]),
@@ -195,4 +196,10 @@ distribution_rpm(
     symlinks = {
         "opt/grakn/core/server/db/": "/var/lib/grakn/db/",
     },
+)
+
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":distribution-rpm",
+    deployment_properties = "//:deployment.properties",
 )


### PR DESCRIPTION
# Why is this PR needed?

So we are able to deploy RPM packages `grakn-core-*` we're building with `distribution_rpm` rules
Needs graknlabs/deployment#28

# What does the PR do?

Adds `deploy_rpm` targets for `grakn-core-bin`, `grakn-core-console`, `grakn-core-server`

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

Deployment of `*.deb` packages