### PR TITLE
[DO NOT MERGE] Add timeout setting to client-java so it doesn't stall forever in case the network is interrupted

### DIFF
--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -84,7 +84,7 @@ public final class GraknClient {
 
     public static final String DEFAULT_URI = "localhost:48555";
 
-    private static final int CONNECTION_TIMEOUT_SECOND = 15;
+    private static final int CONNECTION_TIMEOUT_SECOND = 20;
     private ManagedChannel channel;
     private Keyspaces keyspaces;
 

--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -84,7 +84,7 @@ public final class GraknClient {
 
     public static final String DEFAULT_URI = "localhost:48555";
 
-    private static final int CONNECTION_TIMEOUT_SECOND = 20;
+    private static final int CONNECTION_TIMEOUT_SECOND = 45;
     private ManagedChannel channel;
     private Keyspaces keyspaces;
 

--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -84,7 +84,7 @@ public final class GraknClient {
 
     public static final String DEFAULT_URI = "localhost:48555";
 
-    private static final int CONNECTION_TIMEOUT_SECOND = 45;
+    private static final int CONNECTION_TIMEOUT_SECOND = 90;
     private ManagedChannel channel;
     private Keyspaces keyspaces;
 


### PR DESCRIPTION
## What is the goal of this PR?

Closes https://github.com/graknlabs/grakn/issues/4940. This adds a proper timeout of 15 seconds on the client side so it does not stall forever if the network is interrupted.

## What are the changes implemented in this PR?
Adds a timeout of 15 seconds to `KeyspaceService` and `SessionService`'s blocking and non-blocking stub (the latter used by `Transceiver`)