### PR TITLE
Update @stackb_rules_proto back to upstream

### DIFF
--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -35,6 +35,6 @@ def grpc_dependencies():
 
     git_repository(
         name = "stackb_rules_proto",
-        remote = "https://github.com/graknlabs/rules_proto",
-        commit = "a8c7677d94c6eae84e123008ab656139f2530161",
+        remote = "https://github.com/stackb/rules_proto",
+        commit = "137014a36f389cfcb4987a567b7bd23a7a259cf9",
     )


### PR DESCRIPTION
# Why is this PR needed?

So we can remove `graknlabs/rules_proto`

# What does the PR do?

Updates `@stackb_rules_proto` link to latest upstream

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—