### PR TITLE
GitHub rules naming consistency (fix #4661)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,9 +25,9 @@ load("@graknlabs_bazel_distribution//deb/deployment:rules.bzl", "deploy_deb")
 
 py_binary(
     name = "deploy-github-zip",
-    srcs = ["@graknlabs_bazel_distribution//github:deployment.py"],
+    srcs = ["@graknlabs_bazel_distribution//github:deploy.py"],
     data = [":distribution", ":VERSION", ":deployment.properties", "@ghr_osx_zip//file:file", "@ghr_linux_tar//file:file"],
-    main = "deployment.py"
+    main = "deploy.py"
 )
 
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -144,17 +144,18 @@ node_grpc_compile()
 git_repository(
     name="graknlabs_bazel_distribution",
     remote="https://github.com/graknlabs/bazel-distribution",
-    commit="2e932a2555d1e43f75c8ee676c926399bd12f240"
+    commit="df751d03b1fcbb69ed11dd1e7265020144d7233b"
 )
 
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "dependencies_for_github_deployment")
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "github_dependencies_for_deployment")
+github_dependencies_for_deployment()
+
 pip_import(
     name = "pypi_deployment_dependencies",
     requirements = "@graknlabs_bazel_distribution//pip:requirements.txt",
 )
 load("@pypi_deployment_dependencies//:requirements.bzl", "pip_install")
 pip_install()
-dependencies_for_github_deployment()
 
 
 git_repository(


### PR DESCRIPTION
# Why is this PR needed?

Use new rules with more consistent naming
Fixes #4661

# What does the PR do?

Adapts `graknlabs/grakn` to usage of new rules

# Does it break backwards compatibility?

No

# List of future improvements not on this PR

—
