### PR TITLE
Graql Filters: Sort, Offset, and Limit

### DIFF
--- a/console/test/GraknConsoleIT.java
+++ b/console/test/GraknConsoleIT.java
@@ -320,10 +320,10 @@ public class GraknConsoleIT {
         assertThat(result[result.length - 1], endsWith("> "));
     }
 
-    @Test @Ignore // TODO: un-ignore once we re-enable query limits
+    @Test
     public void when_writingQueryWithLimitOne_expect_oneLineResponse() throws Exception {
         assertConsoleSessionMatches(
-                "match $x sub thing; limit 1; get;",
+                "match $x sub thing; get; limit 1;",
                 anything() // Only one result
         );
     }

--- a/graql/grammar/Graql.g4
+++ b/graql/grammar/Graql.g4
@@ -38,10 +38,10 @@ query_define        :   DEFINE      statement_type+ ;
 query_undefine      :   UNDEFINE    statement_type+ ;
 
 query_insert        :   MATCH       pattern+    INSERT  statement_instance+
-                    |                           INSERT  statement_instance+ ;
+                    |                           INSERT  statement_instance+  ;
 
-query_delete        :   MATCH       pattern+    DELETE  variables   modifier* ; // GET QUERY followed by aggregate fn
-query_get           :   MATCH       pattern+    GET     variables   modifier* ; // GET QUERY followed by group fn, and
+query_delete        :   MATCH       pattern+    DELETE  variables   filters? ;  // GET QUERY followed by aggregate fn
+query_get           :   MATCH       pattern+    GET     variables   filters? ;  // GET QUERY followed by group fn, and
                                                                                 // optionally, an aggregate fn
 
 query_compute       :   COMPUTE     compute_method      compute_conditions? ';';// TODO: embbed ';' into subrule
@@ -56,11 +56,11 @@ query_get_group_agg :   query_get   function_group      function_aggregate ;
 
 variables           :   ( VAR_ ( ',' VAR_ )* )? ';'     ;
 
-modifier            :   offset  |   limit   |   order   ;
+filters             :   sort?       offset?     limit?  ;
 
-offset              :   OFFSET      INTEGER_    ';'     ;
-limit               :   LIMIT       INTEGER_    ';'     ;
-order               :   ORDER     ( ASC|DESC )? ';'     ;
+sort                :   SORT        VAR_        ORDER_? ';' ;
+offset              :   OFFSET      INTEGER_            ';' ;
+limit               :   LIMIT       INTEGER_            ';' ;
 
 // GET AGGREGATE QUERY =========================================================
 //
@@ -229,8 +229,8 @@ AGGREGATE       : 'aggregate'   ;   COMPUTE         : 'compute'     ;
 // DELETE AND GET QUERY MODIFIER KEYWORDS
 
 OFFSET          : 'offset'      ;   LIMIT           : 'limit'       ;
+SORT            : 'sort'        ;   ORDER_           : ASC | DESC    ;
 ASC             : 'asc'         ;   DESC            : 'desc'        ;
-ORDER           : 'order'       ;
 
 // STATEMENT PROPERTY KEYWORDS
 

--- a/graql/java/util/Token.java
+++ b/graql/java/util/Token.java
@@ -24,6 +24,7 @@ public class Token {
      * Graql commands to determine the type of query
      */
     public enum Command {
+        COMPUTE("compute"),
         MATCH("match"),
         DEFINE("define"),
         UNDEFINE("undefine"),
@@ -32,7 +33,8 @@ public class Token {
         GET("get"),
         AGGREGATE("aggregate"),
         GROUP("group"),
-        COMPUTE("compute");
+        OFFSET("offset"),
+        LIMIT("limit");
 
         private final String command;
 
@@ -48,6 +50,32 @@ public class Token {
         public static Command of(String value) {
             for (Command c : Command.values()) {
                 if (c.command.equals(value)) {
+                    return c;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum Filter {
+        SORT("sort"),
+        OFFSET("offset"),
+        LIMIT("limit");
+
+        private final String filter;
+
+        Filter(String filter) {
+            this.filter = filter;
+        }
+
+        @Override
+        public String toString() {
+            return this.filter;
+        }
+
+        public static Filter of(String value) {
+            for (Filter c : Filter.values()) {
+                if (c.filter.equals(value)) {
                     return c;
                 }
             }
@@ -210,6 +238,31 @@ public class Token {
         public static DataType of(String value) {
             for (DataType c : values()) {
                 if (c.type.equals(value)) {
+                    return c;
+                }
+            }
+            return null;
+        }
+    }
+
+    public enum Order {
+        ASC("asc"),
+        DESC("desc");
+
+        private final String order;
+
+        Order(String order) {
+            this.order = order;
+        }
+
+        @Override
+        public String toString() {
+            return this.order;
+        }
+
+        public static Order of(String value) {
+            for (Order c : values()) {
+                if (c.order.equals(value)) {
                     return c;
                 }
             }

--- a/graql/java/util/Triple.java
+++ b/graql/java/util/Triple.java
@@ -1,0 +1,44 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package graql.lang.util;
+
+public class Triple<A, B, C> {
+
+    private A first;
+    private B second;
+    private C third;
+
+    public Triple(A first, B second, C third) {
+        this.first = first;
+        this.second = second;
+        this.third = third;
+    }
+
+    public A first() {
+        return first;
+    }
+
+    public B second() {
+        return second;
+    }
+
+    public C third() {
+        return third;
+    }
+}

--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -252,7 +252,7 @@ public class QueryExecutor {
         return new ConceptSet(conceptsToDelete.stream().map(Concept::id).collect(toSet()));
     }
 
-    @SuppressWarnings("unchecked") // All attribute value are comparable
+    @SuppressWarnings("unchecked") // All attribute values are comparable data types
     public Stream<ConceptMap> get(GraqlGet query) {
         Stream<ConceptMap> answers = match(query.match()).map(result -> result.project(query.vars())).distinct();
 

--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -267,7 +267,7 @@ public class QueryExecutor {
             answers = answers.skip(query.offset().get());
         }
         if (query.limit().isPresent()) {
-            answers = answers.limit(query.offset().get());
+            answers = answers.limit(query.limit().get());
         }
 
         return answers;

--- a/server/src/graql/query/query/GraqlDelete.java
+++ b/server/src/graql/query/query/GraqlDelete.java
@@ -18,12 +18,14 @@
 
 package grakn.core.graql.query.query;
 
+import grakn.core.graql.query.query.builder.Filterable;
 import grakn.core.graql.query.statement.Variable;
 import graql.lang.exception.GraqlException;
 import graql.lang.util.Token;
 
 import javax.annotation.CheckReturnValue;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.stream.Collectors.joining;
@@ -36,16 +38,23 @@ import static java.util.stream.Collectors.joining;
  * flags are provided, e.g. {@code var("x").has("name")} then only those
  * properties are deleted.
  */
-public class GraqlDelete extends GraqlQuery {
+public class GraqlDelete extends GraqlQuery implements Filterable {
 
     private final MatchClause match;
     private final LinkedHashSet<Variable> vars;
+    private final Filterable.Sorting order;
+    private final long offset;
+    private final long limit;
 
     public GraqlDelete(MatchClause match) {
         this(match, new LinkedHashSet<>());
     }
 
     public GraqlDelete(MatchClause match, LinkedHashSet<Variable> vars) {
+        this(match, vars, null, -1, -1);
+    }
+
+    public GraqlDelete(MatchClause match, LinkedHashSet<Variable> vars, Filterable.Sorting order, long offset, long limit) {
         if (match == null) {
             throw new NullPointerException("Null match");
         }
@@ -59,6 +68,10 @@ public class GraqlDelete extends GraqlQuery {
             }
         }
         this.vars = vars;
+
+        this.order = order;
+        this.offset = offset;
+        this.limit = limit;
     }
 
     @CheckReturnValue
@@ -72,33 +85,48 @@ public class GraqlDelete extends GraqlQuery {
         return vars;
     }
 
+    @Override
+    public Optional<Sorting> sort() {
+        return Optional.ofNullable(order);
+    }
+
+    @Override
+    public Optional<Long> offset(){
+        return this.offset < 0 ? Optional.empty() : Optional.of(this.offset);
+    }
+
+    @Override
+    public Optional<Long> limit() {
+        return limit < 0 ? Optional.empty() : Optional.of(limit);
+    }
+
     @Override @SuppressWarnings("Duplicates")
     public String toString() {
-        StringBuilder query = new StringBuilder();
-
-        query.append(match());
+        StringBuilder query = new StringBuilder(match().toString());
         if (match().getPatterns().getPatterns().size()>1) query.append(Token.Char.NEW_LINE);
         else query.append(Token.Char.SPACE);
 
-        // It is important that we use vars (the property) and not vars() (the method)
-        // vars (the property) stores the variables as the user defined
-        // vars() (the method) returns match.vars() if vars (the property) is empty
-        // we want to print vars (the property) as the user defined
         query.append(Token.Command.DELETE);
-        if (!vars.isEmpty()) {
+        if (!vars.isEmpty()) { // Which is not equal to !vars().isEmpty()
             query.append(Token.Char.SPACE).append(
                     vars.stream().map(Variable::toString)
-                            .collect(joining(Token.Char.COMMA_SPACE.toString())).trim()
+                            .collect(joining(Token.Char.COMMA_SPACE.toString()))
             );
         }
         query.append(Token.Char.SEMICOLON);
+
+        if (sort().isPresent() || offset().isPresent() || limit().isPresent()) {
+            query.append(Token.Char.SPACE).append(printFilters());
+        }
 
         return query.toString();
     }
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null) return false;
+        if (!getClass().isAssignableFrom(o.getClass()) &&
+                !o.getClass().isAssignableFrom(getClass())) return false;
 
         GraqlDelete that = (GraqlDelete) o;
 
@@ -106,8 +134,11 @@ public class GraqlDelete extends GraqlQuery {
         // vars (the property) stores the variables as the user defined
         // vars() (the method) returns match.vars() if vars (the property) is empty
         // we want to compare vars() (the method) which determines the final value
-        return this.match().equals(that.match()) &&
-                this.vars().equals(that.vars());
+        return (this.match().equals(that.match()) &&
+                this.vars().equals(that.vars()) &&
+                this.sort().equals(that.sort()) &&
+                this.offset().equals(that.offset()) &&
+                this.limit().equals(that.limit()));
     }
 
     @Override
@@ -119,6 +150,71 @@ public class GraqlDelete extends GraqlQuery {
         h ^= this.vars().hashCode();
         h *= 1000003;
         h ^= this.match().hashCode();
+        h *= 1000003;
+        h ^= this.sort().hashCode();
+        h *= 1000003;
+        h ^= this.offset().hashCode();
+        h *= 1000003;
+        h ^= this.limit().hashCode();
         return h;
+    }
+
+    public static class Unfiltered extends GraqlDelete
+            implements Filterable.Unfiltered<GraqlDelete.Sorted, GraqlDelete.Offsetted, GraqlDelete.Limited> {
+
+        Unfiltered(MatchClause match, LinkedHashSet<Variable> vars) {
+            super(match, vars);
+        }
+
+        @Override
+        public GraqlDelete.Sorted sort(Sorting sorting) {
+            return new GraqlDelete.Sorted(this, sorting);
+        }
+
+        @Override
+        public GraqlDelete.Offsetted offset(long offset) {
+            return new GraqlDelete.Offsetted(this, offset);
+        }
+
+        @Override
+        public GraqlDelete.Limited limit(long limit) {
+            return new GraqlDelete.Limited(this, limit);
+        }
+    }
+
+    public class Sorted extends GraqlDelete implements Filterable.Sorted<GraqlDelete.Offsetted, GraqlDelete.Limited> {
+
+        Sorted(GraqlDelete graqlDelete, Filterable.Sorting order) {
+            super(graqlDelete.match, graqlDelete.vars, order, graqlDelete.offset, graqlDelete.limit);
+        }
+
+        @Override
+        public GraqlDelete.Offsetted offset(long offset) {
+            return new GraqlDelete.Offsetted(this, offset);
+        }
+
+        @Override
+        public GraqlDelete.Limited limit(long limit) {
+            return new GraqlDelete.Limited(this, limit);
+        }
+    }
+
+    public class Offsetted extends GraqlDelete implements Filterable.Offsetted<GraqlDelete.Limited> {
+
+        Offsetted(GraqlDelete graqlDelete, long offset) {
+            super(graqlDelete.match, graqlDelete.vars, graqlDelete.order, offset, graqlDelete.limit);
+        }
+
+        @Override
+        public GraqlDelete.Limited limit(long limit) {
+            return new GraqlDelete.Limited(this, limit);
+        }
+    }
+
+    public class Limited extends GraqlDelete implements Filterable.Limited {
+
+        Limited(GraqlDelete graqlDelete, long limit) {
+            super(graqlDelete.match, graqlDelete.vars, graqlDelete.order, graqlDelete.offset, limit);
+        }
     }
 }

--- a/server/src/graql/query/query/GraqlDelete.java
+++ b/server/src/graql/query/query/GraqlDelete.java
@@ -125,8 +125,9 @@ public class GraqlDelete extends GraqlQuery implements Filterable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass()) &&
-                !o.getClass().isAssignableFrom(getClass())) return false;
+        if (!getClass().isAssignableFrom(o.getClass()) && !o.getClass().isAssignableFrom(getClass())) {
+            return false;
+        }
 
         GraqlDelete that = (GraqlDelete) o;
 

--- a/server/src/graql/query/query/GraqlGet.java
+++ b/server/src/graql/query/query/GraqlGet.java
@@ -19,12 +19,13 @@
 package grakn.core.graql.query.query;
 
 import grakn.core.graql.query.query.builder.AggregateBuilder;
+import grakn.core.graql.query.query.builder.Filterable;
 import grakn.core.graql.query.statement.Variable;
 import graql.lang.exception.GraqlException;
 import graql.lang.util.Token;
 
-import javax.annotation.CheckReturnValue;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.stream.Collectors.joining;
@@ -34,16 +35,24 @@ import static java.util.stream.Collectors.joining;
  * pattern-matching query. The patterns are described in a declarative fashion, then the query will traverse
  * the knowledge base in an efficient fashion to find any matching answers.
  */
-public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Aggregate> {
+public class GraqlGet extends GraqlQuery implements Filterable, AggregateBuilder<GraqlGet.Aggregate> {
 
     private final LinkedHashSet<Variable> vars;
     private final MatchClause match;
+    private final Sorting sorting;
+    private final long offset;
+    private final long limit;
+
 
     public GraqlGet(MatchClause match) {
         this(match, new LinkedHashSet<>());
     }
 
     public GraqlGet(MatchClause match, LinkedHashSet<Variable> vars) {
+        this(match, vars, null, -1, -1);
+    }
+
+    public GraqlGet(MatchClause match, LinkedHashSet<Variable> vars, Sorting sorting, long offset, long limit) {
         if (vars == null) {
             throw new NullPointerException("Null vars");
         }
@@ -57,6 +66,10 @@ public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Ag
             }
         }
         this.match = match;
+
+        this.sorting = sorting;
+        this.offset = offset;
+        this.limit = limit;
     }
 
     @Override
@@ -72,31 +85,39 @@ public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Ag
         return new Group(this, var);
     }
 
-    @CheckReturnValue // TODO: Return LinkedHashSet
+    // TODO: Return LinkedHashSet
     public Set<Variable> vars() {
         if (vars.isEmpty()) return match.getPatterns().variables();
         else return vars;
     }
 
-    @CheckReturnValue
     public MatchClause match() {
         return match;
     }
 
+    @Override
+    public Optional<Sorting> sort() {
+        return Optional.ofNullable(sorting);
+    }
+
+    @Override
+    public Optional<Long> offset() {
+        return this.offset < 0 ? Optional.empty() : Optional.of(this.offset);
+    }
+
+    @Override
+    public Optional<Long> limit() {
+        return limit < 0 ? Optional.empty() : Optional.of(limit);
+    }
+
     @Override @SuppressWarnings("Duplicates")
     public String toString() {
-        StringBuilder query = new StringBuilder();
-
-        query.append(match());
+        StringBuilder query = new StringBuilder(match().toString());
         if (match().getPatterns().getPatterns().size()>1) query.append(Token.Char.NEW_LINE);
         else query.append(Token.Char.SPACE);
 
-        // It is important that we use vars (the property) and not vars() (the method)
-        // vars (the property) stores the variables as the user defined
-        // vars() (the method) returns match.vars() if vars (the property) is empty
-        // we want to print vars (the property) as the user defined
         query.append(Token.Command.GET);
-        if (!vars.isEmpty()) {
+        if (!vars.isEmpty()) { // Which is not equal to !vars().isEmpty()
             query.append(Token.Char.SPACE).append(
                     vars.stream().map(Variable::toString)
                             .collect(joining(Token.Char.COMMA_SPACE.toString()))
@@ -104,13 +125,19 @@ public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Ag
         }
         query.append(Token.Char.SEMICOLON);
 
+        if (sort().isPresent() || offset().isPresent() || limit().isPresent()) {
+            query.append(Token.Char.SPACE).append(printFilters());
+        }
+
         return query.toString();
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (o == null) return false;
+        if (!getClass().isAssignableFrom(o.getClass()) &&
+                !o.getClass().isAssignableFrom(getClass())) return false;
 
         GraqlGet that = (GraqlGet) o;
 
@@ -119,7 +146,10 @@ public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Ag
         // vars() (the method) returns match.vars() if vars (the property) is empty
         // we want to compare vars() (the method) which determines the final value
         return (this.vars().equals(that.vars()) &&
-                this.match().equals(that.match()));
+                this.match().equals(that.match()) &&
+                this.sort().equals(that.sort()) &&
+                this.offset().equals(that.offset()) &&
+                this.limit().equals(that.limit()));
     }
 
     @Override
@@ -131,7 +161,76 @@ public class GraqlGet extends GraqlQuery implements AggregateBuilder<GraqlGet.Ag
         h ^= this.vars().hashCode();
         h *= 1000003;
         h ^= this.match().hashCode();
+        h *= 1000003;
+        h ^= this.sort().hashCode();
+        h *= 1000003;
+        h ^= this.offset().hashCode();
+        h *= 1000003;
+        h ^= this.limit().hashCode();
         return h;
+    }
+
+    public static class Unfiltered extends GraqlGet
+            implements Filterable.Unfiltered<GraqlGet.Sorted, GraqlGet.Offsetted, GraqlGet.Limited> {
+
+        Unfiltered(MatchClause match) {
+            super(match);
+        }
+
+        Unfiltered(MatchClause match, LinkedHashSet<Variable> vars) {
+            super(match, vars);
+        }
+
+        @Override
+        public GraqlGet.Sorted sort(Sorting sorting) {
+            return new GraqlGet.Sorted(this, sorting);
+        }
+
+        @Override
+        public GraqlGet.Offsetted offset(long offset) {
+            return new GraqlGet.Offsetted(this, offset);
+        }
+
+        @Override
+        public GraqlGet.Limited limit(long limit) {
+            return new GraqlGet.Limited(this, limit);
+        }
+    }
+
+    public class Sorted extends GraqlGet implements Filterable.Sorted<GraqlGet.Offsetted, GraqlGet.Limited> {
+
+        Sorted(GraqlGet graqlGet, Sorting order) {
+            super(graqlGet.match, graqlGet.vars, order, graqlGet.offset, graqlGet.limit);
+        }
+
+        @Override
+        public GraqlGet.Offsetted offset(long offset) {
+            return new GraqlGet.Offsetted(this, offset);
+        }
+
+        @Override
+        public GraqlGet.Limited limit(long limit) {
+            return new GraqlGet.Limited(this, limit);
+        }
+    }
+
+    public class Offsetted extends GraqlGet implements Filterable.Offsetted<GraqlGet.Limited> {
+
+        Offsetted(GraqlGet graqlGet, long offset) {
+            super(graqlGet.match, graqlGet.vars, graqlGet.sorting, offset, graqlGet.limit);
+        }
+
+        @Override
+        public GraqlGet.Limited limit(long limit) {
+            return new GraqlGet.Limited(this, limit);
+        }
+    }
+
+    public class Limited extends GraqlGet implements Filterable.Limited {
+
+        Limited(GraqlGet graqlGet, long limit) {
+            super(graqlGet.match, graqlGet.vars, graqlGet.sorting, graqlGet.offset, limit);
+        }
     }
 
     public static class Aggregate extends GraqlQuery {

--- a/server/src/graql/query/query/GraqlGet.java
+++ b/server/src/graql/query/query/GraqlGet.java
@@ -136,8 +136,9 @@ public class GraqlGet extends GraqlQuery implements Filterable, AggregateBuilder
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null) return false;
-        if (!getClass().isAssignableFrom(o.getClass()) &&
-                !o.getClass().isAssignableFrom(getClass())) return false;
+        if (!getClass().isAssignableFrom(o.getClass()) && !o.getClass().isAssignableFrom(getClass())) {
+            return false;
+        }
 
         GraqlGet that = (GraqlGet) o;
 

--- a/server/src/graql/query/query/GraqlGet.java
+++ b/server/src/graql/query/query/GraqlGet.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.query.query;
 
-import grakn.core.graql.query.query.builder.AggregateBuilder;
+import grakn.core.graql.query.query.builder.Aggregatable;
 import grakn.core.graql.query.query.builder.Filterable;
 import grakn.core.graql.query.statement.Variable;
 import graql.lang.exception.GraqlException;
@@ -35,7 +35,7 @@ import static java.util.stream.Collectors.joining;
  * pattern-matching query. The patterns are described in a declarative fashion, then the query will traverse
  * the knowledge base in an efficient fashion to find any matching answers.
  */
-public class GraqlGet extends GraqlQuery implements Filterable, AggregateBuilder<GraqlGet.Aggregate> {
+public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<GraqlGet.Aggregate> {
 
     private final LinkedHashSet<Variable> vars;
     private final MatchClause match;
@@ -314,7 +314,7 @@ public class GraqlGet extends GraqlQuery implements Filterable, AggregateBuilder
 
     }
 
-    public static class Group extends GraqlQuery implements AggregateBuilder<GraqlGet.Group.Aggregate> {
+    public static class Group extends GraqlQuery implements Aggregatable<Group.Aggregate> {
 
         private final GraqlGet query;
         private final Variable var;

--- a/server/src/graql/query/query/GraqlGet.java
+++ b/server/src/graql/query/query/GraqlGet.java
@@ -102,7 +102,7 @@ public class GraqlGet extends GraqlQuery implements Filterable, AggregateBuilder
 
     @Override
     public Optional<Long> offset() {
-        return this.offset < 0 ? Optional.empty() : Optional.of(this.offset);
+        return offset < 0 ? Optional.empty() : Optional.of(offset);
     }
 
     @Override

--- a/server/src/graql/query/query/MatchClause.java
+++ b/server/src/graql/query/query/MatchClause.java
@@ -43,6 +43,8 @@ import java.util.stream.Stream;
  */
 public class MatchClause {
 
+    // TODO: Fix this to be Conjunction<T extends Pattern>
+    //       You can verify that this is a bug by removing Collections.unmodfiableSet() wrapper
     private final Conjunction<Pattern> pattern;
 
     public MatchClause(Conjunction<Pattern> pattern) {
@@ -67,8 +69,8 @@ public class MatchClause {
      * Construct a get query with all all variables mentioned in the query
      */
     @CheckReturnValue
-    public GraqlGet get() {
-        return new GraqlGet(this);
+    public GraqlGet.Unfiltered get() {
+        return new GraqlGet.Unfiltered(this);
     }
 
     /**
@@ -76,7 +78,7 @@ public class MatchClause {
      * @return a Get Query that selects the given variables
      */
     @CheckReturnValue
-    public GraqlGet get(String var, String... vars) {
+    public GraqlGet.Unfiltered get(String var, String... vars) {
         LinkedHashSet<Variable> varSet = Stream
                 .concat(Stream.of(var), Stream.of(vars))
                 .map(Variable::new)
@@ -89,7 +91,7 @@ public class MatchClause {
      * @return a Get Query that selects the given variables
      */
     @CheckReturnValue
-    public GraqlGet get(Variable var, Variable... vars) {
+    public GraqlGet.Unfiltered get(Variable var, Variable... vars) {
         LinkedHashSet<Variable> varSet = new LinkedHashSet<>();
         varSet.add(var);
         varSet.addAll(Arrays.asList(vars));
@@ -101,7 +103,7 @@ public class MatchClause {
      * @return a Get Query that selects the given variables
      */
     @CheckReturnValue
-    public GraqlGet get(List<Variable> vars) {
+    public GraqlGet.Unfiltered get(List<Variable> vars) {
         return get(new LinkedHashSet<>(vars));
     }
 
@@ -110,8 +112,8 @@ public class MatchClause {
      * @return a Get Query that selects the given variables
      */
     @CheckReturnValue
-    public GraqlGet get(LinkedHashSet<Variable> vars) {
-        return new GraqlGet(this, vars);
+    public GraqlGet.Unfiltered get(LinkedHashSet<Variable> vars) {
+        return new GraqlGet.Unfiltered(this, vars);
     }
 
     /**
@@ -137,8 +139,8 @@ public class MatchClause {
      * Construct a delete query with all all variables mentioned in the query
      */
     @CheckReturnValue
-    public GraqlDelete delete() {
-        return new GraqlDelete(this);
+    public GraqlDelete.Unfiltered delete() {
+        return delete(Collections.emptyList());
     }
 
     /**
@@ -146,7 +148,7 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete delete(String var, String... vars) {
+    public final GraqlDelete.Unfiltered delete(String var, String... vars) {
         LinkedHashSet<Variable> varSet = Stream
                 .concat(Stream.of(var), Stream.of(vars))
                 .map(Variable::new)
@@ -159,7 +161,7 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete delete(Variable var, Variable... vars) {
+    public final GraqlDelete.Unfiltered delete(Variable var, Variable... vars) {
         LinkedHashSet<Variable> varSet = new LinkedHashSet<>();
         varSet.add(var);
         varSet.addAll(Arrays.asList(vars));
@@ -171,8 +173,8 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete delete(List<Variable> vars) {
-        return new GraqlDelete(this, new LinkedHashSet<>(vars));
+    public final GraqlDelete.Unfiltered delete(List<Variable> vars) {
+        return delete(new LinkedHashSet<>(vars));
     }
 
     /**
@@ -180,8 +182,8 @@ public class MatchClause {
      * @return a delete query that will delete the given variables for each result of this match clause
      */
     @CheckReturnValue
-    public final GraqlDelete delete(LinkedHashSet<Variable> vars) {
-        return new GraqlDelete(this, vars);
+    public final GraqlDelete.Unfiltered delete(LinkedHashSet<Variable> vars) {
+        return new GraqlDelete.Unfiltered(this, vars);
     }
 
     @Override

--- a/server/src/graql/query/query/builder/Aggregatable.java
+++ b/server/src/graql/query/query/builder/Aggregatable.java
@@ -22,7 +22,7 @@ import grakn.core.graql.query.query.GraqlQuery;
 import grakn.core.graql.query.statement.Variable;
 import graql.lang.util.Token;
 
-public interface AggregateBuilder<T extends GraqlQuery> {
+public interface Aggregatable<T extends GraqlQuery> {
 
     default T count() {
         return aggregate(Token.Statistics.Method.COUNT, null);

--- a/server/src/graql/query/query/builder/Filterable.java
+++ b/server/src/graql/query/query/builder/Filterable.java
@@ -1,0 +1,162 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package grakn.core.graql.query.query.builder;
+
+import grakn.core.graql.query.statement.Statement;
+import grakn.core.graql.query.statement.Variable;
+import graql.lang.util.Token;
+
+import java.util.Optional;
+
+public interface Filterable {
+
+    Optional<Sorting> sort();
+
+    Optional<Long> offset();
+
+    Optional<Long> limit();
+
+    default String printFilters() {
+        StringBuilder filters = new StringBuilder();
+
+        sort().ifPresent(sort -> filters.append(Token.Filter.SORT).append(Token.Char.SPACE)
+                .append(sort).append(Token.Char.SEMICOLON).append(Token.Char.SPACE));
+
+        offset().ifPresent(offset -> filters.append(Token.Filter.OFFSET).append(Token.Char.SPACE)
+                .append(offset).append(Token.Char.SEMICOLON).append(Token.Char.SPACE));
+
+        limit().ifPresent(limit -> filters.append(Token.Filter.LIMIT).append(Token.Char.SPACE)
+                .append(limit).append(Token.Char.SEMICOLON).append(Token.Char.SPACE));
+
+        return filters.toString().trim();
+    }
+
+    interface Unfiltered<S extends Sorted, O extends Offsetted, L extends Limited> extends Filterable {
+
+        default S sort(String var) {
+            return sort(new Variable(var));
+        }
+
+        default S sort(String var, String order) {
+            Token.Order o = Token.Order.of(order);
+            if (o == null) throw new IllegalArgumentException(
+                    "Invalid sorting order. Valid options: '" + Token.Order.ASC +"' or '" + Token.Order.DESC
+            );
+            return sort(new Variable(var), o);
+        }
+
+        default S sort(String var, Token.Order order) {
+            return sort(new Variable(var), order);
+        }
+
+        default S sort(Variable var) {
+            return sort(new Sorting(var));
+        }
+
+        default S sort(Variable var, Token.Order order) {
+            return sort(new Sorting(var, order));
+        }
+
+        default S sort(Statement var) {
+            return sort(new Sorting(var.var()));
+        }
+
+        default S sort(Statement var, Token.Order order) {
+            return sort(new Sorting(var.var(), order));
+        }
+
+        S sort(Sorting sorting);
+
+        O offset(long offset);
+
+        L limit(long limit);
+    }
+
+    interface Sorted<O extends Offsetted, L extends Limited> extends Filterable {
+
+        O offset(long offset);
+
+        L limit(long limit);
+    }
+
+    interface Offsetted<L extends Limited> extends Filterable {
+
+        L limit(long limit);
+    }
+
+    interface Limited extends Filterable {
+
+    }
+
+    class Sorting {
+
+        private Variable var;
+        private Token.Order order;
+
+        public Sorting(Variable var) {
+            this(var, null);
+        }
+        public Sorting(Variable var, Token.Order order) {
+            this.var = var;
+            this.order = order;
+        }
+
+        public Variable var() {
+            return var;
+        }
+
+        public Token.Order order() {
+            return order == null ? Token.Order.ASC : order;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sort = new StringBuilder();
+
+            sort.append(var);
+            if (order != null) {
+                sort.append(Token.Char.SPACE).append(order);
+            }
+
+            return sort.toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+
+            Sorting that = (Sorting) o;
+
+            return (this.var().equals(that.var()) &&
+                    this.order().equals(that.order()));
+        }
+
+        @Override
+        public int hashCode() {
+            int h = 1;
+            h *= 1000003;
+            h ^= this.var().hashCode();
+            h *= 1000003;
+            h ^= this.order().hashCode();
+            return h;
+        }
+    }
+}

--- a/server/test/graql/query/parser/ParserTest.java
+++ b/server/test/graql/query/parser/ParserTest.java
@@ -316,30 +316,55 @@ public class ParserTest {
         assertQueryEquals(expected, parsed, query);
     }
 
-    @Test @Ignore
-    public void testModifierQuery() {
-        String query = "match $y isa movie, has title $n; order by $n; limit 4; offset 2; get;" ;
+    @Test
+    public void testSchemaQuery() {
+        String query = "match $x plays actor; get; sort $x asc;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("y").isa("movie").has("title", var("n"))).get();
-        // TODO: put back .orderBy("n").limit(4).offset(2)
+        GraqlGet expected = match(var("x").plays("actor")).get().sort("x", "asc");
 
         assertQueryEquals(expected, parsed, query);
     }
 
     @Test
-    public void testSchemaQuery() {
-        String query = "match $x plays actor; get;"; // TODO: put back order by $x asc;
+    public void testGetSort() {
+        String query = "match $x isa movie, has rating $r; get; sort $r desc;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").plays("actor")).get(); // TODO: put back .orderBy("x")
+        GraqlGet expected = match(
+                var("x").isa("movie").has("rating", var("r"))
+        ).get().sort("r", "desc");
 
         assertQueryEquals(expected, parsed, query);
     }
 
-    @Test @Ignore // TODO: put back .orderBy("r", desc)
-    public void testOrderQuery() {
-        String query = "match $x isa movie, has release-date $r; order by $r desc; get;";
+    @Test
+    public void testGetSortLimit() {
+        String query = "match $x isa movie, has rating $r; get; sort $r; limit 10;";
         GraqlGet parsed = Graql.parse(query).asGet();
-        GraqlGet expected = match(var("x").isa("movie").has("release-date", var("r"))).get();
+        GraqlGet expected = match(
+                var("x").isa("movie").has("rating", var("r"))
+        ).get().sort("r").limit(10);
+
+        assertQueryEquals(expected, parsed, query);
+    }
+
+    @Test
+    public void testGetSortOffsetLimit() {
+        String query = "match $x isa movie, has rating $r; get; sort $r desc; offset 10; limit 10;";
+        GraqlGet parsed = Graql.parse(query).asGet();
+        GraqlGet expected = match(
+                var("x").isa("movie").has("rating", var("r"))
+        ).get().sort("r", Token.Order.DESC).offset(10).limit(10);
+
+        assertQueryEquals(expected, parsed, query);
+    }
+
+    @Test
+    public void testGetOffsetLimit() {
+        String query = "match $y isa movie, has title $n; get; offset 2; limit 4;" ;
+        GraqlGet parsed = Graql.parse(query).asGet();
+        GraqlGet expected = match(
+                var("y").isa("movie").has("title", var("n"))
+        ).get().offset(2).limit(4);
 
         assertQueryEquals(expected, parsed, query);
     }

--- a/server/test/graql/query/parser/QueryToStringTest.java
+++ b/server/test/graql/query/parser/QueryToStringTest.java
@@ -62,8 +62,7 @@ public class QueryToStringTest {
                         var("y").isa("genre").neq("crime")
                 ),
                 var("y").has("name", var("n"))
-        ).get("x", "y");
-        //TODO: re-add .orderBy("n").limit(8).offset(4)
+        ).get("x", "y").sort("n").offset(4).limit(8);
         assertEquivalent(query, query.toString());
     }
 

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -24,6 +24,8 @@ import grakn.core.graql.answer.Value;
 import grakn.core.graql.concept.AttributeType;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.printer.Printer;
+import grakn.core.graql.printer.StringPrinter;
 import grakn.core.graql.query.query.GraqlGet;
 import grakn.core.graql.query.statement.Variable;
 import grakn.core.rule.GraknTestServer;
@@ -50,6 +52,7 @@ import static java.lang.Math.sqrt;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("Duplicates")
 public class GraqlGetIT {
 
     @Rule
@@ -80,6 +83,62 @@ public class GraqlGetIT {
     public static void closeSession() {
         session.close();
     }
+
+
+    @Test
+    public void testGetSort() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("person").has("name", var("y")))
+                        .get().sort("y")
+        );
+
+        assertEquals("Al Pacino", answers.get(0).get("y").asAttribute().value());
+        assertEquals("Bette Midler", answers.get(1).get("y").asAttribute().value());
+        assertEquals("Jude Law", answers.get(2).get("y").asAttribute().value());
+        assertEquals("Kermit The Frog", answers.get(3).get("y").asAttribute().value());
+    }
+
+    @Test
+    public void testGetSortAscLimit() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("person").has("name", var("y")))
+                        .get().sort("y", "asc").limit(3)
+        );
+
+        assertEquals(3, answers.size());
+        assertEquals("Al Pacino", answers.get(0).get("y").asAttribute().value());
+        assertEquals("Bette Midler", answers.get(1).get("y").asAttribute().value());
+        assertEquals("Jude Law", answers.get(2).get("y").asAttribute().value());
+    }
+
+    @Test
+    public void testGetSortDesc() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("person").has("name", var("y")))
+                        .get().sort("y", "desc")
+        );
+
+        assertEquals(10, answers.size());
+        assertEquals("Sarah Jessica Parker", answers.get(0).get("y").asAttribute().value());
+        assertEquals("Robert de Niro", answers.get(1).get("y").asAttribute().value());
+        assertEquals("Miss Piggy", answers.get(2).get("y").asAttribute().value());
+        assertEquals("Miranda Heart", answers.get(3).get("y").asAttribute().value());
+    }
+
+    @Test
+    public void testGetSortDescOffsetLimit() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("person").has("name", var("y")))
+                        .get().sort("y", "desc").offset(3).limit(4)
+        );
+
+        assertEquals(4, answers.size());
+        assertEquals("Miranda Heart", answers.get(0).get("y").asAttribute().value());
+        assertEquals("Martin Sheen", answers.get(1).get("y").asAttribute().value());
+        assertEquals("Marlon Brando", answers.get(2).get("y").asAttribute().value());
+        assertEquals("Kermit The Frog", answers.get(3).get("y").asAttribute().value());
+    }
+
 
     @Test
     public void testCount() {

--- a/test-integration/graql/reasoner/GeoInferenceIT.java
+++ b/test-integration/graql/reasoner/GeoInferenceIT.java
@@ -360,12 +360,12 @@ public class GeoInferenceIT {
         }
     }
 
-    @Test @Ignore // TODO: enable once we re-implement query limits
+    @Test
     public void testLazy() {
         try (Transaction tx = geoGraphSession.transaction(Transaction.Type.WRITE)) {
             
-            String queryString = "match (geo-entity: $x, entity-location: $y) isa is-located-in; limit 1; get;";
-            String queryString2 = "match (geo-entity: $x, entity-location: $y) isa is-located-in; limit 22; get;";
+            String queryString = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get; limit 1;";
+            String queryString2 = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get; limit 22;";
             String queryString3 = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -209,7 +209,6 @@ public class ReasoningIT {
         }
     }
 
-    @Ignore // TODO: un-ignore once we re-enable query limits
     @Test //Expected result: The query should return 10 unique matches (no duplicates).
     public void distinctLimitedAnswersOfInfinitelyGeneratingRule() {
         try(Session session = server.sessionWithNewKeyspace()) {
@@ -217,7 +216,7 @@ public class ReasoningIT {
             try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
                 
                 
-                String queryString = "match $x isa relation1; get;"; // TODO: put back limit 10
+                String queryString = "match $x isa relation1; get; limit 10:";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
                 assertEquals(10, answers.size());
                 assertEquals(tx.execute(Graql.parse(queryString).asGet(), false).size(), answers.size());
@@ -381,7 +380,7 @@ public class ReasoningIT {
             loadFromFileAndCommit(resourcePath, "testSet23.gql", session);
             try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
                 
-                String queryString = "match (friend1:$x1, friend2:$x2) isa knows-trans; get;"; // TODO: put back limit 60
+                String queryString = "match (friend1:$x1, friend2:$x2) isa knows-trans; get; limit 60;";
                 List<ConceptMap> oldAnswers = tx.execute(Graql.parse(queryString).asGet());
                 for (int i = 0; i < 5; i++) {
                     List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -462,7 +461,7 @@ public class ReasoningIT {
                         "(role1: $x, role2: $y);" +
                         "(role1: $y, role2: $z);" +
                         "(role3: $z, role4: $w) isa relation3;" +
-                        "get;"; // TODO: put back limit 3
+                        "get; limit 3;";
 
                 assertEquals(3, tx.execute(Graql.parse(queryWithTypes).asGet()).size());
 

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -216,7 +216,7 @@ public class ReasoningIT {
             try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
                 
                 
-                String queryString = "match $x isa relation1; get; limit 10:";
+                String queryString = "match $x isa relation1; get; limit 10;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
                 assertEquals(10, answers.size());
                 assertEquals(tx.execute(Graql.parse(queryString).asGet(), false).size(), answers.size());

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -264,23 +264,19 @@ public class BenchmarkBigIT {
                 ConceptId entityId = tx.getEntityType("a-entity").instances().findFirst().get().id();
                 String queryPattern = "(P-from: $x, P-to: $y) isa P;";
                 String queryString = "match " + queryPattern + " get;";
-                String subbedQueryString = "match " +
-                        queryPattern +
+                String subbedQueryString = "match " + queryPattern +
                         " $x id '" + entityId.getValue() + "';" +
                         " get;";
-                String subbedQueryString2 = "match " +
-                        queryPattern +
+                String subbedQueryString2 = "match " + queryPattern +
                         " $y id '" + entityId.getValue() + "';" +
                         " get;";
-                String limitedQueryString = "match " +
-                        queryPattern +
-                        " limit " + limit + ";" +
-                        " get;";
+                String limitedQueryString = "match " + queryPattern +
+                        " get; limit " + limit + ";";
 
                 executeQuery(queryString, tx, "full");
                 executeQuery(subbedQueryString, tx, "first argument bound");
                 executeQuery(subbedQueryString2, tx, "second argument bound");
-                //executeQuery(limitedQueryString, tx, "limit " + limit); // TODO: re-enable after implementing limits
+                executeQuery(limitedQueryString, tx, "limit " + limit);
             }
         }
     }
@@ -318,15 +314,13 @@ public class BenchmarkBigIT {
                         queryPattern +
                         " $y id '" + entityId.getValue() + "';" +
                         " get;";
-                String limitedQueryString = "match " +
-                        queryPattern +
-                        " limit " + limit + ";" +
-                        " get;";
+                String limitedQueryString = "match " + queryPattern +
+                        " get; limit " + limit + ";";
 
                 executeQuery(queryString, tx, "full");
                 executeQuery(subbedQueryString, tx, "first argument bound");
                 executeQuery(subbedQueryString2, tx, "second argument bound");
-                //executeQuery(limitedQueryString, tx, "limit " + limit); // TODO: re-enable after implementing limits
+                executeQuery(limitedQueryString, tx, "limit " + limit);
             }
         }
     }
@@ -353,22 +347,18 @@ public class BenchmarkBigIT {
                 ConceptId lastId = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x has index '" + N + "';get;").asGet())).get("x").id();
                 String queryPattern = "(fromRole: $x, toRole: $y) isa relation" + N + ";";
                 String queryString = "match " + queryPattern + " get;";
-                String subbedQueryString = "match " +
-                        queryPattern +
+                String subbedQueryString = "match " + queryPattern +
                         "$x id '" + firstId.getValue() + "';" +
                         "get;";
-                String subbedQueryString2 = "match " +
-                        queryPattern +
+                String subbedQueryString2 = "match " + queryPattern +
                         "$y id '" + lastId.getValue() + "';" +
                         "get;";
-                String limitedQueryString = "match " +
-                        queryPattern +
-                        "limit 1;" +
-                        "get;";
+                String limitedQueryString = "match " + queryPattern +
+                        "get; limit 1;";
                 assertEquals(1, executeQuery(queryString, tx, "full").size());
                 assertEquals(1, executeQuery(subbedQueryString, tx, "first argument bound").size());
                 assertEquals(1, executeQuery(subbedQueryString2, tx, "second argument bound").size());
-                // assertEquals(1, executeQuery(limitedQueryString, tx, "limit ").size()); // TODO: uncomment
+                 assertEquals(1, executeQuery(limitedQueryString, tx, "limit ").size());
             }
         }
     }

--- a/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
@@ -119,13 +119,11 @@ public class BenchmarkSmallIT {
             final long limit = 1;
             String queryPattern = "(fromRole: $x, toRole: $y) isa relation" + N + ";";
             String queryString = "match " + queryPattern + " get;";
-            String limitedQueryString = "match " +
-                    queryPattern +
-                    "limit " + limit +  ";" +
-                    "get;";
+            String limitedQueryString = "match " + queryPattern +
+                    "get; limit " + limit +  ";";
 
             assertEquals(executeQuery(queryString, tx, "full").size(), limit);
-            // assertEquals(executeQuery(limitedQueryString, tx, "limit").size(), limit); TODO: uncomment
+            assertEquals(executeQuery(limitedQueryString, tx, "limit").size(), limit);
         }
         session.close();
     }
@@ -173,7 +171,7 @@ public class BenchmarkSmallIT {
         String queryString = "match (P-from: $x, P-to: $y) isa P; get;";
         Transaction tx = session.transaction(Transaction.Type.WRITE);
         executeQuery(queryString, tx, "full");
-        // executeQuery(Graql.parse(queryString).asGet().match().limit(limit).get(), "limit " + limit); // TODO: uncomment
+        executeQuery(Graql.parse(queryString).asGet().match().get().limit(limit), tx, "limit " + limit);
         tx.close();
         session.close();
     }
@@ -215,8 +213,8 @@ public class BenchmarkSmallIT {
         assertEquals(executeQuery(query, tx, "full").size(), answers);
         assertEquals(executeQuery(query2, tx, "With specific resource").size(), N);
 
-//        executeQuery(query.match().limit(limit).get(), "limit " + limit); // TODO: uncomment
-//        executeQuery(query2.match().limit(limit).get(), "limit " + limit); // TODO: uncomment
+        executeQuery(query.match().get().limit(limit), tx, "limit " + limit);
+        executeQuery(query2.match().get().limit(limit), tx, "limit " + limit);
         tx.close();
         session.close();
     }
@@ -275,7 +273,7 @@ public class BenchmarkSmallIT {
         executeQuery(query, tx, "full");
         executeQuery(query2, tx, "With specific resource");
         executeQuery(query3, tx, "Single argument bound");
-//        executeQuery(query.match().limit(limit).get(), "limit " + limit); // TODO: uncomment
+        executeQuery(query.match().get().limit(limit), tx, "limit " + limit);
         tx.close();
         session.close();
     }
@@ -322,7 +320,7 @@ public class BenchmarkSmallIT {
         GraqlGet query = Graql.parse(queryString).asGet();
 
         executeQuery(query, tx, "full");
-//        executeQuery(query.match().limit(limit).get(), "limit " + limit); // TODO: uncomment
+        executeQuery(query.match().get().limit(limit), tx, "limit " + limit);
         tx.close();
         session.close();
     }
@@ -377,8 +375,7 @@ public class BenchmarkSmallIT {
 
         String queryString = "match (path-from: $x, path-to: $y) isa path;" +
                 "$x has index 'a0';" +
-                // "limit " + answers + ";" + TODO: uncomment
-                "get $y;";
+                "get $y; limit " + answers + ";";
 
         assertEquals(executeQuery(queryString, tx, "tree").size(), answers);
         tx.close();


### PR DESCRIPTION
# Why is this PR needed?

In PR # #4702 (Refactor Graql query language library - Part 5) we had to remove `order`, `offset`, and `limit` functionalities on the match queries, which we then called _"match modifiers"_. We needed to bring the functionalities back, but this time we refer to them as _"query filters"_, and they come after the `get` or `delete` query variables. We also now refer to `order` as `sort`, because we refer to the argument that determines the direction of `sort` is referred to as `order`. I.e. `sort` takes in a `var` and `order` (in Java: `.sort(Var var, Token.Order order)`. 

For example, you can read the following query:
`match $x isa person, has $name $n; get $x, $n; sort $n desc;`
_"Match all persons and, sort by name desc descending order"_.

# What does the PR do?

This PR implements Graql Filters (Sort, Offset and Limit) back in Graql language, as well as the query execution.

The new grammar for filters are:
```
query_get       :  MATCH       pattern+    GET     variables   filters? ;
query_delete	:  MATCH       pattern+    DELETE  variables   filters? ;

filters         :  sort?       offset?     limit?      ;
sort            :  SORT        VAR_        ORDER_? ';' ;
offset          :  OFFSET      INTEGER_            ';' ;
limit           :  LIMIT       INTEGER_            ';' ;

ORDER_          :  ASC | DESC    ;
```

For example, to query _"get all persons and their names, sort by their names with descending order, and get the 11th to 20th persons in the list"_:
```
match $x isa person, has name $y; get $x, $y; sort $y desc; offset 10; limit 10;
```

Note that that `sort`, `offset` and `limit` are all optional, but can only be written in that order.

This is also reflected in Graql Java:
```
Graql.match(var('x').isa('person').has('name', var('y')).get('x', 'y').sort('y', 'desc').offset(10).limit(10);
```