### PR TITLE
Add a CI job which updates docs (dev branch) to always depend on the latest grakn (master branch)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,33 +264,99 @@ jobs:
             - ./workbase
 
 workflows:
-  workflow-pr:
+  ci-pull-request:
     jobs:
-      - build
-      - client-java
-      - common
-      - console
-      - graql
-      - server
-      - workbase
-      - test-integration
-      - test-integration-reasoner
-      - test-integration-analytics
-      - test-end-to-end
+      - build:
+          filters:
+            branches:
+              ignore: master
+      - client-java:
+          filters:
+            branches:
+              ignore: master
+      - common:
+          filters:
+            branches:
+              ignore: master
+      - console:
+          filters:
+            branches:
+              ignore: master
+      - graql:
+          filters:
+            branches:
+              ignore: master
+      - server:
+          filters:
+            branches:
+              ignore: master
+      - workbase:
+          filters:
+            branches:
+              ignore: master
+      - test-integration:
+          filters:
+            branches:
+              ignore: master
+      - test-integration-reasoner:
+          filters:
+            branches:
+              ignore: master
+      - test-integration-analytics:
+          filters:
+            branches:
+              ignore: master
+      - test-end-to-end:
+          filters:
+            branches:
+              ignore: master
 
-  workflow-master:
+  ci-master-branch:
     jobs:
-      - build
-      - client-java
-      - common
-      - console
-      - graql
-      - server
-      - workbase
-      - test-integration
-      - test-integration-reasoner
-      - test-integration-analytics
-      - test-end-to-end
+      - build:
+          filters:
+            branches:
+              only: master
+      - client-java:
+          filters:
+            branches:
+              only: master
+      - common:
+          filters:
+            branches:
+              only: master
+      - console:
+          filters:
+            branches:
+              only: master
+      - graql:
+          filters:
+            branches:
+              only: master
+      - server:
+          filters:
+            branches:
+              only: master
+      - workbase:
+          filters:
+            branches:
+              only: master
+      - test-integration:
+          filters:
+            branches:
+              only: master
+      - test-integration-reasoner:
+          filters:
+            branches:
+              only: master
+      - test-integration-analytics:
+          filters:
+            branches:
+              only: master
+      - test-end-to-end:
+          filters:
+            branches:
+              only: master
       - docs-update-grakn-dependency-on-dev-branch:
           requires:
             - build
@@ -304,6 +370,9 @@ workflows:
             - test-integration-reasoner
             - test-integration-analytics
             - test-end-to-end
+          filters:
+            branches:
+              only: master
 
   build-and-deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,47 +316,47 @@ workflows:
       - build:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - client-java:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - common:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - console:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - graql:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - server:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - workbase:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - test-integration:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - test-integration-reasoner:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - test-integration-analytics:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - test-end-to-end:
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
       - docs-update-grakn-dependency-on-dev-branch:
           requires:
             - build
@@ -372,7 +372,7 @@ workflows:
             - test-end-to-end
           filters:
             branches:
-              only: docs-update-grakn-dependency-on-dev-branch
+              only: master
 
   build-and-deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,17 @@ jobs:
       - bazel:
           command: bazel test //test-end-to-end:test-end-to-end --test_output=streamed --spawn_strategy=standalone
 
+  docs-update-grakn-dependency-on-dev-branch:
+    machine: true
+    steps:
+      - checkout
+      - run:
+          name: Make docs (development branch) depend on the latest Grakn (master)
+          command: |
+            mkdir docs
+            cd docs
+            python ../.circleci/docs-update-grakn-dependency-on-dev-branch.py
+
   build-workbase-linux:
       machine: true
       working_directory: ~/grakn
@@ -253,8 +264,7 @@ jobs:
             - ./workbase
 
 workflows:
-  version: 2
-  grakn-core-ci:
+  workflow-pr:
     jobs:
       - build
       - client-java
@@ -267,6 +277,33 @@ workflows:
       - test-integration-reasoner
       - test-integration-analytics
       - test-end-to-end
+
+  workflow-master:
+    jobs:
+      - build
+      - client-java
+      - common
+      - console
+      - graql
+      - server
+      - workbase
+      - test-integration
+      - test-integration-reasoner
+      - test-integration-analytics
+      - test-end-to-end
+      - docs-update-grakn-dependency-on-dev-branch:
+          requires:
+            - build
+            - client-java
+            - common
+            - console
+            - graql
+            - server
+            - workbase
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
 
   build-and-deploy:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,47 +316,47 @@ workflows:
       - build:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - client-java:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - common:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - console:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - graql:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - server:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - workbase:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - test-integration:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - test-integration-reasoner:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - test-integration-analytics:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - test-end-to-end:
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
       - docs-update-grakn-dependency-on-dev-branch:
           requires:
             - build
@@ -372,7 +372,7 @@ workflows:
             - test-end-to-end
           filters:
             branches:
-              only: master
+              only: docs-update-grakn-dependency-on-dev-branch
 
   build-and-deploy:
     jobs:

--- a/.circleci/docs-update-grakn-dependency-on-dev-branch.py
+++ b/.circleci/docs-update-grakn-dependency-on-dev-branch.py
@@ -7,9 +7,9 @@ git_username = "Grabl"
 git_email = "grabl@grakn.ai"
 grabl_credential = "grabl:"+os.environ['GRABL_CREDENTIAL']
 
-docs_url = "github.com/graknlabs/test-ci-docs.git" # TODO: update to real location
+docs_url = "github.com/graknlabs/docs.git"
 docs_dev_branch = "development"
-docs_clone_location = "test-ci-docs" # TODO: update to real location
+docs_clone_location = "docs"
 
 grakn_url = "github.com/graknlabs/grakn.git"
 grakn_master_branch = "refs/heads/master"

--- a/.circleci/docs-update-grakn-dependency-on-dev-branch.py
+++ b/.circleci/docs-update-grakn-dependency-on-dev-branch.py
@@ -1,0 +1,49 @@
+import os
+import re
+import subprocess as sp
+
+# TODO: consider not making grakn_master_branch configurable
+git_username = "Grabl"
+git_email = "grabl@grakn.ai"
+grabl_credential = "grabl:"+os.environ['GRABL_TOKEN']
+
+docs_url = "github.com/graknlabs/test-ci-docs.git" # TODO: update to real location
+docs_dev_branch = "development"
+docs_clone_location = "test-ci-docs" # TODO: update to real location
+
+grakn_url = "github.com/graknlabs/grakn.git"
+grakn_master_branch = "refs/heads/master"
+
+if __name__ == '__main__':
+    try:
+        print('** This job will make docs (development branch) depend on the latest grakn (master branch) **')
+        new_commit = sp.check_output(["git", "ls-remote", "https://"+grabl_credential+"@"+grakn_url, grakn_master_branch], stderr=sp.STDOUT).split("\t")[0]    
+        print('The latest commit in ' + grakn_url + '(' + grakn_master_branch + ' branch) is ' + new_commit)
+        sp.check_output(["git", "config", "--global", "user.email", git_email], stderr=sp.STDOUT)
+        sp.check_output(["git", "config", "--global", "user.name", git_username], stderr=sp.STDOUT)
+
+        sp.check_output(["git", "clone", "https://"+grabl_credential+"@"+docs_url, docs_clone_location], stderr=sp.STDOUT)
+        sp.check_output(["git", "checkout", docs_dev_branch], cwd=docs_clone_location, stderr=sp.STDOUT)
+        print(docs_url + ' (' + docs_dev_branch +' branch) successfully cloned to ' + docs_clone_location)
+
+        # update WORKSPACE with the new commit
+        workspace_content = open(os.path.join(docs_clone_location, 'WORKSPACE'), 'r').readlines()
+        marker = 'grakn-dependency: do not remove this comment. this is used by the auto-update script'
+        line_with_marker, _ = filter(lambda (index, line): line.find(marker) != -1, enumerate(workspace_content))[0]
+        workspace_content[line_with_marker] = re.sub(r'[0-9a-f]{40}', new_commit, workspace_content[line_with_marker], 1)
+        open(os.path.join(docs_clone_location, 'WORKSPACE'), 'w').write(''.join(workspace_content))
+        
+        # Commit and push the change
+        sp.check_output(["git", "add", "WORKSPACE"], cwd=docs_clone_location, stderr=sp.STDOUT)
+
+        should_commit = sp.check_output(["git", "status"], cwd=docs_clone_location).find('nothing to commit, working tree clean') == -1
+        if should_commit:
+            sp.check_output(["git", "commit", "-m", "update grakn dependency to latest master"], cwd=docs_clone_location, stderr=sp.STDOUT)
+            print('Pushing the change to ' + docs_url + ' (' + docs_dev_branch + ' branch)')
+            sp.check_output(["git", "push", "https://"+grabl_credential+"@"+docs_url, docs_dev_branch], cwd=docs_clone_location, stderr=sp.STDOUT)
+            print('The change has been pushed to ' + docs_url + ' (' + docs_dev_branch + ' branch)')
+        else:
+            print('docs already depends on ' + new_commit + '. There is nothing to update.')
+    except sp.CalledProcessError as e:
+        print('An error occurred when running "' + str(e.cmd) + '". Process exited with code ' + str(e.returncode) + ' and message "' + e.output + '"')
+        raise e

--- a/.circleci/docs-update-grakn-dependency-on-dev-branch.py
+++ b/.circleci/docs-update-grakn-dependency-on-dev-branch.py
@@ -5,7 +5,7 @@ import subprocess as sp
 # TODO: consider not making grakn_master_branch configurable
 git_username = "Grabl"
 git_email = "grabl@grakn.ai"
-grabl_credential = "grabl:"+os.environ['GRABL_TOKEN']
+grabl_credential = "grabl:"+os.environ['GRABL_CREDENTIAL']
 
 docs_url = "github.com/graknlabs/test-ci-docs.git" # TODO: update to real location
 docs_dev_branch = "development"


### PR DESCRIPTION
# Why is this PR needed?
This PR is a joint effort between me and @sorsaffari creating a solution to keep docs (`development` branch) stay in sync with the latest Grakn `master`

# What does the PR do?
1. Split CI workflows into two: `ci-pull-request` (ran on PRs) and `ci-master-branch` (ran when the PR got merged into `master`)
2. The `ci-master-branch` runs the same tests as in `ci-pull-request` but has an additional job `docs-update-grakn-dependency-on-dev-branch` which gets trigerred once all tests has passed. Said job will update the `WORKSPACE` file in docs (`development` branch) in order to keep it in sync with the latest Grakn

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
N/A