### PR TITLE
Disable automatic dependency collection for rpm building (fix #4811)

### DIFF
--- a/dependencies/distribution/rpm/grakn-core-bin.spec
+++ b/dependencies/distribution/rpm/grakn-core-bin.spec
@@ -4,6 +4,7 @@ Release: 1
 Summary: Grakn Core (bin)
 URL: https://grakn.ai
 License: Apache License, v2.0
+AutoReqProv: no
 
 Source0: {_grakn-core-bin-rpm-tar.tar.gz}
 

--- a/dependencies/distribution/rpm/grakn-core-console.spec
+++ b/dependencies/distribution/rpm/grakn-core-console.spec
@@ -4,6 +4,7 @@ Release: 1
 Summary: Grakn Core (console)
 URL: https://grakn.ai
 License: Apache License, v2.0
+AutoReqProv: no
 
 Source0: {_grakn-core-console-rpm-tar.tar.gz}
 

--- a/dependencies/distribution/rpm/grakn-core-server.spec
+++ b/dependencies/distribution/rpm/grakn-core-server.spec
@@ -4,6 +4,7 @@ Release: 1
 Summary: Grakn Core (server)
 URL: https://grakn.ai
 License: Apache License, v2.0
+AutoReqProv: no
 
 Source0: {_grakn-core-server-rpm-tar.tar.gz}
 


### PR DESCRIPTION
# Why is this PR needed?

So we are able to install RPM packages built on CentOS to CentOS systems

# What does the PR do?

Disables [Automatic Dependencies](http://ftp.rpm.org/max-rpm/s1-rpm-depend-auto-depend.html) feature of RPM
Note, CI run for _this_ PR would not be representative (we don't install built RPM packages yet), so please check [this one](https://circleci.com/gh/vmax/grakn/797) instead

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—
