### PR TITLE
Adapt to splitting client-python out

### DIFF
--- a/protocol/keyspace/BUILD
+++ b/protocol/keyspace/BUILD
@@ -16,6 +16,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+package(
+    default_visibility = ["//visibility:public"]
+)
+
 exports_files([
     "Keyspace.proto"
 ])
@@ -23,5 +27,4 @@ exports_files([
 proto_library(
     name = "keyspace-proto",
     srcs = ["Keyspace.proto"],
-    visibility = ["//visibility:public"]
 )

--- a/protocol/keyspace/BUILD
+++ b/protocol/keyspace/BUILD
@@ -20,18 +20,8 @@ exports_files([
     "Keyspace.proto"
 ])
 
-package(
-    default_visibility = [
-        "//protocol:__subpackages__",
-        "//server:__subpackages__",
-        "//client-java:__subpackages__",
-        "//client-nodejs:__subpackages__",
-        "//client_python:__subpackages__",
-    ]
-)
-
 proto_library(
     name = "keyspace-proto",
     srcs = ["Keyspace.proto"],
-    # proto_source_root = "protocol/keyspace",
+    visibility = ["//visibility:public"]
 )

--- a/protocol/session/BUILD
+++ b/protocol/session/BUILD
@@ -22,32 +22,22 @@ exports_files([
     "Session.proto"
 ])
 
-package(
-    default_visibility = [
-        "//protocol:__subpackages__",
-        "//server:__subpackages__",
-        "//client-java:__subpackages__",
-        "//client-nodejs:__subpackages__",
-        "//client_python:__subpackages__",
-    ]
-)
-
 proto_library(
     name = "concept-proto",
     srcs = ["Concept.proto"],
-    # proto_source_root = "protocol/session",
+    visibility = ["//visibility:public"]
 )
 
 proto_library(
     name = "answer-proto",
     srcs = ["Answer.proto"],
     deps = [":concept-proto"],
-    # proto_source_root = "protocol/session",
+    visibility = ["//visibility:public"]
 )
 
 proto_library(
     name = "session-proto",
     srcs = ["Session.proto"],
     deps = [":concept-proto", ":answer-proto"],
-    # proto_source_root = "protocol/session",
+    visibility = ["//visibility:public"]
 )

--- a/protocol/session/BUILD
+++ b/protocol/session/BUILD
@@ -16,6 +16,10 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
+package(
+    default_visibility = ["//visibility:public"]
+)
+
 exports_files([
     "Concept.proto",
     "Answer.proto",
@@ -25,19 +29,16 @@ exports_files([
 proto_library(
     name = "concept-proto",
     srcs = ["Concept.proto"],
-    visibility = ["//visibility:public"]
 )
 
 proto_library(
     name = "answer-proto",
     srcs = ["Answer.proto"],
     deps = [":concept-proto"],
-    visibility = ["//visibility:public"]
 )
 
 proto_library(
     name = "session-proto",
     srcs = ["Session.proto"],
     deps = [":concept-proto", ":answer-proto"],
-    visibility = ["//visibility:public"]
 )


### PR DESCRIPTION
# Why is this PR needed?

So [`graknlabs/client-python`](https://github.com/graknlabs/client-python) is able to use `//protocol` from this package

# What does the PR do?

Sets visibility for `//protocol` targets to `//visibility:public`