### PR TITLE
Refactor Graql query language library - part 13

### DIFF
--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -318,8 +318,8 @@ public class GraqlQueryException extends GraknException {
         throw new GraqlQueryException("Cannot parse date value " + originalDate + " with format " + originalFormat, cause);
     }
 
-    public static GraqlQueryException noLabelSpecifiedForHas(Statement varPattern) {
-        return create("'has' argument '%s' requires a label", varPattern);
+    public static GraqlQueryException noLabelSpecifiedForHas(Variable var) {
+        return create("'has' argument '%s' requires a label", var);
     }
 
     public static GraqlQueryException insertRolePlayerWithoutRoleType() {

--- a/server/src/graql/internal/executor/property/AbstractExecutor.java
+++ b/server/src/graql/internal/executor/property/AbstractExecutor.java
@@ -27,10 +27,10 @@ import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.reasoner.atom.property.IsAbstractAtom;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.AbstractProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/DataTypeExecutor.java
+++ b/server/src/graql/internal/executor/property/DataTypeExecutor.java
@@ -27,10 +27,10 @@ import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.property.DataTypeAtom;
 import grakn.core.graql.query.Query;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.DataTypeProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Collections;
 import java.util.Set;

--- a/server/src/graql/internal/executor/property/HasAttributeExecutor.java
+++ b/server/src/graql/internal/executor/property/HasAttributeExecutor.java
@@ -31,11 +31,11 @@ import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.reasoner.atom.binary.AttributeAtom;
 import grakn.core.graql.internal.reasoner.atom.predicate.IdPredicate;
 import grakn.core.graql.internal.reasoner.atom.predicate.ValuePredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.HasAttributeProperty;
 import grakn.core.graql.query.pattern.property.IsaProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/server/src/graql/internal/executor/property/HasAttributeTypeExecutor.java
+++ b/server/src/graql/internal/executor/property/HasAttributeTypeExecutor.java
@@ -26,45 +26,97 @@ import grakn.core.graql.concept.ConceptId;
 import grakn.core.graql.concept.Label;
 import grakn.core.graql.concept.SchemaConcept;
 import grakn.core.graql.concept.Type;
+import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.internal.Schema;
 import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.reasoner.atom.binary.HasAtom;
 import grakn.core.graql.query.Graql;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.HasAttributeTypeProperty;
 import grakn.core.graql.query.pattern.property.NeqProperty;
 import grakn.core.graql.query.pattern.property.PlaysProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY;
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY_OWNER;
+import static grakn.core.graql.internal.Schema.ImplicitType.KEY_VALUE;
+import static grakn.core.graql.query.Graql.var;
+
 public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
 
     private final Variable var;
     private final HasAttributeTypeProperty property;
 
+    private final Statement attributeType;
+    private final Statement ownerRole;
+    private final Statement valueRole;
+    private final Statement relationOwner;
+    private final Statement relationValue;
+
     HasAttributeTypeExecutor(Variable var, HasAttributeTypeProperty property) {
         this.var = var;
         this.property = property;
+        this.attributeType = property.attributeType();
+
+        // TODO: this may the cause of issue #4664
+        Label resourceLabel = attributeType.getTypeLabel().orElseThrow(
+                () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType.var())
+        );
+
+        Statement role = Graql.type(Schema.MetaSchema.ROLE.getLabel().getValue());
+
+        // TODO: To fix issue #4664 (querying schema with variable attribute type), it's not enough to just remove the
+        //       exception handling above. We need to be able to restrict the direcitonality of the following ownerRole
+        //       and valueRole. For example, for keys, we restrict the role names to start with `key-`. However, we
+        //       cannot do this because the name of the variable attribute type is unknown. This means that we need to
+        //       change the data structure so that we have meta-super-roles for attribute-owners and attribute-values
+        Statement ownerRole = var().sub(role);
+        Statement valueRole = var().sub(role);
+        Statement relationType = var().sub(Graql.type(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue()));
+
+        // If a key, limit only to the implicit key type
+        if (property.isKey()) {
+            ownerRole = ownerRole.type(KEY_OWNER.getLabel(resourceLabel).getValue());
+            valueRole = valueRole.type(KEY_VALUE.getLabel(resourceLabel).getValue());
+            relationType = relationType.type(KEY.getLabel(resourceLabel).getValue());
+        }
+
+        Statement relationOwner = relationType.relates(ownerRole);
+        Statement relationValue = relationType.relates(valueRole);
+
+        this.ownerRole = ownerRole;
+        this.valueRole = valueRole;
+        if (relationOwner == null) {
+            throw new NullPointerException("Null relationOwner");
+        }
+        this.relationOwner = relationOwner;
+        if (relationValue == null) {
+            throw new NullPointerException("Null relationValue");
+        }
+        this.relationValue = relationValue;
+
     }
 
     @Override
     public Set<EquivalentFragmentSet> matchFragments() {
         Set<EquivalentFragmentSet> fragments = new HashSet<>();
 
-        PlaysProperty playsOwnerProperty = new PlaysProperty(property.ownerRole(), property.isKey());
+        PlaysProperty playsOwnerProperty = new PlaysProperty(ownerRole, property.isKey());
         PlaysExecutor playsOwnerExecutor = new PlaysExecutor(var, playsOwnerProperty);
 
         //TODO: Get this to use real constraints no just the required flag
-        PlaysProperty playsValueProperty = new PlaysProperty(property.valueRole(), false);
-        PlaysExecutor playsValueExecutor = new PlaysExecutor(property.attributeType().var(), playsValueProperty);
+        PlaysProperty playsValueProperty = new PlaysProperty(valueRole, false);
+        PlaysExecutor playsValueExecutor = new PlaysExecutor(attributeType.var(), playsValueProperty);
 
-        NeqProperty neqProperty = new NeqProperty(property.ownerRole());
-        NeqExecutor neqExecutor = new NeqExecutor(property.valueRole().var(), neqProperty);
+        NeqProperty neqProperty = new NeqProperty(ownerRole);
+        NeqExecutor neqExecutor = new NeqExecutor(valueRole.var(), neqProperty);
 
         // Add fragments for HasAttributeType property
         fragments.addAll(playsOwnerExecutor.matchFragments());
@@ -74,7 +126,7 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
         // Add fragments for the implicit relationship property
         // These implicit statements make sure that statement variable (owner) and the attribute type form a
         // connected (non-disjoint) set of fragments for match execution
-        Stream.of(property.ownerRole(), property.valueRole(), property.relationOwner(), property.relationValue())
+        Stream.of(ownerRole, valueRole, relationOwner, relationValue)
                 .forEach(statement -> statement.properties()
                         .forEach(p -> fragments.addAll(PropertyExecutor.create(statement.var(), p).matchFragments())));
 

--- a/server/src/graql/internal/executor/property/IdExecutor.java
+++ b/server/src/graql/internal/executor/property/IdExecutor.java
@@ -26,10 +26,10 @@ import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.predicate.IdPredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.IdProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/NeqExecutor.java
+++ b/server/src/graql/internal/executor/property/NeqExecutor.java
@@ -24,9 +24,9 @@ import grakn.core.graql.admin.ReasonerQuery;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.predicate.NeqPredicate;
+import grakn.core.graql.query.pattern.property.NeqProperty;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
-import grakn.core.graql.query.pattern.property.NeqProperty;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/PlaysExecutor.java
+++ b/server/src/graql/internal/executor/property/PlaysExecutor.java
@@ -29,10 +29,10 @@ import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.binary.PlaysAtom;
 import grakn.core.graql.internal.reasoner.atom.predicate.IdPredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.PlaysProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/server/src/graql/internal/executor/property/RegexExecutor.java
+++ b/server/src/graql/internal/executor/property/RegexExecutor.java
@@ -26,10 +26,10 @@ import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.property.RegexAtom;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.RegexProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/RelatesExecutor.java
+++ b/server/src/graql/internal/executor/property/RelatesExecutor.java
@@ -28,10 +28,10 @@ import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.reasoner.atom.binary.RelatesAtom;
 import grakn.core.graql.internal.reasoner.atom.predicate.IdPredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.RelatesProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Collections;
 import java.util.HashSet;

--- a/server/src/graql/internal/executor/property/ThenExecutor.java
+++ b/server/src/graql/internal/executor/property/ThenExecutor.java
@@ -24,10 +24,10 @@ import grakn.core.graql.admin.ReasonerQuery;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.ThenProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/TypeExecutor.java
+++ b/server/src/graql/internal/executor/property/TypeExecutor.java
@@ -28,10 +28,10 @@ import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.predicate.IdPredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.TypeProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/ValueExecutor.java
+++ b/server/src/graql/internal/executor/property/ValueExecutor.java
@@ -26,10 +26,10 @@ import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
 import grakn.core.graql.internal.reasoner.atom.predicate.ValuePredicate;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.ValueProperty;
 import grakn.core.graql.query.pattern.property.VarProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/executor/property/WhenExecutor.java
+++ b/server/src/graql/internal/executor/property/WhenExecutor.java
@@ -24,10 +24,10 @@ import grakn.core.graql.admin.ReasonerQuery;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.internal.executor.WriteExecutor;
 import grakn.core.graql.internal.gremlin.EquivalentFragmentSet;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.VarProperty;
 import grakn.core.graql.query.pattern.property.WhenProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 
 import java.util.Set;
 

--- a/server/src/graql/internal/gremlin/ConjunctionQuery.java
+++ b/server/src/graql/internal/gremlin/ConjunctionQuery.java
@@ -42,15 +42,13 @@ import static java.util.stream.Collectors.toSet;
 
 /**
  * A query that does not contain any disjunctions, so it can be represented as a single gremlin traversal.
- * <p>
- * The {@code ConjunctionQuery} is passed a {@link Conjunction<  Statement  >}.
+ * The {@code ConjunctionQuery} is passed a {@link Conjunction<Statement>}.
  * {@link EquivalentFragmentSet}s can be extracted from each {@link GraqlTraversal}.
- * <p>
  * The {@link EquivalentFragmentSet}s are sorted to produce a set of lists of {@link Fragment}s. Each list of fragments
  * describes a connected component in the query. Most queries are completely connected, so there will be only one
  * list of fragments in the set. If the query is disconnected (e.g. match $x isa movie, $y isa person), then there
  * will be multiple lists of fragments in the set.
- * <p>
+ *
  * A gremlin traversal is created by concatenating the traversals within each fragment.
  */
 class ConjunctionQuery {
@@ -120,8 +118,8 @@ class ConjunctionQuery {
         return Sets.cartesianProduct(fragments).stream();
     }
 
-    private static Stream<EquivalentFragmentSet> equivalentFragmentSetsRecursive(Statement var) {
-        return var.implicitInnerStatements().stream().flatMap(ConjunctionQuery::equivalentFragmentSets);
+    private static Stream<EquivalentFragmentSet> equivalentFragmentSetsRecursive(Statement statement) {
+        return statement.implicitInnerStatements().stream().flatMap(s -> equivalentFragmentSets(s));
     }
 
     private static Stream<EquivalentFragmentSet> equivalentFragmentSets(Statement statement) {

--- a/server/src/graql/internal/gremlin/ConjunctionQuery.java
+++ b/server/src/graql/internal/gremlin/ConjunctionQuery.java
@@ -119,7 +119,7 @@ class ConjunctionQuery {
     }
 
     private static Stream<EquivalentFragmentSet> equivalentFragmentSetsRecursive(Statement statement) {
-        return statement.implicitInnerStatements().stream().flatMap(s -> equivalentFragmentSets(s));
+        return statement.innerStatements().stream().flatMap(s -> equivalentFragmentSets(s));
     }
 
     private static Stream<EquivalentFragmentSet> equivalentFragmentSets(Statement statement) {

--- a/server/src/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
+++ b/server/src/graql/internal/reasoner/plan/GraqlTraversalPlanner.java
@@ -47,12 +47,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- *
- * <p>
  * Resolution planner using {@link GreedyTraversalPlan} to establish optimal resolution order..
- * </p>
- *
- *
  */
 public class GraqlTraversalPlanner {
 

--- a/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
+++ b/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
@@ -128,11 +128,11 @@ public class HasAttributeTypeProperty extends VarProperty {
     public Stream<Statement> statements() {
         return Stream.of(attributeType);
     }
-
-    @Override
-    public Stream<Statement> statementsImplicit() {
-        return Stream.of(attributeType, ownerRole, valueRole, relationOwner, relationValue);
-    }
+//
+//    @Override
+//    public Stream<Statement> statementsImplicit() {
+//        return Stream.of(attributeType, ownerRole, valueRole, relationOwner, relationValue);
+//    }
 
     @Override
     public Class statementClass() {

--- a/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
+++ b/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
@@ -18,20 +18,11 @@
 
 package grakn.core.graql.query.pattern.property;
 
-import grakn.core.graql.concept.Label;
-import grakn.core.graql.exception.GraqlQueryException;
-import grakn.core.graql.internal.Schema;
-import grakn.core.graql.query.Graql;
 import grakn.core.graql.query.Query;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.StatementType;
 
 import java.util.stream.Stream;
-
-import static grakn.core.graql.internal.Schema.ImplicitType.KEY;
-import static grakn.core.graql.internal.Schema.ImplicitType.KEY_OWNER;
-import static grakn.core.graql.internal.Schema.ImplicitType.KEY_VALUE;
-import static grakn.core.graql.query.Graql.var;
 
 /**
  * Represents the {@code has} and {@code key} properties on a Type.
@@ -46,71 +37,15 @@ import static grakn.core.graql.query.Graql.var;
 public class HasAttributeTypeProperty extends VarProperty {
 
     private final Statement attributeType;
-    private final Statement ownerRole;
-    private final Statement valueRole;
-    private final Statement relationOwner;
-    private final Statement relationValue;
     private final boolean isKey;
 
     public HasAttributeTypeProperty(Statement attributeType, boolean isKey) {
-        // TODO: this may the cause of issue #4664
-        Label resourceLabel = attributeType.getTypeLabel().orElseThrow(
-                () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType.var())
-        );
-
-        Statement role = Graql.type(Schema.MetaSchema.ROLE.getLabel().getValue());
-
-        // TODO: To fix issue #4664 (querying schema with variable attribute type), it's not enough to just remove the
-        //       exception handling above. We need to be able to restrict the direcitonality of the following ownerRole
-        //       and valueRole. For example, for keys, we restrict the role names to start with `key-`. However, we
-        //       cannot do this because the name of the variable attribute type is unknown. This means that we need to
-        //       change the data structure so that we have meta-super-roles for attribute-owners and attribute-values
-        Statement ownerRole = var().sub(role);
-        Statement valueRole = var().sub(role);
-        Statement relationType = var().sub(Graql.type(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue()));
-
-        // If a key, limit only to the implicit key type
-        if (isKey) {
-            ownerRole = ownerRole.type(KEY_OWNER.getLabel(resourceLabel).getValue());
-            valueRole = valueRole.type(KEY_VALUE.getLabel(resourceLabel).getValue());
-            relationType = relationType.type(KEY.getLabel(resourceLabel).getValue());
-        }
-
-        Statement relationOwner = relationType.relates(ownerRole);
-        Statement relationValue = relationType.relates(valueRole);
-
         this.attributeType = attributeType;
-        this.ownerRole = ownerRole;
-        this.valueRole = valueRole;
-        if (relationOwner == null) {
-            throw new NullPointerException("Null relationOwner");
-        }
-        this.relationOwner = relationOwner;
-        if (relationValue == null) {
-            throw new NullPointerException("Null relationValue");
-        }
-        this.relationValue = relationValue;
         this.isKey = isKey;
     }
 
     public Statement attributeType() {
         return attributeType;
-    }
-
-    public Statement ownerRole() {
-        return ownerRole;
-    }
-
-    public Statement valueRole() {
-        return valueRole;
-    }
-
-    public Statement relationOwner() {
-        return relationOwner;
-    }
-
-    public Statement relationValue() {
-        return relationValue;
     }
 
     public boolean isKey() {
@@ -149,19 +84,13 @@ public class HasAttributeTypeProperty extends VarProperty {
 
     @Override
     public boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        if (o instanceof HasAttributeTypeProperty) {
-            HasAttributeTypeProperty that = (HasAttributeTypeProperty) o;
-            return (this.attributeType.equals(that.attributeType))
-                    && (this.ownerRole.equals(that.ownerRole))
-                    && (this.valueRole.equals(that.valueRole))
-                    && (this.relationOwner.equals(that.relationOwner))
-                    && (this.relationValue.equals(that.relationValue))
-                    && (this.isKey == that.isKey);
-        }
-        return false;
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        HasAttributeTypeProperty that = (HasAttributeTypeProperty) o;
+
+        return (this.attributeType.equals(that.attributeType) &&
+                this.isKey == that.isKey);
     }
 
     @Override
@@ -169,14 +98,6 @@ public class HasAttributeTypeProperty extends VarProperty {
         int h = 1;
         h *= 1000003;
         h ^= this.attributeType.hashCode();
-        h *= 1000003;
-        h ^= this.ownerRole.hashCode();
-        h *= 1000003;
-        h ^= this.valueRole.hashCode();
-        h *= 1000003;
-        h ^= this.relationOwner.hashCode();
-        h *= 1000003;
-        h ^= this.relationValue.hashCode();
         h *= 1000003;
         h ^= this.isKey ? 1231 : 1237;
         return h;

--- a/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
+++ b/server/src/graql/query/pattern/property/HasAttributeTypeProperty.java
@@ -55,11 +55,16 @@ public class HasAttributeTypeProperty extends VarProperty {
     public HasAttributeTypeProperty(Statement attributeType, boolean isKey) {
         // TODO: this may the cause of issue #4664
         Label resourceLabel = attributeType.getTypeLabel().orElseThrow(
-                () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType)
+                () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType.var())
         );
 
         Statement role = Graql.type(Schema.MetaSchema.ROLE.getLabel().getValue());
 
+        // TODO: To fix issue #4664 (querying schema with variable attribute type), it's not enough to just remove the
+        //       exception handling above. We need to be able to restrict the direcitonality of the following ownerRole
+        //       and valueRole. For example, for keys, we restrict the role names to start with `key-`. However, we
+        //       cannot do this because the name of the variable attribute type is unknown. This means that we need to
+        //       change the data structure so that we have meta-super-roles for attribute-owners and attribute-values
         Statement ownerRole = var().sub(role);
         Statement valueRole = var().sub(role);
         Statement relationType = var().sub(Graql.type(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue()));
@@ -100,6 +105,14 @@ public class HasAttributeTypeProperty extends VarProperty {
         return valueRole;
     }
 
+    public Statement relationOwner() {
+        return relationOwner;
+    }
+
+    public Statement relationValue() {
+        return relationValue;
+    }
+
     public boolean isKey() {
         return isKey;
     }
@@ -128,11 +141,6 @@ public class HasAttributeTypeProperty extends VarProperty {
     public Stream<Statement> statements() {
         return Stream.of(attributeType);
     }
-//
-//    @Override
-//    public Stream<Statement> statementsImplicit() {
-//        return Stream.of(attributeType, ownerRole, valueRole, relationOwner, relationValue);
-//    }
 
     @Override
     public Class statementClass() {

--- a/server/src/graql/query/pattern/property/VarProperty.java
+++ b/server/src/graql/query/pattern/property/VarProperty.java
@@ -62,15 +62,6 @@ public abstract class VarProperty {
         return Stream.empty();
     }
 
-    /**
-     * Get a stream of any inner Statement within this `VarProperty`, including any that may have been
-     * implicitly created (such as with "has").
-     */
-    @CheckReturnValue
-    public Stream<Statement> statementsImplicit() {
-        return statements();
-    }
-
     @CheckReturnValue // TODO: This should be temporary until we make statements to be strict typing
     public abstract Class statementClass();
 

--- a/server/src/graql/query/pattern/statement/Statement.java
+++ b/server/src/graql/query/pattern/statement/Statement.java
@@ -661,7 +661,7 @@ public class Statement implements Pattern {
     }
 
     /**
-     * @return all variables that this variable references
+     * @return all statements that this statement contains
      */
     @CheckReturnValue
     public Collection<Statement> innerStatements() {
@@ -673,26 +673,9 @@ public class Statement implements Pattern {
         while (!statementStack.isEmpty()) {
             Statement statement = statementStack.pop();
             statements.add(statement);
-            statement.properties().stream().flatMap(varProperty -> varProperty.statements()).forEach(statementStack::add);
-        }
-
-        return statements;
-    }
-
-    /**
-     * Get all inner variables, including implicit variables such as in a has property
-     */
-    @CheckReturnValue
-    public Collection<Statement> implicitInnerStatements() {
-        Stack<Statement> statementStack = new Stack<>();
-        List<Statement> statements = new ArrayList<>();
-
-        statementStack.add(this);
-
-        while (!statementStack.isEmpty()) {
-            Statement var = statementStack.pop();
-            statements.add(var);
-            var.properties().stream().flatMap(varProperty -> varProperty.statementsImplicit()).forEach(statementStack::add);
+            statement.properties().stream()
+                    .flatMap(varProperty -> varProperty.statements())
+                    .forEach(statementStack::add);
         }
 
         return statements;

--- a/server/src/graql/query/pattern/statement/Statement.java
+++ b/server/src/graql/query/pattern/statement/Statement.java
@@ -684,18 +684,18 @@ public class Statement implements Pattern {
      */
     @CheckReturnValue
     public Collection<Statement> implicitInnerStatements() {
-        Stack<Statement> newVars = new Stack<>();
-        List<Statement> vars = new ArrayList<>();
+        Stack<Statement> statementStack = new Stack<>();
+        List<Statement> statements = new ArrayList<>();
 
-        newVars.add(this);
+        statementStack.add(this);
 
-        while (!newVars.isEmpty()) {
-            Statement var = newVars.pop();
-            vars.add(var);
-            var.properties().stream().flatMap(varProperty -> varProperty.statementsImplicit()).forEach(newVars::add);
+        while (!statementStack.isEmpty()) {
+            Statement var = statementStack.pop();
+            statements.add(var);
+            var.properties().stream().flatMap(varProperty -> varProperty.statementsImplicit()).forEach(statementStack::add);
         }
 
-        return vars;
+        return statements;
     }
 
     @Override

--- a/server/src/graql/query/pattern/statement/StatementInstance.java
+++ b/server/src/graql/query/pattern/statement/StatementInstance.java
@@ -45,7 +45,6 @@ public abstract class StatementInstance extends Statement {
         super(var, properties);
     }
 
-    @SuppressWarnings("Duplicates")
     void validateRecursion() {
         Collection<Statement> toValidate = innerStatements();
         toValidate.remove(this);

--- a/test-integration/graql/query/DefineQueryIT.java
+++ b/test-integration/graql/query/DefineQueryIT.java
@@ -30,9 +30,11 @@ import grakn.core.graql.concept.Role;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.graql.internal.Schema;
+import grakn.core.graql.printer.Printer;
 import grakn.core.graql.query.pattern.Pattern;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.rule.GraknTestServer;
+import grakn.core.server.Session;
 import grakn.core.server.Transaction;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.session.SessionImpl;
@@ -48,6 +50,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.List;
+
 import static grakn.core.graql.internal.Schema.ImplicitType.HAS;
 import static grakn.core.graql.internal.Schema.ImplicitType.HAS_OWNER;
 import static grakn.core.graql.internal.Schema.ImplicitType.HAS_VALUE;
@@ -58,7 +62,6 @@ import static grakn.core.graql.internal.Schema.MetaSchema.ENTITY;
 import static grakn.core.graql.internal.Schema.MetaSchema.RELATIONSHIP;
 import static grakn.core.graql.internal.Schema.MetaSchema.ROLE;
 import static grakn.core.graql.internal.Schema.MetaSchema.RULE;
-import static grakn.core.graql.query.Graql.define;
 import static grakn.core.graql.query.Graql.parse;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;


### PR DESCRIPTION
# Why is this PR needed?

This PR is a continuation of PR #4646, and incremental work for issue #4456 where you can find the full description of the goal. In summary, we are refactoring Graql to extract the Graql language library from Grakn's implementation of Graql, and we start with simplifying the Graql codebase first.

# What does the PR do?

This PR focuses on removing any cyclic dependencies that prohibit us from extracting Graql language library from its implementation. In this case: removing the construction of `HasAttributeTypeProperty` internal data structure, namely the _"implicit statements"_. This is now moved to `HasAttributeTypeExecutor.matchFragments()`, which also allowed us to remove the `.innerImplicitStatement()` method from the `Statement` class.