### PR TITLE
Fix pypi url and client java license

### DIFF
--- a/client-java/BUILD
+++ b/client-java/BUILD
@@ -51,6 +51,7 @@ java_library(
         "//dependencies/maven/artifacts/io/grpc:grpc-netty",
         "//dependencies/maven/artifacts/io/netty:netty-all",
     ],
+    resources = ["LICENSE"],
     tags = ["maven_coordinates=grakn.core:client:{pom_version}"],
 )
 

--- a/deployment.properties
+++ b/deployment.properties
@@ -19,7 +19,7 @@
 github.repository=grakn
 maven.repository-url.snapshot=http://maven.grakn.ai/nexus/content/repositories/snapshots/
 maven.repository-url.release=http://maven.grakn.ai/nexus/content/repositories/releases/
-pip.repository-url.pypi=https://pypi.org/legacy/
+pip.repository-url.pypi=https://upload.pypi.org/legacy/
 pip.repository-url.test=https://test.pypi.org/legacy/
 npm.repository-url=https://registry.npmjs.org/
 maven.packages=common,server,console,protocol,client-java


### PR DESCRIPTION
# Why is this PR needed?
- The `client-java` binary does not include `LICENSE` in the JAR
- Pypi deployment URL is wrong

# What does the PR do?
- Fix both issues

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A