### PR TITLE
Adapt to new deploy_pip with `deps` attribute

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,13 +141,20 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
+# TODO(vmax): replace with upstream once graknlabs/bazel-distribution#35 is merged
 git_repository(
     name="graknlabs_bazel_distribution",
-    remote="https://github.com/graknlabs/bazel-distribution",
-    commit="f6bfb0c319cc63b4aaa7abe40f11f89a4d751c8f"
+    remote="https://github.com/vmax/graknlabs-bazel-distribution",
+    commit="f43b5fe4b01633cc97394ff326a60ba2e5755afc"
 )
 
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "dependencies_for_github_deployment")
+pip_import(
+    name = "pypi_deployment_dependencies",
+    requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
+)
+load("@pypi_deployment_dependencies//:requirements.bzl", "pip_install")
+pip_install()
 dependencies_for_github_deployment()
 
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -141,11 +141,10 @@ node_grpc_compile()
 #     Load Deployment Dependencies     #
 ########################################
 
-# TODO(vmax): replace with upstream once graknlabs/bazel-distribution#35 is merged
 git_repository(
     name="graknlabs_bazel_distribution",
-    remote="https://github.com/vmax/graknlabs-bazel-distribution",
-    commit="f43b5fe4b01633cc97394ff326a60ba2e5755afc"
+    remote="https://github.com/graknlabs/bazel-distribution",
+    commit="2e932a2555d1e43f75c8ee676c926399bd12f240"
 )
 
 load("@graknlabs_bazel_distribution//github:dependencies.bzl", "dependencies_for_github_deployment")

--- a/client_python/BUILD
+++ b/client_python/BUILD
@@ -19,6 +19,7 @@
 
 load("@io_bazel_rules_python//python:python.bzl", "py_library", "py_test")
 load("@pypi_dependencies//:requirements.bzl", "requirement")
+load("@pypi_deployment_dependencies//:requirements.bzl", deployment_requirement = "requirement")
 load("@graknlabs_bazel_distribution//pip:rules.bzl", "deploy_pip")
 
 
@@ -42,23 +43,6 @@ py_library(
         requirement("grpcio"),
         requirement("six"),
         requirement("enum34"),
-        # Only needed for deployment
-        requirement("twine"),
-        requirement("setuptools"),
-        requirement("wheel"),
-        requirement("requests"),
-        requirement("urllib3"),
-        requirement("chardet"),
-        requirement("certifi"),
-        requirement("idna"),
-        requirement("tqdm"),
-        requirement("requests_toolbelt"),
-        requirement("pkginfo"),
-        requirement("readme_renderer"),
-        requirement("Pygments"),
-        requirement("docutils"),
-        requirement("bleach"),
-        requirement("webencodings"),
     ]
 )
 
@@ -92,6 +76,24 @@ deploy_pip(
     deployment_properties = "//:deployment.properties",
     description = "A Python client for Grakn.",
     long_description_file = "//client_python:README.md",
+    deps = [
+        deployment_requirement("twine"),
+        deployment_requirement("setuptools"),
+        deployment_requirement("wheel"),
+        deployment_requirement("requests"),
+        deployment_requirement("urllib3"),
+        deployment_requirement("chardet"),
+        deployment_requirement("certifi"),
+        deployment_requirement("idna"),
+        deployment_requirement("tqdm"),
+        deployment_requirement("requests_toolbelt"),
+        deployment_requirement("pkginfo"),
+        deployment_requirement("readme_renderer"),
+        deployment_requirement("Pygments"),
+        deployment_requirement("docutils"),
+        deployment_requirement("bleach"),
+        deployment_requirement("webencodings")
+    ],
     target = ":client_python"
 )
 

--- a/dependencies/pip/requirements.txt
+++ b/dependencies/pip/requirements.txt
@@ -3,20 +3,4 @@ protobuf==3.6.1
 six==1.11.0
 forbiddenfruit==0.1.2
 enum34==1.1.6
-# Deployment-only dependencies
-setuptools>=38.6.0 # for supporting Markdown
-wheel==0.32.3 # for supporting bdist_wheel
-twine==1.12.1 # for uploading the package
-requests==2.21.0 # twine dependency
-urllib3==1.24.1 # requests dependency
-chardet==3.0.4 # requests dependency
-certifi==2018.11.29 # requests dependency
-idna==2.8 # requests dependency
-requests-toolbelt==0.8.0 # requests dependency
-tqdm==4.29.1 # twine dependency
-pkginfo==1.5.0.1 # twine dependency
-readme-renderer==24.0 # twine dependency
-Pygments==2.3.1 # readme-renderer
-docutils==0.14 # readme-renderer
-bleach==3.1.0 # readme-renderer
-webencodings==0.5.1 # bleach
+


### PR DESCRIPTION
# Why is this PR needed?

Needs graknlabs/bazel-distribution#35
To separate dependencies needed for deployment out of dependencies of the library

# What does the PR do?

Utilizes new attribute in `deploy_pip` rule

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—