### PR TITLE
Fix versions so //:distribution can be built and ran on Windows

### DIFF
--- a/daemon/executor/Server.java
+++ b/daemon/executor/Server.java
@@ -169,8 +169,8 @@ public class Server {
     }
 
     private String getServerClassPath() {
-        Path jar = Paths.get("server","services", "lib", "*");
-        return graknHome.resolve(jar) + File.pathSeparator + graknHome.resolve("conf");
+        return graknHome.resolve("server").resolve("services").resolve("lib").toString() + File.separator + "*"
+                + File.pathSeparator + graknHome.resolve("conf");
     }
 
     private static boolean isServerReady(String host, int port) {

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -252,8 +252,8 @@ public class Storage {
     }
 
     private String getStorageClassPath() {
-        Path jar = Paths.get("server", "services", "lib", "*");
-        return graknHome.resolve(jar) + File.pathSeparator + graknHome.resolve("server").resolve("services").resolve("cassandra");
+        return graknHome.resolve("server").resolve("services").resolve("lib").toString() + File.separator + "*"
+                + File.pathSeparator + graknHome.resolve("server").resolve("services").resolve("cassandra");
     }
 
 

--- a/dependencies/compilers/dependencies.bzl
+++ b/dependencies/compilers/dependencies.bzl
@@ -23,14 +23,14 @@ def antlr_dependencies():
     git_repository(
         name = "rules_antlr",
         remote = "https://github.com/graknlabs/rules_antlr",
-        commit = "a802065dc12736d1360946c4bc689c8c8fe0c25f"
+        commit = "3d1806329d7c61241781f7578240d1ff17f9e5d8"
     )
 
 def grpc_dependencies():
     git_repository(
         name = "com_github_grpc_grpc",
         remote = "https://github.com/graknlabs/grpc",
-        commit = "6accbdaccb906f59be846fe11450f662562beef9"
+        commit = "4a1528f6f20a8aa68bdbdc9a66286ec2394fc170"
     )
 
     git_repository(

--- a/dependencies/distribution/dependencies.bzl
+++ b/dependencies/distribution/dependencies.bzl
@@ -24,5 +24,5 @@ def distribution_dependencies():
     git_repository(
         name="graknlabs_bazel_distribution",
         remote="https://github.com/graknlabs/bazel-distribution",
-        commit="796cea2531404509a3298af65ab562b1929c3eb6"
+        commit="5f7a464b943fc3c370c42d2f5b59993ec2cd435f"
     )


### PR DESCRIPTION
# Why is this PR needed?

Needs graknlabs/bazel-distribution#52
So we are able to build and run`//:distribution` on Windows

# What does the PR do?

* Replace `getServerClassPath ` and `getStorageClassPath` to version that don't use `Paths.get` (doing `Paths.get(…, "*")` on Windows throws in runtime
* Update `@rules_antlr` to latest `experimental` which includes bugfix from marcohu/rules_antlr#2
* Update `@com_github_grpc_grpc` to latest `experimental` (based on `v1.18.0`, references updated `@com_google_protobuf` that builds on Windows)

# Does it break backwards compatibility?

—

# List of future improvements not on this PR

—
