### PR TITLE
Graql Filters: Sort, Offset, and Limit - Part 2

### DIFF
--- a/graql/java/exception/ErrorMessage.java
+++ b/graql/java/exception/ErrorMessage.java
@@ -22,7 +22,7 @@ public enum ErrorMessage {
     SYNTAX_ERROR_NO_POINTER("syntax error at line %s:\n%s"),
     SYNTAX_ERROR("syntax error at line %s: \n%s\n%s\n%s"),
     CONFLICTING_PROPERTIES("the following unique properties in '%s' conflict: '%s' and '%s'"),
-    VARIABLE_NOT_IN_QUERY("the variable %s is not in the query"),
+    VARIABLE_OUT_OF_SCOPE("the variable %s is out of scope of the query"),
     NO_PATTERNS("no patterns have been provided. at least one pattern must be provided");
 
     private final String message;

--- a/graql/java/exception/GraqlException.java
+++ b/graql/java/exception/GraqlException.java
@@ -41,8 +41,8 @@ public class GraqlException extends RuntimeException {
         return new GraqlException(graql.lang.exception.ErrorMessage.CONFLICTING_PROPERTIES.getMessage(statement, property, other));
     }
 
-    public static GraqlException varNotInQuery(String var) {
-        return new GraqlException(graql.lang.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(var));
+    public static GraqlException variableOutOfScope(String var) {
+        return new GraqlException(graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE.getMessage(var));
     }
 
     public static GraqlException noPatterns() {

--- a/server/src/graql/answer/ConceptMap.java
+++ b/server/src/graql/answer/ConceptMap.java
@@ -115,7 +115,7 @@ public class ConceptMap implements Answer<ConceptMap> {
     @CheckReturnValue
     public Concept get(Variable var) {
         Concept concept = map.get(var);
-        if (concept == null) throw GraqlException.varNotInQuery(var.toString());
+        if (concept == null) throw GraqlException.variableOutOfScope(var.toString());
         return concept;
     }
 

--- a/server/src/graql/query/query/GraqlGet.java
+++ b/server/src/graql/query/query/GraqlGet.java
@@ -53,20 +53,24 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
     }
 
     public GraqlGet(MatchClause match, LinkedHashSet<Variable> vars, Sorting sorting, long offset, long limit) {
-        if (vars == null) {
-            throw new NullPointerException("Null vars");
-        }
-        this.vars = vars;
         if (match == null) {
             throw new NullPointerException("Null match");
         }
-        for (Variable var : vars) {
-            if (!match.getSelectedNames().contains(var)) {
-                throw GraqlException.varNotInQuery(var.toString());
-            }
-        }
         this.match = match;
 
+        if (vars == null) {
+            throw new NullPointerException("Null vars");
+        }
+        for (Variable var : vars) {
+            if (!match.getSelectedNames().contains(var)) {
+                throw GraqlException.variableOutOfScope(var.toString());
+            }
+        }
+        this.vars = vars;
+
+        if (sorting != null && !vars().contains(sorting.var())) {
+            throw GraqlException.variableOutOfScope(sorting.var().toString());
+        }
         this.sorting = sorting;
         this.offset = offset;
         this.limit = limit;
@@ -200,8 +204,8 @@ public class GraqlGet extends GraqlQuery implements Filterable, Aggregatable<Gra
 
     public class Sorted extends GraqlGet implements Filterable.Sorted<GraqlGet.Offsetted, GraqlGet.Limited> {
 
-        Sorted(GraqlGet graqlGet, Sorting order) {
-            super(graqlGet.match, graqlGet.vars, order, graqlGet.offset, graqlGet.limit);
+        Sorted(GraqlGet graqlGet, Sorting sorting) {
+            super(graqlGet.match, graqlGet.vars, sorting, graqlGet.offset, graqlGet.limit);
         }
 
         @Override

--- a/server/test/graql/query/ConceptMapTest.java
+++ b/server/test/graql/query/ConceptMapTest.java
@@ -51,7 +51,7 @@ public class ConceptMapTest {
         Variable varNotInAnswer = new Variable("y");
 
         exception.expect(GraqlException.class);
-        exception.expectMessage(GraqlException.varNotInQuery(varNotInAnswer.toString()).getMessage());
+        exception.expectMessage(GraqlException.variableOutOfScope(varNotInAnswer.toString()).getMessage());
 
         answer.get(varNotInAnswer);
     }

--- a/server/test/graql/query/parser/QueryToStringTest.java
+++ b/server/test/graql/query/parser/QueryToStringTest.java
@@ -62,7 +62,7 @@ public class QueryToStringTest {
                         var("y").isa("genre").neq("crime")
                 ),
                 var("y").has("name", var("n"))
-        ).get("x", "y").sort("n").offset(4).limit(8);
+        ).get("x", "y", "n").sort("n").offset(4).limit(8);
         assertEquivalent(query, query.toString());
     }
 

--- a/test-integration/graql/query/GraqlDeleteIT.java
+++ b/test-integration/graql/query/GraqlDeleteIT.java
@@ -27,6 +27,7 @@ import grakn.core.graql.graph.MovieGraph;
 import grakn.core.graql.internal.Schema;
 import grakn.core.graql.query.query.MatchClause;
 import grakn.core.graql.query.statement.Statement;
+import grakn.core.graql.query.statement.Variable;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.Transaction;
 import grakn.core.server.session.SessionImpl;
@@ -49,7 +50,7 @@ import static grakn.core.graql.query.Graql.type;
 import static grakn.core.graql.query.Graql.var;
 import static grakn.core.util.GraqlTestUtil.assertExists;
 import static grakn.core.util.GraqlTestUtil.assertNotExists;
-import static graql.lang.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -303,7 +304,7 @@ public class GraqlDeleteIT {
     @Test
     public void whenDeletingAVariableNotInTheQuery_Throw() {
         exception.expect(GraqlException.class);
-        exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(y.var()));
+        exception.expectMessage(VARIABLE_OUT_OF_SCOPE.getMessage(y.var()));
         tx.execute(Graql.match(x.isa("movie")).delete(y.var()));
     }
 
@@ -321,4 +322,10 @@ public class GraqlDeleteIT {
         tx.execute(Graql.match(var()).delete((String) null));
     }
 
+    @Test
+    public void whenSortVarIsNotInQuery_Throw() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage(VARIABLE_OUT_OF_SCOPE.getMessage(new Variable("z")));
+        tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().sort("z"));
+    }
 }

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -139,7 +139,6 @@ public class GraqlGetIT {
         assertEquals("Kermit The Frog", answers.get(3).get("y").asAttribute().value());
     }
 
-
     @Test
     public void testCount() {
         List<Value> count = tx.execute(Graql.match(var("x").isa("movie"), var("y").isa("person"), var("r").rel("x").rel("y")).get().count());

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -24,8 +24,6 @@ import grakn.core.graql.answer.Value;
 import grakn.core.graql.concept.AttributeType;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.graph.MovieGraph;
-import grakn.core.graql.printer.Printer;
-import grakn.core.graql.printer.StringPrinter;
 import grakn.core.graql.query.query.GraqlGet;
 import grakn.core.graql.query.statement.Variable;
 import grakn.core.rule.GraknTestServer;
@@ -46,7 +44,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static grakn.core.graql.query.Graql.var;
-import static graql.lang.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY;
+import static graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE;
 import static java.lang.Math.pow;
 import static java.lang.Math.sqrt;
 import static org.junit.Assert.assertEquals;
@@ -423,7 +421,14 @@ public class GraqlGetIT {
     @Test
     public void whenGroupVarIsNotInQuery_Throw() {
         exception.expect(GraqlException.class);
-        exception.expectMessage(VARIABLE_NOT_IN_QUERY.getMessage(new Variable("z")));
+        exception.expectMessage(VARIABLE_OUT_OF_SCOPE.getMessage(new Variable("z")));
         tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().group("z").count());
+    }
+
+    @Test
+    public void whenSortVarIsNotInQuery_Throw() {
+        exception.expect(GraqlException.class);
+        exception.expectMessage(VARIABLE_OUT_OF_SCOPE.getMessage(new Variable("z")));
+        tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().sort("z"));
     }
 }

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -27,7 +27,6 @@ import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.graql.internal.Schema;
 import grakn.core.graql.query.property.ValueProperty;
-import grakn.core.graql.query.query.GraqlDefine;
 import grakn.core.graql.query.query.MatchClause;
 import grakn.core.graql.query.statement.Statement;
 import grakn.core.graql.query.statement.Variable;
@@ -234,7 +233,7 @@ public class QueryErrorIT {
     @Test
     public void testGetNonExistentVariable() {
         exception.expect(GraqlException.class);
-        exception.expectMessage(graql.lang.exception.ErrorMessage.VARIABLE_NOT_IN_QUERY.getMessage(new Variable("y")));
+        exception.expectMessage(graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE.getMessage(new Variable("y")));
 
         MatchClause match = Graql.match(var("x").isa("movie"));
         Stream<Concept> concepts = tx.stream(match.get("y")).map(ans -> ans.get("y"));


### PR DESCRIPTION
# Why is this PR needed?

This is a continuation of PR #4910, where we implement Graql Filters (Sort, Offset, and Limit).

# What does the PR do?

1) Implemented query execution of GraqlDelete Filters, by extracting the logic to be shared with GraqlGet filter execution

2) Implemented validation check to make sure that the `sort` Variable not `out of scope` of the query