### PR TITLE
Bump version for rules_nodejs

### DIFF
--- a/dependencies/npm/dependencies.bzl
+++ b/dependencies/npm/dependencies.bzl
@@ -22,5 +22,5 @@ def node_dependencies():
     git_repository(
         name = "build_bazel_rules_nodejs",
         remote = "https://github.com/graknlabs/rules_nodejs.git",
-        commit = "5d0c6c78fc62bcffd01297350c694690fca770b8",
+        commit = "ac3f6854365f119130186f971588514ccff503ab",
     )


### PR DESCRIPTION
# Why is this PR needed?

As `client-nodejs` is going to be separated into its own repo (#4821), its targets will be moved one level up, i.e. `//client-nodejs:test-integration` → `//:test-integration`

# What does the PR do?

Updates `rules_nodejs` so targets at root level are supported.

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

Actually removing `client-nodejs`