### PR TITLE
make GraknTestServer takes server config and cassandra config in the constructor

### DIFF
--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -59,8 +59,8 @@ import java.util.UUID;
  * It allows all the integration tests to run concurrently on the same machine.
  */
 public class GraknTestServer extends ExternalResource {
-    private static final Path SERVER_CONFIG =  Paths.get("server/conf/grakn.properties");
-    private static final Path CASSANDRA_CONFIG = Paths.get("test-integration/resources/cassandra-embedded.yaml");
+    private static final Path SERVER_CONFIG_PATH =  Paths.get("server/conf/grakn.properties");
+    private static final Path CASSANDRA_CONFIG_PATH = Paths.get("test-integration/resources/cassandra-embedded.yaml");
 
     private final Path serverConfigPath;
     private final Path cassandraConfigPath;
@@ -77,7 +77,7 @@ public class GraknTestServer extends ExternalResource {
     private SessionStore sessionStore;
 
     public GraknTestServer() {
-        this(SERVER_CONFIG, CASSANDRA_CONFIG);
+        this(SERVER_CONFIG_PATH, CASSANDRA_CONFIG_PATH);
     }
 
     public GraknTestServer(Path serverConfigPath, Path cassandraConfigPath) {

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -59,8 +59,10 @@ import java.util.UUID;
  * It allows all the integration tests to run concurrently on the same machine.
  */
 public class GraknTestServer extends ExternalResource {
+    private static final Path SERVER_CONFIG =  Paths.get("server/conf/grakn.properties");
+    private static final Path CASSANDRA_CONFIG = Paths.get("test-integration/resources/cassandra-embedded.yaml");
 
-    private final String serverConfigPath;
+    private final Path serverConfigPath;
     private final Path cassandraConfigPath;
     private Config serverConfig;
     private Path dataDirTmp;
@@ -75,13 +77,13 @@ public class GraknTestServer extends ExternalResource {
     private SessionStore sessionStore;
 
     public GraknTestServer() {
-        this("server/conf/grakn.properties", "test-integration/resources/cassandra-embedded.yaml");
+        this(SERVER_CONFIG, CASSANDRA_CONFIG);
     }
 
-    public GraknTestServer(String serverConfigPath, String cassandraConfigPath) {
+    public GraknTestServer(Path serverConfigPath, Path cassandraConfigPath) {
         System.setProperty("java.security.manager", "nottodaypotato");
         this.serverConfigPath = serverConfigPath;
-        this.cassandraConfigPath = Paths.get(cassandraConfigPath);
+        this.cassandraConfigPath = cassandraConfigPath;
     }
 
     @Override
@@ -170,7 +172,7 @@ public class GraknTestServer extends ExternalResource {
 
     //Server helpers
     private Config createTestConfig(String dataDir) throws FileNotFoundException {
-        InputStream testConfig = new FileInputStream(serverConfigPath);
+        InputStream testConfig = new FileInputStream(serverConfigPath.toFile());
 
         Config config = Config.read(testConfig);
         config.setConfigProperty(ConfigKey.DATA_DIR, dataDir);

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -60,8 +60,8 @@ import java.util.UUID;
  */
 public class GraknTestServer extends ExternalResource {
 
-    private final static String SERVER_CONFIG_PATH = "server/conf/grakn.properties";
-    private final static Path CASSANDRA_CONFIG_PATH = Paths.get("test-integration/resources/cassandra-embedded.yaml");
+    private final String serverConfigPath;
+    private final Path cassandraConfigPath;
     private Config serverConfig;
     private Path dataDirTmp;
     private Server graknServer;
@@ -75,7 +75,13 @@ public class GraknTestServer extends ExternalResource {
     private SessionStore sessionStore;
 
     public GraknTestServer() {
+        this("server/conf/grakn.properties", "test-integration/resources/cassandra-embedded.yaml");
+    }
+
+    public GraknTestServer(String serverConfigPath, String cassandraConfigPath) {
         System.setProperty("java.security.manager", "nottodaypotato");
+        this.serverConfigPath = serverConfigPath;
+        this.cassandraConfigPath = Paths.get(cassandraConfigPath);
     }
 
     @Override
@@ -140,7 +146,7 @@ public class GraknTestServer extends ExternalResource {
     }
 
     private File buildCassandraConfigWithRandomPorts() throws IOException {
-        byte[] bytes = Files.readAllBytes(CASSANDRA_CONFIG_PATH);
+        byte[] bytes = Files.readAllBytes(cassandraConfigPath);
         String configString = new String(bytes, StandardCharsets.UTF_8);
 
         configString = configString + "\nstorage_port: " + storagePort;
@@ -164,7 +170,7 @@ public class GraknTestServer extends ExternalResource {
 
     //Server helpers
     private Config createTestConfig(String dataDir) throws FileNotFoundException {
-        InputStream testConfig = new FileInputStream(SERVER_CONFIG_PATH);
+        InputStream testConfig = new FileInputStream(serverConfigPath);
 
         Config config = Config.read(testConfig);
         config.setConfigProperty(ConfigKey.DATA_DIR, dataDir);


### PR DESCRIPTION
# Why is this PR needed?
Fixes https://github.com/graknlabs/grakn/issues/4874

# What does the PR do?

Adds a new constructor which accepts paths to config files:
```
public GraknTestServer(String serverConfigPath, String cassandraConfigPath) {
 ...
}
```

# Does it break backwards compatibility?
No

# List of future improvements not on this PR
https://github.com/graknlabs/grakn/issues/4876