### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,11 @@ You can visit the [Setup Guide](https://dev.grakn.ai/docs/running-grakn/install-
 1. Make sure you have the following dependencies installed on your machine:
     - Java 8
     - Python >= 2.7 and Pip >= 18.1
-    - [Bazel >= 0.18.0](https://docs.bazel.build/versions/master/install-os-x.html)
-    - `rpmbuild`, available via `apt install rpm` (Debian derivatives) or `brew install rpm` (macOS)
-
-2. Install Workbase requirements:
+    - [Bazel >= 0.18.0](http://docs.bazel.build/install.html)
+1. Compile (you should get `bazel-genfiles/grakn-core-all.zip` as a result) 
 ```
-$ bazel run @nodejs//:npm install
-```
-3. Compile:
-```
-$ bazel build //...
-```
+$ bazel build //:distribution
+````
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can visit the [Setup Guide](https://dev.grakn.ai/docs/running-grakn/install-
 1. Make sure you have the following dependencies installed on your machine:
     - Java 8
     - Python >= 2.7 and Pip >= 18.1
-    - [Bazel >= 0.18.0](http://docs.bazel.build/install.html)
+    - [Bazel](http://docs.bazel.build/install.html)
 1. Compile (you should get `bazel-genfiles/grakn-core-all.zip` as a result) 
 ```
 $ bazel build //:distribution


### PR DESCRIPTION
## What is the goal of this PR?

- `README` becomes cleaner

## What are the changes implemented in this PR?

- Specify the target to build (`//...` ["compile everything"] is not really helping the user)
- Remove installing Workbase node dependencies (it's now [in a separate repo](https://github.com/graknlabs/workbase))
- Remove `rpmbuild` requirement — it's not needed if you're building `//:distribution`