### PR TITLE
Remove //graql/java:graql deps

### DIFF
--- a/graql/java/BUILD
+++ b/graql/java/BUILD
@@ -27,9 +27,4 @@ jarjar_library(
         "//graql/java/exception:exception",
         "//graql/java/util:util",
     ],
-    deps = [
-        "//dependencies/maven/artifacts/commons-lang:commons-lang",
-        "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",
-        "//dependencies/maven/artifacts/org/antlr:antlr4-runtime", # sync version with @antlr4_runtime//jar
-    ]
 )


### PR DESCRIPTION
# Why is this PR needed?

So we don't have extra dependencies

# What does the PR do?

Removes `deps`of `//graql/java:graql`

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—