### PR TITLE
Reinstate query rewrite

### DIFF
--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -34,7 +34,6 @@ import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.internal.executor.property.PropertyExecutor;
 import grakn.core.graql.internal.gremlin.GraqlTraversal;
 import grakn.core.graql.internal.gremlin.GreedyTraversalPlan;
-import grakn.core.graql.internal.reasoner.query.CompositeQuery;
 import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
 import grakn.core.graql.internal.reasoner.query.ResolvableQuery;
 import grakn.core.graql.query.AggregateQuery;
@@ -57,11 +56,6 @@ import grakn.core.graql.query.pattern.property.VarProperty;
 import grakn.core.graql.query.pattern.statement.Statement;
 import grakn.core.graql.query.pattern.statement.Variable;
 import grakn.core.server.session.TransactionOLTP;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -75,6 +69,10 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import static grakn.core.common.util.CommonUtil.toImmutableList;
 import static grakn.core.common.util.CommonUtil.toImmutableSet;
@@ -97,7 +95,7 @@ public class QueryExecutor {
     }
 
     private Stream<ConceptMap> resolveConjunction(Conjunction<Pattern> conj, TransactionOLTP tx){
-        ResolvableQuery query = ReasonerQueries.resolvable(conj, tx);
+        ResolvableQuery query = ReasonerQueries.resolvable(conj, tx).rewrite();
         query.checkValid();
 
         //TODO

--- a/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -186,7 +186,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
     @Override
     public Set<Atom> rewriteToAtoms(){
         return this.getRelationPlayers().stream()
-                .map(rp -> create(relationPattern(getVarName(), Sets.newHashSet(rp)), getPredicateVariable(), getTypeId(), null, this.getParentQuery()))
+                .map(rp -> create(relationPattern(getVarName().asUserDefined(), Sets.newHashSet(rp)), getPredicateVariable(), getTypeId(), null, this.getParentQuery()))
                 .collect(toSet());
     }
 
@@ -225,7 +225,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         return getRelationPlayers().stream()
                 .map(RelationProperty.RolePlayer::getRole)
                 .flatMap(CommonUtil::optionalToStream)
-                .map(statement -> statement.var())
+                .map(Statement::var)
                 .filter(Variable::isUserDefinedName)
                 .collect(Collectors.toSet());
     }

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -611,7 +611,7 @@ public class ReasoningIT {
 
                 List<ConceptMap> persistedRelations = tx.execute(Graql.<GetQuery>parse("match $r isa relation; get;"),false);
                 List<ConceptMap> inferredRelations = tx.execute(Graql.<GetQuery>parse("match $r isa relation; get;"));
-                assertEquals("New relations were created!", persistedRelations, inferredRelations);
+                assertCollectionsNonTriviallyEqual("New relations were created!", persistedRelations, inferredRelations);
 
                 Set<ConceptMap> variants = Stream.of(
                         Iterables.getOnlyElement(tx.execute(Graql.<GetQuery>parse("match $r (someRole: $x, anotherRole: $y, anotherRole: $z, inferredRole: $z); $y != $z;get;"), false)),
@@ -625,7 +625,12 @@ public class ReasoningIT {
                 assertCollectionsNonTriviallyEqual("Rules are not matched correctly!", variants, inferredRelations);
 
                 List<ConceptMap> derivedRPTriples = tx.execute(Graql.<GetQuery>parse("match (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation; get;"));
-                assertEquals("Rule body is not rewritten correctly!", 2, derivedRPTriples.size());
+                //NB: same answer is obtained from both rules
+                assertEquals("Rule body is not rewritten correctly!", 1, derivedRPTriples.size());
+
+                List<ConceptMap> derivedRelations = tx.execute(Graql.<GetQuery>parse("match $r (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation; get;"));
+                //three symmetric roles hence 3! results
+                assertEquals("Rule body is not rewritten correctly!", 6, derivedRelations.size());
             }
         }
     }

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -574,12 +574,29 @@ public class ReasoningIT {
                 List<ConceptMap> persistedRelations = tx.execute(Graql.<GetQuery>parse("match $r isa relation; get;"),false);
 
                 List<ConceptMap> answers = tx.execute(Graql.<GetQuery>parse("match (someRole: $x, anotherRole: $y, anotherRole: $z, inferredRole: $z); $y != $z;get;"));
-                assertTrue(!answers.isEmpty());
                 assertEquals(1, answers.size());
 
                 List<ConceptMap> answers2 = tx.execute(Graql.<GetQuery>parse("match (someRole: $x, yetAnotherRole: $y, andYetAnotherRole: $y, inferredRole: $z); get;"));
-                assertTrue(!answers2.isEmpty());
                 assertEquals(1, answers2.size());
+
+                List<ConceptMap> answers3 = tx.execute(Graql.<GetQuery>parse("match " +
+                        "(someRole: $x, inferredRole: $z); " +
+                        "not {(anotherRole: $z);};" +
+                        "get;"));
+
+                assertTrue(answers3.isEmpty());
+
+                List<ConceptMap> answers4 = tx.execute(Graql.<GetQuery>parse("match " +
+                        "$r (someRole: $x, inferredRole: $z); " +
+                        "not {$r (anotherRole: $z);};" +
+                        "get;"));
+                assertEquals(2, answers4.size());
+
+                List<ConceptMap> answers5 = tx.execute(Graql.<GetQuery>parse("match " +
+                        "$r (someRole: $x, inferredRole: $z); " +
+                        "not {$r (yetAnotherRole: $y, andYetAnotherRole: $y);};" +
+                        "get;"));
+                assertEquals(2, answers5.size());
 
                 assertEquals("New relations were created!", persistedRelations, tx.execute(Graql.<GetQuery>parse("match $r isa relation; get;"),false));
             }

--- a/test-integration/graql/reasoner/stubs/appendingRPs.gql
+++ b/test-integration/graql/reasoner/stubs/appendingRPs.gql
@@ -37,6 +37,23 @@ then {
     $r(inferredRole: $z) isa relation;
 };
 
+defineAppendAsAnotherRelation sub rule,
+when {
+    (someRole: $x, yetAnotherRole: $y, andYetAnotherRole: $y, inferredRole: $z) isa relation;
+},
+then {
+    (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation;
+};
+
+defineAppendAsAnotherRelationConj sub rule,
+when {
+    (someRole: $x, anotherRole: $y, anotherRole: $z, inferredRole: $z); $y != $z;
+    $y has resource 'value';
+},
+then {
+    (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation;
+};
+
 degenerateRole sub rule,
 when {
     $r(someRole: $x, anotherRole: $y) isa relation;
@@ -60,23 +77,6 @@ when {
 },
 then {
     $r (anotherRole: $y) isa relation;
-};
-
-defineAppendAsAnotherRelation sub rule,
-when {
-    (someRole: $x, yetAnotherRole: $y, andYetAnotherRole: $y, inferredRole: $z) isa relation;
-},
-then {
-    (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation;
-};
-
-defineAppendAsAnotherRelationConj sub rule,
-when {
-    (someRole: $x, anotherRole: $y, anotherRole: $z, inferredRole: $z); $y != $z;
-    $y has resource 'value';
-},
-then {
-    (inferredRole: $x, inferredRole: $y, inferredRole: $z) isa derivedRelation;
 };
 
 insert


### PR DESCRIPTION
# Why is this PR needed?
The initial query rewrite was missing after the addition of pattern negation.
# What does the PR do?
Brings back the query rewrite and an accompanying test.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
No.