### PR TITLE
Allow rules with negation blocks provided they are stratifiable pt II

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,13 +31,18 @@ commands:
       - run:
           name: Bazel - Execute
           command: |
-            if [[ -f ~/.config/gcloud/application_default_credentials.json ]]; then
-              echo "Bazel will be executed with RBE support. This means the build is remotely executed and the cache will be re-used by subsequent CI jobs."
-              CMD="<< parameters.command >> --config=rbe"
-            else
-              echo "Bazel will be executed locally (without RBE support)."
-              CMD="<< parameters.command >>"
-            fi
+            # # TODO: re-add RBE once it's been fixed
+            # if [[ -f ~/.config/gcloud/application_default_credentials.json ]]; then
+            #     echo "Bazel will be executed with RBE support. This means the build is remotely executed and the cache will be re-used by subsequent CI jobs."
+            #     CMD="<< parameters.command >> --config=rbe"
+            # else
+            #     echo "Bazel will be executed locally (without RBE support)."
+            #     CMD="<< parameters.command >>"
+            # fi
+            # echo "Executing $CMD"
+            # $CMD
+            echo "Bazel will be executed locally because there is an issue with the RBE execution. TODO: re-activate RBE once it's been fixed"
+            CMD="<< parameters.command >>"
             echo "Executing $CMD"
             $CMD
 

--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -120,7 +120,7 @@ public class QueryExecutor {
         try {
             if (!infer) {
                 GraqlTraversal graqlTraversal = GreedyTraversalPlan.createTraversal(matchClause.getPatterns(), transaction);
-              return traversal(matchClause.getPatterns().variables(), graqlTraversal);
+                return traversal(matchClause.getPatterns().variables(), graqlTraversal);
             }
 
             Iterator<Conjunction<Pattern>> conjIt = matchClause.getPatterns().getNegationDNF().getPatterns().iterator();

--- a/server/src/graql/internal/reasoner/atom/Atom.java
+++ b/server/src/graql/internal/reasoner/atom/Atom.java
@@ -341,7 +341,10 @@ public abstract class Atom extends AtomicBase {
     /**
      * @return list of types this atom can take
      */
-    public ImmutableList<SchemaConcept> getPossibleTypes() { return ImmutableList.of(getSchemaConcept());}
+    public ImmutableList<Type> getPossibleTypes() {
+        return (getSchemaConcept() != null && getSchemaConcept().isType())?
+                ImmutableList.of(getSchemaConcept().asType()) :
+                ImmutableList.of();}
 
     /**
      * @param sub partial substitution

--- a/server/src/graql/internal/reasoner/atom/Atom.java
+++ b/server/src/graql/internal/reasoner/atom/Atom.java
@@ -221,7 +221,7 @@ public abstract class Atom extends AtomicBase {
                 .map(IsaProperty::isExplicit).orElse(false);
 
         return getPossibleTypes().stream()
-                .flatMap(type -> RuleUtils.getRulesWithType(type, isDirect, tx()))
+                .flatMap(type -> tx().ruleCache().getRulesWithType(type, isDirect))
                 .distinct();
     }
 

--- a/server/src/graql/internal/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/IsaAtom.java
@@ -149,8 +149,8 @@ public abstract class IsaAtom extends IsaAtomBase {
         return this;
     }
 
-    private ImmutableList<SchemaConcept> inferPossibleTypes(ConceptMap sub){
-        if (getSchemaConcept() != null) return ImmutableList.of(this.getSchemaConcept());
+    private ImmutableList<Type> inferPossibleTypes(ConceptMap sub){
+        if (getSchemaConcept() != null) return ImmutableList.of(getSchemaConcept().asType());
         if (sub.containsVar(getPredicateVariable())) return ImmutableList.of(sub.get(getPredicateVariable()).asType());
 
         //determine compatible types from played roles
@@ -188,7 +188,7 @@ public abstract class IsaAtom extends IsaAtomBase {
     }
 
     @Override
-    public ImmutableList<SchemaConcept> getPossibleTypes() { return inferPossibleTypes(new ConceptMap()); }
+    public ImmutableList<Type> getPossibleTypes() { return inferPossibleTypes(new ConceptMap()); }
 
     @Override
     public List<Atom> atomOptions(ConceptMap sub) {

--- a/server/src/graql/internal/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/internal/reasoner/query/CompositeQuery.java
@@ -110,7 +110,7 @@ public class CompositeQuery implements ResolvableQuery {
      *
      * Where the sets of variables:
      * V = {x1, ..., xn}
-     * Vp = {xi, ..., xj
+     * Vp = {xi, ..., xj}
      * Vn = {xk, ..., xm}
      * Vr = {xk', ..., xm'}
      *
@@ -121,37 +121,29 @@ public class CompositeQuery implements ResolvableQuery {
      * Vr e Vn
      *
      * This procedure can follow recursively for multiple nested negation blocks.
-     * Then, for the negation to be safe, we require the variables of the head of the rules to be bound.
-     * NB: as Vr is a subset of Vn, we do only require a subset of variables in the negation block to be bound.
+     * Then, for the negation to be safe, we require:
+     *
+     * - the set of variables Vr to be non-empty
+     *
+     * NB: We do not require the negation blocks to be ground with respect to the positive part as we can rewrite the
+     * negation blocks in terms of a ground relation defined via rule. i.e.:
+     *
+     * Q(x) :- T(x), (x, y), NOT{ (y, z) }
+     *
+     * can be rewritten as:
+     *
+     * Q(x) :- T(x), (x, y), NOT{ ?(y) }
+     * ?(y) :- (y, z)
      *
      * @return true if this composite query is safe to resolve
      */
     private boolean isNegationSafe(){
-        if (isPositive()) return true;
-        //check if p+1 is positive
-        if (getComplementQueries().stream().allMatch(ReasonerQuery::isPositive)){
-            //simple p boundedness check
-            Set<Variable> intersection = Sets.intersection(
-                    getConjunctiveQuery().getVarNames(),
-                    getComplementQueries().stream().flatMap(q -> q.getVarNames().stream()).collect(Collectors.toSet())
-            );
-            return !intersection.isEmpty();
-        } else {
-            Set<CompositeQuery> p1Queries = getComplementQueries().stream().map(q -> (CompositeQuery) q).collect(Collectors.toSet());
-            Set<ResolvableQuery> p2Queries = p1Queries.stream().flatMap(q -> q.getComplementQueries().stream()).collect(Collectors.toSet());
-            //check if p+2 composite
-            if (p2Queries.stream().noneMatch(ReasonerQuery::isPositive)){
-                //do complex check
-                Set<Variable> p0bindings = this.bindingVariables();
-                Set<Set<Variable>> p1PositiveBindings = p1Queries.stream().map(p1q -> p1q.getConjunctiveQuery().getVarNames()).collect(Collectors.toSet());
-                Set<Set<Variable>> p2PositiveBindings = p2Queries.stream().map(q -> (CompositeQuery) q).map(p2q -> p2q.getConjunctiveQuery().getVarNames()).collect(Collectors.toSet());
-                if( !p1PositiveBindings.stream().allMatch(p1 -> p1.containsAll(p0bindings))
-                    || !p2PositiveBindings.stream().allMatch(p2 -> p1PositiveBindings.stream().allMatch(p1 -> p1.containsAll(p2)))){
-                    return false;
-                }
-            }
-            return p1Queries.stream().allMatch(CompositeQuery::isNegationSafe);
-        }
+        if (this.isPositive()) return true;
+        if (bindingVariables().isEmpty()) return false;
+        //check nested blocks
+        return getComplementQueries().stream()
+                .map(ResolvableQuery::asComposite)
+                .allMatch(CompositeQuery::isNegationSafe);
     }
 
     private Set<Variable> bindingVariables(){

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -240,6 +240,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     private Stream<Pair<InferenceRule, Unifier>> getRuleStream() {
+
+        //TODO stratify rules
         return getAtom().getApplicableRules()
                 .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
                 .sorted(Comparator.comparing(rt -> -rt.getKey().resolutionPriority()));

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -239,16 +239,6 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     private Stream<Pair<InferenceRule, Unifier>> getRuleStream() {
-        Set<InferenceRule> collect = getAtom().getApplicableRules().collect(Collectors.toSet());
-        Set<InferenceRule> collect1 = RuleUtils
-                .stratifyRules(collect)
-                .collect(Collectors.toSet());
-        if(!collect.equals(collect1)){
-            System.out.println();
-            Set<InferenceRule> collect2 = RuleUtils
-                    .stratifyRules(collect)
-                    .collect(Collectors.toSet());
-        }
         return RuleUtils
                 .stratifyRules(getAtom().getApplicableRules().collect(Collectors.toSet()))
                 .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)));

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -239,6 +239,16 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     private Stream<Pair<InferenceRule, Unifier>> getRuleStream() {
+        Set<InferenceRule> collect = getAtom().getApplicableRules().collect(Collectors.toSet());
+        Set<InferenceRule> collect1 = RuleUtils
+                .stratifyRules(collect)
+                .collect(Collectors.toSet());
+        if(!collect.equals(collect1)){
+            System.out.println();
+            Set<InferenceRule> collect2 = RuleUtils
+                    .stratifyRules(collect)
+                    .collect(Collectors.toSet());
+        }
         return RuleUtils
                 .stratifyRules(getAtom().getApplicableRules().collect(Collectors.toSet()))
                 .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)));

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -23,16 +23,15 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import grakn.core.graql.internal.reasoner.atom.Atomic;
-import grakn.core.graql.internal.reasoner.unifier.MultiUnifier;
-import grakn.core.graql.internal.reasoner.unifier.Unifier;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.internal.reasoner.atom.Atom;
+import grakn.core.graql.internal.reasoner.atom.Atomic;
 import grakn.core.graql.internal.reasoner.atom.binary.TypeAtom;
 import grakn.core.graql.internal.reasoner.atom.predicate.NeqPredicate;
 import grakn.core.graql.internal.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.internal.reasoner.cache.SemanticDifference;
 import grakn.core.graql.internal.reasoner.rule.InferenceRule;
+import grakn.core.graql.internal.reasoner.rule.RuleUtils;
 import grakn.core.graql.internal.reasoner.state.AnswerState;
 import grakn.core.graql.internal.reasoner.state.AtomicState;
 import grakn.core.graql.internal.reasoner.state.AtomicStateProducer;
@@ -40,15 +39,15 @@ import grakn.core.graql.internal.reasoner.state.CacheCompletionState;
 import grakn.core.graql.internal.reasoner.state.NeqComplementState;
 import grakn.core.graql.internal.reasoner.state.QueryStateBase;
 import grakn.core.graql.internal.reasoner.state.ResolutionState;
+import grakn.core.graql.internal.reasoner.unifier.MultiUnifier;
 import grakn.core.graql.internal.reasoner.unifier.MultiUnifierImpl;
+import grakn.core.graql.internal.reasoner.unifier.Unifier;
 import grakn.core.graql.internal.reasoner.unifier.UnifierType;
 import grakn.core.graql.internal.reasoner.utils.Pair;
 import grakn.core.graql.query.pattern.Conjunction;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.server.session.TransactionOLTP;
-
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -240,10 +239,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     }
 
     private Stream<Pair<InferenceRule, Unifier>> getRuleStream() {
-
-        //TODO stratify rules
-        return getAtom().getApplicableRules()
-                .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)))
-                .sorted(Comparator.comparing(rt -> -rt.getKey().resolutionPriority()));
+        return RuleUtils
+                .stratifyRules(getAtom().getApplicableRules().collect(Collectors.toSet()))
+                .flatMap(r -> r.getMultiUnifier(getAtom()).stream().map(unifier -> new Pair<>(r, unifier)));
     }
 }

--- a/server/src/graql/internal/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/internal/reasoner/rule/RuleUtils.java
@@ -63,9 +63,11 @@ public class RuleUtils {
                         rule.getBody()
                                 .getAtoms(Atom.class)
                                 .flatMap(at -> at.getPossibleTypes().stream())
-                                .flatMap(Type::subs)
+                                .flatMap(type -> Stream.concat(
+                                        Stream.of(type),
+                                        type.subs().filter(t -> !Schema.MetaSchema.isMetaLabel(t.label())))
+                                )
                                 .filter(t -> !t.isAbstract())
-                                .filter(whenType -> !Schema.MetaSchema.isMetaLabel(whenType.label()))
                                 .forEach(whenType ->
                                         rule.getHead()
                                                 .getAtom()
@@ -87,9 +89,12 @@ public class RuleUtils {
         rules
                 .forEach(rule ->
                         rule.whenTypes()
-                                .filter(whenType -> !Schema.MetaSchema.isMetaLabel(whenType.label()))
+                                .flatMap(Type::subs)
+                                .filter(t -> !t.isAbstract())
                                 .forEach(whenType ->
                                         rule.thenTypes()
+                                                .flatMap(Type::sups)
+                                                .filter(t -> !t.isAbstract())
                                                 .forEach(thenType -> graph.put(whenType, thenType))
                                 )
                 );

--- a/server/src/graql/internal/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/internal/reasoner/rule/RuleUtils.java
@@ -33,22 +33,13 @@ import grakn.core.graql.internal.reasoner.query.CompositeQuery;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueryImpl;
 import grakn.core.graql.internal.reasoner.utils.TarjanSCC;
-import grakn.core.graql.query.pattern.Negation;
-import grakn.core.graql.query.pattern.Pattern;
-import grakn.core.graql.query.pattern.property.IsaProperty;
 import grakn.core.server.Transaction;
 import grakn.core.server.session.TransactionOLTP;
-
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Stack;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
@@ -86,9 +77,13 @@ public class RuleUtils {
         rules
                 .forEach(rule ->
                         rule.whenTypes()
+                                .flatMap(Type::subs)
+                                .filter(t -> !t.isAbstract())
                                 .filter(whenType -> !Schema.MetaSchema.isMetaLabel(whenType.label()))
                                 .forEach(whenType ->
                                         rule.thenTypes()
+                                                .flatMap(Type::sups)
+                                                .filter(t -> !t.isAbstract())
                                                 .forEach(thenType -> graph.put(whenType, thenType))
                         )
                 );

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -21,9 +21,6 @@ package grakn.core.server.kb;
 import com.google.common.collect.Iterables;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.util.CommonUtil;
-import grakn.core.graql.internal.reasoner.atom.Atomic;
-import grakn.core.graql.internal.reasoner.query.CompositeQuery;
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
 import grakn.core.graql.concept.Attribute;
 import grakn.core.graql.concept.Label;
 import grakn.core.graql.concept.Relation;
@@ -34,11 +31,12 @@ import grakn.core.graql.concept.SchemaConcept;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.Schema;
+import grakn.core.graql.internal.reasoner.atom.Atomic;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
+import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
 import grakn.core.graql.internal.reasoner.rule.RuleUtils;
 import grakn.core.graql.query.Graql;
 import grakn.core.graql.query.pattern.Conjunction;
-import grakn.core.graql.query.pattern.Disjunction;
 import grakn.core.graql.query.pattern.Pattern;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.server.Transaction;
@@ -49,7 +47,6 @@ import grakn.core.server.kb.concept.SchemaConceptImpl;
 import grakn.core.server.kb.concept.TypeImpl;
 import grakn.core.server.kb.structure.Casting;
 import grakn.core.server.session.TransactionOLTP;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -298,7 +295,7 @@ class ValidateGlobalRules {
      */
     static Set<String> validateRuleIsValidClause(TransactionOLTP graph, Rule rule){
         Set<String> errors = new HashSet<>();
-        CompositeQuery composite = ReasonerQueries.composite(rule.when().getNegationDNF().getPatterns().iterator().next(), graph);
+        //TODO negation block validation
         if (rule.when().getDisjunctiveNormalForm().getPatterns().size() > 1){
             errors.add(ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_BODY.getMessage(rule.label()));
         }

--- a/server/src/server/kb/concept/SchemaConceptImpl.java
+++ b/server/src/server/kb/concept/SchemaConceptImpl.java
@@ -158,6 +158,9 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
 
             //Clear internal caching
             txCacheClear();
+
+            //clear rule cache
+            vertex().tx().ruleCache().clear();
         } else {
             throw TransactionException.cannotBeDeleted(this);
         }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -617,6 +617,7 @@ public class TransactionOLTP implements Transaction {
                     .map(type -> this.<SchemaConcept>getSchemaConcept(Label.of(type)))
                     .filter(Objects::nonNull)
                     .filter(Concept::isType)
+                    .map(Concept::asType)
                     .forEach(type -> ruleCache.updateRules(type, rule));
         }
         return rule;

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -795,7 +795,7 @@ public class TransactionOLTP implements Transaction {
             //Ignored for Tinker
         } finally {
             cache().closeTx(closedReason);
-            ruleCache().closeTx();
+            ruleCache().clear();
         }
     }
 
@@ -814,7 +814,6 @@ public class TransactionOLTP implements Transaction {
         if (logsExist) {
             return Optional.of(CommitLog.create(keyspace(), newInstances, newAttributes));
         }
-
 
         return Optional.empty();
     }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -764,6 +764,7 @@ public class TransactionOLTP implements Transaction {
             validateGraph();
             commitTransactionInternal();
             cache().writeToGraphCache(true);
+            //TODO update cache here
         } finally {
             closeTransaction(closeMessage);
         }

--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -61,7 +61,7 @@ public class RuleCache {
      */
     public Set<Rule> updateRules(Type type, Rule rule) {
         Set<Rule> match = ruleMap.get(type);
-        if (match == null) {
+        if (match.isEmpty()) {
             Set<Rule> rules = Sets.newHashSet(rule);
             getTypes(type, false).stream()
                     .flatMap(SchemaConcept::thenRules)
@@ -103,7 +103,7 @@ public class RuleCache {
         if (type == null) return getRules();
 
         Set<Rule> match = ruleMap.get(type);
-        if (match != null) return match.stream();
+        if (!match.isEmpty()) return match.stream();
 
         return getTypes(type, direct).stream()
                 .flatMap(SchemaConcept::thenRules)

--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -57,20 +57,15 @@ public class RuleCache {
     /**
      * @param type rule head's type
      * @param rule to be appended
-     * @return updated entry value
      */
-    public Set<Rule> updateRules(Type type, Rule rule) {
+    public void updateRules(Type type, Rule rule) {
         Set<Rule> match = ruleMap.get(type);
         if (match.isEmpty()) {
-            Set<Rule> rules = Sets.newHashSet(rule);
             getTypes(type, false).stream()
                     .flatMap(SchemaConcept::thenRules)
                     .forEach(r -> ruleMap.put(type, r));
-            return rules;
         }
         ruleMap.put(type, rule);
-        match.add(rule);
-        return match;
     }
 
     /**
@@ -128,7 +123,7 @@ public class RuleCache {
     /**
      * cleans cache contents
      */
-    public void closeTx() {
+    public void clear() {
         ruleMap.clear();
         ruleConversionMap.clear();
     }

--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 
 /**
  * Caches rules applicable to schema concepts and their conversion to InferenceRule object (parsing is expensive when large number of rules present).
- * NB: non-committed rules are alse cached.
+ * NB: non-committed rules are also cached.
  */
 public class RuleCache {
 

--- a/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
@@ -179,12 +179,12 @@ public class AtomicRuleApplicabilityIT {
         Atom relation2 = ReasonerQueries.create(conjunction(relationString2, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
         Atom relation3 = ReasonerQueries.create(conjunction(relationString3, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
         Atom relation4 = ReasonerQueries.create(conjunction(relationString4, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
-        Set<InferenceRule> rules = RuleUtils.getRules(tx).map(r -> new InferenceRule(r, tx)).collect(Collectors.toSet());
+        Set<InferenceRule> rules = tx.ruleCache().getRules().map(r -> new InferenceRule(r, tx)).collect(Collectors.toSet());
 
         assertEquals(rules.stream().filter(r -> r.getRule().label().equals(Label.of("attributed-relation-long-rule"))).collect(Collectors.toSet()), relation.getApplicableRules().collect(toSet()));
         assertEquals(rules.stream().filter(r -> r.getRule().label().getValue().contains("attributed-relation")).collect(toSet()), relation2.getApplicableRules().collect(toSet()));
         assertEquals(rules.stream().filter(r -> r.getRule().label().getValue().contains("attributed-relation")).collect(toSet()), relation3.getApplicableRules().collect(toSet()));
-        assertEquals(RuleUtils.getRules(tx).count() - 1, relation4.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().count() - 1, relation4.getApplicableRules().count());
         tx.close();
     }
 
@@ -217,7 +217,7 @@ public class AtomicRuleApplicabilityIT {
         Atom relation2 = ReasonerQueries.create(conjunction(relationString2, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
         Atom relation3 = ReasonerQueries.create(conjunction(relationString3, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
 
-        Set<InferenceRule> rules = RuleUtils.getRules(tx).map(r -> new InferenceRule(r, tx)).collect(Collectors.toSet());
+        Set<InferenceRule> rules = tx.ruleCache().getRules().map(r -> new InferenceRule(r, tx)).collect(Collectors.toSet());
 
         assertEquals(rules.stream().filter(r -> r.getRule().label().getValue().contains("attributed-relation")).collect(Collectors.toSet()), relation.getApplicableRules().collect(Collectors.toSet()));
         assertEquals(rules.stream().filter(r -> r.getRule().label().equals(Label.of("attributed-relation-string-rule"))).collect(Collectors.toSet()), relation2.getApplicableRules().collect(Collectors.toSet()));
@@ -307,7 +307,7 @@ public class AtomicRuleApplicabilityIT {
         Atom type4 = ReasonerQueries.atomic(conjunction(typeString4, tx), tx).getAtom();
         Atom type5 = ReasonerQueries.atomic(conjunction(typeString5, tx), tx).getAtom();
 
-        List<InferenceRule> rules = RuleUtils.getRules(tx).map(r -> new InferenceRule(r, tx)).collect(Collectors.toList());
+        List<InferenceRule> rules = tx.ruleCache().getRules().map(r -> new InferenceRule(r, tx)).collect(Collectors.toList());
         assertEquals(2, type.getApplicableRules().count());
         assertEquals(1, type2.getApplicableRules().count());
         assertEquals(3, type3.getApplicableRules().count());
@@ -322,7 +322,7 @@ public class AtomicRuleApplicabilityIT {
         String relationString = "{ ($x, $y); };";
         Atom relation = ReasonerQueries.atomic(conjunction(relationString, tx), tx).getAtom();
         assertEquals(
-                RuleUtils.getRules(tx).count(),
+                tx.ruleCache().getRules().count(),
                 relation.getApplicableRules().count()
         );
         tx.close();
@@ -338,9 +338,9 @@ public class AtomicRuleApplicabilityIT {
         Atom type2 = ReasonerQueries.atomic(conjunction(typeString2, tx), tx).getAtom();
         Atom type3 = ReasonerQueries.create(conjunction(typeString3, tx), tx).getAtoms(IsaAtom.class).filter(at -> at.getSchemaConcept() == null).findFirst().orElse(null);
 
-        assertEquals(RuleUtils.getRules(tx).count(), type.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().count(), type.getApplicableRules().count());
         assertThat(type2.getApplicableRules().collect(toSet()), empty());
-        assertEquals(RuleUtils.getRules(tx).filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), type3.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), type3.getApplicableRules().count());
         tx.close();
     }
 
@@ -353,7 +353,7 @@ public class AtomicRuleApplicabilityIT {
         Atom type2 = ReasonerQueries.create(conjunction(typeString2, tx), tx).getAtoms(IsaAtom.class).findFirst().orElse(null);
         assertThat(type.getApplicableRules().collect(toSet()), empty());
         assertEquals(
-                RuleUtils.getRules(tx).filter(r -> r.thenTypes().anyMatch(c -> c.label().equals(Label.of("binary")))).count(),
+                tx.ruleCache().getRules().filter(r -> r.thenTypes().anyMatch(c -> c.label().equals(Label.of("binary")))).count(),
                 type2.getApplicableRules().count()
         );
         tx.close();
@@ -365,7 +365,7 @@ public class AtomicRuleApplicabilityIT {
         String relationString = "{ $x isa $type; };";
         Atom relation = ReasonerQueries.atomic(conjunction(relationString, tx), tx).getAtom();
         assertEquals(
-                RuleUtils.getRules(tx).count(),
+                tx.ruleCache().getRules().count(),
                 relation.getApplicableRules().count()
         );
         tx.close();
@@ -412,10 +412,10 @@ public class AtomicRuleApplicabilityIT {
         Atom relation3 = ReasonerQueries.create(conjunction(relationString3, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
 
         assertEquals(7, relation.getApplicableRules().count());
-        assertEquals(RuleUtils.getRules(tx).filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), relation2.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), relation2.getApplicableRules().count());
 
         //TODO not filtered correctly
-        //assertEquals(RuleUtils.getRules(tx).filter(r -> r.thenTypes().allMatch(Concept::isAttributeType)).count(), relation3.getApplicableRules().count());
+        //assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isAttributeType)).count(), relation3.getApplicableRules().count());
         tx.close();
     }
 

--- a/test-integration/graql/reasoner/atomic/AtomicTypeInferenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicTypeInferenceIT.java
@@ -21,6 +21,7 @@ package grakn.core.graql.reasoner.atomic;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.reasoner.atom.Atomic;
 import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
 import grakn.core.graql.answer.ConceptMap;
@@ -113,9 +114,9 @@ public class AtomicTypeInferenceIT {
         String patternString3 = "{ $x isa twoRoleEntity; ($x, $y); };";
         String subbedPatternString3 = "{ $x id '" + conceptId(tx, "twoRoleEntity") + "';($x, $y); };";
 
-        List<SchemaConcept> possibleTypes = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
 
         typeInference(allRelations(tx), patternString, subbedPatternString, tx);
@@ -146,12 +147,12 @@ public class AtomicTypeInferenceIT {
                 "$x id '" + conceptId(tx, "yetAnotherSingleRoleEntity") + "';" +
                 "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
 
-        List<SchemaConcept> possibleTypes = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
 
-        List<SchemaConcept> possibleTypes2 = Collections.singletonList(tx.getSchemaConcept(Label.of("twoRoleBinary")));
+        List<Type> possibleTypes2 = Collections.singletonList(tx.getType(Label.of("twoRoleBinary")));
 
         typeInference(possibleTypes, patternString, subbedPatternString, tx);
         typeInference(possibleTypes, patternString2, subbedPatternString2, tx);
@@ -166,10 +167,10 @@ public class AtomicTypeInferenceIT {
         String patternString2 = "{ (role2: $x, $y); };";
         String patternString3 = "{ (role3: $x, $y); };";
 
-        List<SchemaConcept> possibleTypes = Collections.singletonList(tx.getSchemaConcept(Label.of("twoRoleBinary")));
-        List<SchemaConcept> possibleTypes2 = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Collections.singletonList(tx.getSchemaConcept(Label.of("twoRoleBinary")));
+        List<Type> possibleTypes2 = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
 
         typeInference(possibleTypes, patternString, tx);
@@ -203,9 +204,9 @@ public class AtomicTypeInferenceIT {
         String subbedPatternString3 = "{(role1: $x, $y);" +
                 "$y id '" + conceptId(tx, "anotherTwoRoleEntity") + "';};";
 
-        List<SchemaConcept> possibleTypes = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
 
         typeInference(possibleTypes, patternString, subbedPatternString, tx);
@@ -258,9 +259,9 @@ public class AtomicTypeInferenceIT {
                 "$x id '" + conceptId(tx, "singleRoleEntity") + "';" +
                 "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
 
-        List<SchemaConcept> possibleTypes = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
         typeInference(possibleTypes, patternString, subbedPatternString, tx);
         tx.close();
@@ -284,9 +285,9 @@ public class AtomicTypeInferenceIT {
 
         typeInference(Collections.singletonList(tx.getSchemaConcept(Label.of("threeRoleBinary"))), patternString, subbedPatternString, tx);
 
-        List<SchemaConcept> possibleTypes = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> possibleTypes = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
         typeInference(possibleTypes, patternString2, subbedPatternString2, tx);
         tx.close();
@@ -356,15 +357,15 @@ public class AtomicTypeInferenceIT {
         assertEquals(midAtom.getPossibleTypes(), YZatom.getPossibleTypes());
 
         //differently prioritised options arise from using neighbour information
-        List<SchemaConcept> firstTypeOption = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("twoRoleBinary")),
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> firstTypeOption = Lists.newArrayList(
+                tx.getType(Label.of("twoRoleBinary")),
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
-        List<SchemaConcept> secondTypeOption = Lists.newArrayList(
-                tx.getSchemaConcept(Label.of("anotherTwoRoleBinary")),
-                tx.getSchemaConcept(Label.of("twoRoleBinary")),
-                tx.getSchemaConcept(Label.of("threeRoleBinary"))
+        List<Type> secondTypeOption = Lists.newArrayList(
+                tx.getType(Label.of("anotherTwoRoleBinary")),
+                tx.getType(Label.of("twoRoleBinary")),
+                tx.getType(Label.of("threeRoleBinary"))
         );
         typeInference(secondTypeOption, XYatom.getCombinedPattern().toString(), tx);
         typeInference(firstTypeOption, YZatom.getCombinedPattern().toString(), tx);
@@ -372,10 +373,10 @@ public class AtomicTypeInferenceIT {
         tx.close();
     }
 
-    private void typeInference(List<SchemaConcept> possibleTypes, String pattern, TransactionOLTP tx){
+    private void typeInference(List<Type> possibleTypes, String pattern, TransactionOLTP tx){
         ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(pattern, tx), tx);
         Atom atom = query.getAtom();
-        List<SchemaConcept> relationshipTypes = atom.getPossibleTypes();
+        List<Type> relationshipTypes = atom.getPossibleTypes();
 
         if (possibleTypes.size() == 1){
             assertEquals(possibleTypes, relationshipTypes);
@@ -388,14 +389,14 @@ public class AtomicTypeInferenceIT {
         typeInferenceQueries(possibleTypes, pattern, tx);
     }
 
-    private void typeInference(List<SchemaConcept> possibleTypes, String pattern, String subbedPattern, TransactionOLTP tx){
+    private void typeInference(List<Type> possibleTypes, String pattern, String subbedPattern, TransactionOLTP tx){
         ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(pattern, tx), tx);
         ReasonerAtomicQuery subbedQuery = ReasonerQueries.atomic(conjunction(subbedPattern, tx), tx);
         Atom atom = query.getAtom();
         Atom subbedAtom = subbedQuery.getAtom();
 
-        List<SchemaConcept> relationshipTypes = atom.getPossibleTypes();
-        List<SchemaConcept> subbedRelationshipTypes = subbedAtom.getPossibleTypes();
+        List<Type> relationshipTypes = atom.getPossibleTypes();
+        List<Type> subbedRelationshipTypes = subbedAtom.getPossibleTypes();
         if (possibleTypes.size() == 1){
             assertEquals(possibleTypes, relationshipTypes);
             assertEquals(relationshipTypes, subbedRelationshipTypes);
@@ -413,14 +414,14 @@ public class AtomicTypeInferenceIT {
         typeInferenceQueries(possibleTypes, subbedPattern, tx);
     }
 
-    private void typeInferenceQueries(List<SchemaConcept> possibleTypes, String pattern, TransactionOLTP tx) {
+    private void typeInferenceQueries(List<Type> possibleTypes, String pattern, TransactionOLTP tx) {
         List<ConceptMap> typedAnswers = typedAnswers(possibleTypes, pattern, tx);
         List<ConceptMap> unTypedAnswers = tx.execute(Graql.match(Graql.parsePattern(pattern)).get());
         assertEquals(typedAnswers.size(), unTypedAnswers.size());
         GraqlTestUtil.assertCollectionsEqual(typedAnswers, unTypedAnswers);
     }
 
-    private List<ConceptMap> typedAnswers(List<SchemaConcept> possibleTypes, String pattern, TransactionOLTP tx){
+    private List<ConceptMap> typedAnswers(List<Type> possibleTypes, String pattern, TransactionOLTP tx){
         List<ConceptMap> answers = new ArrayList<>();
         ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(pattern, tx), tx);
         for(SchemaConcept type : possibleTypes){
@@ -430,7 +431,7 @@ public class AtomicTypeInferenceIT {
         return answers;
     }
 
-    private List<SchemaConcept> allRelations(TransactionOLTP tx){
+    private List<Type> allRelations(TransactionOLTP tx){
         RelationType metaType = tx.getRelationshipType(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue());
         return metaType.subs().filter(t -> !t.equals(metaType)).collect(Collectors.toList());
     }

--- a/test-integration/graql/reasoner/cache/RuleCacheIT.java
+++ b/test-integration/graql/reasoner/cache/RuleCacheIT.java
@@ -20,6 +20,7 @@ package grakn.core.graql.reasoner.cache;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.reasoner.unifier.Unifier;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.concept.Entity;
@@ -130,8 +131,8 @@ public class RuleCacheIT {
     public void whenGettingRulesWithType_correctRulesAreObtained(){
         RuleCache ruleCache = tx.ruleCache();
 
-        SchemaConcept reifyingRelation = tx.getSchemaConcept(Label.of("reifying-relation"));
-        SchemaConcept ternary = tx.getSchemaConcept(Label.of("ternary"));
+        Type reifyingRelation = tx.getType(Label.of("reifying-relation"));
+        Type ternary = tx.getType(Label.of("ternary"));
         Set<Rule> rulesWithBinary = ruleCache.getRulesWithType(reifyingRelation).collect(toSet());
         Set<Rule> rulesWithTernary = ruleCache.getRulesWithType(ternary).collect(toSet());
 
@@ -152,7 +153,7 @@ public class RuleCacheIT {
         Pattern then = Graql.parsePattern("{ (someRole: $x, subRole: $y) isa binary; };");
         Rule dummyRule = tx.putRule("dummyRule", when, then);
 
-        SchemaConcept binary = tx.getSchemaConcept(Label.of("binary"));
+        Type binary = tx.getType(Label.of("binary"));
         Set<Rule> cachedRules = tx.ruleCache().getRulesWithType(binary).collect(Collectors.toSet());
         assertTrue(cachedRules.contains(dummyRule));
     }
@@ -166,8 +167,7 @@ public class RuleCacheIT {
         Pattern then = Graql.parsePattern("{ (someRole: $x, subRole: $y) isa binary; };");
         Rule dummyRule = tx.putRule("dummyRule", when, then);
 
-        SchemaConcept binary = tx.getSchemaConcept(Label.of("binary"));
-
+        Type binary = tx.getType(Label.of("binary"));
         Set<Rule> commitedRules = binary.thenRules().collect(Collectors.toSet());
         Set<Rule> cachedRules = tx.ruleCache().getRulesWithType(binary).collect(toSet());
         assertEquals(Sets.union(commitedRules, Sets.newHashSet(dummyRule)), cachedRules);
@@ -179,7 +179,7 @@ public class RuleCacheIT {
     public void whenDeletingARule_cacheContainsUpdatedEntry(){
         tx.execute(Graql.<UndefineQuery>parse("undefine $x sub rule label 'rule-0';"));
 
-        SchemaConcept binary = tx.getSchemaConcept(Label.of("binary"));
+        Type binary = tx.getType(Label.of("binary"));
         Set<Rule> rules = tx.ruleCache().getRulesWithType(binary).collect(Collectors.toSet());
         assertTrue(rules.isEmpty());
     }

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -109,9 +109,9 @@ public class NegationIT {
                     "{" +
                             "$r isa entity;" +
                             "not {" +
-                                "($r, $i);" +
+                                "($r2, $i);" +
                                 "not {" +
-                                    "($j, $k);" +
+                                    "$i isa entity;" +
                                 "};" +
                             "};" +
                             "};"
@@ -483,7 +483,7 @@ public class NegationIT {
                     "get $r;"
             )).collect(Collectors.toSet());
 
-            assertEquals(recipesWithoutAllergenIngredients, Sets.difference(allRecipes, recipesContainingAllergens));
+            assertEquals(Sets.difference(allRecipes, recipesContainingAllergens), recipesWithoutAllergenIngredients);
         }
     }
 

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -107,7 +107,7 @@ public class QueryIT {
                 String patternString = "{ ($x, $y) isa inferred; };";
                 ReasonerQueryImpl query = ReasonerQueries.create(conjunction(patternString, tx), tx);
                 assertTrue(RuleUtils.subGraphIsCyclical(
-                        RuleUtils.getRules(tx).map(r -> new InferenceRule(r, tx)).collect(toSet()))
+                        tx.ruleCache().getRules().map(r -> new InferenceRule(r, tx)).collect(toSet()))
                 );
                 assertTrue(query.requiresReiteration());
             }
@@ -136,7 +136,7 @@ public class QueryIT {
                 String patternString = "{ $x isa baseEntity;};";
                 ReasonerQueryImpl query = ReasonerQueries.create(conjunction(patternString, tx), tx);
                 assertTrue(RuleUtils.subGraphIsCyclical(
-                        RuleUtils.getRules(tx).map(r -> new InferenceRule(r, tx)).collect(toSet()))
+                        tx.ruleCache().getRules().map(r -> new InferenceRule(r, tx)).collect(toSet()))
                 );
                 assertTrue(query.requiresReiteration());
             }

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -77,8 +77,6 @@ public class QueryIT {
         }
     }
 
-    //TODO go over stratification with type hierarchies
-    @Ignore
     @Test
     public void testQueryReiterationCondition_CyclicalRuleGraphWithTypeHierarchiesInBodies(){
         try (SessionImpl session = server.sessionWithNewKeyspace()) {
@@ -116,8 +114,6 @@ public class QueryIT {
         }
     }
 
-    //TODO go over stratification with type hierarchies
-    @Ignore
     @Test
     public void testQueryReiterationCondition_CyclicalRuleGraphWithTypeHierarchiesInHead(){
         try (SessionImpl session = server.sessionWithNewKeyspace()) {

--- a/test-integration/graql/reasoner/stubs/recipeTest.gql
+++ b/test-integration/graql/reasoner/stubs/recipeTest.gql
@@ -1,16 +1,23 @@
 define
 
 named-entity sub entity,
+    abstract,
     has name;
+
+ingredientBase sub named-entity,
+    abstract,
+    plays contained-ingredient,
+    plays required-ingredient;
+
+recipeBase sub named-entity,
+    abstract,
+    plays requiring-recipe;
 
 pantry sub entity,
     plays containing-pantry;
-recipe sub named-entity,
-    plays requiring-recipe;
-ingredient sub named-entity,
-    plays contained-ingredient,
-    plays required-ingredient;
-allergenic-ingredient sub ingredient;
+recipe sub recipeBase;
+ingredient sub ingredientBase;
+allergenic-ingredient sub ingredientBase;
 
 requires sub relationship,
     relates required-ingredient,
@@ -23,9 +30,9 @@ containes sub relationship,
 name sub attribute, datatype string;
 
 
-available-ingredient-occuring-in-recipe sub ingredient;
-available-ingredient sub ingredient;
-recipe-with-unavailable-ingredient sub recipe;
+available-ingredient-occuring-in-recipe sub ingredientBase;
+available-ingredient sub ingredientBase;
+recipe-with-unavailable-ingredient sub recipeBase;
 
 rule-1 sub rule,
     when {

--- a/test-integration/server/kb/BUILD
+++ b/test-integration/server/kb/BUILD
@@ -49,6 +49,7 @@ java_test(
     test_class = "grakn.core.server.kb.RuleTest",
     deps = [
         "//common",
+        "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//server",
         "//test-integration/rule:grakn-test-server",

--- a/test-integration/server/kb/RuleTest.java
+++ b/test-integration/server/kb/RuleTest.java
@@ -522,7 +522,7 @@ public class RuleTest {
             tx.commit();
         }
         try(TransactionOLTP tx = session.transaction(Transaction.Type.WRITE)) {
-            List<Rule> rules = RuleUtils.stratifyRules(RuleUtils.getRules(tx).map(rule -> new InferenceRule(rule, tx)).collect(Collectors.toSet()))
+            List<Rule> rules = RuleUtils.stratifyRules(tx.ruleCache().getRules().map(rule -> new InferenceRule(rule, tx)).collect(Collectors.toSet()))
                     .map(InferenceRule::getRule).collect(Collectors.toList());
             assertTrue(rules.equals(expected1) || rules.equals(expected2));
             expected1.forEach(Concept::delete);


### PR DESCRIPTION
# Why is this PR needed?
Continuation of #4848 for #4790.
# What does the PR do?
- simplifies safety condition for queries
- orders rule firing based on stratification
- simplifies rule cache
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
Rule validation at commit time.