### PR TITLE
Refactor Graql query language library - part 14 (in progress)

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -160,7 +160,6 @@ public enum ErrorMessage {
     LABEL_NOT_FOUND("label '%s' not found"),
     NOT_A_ROLE_TYPE("'%s' is not a role type. perhaps you meant 'isa %s'?"),
     NOT_A_RELATION_TYPE("'%s' is not a relation type. perhaps you forgot to separate your statements with a ';'?"),
-    CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'"),
     NON_POSITIVE_LIMIT("limit %s should be positive"),
     NEGATIVE_OFFSET("offset %s should be non-negative"),
     INVALID_VALUE("unsupported attribute value type %s"),

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -167,8 +167,6 @@ public enum ErrorMessage {
     AGGREGATE_ARGUMENT_NUM("aggregate '%s' takes %s arguments, but got %s"),
     UNKNOWN_AGGREGATE("unknown aggregate '%s'"),
 
-    VARIABLE_NOT_IN_QUERY("the variable %s is not in the query"),
-    NO_PATTERNS("no patterns have been provided. at least one pattern must be provided"),
     MATCH_INVALID("cannot match on property of type [%s]"),
     MULTIPLE_TX("a graph has been specified twice for this query"),
 

--- a/graql/java/exception/ErrorMessage.java
+++ b/graql/java/exception/ErrorMessage.java
@@ -20,7 +20,8 @@ package graql.exception;
 
 public enum ErrorMessage {
     SYNTAX_ERROR_NO_POINTER("syntax error at line %s:\n%s"),
-    SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s");
+    SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s"),
+    CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'");
 
     private final String message;
 

--- a/graql/java/exception/ErrorMessage.java
+++ b/graql/java/exception/ErrorMessage.java
@@ -21,7 +21,9 @@ package graql.exception;
 public enum ErrorMessage {
     SYNTAX_ERROR_NO_POINTER("syntax error at line %s:\n%s"),
     SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s"),
-    CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'");
+    CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'"),
+    VARIABLE_NOT_IN_QUERY("the variable %s is not in the query"),
+    NO_PATTERNS("no patterns have been provided. at least one pattern must be provided");
 
     private final String message;
 

--- a/graql/java/exception/GraqlException.java
+++ b/graql/java/exception/GraqlException.java
@@ -1,0 +1,21 @@
+package graql.exception;
+
+
+public class GraqlException extends RuntimeException {
+
+    protected GraqlException(String error) {
+        super(error);
+    }
+
+    protected GraqlException(String error, Exception e) {
+        super(error, e);
+    }
+
+    public static GraqlException conflictingProperties(String statement, String property, String other) {
+        return new GraqlException(ErrorMessage.CONFLICTING_PROPERTIES.getMessage(statement, property, other));
+    }
+
+    public String getName() {
+        return this.getClass().getName();
+    }
+}

--- a/graql/java/exception/GraqlException.java
+++ b/graql/java/exception/GraqlException.java
@@ -33,6 +33,14 @@ public class GraqlException extends RuntimeException {
         return new GraqlException(ErrorMessage.CONFLICTING_PROPERTIES.getMessage(statement, property, other));
     }
 
+    public static GraqlException varNotInQuery(String var) {
+        return new GraqlException(ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(var));
+    }
+
+    public static GraqlException noPatterns() {
+        return new GraqlException(ErrorMessage.NO_PATTERNS.getMessage());
+    }
+
     public String getName() {
         return this.getClass().getName();
     }

--- a/graql/java/exception/GraqlException.java
+++ b/graql/java/exception/GraqlException.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package graql.exception;
 
 

--- a/server/src/graql/admin/ReasonerQuery.java
+++ b/server/src/graql/admin/ReasonerQuery.java
@@ -31,12 +31,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- *
- * <p>
  * Interface for conjunctive reasoner queries.
- * </p>
- *
- *
  */
 public interface ReasonerQuery{
 

--- a/server/src/graql/answer/ConceptMap.java
+++ b/server/src/graql/answer/ConceptMap.java
@@ -34,6 +34,7 @@ import grakn.core.graql.internal.reasoner.explanation.QueryExplanation;
 import grakn.core.graql.internal.reasoner.utils.Pair;
 import grakn.core.graql.internal.reasoner.utils.ReasonerUtils;
 import grakn.core.graql.query.pattern.statement.Variable;
+import graql.exception.GraqlException;
 
 import javax.annotation.CheckReturnValue;
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class ConceptMap implements Answer<ConceptMap> {
     @CheckReturnValue
     public Concept get(Variable var) {
         Concept concept = map.get(var);
-        if (concept == null) throw GraqlQueryException.varNotInQuery(var);
+        if (concept == null) throw GraqlException.varNotInQuery(var.toString());
         return concept;
     }
 

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -32,7 +32,6 @@ import grakn.core.graql.concept.Type;
 import grakn.core.graql.query.ComputeQuery;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
-import grakn.core.graql.query.pattern.property.VarProperty;
 
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
@@ -49,7 +48,6 @@ import static grakn.core.common.exception.ErrorMessage.MISSING_COMPUTE_CONDITION
 import static grakn.core.common.exception.ErrorMessage.NEGATIVE_OFFSET;
 import static grakn.core.common.exception.ErrorMessage.NON_POSITIVE_LIMIT;
 import static grakn.core.common.exception.ErrorMessage.UNEXPECTED_RESULT;
-import static grakn.core.common.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static grakn.core.graql.query.ComputeQuery.ALGORITHMS_ACCEPTED;
 import static grakn.core.graql.query.ComputeQuery.ARGUMENTS_ACCEPTED;
 import static grakn.core.graql.query.ComputeQuery.CONDITIONS_ACCEPTED;
@@ -80,10 +78,6 @@ public class GraqlQueryException extends GraknException {
 
     public static GraqlQueryException create(String formatString, Object... args) {
         return new GraqlQueryException(String.format(formatString, args));
-    }
-
-    public static GraqlQueryException noPatterns() {
-        return new GraqlQueryException(ErrorMessage.NO_PATTERNS.getMessage());
     }
 
     public static GraqlQueryException incorrectAggregateArgumentNumber(
@@ -200,10 +194,6 @@ public class GraqlQueryException extends GraknException {
      */
     public static GraqlQueryException insertExistingConcept(Statement pattern, Concept concept) {
         return create("cannot overwrite properties `%s` on  concept `%s`", pattern, concept);
-    }
-
-    public static GraqlQueryException varNotInQuery(Variable var) {
-        return new GraqlQueryException(VARIABLE_NOT_IN_QUERY.getMessage(var));
     }
 
     public static GraqlQueryException noTx() {

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -93,14 +93,6 @@ public class GraqlQueryException extends GraknException {
         return new GraqlQueryException(message);
     }
 
-    public static GraqlQueryException conflictingProperties(
-            Statement varPattern, VarProperty property, VarProperty other) {
-        String message = ErrorMessage.CONFLICTING_PROPERTIES.getMessage(
-                varPattern.getPrintableName(), property.toString(), other.toString()
-        );
-        return new GraqlQueryException(message);
-    }
-
     public static GraqlQueryException idNotFound(ConceptId id) {
         return new GraqlQueryException(ErrorMessage.ID_NOT_FOUND.getMessage(id));
     }

--- a/server/src/graql/internal/executor/property/HasAttributeTypeExecutor.java
+++ b/server/src/graql/internal/executor/property/HasAttributeTypeExecutor.java
@@ -66,7 +66,7 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
         this.attributeType = property.attributeType();
 
         // TODO: this may the cause of issue #4664
-        Label resourceLabel = attributeType.getTypeLabel().orElseThrow(
+        String type = attributeType.getType().orElseThrow(
                 () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType.var())
         );
 
@@ -83,9 +83,9 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
 
         // If a key, limit only to the implicit key type
         if (property.isKey()) {
-            ownerRole = ownerRole.type(KEY_OWNER.getLabel(resourceLabel).getValue());
-            valueRole = valueRole.type(KEY_VALUE.getLabel(resourceLabel).getValue());
-            relationType = relationType.type(KEY.getLabel(resourceLabel).getValue());
+            ownerRole = ownerRole.type(KEY_OWNER.getLabel(type).getValue());
+            valueRole = valueRole.type(KEY_VALUE.getLabel(type).getValue());
+            relationType = relationType.type(KEY.getLabel(type).getValue());
         }
 
         Statement relationOwner = relationType.relates(ownerRole);
@@ -137,13 +137,13 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         //NB: HasResourceType is a special case and it doesn't allow variables as resource types
         Variable varName = var.asUserDefined();
-        Label label = property.attributeType().getTypeLabel().orElse(null);
+        String label = property.attributeType().getType().orElse(null);
 
         Variable predicateVar = new Variable();
-        SchemaConcept attributeType = parent.tx().getSchemaConcept(label);
+        SchemaConcept attributeType = parent.tx().getSchemaConcept(Label.of(label));
         ConceptId predicateId = attributeType != null ? attributeType.id() : null;
         //isa part
-        Statement resVar = new Statement(varName).has(Graql.type(label.getValue()));
+        Statement resVar = new Statement(varName).has(Graql.type(label));
         return HasAtom.create(resVar, predicateVar, predicateId, parent);
     }
 

--- a/server/src/graql/internal/executor/property/RelationExecutor.java
+++ b/server/src/graql/internal/executor/property/RelationExecutor.java
@@ -140,9 +140,9 @@ public class RelationExecutor implements PropertyExecutor.Insertable {
         //Isa present
         if (isaProp != null) {
             Statement isaVar = isaProp.type();
-            Label label = isaVar.getTypeLabel().orElse(null);
+            String label = isaVar.getType().orElse(null);
             if (label != null) {
-                predicate = IdPredicate.create(typeVariable, label, parent);
+                predicate = IdPredicate.create(typeVariable, Label.of(label), parent);
             } else {
                 typeVariable = isaVar.var();
                 predicate = getUserDefinedIdPredicate(typeVariable, otherStatements, parent);

--- a/server/src/graql/internal/gremlin/ConjunctionQuery.java
+++ b/server/src/graql/internal/gremlin/ConjunctionQuery.java
@@ -21,7 +21,6 @@ package grakn.core.graql.internal.gremlin;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.internal.executor.property.PropertyExecutor;
 import grakn.core.graql.internal.gremlin.fragment.Fragment;
 import grakn.core.graql.internal.gremlin.sets.EquivalentFragmentSets;
@@ -29,6 +28,7 @@ import grakn.core.graql.query.pattern.Conjunction;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.server.Transaction;
+import graql.exception.GraqlException;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -64,7 +64,7 @@ class ConjunctionQuery {
         statements = patternConjunction.getPatterns();
 
         if (statements.size() == 0) {
-            throw GraqlQueryException.noPatterns();
+            throw GraqlException.noPatterns();
         }
 
         ImmutableSet<EquivalentFragmentSet> fragmentSets =

--- a/server/src/graql/internal/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueries.java
@@ -31,12 +31,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- *
- * <p>
  * Factory for reasoner queries.
- * </p>
- *
- *
  */
 public class ReasonerQueries {
 

--- a/server/src/graql/query/DeleteQuery.java
+++ b/server/src/graql/query/DeleteQuery.java
@@ -18,8 +18,8 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.query.pattern.statement.Variable;
+import graql.exception.GraqlException;
 
 import javax.annotation.CheckReturnValue;
 import java.util.LinkedHashSet;
@@ -54,7 +54,7 @@ public class DeleteQuery implements Query {
         }
         for (Variable var : vars) {
             if (!match.getSelectedNames().contains(var)) {
-                throw GraqlQueryException.varNotInQuery(var);
+                throw GraqlException.varNotInQuery(var.toString());
             }
         }
         this.vars = vars;

--- a/server/src/graql/query/GetQuery.java
+++ b/server/src/graql/query/GetQuery.java
@@ -18,8 +18,8 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.query.pattern.statement.Variable;
+import graql.exception.GraqlException;
 
 import javax.annotation.CheckReturnValue;
 import java.util.LinkedHashSet;
@@ -51,7 +51,7 @@ public class GetQuery implements Query {
         }
         for (Variable var : vars) {
             if (!match.getSelectedNames().contains(var)) {
-                throw GraqlQueryException.varNotInQuery(var);
+                throw GraqlException.varNotInQuery(var.toString());
             }
         }
         this.match = match;

--- a/server/src/graql/query/InsertQuery.java
+++ b/server/src/graql/query/InsertQuery.java
@@ -18,8 +18,8 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.query.pattern.statement.Statement;
+import graql.exception.GraqlException;
 
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nullable;
@@ -39,7 +39,7 @@ public class InsertQuery implements Query {
 
     public InsertQuery(@Nullable MatchClause match, List<Statement> statements) {
         if (statements.isEmpty()) {
-            throw GraqlQueryException.noPatterns();
+            throw GraqlException.noPatterns();
         }
 
         this.match = match;

--- a/server/src/graql/query/MatchClause.java
+++ b/server/src/graql/query/MatchClause.java
@@ -18,11 +18,11 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.query.pattern.Conjunction;
 import grakn.core.graql.query.pattern.Pattern;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
+import graql.exception.GraqlException;
 
 import javax.annotation.CheckReturnValue;
 import java.util.ArrayList;
@@ -46,7 +46,7 @@ public class MatchClause {
 
     public MatchClause(Conjunction<Pattern> pattern) {
         if (pattern.getPatterns().size() == 0) {
-            throw GraqlQueryException.noPatterns();
+            throw GraqlException.noPatterns();
         }
 
         this.pattern = pattern;

--- a/server/src/graql/query/pattern/Conjunction.java
+++ b/server/src/graql/query/pattern/Conjunction.java
@@ -18,18 +18,14 @@
 
 package grakn.core.graql.query.pattern;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import grakn.core.graql.admin.ReasonerQuery;
-import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
 import grakn.core.graql.query.Graql;
 import grakn.core.graql.query.Query;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
-import grakn.core.server.Transaction;
-import grakn.core.server.session.TransactionOLTP;
 
 import javax.annotation.CheckReturnValue;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -98,17 +94,7 @@ public class Conjunction<T extends Pattern> implements Pattern {
 
     @Override
     public Set<Variable> variables() {
-        return getPatterns().stream().map(Pattern::variables).reduce(ImmutableSet.of(), Sets::union);
-    }
-
-    /**
-     * @return the corresponding reasoner query
-     */
-    @CheckReturnValue
-    public ReasonerQuery toReasonerQuery(Transaction tx) {
-        Conjunction<Pattern> pattern = getNegationDNF().getPatterns().iterator().next();
-        // TODO: This cast is unsafe - this method should accept an `TransactionImpl`
-        return ReasonerQueries.composite(pattern, (TransactionOLTP) tx);
+        return getPatterns().stream().map(Pattern::variables).reduce(new HashSet<>(), Sets::union);
     }
 
     private static <U extends Pattern> Conjunction<U> fromConjunctions(List<Conjunction<U>> conjunctions) {

--- a/server/src/graql/query/pattern/statement/StatementInstance.java
+++ b/server/src/graql/query/pattern/statement/StatementInstance.java
@@ -157,7 +157,7 @@ public abstract class StatementInstance extends Statement {
 
         @CheckReturnValue
         StatementThing addProperty(VarProperty property) {
-            validateNonUniqueOrThrow(property);
+            validateNoConflictOrThrow(property);
             LinkedHashSet<VarProperty> newProperties = new LinkedHashSet<>(this.properties());
             newProperties.add(property);
             return new StatementThing(this.var(), newProperties);
@@ -264,7 +264,7 @@ public abstract class StatementInstance extends Statement {
 
         @CheckReturnValue
         StatementRelation addProperty(VarProperty property) {
-            validateNonUniqueOrThrow(property);
+            validateNoConflictOrThrow(property);
             LinkedHashSet<VarProperty> newProperties = new LinkedHashSet<>(this.properties());
             newProperties.add(property);
             return new StatementRelation(this.var(), newProperties);
@@ -306,7 +306,7 @@ public abstract class StatementInstance extends Statement {
 
         @CheckReturnValue
         StatementAttribute addProperty(VarProperty property) {
-            validateNonUniqueOrThrow(property);
+            validateNoConflictOrThrow(property);
             LinkedHashSet<VarProperty> newProperties = new LinkedHashSet<>(this.properties());
             newProperties.add(property);
             return new StatementAttribute(this.var(), newProperties);

--- a/server/src/graql/query/pattern/statement/StatementType.java
+++ b/server/src/graql/query/pattern/statement/StatementType.java
@@ -54,7 +54,7 @@ public class StatementType extends Statement {
 
     @CheckReturnValue
     private StatementType addProperty(VarProperty property) {
-        validateNonUniqueOrThrow(property);
+        validateNoConflictOrThrow(property);
         LinkedHashSet<VarProperty> newProperties = new LinkedHashSet<>(this.properties());
         newProperties.add(property);
         return new StatementType(this.var(), newProperties);

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -291,8 +291,8 @@ class ValidateGlobalRules {
     }
 
     private static ReasonerQuery combinedRuleQuery(Transaction graph, Rule rule){
-        ReasonerQuery bodyQuery = rule.when().getNegationDNF().getPatterns().iterator().next().toReasonerQuery(graph);
-        ReasonerQuery headQuery =  rule.then().getNegationDNF().getPatterns().iterator().next().toReasonerQuery(graph);
+        ReasonerQuery bodyQuery = Iterables.getOnlyElement(rule.when().getNegationDNF().getPatterns()).toReasonerQuery(graph);
+        ReasonerQuery headQuery = Iterables.getOnlyElement(rule.then().getNegationDNF().getPatterns()).toReasonerQuery(graph);
         return headQuery.conjunction(bodyQuery);
     }
 

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -371,10 +371,10 @@ class ValidateGlobalRules {
 
         pattern.statements().stream()
                 .flatMap(statement -> statement.innerStatements().stream())
-                .flatMap(statement -> statement.getTypeLabels().stream()).forEach(typeLabel -> {
-                    SchemaConcept schemaConcept = graph.getSchemaConcept(typeLabel);
+                .flatMap(statement -> statement.getTypes().stream()).forEach(type -> {
+                    SchemaConcept schemaConcept = graph.getSchemaConcept(Label.of(type));
                     if(schemaConcept == null){
-                        errors.add(ErrorMessage.VALIDATION_RULE_MISSING_ELEMENTS.getMessage(side, rule.label(), typeLabel));
+                        errors.add(ErrorMessage.VALIDATION_RULE_MISSING_ELEMENTS.getMessage(side, rule.label(), type));
                     } else {
                         if(Schema.VertexProperty.RULE_WHEN.equals(side)){
                             if (schemaConcept.isType()){

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -33,6 +33,7 @@ import grakn.core.graql.concept.SchemaConcept;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.Schema;
+import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
 import grakn.core.graql.query.pattern.Conjunction;
 import grakn.core.graql.query.pattern.Disjunction;
 import grakn.core.graql.query.pattern.Pattern;
@@ -44,6 +45,7 @@ import grakn.core.server.kb.concept.RuleImpl;
 import grakn.core.server.kb.concept.SchemaConceptImpl;
 import grakn.core.server.kb.concept.TypeImpl;
 import grakn.core.server.kb.structure.Casting;
+import grakn.core.server.session.TransactionOLTP;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -276,7 +278,7 @@ class ValidateGlobalRules {
      * @param rule the rule to be validated
      * @return Error messages if the rule is not a valid Horn clause (in implication form, conjunction in the body, single-atom conjunction in the head)
      */
-    static Set<String> validateRuleIsValidHornClause(Transaction graph, Rule rule){
+    static Set<String> validateRuleIsValidHornClause(TransactionOLTP graph, Rule rule){
         Set<String> errors = new HashSet<>();
         if (!combinedRuleQuery(graph, rule).isPositive()){
             errors.add(ErrorMessage.VALIDATION_RULE_NEGATIVE_STATEMENTS_UNSUPPORTED_IN_RULES.getMessage(rule.label()));
@@ -290,9 +292,9 @@ class ValidateGlobalRules {
         return errors;
     }
 
-    private static ReasonerQuery combinedRuleQuery(Transaction graph, Rule rule){
-        ReasonerQuery bodyQuery = Iterables.getOnlyElement(rule.when().getNegationDNF().getPatterns()).toReasonerQuery(graph);
-        ReasonerQuery headQuery = Iterables.getOnlyElement(rule.then().getNegationDNF().getPatterns()).toReasonerQuery(graph);
+    private static ReasonerQuery combinedRuleQuery(TransactionOLTP graph, Rule rule){
+        ReasonerQuery bodyQuery = ReasonerQueries.create(Iterables.getOnlyElement(rule.when().getDisjunctiveNormalForm().getPatterns()), graph);
+        ReasonerQuery headQuery = ReasonerQueries.create(Iterables.getOnlyElement(rule.then().getDisjunctiveNormalForm().getPatterns()), graph);
         return headQuery.conjunction(bodyQuery);
     }
 
@@ -302,7 +304,7 @@ class ValidateGlobalRules {
      * @param rule the rule to be validated ontologically
      * @return Error messages if the rule has ontological inconsistencies
      */
-    static Set<String> validateRuleOntologically(Transaction graph, Rule rule) {
+    static Set<String> validateRuleOntologically(TransactionOLTP graph, Rule rule) {
         Set<String> errors = new HashSet<>();
 
         //both body and head refer to the same graph and have to be valid with respect to the schema that governs it
@@ -318,15 +320,16 @@ class ValidateGlobalRules {
      * @param rule the rule to be validated
      * @return Error messages if the rule head is invalid - is not a single-atom conjunction, doesn't contain illegal atomics and is ontologically valid
      */
-    private static Set<String> validateRuleHead(Transaction graph, Rule rule) {
+    private static Set<String> validateRuleHead(TransactionOLTP graph, Rule rule) {
         Set<String> errors = new HashSet<>();
         Set<Conjunction<Statement>> headPatterns = rule.then().getDisjunctiveNormalForm().getPatterns();
+        Set<Conjunction<Statement>> bodyPatterns = rule.when().getDisjunctiveNormalForm().getPatterns();
 
         if (headPatterns.size() != 1){
             errors.add(ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_HEAD.getMessage(rule.label()));
         } else {
-            ReasonerQuery bodyQuery = Iterables.getOnlyElement(rule.when().getDisjunctiveNormalForm().getPatterns()).toReasonerQuery(graph);
-            ReasonerQuery headQuery = Iterables.getOnlyElement(headPatterns).toReasonerQuery(graph);
+            ReasonerQuery bodyQuery = ReasonerQueries.create(Iterables.getOnlyElement(bodyPatterns), graph);
+            ReasonerQuery headQuery = ReasonerQueries.create(Iterables.getOnlyElement(headPatterns), graph);
             ReasonerQuery combinedQuery = headQuery.conjunction(bodyQuery);
 
             Set<Atomic> headAtoms = headQuery.getAtoms();

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -613,8 +613,8 @@ public class TransactionOLTP implements Transaction {
         //NB: this will cache also non-committed rules
         if (rule.then() != null) {
             rule.then().statements().stream()
-                    .flatMap(v -> v.getTypeLabels().stream())
-                    .map(vl -> this.<SchemaConcept>getSchemaConcept(vl))
+                    .flatMap(v -> v.getTypes().stream())
+                    .map(type -> this.<SchemaConcept>getSchemaConcept(Label.of(type)))
                     .filter(Objects::nonNull)
                     .filter(Concept::isType)
                     .forEach(type -> ruleCache.updateRules(type, rule));

--- a/server/test/graql/query/BUILD
+++ b/server/test/graql/query/BUILD
@@ -23,6 +23,7 @@ java_test(
     test_class = "grakn.core.graql.query.ConceptMapTest",
     srcs = ["ConceptMapTest.java"],
     deps = [
+        "//graql/java:graql",
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/org/mockito:mockito-core",
         "//server"],

--- a/server/test/graql/query/ConceptMapTest.java
+++ b/server/test/graql/query/ConceptMapTest.java
@@ -23,6 +23,7 @@ import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.concept.Concept;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.query.pattern.statement.Variable;
+import graql.exception.GraqlException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -50,8 +51,8 @@ public class ConceptMapTest {
     public void whenGettingAConceptThatIsNotInTheAnswer_Throw() {
         Variable varNotInAnswer = new Variable("y");
 
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.varNotInQuery(varNotInAnswer).getMessage());
+        exception.expect(GraqlException.class);
+        exception.expectMessage(GraqlException.varNotInQuery(varNotInAnswer.toString()).getMessage());
 
         answer.get(varNotInAnswer);
     }

--- a/test-integration/graql/query/AggregateQueryIT.java
+++ b/test-integration/graql/query/AggregateQueryIT.java
@@ -42,7 +42,7 @@ import org.junit.rules.ExpectedException;
 import java.util.Collections;
 import java.util.List;
 
-import static grakn.core.common.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static grakn.core.graql.query.Graql.var;
 import static java.lang.Math.pow;
 import static java.lang.Math.sqrt;

--- a/test-integration/graql/query/AggregateQueryIT.java
+++ b/test-integration/graql/query/AggregateQueryIT.java
@@ -23,12 +23,12 @@ import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Value;
 import grakn.core.graql.concept.AttributeType;
 import grakn.core.graql.concept.Thing;
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.Session;
 import grakn.core.server.Transaction;
+import graql.exception.GraqlException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -42,8 +42,8 @@ import org.junit.rules.ExpectedException;
 import java.util.Collections;
 import java.util.List;
 
-import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static grakn.core.graql.query.Graql.var;
+import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static java.lang.Math.pow;
 import static java.lang.Math.sqrt;
 import static org.junit.Assert.assertEquals;
@@ -363,7 +363,7 @@ public class AggregateQueryIT {
 
     @Test
     public void whenGroupVarIsNotInQuery_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(new Variable("z")));
         tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().group("z").count());
     }

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -93,8 +93,9 @@ java_test(
     test_class = "grakn.core.graql.query.InsertQueryIT",
     srcs = ["InsertQueryIT.java"],
     deps = [
-        "//common",
-        "//server",
+        "//common:common",
+        "//graql/java:graql",
+        "//server:server",
         "//test-integration/graql/graph:movie-graph",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
@@ -191,8 +192,9 @@ java_test(
     test_class = "grakn.core.graql.query.QueryErrorIT",
     srcs = ["QueryErrorIT.java"],
     deps = [
-        "//common",
-        "//server",
+        "//common:common",
+        "//graql/java:graql",
+        "//server:server",
         "//test-integration/graql/graph:movie-graph",
         "//test-integration/rule:grakn-test-server",
 

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -23,8 +23,9 @@ java_test(
     test_class = "grakn.core.graql.query.AggregateQueryIT",
     srcs = ["AggregateQueryIT.java"],
     deps = [
-        "//common",
-        "//server",
+        "//common:common",
+        "//graql/java:graql",
+        "//server:server",
         "//test-integration/graql/graph:movie-graph",
         "//test-integration/rule:grakn-test-server",
     ],
@@ -70,8 +71,9 @@ java_test(
     test_class = "grakn.core.graql.query.DeleteQueryIT",
     srcs = ["DeleteQueryIT.java"],
     deps = [
-        "//common",
-        "//server",
+        "//common:common",
+        "//graql/java:graql",
+        "//server:server",
         "//test-integration/graql/graph:movie-graph",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",

--- a/test-integration/graql/query/DeleteQueryIT.java
+++ b/test-integration/graql/query/DeleteQueryIT.java
@@ -37,7 +37,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static grakn.core.common.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
 import static grakn.core.util.GraqlTestUtil.assertExists;

--- a/test-integration/graql/query/DeleteQueryIT.java
+++ b/test-integration/graql/query/DeleteQueryIT.java
@@ -28,6 +28,7 @@ import grakn.core.rule.GraknTestServer;
 import grakn.core.server.Transaction;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
+import graql.exception.GraqlException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -37,11 +38,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
 import static grakn.core.util.GraqlTestUtil.assertExists;
 import static grakn.core.util.GraqlTestUtil.assertNotExists;
+import static graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -226,7 +227,7 @@ public class DeleteQueryIT {
 
     @Test
     public void whenDeletingAVariableNotInTheQuery_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(y.var()));
         tx.execute(Graql.match(x.isa("movie")).delete(y.var()));
     }

--- a/test-integration/graql/query/InsertQueryIT.java
+++ b/test-integration/graql/query/InsertQueryIT.java
@@ -36,16 +36,15 @@ import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.graql.internal.Schema;
 import grakn.core.graql.query.pattern.Pattern;
-import grakn.core.graql.query.pattern.property.VarProperty;
-import grakn.core.graql.query.pattern.statement.Statement;
-import grakn.core.graql.query.pattern.statement.StatementInstance;
-import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.graql.query.pattern.property.IsaProperty;
+import grakn.core.graql.query.pattern.statement.Statement;
+import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.Transaction;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
+import graql.exception.GraqlException;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -257,7 +256,7 @@ public class InsertQueryIT {
 
     @Test
     public void testErrorWhenInsertWithMultipleIds() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(allOf(containsString("id"), containsString("123"), containsString("456")));
         tx.execute(Graql.insert(var().id("123").id("456").isa("movie")));
     }

--- a/test-integration/graql/query/InsertQueryIT.java
+++ b/test-integration/graql/query/InsertQueryIT.java
@@ -63,13 +63,13 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static grakn.core.graql.internal.Schema.MetaSchema.ENTITY;
 import static grakn.core.graql.query.Graql.gt;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
 import static grakn.core.util.GraqlTestUtil.assertExists;
 import static grakn.core.util.GraqlTestUtil.assertNotExists;
+import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -549,7 +549,7 @@ public class InsertQueryIT {
 
     @Test
     public void whenMatchInsertingAnEmptyPattern_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
         tx.execute(Graql.match(var()).insert(Collections.EMPTY_SET));
     }
@@ -566,7 +566,7 @@ public class InsertQueryIT {
 
     @Test
     public void whenInsertingAnEmptyPattern_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
         tx.execute(Graql.insert(Collections.EMPTY_SET));
     }

--- a/test-integration/graql/query/InsertQueryIT.java
+++ b/test-integration/graql/query/InsertQueryIT.java
@@ -63,7 +63,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import static grakn.core.common.exception.ErrorMessage.NO_PATTERNS;
+import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static grakn.core.graql.internal.Schema.MetaSchema.ENTITY;
 import static grakn.core.graql.query.Graql.gt;
 import static grakn.core.graql.query.Graql.type;

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -51,7 +51,7 @@ import org.junit.rules.ExpectedException;
 import java.util.stream.Stream;
 
 import static grakn.core.common.exception.ErrorMessage.INVALID_VALUE;
-import static grakn.core.common.exception.ErrorMessage.NO_PATTERNS;
+import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
 import static org.hamcrest.core.AllOf.allOf;
@@ -233,7 +233,7 @@ public class QueryErrorIT {
     @Test
     public void testGetNonExistentVariable() {
         exception.expect(GraqlQueryException.class);
-        exception.expectMessage(ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(new Variable("y")));
+        exception.expectMessage(graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(new Variable("y")));
 
         MatchClause match = Graql.match(var("x").isa("movie"));
         Stream<Concept> concepts = tx.stream(match.get("y")).map(ans -> ans.get("y"));

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -51,9 +51,9 @@ import org.junit.rules.ExpectedException;
 import java.util.stream.Stream;
 
 import static grakn.core.common.exception.ErrorMessage.INVALID_VALUE;
-import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
+import static graql.exception.ErrorMessage.NO_PATTERNS;
 import static org.hamcrest.core.AllOf.allOf;
 import static org.hamcrest.core.StringContains.containsString;
 
@@ -170,7 +170,7 @@ public class QueryErrorIT {
 
     @Test
     public void testExceptionWhenNoPatternsProvided() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(NO_PATTERNS.getMessage());
         //noinspection ResultOfMethodCallIgnored
         Graql.match();
@@ -232,7 +232,7 @@ public class QueryErrorIT {
 
     @Test
     public void testGetNonExistentVariable() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(graql.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(new Variable("y")));
 
         MatchClause match = Graql.match(var("x").isa("movie"));

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -37,6 +37,7 @@ import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
+import graql.exception.GraqlException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -141,7 +142,7 @@ public class QueryErrorIT {
 
     @Test
     public void testErrorMultipleIsa() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlException.class);
         exception.expectMessage(allOf(
                 containsString("abc"), containsString("isa"), containsString("person"), containsString("has-cast")
         ));


### PR DESCRIPTION
# Why is this PR needed?

This PR is a continuation of PR #4646, and incremental work for issue #4456 where you can find the full description of the goal. In summary, we are refactoring Graql to extract the Graql language library from Grakn's implementation of Graql, and we start with simplifying the Graql codebase first.

# What does the PR do?

- Removed dependencies to internal dependencies from `Statement`
- Migrated Graql language exceptions fron `grakn.core.graql.exception.GraqlQueryException` to `graql.exception.GraqlException`
- Removed `Conjunction.toReasonerQuery`, and replaced its usage with `ReasonerQueries.create()`