### PR TITLE
Simplify query processing

### DIFF
--- a/server/src/graql/admin/ReasonerQuery.java
+++ b/server/src/graql/admin/ReasonerQuery.java
@@ -31,9 +31,17 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
+ *
+ * <p>
  * Interface for conjunctive reasoner queries.
+ * </p>
+ *
+ *
  */
 public interface ReasonerQuery{
+
+    @CheckReturnValue
+    ReasonerQuery copy();
 
     /**
      * @param q query to combine
@@ -53,6 +61,12 @@ public interface ReasonerQuery{
      */
     @CheckReturnValue
     default boolean isPositive(){ return true;}
+
+    /**
+     * @return true if this query is atomic
+     */
+    @CheckReturnValue
+    boolean isAtomic();
 
     /**
      * validate the query wrt transaction it is defined in
@@ -119,21 +133,6 @@ public interface ReasonerQuery{
      */
     @CheckReturnValue
     MultiUnifier getMultiUnifier(ReasonerQuery parent);
-
-    /**
-     * resolves the query
-     * @return stream of answers
-     */
-    @CheckReturnValue
-    Stream<ConceptMap> resolve();
-
-    /**
-     * reiteration might be required if rule graph contains loops with negative flux
-     * or there exists a rule which head satisfies body
-     * @return true if because of the rule graph form, the resolution of this query may require reiteration
-     */
-    @CheckReturnValue
-    boolean requiresReiteration();
 
     /**
      * Returns a var-type map local to this query. Map is cached.

--- a/server/src/graql/admin/ReasonerQuery.java
+++ b/server/src/graql/admin/ReasonerQuery.java
@@ -40,9 +40,6 @@ import java.util.stream.Stream;
  */
 public interface ReasonerQuery{
 
-    @CheckReturnValue
-    ReasonerQuery copy();
-
     /**
      * @param q query to combine
      * @return a query formed as conjunction of this and provided query

--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -36,6 +36,7 @@ import grakn.core.graql.internal.gremlin.GraqlTraversal;
 import grakn.core.graql.internal.gremlin.GreedyTraversalPlan;
 import grakn.core.graql.internal.reasoner.query.CompositeQuery;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
+import grakn.core.graql.internal.reasoner.query.ResolvableQuery;
 import grakn.core.graql.query.AggregateQuery;
 import grakn.core.graql.query.ComputeQuery;
 import grakn.core.graql.query.DefineQuery;
@@ -96,7 +97,7 @@ public class QueryExecutor {
     }
 
     private Stream<ConceptMap> resolveConjunction(Conjunction<Pattern> conj, TransactionOLTP tx){
-        CompositeQuery query = ReasonerQueries.composite(conj, tx);
+        ResolvableQuery query = ReasonerQueries.resolvable(conj, tx);
         query.checkValid();
 
         //TODO

--- a/server/src/graql/internal/reasoner/ResolutionIterator.java
+++ b/server/src/graql/internal/reasoner/ResolutionIterator.java
@@ -65,7 +65,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
         while(!states.isEmpty()) {
             ResolutionState state = states.pop();
 
-            System.out.println("state: " + state);
+            LOG.trace("state: " + state);
 
             if (state.isAnswerState() && state.isTopState()) {
                 return state.getSubstitution();
@@ -76,10 +76,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);
             } else {
-                System.out.println("new state: NULL");
-            }
-            if(states.isEmpty()){
-                System.out.println();
+                LOG.trace("new state: NULL");
             }
         }
         return null;

--- a/server/src/graql/internal/reasoner/ResolutionIterator.java
+++ b/server/src/graql/internal/reasoner/ResolutionIterator.java
@@ -20,16 +20,16 @@ package grakn.core.graql.internal.reasoner;
 
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
-import grakn.core.graql.internal.reasoner.query.CompositeQuery;
+import grakn.core.graql.internal.reasoner.query.ReasonerAtomicQuery;
+import grakn.core.graql.internal.reasoner.query.ResolvableQuery;
 import grakn.core.graql.internal.reasoner.state.ResolutionState;
 import grakn.core.graql.internal.reasoner.unifier.UnifierImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashSet;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.Stack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -43,7 +43,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
 
     private int iter = 0;
     private long oldAns = 0;
-    private final CompositeQuery query;
+    private final ResolvableQuery query;
     private final Set<ConceptMap> answers = new HashSet<>();
 
     private final MultilevelSemanticCache cache;
@@ -54,18 +54,18 @@ public class ResolutionIterator extends ReasonerQueryIterator {
 
     private static final Logger LOG = LoggerFactory.getLogger(ResolutionIterator.class);
 
-    public ResolutionIterator(CompositeQuery q, MultilevelSemanticCache cache){
+    public ResolutionIterator(ResolvableQuery q, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache, boolean reiterate){
         this.query = q;
-        this.reiterationRequired = q.requiresReiteration();
+        this.reiterationRequired = reiterate;
         this.cache = cache;
-        states.push(query.subGoal(new ConceptMap(), new UnifierImpl(), null, new HashSet<>(), cache));
+        states.push(query.subGoal(new ConceptMap(), new UnifierImpl(), null, subGoals, cache));
     }
 
     private ConceptMap findNextAnswer(){
         while(!states.isEmpty()) {
             ResolutionState state = states.pop();
 
-            LOG.trace("state: " + state);
+            System.out.println("state: " + state);
 
             if (state.isAnswerState() && state.isTopState()) {
                 return state.getSubstitution();
@@ -76,7 +76,10 @@ public class ResolutionIterator extends ReasonerQueryIterator {
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);
             } else {
-                LOG.trace("new state: NULL");
+                System.out.println("new state: NULL");
+            }
+            if(states.isEmpty()){
+                System.out.println();
             }
         }
         return null;

--- a/server/src/graql/internal/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/internal/reasoner/query/CompositeQuery.java
@@ -29,7 +29,6 @@ import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.reasoner.ResolutionIterator;
 import grakn.core.graql.internal.reasoner.atom.Atom;
 import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
-import grakn.core.graql.internal.reasoner.state.ConjunctiveState;
 import grakn.core.graql.internal.reasoner.state.CompositeState;
 import grakn.core.graql.internal.reasoner.state.QueryStateBase;
 import grakn.core.graql.internal.reasoner.state.ResolutionState;
@@ -106,7 +105,6 @@ public class CompositeQuery implements ResolvableQuery {
                 .map(p -> p.getNegationDNF().getPatterns().iterator().next())
                 .collect(Collectors.toSet());
     }
-
 
     @Override
     public CompositeQuery withSubstitution(ConceptMap sub){
@@ -280,7 +278,7 @@ public class CompositeQuery implements ResolvableQuery {
     @Override
     public ResolutionState subGoal(ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache){
         return isPositive()?
-                new ConjunctiveState(conjunctiveQuery, sub, u, parent, subGoals, cache) :
+                getConjunctiveQuery().subGoal(sub, u, parent, subGoals, cache) :
                 new CompositeState(this, sub, u, parent, subGoals, cache);
     }
 }

--- a/server/src/graql/internal/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/internal/reasoner/query/CompositeQuery.java
@@ -134,8 +134,12 @@ public class CompositeQuery implements ResolvableQuery {
     }
 
     @Override
-    public ReasonerQuery copy() {
-        return null;
+    public ResolvableQuery copy() {
+        return new CompositeQuery(
+                getConjunctiveQuery().copy(),
+                getComplementQueries().stream().map(ResolvableQuery::copy).collect(Collectors.toSet()),
+                this.tx()
+        );
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/internal/reasoner/query/CompositeQuery.java
@@ -27,6 +27,7 @@ import grakn.core.graql.admin.Unifier;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.reasoner.ResolutionIterator;
+import grakn.core.graql.internal.reasoner.atom.Atom;
 import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.internal.reasoner.state.ConjunctiveState;
 import grakn.core.graql.internal.reasoner.state.CompositeState;
@@ -60,10 +61,10 @@ import java.util.stream.Stream;
  * The negative part is stored in terms of the negation complement - hence all stored queries are positive.
  *
  */
-public class CompositeQuery implements ReasonerQuery {
+public class CompositeQuery implements ResolvableQuery {
 
     final private ReasonerQueryImpl conjunctiveQuery;
-    final private Set<CompositeQuery> complementQueries;
+    final private Set<ResolvableQuery> complementQueries;
     final private TransactionOLTP tx;
 
     CompositeQuery(Conjunction<Pattern> pattern, TransactionOLTP tx) {
@@ -76,19 +77,19 @@ public class CompositeQuery implements ReasonerQuery {
         this.tx = tx;
         //conjunction of negation patterns
         Set<Conjunction<Pattern>> complementPattern = complementPattern(pattern);
-        this.conjunctiveQuery = new ReasonerQueryImpl(positiveConj, tx);
+        this.conjunctiveQuery = ReasonerQueries.create(positiveConj, tx);
         this.complementQueries = complementPattern.stream()
-                        .map(comp -> new CompositeQuery(comp, tx))
-                        .collect(Collectors.toSet());
+                .map(comp -> ReasonerQueries.resolvable(comp, tx))
+                .collect(Collectors.toSet());
 
         if (!isNegationSafe()){
             throw new IllegalStateException("Query:\n" + this + "\nis unsafe! Negated pattern variables not bound!");
         }
     }
 
-    CompositeQuery(ReasonerQueryImpl conj, Set<CompositeQuery> neg, TransactionOLTP tx) {
+    private CompositeQuery(ReasonerQueryImpl conj, Set<ResolvableQuery> comp, TransactionOLTP tx) {
         this.conjunctiveQuery = conj;
-        this.complementQueries = neg;
+        this.complementQueries = comp;
         this.tx = tx;
     }
 
@@ -106,11 +107,9 @@ public class CompositeQuery implements ReasonerQuery {
                 .collect(Collectors.toSet());
     }
 
-    /**
-     * @param sub substitution to be inserted into the query
-     * @return corresponding query with additional substitution
-     */
-    CompositeQuery withSubstitution(ConceptMap sub){
+
+    @Override
+    public CompositeQuery withSubstitution(ConceptMap sub){
         return new CompositeQuery(
                 getConjunctiveQuery().withSubstitution(sub),
                 getComplementQueries().stream().map(q -> q.withSubstitution(sub)).collect(Collectors.toSet()),
@@ -118,16 +117,32 @@ public class CompositeQuery implements ReasonerQuery {
         );
     }
 
+    @Override
     public CompositeQuery inferTypes() {
         return new CompositeQuery(getConjunctiveQuery().inferTypes(), getComplementQueries(), this.tx());
+    }
+
+    @Override
+    public ResolvableQuery positive() {
+        return new CompositeQuery(getConjunctiveQuery().positive(), getComplementQueries(), tx());
     }
 
     public ReasonerQueryImpl getConjunctiveQuery() {
         return conjunctiveQuery;
     }
 
-    public Set<CompositeQuery> getComplementQueries() {
+    public Set<ResolvableQuery> getComplementQueries() {
         return complementQueries;
+    }
+
+    @Override
+    public ReasonerQuery copy() {
+        return null;
+    }
+
+    @Override
+    public boolean isAtomic() {
+        return getComplementQueries().isEmpty() && getConjunctiveQuery().isAtomic();
     }
 
     @Override
@@ -138,17 +153,17 @@ public class CompositeQuery implements ReasonerQuery {
     @Override
     public String toString(){
         return getConjunctiveQuery().toString() +
-                (getComplementQueries() != null? "\nNOT{\n" + getComplementQueries() + "\n}" : "");
+                (!getComplementQueries().isEmpty()? "\nNOT{\n" + getComplementQueries() + "\n}" : "");
     }
 
     @Override
     public ReasonerQuery conjunction(ReasonerQuery q) {
         return new CompositeQuery(
                 Graql.and(
-                    Sets.union(
-                        this.getPattern().getPatterns(),
-                        q.getPattern().getPatterns()
-                    )),
+                        Sets.union(
+                                this.getPattern().getPatterns(),
+                                q.getPattern().getPatterns()
+                        )),
                 this.tx()
         );
     }
@@ -159,7 +174,7 @@ public class CompositeQuery implements ReasonerQuery {
     @Override
     public void checkValid() {
         getConjunctiveQuery().checkValid();
-        getComplementQueries().forEach(CompositeQuery::checkValid);
+        getComplementQueries().forEach(ResolvableQuery::checkValid);
     }
 
     @Override
@@ -179,14 +194,14 @@ public class CompositeQuery implements ReasonerQuery {
     @Override
     public Conjunction<Pattern> getPattern() {
         Set<Pattern> pattern = Sets.newHashSet(getConjunctiveQuery().getPattern());
-        getComplementQueries().stream().map(CompositeQuery::getPattern).forEach(pattern::add);
+        getComplementQueries().stream().map(ResolvableQuery::getPattern).forEach(pattern::add);
         return Graql.and(pattern);
     }
 
     @Override
     public ConceptMap getSubstitution() {
         ConceptMap sub = getConjunctiveQuery().getSubstitution();
-        for (CompositeQuery comp : getComplementQueries()) {
+        for (ResolvableQuery comp : getComplementQueries()) {
             sub = sub.merge(comp.getSubstitution());
         }
         return sub;
@@ -195,13 +210,13 @@ public class CompositeQuery implements ReasonerQuery {
     @Override
     public Set<String> validateOntologically() {
         Set<String> validation = getConjunctiveQuery().validateOntologically();
-        getComplementQueries().stream().map(CompositeQuery::validateOntologically).forEach(validation::addAll);
+        getComplementQueries().stream().map(ResolvableQuery::validateOntologically).forEach(validation::addAll);
         return validation;
     }
 
     @Override
     public boolean isRuleResolvable() {
-        return getConjunctiveQuery().isRuleResolvable() || getComplementQueries().stream().anyMatch(CompositeQuery::isRuleResolvable);
+        return getConjunctiveQuery().isRuleResolvable() || getComplementQueries().stream().anyMatch(ResolvableQuery::isRuleResolvable);
     }
 
     @Override
@@ -227,26 +242,42 @@ public class CompositeQuery implements ReasonerQuery {
 
     @Override
     public Stream<ConceptMap> resolve() {
-        return resolve(new MultilevelSemanticCache());
+        return resolve(new HashSet<>(), new MultilevelSemanticCache(), this.requiresReiteration());
+    }
+
+    @Override
+    public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache, boolean reiterate){
+        return new ResolutionIterator(this, subGoals, cache, reiterate).hasStream();
     }
 
     @Override
     public boolean requiresReiteration() {
-        return getConjunctiveQuery().requiresReiteration() || getComplementQueries().stream().anyMatch(CompositeQuery::requiresReiteration);
+        return getConjunctiveQuery().requiresReiteration() || getComplementQueries().stream().anyMatch(ResolvableQuery::requiresReiteration);
     }
 
-    public Stream<ConceptMap> resolve(MultilevelSemanticCache cache){
-        return new ResolutionIterator(this, cache).hasStream();
+    @Override
+    public Stream<Atom> selectAtoms() {
+        return getAtoms(Atom.class).filter(Atomic::isSelectable);
     }
 
-    /**
-     * @param sub partial substitution
-     * @param u unifier with parent state
-     * @param parent parent state
-     * @param subGoals set of visited sub goals
-     * @param cache query cache
-     * @return resolution subGoal formed from this query
-     */
+    @Override
+    public boolean requiresDecomposition() {
+        return getConjunctiveQuery().requiresDecomposition() ||
+                (!getComplementQueries().isEmpty() && getComplementQueries().stream().anyMatch(ResolvableQuery::requiresDecomposition));
+    }
+
+    @Override
+    public CompositeQuery rewrite(){
+        return new CompositeQuery(
+                getConjunctiveQuery().rewrite(),
+                getComplementQueries().isEmpty()?
+                        getComplementQueries() :
+                        getComplementQueries().stream().map(ResolvableQuery::rewrite).collect(Collectors.toSet()),
+                tx()
+        );
+    }
+
+    @Override
     public ResolutionState subGoal(ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache){
         return isPositive()?
                 new ConjunctiveState(conjunctiveQuery, sub, u, parent, subGoals, cache) :

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -206,7 +206,10 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
 
     @Override
     public ResolutionState subGoal(ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache){
-        return new AtomicStateProducer(this, sub, u, parent, subGoals, cache);
+        if (getAtom().getSchemaConcept() == null) return new AtomicStateProducer(this, sub, u, parent, subGoals, cache);
+        return this.getAtoms(NeqPredicate.class).findFirst().isPresent() ?
+                new NeqComplementState(this, sub, u, parent, subGoals, cache) :
+                new AtomicState(this, sub, u, parent, subGoals, cache);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -92,7 +92,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     @Override
-    public ReasonerQuery copy(){ return new ReasonerAtomicQuery(this);}
+    public ReasonerAtomicQuery copy(){ return new ReasonerAtomicQuery(this);}
 
     @Override
     public ReasonerAtomicQuery withSubstitution(ConceptMap sub){

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -35,8 +35,10 @@ import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.internal.reasoner.cache.SemanticDifference;
 import grakn.core.graql.internal.reasoner.rule.InferenceRule;
 import grakn.core.graql.internal.reasoner.state.AnswerState;
+import grakn.core.graql.internal.reasoner.state.AtomicState;
 import grakn.core.graql.internal.reasoner.state.AtomicStateProducer;
 import grakn.core.graql.internal.reasoner.state.CacheCompletionState;
+import grakn.core.graql.internal.reasoner.state.NeqComplementState;
 import grakn.core.graql.internal.reasoner.state.QueryStateBase;
 import grakn.core.graql.internal.reasoner.state.ResolutionState;
 import grakn.core.graql.internal.reasoner.unifier.MultiUnifierImpl;
@@ -240,12 +242,9 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
         return Iterators.concat(dbIterator, dbCompletionIterator, subGoalIterator);
     }
 
-    /**
-     * @return stream of all rules applicable to this atom including permuted cases when the role types are meta roles
-     */
     private Stream<Pair<InferenceRule, Unifier>> getRuleStream() {
-        return this.getAtom().getApplicableRules()
-                .flatMap(r -> r.getMultiUnifier(this.getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
+        return getAtom().getApplicableRules()
+                .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
                 .sorted(Comparator.comparing(rt -> -rt.getKey().resolutionPriority()));
     }
 }

--- a/server/src/graql/internal/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueries.java
@@ -35,6 +35,11 @@ import java.util.Set;
  */
 public class ReasonerQueries {
 
+
+    public static CompositeQuery composite(Conjunction<Pattern> pattern, TransactionOLTP tx) {
+        return new CompositeQuery(pattern, tx).inferTypes();
+    }
+
     /**
      *
      * @param pattern

--- a/server/src/graql/internal/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueries.java
@@ -35,16 +35,10 @@ import java.util.Set;
  */
 public class ReasonerQueries {
 
-
-    public static CompositeQuery composite(Conjunction<Pattern> pattern, TransactionOLTP tx) {
-        return new CompositeQuery(pattern, tx).inferTypes();
-    }
-
     /**
-     *
-     * @param pattern
-     * @param tx
-     * @return
+     * @param pattern conjunctive pattern defining the query
+     * @param tx corresponding transaction
+     * @return a resolvable reasoner query constructed from provided conjunctive pattern
      */
     public static ResolvableQuery resolvable(Conjunction<Pattern> pattern, TransactionOLTP tx){
         CompositeQuery query = new CompositeQuery(pattern, tx).inferTypes();
@@ -55,10 +49,9 @@ public class ReasonerQueries {
     }
 
     /**
-     *
-     * @param q
-     * @param sub
-     * @return
+     * @param q base query for substitution to be attached
+     * @param sub (partial) substitution
+     * @return resolvable query with the substitution contained in the query
      */
     public static ResolvableQuery resolvable(ResolvableQuery q, ConceptMap sub){
         return q.withSubstitution(sub).inferTypes();

--- a/server/src/graql/internal/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueries.java
@@ -35,11 +35,27 @@ import java.util.Set;
  */
 public class ReasonerQueries {
 
-    public static CompositeQuery composite(Conjunction<Pattern> pattern, TransactionOLTP tx){
-        return new CompositeQuery(pattern, tx).inferTypes();
+    /**
+     *
+     * @param pattern
+     * @param tx
+     * @return
+     */
+    public static ResolvableQuery resolvable(Conjunction<Pattern> pattern, TransactionOLTP tx){
+        CompositeQuery query = new CompositeQuery(pattern, tx).inferTypes();
+        return query.isAtomic()?
+                new ReasonerAtomicQuery(query.getAtoms(), tx) :
+                query.isPositive()?
+                        query.getConjunctiveQuery() : query;
     }
 
-    public static CompositeQuery composite(CompositeQuery q, ConceptMap sub){
+    /**
+     *
+     * @param q
+     * @param sub
+     * @return
+     */
+    public static ResolvableQuery resolvable(ResolvableQuery q, ConceptMap sub){
         return q.withSubstitution(sub).inferTypes();
     }
 

--- a/server/src/graql/internal/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueries.java
@@ -127,15 +127,6 @@ public class ReasonerQueries {
     }
 
     /**
-     * create an atomic query copy from the provided query with the types inferred
-     * @param q query to be copied
-     * @return copied atomic query with inferred types
-     */
-    public static ReasonerAtomicQuery atomic(ReasonerAtomicQuery q){
-        return new ReasonerAtomicQuery(q).inferTypes();
-    }
-
-    /**
      * create an atomic query by combining an existing atomic query and a substitution
      * @param q base query for substitution to be attached
      * @param sub (partial) substitution

--- a/server/src/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -50,6 +50,7 @@ import grakn.core.graql.internal.reasoner.rule.RuleUtils;
 import grakn.core.graql.internal.reasoner.state.AnswerState;
 import grakn.core.graql.internal.reasoner.state.ConjunctiveState;
 import grakn.core.graql.internal.reasoner.state.CumulativeState;
+import grakn.core.graql.internal.reasoner.state.NeqComplementState;
 import grakn.core.graql.internal.reasoner.state.QueryStateBase;
 import grakn.core.graql.internal.reasoner.state.ResolutionState;
 import grakn.core.graql.internal.reasoner.unifier.UnifierType;
@@ -80,7 +81,7 @@ import java.util.stream.Stream;
  * Base reasoner query providing resolution and atom handling facilities for conjunctive graql queries.
  *
  */
-public class ReasonerQueryImpl implements ReasonerQuery {
+public class ReasonerQueryImpl implements ResolvableQuery {
 
     private final TransactionOLTP tx;
     private final ImmutableSet<Atomic> atomSet;
@@ -130,24 +131,18 @@ public class ReasonerQueryImpl implements ReasonerQuery {
         );
     }
 
-    /**
-     * @param sub substitution to be inserted into the query
-     * @return corresponding query with additional substitution
-     */
+
+    @Override
     public ReasonerQueryImpl withSubstitution(ConceptMap sub){
         return new ReasonerQueryImpl(Sets.union(this.getAtoms(), sub.toPredicates(this)), this.tx());
     }
 
-    /**
-     * @return corresponding reasoner query with inferred types
-     */
+    @Override
     public ReasonerQueryImpl inferTypes() {
         return new ReasonerQueryImpl(getAtoms().stream().map(Atomic::inferTypes).collect(Collectors.toSet()), tx());
     }
 
-    /**
-     * @return corresponding positive query (with neq predicates removed)
-     */
+    @Override
     public ReasonerQueryImpl positive(){
         return new ReasonerQueryImpl(getAtoms().stream().filter(at -> !(at instanceof NeqPredicate)).collect(Collectors.toSet()), tx());
     }
@@ -173,6 +168,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
                 "\n}";
     }
 
+    @Override
     public ReasonerQuery copy() {
         return new ReasonerQueryImpl(this);
     }
@@ -191,14 +187,6 @@ public class ReasonerQueryImpl implements ReasonerQuery {
         return ReasonerQueryEquivalence.AlphaEquivalence.hash(this);
     }
 
-    /**
-     * @param q query to be compared with
-     * @return true if two queries are alpha-equivalent
-     */
-    public boolean isEquivalent(ReasonerQueryImpl q) {
-        return ReasonerQueryEquivalence.AlphaEquivalence.equivalent(this, q);
-    }
-
     @Override
     public TransactionOLTP tx() {
         return tx;
@@ -207,6 +195,7 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     @Override
     public void checkValid() { getAtoms().forEach(Atomic::checkValid);}
 
+    @Override
     public Conjunction<Pattern> getPattern() {
         return Graql.and(
                 getAtoms().stream()
@@ -229,23 +218,9 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     }
 
     /**
-     * @return true if this query contains disconnected atoms that are unbounded
-     */
-    public boolean isBoundlesslyDisconnected(){
-        return !isAtomic()
-                && selectAtoms()
-                .filter(at -> !at.isBounded())
-                .anyMatch(Atom::isDisconnected);
-    }
-
-    /**
-     * @return true if the query requires direct schema lookups
-     */
-    public boolean requiresSchema(){ return selectAtoms().anyMatch(Atom::requiresSchema);}
-
-    /**
      * @return true if this query is atomic
      */
+    @Override
     public boolean isAtomic() {
         return atomSet.stream().filter(Atomic::isSelectable).count() == 1;
     }
@@ -269,6 +244,36 @@ public class ReasonerQueryImpl implements ReasonerQuery {
                         //check if it can play it
                         .anyMatch(e -> e.getKey().players().noneMatch(parentTypes::contains)));
     }
+
+    /**
+     * @param q query to be compared with
+     * @return true if two queries are alpha-equivalent
+     */
+    public boolean isEquivalent(ReasonerQueryImpl q) {
+        return ReasonerQueryEquivalence.AlphaEquivalence.equivalent(this, q);
+    }
+
+    /**
+     * @return true if this query is a ground query
+     */
+    public boolean isGround(){
+        return getSubstitution().vars().containsAll(getVarNames());
+    }
+
+    /**
+     * @return true if this query contains disconnected atoms that are unbounded
+     */
+    public boolean isBoundlesslyDisconnected(){
+        return !isAtomic()
+                && selectAtoms()
+                .filter(at -> !at.isBounded())
+                .anyMatch(Atom::isDisconnected);
+    }
+
+    /**
+     * @return true if the query requires direct schema lookups
+     */
+    public boolean requiresSchema(){ return selectAtoms().anyMatch(Atom::requiresSchema);}
 
     @Override
     public Set<Atomic> getAtoms() { return atomSet;}
@@ -396,13 +401,6 @@ public class ReasonerQueryImpl implements ReasonerQuery {
         return transform;
     }
 
-    /**
-     * @return selected atoms
-     */
-    public Stream<Atom> selectAtoms() {
-        return getAtoms(Atom.class).filter(Atomic::isSelectable);
-    }
-
     /** Does id predicates -> answer conversion
      * @return substitution obtained from all id predicates (including internal) in the query
      */
@@ -440,21 +438,25 @@ public class ReasonerQueryImpl implements ReasonerQuery {
     }
 
     /**
-     * @return true if this query is a ground query
+     * @return selected atoms
      */
-    public boolean isGround(){
-        return getSubstitution().vars().containsAll(getVarNames());
+    @Override
+    public Stream<Atom> selectAtoms() {
+        return getAtoms(Atom.class).filter(Atomic::isSelectable);
     }
 
     /**
      * @return true if this query requires atom decomposition
      */
+    @Override
     public boolean requiresDecomposition(){
         return this.selectAtoms().anyMatch(Atom::requiresDecomposition);
     }
+
     /**
      * @return rewritten (decomposed) version of the query
      */
+    @Override
     public ReasonerQueryImpl rewrite(){
         if (!requiresDecomposition()) return this;
         return new ReasonerQueryImpl(
@@ -474,23 +476,19 @@ public class ReasonerQueryImpl implements ReasonerQuery {
 
     @Override
     public Stream<ConceptMap> resolve() {
-        return resolve(new MultilevelSemanticCache());
+        return resolve(new HashSet<>(), new MultilevelSemanticCache(), this.requiresReiteration());
     }
 
-    public Stream<ConceptMap> resolve(MultilevelSemanticCache cache){
-        return new ResolutionIterator(new CompositeQuery(this, new HashSet<>(), tx()), cache).hasStream();
+    @Override
+    public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache, boolean reiterate){
+        return new ResolutionIterator(this, subGoals, cache, reiterate).hasStream();
     }
 
-    /**
-     * @param sub partial substitution
-     * @param u unifier with parent state
-     * @param parent parent state
-     * @param subGoals set of visited sub goals
-     * @param cache query cache
-     * @return resolution subGoal formed from this query
-     */
+    @Override
     public ResolutionState subGoal(ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache){
-        return new ConjunctiveState(this, sub, u, parent, subGoals, cache);
+        return this.getAtoms(NeqPredicate.class).findFirst().isPresent() ?
+                new NeqComplementState(this, sub, u, parent, subGoals, cache) :
+                new ConjunctiveState(this, sub, u, parent, subGoals, cache);
     }
 
     /**

--- a/server/src/graql/internal/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerQueryImpl.java
@@ -169,7 +169,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     }
 
     @Override
-    public ReasonerQuery copy() {
+    public ReasonerQueryImpl copy() {
         return new ReasonerQueryImpl(this);
     }
 

--- a/server/src/graql/internal/reasoner/query/ResolvableQuery.java
+++ b/server/src/graql/internal/reasoner/query/ResolvableQuery.java
@@ -37,22 +37,28 @@ import javax.annotation.CheckReturnValue;
 public interface ResolvableQuery extends ReasonerQuery {
 
     @CheckReturnValue
+    ResolvableQuery copy();
+
+    @CheckReturnValue
     Stream<Atom> selectAtoms();
 
     /**
      * @param sub substitution to be inserted into the query
      * @return corresponding query with additional substitution
      */
+    @CheckReturnValue
     ResolvableQuery withSubstitution(ConceptMap sub);
 
     /**
      * @return corresponding positive query (with neq predicates removed)
      */
+    @CheckReturnValue
     ResolvableQuery positive();
 
     /**
      * @return corresponding reasoner query with inferred types
      */
+    @CheckReturnValue
     ResolvableQuery inferTypes();
 
     @CheckReturnValue
@@ -79,9 +85,15 @@ public interface ResolvableQuery extends ReasonerQuery {
     @CheckReturnValue
     Stream<ConceptMap> resolve();
 
+    /**
+     *
+     * @param subGoals already visited subgoals
+     * @param cache query cache
+     * @param reiterate true if reiteration should be performed
+     * @return stream of resolved answers
+     */
     @CheckReturnValue
     Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache, boolean reiterate);
-
 
     /**
      * @param sub partial substitution

--- a/server/src/graql/internal/reasoner/query/ResolvableQuery.java
+++ b/server/src/graql/internal/reasoner/query/ResolvableQuery.java
@@ -1,0 +1,96 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.internal.reasoner.query;
+
+import grakn.core.graql.admin.ReasonerQuery;
+import grakn.core.graql.admin.Unifier;
+import grakn.core.graql.answer.ConceptMap;
+import grakn.core.graql.internal.reasoner.atom.Atom;
+import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
+import grakn.core.graql.internal.reasoner.state.QueryStateBase;
+import grakn.core.graql.internal.reasoner.state.ResolutionState;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.CheckReturnValue;
+
+/**
+ *
+ * Interface for resolvable reasoner queries.
+ *
+ */
+public interface ResolvableQuery extends ReasonerQuery {
+
+    @CheckReturnValue
+    Stream<Atom> selectAtoms();
+
+    /**
+     * @param sub substitution to be inserted into the query
+     * @return corresponding query with additional substitution
+     */
+    ResolvableQuery withSubstitution(ConceptMap sub);
+
+    /**
+     * @return corresponding positive query (with neq predicates removed)
+     */
+    ResolvableQuery positive();
+
+    /**
+     * @return corresponding reasoner query with inferred types
+     */
+    ResolvableQuery inferTypes();
+
+    @CheckReturnValue
+    boolean requiresDecomposition();
+
+    /**
+     * reiteration might be required if rule graph contains loops with negative flux
+     * or there exists a rule which head satisfies body
+     * @return true if because of the rule graph form, the resolution of this query may require reiteration
+     */
+    @CheckReturnValue
+    boolean requiresReiteration();
+
+    /**
+     * @return rewritten (decomposed) version of the query
+     */
+    @CheckReturnValue
+    ResolvableQuery rewrite();
+
+    /**
+     * resolves the query
+     * @return stream of answers
+     */
+    @CheckReturnValue
+    Stream<ConceptMap> resolve();
+
+    @CheckReturnValue
+    Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache, boolean reiterate);
+
+
+    /**
+     * @param sub partial substitution
+     * @param u unifier with parent state
+     * @param parent parent state
+     * @param subGoals set of visited sub goals
+     * @param cache query cache
+     * @return resolution subGoal formed from this query
+     */
+    @CheckReturnValue
+    ResolutionState subGoal(ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache);
+}

--- a/server/src/graql/internal/reasoner/state/AtomicState.java
+++ b/server/src/graql/internal/reasoner/state/AtomicState.java
@@ -37,12 +37,12 @@ import java.util.Set;
  * Query state corresponding to an atomic query ({@link ReasonerAtomicQuery}) in the resolution tree.
  */
 @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
-class AtomicState extends QueryState<ReasonerAtomicQuery> {
+public class AtomicState extends QueryState<ReasonerAtomicQuery> {
 
     private MultiUnifier cacheUnifier = null;
     private CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> cacheEntry = null;
 
-    AtomicState(ReasonerAtomicQuery query,
+    public AtomicState(ReasonerAtomicQuery query,
                 ConceptMap sub,
                 Unifier u,
                 QueryStateBase parent,

--- a/server/src/graql/internal/reasoner/state/AtomicStateProducer.java
+++ b/server/src/graql/internal/reasoner/state/AtomicStateProducer.java
@@ -18,23 +18,17 @@
 
 package grakn.core.graql.internal.reasoner.state;
 
-import com.google.common.collect.Iterators;
 import grakn.core.graql.admin.Unifier;
 import grakn.core.graql.answer.ConceptMap;
-import grakn.core.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.internal.reasoner.query.ReasonerAtomicQuery;
-
 import java.util.Iterator;
 import java.util.Set;
 
 /**
  *
  * <p>
- * State producing {@link AtomicState}s:
- * - typed {@link AtomicState}s if type inference is required
- * - {@link AtomicState} for non-negated non-ambiguous {@link ReasonerAtomicQuery}
- * - {@link NeqComplementState} for non-ambiguous {@link ReasonerAtomicQuery} with negation
+ * State producing {@link AtomicState}s when when atom type is unknown and type inference is required
  * </p>
  *
  *
@@ -45,16 +39,7 @@ public class AtomicStateProducer extends QueryStateBase {
 
     public AtomicStateProducer(ReasonerAtomicQuery query, ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache) {
         super(sub, u, parent, subGoals, cache);
-
-        if(query.getAtom().getSchemaConcept() == null){
-            this.subGoalIterator = query.subGoals(sub, u, parent, subGoals, cache).iterator();
-        } else {
-            this.subGoalIterator = Iterators.singletonIterator(
-                    query.getAtoms(NeqPredicate.class).findFirst().isPresent() ?
-                            new NeqComplementState(query, sub, u, parent, subGoals, cache) :
-                            new AtomicState(query, sub, u, parent, subGoals, cache)
-            );
-        }
+        this.subGoalIterator = query.subGoals(sub, u, parent, subGoals, cache).iterator();
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/state/CompositeState.java
+++ b/server/src/graql/internal/reasoner/state/CompositeState.java
@@ -57,25 +57,30 @@ import java.util.Set;
  * @author Kasper Piskorski
  *
  */
-public class CompositeState extends ConjunctiveState {
+public class CompositeState extends QueryStateBase {
 
     private final ResolutionState baseConjunctionState;
     private boolean visited = false;
 
+    private final CompositeQuery query;
     private final Set<ResolvableQuery> complements;
 
     public CompositeState(CompositeQuery query, ConceptMap sub, Unifier u, QueryStateBase parent, Set<ReasonerAtomicQuery> subGoals, MultilevelSemanticCache cache) {
-        super(query.getConjunctiveQuery(), sub, u, parent, subGoals, cache);
-        this.baseConjunctionState = getQuery().subGoal(getSubstitution(), getUnifier(), this, getVisitedSubGoals(), getCache());
+        super(sub, u, parent, subGoals, cache);
+        this.query = query;
+        this.baseConjunctionState = query.getConjunctiveQuery().subGoal(getSubstitution(), getUnifier(), this, getVisitedSubGoals(), getCache());
         this.complements = query.getComplementQueries();
     }
 
     @Override
     public String toString(){
         return getClass().getSimpleName() + "@" + Integer.toHexString(hashCode()) + "\n" +
-                getQuery().toString() +
+                query.toString() +
                 (!complements.isEmpty()? "\nNOT{\n" + complements + "\n}" : "");
     }
+
+    @Override
+    ConceptMap consumeAnswer(AnswerState state) { return state.getSubstitution(); }
 
     @Override
     public ResolutionState propagateAnswer(AnswerState state) {
@@ -83,13 +88,7 @@ public class CompositeState extends ConjunctiveState {
 
         boolean isNegationSatisfied = complements.stream()
                 .map(q -> ReasonerQueries.resolvable(q, answer))
-                .noneMatch(q -> {
-                    System.out.println(">>>>>>>>Resolve complement query; " + q);
-                    return q.resolve(getVisitedSubGoals(), getCache(), q.requiresReiteration()).findFirst().isPresent();
-                });
-
-        if (isNegationSatisfied) System.out.println(">>>>>>>>Answer not found -> negation satisfied with answer: " + answer);
-        else{ System.out.println(">>>>>>>>Answer found -> negation not satisfied!");}
+                .noneMatch(q -> q.resolve(getVisitedSubGoals(), getCache(), q.requiresReiteration()).findFirst().isPresent());
 
         return isNegationSatisfied?
                 new AnswerState(answer, getUnifier(), getParentState()) :

--- a/server/src/graql/internal/reasoner/state/NeqComplementState.java
+++ b/server/src/graql/internal/reasoner/state/NeqComplementState.java
@@ -73,7 +73,6 @@ public class NeqComplementState extends QueryStateBase {
                 .project(this.neqPredicates.stream().flatMap(p -> p.getVarNames().stream()).collect(Collectors.toSet()));
 
         this.complementState = query.positive().subGoal(sub, u, this, subGoals, cache);
-        //new AtomicState(query.positive(), sub, u, this, subGoals, cache);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/state/NeqComplementState.java
+++ b/server/src/graql/internal/reasoner/state/NeqComplementState.java
@@ -26,6 +26,7 @@ import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.internal.reasoner.query.ReasonerAtomicQuery;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
 
+import grakn.core.graql.internal.reasoner.query.ResolvableQuery;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -53,25 +54,26 @@ import java.util.stream.Collectors;
 @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 public class NeqComplementState extends QueryStateBase {
 
-    private final AtomicState complementState;
+    private final ResolutionState complementState;
     private boolean visited = false;
 
     private final ConceptMap neqPredicateSub;
     private final Set<NeqPredicate> neqPredicates;
 
-    NeqComplementState(ReasonerAtomicQuery q,
-                       ConceptMap sub,
-                       Unifier u,
-                       QueryStateBase parent,
-                       Set<ReasonerAtomicQuery> subGoals,
-                       MultilevelSemanticCache cache) {
+    public NeqComplementState(ResolvableQuery q,
+                              ConceptMap sub,
+                              Unifier u,
+                              QueryStateBase parent,
+                              Set<ReasonerAtomicQuery> subGoals,
+                              MultilevelSemanticCache cache) {
         super(sub, u, parent, subGoals, cache);
-        ReasonerAtomicQuery query = ReasonerQueries.atomic(q, sub);
+        ResolvableQuery query = ReasonerQueries.resolvable(q, sub);
         this.neqPredicates = q.getAtoms(NeqPredicate.class).collect(Collectors.toSet());
         this.neqPredicateSub = query.getSubstitution().merge(sub)
                 .project(this.neqPredicates.stream().flatMap(p -> p.getVarNames().stream()).collect(Collectors.toSet()));
 
-        this.complementState = new AtomicState(query.positive(), sub, u, this, subGoals, cache);
+        this.complementState = query.positive().subGoal(sub, u, this, subGoals, cache);
+        //new AtomicState(query.positive(), sub, u, this, subGoals, cache);
     }
 
     @Override
@@ -87,7 +89,7 @@ public class NeqComplementState extends QueryStateBase {
 
     @Override
     ConceptMap consumeAnswer(AnswerState state) {
-        return complementState.consumeAnswer(state);
+        return state.getSubstitution();
     }
 
     @Override

--- a/test-integration/graql/reasoner/query/AtomicQueryIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryIT.java
@@ -205,7 +205,7 @@ public class AtomicQueryIT {
         String patternString = "{ ($x, $y) isa is-located-in; };";
         Conjunction<Statement> pattern = conjunction(patternString);
         ReasonerAtomicQuery atomicQuery = ReasonerQueries.atomic(pattern, tx);
-        ReasonerAtomicQuery copy = ReasonerQueries.atomic(atomicQuery);
+        ReasonerAtomicQuery copy = atomicQuery.copy();
         assertEquals(atomicQuery, copy);
         assertEquals(atomicQuery.hashCode(), copy.hashCode());
         tx.close();

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -55,6 +55,7 @@ import static grakn.core.graql.query.Graql.rel;
 import static grakn.core.graql.query.Graql.var;
 import static grakn.core.util.GraqlTestUtil.assertCollectionsEqual;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -221,8 +222,9 @@ public class NegationIT {
                             "get;"
             ));
 
-            List<ConceptMap> fullAnswers = tx.execute(Graql.<GetQuery>parse("match $x isa entity;get;"));
-            Set<ConceptMap> expectedAnswers = fullAnswers.stream().filter(ans -> ans.get("x").asThing().attributes().noneMatch(a -> a.value().equals(specificStringValue))).collect(toSet());
+            List<ConceptMap> expectedAnswers = tx.stream(Graql.<GetQuery>parse("match $x isa entity;get;"))
+                    .filter(ans -> ans.get("x").asThing().attributes().noneMatch(a -> a.value().equals(specificStringValue))).collect(toList());
+
             assertCollectionsEqual(
                     expectedAnswers,
                     answersWithoutSpecificStringValue
@@ -242,10 +244,11 @@ public class NegationIT {
                             "get;"
             ));
 
-            List<ConceptMap> fullAnswers = tx.execute(Graql.<GetQuery>parse("match $x has attribute $r;get;"));
+            List<ConceptMap> expectedAnswers = tx.stream(Graql.<GetQuery>parse("match $x has attribute $r;get;"))
+                    .filter(ans -> !ans.get("r").asAttribute().value().equals(specificStringValue)).collect(toList());
 
             assertCollectionsEqual(
-                    fullAnswers.stream().filter(ans -> !ans.get("r").asAttribute().value().equals(specificStringValue)).collect(toSet()),
+                    expectedAnswers,
                     answersWithoutSpecificStringValue
             );
         }

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -50,7 +50,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static grakn.core.util.GraqlTestUtil.assertNonTrivialEquals;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
@@ -97,7 +96,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -123,7 +122,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -149,7 +148,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -175,7 +174,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -201,7 +200,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -227,7 +226,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -253,7 +252,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -50,9 +50,10 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static grakn.core.util.GraqlTestUtil.assertNonTrivialEquals;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertEquals;
+import static junit.framework.TestCase.assertEquals;
 
 @SuppressWarnings("Duplicates")
 public class SemanticDifferenceIT {
@@ -96,7 +97,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -122,7 +123,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -148,7 +149,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -174,7 +175,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -200,7 +201,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -226,7 +227,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 
@@ -252,7 +253,7 @@ public class SemanticDifferenceIT {
             assertEquals(expected, semanticPair.getValue());
             Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
             Set<ConceptMap> propagatedAnswers = projectAnswersToChild(child, parent, semanticPair.getKey(), semanticPair.getValue());
-            assertEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            assertNonTrivialEquals(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
         }
     }
 

--- a/test-integration/util/GraqlTestUtil.java
+++ b/test-integration/util/GraqlTestUtil.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -70,6 +71,11 @@ public class GraqlTestUtil {
 
     public static <T> void assertCollectionsEqual(String msg, Collection<T> c1, Collection<T> c2) {
         assertTrue(msg, CollectionUtils.isEqualCollection(c1, c2));
+    }
+
+    public static <T> void assertNonTrivialEquals(String msg, Collection<T> c1, Collection<T> c2){
+        assertFalse("Trivial equality!", c1.isEmpty() == c2.isEmpty());
+        assertEquals(msg, c1, c2);
     }
 
     public static void loadFromFile(String gqlPath, String file, Transaction tx) {


### PR DESCRIPTION
# Why is this PR needed?
- simplifies query processing
- lays ground for #4790 
# What does the PR do?
- Unifies handling of `ReasonerQueryImpl`, `ReasonerAtomicQuery` and `CompositeQuery` by making them extend a common interface - `ResolvableQuery`. 
- Reduces extra processing by trying to construct more appropriate resolution states