### PR TITLE
Fixed Graql String sorting to ignore case

### DIFF
--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -237,9 +237,17 @@ public class QueryExecutor {
     @SuppressWarnings("unchecked") // All attribute values are comparable data types
     private Stream<ConceptMap> filter(Filterable query, Stream<ConceptMap> answers) {
         if (query.sort().isPresent()) {
-            Comparator<ConceptMap> comparator = Comparator.comparing(
-                    answer -> (Comparable<? super Comparable>) answer.get(query.sort().get().var()).asAttribute().value()
-            );
+            Variable var = query.sort().get().var();
+            Comparator<ConceptMap> comparator = (map1, map2) -> {
+                Object val1 = map1.get(var).asAttribute().value();
+                Object val2 = map2.get(var).asAttribute().value();
+
+                if (val1 instanceof String) {
+                    return ((String) val1).compareToIgnoreCase((String) val2);
+                } else {
+                    return ((Comparable<? super Comparable>) val1).compareTo((Comparable<? super Comparable>) val2);
+                }
+            };
             comparator = (query.sort().get().order() == Token.Order.DESC) ? comparator.reversed() : comparator;
             answers = answers.sorted(comparator);
         }

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -24,6 +24,7 @@ import grakn.core.graql.answer.Value;
 import grakn.core.graql.concept.AttributeType;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.graph.MovieGraph;
+import grakn.core.graql.printer.Printer;
 import grakn.core.graql.query.query.GraqlGet;
 import grakn.core.graql.query.statement.Variable;
 import grakn.core.rule.GraknTestServer;
@@ -135,6 +136,23 @@ public class GraqlGetIT {
         assertEquals("Martin Sheen", answers.get(1).get("y").asAttribute().value());
         assertEquals("Marlon Brando", answers.get(2).get("y").asAttribute().value());
         assertEquals("Kermit The Frog", answers.get(3).get("y").asAttribute().value());
+    }
+
+    @Test
+    public void testGetSortStringIgnoreCase() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("name")).get().sort("x").limit(5)
+        );
+
+        for(ConceptMap answer : answers) {
+            System.out.println(Printer.stringPrinter(false).toString(answer));
+        }
+        assertEquals(5, answers.size());
+        assertEquals("0", answers.get(0).get("x").asAttribute().value());
+        assertEquals("1", answers.get(1).get("x").asAttribute().value());
+        assertEquals("action", answers.get(2).get("x").asAttribute().value());
+        assertEquals("Al Pacino", answers.get(3).get("x").asAttribute().value());
+        assertEquals("Benjamin L. Willard", answers.get(4).get("x").asAttribute().value());
     }
 
     @Test


### PR DESCRIPTION
# Why is this PR needed?

Fixes #4828, where the sorting of Strings in Graql does not ignore the case. This resulted in weird behaviour where all capital letters come ahead of all small case letters.

# What does the PR do?

We set the string sorting in Graql Filters to ignore case.
