### PR TITLE
Update link to distribution rules

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -17,15 +17,15 @@
 #
 
 exports_files(["grakn", "VERSION", "deployment.properties"], visibility = ["//visibility:public"])
-load("@graknlabs_rules_deployment//brew:rules.bzl", deploy_brew = "deploy_brew")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
-load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
-load("@graknlabs_rules_deployment//deb/deployment:rules.bzl", "deploy_deb")
+load("@graknlabs_bazel_distribution//brew:rules.bzl", deploy_brew = "deploy_brew")
+load("@graknlabs_bazel_distribution//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_bazel_distribution//rpm/deployment:rules.bzl", "deploy_rpm")
+load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
 
 
 py_binary(
     name = "deploy-github-zip",
-    srcs = ["@graknlabs_rules_deployment//github:deployment.py"],
+    srcs = ["@graknlabs_bazel_distribution//github:deployment.py"],
     data = [":distribution", ":VERSION", ":deployment.properties", "@ghr_osx_zip//file:file", "@ghr_linux_tar//file:file"],
     main = "deployment.py"
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -143,12 +143,12 @@ node_grpc_compile()
 
 
 git_repository(
-   name="graknlabs_rules_deployment",
-    remote="https://github.com/graknlabs/deployment",
+    name="graknlabs_bazel_distribution",
+    remote="https://github.com/graknlabs/bazel-distribution",
     commit="ccb0c649583290658fa981971c4994d7e32b7899"
 )
 
-load("@graknlabs_rules_deployment//github:dependencies.bzl", "dependencies_for_github_deployment")
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "dependencies_for_github_deployment")
 dependencies_for_github_deployment()
 
 

--- a/client-nodejs/BUILD
+++ b/client-nodejs/BUILD
@@ -22,7 +22,7 @@ exports_files([
 
 load("@stackb_rules_proto//node:node_grpc_compile.bzl", "node_grpc_compile")
 load("@build_bazel_rules_nodejs//:defs.bzl", "npm_package", "nodejs_jest_test", "babel_library")
-load("@graknlabs_rules_deployment//npm:rules.bzl", "deploy_npm")
+load("@graknlabs_bazel_distribution//npm:rules.bzl", "deploy_npm")
 
 
 node_grpc_compile(

--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -19,7 +19,7 @@
 
 load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
-load("@graknlabs_rules_deployment//pip:rules.bzl", "deploy_pip")
+load("@graknlabs_bazel_distribution//pip:rules.bzl", "deploy_pip")
 
 
 py_library(

--- a/client_python/grakn/BUILD
+++ b/client_python/grakn/BUILD
@@ -1,6 +1,6 @@
 load("@stackb_rules_proto//python:python_grpc_compile.bzl", "python_grpc_compile")
 load("@io_bazel_rules_python//python:python.bzl", "py_library")
-load("@graknlabs_rules_deployment//pip:rules.bzl", "py_replace_imports")
+load("@graknlabs_bazel_distribution//pip:rules.bzl", "py_replace_imports")
 
 
 exports_files([

--- a/console/BUILD
+++ b/console/BUILD
@@ -18,9 +18,9 @@
 
 package(default_visibility = ["//visibility:__subpackages__"])
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
-load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
-load("@graknlabs_rules_deployment//deb/deployment:rules.bzl", "deploy_deb")
+load("@graknlabs_bazel_distribution//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_bazel_distribution//rpm/deployment:rules.bzl", "deploy_rpm")
+load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
 
 java_library(
     name = "console",

--- a/dependencies/maven/BUILD
+++ b/dependencies/maven/BUILD
@@ -18,8 +18,8 @@
 
 genrule(
     name = "deployment_rules",
-    srcs = ["@graknlabs_rules_deployment//maven/templates:rules.bzl", "//:deployment.properties"],
-    cmd = "$(location @graknlabs_rules_deployment//maven:deployment_rules_builder.py) $(location @graknlabs_rules_deployment//maven/templates:rules.bzl) $@ $(location //:deployment.properties) //:VERSION //:deployment.properties",
+    srcs = ["@graknlabs_bazel_distribution//maven/templates:rules.bzl", "//:deployment.properties"],
+    cmd = "$(location @graknlabs_bazel_distribution//maven:deployment_rules_builder.py) $(location @graknlabs_bazel_distribution//maven/templates:rules.bzl) $@ $(location //:deployment.properties) //:VERSION //:deployment.properties",
     outs = ["rules.bzl"],
-    tools = ["@graknlabs_rules_deployment//maven:deployment_rules_builder.py"]
+    tools = ["@graknlabs_bazel_distribution//maven:deployment_rules_builder.py"]
 )

--- a/dependencies/maven/rules.bzl
+++ b/dependencies/maven/rules.bzl
@@ -244,11 +244,11 @@ deploy_maven_jar = rule(
         ),
         "_pom_xml_template": attr.label(
             allow_single_file = True,
-            default = "@graknlabs_rules_deployment//maven/templates:pom.xml",
+            default = "@graknlabs_bazel_distribution//maven/templates:pom.xml",
         ),
         "_deployment_script_template": attr.label(
             allow_single_file = True,
-            default = "@graknlabs_rules_deployment//maven/templates:deploy.sh",
+            default = "@graknlabs_bazel_distribution//maven/templates:deploy.sh",
         )
     },
     executable = True,

--- a/server/BUILD
+++ b/server/BUILD
@@ -19,9 +19,9 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
-load("@graknlabs_rules_deployment//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
-load("@graknlabs_rules_deployment//rpm/deployment:rules.bzl", "deploy_rpm")
-load("@graknlabs_rules_deployment//deb/deployment:rules.bzl", "deploy_deb")
+load("@graknlabs_bazel_distribution//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
+load("@graknlabs_bazel_distribution//rpm/deployment:rules.bzl", "deploy_rpm")
+load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
 
 exports_files(
     glob(["conf/**", "services/**"]),


### PR DESCRIPTION
# Why is this PR needed?

So we call [`graknlabs/bazel-distribution`](https://github.com/graknlabs/bazel-distribution) by proper name

# What does the PR do?

Replaces `@graknlabs_rules_deployment` with `@graknlabs_bazel_distribution`

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

No
