### PR TITLE
Fixed GraknClient (client-java) constructor

### DIFF
--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -86,6 +86,10 @@ public final class GraknClient {
     private ManagedChannel channel;
     private Keyspaces keyspaces;
 
+    public GraknClient() {
+        this(DEFAULT_URI);
+    }
+
     public GraknClient(String address) {
         this(address, false);
     }
@@ -103,9 +107,9 @@ public final class GraknClient {
         keyspaces = new Keyspaces();
     }
 
-    public GraknClient(ManagedChannel channel) {
+    public GraknClient overrideChannel(ManagedChannel channel) {
         this.channel = channel;
-        keyspaces = new Keyspaces();
+        return this;
     }
 
     public Session session(String keyspace) {

--- a/client-java/test/GraknClientTest.java
+++ b/client-java/test/GraknClientTest.java
@@ -100,7 +100,7 @@ public class GraknClientTest {
     public void setUp() {
         serverRule.getServiceRegistry().addService(sessionService);
         serverRule.getServiceRegistry().addService(keyspaceService);
-        session = new GraknClient(serverRule.getChannel()).session(KEYSPACE.getName());
+        session = new GraknClient().overrideChannel(serverRule.getChannel()).session(KEYSPACE.getName());
     }
 
     @Test

--- a/dependencies/git/dependencies.bzl
+++ b/dependencies/git/dependencies.bzl
@@ -22,5 +22,5 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "e8f9e0c4fdb3ea0d76aab957b7c005d22f514094"
+        commit = "ff73e8c5a0ffae51902f65165367983a5b7a9c5a"
     )


### PR DESCRIPTION
## What is the goal of this PR?

GraknClient (in client-java) has several overloaded constructors. 2 of them are:
- `GraknClient(String host)`, which is the default one users should use, and
- `GraknClient(ManagedChannel channel)`, which allows us to override the channel by injection, useful for tests.

However, in user environments which requires explicit declaration of direct dependencies (even if they are already transitively loaded), e.g. in Bazel, this becomes an issue. The above constructor overloading makes `io.grpc.ManagedChannel` to be a direct dependency, which leads in a compile-time issue if the user is unaware. In most cases, this is unexpected, even though correct.

## What are the changes implemented in this PR?

The solution is to remove the second constructor `GraknClient(ManagedChannel channel)`, and provide a method to override the constructed channel. Although this is not so ideal, it's the lesser of all evils.