### PR TITLE
do not stratify rules when they are positive

### DIFF
--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -197,10 +197,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
 
     @Override
     protected Stream<ReasonerQueryImpl> getQueryStream(ConceptMap sub){
-        Atom atom = getAtom();
-        return atom.getSchemaConcept() == null?
-                atom.atomOptions(sub).stream().map(ReasonerAtomicQuery::new) :
-                Stream.of(this);
+        return getAtom().atomOptions(sub).stream().map(ReasonerAtomicQuery::new);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/internal/reasoner/rule/RuleUtils.java
@@ -119,6 +119,7 @@ public class RuleUtils {
 
 
     public static Stream<InferenceRule> stratifyRules(Set<InferenceRule> rules){
+        if(rules.stream().allMatch(r -> r.getBody().isPositive())) return rules.stream();
         Multimap<Type, InferenceRule> typeMap = HashMultimap.create();
         rules.forEach(r -> r.getRule().thenTypes().flatMap(Type::sups).forEach(t -> typeMap.put(t, r)));
         HashMultimap<Type, Type> typeGraph = typeGraph(rules);


### PR DESCRIPTION
# Why is this PR needed?
No rule stratification is needed when we are dealing with positive rules.
# What does the PR do?
Shortcircuits startification if no negative rules are present.
# Does it break backwards compatibility?
No.
# List of future improvements not on this PR
NO.