### PR TITLE
Simplify checkstyle integration (fix #4825)

### DIFF
--- a/client-java/BUILD
+++ b/client-java/BUILD
@@ -19,6 +19,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 
 java_library(
     name = "client-java",
@@ -53,14 +54,11 @@ java_library(
     tags = ["maven_coordinates=grakn.core:client:{pom_version}"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
-    name = "client-java-checkstyle",
-    target = ":client-java",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":client-java"
+    ],
 )
 
 deploy_maven_jar(

--- a/client-java/concept/test/BUILD
+++ b/client-java/concept/test/BUILD
@@ -18,6 +18,8 @@
 
 package(default_visibility = ["//visibility:__pkg__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "remote-concept-it",
     srcs = ["RemoteConceptIT.java"],
@@ -37,11 +39,7 @@ java_test(
 )
 
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
-    name = "remote-concept-it-checkstyle",
-    target = ":remote-concept-it",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [":remote-concept-it"],
 )

--- a/client-java/test/BUILD
+++ b/client-java/test/BUILD
@@ -46,14 +46,6 @@ java_test(
     size = "small",
 )
 
-checkstyle_test(
-    name = "grakn-client-test-checkstyle",
-    target = ":grakn-client-test",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
-)
-
 java_test(
     name = "grakn-client-it",
     srcs = ["GraknClientIT.java"],
@@ -75,10 +67,9 @@ java_test(
 )
 
 checkstyle_test(
-    name = "grakn-client-it-checkstyle",
-    target = ":grakn-client-it",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":grakn-client-test",
+        ":grakn-client-it",
+    ],
 )

--- a/common/config/BUILD
+++ b/common/config/BUILD
@@ -18,9 +18,6 @@ java_library(
 
 load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
-    name = "config-checkstyle",
-    target = ":config",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [":config"],
 )

--- a/common/config/test/BUILD
+++ b/common/config/test/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
      name = "grakn-config-test",
      test_class = "grakn.core.common.config.test.ConfigTest",
@@ -7,11 +9,9 @@ java_test(
      size = "small"
  )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "grakn-config-test-checkstyle",
- target = ":grakn-config-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":grakn-config-test"
+    ],
 )

--- a/common/exception/BUILD
+++ b/common/exception/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "exception",
     srcs = [
@@ -11,12 +13,9 @@ java_library(
     visibility = ["//common:__subpackages__"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "exception-checkstyle",
- target = ":exception",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":exception"
+    ],
 )

--- a/common/http/BUILD
+++ b/common/http/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "http",
     srcs = ["SimpleURI.java"],
@@ -7,11 +9,9 @@ java_library(
     visibility = ["//common:__subpackages__"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "http-checkstyle",
- target = ":http",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":http"
+    ],
 )

--- a/common/util/BUILD
+++ b/common/util/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "util",
     srcs = ["CommonUtil.java",
@@ -9,11 +11,9 @@ java_library(
     visibility = ["//common:__subpackages__"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "util-checkstyle",
- target = ":util",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":util"
+    ],
 )

--- a/config/checkstyle/BUILD
+++ b/config/checkstyle/BUILD
@@ -4,7 +4,7 @@ exports_files([
 ])
 
 filegroup(
-    name = "licenses",
+    name = "license_files",
     srcs = [
         "checkstyle-file-header-agpl.txt",
         "checkstyle-file-header-apache.txt",

--- a/console/BUILD
+++ b/console/BUILD
@@ -21,6 +21,8 @@ load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
 load("@graknlabs_bazel_distribution//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
 load("@graknlabs_bazel_distribution//rpm/deployment:rules.bzl", "deploy_rpm")
 load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 
 java_library(
     name = "console",
@@ -50,13 +52,11 @@ java_library(
     tags = ["maven_coordinates=grakn.core:console:{pom_version}"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "console-checkstyle",
- target = ":console",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":console"
+    ],
 )
 
 java_binary(

--- a/console/test/BUILD
+++ b/console/test/BUILD
@@ -18,6 +18,8 @@
 
 package(default_visibility = ["//visibility:__pkg__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "grakn-console-it",
     srcs = ["GraknConsoleIT.java"],
@@ -43,12 +45,9 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "grakn-console-it-checkstyle",
- target = ":grakn-console-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":grakn-console-it"
+    ],
 )

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -18,6 +18,8 @@
 
 package(default_visibility = ["//visibility:__pkg__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "daemon",
     srcs = glob(["**/*.java"]),
@@ -41,11 +43,9 @@ java_library(
     visibility = ["//server:__pkg__"],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "daemon-checkstyle",
- target = ":daemon",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":daemon"
+    ],
 )

--- a/daemon/exception/BUILD
+++ b/daemon/exception/BUILD
@@ -18,6 +18,8 @@
 
 package(default_visibility = ["//daemon:__subpackages__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "exception",
     srcs = glob(["**/*.java"]),
@@ -27,11 +29,7 @@ java_library(
     ]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "exception-checkstyle",
- target = ":exception",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [":exception"],
 )

--- a/daemon/executor/BUILD
+++ b/daemon/executor/BUILD
@@ -18,6 +18,8 @@
 
 package(default_visibility = ["//daemon:__pkg__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "grakn-daemon-executor",
     srcs = glob(["**/*.java"]),
@@ -41,12 +43,9 @@ java_library(
     ]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "grakn-daemon-executor-checkstyle",
- target = ":grakn-daemon-executor",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":grakn-daemon-executor"
+    ],
 )

--- a/dependencies/tools/checkstyle/checkstyle.bzl
+++ b/dependencies/tools/checkstyle/checkstyle.bzl
@@ -125,7 +125,7 @@ def _checkstyle_test_impl(ctx):
         is_executable = True,
     )
 
-    files = [ctx.outputs.checkstyle_script] + ctx.files.licenses + all_java_files + ctx.files._classpath + inputs
+    files = [ctx.outputs.checkstyle_script] + ctx.files.license_files + all_java_files + ctx.files._classpath + inputs
     runfiles = ctx.runfiles(
         files = files,
         collect_data = True
@@ -142,15 +142,18 @@ checkstyle_test = rule(
     attrs = {
         "config": attr.label(
             allow_single_file=True,
-            doc = "A checkstyle configuration file"
+            doc = "A checkstyle configuration file",
+            default = "//config/checkstyle:checkstyle.xml"
         ),
         "suppressions": attr.label(
             allow_single_file=True,
-            doc = "A checkstyle suppressions file"
+            doc = "A checkstyle suppressions file",
+            default = "//config/checkstyle:checkstyle-suppressions.xml",
         ),
-        "licenses": attr.label_list(
+        "license_files": attr.label_list(
             allow_files=True,
-            doc = "License file(s) that can be used with the checkstyle license target"
+            doc = "License file(s) that can be used with the checkstyle license target",
+            default = ["//config/checkstyle:license_files"]
         ),
         "properties": attr.label(
             allow_single_file=True,

--- a/graql/java/exception/BUILD
+++ b/graql/java/exception/BUILD
@@ -18,17 +18,16 @@
 
 package(default_visibility = ["//graql/java:__subpackages__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 
 java_library(
     name = "exception",
     srcs = glob(["**/*.java"]),
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
-    name = "exception-checkstyle",
-    target = ":exception",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":exception"
+    ],
 )

--- a/graql/java/parser/BUILD
+++ b/graql/java/parser/BUILD
@@ -19,6 +19,7 @@
 package(default_visibility = ["//visibility:public"]) # TODO: Needs to be replaced with below
 #package(default_visibility = ["//graql/java:__subpackages__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 
 java_library(
     name = "parser",
@@ -33,12 +34,9 @@ java_library(
     ]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "parser-checkstyle",
- target = ":parser",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":parser"
+    ],
 )

--- a/graql/java/parser/test/BUILD
+++ b/graql/java/parser/test/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "gremlin-visitor-test",
     test_class = "graql.parser.test.GremlinVisitorTest",
@@ -27,11 +29,9 @@ java_test(
     size = "small"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "gremlin-visitor-test-checkstyle",
- target = ":gremlin-visitor-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":gremlin-visitor-test"
+    ],
 )

--- a/graql/java/util/BUILD
+++ b/graql/java/util/BUILD
@@ -18,6 +18,7 @@
 
 package(default_visibility = ["//graql/java:__subpackages__"])
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 
 java_library(
     name = "util",
@@ -30,11 +31,7 @@ java_library(
         ]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
-    name = "util-checkstyle",
-    target = ":util",
-    config = "//config/checkstyle:checkstyle.xml",
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [":util"],
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -22,6 +22,7 @@ load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
 load("@graknlabs_bazel_distribution//distribution:rules.bzl", "distribution_structure", "distribution_zip", "distribution_deb", "distribution_rpm")
 load("@graknlabs_bazel_distribution//rpm/deployment:rules.bzl", "deploy_rpm")
 load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 
 exports_files(
     glob(["conf/**", "services/**"]),
@@ -88,14 +89,11 @@ java_library(
 
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "server-checkstyle",
- target = ":server",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":server"
+    ],
 )
 
 java_binary(

--- a/server/test/graql/internal/gremlin/BUILD
+++ b/server/test/graql/internal/gremlin/BUILD
@@ -14,15 +14,6 @@ java_test(
     size = "small"
 )
 
-checkstyle_test(
- name = "graql-traversal-test-checkstyle",
- target = ":graql-traversal-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "conjunction-query-test",
     test_class = "grakn.core.graql.internal.gremlin.ConjunctionQueryTest",
@@ -35,10 +26,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "conjunction-query-test-checkstyle",
- target = ":conjunction-query-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":graql-traversal-test",
+        ":conjunction-query-test"
+    ],
 )

--- a/server/test/graql/internal/gremlin/fragment/BUILD
+++ b/server/test/graql/internal/gremlin/fragment/BUILD
@@ -12,30 +12,12 @@ java_test(
     size = "small"
 )
 
-checkstyle_test(
- name = "in-plays-fragment-test-checkstyle",
- target = ":in-plays-fragment-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "isa-explicit-test",
     srcs = ["IsaExplicitTest.java"],
     test_class = "grakn.core.graql.internal.gremlin.fragment.IsaExplicitTest",
     deps = ["//server"],
     size = "small"
-)
-
-checkstyle_test(
- name = "isa-explicit-test-checkstyle",
- target = ":isa-explicit-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -51,10 +33,10 @@ java_test(
 )
 
 checkstyle_test(
- name = "out-plays-fragment-test-checkstyle",
- target = ":out-plays-fragment-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":in-plays-fragment-test",
+        ":isa-explicit-test",
+        ":out-plays-fragment-test"
+    ],
 )

--- a/server/test/graql/internal/gremlin/sets/BUILD
+++ b/server/test/graql/internal/gremlin/sets/BUILD
@@ -14,12 +14,11 @@ java_test(
 )
 
 checkstyle_test(
- name = "label-fragment-set-test-checkstyle",
- target = ":label-fragment-set-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":label-fragment-set-test",
+        ":roleplayer-fragment-set-test",
+    ],
 )
 
 java_test(
@@ -32,13 +31,4 @@ java_test(
         "//dependencies/maven/artifacts/org/mockito:mockito-core",
         "//server"],
     size = "small"
-)
-
-checkstyle_test(
- name = "roleplayer-fragment-set-test-checkstyle",
- target = ":roleplayer-fragment-set-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )

--- a/server/test/graql/internal/gremlin/spanningtree/BUILD
+++ b/server/test/graql/internal/gremlin/spanningtree/BUILD
@@ -8,29 +8,12 @@ java_test(
     size = "small"
 )
 
-checkstyle_test(
- name = "chu-liu-edmonds-test-checkstyle",
- target = ":chu-liu-edmonds-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "fibonacci-heap-test",
     test_class = "grakn.core.graql.internal.gremlin.spanningtree.datastructure.FibonacciHeapTest",
     srcs = ["datastructure/FibonacciHeapTest.java"],
     deps = ["//server", "//dependencies/maven/artifacts/com/google/guava:guava"],
     size = "small"
-)
-
-checkstyle_test(
- name = "fibonacci-heap-test-checkstyle",
- target = ":fibonacci-heap-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
 )
 
 java_test(
@@ -42,10 +25,10 @@ java_test(
 )
 
 checkstyle_test(
- name = "fibonacci-queue-test-checkstyle",
- target = ":fibonacci-queue-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":chu-liu-edmonds-test",
+        ":fibonacci-heap-test",
+        ":fibonacci-queue-test"
+    ]
 )

--- a/server/test/graql/parser/BUILD
+++ b/server/test/graql/parser/BUILD
@@ -31,15 +31,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "parser-test-checkstyle",
- target = ":parser-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "query-to-string-test",
     test_class = "grakn.core.graql.parser.QueryToStringTest",
@@ -53,10 +44,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "query-to-string-test-checkstyle",
- target = ":query-to-string-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":parser-test",
+        ":query-to-string-test"
+    ]
 )

--- a/server/test/graql/query/BUILD
+++ b/server/test/graql/query/BUILD
@@ -29,15 +29,6 @@ java_test(
     size = "small"
 )
 
-checkstyle_test(
- name = "concept-map-test-checkstyle",
- target = ":concept-map-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "delete-query-test",
     test_class = "grakn.core.graql.query.DeleteQueryTest",
@@ -46,15 +37,6 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//server"],
     size = "small"
-)
-
-checkstyle_test(
- name = "delete-query-test-checkstyle",
- target = ":delete-query-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -70,10 +52,10 @@ java_test(
 )
 
 checkstyle_test(
- name = "insert-query-test-checkstyle",
- target = ":insert-query-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":concept-map-test",
+        ":delete-query-test",
+        ":insert-query-test"
+    ]
 )

--- a/server/test/graql/query/pattern/BUILD
+++ b/server/test/graql/query/pattern/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "pattern-impl-test",
     test_class = "grakn.core.graql.query.pattern.PatternTest",
@@ -26,12 +28,9 @@ java_test(
     size = "small"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "pattern-impl-test-checkstyle",
- target = ":pattern-impl-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":pattern-impl-test"
+    ],
 )

--- a/server/test/graql/query/predicate/BUILD
+++ b/server/test/graql/query/predicate/BUILD
@@ -9,12 +9,12 @@ java_test(
 )
 
 checkstyle_test(
- name = "eq-predicate-test-checkstyle",
- target = ":eq-predicate-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":eq-predicate-test",
+        ":regex-predicate-test",
+        ":comparator-predicate-test"
+    ]
 )
 
 java_test(
@@ -25,15 +25,6 @@ java_test(
         "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",
         "//server"],
     size = "small"
-)
-
-checkstyle_test(
- name = "regex-predicate-test-checkstyle",
- target = ":regex-predicate-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -47,12 +38,4 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava:guava",
     ],
     size = "small"
-)
-
-checkstyle_test(
- name = "comparator-predicate-test-checkstyle",
- target = ":comparator-predicate-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
 )

--- a/server/test/server/deduplicator/BUILD
+++ b/server/test/server/deduplicator/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "rocks-db-queue-test",
     test_class = "grakn.core.server.deduplicator.RocksDbQueueTest",
@@ -29,12 +31,9 @@ java_test(
     flaky = True
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "rocks-db-queue-test-checkstyle",
- target = ":rocks-db-queue-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":rocks-db-queue-test"
+    ],
 )

--- a/server/test/server/keyspace/BUILD
+++ b/server/test/server/keyspace/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "keyspace-test",
     test_class = "grakn.core.server.keyspace.KeyspacesTest",
@@ -6,12 +8,9 @@ java_test(
     size = "small"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "keyspace-test-checkstyle",
- target = ":keyspace-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":keyspace-test"
+    ],
 )

--- a/server/test/server/util/BUILD
+++ b/server/test/server/util/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "server-lock-manager-test",
     test_class = "grakn.core.server.util.ServerLockManagerTest",
@@ -26,12 +28,7 @@ java_test(
     size = "small"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "server-lock-manager-test-checkstyle",
- target = ":server-lock-manager-test",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [":server-lock-manager-test"],
 )

--- a/test-end-to-end/client-java/BUILD
+++ b/test-end-to-end/client-java/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "client-java-e2e",
     test_class = "grakn.core.client.ClientJavaE2E",
@@ -14,12 +16,9 @@ java_test(
     data = ["//:distribution"]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "client-java-e2e-checkstyle",
- target = ":client-java-e2e",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":client-java-e2e"
+    ],
 )

--- a/test-end-to-end/deduplicator/BUILD
+++ b/test-end-to-end/deduplicator/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "attribute-deduplicator-e2e",
     test_class = "grakn.core.deduplicator.AttributeDeduplicatorE2E",
@@ -15,12 +17,7 @@ java_test(
     data = ["//:distribution"]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "attribute-deduplicator-e2e-checkstyle",
- target = ":attribute-deduplicator-e2e",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [":attribute-deduplicator-e2e"],
 )

--- a/test-end-to-end/distribution/BUILD
+++ b/test-end-to-end/distribution/BUILD
@@ -14,15 +14,6 @@ java_test(
     data = ["//:distribution"]
 )
 
-checkstyle_test(
- name = "grakn-graql-commands-e2e-checkstyle",
- target = ":grakn-graql-commands-e2e",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "grakn-graql-commands-with-a-running-grakn-e2e",
     test_class = "grakn.core.distribution.GraknGraqlCommands_WithARunningGraknE2E",
@@ -38,10 +29,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "grakn-graql-commands-with-a-running-grakn-e2e-checkstyle",
- target = ":grakn-graql-commands-with-a-running-grakn-e2e",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":grakn-graql-commands-e2e",
+        ":grakn-graql-commands-with-a-running-grakn-e2e"
+    ]
 )

--- a/test-integration/graql/analytics/BUILD
+++ b/test-integration/graql/analytics/BUILD
@@ -13,15 +13,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "analytics-it-checkstyle",
- target = ":analytics-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "connected-component-it",
     test_class = "grakn.core.graql.analytics.ConnectedComponentIT",
@@ -33,15 +24,6 @@ java_test(
     ],
     size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "connected-component-it-checkstyle",
- target = ":connected-component-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -56,15 +38,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "coreness-it-checkstyle",
- target = ":coreness-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "count-it",
     test_class = "grakn.core.graql.analytics.CountIT",
@@ -75,15 +48,6 @@ java_test(
     ],
     size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "count-it-checkstyle",
- target = ":count-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -99,15 +63,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "degree-it-checkstyle",
- target = ":degree-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "kcore-it",
     test_class = "grakn.core.graql.analytics.KCoreIT",
@@ -118,15 +73,6 @@ java_test(
     ],
     size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "kcore-it-checkstyle",
- target = ":kcore-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -140,15 +86,6 @@ java_test(
     ],
     size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "path-it-checkstyle",
- target = ":path-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -165,10 +102,15 @@ java_test(
 )
 
 checkstyle_test(
- name = "statistics-it-checkstyle",
- target = ":statistics-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":analytics-it",
+        ":connected-component-it",
+        ":coreness-it",
+        ":count-it",
+        ":degree-it",
+        ":kcore-it",
+        ":path-it",
+        ":statistics-it"
+    ]
 )

--- a/test-integration/graql/graph/BUILD
+++ b/test-integration/graql/graph/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "movie-graph",
     srcs = ["MovieGraph.java"],
@@ -26,12 +28,9 @@ java_library(
     ],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "movie-graph-checkstyle",
- target = ":movie-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
+    name = "checkstyle",
+    targets = [
+        ":movie-graph"
+    ],
+ )

--- a/test-integration/graql/internal/BUILD
+++ b/test-integration/graql/internal/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "isa-explicit-it",
     test_class = "grakn.core.graql.internal.IsaExplicitIT",
@@ -29,12 +31,7 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "isa-explicit-it-checkstyle",
- target = ":isa-explicit-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [":isa-explicit-it"],
 )

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -31,15 +31,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "aggregate-query-it-checkstyle",
- target = ":aggregate-query-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "define-query-it",
     test_class = "grakn.core.graql.query.DefineQueryIT",
@@ -56,15 +47,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "define-query-it-checkstyle",
- target = ":define-query-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "delete-query-it",
     test_class = "grakn.core.graql.query.DeleteQueryIT",
@@ -77,15 +59,6 @@ java_test(
         "//test-integration/util:graql-test-util",
     ],
     size = "medium"
-)
-
-checkstyle_test(
- name = "delete-query-it-checkstyle",
- target = ":delete-query-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -106,15 +79,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "insert-query-it-checkstyle",
- target = ":insert-query-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "undefine-query-it",
     test_class = "grakn.core.graql.query.UndefineQueryIT",
@@ -132,15 +96,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "undefine-query-it-checkstyle",
- target = ":undefine-query-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "query-builder-it",
     test_class = "grakn.core.graql.query.QueryBuilderIT",
@@ -152,15 +107,6 @@ java_test(
         "//test-integration/util:graql-test-util",
     ],
     size = "medium"
-)
-
-checkstyle_test(
- name = "query-builder-it-checkstyle",
- target = ":query-builder-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -175,15 +121,6 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava:guava",
     ],
     size = "medium"
-)
-
-checkstyle_test(
- name = "query-admin-it-checkstyle",
- target = ":query-admin-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -202,15 +139,6 @@ java_test(
     size = "medium"
 )
 
-checkstyle_test(
- name = "query-error-it-checkstyle",
- target = ":query-error-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "query-planner-it",
     test_class = "grakn.core.graql.query.QueryPlannerIT",
@@ -227,10 +155,16 @@ java_test(
 )
 
 checkstyle_test(
- name = "query-planner-it-checkstyle",
- target = ":query-planner-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":aggregate-query-it",
+        ":define-query-it",
+        ":delete-query-it",
+        ":insert-query-it",
+        ":undefine-query-it",
+        ":query-builder-it",
+        ":query-admin-it",
+        ":query-error-it",
+        ":query-planner-it"
+    ]
 )

--- a/test-integration/graql/query/pattern/BUILD
+++ b/test-integration/graql/query/pattern/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "pattern-it",
     test_class = "grakn.core.graql.query.pattern.PatternIT",
@@ -32,12 +34,9 @@ java_test(
     size = "medium"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "pattern-it-checkstyle",
- target = ":pattern-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":pattern-it"
+    ],
 )

--- a/test-integration/graql/reasoner/BUILD
+++ b/test-integration/graql/reasoner/BUILD
@@ -17,14 +17,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
- name = "reasoning-it-checkstyle",
- target = ":reasoning-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-)
-
 java_test(
     name = "geo-inference-it",
     size = "medium",
@@ -46,10 +38,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "geo-inference-it-checkstyle",
- target = ":geo-inference-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":reasoning-it",
+        ":geo-inference-it",
+    ]
 )

--- a/test-integration/graql/reasoner/atomic/BUILD
+++ b/test-integration/graql/reasoner/atomic/BUILD
@@ -16,15 +16,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "atomic-type-inference-it-checkstyle",
- target = ":atomic-type-inference-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "atomic-unification-it",
     srcs = ["AtomicUnificationIT.java"],
@@ -40,15 +31,6 @@ java_test(
     resources = ["//test-integration/graql/reasoner/resources:generic-schema"],
     size = "medium",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "atomic-unification-it-checkstyle",
- target = ":atomic-unification-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -69,15 +51,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "atomic-rule-applicability-it-checkstyle",
- target = ":atomic-rule-applicability-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "atomic-role-inference-it",
     srcs = ["AtomicRoleInferenceIT.java"],
@@ -93,15 +66,6 @@ java_test(
                      "//test-integration/graql/reasoner/resources:generic-schema"],
     size = "medium",
     classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "atomic-role-inference-it-checkstyle",
- target = ":atomic-role-inference-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -120,10 +84,12 @@ java_test(
 )
 
 checkstyle_test(
- name = "atomic-equivalence-it-checkstyle",
- target = ":atomic-equivalence-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":atomic-type-inference-it",
+        ":atomic-unification-it",
+        ":atomic-rule-applicability-it",
+        ":atomic-role-inference-it",
+        ":atomic-equivalence-it"
+    ],
 )

--- a/test-integration/graql/reasoner/benchmark/BUILD
+++ b/test-integration/graql/reasoner/benchmark/BUILD
@@ -20,15 +20,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "benchmark-big-it-checkstyle",
- target = ":benchmark-big-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "benchmark-small-it",
     test_class = "grakn.core.graql.reasoner.benchmark.BenchmarkSmallIT",
@@ -53,10 +44,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "benchmark-small-it-checkstyle",
- target = ":benchmark-small-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":benchmark-big-it",
+        ":benchmark-small-it"
+    ]
 )

--- a/test-integration/graql/reasoner/cache/BUILD
+++ b/test-integration/graql/reasoner/cache/BUILD
@@ -1,3 +1,5 @@
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "rule-cache-it",
     size = "medium",
@@ -12,12 +14,9 @@ java_test(
     ],
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "rule-cache-it-checkstyle",
- target = ":rule-cache-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":rule-cache-it"
+    ],
 )

--- a/test-integration/graql/reasoner/graph/BUILD
+++ b/test-integration/graql/reasoner/graph/BUILD
@@ -29,15 +29,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "diagonal-graph-checkstyle",
- target = ":diagonal-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "dual-linear-transitivity-graph",
     srcs = ["DualLinearTransitivityMatrixGraph.java"],
@@ -47,15 +38,6 @@ java_library(
         "//server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "dual-linear-transitivity-graph-checkstyle",
- target = ":dual-linear-transitivity-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_library(
@@ -74,29 +56,11 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "generic-schema-graph-checkstyle",
- target = ":generic-schema-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "geo-graph",
     srcs = ["GeoGraph.java"],
     visibility = ["//test-integration:__subpackages__"],
     deps = ["//server"],
-)
-
-checkstyle_test(
- name = "geo-graph-checkstyle",
- target = ":geo-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_library(
@@ -108,15 +72,6 @@ java_library(
         "//server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "linear-transitivity-matrix-graph-checkstyle",
- target = ":linear-transitivity-matrix-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_library(
@@ -131,15 +86,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "nguyen-graph-checkstyle",
- target = ":nguyen-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "path-matrix-graph",
     srcs = ["PathMatrixGraph.java"],
@@ -152,14 +98,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "path-matrix-graph-checkstyle",
- target = ":path-matrix-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-)
-
 java_library(
     name = "path-tree-graph",
     srcs = ["PathTreeGraph.java"],
@@ -170,14 +108,6 @@ java_library(
         "//server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "path-tree-graph-checkstyle",
- target = ":path-tree-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
 )
 
 java_library(
@@ -195,15 +125,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "path-tree-symmetric-graph-checkstyle",
- target = ":path-tree-symmetric-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "tail-recursion-graph",
     srcs = ["TailRecursionGraph.java"],
@@ -216,15 +137,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "tail-recursion-graph-checkstyle",
- target = ":tail-recursion-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "transitivity-chain-graph",
     srcs = ["TransitivityChainGraph.java"],
@@ -234,15 +146,6 @@ java_library(
         "//server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "transitivity-chain-graph-checkstyle",
- target = ":transitivity-chain-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_library(
@@ -257,10 +160,19 @@ java_library(
 )
 
 checkstyle_test(
- name = "transitivity-matrix-graph-checkstyle",
- target = ":transitivity-matrix-graph",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+ name = "checkstyle",
+ targets = [
+   ":diagonal-graph",
+   ":dual-linear-transitivity-graph",
+   ":generic-schema-graph",
+   ":geo-graph",
+   ":linear-transitivity-matrix-graph",
+   ":nguyen-graph",
+   ":path-matrix-graph",
+   ":path-tree-graph",
+   ":path-tree-symmetric-graph",
+   ":tail-recursion-graph",
+   ":transitivity-chain-graph",
+   ":transitivity-matrix-graph",
+ ],
 )

--- a/test-integration/graql/reasoner/pattern/BUILD
+++ b/test-integration/graql/reasoner/pattern/BUILD
@@ -6,15 +6,6 @@ java_library(
     visibility = ["//test-integration:__subpackages__"],
 )
 
-checkstyle_test(
- name = "query-pattern-checkstyle",
- target = ":query-pattern",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "relation-pattern",
     srcs = ["RelationPattern.java"],
@@ -26,15 +17,6 @@ java_library(
     ],
 )
 
-checkstyle_test(
- name = "relation-pattern-checkstyle",
- target = ":relation-pattern",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_library(
     name = "resource-pattern",
     srcs = ["AttributePattern.java"],
@@ -44,15 +26,6 @@ java_library(
         "//server",
         "//test-integration/graql/reasoner/pattern:query-pattern",
     ],
-)
-
-checkstyle_test(
- name = "resource-pattern-checkstyle",
- target = ":resource-pattern",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_library(
@@ -67,10 +40,11 @@ java_library(
 )
 
 checkstyle_test(
- name = "type-pattern-checkstyle",
- target = ":type-pattern",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":query-pattern",
+        ":relation-pattern",
+        ":resource-pattern",
+        ":type-pattern"
+    ]
 )

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -16,14 +16,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
-    name = "query-equivalence-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":query-equivalence-it",
-)
-
 java_test(
     name = "atomic-query-it",
     size = "medium",
@@ -39,14 +31,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
-    name = "atomic-query-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":atomic-query-it",
 )
 
 java_test(
@@ -68,14 +52,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
-    name = "negation-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":negation-it",
 )
 
 java_test(
@@ -106,14 +82,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
-    name = "query-unification-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":query-unification-it",
-)
-
 java_test(
     name = "query-validity-it",
     size = "medium",
@@ -128,14 +96,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
-    name = "query-validity-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":query-validity-it",
-)
-
 java_test(
     name = "query-it",
     size = "medium",
@@ -147,14 +107,6 @@ java_test(
         "//test-integration/graql/reasoner/graph:geo-graph",
         "//test-integration/rule:grakn-test-server",
     ],
-)
-
-checkstyle_test(
-    name = "query-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":query-it",
 )
 
 java_test(
@@ -173,14 +125,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
-    name = "ontological-query-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":ontological-query-it",
-)
-
 java_test(
     name = "resolution-plan-it",
     size = "medium",
@@ -194,14 +138,6 @@ java_test(
         "//server",
         "//test-integration/rule:grakn-test-server",
     ],
-)
-
-checkstyle_test(
-    name = "resolution-plan-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":resolution-plan-it",
 )
 
 java_test(
@@ -219,14 +155,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
-    name = "semantic-difference-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":semantic-difference-it",
 )
 
 java_test(
@@ -254,9 +182,17 @@ java_test(
 )
 
 checkstyle_test(
-    name = "subsumption-it-checkstyle",
-    config = "//config/checkstyle:checkstyle.xml",
-    licenses = ["//config/checkstyle:licenses"],
-    suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
-    target = ":subsumption-it",
+    name = "checkstyle",
+    targets = [
+        ":atomic-query-it",
+        ":query-equivalence-it",
+        ":negation-it",
+        ":query-unification-it",
+        ":query-validity-it",
+        ":query-it",
+        ":ontological-query-it",
+        ":resolution-plan-it",
+        ":semantic-difference-it",
+        "//test-integration/graql/reasoner/query:subsumption-it",
+    ]
 )

--- a/test-integration/graql/reasoner/reasoning/BUILD
+++ b/test-integration/graql/reasoner/reasoning/BUILD
@@ -14,15 +14,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
- name = "neq-predicate-it-checkstyle",
- target = ":neq-predicate-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "recursion-it",
     size = "large",
@@ -52,15 +43,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
- name = "recursion-it-checkstyle",
- target = ":recursion-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
     name = "attribute-attachment-it",
     size = "medium",
@@ -77,14 +59,6 @@ java_test(
     ],
 )
 
-checkstyle_test(
- name = "attribute-attachment-it-checkstyle",
- target = ":attribute-attachment-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-)
-
 java_test(
     name = "type-generation-it",
     size = "medium",
@@ -97,15 +71,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "type-generation-it-checkstyle",
- target = ":type-generation-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -121,15 +86,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
     ],
-)
-
-checkstyle_test(
- name = "type-hierarchies-it-checkstyle",
- target = ":type-hierarchies-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -149,10 +105,13 @@ java_test(
 )
 
 checkstyle_test(
- name = "variable-roles-it-checkstyle",
- target = ":variable-roles-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":attribute-attachment-it",
+        ":neq-predicate-it",
+        ":recursion-it",
+        ":type-generation-it",
+        ":type-hierarchies-it",
+        ":variable-roles-it",
+    ]
 )

--- a/test-integration/rule/BUILD
+++ b/test-integration/rule/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_library(
     name = "grakn-test-server",
     srcs = ["GraknTestServer.java"],
@@ -37,12 +39,9 @@ java_library(
     visibility = ["//visibility:public"]
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "grakn-test-server-checkstyle",
- target = ":grakn-test-server",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":grakn-test-server"
+    ],
 )

--- a/test-integration/server/BUILD
+++ b/test-integration/server/BUILD
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
+
 java_test(
     name = "attribute-deduplicator-it",
     test_class = "grakn.core.server.AttributeDeduplicatorIT",
@@ -27,12 +29,9 @@ java_test(
     size = "large"
 )
 
-load("//dependencies/tools/checkstyle:checkstyle.bzl", "checkstyle_test")
 checkstyle_test(
- name = "attribute-deduplicator-it-checkstyle",
- target = ":attribute-deduplicator-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":attribute-deduplicator-it"
+    ],
 )

--- a/test-integration/server/kb/BUILD
+++ b/test-integration/server/kb/BUILD
@@ -14,15 +14,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "validator-it-checkstyle",
- target = ":validator-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
   name = "validate-global-rules-it",
   srcs = ["ValidateGlobalRulesIT.java"],
@@ -33,15 +24,6 @@ java_test(
   ],
   size = "medium",
   classpath_resources = ["//test-integration/resources:logback-test"]
-)
-
-checkstyle_test(
- name = "validate-global-rules-it-checkstyle",
- target = ":validate-global-rules-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -60,10 +42,10 @@ java_test(
 )
 
 checkstyle_test(
- name = "grakn-tx-it-checkstyle",
- target = ":grakn-tx-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":validator-it",
+        ":validate-global-rules-it",
+        ":grakn-tx-it",
+    ]
 )

--- a/test-integration/server/kb/concept/BUILD
+++ b/test-integration/server/kb/concept/BUILD
@@ -14,14 +14,6 @@ java_test(
      size = "medium",
 )
 
-checkstyle_test(
- name = "attribute-it-checkstyle",
- target = ":attribute-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
 java_test(
      name = "attribute-type-it",
      srcs = ["AttributeTypeIT.java"],
@@ -35,14 +27,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "attribute-type-it-checkstyle",
- target = ":attribute-type-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
 java_test(
      name = "concept-it",
      srcs = ["ConceptIT.java"],
@@ -55,15 +39,6 @@ java_test(
      ],
      classpath_resources = ["//test-integration/resources:logback-test"],
      size = "medium"
-)
-
-checkstyle_test(
- name = "concept-it-checkstyle",
- target = ":concept-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -79,15 +54,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "entity-it-checkstyle",
- target = ":entity-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
      name = "entity-type-it",
      srcs = ["EntityTypeIT.java"],
@@ -101,15 +67,6 @@ java_test(
      ],
      classpath_resources = ["//test-integration/resources:logback-test"],
      size = "large"
-)
-
-checkstyle_test(
- name = "entity-type-it-checkstyle",
- target = ":entity-type-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
 )
 
 java_test(
@@ -128,15 +85,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "relationship-it-checkstyle",
- target = ":relationship-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
      name = "relationship-type-it",
      srcs = ["RelationTypeIT.java"],
@@ -150,14 +98,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "relationship-type-it-checkstyle",
- target = ":relationship-type-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
 java_test(
      name = "role-it",
      srcs = ["RoleIT.java"],
@@ -171,14 +111,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "role-it-checkstyle",
- target = ":role-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
 java_test(
      name = "schema-concept-it",
      srcs = ["SchemaConceptIT.java"],
@@ -194,14 +126,6 @@ java_test(
      size = "medium"
 )
 
-checkstyle_test(
- name = "schema-concept-it-checkstyle",
- target = ":schema-concept-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
 java_test(
      name = "schema-mutation-it",
      srcs = ["SchemaMutationIT.java"],
@@ -218,10 +142,17 @@ java_test(
 )
 
 checkstyle_test(
- name = "schema-mutation-it-checkstyle",
- target = ":schema-mutation-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":attribute-it",
+        ":attribute-type-it",
+        ":concept-it",
+        ":entity-it",
+        ":entity-type-it",
+        ":relationship-it",
+        ":relationship-type-it",
+        ":role-it",
+        ":schema-concept-it",
+        ":schema-mutation-it",
+    ]
 )

--- a/test-integration/server/kb/structure/BUILD
+++ b/test-integration/server/kb/structure/BUILD
@@ -13,15 +13,6 @@ java_test(
   classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
-checkstyle_test(
- name = "casting-it-checkstyle",
- target = ":casting-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
-)
-
 java_test(
   name = "edge-it",
   srcs = ["EdgeIT.java"],
@@ -36,10 +27,9 @@ java_test(
 )
 
 checkstyle_test(
- name = "edge-it-checkstyle",
- target = ":edge-it",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
-
+    name = "checkstyle",
+    targets = [
+        ":casting-it",
+        ":edge-it"
+    ]
 )

--- a/test-integration/util/BUILD
+++ b/test-integration/util/BUILD
@@ -12,9 +12,8 @@ java_library(
 )
 
 checkstyle_test(
- name = "graql-test-util-checkstyle",
- target = ":graql-test-util",
- config = "//config/checkstyle:checkstyle.xml",
- suppressions = "//config/checkstyle:checkstyle-suppressions.xml",
- licenses = ["//config/checkstyle:licenses"],
+    name = "checkstyle",
+    targets = [
+        ":graql-test-util"
+    ],
 )


### PR DESCRIPTION
# Why is this PR needed?

So checkstyle targets are easier to read; fixes #4825

# What does the PR do?

1. Utilizes new attribute `targets`, merging all `checkstyle` targets to one per `BUILD` file
2. Adapt `check-for-missing-checkstyle-rule.py ` to be Python 3 compatible
3. Moves `config`, `suppressions`, `license_files` (former `licenses`, renamed due to bazelbuild/bazel#7194) to `default` of attributes

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—