### PR TITLE
General clean up of client-java and concept API - part 2

### DIFF
--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -311,10 +311,10 @@ public final class GraknClient {
 
         @Nullable
         @Override
-        public RelationType getRelationshipType(String label) {
+        public RelationType getRelationType(String label) {
             SchemaConcept concept = getSchemaConcept(Label.of(label));
-            if (concept == null || !concept.isRelationshipType()) return null;
-            return concept.asRelationshipType();
+            if (concept == null || !concept.isRelationType()) return null;
+            return concept.asRelationType();
         }
 
         @Nullable
@@ -391,9 +391,9 @@ public final class GraknClient {
         }
 
         @Override
-        public RelationType putRelationshipType(Label label) {
-            transceiver.send(RequestBuilder.Transaction.putRelationshipType(label));
-            return RemoteConcept.of(responseOrThrow().getPutRelationTypeRes().getRelationType(), this).asRelationshipType();
+        public RelationType putRelationType(Label label) {
+            transceiver.send(RequestBuilder.Transaction.putRelationType(label));
+            return RemoteConcept.of(responseOrThrow().getPutRelationTypeRes().getRelationType(), this).asRelationType();
         }
 
         @Override

--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -77,7 +77,7 @@ import static grakn.core.common.util.CommonUtil.toImmutableSet;
 
 /**
  * Entry-point which communicates with a running Grakn server using gRPC.
- * For now, only a subset of {@link grakn.core.server.Session} and {@link grakn.core.server.Transaction} features are supported.
+ * For now, only a subset of grakn.core.server.Session and grakn.core.server.Transaction features are supported.
  */
 public final class GraknClient {
 
@@ -121,7 +121,7 @@ public final class GraknClient {
     }
 
     /**
-     * Remote implementation of {@link grakn.core.server.Session} that communicates with a Grakn server using gRPC.
+     * Remote implementation of grakn.core.server.Session that communicates with a Grakn server using gRPC.
      *
      * @see Transaction
      * @see GraknClient
@@ -181,7 +181,7 @@ public final class GraknClient {
     }
 
     /**
-     * Remote implementation of {@link grakn.core.server.Transaction} that communicates with a Grakn server using gRPC.
+     * Remote implementation of grakn.core.server.Transaction that communicates with a Grakn server using gRPC.
      */
     public final class Transaction implements grakn.core.server.Transaction {
 
@@ -485,8 +485,8 @@ public final class GraknClient {
         }
 
         /**
-         * A client-side iterator over gRPC messages. Will send {@link SessionProto.Transaction.Iter.Req} messages until
-         * {@link SessionProto.Transaction.Iter.Res} returns done as a message.
+         * A client-side iterator over gRPC messages. Will send SessionProto.Transaction.Iter.Req messages until
+         * SessionProto.Transaction.Iter.Res returns done as a message.
          *
          * @param <T> class type of objects being iterated
          */

--- a/client-java/concept/RemoteAttribute.java
+++ b/client-java/concept/RemoteAttribute.java
@@ -33,7 +33,7 @@ import java.time.ZoneId;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Attribute}
+ * Client implementation of Attribute
  *
  * @param <D> The data type of this attribute
  */

--- a/client-java/concept/RemoteAttributeType.java
+++ b/client-java/concept/RemoteAttributeType.java
@@ -31,7 +31,7 @@ import grakn.core.protocol.ConceptProto;
 import javax.annotation.Nullable;
 
 /**
- * Client implementation of {@link AttributeType}
+ * Client implementation of AttributeType
  *
  * @param <D> The data type of this attribute type
  */

--- a/client-java/concept/RemoteConcept.java
+++ b/client-java/concept/RemoteConcept.java
@@ -57,13 +57,13 @@ public abstract class RemoteConcept<SomeConcept extends Concept> implements Conc
             case ENTITY:
                 return RemoteEntity.construct(tx, id);
             case RELATION:
-                return RemoteRelationship.construct(tx, id);
+                return RemoteRelation.construct(tx, id);
             case ATTRIBUTE:
                 return RemoteAttribute.construct(tx, id);
             case ENTITY_TYPE:
                 return RemoteEntityType.construct(tx, id);
             case RELATION_TYPE:
-                return RemoteRelationshipType.construct(tx, id);
+                return RemoteRelationType.construct(tx, id);
             case ATTRIBUTE_TYPE:
                 return RemoteAttributeType.construct(tx, id);
             case ROLE:

--- a/client-java/concept/RemoteConcept.java
+++ b/client-java/concept/RemoteConcept.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * Client implementation of {@link Concept}
+ * Client implementation of Concept
  *
  * @param <SomeConcept> represents the actual class of object to downcast to
  */

--- a/client-java/concept/RemoteEntity.java
+++ b/client-java/concept/RemoteEntity.java
@@ -26,7 +26,7 @@ import grakn.core.graql.concept.Entity;
 import grakn.core.graql.concept.EntityType;
 
 /**
- * Client implementation of {@link Entity}
+ * Client implementation of Entity
  */
 public class RemoteEntity extends RemoteThing<Entity, EntityType> implements Entity {
 

--- a/client-java/concept/RemoteEntityType.java
+++ b/client-java/concept/RemoteEntityType.java
@@ -29,7 +29,6 @@ import grakn.core.protocol.ConceptProto;
 
 /**
  * Client implementation of a MetaType, a special type of {@link Type}
- * <p>
  * TODO: This class is not defined in Concept API, and at server side implementation.
  * TODO: we should remove this class, or implement properly on server side.
  */

--- a/client-java/concept/RemoteEntityType.java
+++ b/client-java/concept/RemoteEntityType.java
@@ -28,7 +28,7 @@ import grakn.core.graql.concept.Type;
 import grakn.core.protocol.ConceptProto;
 
 /**
- * Client implementation of a MetaType, a special type of {@link Type}
+ * Client implementation of a MetaType, a special type of Type
  * TODO: This class is not defined in Concept API, and at server side implementation.
  * TODO: we should remove this class, or implement properly on server side.
  */

--- a/client-java/concept/RemoteMetaType.java
+++ b/client-java/concept/RemoteMetaType.java
@@ -26,7 +26,7 @@ import grakn.core.graql.concept.Thing;
 import grakn.core.graql.concept.Type;
 
 /**
- * Client implementation of {@link Type}
+ * Client implementation of Type
  */
 public class RemoteMetaType extends RemoteType<Type, Thing> {
 

--- a/client-java/concept/RemoteRelation.java
+++ b/client-java/concept/RemoteRelation.java
@@ -40,14 +40,14 @@ import java.util.stream.Stream;
 /**
  * Client implementation of Relation
  */
-public class RemoteRelationship extends RemoteThing<Relation, RelationType> implements Relation {
+public class RemoteRelation extends RemoteThing<Relation, RelationType> implements Relation {
 
-    RemoteRelationship(GraknClient.Transaction tx, ConceptId id) {
+    RemoteRelation(GraknClient.Transaction tx, ConceptId id) {
         super(tx, id);
     }
 
-    static RemoteRelationship construct(GraknClient.Transaction tx, ConceptId id) {
-        return new RemoteRelationship(tx, id);
+    static RemoteRelation construct(GraknClient.Transaction tx, ConceptId id) {
+        return new RemoteRelation(tx, id);
     }
 
     @Override // TODO: Weird. Why is this not a stream, while other collections are returned as stream
@@ -107,7 +107,7 @@ public class RemoteRelationship extends RemoteThing<Relation, RelationType> impl
 
     @Override
     final RelationType asCurrentType(Concept concept) {
-        return concept.asRelationshipType();
+        return concept.asRelationType();
     }
 
     @Override

--- a/client-java/concept/RemoteRelationType.java
+++ b/client-java/concept/RemoteRelationType.java
@@ -33,14 +33,14 @@ import java.util.stream.Stream;
 /**
  * Client implementation of RelationType
  */
-public class RemoteRelationshipType extends RemoteType<RelationType, Relation> implements RelationType {
+public class RemoteRelationType extends RemoteType<RelationType, Relation> implements RelationType {
 
-    RemoteRelationshipType(GraknClient.Transaction tx, ConceptId id) {
+    RemoteRelationType(GraknClient.Transaction tx, ConceptId id) {
         super(tx, id);
     }
 
-    static RemoteRelationshipType construct(GraknClient.Transaction tx, ConceptId id) {
-        return new RemoteRelationshipType(tx, id);
+    static RemoteRelationType construct(GraknClient.Transaction tx, ConceptId id) {
+        return new RemoteRelationType(tx, id);
     }
 
     @Override
@@ -84,12 +84,12 @@ public class RemoteRelationshipType extends RemoteType<RelationType, Relation> i
 
     @Override
     final RelationType asCurrentBaseType(Concept other) {
-        return other.asRelationshipType();
+        return other.asRelationType();
     }
 
     @Override
     final boolean equalsCurrentBaseType(Concept other) {
-        return other.isRelationshipType();
+        return other.isRelationType();
     }
 
     @Override

--- a/client-java/concept/RemoteRelationship.java
+++ b/client-java/concept/RemoteRelationship.java
@@ -38,7 +38,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Relation}
+ * Client implementation of Relation
  */
 public class RemoteRelationship extends RemoteThing<Relation, RelationType> implements Relation {
 

--- a/client-java/concept/RemoteRelationshipType.java
+++ b/client-java/concept/RemoteRelationshipType.java
@@ -31,7 +31,7 @@ import grakn.core.protocol.ConceptProto;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link RelationType}
+ * Client implementation of RelationType
  */
 public class RemoteRelationshipType extends RemoteType<RelationType, Relation> implements RelationType {
 

--- a/client-java/concept/RemoteRole.java
+++ b/client-java/concept/RemoteRole.java
@@ -30,7 +30,7 @@ import grakn.core.protocol.ConceptProto;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Role}
+ * Client implementation of Role
  */
 public class RemoteRole extends RemoteSchemaConcept<Role> implements Role {
 

--- a/client-java/concept/RemoteRole.java
+++ b/client-java/concept/RemoteRole.java
@@ -43,11 +43,11 @@ public class RemoteRole extends RemoteSchemaConcept<Role> implements Role {
     }
 
     @Override
-    public final Stream<RelationType> relationships() {
+    public final Stream<RelationType> relations() {
         ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                 .setRoleRelationsReq(ConceptProto.Role.Relations.Req.getDefaultInstance()).build();
         int iteratorId = runMethod(method).getRoleRelationsIter().getId();
-        return conceptStream(iteratorId, res -> res.getRoleRelationsIterRes().getRelationType()).map(Concept::asRelationshipType);
+        return conceptStream(iteratorId, res -> res.getRoleRelationsIterRes().getRelationType()).map(Concept::asRelationType);
     }
 
     @Override

--- a/client-java/concept/RemoteRule.java
+++ b/client-java/concept/RemoteRule.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Rule}
+ * Client implementation of Rule
  */
 public class RemoteRule extends RemoteSchemaConcept<Rule> implements Rule {
 

--- a/client-java/concept/RemoteSchemaConcept.java
+++ b/client-java/concept/RemoteSchemaConcept.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link SchemaConcept}
+ * Client implementation of SchemaConcept
  *
  * @param <SomeSchemaConcept> The exact type of this class
  */

--- a/client-java/concept/RemoteThing.java
+++ b/client-java/concept/RemoteThing.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Thing}
+ * Client implementation of Thing
  *
  * @param <SomeThing> The exact type of this class
  * @param <SomeType>  the type of an instance of this class

--- a/client-java/concept/RemoteThing.java
+++ b/client-java/concept/RemoteThing.java
@@ -84,7 +84,7 @@ abstract class RemoteThing<SomeThing extends Thing, SomeType extends Type> exten
     }
 
     @Override
-    public final Stream<Relation> relationships(Role... roles) {
+    public final Stream<Relation> relations(Role... roles) {
         ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                 .setThingRelationsReq(ConceptProto.Thing.Relations.Req.newBuilder()
                                               .addAllRoles(RequestBuilder.Concept.concepts(Arrays.asList(roles)))).build();
@@ -111,7 +111,7 @@ abstract class RemoteThing<SomeThing extends Thing, SomeType extends Type> exten
     @Override
     @Deprecated
     public final Relation relhas(Attribute attribute) {
-        // TODO: replace usage of this method as a getter, with relationships(Attribute attribute)
+        // TODO: replace usage of this method as a getter, with relations(Attribute attribute)
         // TODO: then remove this method altogether and just use has(Attribute attribute)
         ConceptProto.Method.Req method = ConceptProto.Method.Req.newBuilder()
                 .setThingRelhasReq(ConceptProto.Thing.Relhas.Req.newBuilder()

--- a/client-java/concept/RemoteType.java
+++ b/client-java/concept/RemoteType.java
@@ -33,7 +33,7 @@ import grakn.core.server.exception.TransactionException;
 import java.util.stream.Stream;
 
 /**
- * Client implementation of {@link Type}
+ * Client implementation of Type
  *
  * @param <SomeType>  The exact type of this class
  * @param <SomeThing> the exact type of instances of this class

--- a/client-java/concept/test/RemoteConceptIT.java
+++ b/client-java/concept/test/RemoteConceptIT.java
@@ -60,7 +60,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Integration Tests for testing methods of all subclasses of {@link grakn.core.client.concept.RemoteConcept}.
+ * Integration Tests for testing methods of all subclasses of grakn.core.client.concept.RemoteConcept.
  */
 public class RemoteConceptIT {
 

--- a/client-java/concept/test/RemoteConceptIT.java
+++ b/client-java/concept/test/RemoteConceptIT.java
@@ -80,7 +80,7 @@ public class RemoteConceptIT {
     private Label MAN = Label.of("man");
     private Label BOY = Label.of("boy");
 
-    // Relationship Type Labels
+    // Relation Type Labels
     private Label HUSBAND = Label.of("husband");
     private Label WIFE = Label.of("wife");
     private Label MARRIAGE = Label.of("marriage");
@@ -163,17 +163,17 @@ public class RemoteConceptIT {
         man = tx.putEntityType(MAN);
         boy = tx.putEntityType(BOY);
 
-        // Relationship Types
+        // Relation Types
         husband = tx.putRole(HUSBAND);
         wife = tx.putRole(WIFE);
-        marriage = tx.putRelationshipType(MARRIAGE).relates(wife).relates(husband);
+        marriage = tx.putRelationType(MARRIAGE).relates(wife).relates(husband);
 
         employer = tx.putRole(EMPLOYER);
         employee = tx.putRole(EMPLOYEE);
-        employment = tx.putRelationshipType(EMPLOYMENT).relates(employee).relates(employer);
+        employment = tx.putRelationType(EMPLOYMENT).relates(employee).relates(employer);
 
         friend = tx.putRole(FRIEND);
-        friendship = tx.putRelationshipType(FRIENDSHIP);
+        friendship = tx.putRelationType(FRIENDSHIP);
 
         person.plays(wife).plays(husband);
 
@@ -194,7 +194,7 @@ public class RemoteConceptIT {
         alice = person.create().has(emailAlice).has(nameAlice).has(age20);
         bob = person.create().has(emailBob).has(nameBob).has(age20);
 
-        // Relationships
+        // Relations
         aliceAndBob = marriage.create().assign(wife, alice).assign(husband, bob);
         selfEmployment = employment.create().assign(employer, alice).assign(employee, alice);
 
@@ -387,21 +387,21 @@ public class RemoteConceptIT {
     }
 
     @Test
-    public void whenCallingRelationshipsWithNoArguments_GetTheExpectedResult() {
-        assertThat(alice.relationships().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment));
-        assertThat(bob.relationships().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob));
+    public void whenCallingRelationsWithNoArguments_GetTheExpectedResult() {
+        assertThat(alice.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob, selfEmployment));
+        assertThat(bob.relations().filter(rel -> !rel.type().isImplicit()).collect(toSet()), containsInAnyOrder(aliceAndBob));
     }
 
     @Test
-    public void whenCallingRelationshipsWithRoles_GetTheExpectedResult() {
-        assertThat(alice.relationships(wife).collect(toSet()), containsInAnyOrder(aliceAndBob));
-        assertThat(bob.relationships(husband).collect(toSet()), containsInAnyOrder(aliceAndBob));
+    public void whenCallingRelationsWithRoles_GetTheExpectedResult() {
+        assertThat(alice.relations(wife).collect(toSet()), containsInAnyOrder(aliceAndBob));
+        assertThat(bob.relations(husband).collect(toSet()), containsInAnyOrder(aliceAndBob));
     }
 
     @Test
-    public void whenCallingRelationshipTypes_GetTheExpectedResult() {
-        assertThat(wife.relationships().collect(toSet()), containsInAnyOrder(marriage));
-        assertThat(husband.relationships().collect(toSet()), containsInAnyOrder(marriage));
+    public void whenCallingRelationTypes_GetTheExpectedResult() {
+        assertThat(wife.relations().collect(toSet()), containsInAnyOrder(marriage));
+        assertThat(husband.relations().collect(toSet()), containsInAnyOrder(marriage));
     }
 
     @Test
@@ -479,7 +479,7 @@ public class RemoteConceptIT {
     }
 
     @Test
-    public void whenSettingAndDeletingRelationshipRelatesRole_RoleInRelationshipIsSetAndDeleted() {
+    public void whenSettingAndDeletingRelationRelatesRole_RoleInRelationIsSetAndDeleted() {
         friendship.relates(friend);
         assertTrue(friendship.roles().anyMatch(c -> c.equals(friend)));
 
@@ -532,7 +532,7 @@ public class RemoteConceptIT {
     }
 
     @Test
-    public void whenCallingAddRelationship_TypeIsCorrect() {
+    public void whenCallingAddRelation_TypeIsCorrect() {
         Relation newMarriage = marriage.create();
         assertEquals(marriage, newMarriage.type());
     }
@@ -553,7 +553,7 @@ public class RemoteConceptIT {
     }
 
     @Test
-    public void whenCallingAddAttributeRelationshipOnThing_RelationshipIsImplicit() {
+    public void whenCallingAddAttributeRelationOnThing_RelationIsImplicit() {
         assertTrue(alice.relhas(emailAlice).type().isImplicit());
         assertTrue(alice.relhas(nameAlice).type().isImplicit());
         assertTrue(alice.relhas(age20).type().isImplicit());

--- a/client-java/rpc/RequestBuilder.java
+++ b/client-java/rpc/RequestBuilder.java
@@ -127,7 +127,7 @@ public class RequestBuilder {
             return SessionProto.Transaction.Req.newBuilder().setPutAttributeTypeReq(request).build();
         }
 
-        public static SessionProto.Transaction.Req putRelationshipType(Label label) {
+        public static SessionProto.Transaction.Req putRelationType(Label label) {
             SessionProto.Transaction.PutRelationType.Req request = SessionProto.Transaction.PutRelationType.Req.newBuilder()
                     .setLabel(label.getValue())
                     .build();
@@ -172,13 +172,13 @@ public class RequestBuilder {
         private static ConceptProto.Concept.BASE_TYPE getBaseType(grakn.core.graql.concept.Concept concept) {
             if (concept.isEntityType()) {
                 return ConceptProto.Concept.BASE_TYPE.ENTITY_TYPE;
-            } else if (concept.isRelationshipType()) {
+            } else if (concept.isRelationType()) {
                 return ConceptProto.Concept.BASE_TYPE.RELATION_TYPE;
             } else if (concept.isAttributeType()) {
                 return ConceptProto.Concept.BASE_TYPE.ATTRIBUTE_TYPE;
             } else if (concept.isEntity()) {
                 return ConceptProto.Concept.BASE_TYPE.ENTITY;
-            } else if (concept.isRelationship()) {
+            } else if (concept.isRelation()) {
                 return ConceptProto.Concept.BASE_TYPE.RELATION;
             } else if (concept.isAttribute()) {
                 return ConceptProto.Concept.BASE_TYPE.ATTRIBUTE;

--- a/client-java/rpc/ResponseReader.java
+++ b/client-java/rpc/ResponseReader.java
@@ -43,7 +43,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * An RPC Response reader class to convert {@link AnswerProto} messages into Graql {@link Answer}s.
+ * An RPC Response reader class to convert AnswerProto messages into Graql Answers.
  */
 public class ResponseReader {
 

--- a/client-java/rpc/Transceiver.java
+++ b/client-java/rpc/Transceiver.java
@@ -33,10 +33,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 
 /**
- * Wrapper making transaction calls to the Grakn RPC Server - handles sending a stream of {@link Transaction.Req} and
- * receiving a stream of {@link Transaction.Res}.
- * A request is sent with the {@link #send(Transaction.Req)}} method, and you can block for a response with the
- * {@link #receive()} method.
+ * Wrapper making transaction calls to the Grakn RPC Server - handles sending a stream of Transaction.Req and
+ * receiving a stream of Transaction.Res.
+ * A request is sent with the #send(Transaction.Req)} method, and you can block for a response with the
+ * #receive() method.
  * {@code
  * try (Transceiver tx = Transceiver.create(stub) {
  * tx.send(openMessage);
@@ -103,8 +103,8 @@ public class Transceiver implements AutoCloseable {
     }
 
     /**
-     * A {@link StreamObserver} that stores all responses in a blocking queue.
-         * A response can be polled with the {@link #poll()} method.
+     * A StreamObserver that stores all responses in a blocking queue.
+         * A response can be polled with the #poll() method.
      */
     private static class ResponseListener implements StreamObserver<Transaction.Res>, AutoCloseable {
 
@@ -160,8 +160,8 @@ public class Transceiver implements AutoCloseable {
     }
 
     /**
-     * A response from the gRPC server, that may be a successful response {@link #ok(Transaction.Res), an error
-     * {@link #error(StatusRuntimeException)}} or a "completed" message {@link #completed()}.
+     * A response from the gRPC server, that may be a successful response #ok(Transaction.Res), an error
+     * {#error(StatusRuntimeException)} or a "completed" message #completed().
      */
     public static class Response {
 
@@ -269,7 +269,7 @@ public class Transceiver implements AutoCloseable {
         }
 
         /**
-         * Enum indicating the type of {@link Response}.
+         * Enum indicating the type of Response.
          */
         public enum Type {
             OK, ERROR, COMPLETED

--- a/client-java/rpc/Transceiver.java
+++ b/client-java/rpc/Transceiver.java
@@ -35,10 +35,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Wrapper making transaction calls to the Grakn RPC Server - handles sending a stream of {@link Transaction.Req} and
  * receiving a stream of {@link Transaction.Res}.
- * <p>
  * A request is sent with the {@link #send(Transaction.Req)}} method, and you can block for a response with the
  * {@link #receive()} method.
- * <p>
  * {@code
  * try (Transceiver tx = Transceiver.create(stub) {
  * tx.send(openMessage);
@@ -66,8 +64,7 @@ public class Transceiver implements AutoCloseable {
 
     /**
      * Send a request and return immediately.
-     * <p>
-     * This method is non-blocking - it returns immediately.
+         * This method is non-blocking - it returns immediately.
      */
     public void send(Transaction.Req request) {
         if (responseListener.terminated.get()) {
@@ -107,8 +104,7 @@ public class Transceiver implements AutoCloseable {
 
     /**
      * A {@link StreamObserver} that stores all responses in a blocking queue.
-     * <p>
-     * A response can be polled with the {@link #poll()} method.
+         * A response can be polled with the {@link #poll()} method.
      */
     private static class ResponseListener implements StreamObserver<Transaction.Res>, AutoCloseable {
 

--- a/client-java/test/GraknClientIT.java
+++ b/client-java/test/GraknClientIT.java
@@ -217,8 +217,8 @@ public class GraknClientIT {
     }
 
     @Test
-    @Ignore // TODO: complete with richer relationship structures
-    public void testGetQueryForRelationship() {
+    @Ignore // TODO: complete with richer relation structures
+    public void testGetQueryForRelation() {
         try (GraknClient.Transaction tx = remoteSession.transaction(Transaction.Type.WRITE)) {
             List<ConceptMap> directorships = tx.execute(Graql.match(var("x").isa("directed-by")).get());
 
@@ -359,8 +359,8 @@ public class GraknClientIT {
                 assertEquals(localConcept.isAttributeType(), remoteConcept.isAttributeType());
                 assertEquals(localConcept.isEntity(), remoteConcept.isEntity());
                 assertEquals(localConcept.isEntityType(), remoteConcept.isEntityType());
-                assertEquals(localConcept.isRelationship(), remoteConcept.isRelationship());
-                assertEquals(localConcept.isRelationshipType(), remoteConcept.isRelationshipType());
+                assertEquals(localConcept.isRelation(), remoteConcept.isRelation());
+                assertEquals(localConcept.isRelationType(), remoteConcept.isRelationType());
                 assertEquals(localConcept.isRole(), remoteConcept.isRole());
                 assertEquals(localConcept.isRule(), remoteConcept.isRule());
                 assertEquals(localConcept.isSchemaConcept(), remoteConcept.isSchemaConcept());
@@ -380,7 +380,7 @@ public class GraknClientIT {
             AttributeType email = tx.putAttributeType("email", DataType.STRING);
             Role actor = tx.putRole("actor");
             Role characterBeingPlayed = tx.putRole("character-being-played");
-            RelationType hasCast = tx.putRelationshipType("has-cast").relates(actor).relates(characterBeingPlayed);
+            RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
             person.key(email).has(name);
             person.plays(actor).plays(characterBeingPlayed);
 
@@ -402,14 +402,14 @@ public class GraknClientIT {
 
 
     @Test
-    public void testGettingARelationship_TheInformationOnTheRelationshipIsCorrect() {
+    public void testGettingARelation_TheInformationOnTheRelationIsCorrect() {
         try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
             EntityType person = tx.putEntityType("person");
             AttributeType name = tx.putAttributeType("name", DataType.STRING);
             AttributeType email = tx.putAttributeType("email", DataType.STRING);
             Role actor = tx.putRole("actor");
             Role characterBeingPlayed = tx.putRole("character-being-played");
-            RelationType hasCast = tx.putRelationshipType("has-cast").relates(actor).relates(characterBeingPlayed);
+            RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
             person.key(email).has(name);
             person.plays(actor).plays(characterBeingPlayed);
 
@@ -477,7 +477,7 @@ public class GraknClientIT {
             AttributeType email = tx.putAttributeType("email", DataType.STRING);
             Role actor = tx.putRole("actor");
             Role characterBeingPlayed = tx.putRole("character-being-played");
-            RelationType hasCast = tx.putRelationshipType("has-cast").relates(actor).relates(characterBeingPlayed);
+            RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
             person.key(email).has(name);
             person.plays(actor).plays(characterBeingPlayed);
 
@@ -498,7 +498,7 @@ public class GraknClientIT {
             assertEqualConcepts(localConcept, remoteConcept, Thing::attributes);
             assertEqualConcepts(localConcept, remoteConcept, Thing::keys);
 //            assertEqualConcepts(localConcept, remoteConcept, Thing::plays); // TODO: re-enable when #19630 is fixed
-            assertEqualConcepts(localConcept, remoteConcept, Thing::relationships);
+            assertEqualConcepts(localConcept, remoteConcept, Thing::relations);
         }
     }
 
@@ -508,7 +508,7 @@ public class GraknClientIT {
             Role productionWithCast = tx.putRole("production-with-cast");
             Role actor = tx.putRole("actor");
             Role characterBeingPlayed = tx.putRole("character-being-played");
-            tx.putRelationshipType("has-cast").relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
+            tx.putRelationType("has-cast").relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
             EntityType person = tx.putEntityType("person").plays(actor).plays(characterBeingPlayed);
 
             person.has(tx.putAttributeType("gender", DataType.STRING));
@@ -539,7 +539,7 @@ public class GraknClientIT {
             Role productionWithCast = localTx.putRole("production-with-cast");
             Role actor = localTx.putRole("actor");
             Role characterBeingPlayed = localTx.putRole("character-being-played");
-            localTx.putRelationshipType("has-cast")
+            localTx.putRelationType("has-cast")
                     .relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
             localTx.commit();
         }
@@ -551,7 +551,7 @@ public class GraknClientIT {
             Role localConcept = localTx.getConcept(remoteConcept.id()).asRole();
 
             assertEqualConcepts(localConcept, remoteConcept, Role::players);
-            assertEqualConcepts(localConcept, remoteConcept, Role::relationships);
+            assertEqualConcepts(localConcept, remoteConcept, Role::relations);
         }
     }
 
@@ -601,12 +601,12 @@ public class GraknClientIT {
     }
 
     @Test
-    public void testGettingARelationshipType_TheInformationOnTheRelationshipTypeIsCorrect() {
+    public void testGettingARelationType_TheInformationOnTheRelationTypeIsCorrect() {
         try (Transaction localTx = localSession.transaction(Transaction.Type.WRITE)) {
             Role productionWithCast = localTx.putRole("production-with-cast");
             Role actor = localTx.putRole("actor");
             Role characterBeingPlayed = localTx.putRole("character-being-played");
-            localTx.putRelationshipType("has-cast")
+            localTx.putRelationType("has-cast")
                     .relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
             localTx.commit();
         }
@@ -614,8 +614,8 @@ public class GraknClientIT {
              Transaction localTx = localSession.transaction(Transaction.Type.READ)
         ) {
             GraqlGet query = Graql.match(var("x").type("has-cast")).get();
-            RelationType remoteConcept = remoteTx.stream(query).findAny().get().get("x").asRelationshipType();
-            RelationType localConcept = localTx.getConcept(remoteConcept.id()).asRelationshipType();
+            RelationType remoteConcept = remoteTx.stream(query).findAny().get().get("x").asRelationType();
+            RelationType localConcept = localTx.getConcept(remoteConcept.id()).asRelationType();
 
             assertEqualConcepts(localConcept, remoteConcept, RelationType::roles);
         }
@@ -698,7 +698,7 @@ public class GraknClientIT {
             Role owner = tx.putRole("owner");
             EntityType animal = tx.putEntityType("animal").plays(pet);
             EntityType human = tx.putEntityType("human").plays(owner);
-            RelationType petOwnership = tx.putRelationshipType("pet-ownership").relates(pet).relates(owner);
+            RelationType petOwnership = tx.putRelationType("pet-ownership").relates(pet).relates(owner);
             AttributeType<Long> age = tx.putAttributeType("age", DataType.LONG);
             human.has(age);
 
@@ -867,13 +867,13 @@ public class GraknClientIT {
             dog.isAbstract(true).isAbstract(false);
             cat.isAbstract(true);
 
-            RelationType chases = tx.putRelationshipType("chases");
+            RelationType chases = tx.putRelationType("chases");
             Role chased = tx.putRole("chased");
             Role chaser = tx.putRole("chaser");
             chases.relates(chased).relates(chaser);
 
             Role pointlessRole = tx.putRole("pointless-role");
-            tx.putRelationshipType("pointless").relates(pointlessRole);
+            tx.putRelationType("pointless").relates(pointlessRole);
 
             chases.relates(pointlessRole).unrelate(pointlessRole);
 
@@ -910,7 +910,7 @@ public class GraknClientIT {
             EntityType animal = tx.getEntityType("animal");
             EntityType dog = tx.getEntityType("dog");
             EntityType cat = tx.getEntityType("feline");
-            RelationType chases = tx.getRelationshipType("chases");
+            RelationType chases = tx.getRelationType("chases");
             Role chased = tx.getRole("chased");
             Role chaser = tx.getRole("chaser");
             AttributeType<String> name = tx.getAttributeType("name");

--- a/client-java/test/GraknClientTest.java
+++ b/client-java/test/GraknClientTest.java
@@ -283,7 +283,7 @@ public class GraknClientTest {
     }
 
     @Test
-    public void whenPuttingRelationshipType_EnsureCorrectRequestIsSent() {
+    public void whenPuttingRelationType_EnsureCorrectRequestIsSent() {
         ConceptId id = ConceptId.of(V123);
         Label label = Label.of("foo");
 
@@ -296,9 +296,9 @@ public class GraknClientTest {
             SessionProto.Transaction.Res response = SessionProto.Transaction.Res.newBuilder()
                     .setPutRelationTypeRes(SessionProto.Transaction.PutRelationType.Res.newBuilder()
                                                    .setRelationType(protoConcept)).build();
-            server.setResponse(RequestBuilder.Transaction.putRelationshipType(label), response);
+            server.setResponse(RequestBuilder.Transaction.putRelationType(label), response);
 
-            assertEquals(RemoteConcept.of(protoConcept, tx), tx.putRelationshipType(label));
+            assertEquals(RemoteConcept.of(protoConcept, tx), tx.putRelationType(label));
         }
     }
 

--- a/client-java/test/GraknClientTest.java
+++ b/client-java/test/GraknClientTest.java
@@ -73,7 +73,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 /**
- * Unit Tests for {@link GraknClient.Transaction}
+ * Unit Tests for GraknClient.Transaction
  */
 @SuppressWarnings("Duplicates")
 public class GraknClientTest {
@@ -85,7 +85,7 @@ public class GraknClientTest {
     private static final int ITERATOR = 100;
     @Rule
     public final ExpectedException exception = ExpectedException.none();
-    // The gRPC server itself is "real" and can be connected to using the {@link #channel()}
+    // The gRPC server itself is "real" and can be connected to using the #channel()
     @Rule
     public final GrpcServerRule serverRule = new GrpcServerRule().directExecutor();
     @Rule

--- a/client-java/test/GraknServerRPCMock.java
+++ b/client-java/test/GraknServerRPCMock.java
@@ -48,17 +48,11 @@ import static org.mockito.Mockito.mock;
 /**
  * Semi-mocked gRPC server that can handle transactions.
  *
- * <p>
  * The {@link #sessionService()} and {@link #requestListener()} are both mock objects and should be used with
  * {@link org.mockito.Mockito#verify(Object)}.
- * </p>
- * <p>
  * By default, the server will return a "done" {@link Transaction.Res} to every message. And will respond
  * with {@link StreamObserver#onCompleted()} when receiving a {@link StreamObserver#onCompleted()} from the client.
- * </p>
- * <p>
  * In order to mock additional responses, use the method {@link #setResponse(Transaction.Req, Transaction.Res...)}.
- * </p>
  */
 public final class GraknServerRPCMock extends ExternalResource {
 

--- a/client-java/test/GraknServerRPCMock.java
+++ b/client-java/test/GraknServerRPCMock.java
@@ -48,11 +48,11 @@ import static org.mockito.Mockito.mock;
 /**
  * Semi-mocked gRPC server that can handle transactions.
  *
- * The {@link #sessionService()} and {@link #requestListener()} are both mock objects and should be used with
- * {@link org.mockito.Mockito#verify(Object)}.
- * By default, the server will return a "done" {@link Transaction.Res} to every message. And will respond
- * with {@link StreamObserver#onCompleted()} when receiving a {@link StreamObserver#onCompleted()} from the client.
- * In order to mock additional responses, use the method {@link #setResponse(Transaction.Req, Transaction.Res...)}.
+ * The #sessionService() and #requestListener() are both mock objects and should be used with
+ * org.mockito.Mockito#verify(Object).
+ * By default, the server will return a "done" Transaction.Res to every message. And will respond
+ * with StreamObserver#onCompleted() when receiving a StreamObserver#onCompleted() from the client.
+ * In order to mock additional responses, use the method #setResponse(Transaction.Req, Transaction.Res...).
  */
 public final class GraknServerRPCMock extends ExternalResource {
 
@@ -194,14 +194,14 @@ public final class GraknServerRPCMock extends ExternalResource {
     }
 
     /**
-     * Contains a mutable map of iterators of {@link Transaction.Res}s for gRPC. These iterators are used for returning
+     * Contains a mutable map of iterators of Transaction.Ress for gRPC. These iterators are used for returning
      * lazy, streaming responses such as for Graql query results.
      */
     public class ServerIteratorsMock {
         private final Map<Integer, Iterator<Transaction.Res>> iterators = new ConcurrentHashMap<>();
 
         /**
-         * Return the next response from an iterator. {@link SessionProto.Transaction.Iter.Res} response will return
+         * Return the next response from an iterator. SessionProto.Transaction.Iter.Res response will return
          * done if the iterator is exhausted.
          */
         public Optional<Transaction.Res> next(int iteratorId) {

--- a/server/src/graql/concept/Attribute.java
+++ b/server/src/graql/concept/Attribute.java
@@ -86,7 +86,7 @@ public interface Attribute<D> extends Thing {
     /**
      * Creates a relation from this instance to the provided Attribute.
      *
-     * @param attribute The Attribute to which a relationship is created
+     * @param attribute The Attribute to which a relation is created
      * @return The instance itself
      */
     @Override

--- a/server/src/graql/concept/Attribute.java
+++ b/server/src/graql/concept/Attribute.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * Represent a literal Attribute in the graph.
  * Acts as an Thing when relating to other instances except it has the added functionality of:
  * 1. It is unique to its AttributeType based on it's value.
- * 2. It has an {@link AttributeType.DataType} associated with it which constrains the allowed values.
+ * 2. It has an AttributeType.DataType associated with it which constrains the allowed values.
  *
  * @param <D> The data type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
@@ -46,7 +46,7 @@ public interface Attribute<D> extends Thing {
     /**
      * Retrieves the type of the Attribute, that is, the AttributeType of which this resource is an Thing.
      *
-     * @return The {@link AttributeType of which this resource is an Thing.
+     * @return The AttributeType of which this resource is an Thing.
      */
     @Override
     AttributeType<D> type();

--- a/server/src/graql/concept/AttributeType.java
+++ b/server/src/graql/concept/AttributeType.java
@@ -197,7 +197,6 @@ public interface AttributeType<D> extends Type {
     /**
      * Retrieve the regular expression to which instances of this AttributeType must conform, or {@code null} if no
      * regular expression is set.
-     * <p>
      * By default, an AttributeType does not have a regular expression set.
      *
      * @return The regular expression to which instances of this AttributeType must conform.

--- a/server/src/graql/concept/Concept.java
+++ b/server/src/graql/concept/Concept.java
@@ -100,7 +100,7 @@ public interface Concept {
      * @return A RelationType if the Concept is a RelationType
      */
     @CheckReturnValue
-    default RelationType asRelationshipType() {
+    default RelationType asRelationType() {
         throw TransactionException.invalidCasting(this, RelationType.class);
     }
 
@@ -210,7 +210,7 @@ public interface Concept {
      * @return true if the Concept is a RelationType
      */
     @CheckReturnValue
-    default boolean isRelationshipType() {
+    default boolean isRelationType() {
         return false;
     }
 
@@ -250,7 +250,7 @@ public interface Concept {
      * @return true if the Concept is a Relation
      */
     @CheckReturnValue
-    default boolean isRelationship() {
+    default boolean isRelation() {
         return false;
     }
 

--- a/server/src/graql/concept/Entity.java
+++ b/server/src/graql/concept/Entity.java
@@ -39,7 +39,7 @@ public interface Entity extends Thing {
     /**
      * Creates a relation from this instance to the provided Attribute.
      *
-     * @param attribute The Attribute to which a relationship is created
+     * @param attribute The Attribute to which a relation is created
      * @return The instance itself
      */
     @Override

--- a/server/src/graql/concept/Relation.java
+++ b/server/src/graql/concept/Relation.java
@@ -109,7 +109,7 @@ public interface Relation extends Thing {
     @Deprecated
     @CheckReturnValue
     @Override
-    default boolean isRelationship() {
+    default boolean isRelation() {
         return true;
     }
 }

--- a/server/src/graql/concept/Relation.java
+++ b/server/src/graql/concept/Relation.java
@@ -24,10 +24,10 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * Encapsulates relationships between Thing
+ * Encapsulates relations between Thing
  * A relation which is an instance of a RelationType defines how instances may relate to one another.
  * It represents how different entities relate to one another.
- * Relation are used to model n-ary relationships between instances.
+ * Relation are used to model n-ary relations between instances.
  */
 public interface Relation extends Thing {
     //------------------------------------- Modifiers ----------------------------------
@@ -35,7 +35,7 @@ public interface Relation extends Thing {
     /**
      * Creates a relation from this instance to the provided Attribute.
      *
-     * @param attribute The Attribute to which a relationship is created
+     * @param attribute The Attribute to which a relation is created
      * @return The instance itself
      */
     @Override

--- a/server/src/graql/concept/RelationType.java
+++ b/server/src/graql/concept/RelationType.java
@@ -190,14 +190,14 @@ public interface RelationType extends Type {
     @Deprecated
     @CheckReturnValue
     @Override
-    default RelationType asRelationshipType() {
+    default RelationType asRelationType() {
         return this;
     }
 
     @Deprecated
     @CheckReturnValue
     @Override
-    default boolean isRelationshipType() {
+    default boolean isRelationType() {
         return true;
     }
 }

--- a/server/src/graql/concept/RelationType.java
+++ b/server/src/graql/concept/RelationType.java
@@ -88,7 +88,7 @@ public interface RelationType extends Type {
     /**
      * Sets a new Role for this RelationType.
      *
-     * @param role A new role which is part of this relationship.
+     * @param role A new role which is part of this relation.
      * @return The RelationType itself.
      * @see Role
      */

--- a/server/src/graql/concept/Role.java
+++ b/server/src/graql/concept/Role.java
@@ -78,7 +78,7 @@ public interface Role extends SchemaConcept {
      * @see RelationType
      */
     @CheckReturnValue
-    Stream<RelationType> relationships();
+    Stream<RelationType> relations();
 
     /**
      * Returns a collection of the Types that can play this Role.

--- a/server/src/graql/concept/SchemaConcept.java
+++ b/server/src/graql/concept/SchemaConcept.java
@@ -77,7 +77,6 @@ public interface SchemaConcept extends Concept {
 
     /**
      * Get all indirect subs of this concept.
-     * <p>
      * The indirect subs are the concept itself and all indirect subs of direct subs.
      *
      * @return All the indirect sub-types of this SchemaConcept
@@ -87,7 +86,6 @@ public interface SchemaConcept extends Concept {
 
     /**
      * Return whether the SchemaConcept was created implicitly.
-     * <p>
      * By default, SchemaConcept are not implicit.
      *
      * @return returns true if the type was created implicitly through the Attribute syntax

--- a/server/src/graql/concept/SchemaConcept.java
+++ b/server/src/graql/concept/SchemaConcept.java
@@ -68,9 +68,9 @@ public interface SchemaConcept extends Concept {
     SchemaConcept sup();
 
     /**
-     * @return All super-concepts of this {@link SchemaConcept } including itself and excluding the meta
-     * {@link Schema.MetaSchema#THING}.
-     * If you want to include {@link Schema.MetaSchema#THING}, use Transaction.sups().
+     * @return All super-concepts of this SchemaConcept  including itself and excluding the meta
+     * Schema.MetaSchema#THING.
+     * If you want to include Schema.MetaSchema#THING, use Transaction.sups().
      * @see Schema.MetaSchema#THING
      */
     Stream<? extends SchemaConcept> sups();

--- a/server/src/graql/concept/Thing.java
+++ b/server/src/graql/concept/Thing.java
@@ -61,7 +61,7 @@ public interface Thing extends Concept {
 
     /**
      * Creates a Relation from this Thing to the provided Attribute.
-     * This has the same effect as {@link #relhas(Attribute)}, but returns the instance itself to allow
+     * This has the same effect as #relhas(Attribute), but returns the instance itself to allow
      * method chaining.
      *
      * @param attribute The Attribute to which a Relation is created
@@ -71,7 +71,7 @@ public interface Thing extends Concept {
 
     /**
      * Creates a Relation from this instance to the provided Attribute.
-     * This has the same effect as {@link #has(Attribute)}, but returns the new Relation.
+     * This has the same effect as #has(Attribute), but returns the new Relation.
      *
      * @param attribute The Attribute to which a Relation is created
      * @return The Relation connecting the Thing and the Attribute

--- a/server/src/graql/concept/Thing.java
+++ b/server/src/graql/concept/Thing.java
@@ -48,7 +48,7 @@ public interface Thing extends Concept {
      * @see Relation
      */
     @CheckReturnValue
-    Stream<Relation> relationships(Role... roles);
+    Stream<Relation> relations(Role... roles);
 
     /**
      * Determine the Roles that this Thing is currently playing.

--- a/server/src/graql/concept/Thing.java
+++ b/server/src/graql/concept/Thing.java
@@ -61,10 +61,8 @@ public interface Thing extends Concept {
 
     /**
      * Creates a Relation from this Thing to the provided Attribute.
-     * <p>
      * This has the same effect as {@link #relhas(Attribute)}, but returns the instance itself to allow
      * method chaining.
-     * </p>
      *
      * @param attribute The Attribute to which a Relation is created
      * @return The instance itself
@@ -73,9 +71,7 @@ public interface Thing extends Concept {
 
     /**
      * Creates a Relation from this instance to the provided Attribute.
-     * <p>
      * This has the same effect as {@link #has(Attribute)}, but returns the new Relation.
-     * </p>
      *
      * @param attribute The Attribute to which a Relation is created
      * @return The Relation connecting the Thing and the Attribute

--- a/server/src/graql/internal/executor/ComputeExecutor.java
+++ b/server/src/graql/internal/executor/ComputeExecutor.java
@@ -436,7 +436,7 @@ class ComputeExecutor {
                         Label typeLabel = Label.of(t);
                         Type type = tx.getSchemaConcept(typeLabel);
                         if (type == null) throw GraqlQueryException.labelNotFound(typeLabel);
-                        if (type.isRelationshipType()) throw GraqlQueryException.kCoreOnRelationshipType(typeLabel);
+                        if (type.isRelationType()) throw GraqlQueryException.kCoreOnRelationshipType(typeLabel);
                         return type.subs();
                     })
                     .map(SchemaConcept::label)
@@ -626,8 +626,8 @@ class ComputeExecutor {
      */
     private Set<Label> scopeTypeLabelsImplicitPlayers(GraqlCompute query) {
         return scopeTypes(query)
-                .filter(Concept::isRelationshipType)
-                .map(Concept::asRelationshipType)
+                .filter(Concept::isRelationType)
+                .map(Concept::asRelationType)
                 .filter(RelationType::isImplicit)
                 .flatMap(RelationType::roles)
                 .flatMap(Role::players)

--- a/server/src/graql/internal/executor/ConceptBuilder.java
+++ b/server/src/graql/internal/executor/ConceptBuilder.java
@@ -392,8 +392,8 @@ public class ConceptBuilder {
 
         if (type.isEntityType()) {
             return type.asEntityType().create();
-        } else if (type.isRelationshipType()) {
-            return type.asRelationshipType().create();
+        } else if (type.isRelationType()) {
+            return type.asRelationType().create();
         } else if (type.isAttributeType()) {
             return type.asAttributeType().create(use(VALUE));
         } else if (type.label().equals(Schema.MetaSchema.THING.getLabel())) {
@@ -411,8 +411,8 @@ public class ConceptBuilder {
 
         if (superConcept.isEntityType()) {
             concept = executor.tx().putEntityType(label);
-        } else if (superConcept.isRelationshipType()) {
-            concept = executor.tx().putRelationshipType(label);
+        } else if (superConcept.isRelationType()) {
+            concept = executor.tx().putRelationType(label);
         } else if (superConcept.isRole()) {
             concept = executor.tx().putRole(label);
         } else if (superConcept.isAttributeType()) {
@@ -438,8 +438,8 @@ public class ConceptBuilder {
     public static void setSuper(SchemaConcept subConcept, SchemaConcept superConcept) {
         if (superConcept.isEntityType()) {
             subConcept.asEntityType().sup(superConcept.asEntityType());
-        } else if (superConcept.isRelationshipType()) {
-            subConcept.asRelationshipType().sup(superConcept.asRelationshipType());
+        } else if (superConcept.isRelationType()) {
+            subConcept.asRelationType().sup(superConcept.asRelationType());
         } else if (superConcept.isRole()) {
             subConcept.asRole().sup(superConcept.asRole());
         } else if (superConcept.isAttributeType()) {

--- a/server/src/graql/internal/executor/QueryExecutor.java
+++ b/server/src/graql/internal/executor/QueryExecutor.java
@@ -409,7 +409,7 @@ public class QueryExecutor {
         maybeLabel.ifPresent(label -> {
             SchemaConcept schemaConcept = transaction.getSchemaConcept(label);
 
-            if (schemaConcept == null || !schemaConcept.isRelationshipType()) {
+            if (schemaConcept == null || !schemaConcept.isRelationType()) {
                 throw GraqlQueryException.notARelationType(label);
             }
         });

--- a/server/src/graql/internal/executor/property/RelatesExecutor.java
+++ b/server/src/graql/internal/executor/property/RelatesExecutor.java
@@ -117,7 +117,7 @@ public class RelatesExecutor implements PropertyExecutor.Definable {
         @Override
         public void execute(WriteExecutor executor) {
             Role role = executor.getConcept(property.role().var()).asRole();
-            executor.getConcept(var).asRelationshipType().relates(role);
+            executor.getConcept(var).asRelationType().relates(role);
         }
     }
 
@@ -176,7 +176,7 @@ public class RelatesExecutor implements PropertyExecutor.Definable {
 
         @Override
         public void execute(WriteExecutor executor) {
-            RelationType relationshipType = executor.getConcept(var).asRelationshipType();
+            RelationType relationshipType = executor.getConcept(var).asRelationType();
             Role role = executor.getConcept(property.role().var()).asRole();
 
             if (!relationshipType.isDeleted() && !role.isDeleted()) {

--- a/server/src/graql/internal/gremlin/GreedyTraversalPlan.java
+++ b/server/src/graql/internal/gremlin/GreedyTraversalPlan.java
@@ -316,7 +316,7 @@ public class GreedyTraversalPlan {
     }
 
     private static void addAllPossibleRelationships(Multimap<Type, RelationType> relationshipMap, Type metaType) {
-        metaType.subs().forEach(type -> type.playing().flatMap(Role::relationships)
+        metaType.subs().forEach(type -> type.playing().flatMap(Role::relations)
                 .forEach(relationshipType -> relationshipMap.put(type, relationshipType)));
     }
 

--- a/server/src/graql/internal/gremlin/sets/IsaFragmentSet.java
+++ b/server/src/graql/internal/gremlin/sets/IsaFragmentSet.java
@@ -85,6 +85,6 @@ abstract class IsaFragmentSet extends EquivalentFragmentSet {
     };
 
     private static boolean mayHaveEdgeInstances(SchemaConcept concept) {
-        return concept.isRelationshipType() && concept.isImplicit();
+        return concept.isRelationType() && concept.isImplicit();
     }
 }

--- a/server/src/graql/internal/gremlin/sets/RolePlayerFragmentSet.java
+++ b/server/src/graql/internal/gremlin/sets/RolePlayerFragmentSet.java
@@ -150,8 +150,8 @@ abstract class RolePlayerFragmentSet extends EquivalentFragmentSet {
             Set<RelationType> relTypes = relLabels.stream()
                     .map(tx::<SchemaConcept>getSchemaConcept)
                     .filter(Objects::nonNull)
-                    .filter(Concept::isRelationshipType)
-                    .map(Concept::asRelationshipType)
+                    .filter(Concept::isRelationType)
+                    .map(Concept::asRelationType)
                     .collect(toSet());
 
             Set<Role> roles = roleLabels.stream()
@@ -215,7 +215,7 @@ abstract class RolePlayerFragmentSet extends EquivalentFragmentSet {
             Stream<SchemaConcept> concepts =
                     relationLabel.labels().stream().map(graph::<SchemaConcept>getSchemaConcept);
 
-            if (concepts.allMatch(schemaConcept -> schemaConcept != null && schemaConcept.isRelationshipType())) {
+            if (concepts.allMatch(schemaConcept -> schemaConcept != null && schemaConcept.isRelationType())) {
                 fragmentSets.remove(rolePlayer);
                 fragmentSets.add(rolePlayer.addRelationshipTypeLabels(relationLabel.labels()));
 

--- a/server/src/graql/internal/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/AttributeAtom.java
@@ -312,7 +312,7 @@ public abstract class AttributeAtom extends Binary{
         if (owner.asThing().attributes(attribute.type()).noneMatch(a -> a.equals(attribute))) {
             if (owner.isEntity()) {
                 EntityImpl.from(owner.asEntity()).attributeInferred(attribute);
-            } else if (owner.isRelationship()) {
+            } else if (owner.isRelation()) {
                 RelationImpl.from(owner.asRelation()).attributeInferred(attribute);
             } else if (owner.isAttribute()) {
                 AttributeImpl.from(owner.asAttribute()).attributeInferred(attribute);

--- a/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/RelationshipAtom.java
@@ -419,7 +419,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
     public Set<String> validateOntologically() {
         Set<String> errors = new HashSet<>();
         SchemaConcept type = getSchemaConcept();
-        if (type != null && !type.isRelationshipType()){
+        if (type != null && !type.isRelationType()){
             errors.add(ErrorMessage.VALIDATION_RULE_INVALID_RELATION_TYPE.getMessage(type.label()));
             return errors;
         }
@@ -430,7 +430,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
             Role role = e.getKey();
             if (!Schema.MetaSchema.isMetaLabel(role.label())) {
                 //check whether this role can be played in this relation
-                if (type != null && type.asRelationshipType().roles().noneMatch(r -> r.equals(role))) {
+                if (type != null && type.asRelationType().roles().noneMatch(r -> r.equals(role))) {
                     errors.add(ErrorMessage.VALIDATION_RULE_ROLE_CANNOT_BE_PLAYED.getMessage(role.label(), type.label()));
                 }
 
@@ -739,7 +739,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         Transaction graph = getParentQuery().tx();
         Role metaRole = graph.getMetaRole();
         List<RelationProperty.RolePlayer> allocatedRelationPlayers = new ArrayList<>();
-        RelationType relType = getSchemaConcept() != null? getSchemaConcept().asRelationshipType() : null;
+        RelationType relType = getSchemaConcept() != null? getSchemaConcept().asRelationType() : null;
 
         //explicit role types from castings
         List<RelationProperty.RolePlayer> inferredRelationPlayers = new ArrayList<>();
@@ -762,8 +762,8 @@ public abstract class RelationshipAtom extends IsaAtomBase {
         Set<Role> possibleRoles = relType != null?
                 relType.roles().collect(toSet()) :
                 inferPossibleTypes(sub).stream()
-                        .filter(Concept::isRelationshipType)
-                        .map(Concept::asRelationshipType)
+                        .filter(Concept::isRelationType)
+                        .map(Concept::asRelationType)
                         .flatMap(RelationType::roles).collect(toSet());
 
         //possible role types for each casting based on its type
@@ -1044,7 +1044,7 @@ public abstract class RelationshipAtom extends IsaAtomBase {
 
     @Override
     public Stream<ConceptMap> materialise(){
-        RelationType relationType = getSchemaConcept().asRelationshipType();
+        RelationType relationType = getSchemaConcept().asRelationType();
         Multimap<Role, Variable> roleVarMap = getRoleVarMap();
         ConceptMap substitution = getParentQuery().getSubstitution();
 

--- a/server/src/graql/internal/reasoner/atom/binary/TypeAtom.java
+++ b/server/src/graql/internal/reasoner/atom/binary/TypeAtom.java
@@ -65,7 +65,7 @@ public abstract class TypeAtom extends Binary{
 
     @Override
     public boolean requiresMaterialisation() {
-        return isUserDefined() && getSchemaConcept() != null && getSchemaConcept().isRelationshipType();
+        return isUserDefined() && getSchemaConcept() != null && getSchemaConcept().isRelationType();
     }
 
     /**

--- a/server/src/graql/internal/reasoner/cache/SemanticDifference.java
+++ b/server/src/graql/internal/reasoner/cache/SemanticDifference.java
@@ -75,7 +75,7 @@ public class SemanticDifference {
         if (!answer.containsVar(var)) return new HashSet<>();
         Set<Role> roleAndTheirSubs = roles.stream().flatMap(Role::subs).collect(Collectors.toSet());
         return answer.get(var).asThing()
-                .relationships(roleAndTheirSubs.toArray(new Role[0]))
+                .relations(roleAndTheirSubs.toArray(new Role[0]))
                 .collect(Collectors.toSet());
     }
 

--- a/server/src/graql/internal/reasoner/rule/InferenceRule.java
+++ b/server/src/graql/internal/reasoner/rule/InferenceRule.java
@@ -288,7 +288,7 @@ public class InferenceRule {
     public boolean appendsRolePlayers(){
         Atom headAtom = getHead().getAtom();
         SchemaConcept headType = headAtom.getSchemaConcept();
-        if (headType.isRelationshipType()
+        if (headType.isRelationType()
                 && headAtom.getVarName().isUserDefinedName()) {
             RelationshipAtom bodyAtom = getBody().getAtoms(RelationshipAtom.class)
                     .filter(at -> Objects.nonNull(at.getSchemaConcept()))

--- a/server/src/graql/internal/reasoner/utils/conversion/SchemaConceptConverter.java
+++ b/server/src/graql/internal/reasoner/utils/conversion/SchemaConceptConverter.java
@@ -45,7 +45,7 @@ public interface SchemaConceptConverter<T extends SchemaConcept>{
         Multimap<RelationType, Role> relationMap = HashMultimap.create();
 
         toCompatibleRoles(entryConcept)
-                .forEach(role -> role.relationships()
+                .forEach(role -> role.relations()
                         .forEach(rel -> relationMap.put(rel, role)));
         return relationMap;
     }

--- a/server/src/graql/printer/StringPrinter.java
+++ b/server/src/graql/printer/StringPrinter.java
@@ -110,7 +110,7 @@ public class StringPrinter extends Printer<StringBuilder> {
                     .append(conceptId(concept.id()));
         }
 
-        if (concept.isRelationship()) {
+        if (concept.isRelation()) {
             List<String> rolePlayerList = new LinkedList<>();
             for (Map.Entry<Role, Set<Thing>> rolePlayers : concept.asRelation().rolePlayersMap().entrySet()) {
                 Role role = rolePlayers.getKey();

--- a/server/src/server/Session.java
+++ b/server/src/server/Session.java
@@ -32,7 +32,7 @@ public interface Session extends AutoCloseable {
     /**
      * Gets a new transaction bound to the keyspace of this Session.
      *
-     * @param transactionType The type of transaction to open see {@link Transaction.Type} for more details
+     * @param transactionType The type of transaction to open see Transaction.Type for more details
      * @return A new Grakn graph transaction
      * @see Transaction
      */
@@ -41,14 +41,13 @@ public interface Session extends AutoCloseable {
 
     /**
      * Closes the main connection to the graph. This should be done at the end of using the graph.
-     *
      */
     void close();
 
     /**
-     * Use to determine which {@link Keyspace} this {@link Session} is interacting with.
+     * Use to determine which Keyspace this Session is interacting with.
      *
-     * @return The {@link Keyspace} of the knowledge base this {@link Session} is interacting with.
+     * @return The Keyspace of the knowledge base this Session is interacting with.
      */
     Keyspace keyspace();
 }

--- a/server/src/server/Transaction.java
+++ b/server/src/server/Transaction.java
@@ -64,8 +64,8 @@ public interface Transaction extends AutoCloseable {
 
     /**
      * An enum that determines the type of Grakn Transaction.
-     * This class is used to describe how a transaction on {@link Transaction} should behave.
-     * When producing a graph using a {@link Session} one of the following enums must be provided:
+     * This class is used to describe how a transaction on Transaction should behave.
+     * When producing a graph using a Session one of the following enums must be provided:
      * READ - A read only transaction. If you attempt to mutate the graph with such a transaction an exception will be thrown.
      * WRITE - A transaction which allows you to mutate the graph.
      * BATCH - A transaction which allows mutations to be performed more quickly but disables some consistency checks.
@@ -336,7 +336,7 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Get the root of all {@link RelationType}.
+     * Get the root of all RelationType.
      *
      * @return The meta relation type -> relation-type.
      */
@@ -346,7 +346,7 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Get the root of all the {@link Role}.
+     * Get the root of all the Role.
      *
      * @return The meta role type -> role-type.
      */
@@ -356,7 +356,7 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Get the root of all the {@link AttributeType}.
+     * Get the root of all the AttributeType.
      *
      * @return The meta resource type -> resource-type.
      */
@@ -376,9 +376,9 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Get the root of all {@link Rule}s;
+     * Get the root of all Rules;
      *
-     * @return The meta {@link Rule}
+     * @return The meta Rule
      */
     @CheckReturnValue
     default Rule getMetaRule() {
@@ -388,13 +388,11 @@ public interface Transaction extends AutoCloseable {
     //------------------------------------- Admin Specific Operations ----------------------------------
 
     /**
-     * Get all super-concepts of the given {@link SchemaConcept} including itself and including the meta-type
-     * {@link Schema.MetaSchema#THING}.
-     *
+     * Get all super-concepts of the given SchemaConcept including itself and including the meta-type
+     * Schema.MetaSchema#THING.
      * <p>
-     * If you want a more precise type that will exclude {@link Schema.MetaSchema#THING}, use
-     * {@link SchemaConcept#sups()}.
-     * </p>
+     * If you want a more precise type that will exclude Schema.MetaSchema#THING, use
+     * SchemaConcept#sups().
      */
     @CheckReturnValue
     Stream<SchemaConcept> sups(SchemaConcept schemaConcept);
@@ -402,42 +400,42 @@ public interface Transaction extends AutoCloseable {
     //------------------------------------- Concept Construction ----------------------------------
 
     /**
-     * Create a new {@link EntityType} with super-type {@code entity}, or return a pre-existing {@link EntityType},
+     * Create a new EntityType with super-type {@code entity}, or return a pre-existing EntityType,
      * with the specified label.
      *
-     * @param label A unique label for the {@link EntityType}
-     * @return A new or existing {@link EntityType} with the provided label
+     * @param label A unique label for the EntityType
+     * @return A new or existing EntityType with the provided label
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link EntityType}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-EntityType.
      */
     default EntityType putEntityType(String label) {
         return putEntityType(Label.of(label));
     }
 
     /**
-     * Create a new {@link EntityType} with super-type {@code entity}, or return a pre-existing {@link EntityType},
+     * Create a new EntityType with super-type {@code entity}, or return a pre-existing EntityType,
      * with the specified label.
      *
-     * @param label A unique label for the {@link EntityType}
-     * @return A new or existing {@link EntityType} with the provided label
+     * @param label A unique label for the EntityType
+     * @return A new or existing EntityType with the provided label
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link EntityType}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-EntityType.
      */
     EntityType putEntityType(Label label);
 
     /**
-     * Create a new non-unique {@link AttributeType} with super-type {@code resource}, or return a pre-existing
-     * non-unique {@link AttributeType}, with the specified label and data type.
+     * Create a new non-unique AttributeType with super-type {@code resource}, or return a pre-existing
+     * non-unique AttributeType, with the specified label and data type.
      *
-     * @param label    A unique label for the {@link AttributeType}
-     * @param dataType The data type of the {@link AttributeType}.
+     * @param label    A unique label for the AttributeType
+     * @param dataType The data type of the AttributeType.
      *                 Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
      * @param <V>      The data type of the resource type. Supported types include: String, Long, Double, Boolean.
      *                 This should match the parameter type
-     * @return A new or existing {@link AttributeType} with the provided label and data type.
+     * @return A new or existing AttributeType with the provided label and data type.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link AttributeType}.
-     * @throws TransactionException       if the {@param label} is already in use by an existing {@link AttributeType} which is
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
+     * @throws TransactionException       if the {@param label} is already in use by an existing AttributeType which is
      *                                    unique or has a different datatype.
      */
     default <V> AttributeType<V> putAttributeType(String label, AttributeType.DataType<V> dataType) {
@@ -445,140 +443,140 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Create a new non-unique {@link AttributeType} with super-type {@code resource}, or return a pre-existing
-     * non-unique {@link AttributeType}, with the specified label and data type.
+     * Create a new non-unique AttributeType with super-type {@code resource}, or return a pre-existing
+     * non-unique AttributeType, with the specified label and data type.
      *
-     * @param label    A unique label for the {@link AttributeType}
-     * @param dataType The data type of the {@link AttributeType}.
+     * @param label    A unique label for the AttributeType
+     * @param dataType The data type of the AttributeType.
      *                 Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
      * @param <V>      The data type of the resource type. Supported types include: String, Long, Double, Boolean.
      *                 This should match the parameter type
-     * @return A new or existing {@link AttributeType} with the provided label and data type.
+     * @return A new or existing AttributeType with the provided label and data type.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link AttributeType}.
-     * @throws TransactionException       if the {@param label} is already in use by an existing {@link AttributeType} which is
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
+     * @throws TransactionException       if the {@param label} is already in use by an existing AttributeType which is
      *                                    unique or has a different datatype.
      */
     <V> AttributeType<V> putAttributeType(Label label, AttributeType.DataType<V> dataType);
 
     /**
-     * Create a {@link Rule} with super-type {@code rule}, or return a pre-existing {@link Rule}, with the
+     * Create a Rule with super-type {@code rule}, or return a pre-existing Rule, with the
      * specified label.
      *
-     * @param label A unique label for the {@link Rule}
-     * @param when  A string representing the when part of the {@link Rule}
-     * @param then  A string representing the then part of the {@link Rule}
-     * @return new or existing {@link Rule} with the provided label.
+     * @param label A unique label for the Rule
+     * @param when  A string representing the when part of the Rule
+     * @param then  A string representing the then part of the Rule
+     * @return new or existing Rule with the provided label.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link Rule}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-Rule.
      */
     default Rule putRule(String label, Pattern when, Pattern then) {
         return putRule(Label.of(label), when, then);
     }
 
     /**
-     * Create a {@link Rule} with super-type {@code rule}, or return a pre-existing {@link Rule}, with the
+     * Create a Rule with super-type {@code rule}, or return a pre-existing Rule, with the
      * specified label.
      *
-     * @param label A unique label for the {@link Rule}
-     * @return new or existing {@link Rule} with the provided label.
+     * @param label A unique label for the Rule
+     * @return new or existing Rule with the provided label.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link Rule}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-Rule.
      */
     Rule putRule(Label label, Pattern when, Pattern then);
 
     /**
-     * Create a {@link RelationType} with super-type {@code relation}, or return a pre-existing {@link RelationType},
+     * Create a RelationType with super-type {@code relation}, or return a pre-existing RelationType,
      * with the specified label.
      *
-     * @param label A unique label for the {@link RelationType}
-     * @return A new or existing {@link RelationType} with the provided label.
+     * @param label A unique label for the RelationType
+     * @return A new or existing RelationType with the provided label.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link RelationType}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-RelationType.
      */
     default RelationType putRelationType(String label) {
         return putRelationType(Label.of(label));
     }
 
     /**
-     * Create a {@link RelationType} with super-type {@code relation}, or return a pre-existing {@link RelationType},
+     * Create a RelationType with super-type {@code relation}, or return a pre-existing RelationType,
      * with the specified label.
      *
-     * @param label A unique label for the {@link RelationType}
-     * @return A new or existing {@link RelationType} with the provided label.
+     * @param label A unique label for the RelationType
+     * @return A new or existing RelationType with the provided label.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link RelationType}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-RelationType.
      */
     RelationType putRelationType(Label label);
 
     /**
-     * Create a {@link Role} with super-type {@code role}, or return a pre-existing {@link Role}, with the
+     * Create a Role with super-type {@code role}, or return a pre-existing Role, with the
      * specified label.
      *
-     * @param label A unique label for the {@link Role}
-     * @return new or existing {@link Role} with the provided Id.
+     * @param label A unique label for the Role
+     * @return new or existing Role with the provided Id.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link Role}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-Role.
      */
     default Role putRole(String label) {
         return putRole(Label.of(label));
     }
 
     /**
-     * Create a {@link Role} with super-type {@code role}, or return a pre-existing {@link Role}, with the
+     * Create a Role with super-type {@code role}, or return a pre-existing Role, with the
      * specified label.
      *
-     * @param label A unique label for the {@link Role}
-     * @return new or existing {@link Role} with the provided Id.
+     * @param label A unique label for the Role
+     * @return new or existing Role with the provided Id.
      * @throws TransactionException       if the graph is closed
-     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link Role}.
+     * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-Role.
      */
     Role putRole(Label label);
 
     //------------------------------------- Concept Lookup ----------------------------------
 
     /**
-     * Get the {@link Concept} with identifier provided, if it exists.
+     * Get the Concept with identifier provided, if it exists.
      *
-     * @param id A unique identifier for the {@link Concept} in the graph.
-     * @return The {@link Concept} with the provided id or null if no such {@link Concept} exists.
+     * @param id A unique identifier for the Concept in the graph.
+     * @return The Concept with the provided id or null if no such Concept exists.
      * @throws TransactionException if the graph is closed
-     * @throws ClassCastException   if the concept is not an instance of {@link T}
+     * @throws ClassCastException   if the concept is not an instance of T
      */
     @CheckReturnValue
     @Nullable
     <T extends Concept> T getConcept(ConceptId id);
 
     /**
-     * Get the {@link SchemaConcept} with the label provided, if it exists.
+     * Get the SchemaConcept with the label provided, if it exists.
      *
-     * @param label A unique label which identifies the {@link SchemaConcept} in the graph.
-     * @return The {@link SchemaConcept} with the provided label or null if no such {@link SchemaConcept} exists.
+     * @param label A unique label which identifies the SchemaConcept in the graph.
+     * @return The SchemaConcept with the provided label or null if no such SchemaConcept exists.
      * @throws TransactionException if the graph is closed
-     * @throws ClassCastException   if the type is not an instance of {@link T}
+     * @throws ClassCastException   if the type is not an instance of T
      */
     @CheckReturnValue
     @Nullable
     <T extends SchemaConcept> T getSchemaConcept(Label label);
 
     /**
-     * Get the {@link grakn.core.graql.concept.Type} with the label provided, if it exists.
+     * Get the grakn.core.graql.concept.Type with the label provided, if it exists.
      *
-     * @param label A unique label which identifies the {@link grakn.core.graql.concept.Type} in the graph.
-     * @return The {@link grakn.core.graql.concept.Type} with the provided label or null if no such {@link grakn.core.graql.concept.Type} exists.
+     * @param label A unique label which identifies the grakn.core.graql.concept.Type in the graph.
+     * @return The grakn.core.graql.concept.Type with the provided label or null if no such grakn.core.graql.concept.Type exists.
      * @throws TransactionException if the graph is closed
-     * @throws ClassCastException   if the type is not an instance of {@link T}
+     * @throws ClassCastException   if the type is not an instance of T
      */
     @CheckReturnValue
     @Nullable
     <T extends grakn.core.graql.concept.Type> T getType(Label label);
 
     /**
-     * Get all {@link Attribute} holding the value provided, if they exist.
+     * Get all Attribute holding the value provided, if they exist.
      *
-     * @param value A value which an {@link Attribute} in the graph may be holding.
+     * @param value A value which an Attribute in the graph may be holding.
      * @param <V>   The data type of the value. Supported types include: String, Long, Double, and Boolean.
-     * @return The {@link Attribute}s holding the provided value or an empty collection if no such {@link Attribute} exists.
+     * @return The Attributes holding the provided value or an empty collection if no such Attribute exists.
      * @throws TransactionException if the graph is closed
      */
     @CheckReturnValue
@@ -596,10 +594,10 @@ public interface Transaction extends AutoCloseable {
     EntityType getEntityType(String label);
 
     /**
-     * Get the {@link RelationType} with the label provided, if it exists.
+     * Get the RelationType with the label provided, if it exists.
      *
-     * @param label A unique label which identifies the {@link RelationType} in the graph.
-     * @return The {@link RelationType} with the provided label or null if no such {@link RelationType} exists.
+     * @param label A unique label which identifies the RelationType in the graph.
+     * @return The RelationType with the provided label or null if no such RelationType exists.
      * @throws TransactionException if the graph is closed
      */
     @CheckReturnValue
@@ -607,11 +605,11 @@ public interface Transaction extends AutoCloseable {
     RelationType getRelationType(String label);
 
     /**
-     * Get the {@link AttributeType} with the label provided, if it exists.
+     * Get the AttributeType with the label provided, if it exists.
      *
-     * @param label A unique label which identifies the {@link AttributeType} in the graph.
+     * @param label A unique label which identifies the AttributeType in the graph.
      * @param <V>   The data type of the value. Supported types include: String, Long, Double, and Boolean.
-     * @return The {@link AttributeType} with the provided label or null if no such {@link AttributeType} exists.
+     * @return The AttributeType with the provided label or null if no such AttributeType exists.
      * @throws TransactionException if the graph is closed
      */
     @CheckReturnValue
@@ -630,10 +628,10 @@ public interface Transaction extends AutoCloseable {
     Role getRole(String label);
 
     /**
-     * Get the {@link Rule} with the label provided, if it exists.
+     * Get the Rule with the label provided, if it exists.
      *
-     * @param label A unique label which identifies the {@link Rule} in the graph.
-     * @return The {@link Rule} with the provided label or null if no such Rule Type exists.
+     * @param label A unique label which identifies the Rule in the graph.
+     * @return The Rule with the provided label or null if no such Rule Type exists.
      * @throws TransactionException if the graph is closed
      */
     @CheckReturnValue
@@ -649,16 +647,16 @@ public interface Transaction extends AutoCloseable {
     Type type();
 
     /**
-     * Returns the {@link Session} which was used to create this {@link Transaction}
+     * Returns the Session which was used to create this Transaction
      *
-     * @return the owner {@link Session}
+     * @return the owner Session
      */
     Session session();
 
     /**
-     * Utility function to get {@link Keyspace} of the knowledge base.
+     * Utility function to get Keyspace of the knowledge base.
      *
-     * @return The {@link Keyspace} of the knowledge base.
+     * @return The Keyspace of the knowledge base.
      */
     @CheckReturnValue
     default Keyspace keyspace() {
@@ -674,13 +672,13 @@ public interface Transaction extends AutoCloseable {
     boolean isClosed();
 
     /**
-     * Closes the current transaction. Rendering this graph unusable. You must use the {@link Session} to
+     * Closes the current transaction. Rendering this graph unusable. You must use the Session to
      * get a new open transaction.
      */
     void close();
 
     /**
-     * Reverts any changes done to the graph and closes the transaction. You must use the {@link Session} to
+     * Reverts any changes done to the graph and closes the transaction. You must use the Session to
      * get a new open transaction.
      */
     default void abort() {
@@ -688,7 +686,7 @@ public interface Transaction extends AutoCloseable {
     }
 
     /**
-     * Commits any changes to the graph and closes the transaction. You must use the {@link Session} to
+     * Commits any changes to the graph and closes the transaction. You must use the Session to
      * get a new open transaction.
      */
     void commit();

--- a/server/src/server/Transaction.java
+++ b/server/src/server/Transaction.java
@@ -496,8 +496,8 @@ public interface Transaction extends AutoCloseable {
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link RelationType}.
      */
-    default RelationType putRelationshipType(String label) {
-        return putRelationshipType(Label.of(label));
+    default RelationType putRelationType(String label) {
+        return putRelationType(Label.of(label));
     }
 
     /**
@@ -509,7 +509,7 @@ public interface Transaction extends AutoCloseable {
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-{@link RelationType}.
      */
-    RelationType putRelationshipType(Label label);
+    RelationType putRelationType(Label label);
 
     /**
      * Create a {@link Role} with super-type {@code role}, or return a pre-existing {@link Role}, with the
@@ -604,7 +604,7 @@ public interface Transaction extends AutoCloseable {
      */
     @CheckReturnValue
     @Nullable
-    RelationType getRelationshipType(String label);
+    RelationType getRelationType(String label);
 
     /**
      * Get the {@link AttributeType} with the label provided, if it exists.

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -21,7 +21,6 @@ package grakn.core.server.kb;
 import com.google.common.collect.Iterables;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.util.CommonUtil;
-import grakn.core.graql.concept.Attribute;
 import grakn.core.graql.concept.Label;
 import grakn.core.graql.concept.Relation;
 import grakn.core.graql.concept.RelationType;
@@ -68,28 +67,22 @@ import static grakn.core.common.exception.ErrorMessage.VALIDATION_REQUIRED_RELAT
 import static grakn.core.common.exception.ErrorMessage.VALIDATION_ROLE_TYPE_MISSING_RELATION_TYPE;
 
 /**
- * <p>
- *     Specific Validation Rules
- * </p>
- *
- * <p>
- *     This class contains the implementation for the following validation rules:
- *     1. Plays Validation which ensures that a {@link Thing} is allowed to play the {@link Role}
- *        it has been assigned to.
- *     2. Relates Validation which ensures that every {@link Role} which is not abstract is
- *        assigned to a {@link RelationType} via {@link RelationType#relates(Role)}.
- *     3. Minimum Role Validation which ensures that every {@link RelationType} has at least 2 {@link Role}
- *        assigned to it via {@link RelationType#relates(Role)}.
- *     4. {@link Relation} Structure Validation which ensures that each {@link Relation} has the
- *        correct structure.
- *     5. Abstract Type Validation which ensures that each abstract {@link Type} has no {@link Thing}.
- *     6. {@link RelationType} Hierarchy Validation which ensures that {@link RelationType} with a hierarchical structure
- *        have a valid matching {@link Role} hierarchical structure.
- *     7. Required Resources validation which ensures that each {@link Thing} with required
- *        {@link Attribute} has a valid {@link Relation} to that {@link Attribute}.
- *     8. Unique {@link Relation} Validation which ensures that no duplicate {@link Relation} are created.
- * </p>
- *
+ * Specific Validation Rules
+ * This class contains the implementation for the following validation rules:
+ * 1. Plays Validation which ensures that a Thing is allowed to play the Role
+ * it has been assigned to.
+ * 2. Relates Validation which ensures that every Role which is not abstract is
+ * assigned to a RelationType via RelationType#relates(Role).
+ * 3. Minimum Role Validation which ensures that every RelationType has at least 2 Role
+ * assigned to it via RelationType#relates(Role).
+ * 4. Relation Structure Validation which ensures that each Relation has the
+ * correct structure.
+ * 5. Abstract Type Validation which ensures that each abstract Type has no Thing.
+ * 6. RelationType Hierarchy Validation which ensures that RelationType with a hierarchical structure
+ * have a valid matching Role hierarchical structure.
+ * 7. Required Resources validation which ensures that each Thing with required
+ * Attribute has a valid Relation to that Attribute.
+ * 8. Unique Relation Validation which ensures that no duplicate Relation are created.
  */
 class ValidateGlobalRules {
     private ValidateGlobalRules() {
@@ -97,11 +90,10 @@ class ValidateGlobalRules {
     }
 
     /**
-     * This method checks if the plays edge has been added between the roleplayer's {@link Type} and
-     * the {@link Role} being played.
-     *
-     * It also checks if the {@link Role} of the {@link Casting} has been linked to the {@link RelationType} of the
-     * {@link Relation} which the {@link Casting} connects to.
+     * This method checks if the plays edge has been added between the roleplayer's Type and
+     * the Role being played.
+         * It also checks if the Role of the Casting has been linked to the RelationType of the
+     * Relation which the Casting connects to.
      *
      * @return Specific errors if any are found
      */
@@ -121,44 +113,43 @@ class ValidateGlobalRules {
     }
 
     /**
-     * Checks if the {@link Role} of the {@link Casting} has been linked to the {@link RelationType} of
-     * the {@link Relation} which the {@link Casting} connects to.
+     * Checks if the Role of the Casting has been linked to the RelationType of
+     * the Relation which the Casting connects to.
      *
-     * @param role the {@link Role} which the {@link Casting} refers to
-     * @param relationshipType the {@link RelationType} which should connect to the role
-     * @param relationship the {@link Relation} which the {@link Casting} refers to
+     * @param role             the Role which the Casting refers to
+     * @param relationshipType the RelationType which should connect to the role
+     * @param relationship     the Relation which the Casting refers to
      * @return an error if one is found
      */
-    private static Optional<String> roleNotLinkedToRelationShip(Role role, RelationType relationshipType, Relation relationship){
+    private static Optional<String> roleNotLinkedToRelationShip(Role role, RelationType relationshipType, Relation relationship) {
         boolean notFound = role.relations().
                 noneMatch(innerRelationType -> innerRelationType.label().equals(relationshipType.label()));
-        if(notFound){
+        if (notFound) {
             return Optional.of(VALIDATION_RELATION_CASTING_LOOP_FAIL.getMessage(relationship.id(), role.label(), relationshipType.label()));
         }
         return Optional.empty();
     }
 
     /**
-     * Checks  if the plays edge has been added between the roleplayer's {@link Type} and
-     * the {@link Role} being played.
+     * Checks  if the plays edge has been added between the roleplayer's Type and
+     * the Role being played.
+         * Also checks that required Role are satisfied
      *
-     * Also checks that required {@link Role} are satisfied
-     *
-     * @param role The {@link Role} which the role-player is playing
+     * @param role  The Role which the role-player is playing
      * @param thing the role-player
      * @return an error if one is found
      */
-    private static Optional<String> roleNotAllowedToBePlayed(Role role, Thing thing){
+    private static Optional<String> roleNotAllowedToBePlayed(Role role, Thing thing) {
         TypeImpl<?, ?> currentConcept = (TypeImpl<?, ?>) thing.type();
 
         boolean satisfiesPlays = false;
-        while(currentConcept != null){
+        while (currentConcept != null) {
             Map<Role, Boolean> plays = currentConcept.directPlays();
 
             for (Map.Entry<Role, Boolean> playsEntry : plays.entrySet()) {
                 Role rolePlayed = playsEntry.getKey();
                 Boolean required = playsEntry.getValue();
-                if(rolePlayed.label().equals(role.label())){
+                if (rolePlayed.label().equals(role.label())) {
                     satisfiesPlays = true;
 
                     // Assert unique relationship for this role type
@@ -170,7 +161,7 @@ class ValidateGlobalRules {
             currentConcept = (TypeImpl) currentConcept.sup();
         }
 
-        if(satisfiesPlays) {
+        if (satisfiesPlays) {
             return Optional.empty();
         } else {
             return Optional.of(VALIDATION_CASTING.getMessage(thing.type().label(), thing.id(), role.label()));
@@ -178,24 +169,22 @@ class ValidateGlobalRules {
     }
 
     /**
-     *
      * @param role The Role to validate
      * @return An error message if the relates does not have a single incoming RELATES edge
      */
-    static Optional<String> validateHasSingleIncomingRelatesEdge(Role role){
-        if(!role.relations().findAny().isPresent()) {
+    static Optional<String> validateHasSingleIncomingRelatesEdge(Role role) {
+        if (!role.relations().findAny().isPresent()) {
             return Optional.of(VALIDATION_ROLE_TYPE_MISSING_RELATION_TYPE.getMessage(role.label()));
         }
         return Optional.empty();
     }
 
     /**
-     *
-     * @param relationshipType The {@link RelationType} to validate
+     * @param relationshipType The RelationType to validate
      * @return An error message if the relationTypes does not have at least 1 role
      */
     static Optional<String> validateHasMinimumRoles(RelationType relationshipType) {
-        if(relationshipType.isAbstract() || relationshipType.roles().iterator().hasNext()){
+        if (relationshipType.isAbstract() || relationshipType.roles().iterator().hasNext()) {
             return Optional.empty();
         } else {
             return Optional.of(VALIDATION_RELATION_TYPE.getMessage(relationshipType.label()));
@@ -203,13 +192,12 @@ class ValidateGlobalRules {
     }
 
     /**
-     *
-     * @param relationshipType the {@link RelationType} to be validated
-     * @return Error messages if the role type sub structure does not match the {@link RelationType} sub structure
+     * @param relationshipType the RelationType to be validated
+     * @return Error messages if the role type sub structure does not match the RelationType sub structure
      */
-    static Set<String> validateRelationTypesToRolesSchema(RelationType relationshipType){
+    static Set<String> validateRelationTypesToRolesSchema(RelationType relationshipType) {
         RelationTypeImpl superRelationType = (RelationTypeImpl) relationshipType.sup();
-        if(Schema.MetaSchema.isMetaLabel(superRelationType.label()) || superRelationType.isAbstract()){ //If super type is a meta type no validation needed
+        if (Schema.MetaSchema.isMetaLabel(superRelationType.label()) || superRelationType.isAbstract()) { //If super type is a meta type no validation needed
             return Collections.emptySet();
         }
 
@@ -221,7 +209,7 @@ class ValidateGlobalRules {
 
         //TODO: Determine if this check is redundant
         //Check 1) Every role of relationTypes is the sub of a role which is in the relates of it's supers
-        if(!superRelationType.isAbstract()) {
+        if (!superRelationType.isAbstract()) {
             Set<Label> allSuperRolesPlayed = new HashSet<>();
             superRelationType.sups().forEach(rel -> rel.roles().forEach(roleType -> allSuperRolesPlayed.add(roleType.label())));
 
@@ -229,7 +217,7 @@ class ValidateGlobalRules {
                 boolean validRoleTypeFound = SchemaConceptImpl.from(relate).sups().
                         anyMatch(superRole -> allSuperRolesPlayed.contains(superRole.label()));
 
-                if(!validRoleTypeFound){
+                if (!validRoleTypeFound) {
                     errorMessages.add(VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(relate.label(), relationshipType.label(), "super", "super", superRelationType.label()));
                 }
             }
@@ -239,32 +227,31 @@ class ValidateGlobalRules {
         for (Role superRelate : superRelates) {
             boolean subRoleNotFoundInRelates = superRelate.subs().noneMatch(sub -> relatesLabels.contains(sub.label()));
 
-            if(subRoleNotFoundInRelates){
+            if (subRoleNotFoundInRelates) {
                 errorMessages.add(VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(superRelate.label(), superRelationType.label(), "sub", "sub", relationshipType.label()));
             }
         }
 
-       return errorMessages;
+        return errorMessages;
     }
 
     /**
-     *
      * @param thing The thing to be validated
      * @return An error message if the thing does not have all the required resources
      */
     static Optional<String> validateInstancePlaysAllRequiredRoles(Thing thing) {
         TypeImpl<?, ?> currentConcept = (TypeImpl) thing.type();
 
-        while(currentConcept != null){
+        while (currentConcept != null) {
 
             Map<Role, Boolean> plays = currentConcept.directPlays();
             for (Map.Entry<Role, Boolean> playsEntry : plays.entrySet()) {
-                if(playsEntry.getValue()){
+                if (playsEntry.getValue()) {
                     Role role = playsEntry.getKey();
                     // Assert there is a relationship for this type
                     Stream<Relation> relationships = thing.relations(role);
 
-                    if(!CommonUtil.containsOnly(relationships, 1)){
+                    if (!CommonUtil.containsOnly(relationships, 1)) {
                         Label resourceTypeLabel = Schema.ImplicitType.explicitLabel(role.label());
                         return Optional.of(VALIDATION_NOT_EXACTLY_ONE_KEY.getMessage(thing.id(), resourceTypeLabel));
                     }
@@ -276,14 +263,13 @@ class ValidateGlobalRules {
     }
 
     /**
-     *
      * @param graph
      * @param rules
      */
-    static Set<String> validateRuleStratifiability(TransactionOLTP graph, Set<Rule> rules){
+    static Set<String> validateRuleStratifiability(TransactionOLTP graph, Set<Rule> rules) {
         Set<String> errors = new HashSet<>();
         List<Set<Type>> negativeCycles = RuleUtils.negativeCycles(rules, graph);
-        if (!negativeCycles.isEmpty()){
+        if (!negativeCycles.isEmpty()) {
             errors.add(ErrorMessage.VALIDATION_RULE_GRAPH_NOT_STRATIFIABLE.getMessage(negativeCycles));
         }
         return errors;
@@ -291,20 +277,19 @@ class ValidateGlobalRules {
 
     /**
      * @param graph graph used to ensure the rule is a valid Horn clause
-     * @param rule the rule to be validated
+     * @param rule  the rule to be validated
      * @return Error messages if the rule is not a valid Horn clause (in implication form, conjunction in the body, single-atom conjunction in the head)
      */
-    static Set<String> validateRuleIsValidClause(TransactionOLTP graph, Rule rule){
+    static Set<String> validateRuleIsValidClause(TransactionOLTP graph, Rule rule) {
         Set<String> errors = new HashSet<>();
         Set<Conjunction<Pattern>> patterns = rule.when().getNegationDNF().getPatterns();
-        if (patterns.size() > 1){
+        if (patterns.size() > 1) {
             errors.add(ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_BODY.getMessage(rule.label()));
-        }
-        else {
+        } else {
             errors.addAll(CompositeQuery.validateAsRuleBody(Iterables.getOnlyElement(patterns), rule, graph));
         }
 
-        if (errors.isEmpty()){
+        if (errors.isEmpty()) {
             errors.addAll(validateRuleHead(graph, rule));
         }
         return errors;
@@ -312,10 +297,10 @@ class ValidateGlobalRules {
 
     /**
      * @param graph graph (tx) of interest
-     * @param rule the rule to be cast into a combined conjunction query
+     * @param rule  the rule to be cast into a combined conjunction query
      * @return a combined conjunction created from statements from both the body and the head of the rule
      */
-    private static ReasonerQuery combinedRuleQuery(TransactionOLTP graph, Rule rule){
+    private static ReasonerQuery combinedRuleQuery(TransactionOLTP graph, Rule rule) {
         ReasonerQuery bodyQuery = ReasonerQueries.create(Graql.and(rule.when().getDisjunctiveNormalForm().getPatterns().stream().flatMap(conj -> conj.getPatterns().stream()).collect(Collectors.toSet())), graph);
         ReasonerQuery headQuery = ReasonerQueries.create(Graql.and(rule.then().getDisjunctiveNormalForm().getPatterns().stream().flatMap(conj -> conj.getPatterns().stream()).collect(Collectors.toSet())), graph);
         return headQuery.conjunction(bodyQuery);
@@ -323,8 +308,9 @@ class ValidateGlobalRules {
 
     /**
      * NB: this only gets checked if the rule obeys the Horn clause form
+     *
      * @param graph graph used to ensure the rule is a valid Horn clause
-     * @param rule the rule to be validated ontologically
+     * @param rule  the rule to be validated ontologically
      * @return Error messages if the rule has ontological inconsistencies
      */
     static Set<String> validateRuleOntologically(TransactionOLTP graph, Rule rule) {
@@ -340,7 +326,7 @@ class ValidateGlobalRules {
 
     /**
      * @param graph graph used to ensure the rule head is valid
-     * @param rule the rule to be validated
+     * @param rule  the rule to be validated
      * @return Error messages if the rule head is invalid - is not a single-atom conjunction, doesn't contain illegal atomics and is ontologically valid
      */
     private static Set<String> validateRuleHead(TransactionOLTP graph, Rule rule) {
@@ -348,7 +334,7 @@ class ValidateGlobalRules {
         Set<Conjunction<Statement>> headPatterns = rule.then().getDisjunctiveNormalForm().getPatterns();
         Set<Conjunction<Statement>> bodyPatterns = rule.when().getDisjunctiveNormalForm().getPatterns();
 
-        if (headPatterns.size() != 1){
+        if (headPatterns.size() != 1) {
             errors.add(ErrorMessage.VALIDATION_RULE_DISJUNCTION_IN_HEAD.getMessage(rule.label()));
         } else {
             ReasonerQuery bodyQuery = ReasonerQueries.create(Iterables.getOnlyElement(bodyPatterns), graph);
@@ -373,11 +359,10 @@ class ValidateGlobalRules {
     }
 
     /**
-     *
      * @param rule The rule to be validated
      * @return Error messages if the when or then of a rule refers to a non existent type
      */
-    static Set<String> validateRuleSchemaConceptExist(Transaction graph, Rule rule){
+    static Set<String> validateRuleSchemaConceptExist(Transaction graph, Rule rule) {
         Set<String> errors = new HashSet<>();
         errors.addAll(checkRuleSideInvalid(graph, rule, Schema.VertexProperty.RULE_WHEN, rule.when()));
         errors.addAll(checkRuleSideInvalid(graph, rule, Schema.VertexProperty.RULE_THEN, rule.then()));
@@ -385,10 +370,9 @@ class ValidateGlobalRules {
     }
 
     /**
-     *
-     * @param graph The graph to query against
-     * @param rule The rule the pattern was extracted from
-     * @param side The side from which the pattern was extracted
+     * @param graph   The graph to query against
+     * @param rule    The rule the pattern was extracted from
+     * @param side    The side from which the pattern was extracted
      * @param pattern The pattern from which we will extract the types in the pattern
      * @return A list of errors if the pattern refers to any non-existent types in the graph
      */
@@ -398,33 +382,34 @@ class ValidateGlobalRules {
         pattern.statements().stream()
                 .flatMap(statement -> statement.innerStatements().stream())
                 .flatMap(statement -> statement.getTypes().stream()).forEach(type -> {
-                    SchemaConcept schemaConcept = graph.getSchemaConcept(Label.of(type));
-                    if(schemaConcept == null){
-                        errors.add(ErrorMessage.VALIDATION_RULE_MISSING_ELEMENTS.getMessage(side, rule.label(), type));
-                    } else {
-                        if(Schema.VertexProperty.RULE_WHEN.equals(side)){
-                            if (schemaConcept.isType()){
-                                RuleImpl.from(rule).addHypothesis(schemaConcept.asType());
-                            }
-                        } else if (Schema.VertexProperty.RULE_THEN.equals(side)){
-                            if (schemaConcept.isType()) {
-                                RuleImpl.from(rule).addConclusion(schemaConcept.asType());
-                            }
-                        } else {
-                            throw TransactionException.invalidPropertyUse(rule, side);
-                        }
+            SchemaConcept schemaConcept = graph.getSchemaConcept(Label.of(type));
+            if (schemaConcept == null) {
+                errors.add(ErrorMessage.VALIDATION_RULE_MISSING_ELEMENTS.getMessage(side, rule.label(), type));
+            } else {
+                if (Schema.VertexProperty.RULE_WHEN.equals(side)) {
+                    if (schemaConcept.isType()) {
+                        RuleImpl.from(rule).addHypothesis(schemaConcept.asType());
                     }
-                });
+                } else if (Schema.VertexProperty.RULE_THEN.equals(side)) {
+                    if (schemaConcept.isType()) {
+                        RuleImpl.from(rule).addConclusion(schemaConcept.asType());
+                    }
+                } else {
+                    throw TransactionException.invalidPropertyUse(rule, side);
+                }
+            }
+        });
 
         return errors;
     }
 
     /**
-     * Checks if a {@link Relation} has at least one role player.
-     * @param relationship The {@link Relation} to check
+     * Checks if a Relation has at least one role player.
+     *
+     * @param relationship The Relation to check
      */
     static Optional<String> validateRelationshipHasRolePlayers(Relation relationship) {
-        if(!relationship.rolePlayers().findAny().isPresent()){
+        if (!relationship.rolePlayers().findAny().isPresent()) {
             return Optional.of(ErrorMessage.VALIDATION_RELATIONSHIP_WITH_NO_ROLE_PLAYERS.getMessage(relationship.id(), relationship.type().label()));
         }
         return Optional.empty();

--- a/server/src/server/kb/ValidateGlobalRules.java
+++ b/server/src/server/kb/ValidateGlobalRules.java
@@ -130,7 +130,7 @@ class ValidateGlobalRules {
      * @return an error if one is found
      */
     private static Optional<String> roleNotLinkedToRelationShip(Role role, RelationType relationshipType, Relation relationship){
-        boolean notFound = role.relationships().
+        boolean notFound = role.relations().
                 noneMatch(innerRelationType -> innerRelationType.label().equals(relationshipType.label()));
         if(notFound){
             return Optional.of(VALIDATION_RELATION_CASTING_LOOP_FAIL.getMessage(relationship.id(), role.label(), relationshipType.label()));
@@ -162,8 +162,8 @@ class ValidateGlobalRules {
                     satisfiesPlays = true;
 
                     // Assert unique relationship for this role type
-                    if (required && !CommonUtil.containsOnly(thing.relationships(role), 1)) {
-                        return Optional.of(VALIDATION_REQUIRED_RELATION.getMessage(thing.id(), thing.type().label(), role.label(), thing.relationships(role).count()));
+                    if (required && !CommonUtil.containsOnly(thing.relations(role), 1)) {
+                        return Optional.of(VALIDATION_REQUIRED_RELATION.getMessage(thing.id(), thing.type().label(), role.label(), thing.relations(role).count()));
                     }
                 }
             }
@@ -183,7 +183,7 @@ class ValidateGlobalRules {
      * @return An error message if the relates does not have a single incoming RELATES edge
      */
     static Optional<String> validateHasSingleIncomingRelatesEdge(Role role){
-        if(!role.relationships().findAny().isPresent()) {
+        if(!role.relations().findAny().isPresent()) {
             return Optional.of(VALIDATION_ROLE_TYPE_MISSING_RELATION_TYPE.getMessage(role.label()));
         }
         return Optional.empty();
@@ -262,7 +262,7 @@ class ValidateGlobalRules {
                 if(playsEntry.getValue()){
                     Role role = playsEntry.getKey();
                     // Assert there is a relationship for this type
-                    Stream<Relation> relationships = thing.relationships(role);
+                    Stream<Relation> relationships = thing.relations(role);
 
                     if(!CommonUtil.containsOnly(relationships, 1)){
                         Label resourceTypeLabel = Schema.ImplicitType.explicitLabel(role.label());

--- a/server/src/server/kb/Validator.java
+++ b/server/src/server/kb/Validator.java
@@ -31,38 +31,29 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * <p>
- *     Ensures each concept undergoes the correct type of validation.
- * </p>
- *
- * <p>
- *      Handles calling the relevant validation defined in {@link ValidateGlobalRules} depending on the
- *      type of the concept.
- * </p>
- *
- *
+ * Ensures each concept undergoes the correct type of validation.
+ * Handles calling the relevant validation defined in ValidateGlobalRules depending on the
+ * type of the concept.
  */
 public class Validator {
     private final TransactionOLTP graknGraph;
     private final List<String> errorsFound = new ArrayList<>();
 
-    public Validator(TransactionOLTP graknGraph){
+    public Validator(TransactionOLTP graknGraph) {
         this.graknGraph = graknGraph;
     }
 
     /**
-     *
      * @return Any errors found during validation
      */
-    public List<String> getErrorsFound(){
+    public List<String> getErrorsFound() {
         return errorsFound;
     }
 
     /**
-     *
      * @return True if the data and schema conforms to our concept.
      */
-    public boolean validate(){
+    public boolean validate() {
         //Validate Things
         graknGraph.cache().getModifiedThings().forEach(this::validateThing);
 
@@ -92,10 +83,11 @@ public class Validator {
      * Validation rules exclusive to rules
      * the precedence of validation is: labelValidation -> ontologicalValidation -> clauseValidation
      * each of the validation happens only if the preceding validation yields no errors
+     *
      * @param graph the graph to query against
-     * @param rule the rule which needs to be validated
+     * @param rule  the rule which needs to be validated
      */
-    private void validateRule(TransactionOLTP graph, Rule rule){
+    private void validateRule(TransactionOLTP graph, Rule rule) {
         Set<String> labelErrors = ValidateGlobalRules.validateRuleSchemaConceptExist(graph, rule);
         errorsFound.addAll(labelErrors);
         if (labelErrors.isEmpty()) {
@@ -109,42 +101,47 @@ public class Validator {
 
     /**
      * Validation rules exclusive to role players
+     *
      * @param casting The Role player to validate
      */
-    private void validateCasting(Casting casting){
+    private void validateCasting(Casting casting) {
         errorsFound.addAll(ValidateGlobalRules.validatePlaysAndRelatesStructure(casting));
     }
 
     /**
      * Validation rules exclusive to role
-     * @param role The {@link Role} to validate
+     *
+     * @param role The Role to validate
      */
-    private void validateRole(Role role){
+    private void validateRole(Role role) {
         ValidateGlobalRules.validateHasSingleIncomingRelatesEdge(role).ifPresent(errorsFound::add);
     }
 
     /**
      * Validation rules exclusive to relation types
+     *
      * @param relationshipType The relationTypes to validate
      */
-    private void validateRelationType(RelationType relationshipType){
+    private void validateRelationType(RelationType relationshipType) {
         ValidateGlobalRules.validateHasMinimumRoles(relationshipType).ifPresent(errorsFound::add);
         errorsFound.addAll(ValidateGlobalRules.validateRelationTypesToRolesSchema(relationshipType));
     }
 
     /**
      * Validation rules exclusive to instances
-     * @param thing The {@link Thing} to validate
+     *
+     * @param thing The Thing to validate
      */
     private void validateThing(Thing thing) {
         ValidateGlobalRules.validateInstancePlaysAllRequiredRoles(thing).ifPresent(errorsFound::add);
     }
 
     /**
-     * Validates that {@link Relation}s can be committed.
-     * @param relationship The {@link Relation} to validate
+     * Validates that Relations can be committed.
+     *
+     * @param relationship The Relation to validate
      */
-    private void validateRelationship(Relation relationship){
+    private void validateRelationship(Relation relationship) {
         ValidateGlobalRules.validateRelationshipHasRolePlayers(relationship).ifPresent(errorsFound::add);
     }
 }

--- a/server/src/server/kb/cache/CacheOwner.java
+++ b/server/src/server/kb/cache/CacheOwner.java
@@ -23,33 +23,32 @@ import grakn.core.graql.concept.Concept;
 import java.util.Collection;
 
 /**
- * <p>
- *     Indicates a {@link Cache} is contained within the class
- * </p>
- *
- * <p>
- *     Wraps up behaviour which needs to be handled whenever a {@link Cache} is used in a class
- * </p>
- *
- *
+ * Indicates a Cache is contained within the class
+ * Wraps up behaviour which needs to be handled whenever a Cache is used in a class
  */
 public interface CacheOwner {
 
     /**
-     *
-     * @return all the caches beloning to the {@link CacheOwner}
+     * Helper method to cast Concept into CacheOwner
+     */
+    static CacheOwner from(Concept concept) {
+        return (CacheOwner) concept;
+    }
+
+    /**
+     * @return all the caches beloning to the CacheOwner
      */
     Collection<Cache> caches();
 
     /**
-     * Clears the internal {@link Cache}
+     * Clears the internal Cache
      */
     default void txCacheClear() {
         caches().forEach(Cache::clear);
     }
 
     /**
-     * Registers a {@link Cache} so that later it can be cleaned up
+     * Registers a Cache so that later it can be cleaned up
      */
     default void registerCache(Cache cache) {
         caches().add(cache);
@@ -58,14 +57,7 @@ public interface CacheOwner {
     /**
      * Flushes the internal transaction caches so they can refresh with persisted graph
      */
-    default void txCacheFlush(){
+    default void txCacheFlush() {
         caches().forEach(Cache::flush);
-    }
-
-    /**
-     * Helper method to cast {@link Concept} into {@link CacheOwner}
-     */
-    static CacheOwner from(Concept concept){
-        return (CacheOwner) concept;
     }
 }

--- a/server/src/server/kb/cache/Cacheable.java
+++ b/server/src/server/kb/cache/Cacheable.java
@@ -32,70 +32,64 @@ import java.util.Set;
 import java.util.function.UnaryOperator;
 
 /**
- * <p>
- *     Contains the functionality needed to add an {@link Object} to {@link Cache}
- * </p>
- *
- * <p>
- *     This is used to wrap functionality needed by {@link Cache}.
- *     Specifically it is used to ensure that when flushing {@link Cache#valueGlobal} into {@link Cache#valueTx}
- *     no cache leaks can occur. For example this is needed when caching {@link java.util.Collection}
- * </p>
- *
+ * Contains the functionality needed to add an Object to Cache
+ * This is used to wrap functionality needed by Cache.
+ * Specifically it is used to ensure that when flushing Cache#valueGlobal into Cache#valueTx
+ * no cache leaks can occur. For example this is needed when caching java.util.Collection
  *
  * @param <V>
  */
 public class Cacheable<V> {
     private final UnaryOperator<V> copier;
 
-    private Cacheable(UnaryOperator<V> copier){
+    private Cacheable(UnaryOperator<V> copier) {
         this.copier = copier;
     }
 
     // Constructors for supported cache-able items
-    public static Cacheable<ConceptId> conceptId(){
+    public static Cacheable<ConceptId> conceptId() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static Cacheable<Long> number(){
+    public static Cacheable<Long> number() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static Cacheable<Label> label(){
+    public static Cacheable<Label> label() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static Cacheable<LabelId> labelId(){
+    public static Cacheable<LabelId> labelId() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static Cacheable<Boolean> bool(){
+    public static Cacheable<Boolean> bool() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static Cacheable<Shard> shard(){
+    public static Cacheable<Shard> shard() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static <T extends Concept> Cacheable<T> concept(){
+    public static <T extends Concept> Cacheable<T> concept() {
         return new Cacheable<>((o) -> o);
     }
 
-    public static <T> Cacheable<Set<T>> set(){
+    public static <T> Cacheable<Set<T>> set() {
         return new Cacheable<>(HashSet::new);
     }
 
-    public static <K, T> Cacheable<Map<K, T>> map(){
+    public static <K, T> Cacheable<Map<K, T>> map() {
         return new Cacheable<>(HashMap::new);
     }
 
     /**
-     * Copies the old value into a new value. How this copying is done is dictated by {@link Cacheable#copier}
+     * Copies the old value into a new value. How this copying is done is dictated by Cacheable#copier
      *
      * @param oldValue The old value
-     * @return the new value as defined by {@link Cacheable#copier}
+     * @return the new value as defined by Cacheable#copier
      */
-    public V copy(V oldValue){
+    public V copy(V oldValue) {
         return copier.apply(oldValue);
     }
 }

--- a/server/src/server/kb/concept/AttributeImpl.java
+++ b/server/src/server/kb/concept/AttributeImpl.java
@@ -32,7 +32,7 @@ import java.util.stream.Stream;
  * Represent a literal resource in the graph.
  * Acts as an Thing when relating to other instances except it has the added functionality of:
  * 1. It is unique to its AttributeType based on it's value.
- * 2. It has a {@link AttributeType.DataType} associated with it which constrains the allowed values.
+ * 2. It has a AttributeType.DataType associated with it which constrains the allowed values.
  *
  * @param <D> The data type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean

--- a/server/src/server/kb/concept/AttributeImpl.java
+++ b/server/src/server/kb/concept/AttributeImpl.java
@@ -89,6 +89,10 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
         }
     }
 
+    public static AttributeImpl from(Attribute attribute) {
+        return (AttributeImpl) attribute;
+    }
+
     /**
      * @return The data type of this Attribute's AttributeType.
      */
@@ -130,9 +134,5 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
     @Override
     public String innerToString() {
         return super.innerToString() + "- Value [" + value() + "] ";
-    }
-
-    public static AttributeImpl from(Attribute attribute) {
-        return (AttributeImpl) attribute;
     }
 }

--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  * An ontological element which models and categorises the various Attribute in the graph.
  * This ontological element behaves similarly to Type when defining how it relates to other
  * types. It has two additional functions to be aware of:
- * 1. It has a {@link AttributeType.DataType} constraining the data types of the values it's instances may take.
+ * 1. It has a AttributeType.DataType constraining the data types of the values it's instances may take.
  * 2. Any of it's instances are unique to the type.
  * For example if you have a AttributeType modelling month throughout the year there can only be one January.
  *

--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -32,21 +32,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * <p>
- *     An ontological element which models and categorises the various Attribute in the graph.
- * </p>
- *
- * <p>
- *     This ontological element behaves similarly to Type when defining how it relates to other
- *     types. It has two additional functions to be aware of:
- *     1. It has a {@link AttributeType.DataType} constraining the data types of the values it's instances may take.
- *     2. Any of it's instances are unique to the type.
- *     For example if you have a AttributeType modelling month throughout the year there can only be one January.
- * </p>
- *
+ * An ontological element which models and categorises the various Attribute in the graph.
+ * This ontological element behaves similarly to Type when defining how it relates to other
+ * types. It has two additional functions to be aware of:
+ * 1. It has a {@link AttributeType.DataType} constraining the data types of the values it's instances may take.
+ * 2. Any of it's instances are unique to the type.
+ * For example if you have a AttributeType modelling month throughout the year there can only be one January.
  *
  * @param <D> The data type of this resource type.
- *           Supported Types include: String, Long, Double, and Boolean
+ *            Supported Types include: String, Long, Double, and Boolean
  */
 public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D>> implements AttributeType<D> {
     private AttributeTypeImpl(VertexElement vertexElement) {
@@ -58,7 +52,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
         vertex().propertyImmutable(Schema.VertexProperty.DATA_TYPE, dataType, dataType(), DataType::getName);
     }
 
-    public static <D> AttributeTypeImpl<D> get(VertexElement vertexElement){
+    public static <D> AttributeTypeImpl<D> get(VertexElement vertexElement) {
         return new AttributeTypeImpl<>(vertexElement);
     }
 
@@ -66,12 +60,16 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
         return new AttributeTypeImpl<>(vertexElement, type, dataType);
     }
 
+    public static AttributeTypeImpl from(AttributeType attributeType) {
+        return (AttributeTypeImpl) attributeType;
+    }
+
     /**
      * This method is overridden so that we can check that the regex of the new super type (if it has a regex)
      * can be applied to all the existing instances.
      */
     @Override
-    public AttributeType<D> sup(AttributeType<D> superType){
+    public AttributeType<D> sup(AttributeType<D> superType) {
         ((AttributeTypeImpl<D>) superType).sups().forEach(st -> checkInstancesMatchRegex(st.regex()));
         return super.sup(superType);
     }
@@ -82,7 +80,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      */
     @Override
     public AttributeType<D> regex(String regex) {
-        if(dataType() == null || !dataType().equals(DataType.STRING)) {
+        if (dataType() == null || !dataType().equals(DataType.STRING)) {
             throw TransactionException.cannotSetRegex(this);
         }
 
@@ -94,16 +92,16 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     /**
      * Checks that existing instances match the provided regex.
      *
-     * @throws TransactionException when an instance does not match the provided regex
      * @param regex The regex to check against
+     * @throws TransactionException when an instance does not match the provided regex
      */
-    private void checkInstancesMatchRegex(@Nullable String regex){
-        if(regex != null) {
+    private void checkInstancesMatchRegex(@Nullable String regex) {
+        if (regex != null) {
             Pattern pattern = Pattern.compile(regex);
             instances().forEach(resource -> {
                 String value = (String) resource.value();
                 Matcher matcher = pattern.matcher(value);
-                if(!matcher.matches()){
+                if (!matcher.matches()) {
                     throw TransactionException.regexFailure(this, value, regex);
                 }
             });
@@ -124,7 +122,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
         Objects.requireNonNull(value);
 
         BiFunction<VertexElement, AttributeType<D>, Attribute<D>> instanceBuilder = (vertex, type) -> {
-            if(dataType().equals(DataType.STRING)) checkConformsToRegexes(value);
+            if (dataType().equals(DataType.STRING)) checkConformsToRegexes(value);
             return vertex().tx().factory().buildAttribute(vertex, type, value);
         };
 
@@ -135,31 +133,29 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      * Utility method used to create or find an instance of this type
      *
      * @param instanceBaseType The base type of the instances of this type
-     * @param finder The method to find the instrance if it already exists
-     * @param producer The factory method to produce the instance if it doesn't exist
+     * @param finder           The method to find the instrance if it already exists
+     * @param producer         The factory method to produce the instance if it doesn't exist
      * @return A new or already existing instance
      */
     private Attribute<D> putInstance(Schema.BaseType instanceBaseType, Supplier<Attribute<D>> finder, BiFunction<VertexElement, AttributeType<D>, Attribute<D>> producer, boolean isInferred) {
         Attribute<D> instance = finder.get();
-        if(instance == null) {
+        if (instance == null) {
             instance = addInstance(instanceBaseType, producer, isInferred);
         } else {
-            if(isInferred && !instance.isInferred()){
+            if (isInferred && !instance.isInferred()) {
                 throw TransactionException.nonInferredThingExists(instance);
             }
         }
         return instance;
     }
 
-
-
     /**
      * Checks if all the regex's of the types of this resource conforms to the value provided.
      *
-     * @throws TransactionException when the value does not conform to the regex of its types
      * @param value The value to check the regexes against.
+     * @throws TransactionException when the value does not conform to the regex of its types
      */
-    private void checkConformsToRegexes(D value){
+    private void checkConformsToRegexes(D value) {
         //Not checking the datatype because the regex will always be null for non strings.
         this.sups().forEach(sup -> {
             String regex = sup.regex();
@@ -191,10 +187,6 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Override
     public String regex() {
         return vertex().property(Schema.VertexProperty.REGEX);
-    }
-
-    public static AttributeTypeImpl from(AttributeType attributeType){
-        return (AttributeTypeImpl) attributeType;
     }
 
 }

--- a/server/src/server/kb/concept/ConceptImpl.java
+++ b/server/src/server/kb/concept/ConceptImpl.java
@@ -44,6 +44,7 @@ import java.util.stream.Stream;
  */
 public abstract class ConceptImpl implements Concept, ConceptVertex, CacheOwner {
     private final Set<Cache> registeredCaches = new HashSet<>();
+    private final VertexElement vertexElement;
     //WARNING: DO not flush the current shard into the central cache. It is not safe to do so in a concurrent environment
     private final Cache<Shard> currentShard = Cache.createTxCache(this, Cacheable.shard(), () -> {
         String currentShardId = vertex().property(Schema.VertexProperty.CURRENT_SHARD);
@@ -52,7 +53,6 @@ public abstract class ConceptImpl implements Concept, ConceptVertex, CacheOwner 
     });
     private final Cache<Long> shardCount = Cache.createSessionCache(this, Cacheable.number(), () -> shards().count());
     private final Cache<ConceptId> conceptId = Cache.createPersistentCache(this, Cacheable.conceptId(), () -> ConceptId.of(vertex().property(Schema.VertexProperty.ID)));
-    private final VertexElement vertexElement;
 
     ConceptImpl(VertexElement vertexElement) {
         this.vertexElement = vertexElement;
@@ -105,7 +105,7 @@ public abstract class ConceptImpl implements Concept, ConceptVertex, CacheOwner 
         switch (direction) {
             case BOTH:
                 return vertex().getEdgesOfType(direction, label).
-                        flatMap(edge -> Stream.<X>of(
+                        flatMap(edge -> Stream.of(
                                 vertex().tx().factory().buildConcept(edge.source()),
                                 vertex().tx().factory().buildConcept(edge.target()))
                         );

--- a/server/src/server/kb/concept/ConceptVertex.java
+++ b/server/src/server/kb/concept/ConceptVertex.java
@@ -22,22 +22,15 @@ import grakn.core.graql.concept.Concept;
 import grakn.core.server.kb.structure.VertexElement;
 
 /**
- * <p>
- *     A Concept represented as a VertexElement
- * </p>
- *
- * <p>
- *     This class is helper used to ensure that any concept which needs to contain a VertexElement can handle it.
- *     Either by returning an existing one r going through some reification procedure to return a new one.
- * </p>
- *
- *
+ * A Concept represented as a VertexElement
+ * This class is helper used to ensure that any concept which needs to contain a VertexElement can handle it.
+ * Either by returning an existing one r going through some reification procedure to return a new one.
  */
 public interface ConceptVertex {
 
-    VertexElement vertex();
-
-    static ConceptVertex from(Concept concept){
+    static ConceptVertex from(Concept concept) {
         return (ConceptVertex) concept;
     }
+
+    VertexElement vertex();
 }

--- a/server/src/server/kb/concept/ElementFactory.java
+++ b/server/src/server/kb/concept/ElementFactory.java
@@ -47,93 +47,89 @@ import java.util.function.Function;
 import static grakn.core.graql.internal.Schema.BaseType.RELATIONSHIP_TYPE;
 
 /**
- * <p>
- *     Constructs Concepts And Edges
- * </p>
- *
- * <p>
- *     This class turns Tinkerpop Vertex and {@link org.apache.tinkerpop.gremlin.structure.Edge}
- *     into Grakn Concept and EdgeElement.
- *
- *     Construction is only successful if the vertex and edge properties contain the needed information.
- *     A concept must include a label which is a {@link Schema.BaseType}.
- *     An edge must include a label which is a {@link Schema.EdgeLabel}.
- * </p>
- *
+ * Constructs Concepts And Edges
+ * This class turns Tinkerpop Vertex and {@link org.apache.tinkerpop.gremlin.structure.Edge}
+ * into Grakn Concept and EdgeElement.
+ * Construction is only successful if the vertex and edge properties contain the needed information.
+ * A concept must include a label which is a {@link Schema.BaseType}.
+ * An edge must include a label which is a {@link Schema.EdgeLabel}.
  */
 public final class ElementFactory {
     private final TransactionOLTP tx;
     private final JanusGraph graph;
 
-    public ElementFactory(TransactionOLTP tx, JanusGraph graph){
+    public ElementFactory(TransactionOLTP tx, JanusGraph graph) {
         this.tx = tx;
         this.graph = graph;
     }
 
-    private <X extends Concept, E extends AbstractElement> X   getOrBuildConcept(E element, ConceptId conceptId, Function<E, X> conceptBuilder){
-        if(!tx.cache().isConceptCached(conceptId)){
+    private <X extends Concept, E extends AbstractElement> X getOrBuildConcept(E element, ConceptId conceptId, Function<E, X> conceptBuilder) {
+        if (!tx.cache().isConceptCached(conceptId)) {
             X newConcept = conceptBuilder.apply(element);
             tx.cache().cacheConcept(newConcept);
         }
         return tx.cache().getCachedConcept(conceptId);
     }
 
-    private <X extends Concept> X getOrBuildConcept(VertexElement element, Function<VertexElement, X> conceptBuilder){
+    private <X extends Concept> X getOrBuildConcept(VertexElement element, Function<VertexElement, X> conceptBuilder) {
         ConceptId conceptId = ConceptId.of(element.property(Schema.VertexProperty.ID));
         return getOrBuildConcept(element, conceptId, conceptBuilder);
     }
 
-    private <X extends Concept> X getOrBuildConcept(EdgeElement element, Function<EdgeElement, X> conceptBuilder){
+    private <X extends Concept> X getOrBuildConcept(EdgeElement element, Function<EdgeElement, X> conceptBuilder) {
         ConceptId conceptId = ConceptId.of(element.id().getValue());
         return getOrBuildConcept(element, conceptId, conceptBuilder);
     }
 
     // ---------------------------------------- Building Attribute Types  -----------------------------------------------
-    public <V> AttributeTypeImpl<V> buildAttributeType(VertexElement vertex, AttributeType<V> type, AttributeType.DataType<V> dataType){
+    public <V> AttributeTypeImpl<V> buildAttributeType(VertexElement vertex, AttributeType<V> type, AttributeType.DataType<V> dataType) {
         return getOrBuildConcept(vertex, (v) -> AttributeTypeImpl.create(v, type, dataType));
     }
 
     // ------------------------------------------ Building Attribute
-    <V> AttributeImpl<V> buildAttribute(VertexElement vertex, AttributeType<V> type, Object persitedValue){
+    <V> AttributeImpl<V> buildAttribute(VertexElement vertex, AttributeType<V> type, Object persitedValue) {
         return getOrBuildConcept(vertex, (v) -> AttributeImpl.create(v, type, persitedValue));
     }
 
     // ---------------------------------------- Building Relationship Types  -----------------------------------------------
-    public RelationTypeImpl buildRelationshipType(VertexElement vertex, RelationType type){
+    public RelationTypeImpl buildRelationshipType(VertexElement vertex, RelationType type) {
         return getOrBuildConcept(vertex, (v) -> RelationTypeImpl.create(v, type));
     }
 
     // -------------------------------------------- Building Relations
-    RelationImpl buildRelation(VertexElement vertex, RelationType type){
+    RelationImpl buildRelation(VertexElement vertex, RelationType type) {
         return getOrBuildConcept(vertex, (v) -> RelationImpl.create(buildRelationReified(v, type)));
     }
-    public RelationImpl buildRelation(EdgeElement edge, RelationType type, Role owner, Role value){
+
+    public RelationImpl buildRelation(EdgeElement edge, RelationType type, Role owner, Role value) {
         return getOrBuildConcept(edge, (e) -> RelationImpl.create(RelationEdge.create(type, owner, value, edge)));
     }
-    RelationImpl buildRelation(EdgeElement edge){
+
+    RelationImpl buildRelation(EdgeElement edge) {
         return getOrBuildConcept(edge, (e) -> RelationImpl.create(RelationEdge.get(edge)));
     }
-    RelationReified buildRelationReified(VertexElement vertex, RelationType type){
+
+    RelationReified buildRelationReified(VertexElement vertex, RelationType type) {
         return RelationReified.create(vertex, type);
     }
 
     // ----------------------------------------- Building Entity Types  ------------------------------------------------
-    public EntityTypeImpl buildEntityType(VertexElement vertex, EntityType type){
+    public EntityTypeImpl buildEntityType(VertexElement vertex, EntityType type) {
         return getOrBuildConcept(vertex, (v) -> EntityTypeImpl.create(v, type));
     }
 
     // ------------------------------------------- Building Entities
-    EntityImpl buildEntity(VertexElement vertex, EntityType type){
+    EntityImpl buildEntity(VertexElement vertex, EntityType type) {
         return getOrBuildConcept(vertex, (v) -> EntityImpl.create(v, type));
     }
 
     // ----------------------------------------- Building Rules --------------------------------------------------
-    public RuleImpl buildRule(VertexElement vertex, Rule type, Pattern when, Pattern then){
+    public RuleImpl buildRule(VertexElement vertex, Rule type, Pattern when, Pattern then) {
         return getOrBuildConcept(vertex, (v) -> RuleImpl.create(v, type, when, then));
     }
 
     // ------------------------------------------ Building Roles  Types ------------------------------------------------
-    public RoleImpl buildRole(VertexElement vertex, Role type){
+    public RoleImpl buildRole(VertexElement vertex, Role type) {
         return getOrBuildConcept(vertex, (v) -> RoleImpl.create(v, type));
     }
 
@@ -144,21 +140,21 @@ public final class ElementFactory {
      * @param vertex A vertex of an unknown type
      * @return A concept built to the correct type
      */
-    public <X extends Concept> X buildConcept(Vertex vertex){
+    public <X extends Concept> X buildConcept(Vertex vertex) {
         return buildConcept(buildVertexElement(vertex));
     }
 
-    public <X extends Concept> X buildConcept(VertexElement vertexElement){
+    public <X extends Concept> X buildConcept(VertexElement vertexElement) {
         Schema.BaseType type;
 
         try {
             type = getBaseType(vertexElement);
-        } catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             throw TemporaryWriteException.indexOverlap(vertexElement.element(), e);
         }
 
         ConceptId conceptId = ConceptId.of(vertexElement.property(Schema.VertexProperty.ID));
-        if(!tx.cache().isConceptCached(conceptId)){
+        if (!tx.cache().isConceptCached(conceptId)) {
             Concept concept;
             switch (type) {
                 case RELATIONSHIP:
@@ -203,15 +199,15 @@ public final class ElementFactory {
      * @param edge A Edge of an unknown type
      * @return A concept built to the correct type
      */
-    public <X extends Concept> X buildConcept(Edge edge){
+    public <X extends Concept> X buildConcept(Edge edge) {
         return buildConcept(buildEdgeElement(edge));
     }
 
-    public <X extends Concept> X buildConcept(EdgeElement edgeElement){
+    public <X extends Concept> X buildConcept(EdgeElement edgeElement) {
         Schema.EdgeLabel label = Schema.EdgeLabel.valueOf(edgeElement.label().toUpperCase(Locale.getDefault()));
 
         ConceptId conceptId = ConceptId.of(edgeElement.id().getValue());
-        if(!tx.cache().isConceptCached(conceptId)){
+        if (!tx.cache().isConceptCached(conceptId)) {
             Concept concept;
             switch (label) {
                 case ATTRIBUTE:
@@ -233,40 +229,39 @@ public final class ElementFactory {
      * @param vertex The vertex to build a concept from
      * @return The base type of the vertex, if it is a valid concept.
      */
-    private Schema.BaseType getBaseType(VertexElement vertex){
+    private Schema.BaseType getBaseType(VertexElement vertex) {
         try {
             return Schema.BaseType.valueOf(vertex.label());
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             //Base type appears to be invalid. Let's try getting the type via the shard edge
             Optional<VertexElement> type = vertex.getEdgesOfType(Direction.OUT, Schema.EdgeLabel.SHARD).
                     map(EdgeElement::target).findAny();
 
-            if(type.isPresent()){
+            if (type.isPresent()) {
                 String label = type.get().label();
-                if(label.equals(Schema.BaseType.ENTITY_TYPE.name())) return Schema.BaseType.ENTITY;
-                if(label.equals(RELATIONSHIP_TYPE.name())) return Schema.BaseType.RELATIONSHIP;
-                if(label.equals(Schema.BaseType.ATTRIBUTE_TYPE.name())) return Schema.BaseType.ATTRIBUTE;
+                if (label.equals(Schema.BaseType.ENTITY_TYPE.name())) return Schema.BaseType.ENTITY;
+                if (label.equals(RELATIONSHIP_TYPE.name())) return Schema.BaseType.RELATIONSHIP;
+                if (label.equals(Schema.BaseType.ATTRIBUTE_TYPE.name())) return Schema.BaseType.ATTRIBUTE;
             }
         }
         throw new IllegalStateException("Could not determine the base type of vertex [" + vertex + "]");
     }
 
     // ---------------------------------------- Non Concept Construction -----------------------------------------------
-    public EdgeElement buildEdgeElement(Edge edge){
+    public EdgeElement buildEdgeElement(Edge edge) {
         return new EdgeElement(tx, edge);
     }
 
 
-
-    Shard buildShard(ConceptImpl shardOwner, VertexElement vertexElement){
+    Shard buildShard(ConceptImpl shardOwner, VertexElement vertexElement) {
         return new Shard(shardOwner, vertexElement);
     }
 
-    Shard buildShard(VertexElement vertexElement){
+    Shard buildShard(VertexElement vertexElement) {
         return new Shard(vertexElement);
     }
 
-    Shard buildShard(Vertex vertex){
+    Shard buildShard(Vertex vertex) {
         return new Shard(buildVertexElement(vertex));
     }
 
@@ -277,8 +272,8 @@ public final class ElementFactory {
      * @param vertex A vertex which can possibly be turned into a VertexElement
      * @return A VertexElement of
      */
-    public VertexElement buildVertexElement(Vertex vertex){
-        if(!tx.isValidElement(vertex)){
+    public VertexElement buildVertexElement(Vertex vertex) {
+        if (!tx.isValidElement(vertex)) {
             Objects.requireNonNull(vertex);
             throw TransactionException.invalidElement(vertex);
         }
@@ -288,16 +283,16 @@ public final class ElementFactory {
     /**
      * Creates a new VertexElement with a ConceptId which can optionally be set.
      *
-     * @param baseType The {@link Schema.BaseType}
+     * @param baseType   The {@link Schema.BaseType}
      * @param conceptIds the optional ConceptId to set as the new ConceptId
      * @return a new VertexElement
      */
-    public VertexElement addVertexElement(Schema.BaseType baseType, ConceptId ... conceptIds) {
+    public VertexElement addVertexElement(Schema.BaseType baseType, ConceptId... conceptIds) {
         Vertex vertex = graph.addVertex(baseType.name());
         String newConceptId = Schema.PREFIX_VERTEX + vertex.id().toString();
-        if(conceptIds.length > 1){
+        if (conceptIds.length > 1) {
             throw new IllegalArgumentException("Cannot provide more than one concept id when creating a new concept");
-        } else if (conceptIds.length == 1){
+        } else if (conceptIds.length == 1) {
             newConceptId = conceptIds[0].getValue();
         }
         vertex.property(Schema.VertexProperty.ID.name(), newConceptId);

--- a/server/src/server/kb/concept/ElementFactory.java
+++ b/server/src/server/kb/concept/ElementFactory.java
@@ -48,11 +48,11 @@ import static grakn.core.graql.internal.Schema.BaseType.RELATIONSHIP_TYPE;
 
 /**
  * Constructs Concepts And Edges
- * This class turns Tinkerpop Vertex and {@link org.apache.tinkerpop.gremlin.structure.Edge}
+ * This class turns Tinkerpop Vertex and org.apache.tinkerpop.gremlin.structure.Edge
  * into Grakn Concept and EdgeElement.
  * Construction is only successful if the vertex and edge properties contain the needed information.
- * A concept must include a label which is a {@link Schema.BaseType}.
- * An edge must include a label which is a {@link Schema.EdgeLabel}.
+ * A concept must include a label which is a Schema.BaseType.
+ * An edge must include a label which is a Schema.EdgeLabel.
  */
 public final class ElementFactory {
     private final TransactionOLTP tx;
@@ -283,7 +283,7 @@ public final class ElementFactory {
     /**
      * Creates a new VertexElement with a ConceptId which can optionally be set.
      *
-     * @param baseType   The {@link Schema.BaseType}
+     * @param baseType   The Schema.BaseType
      * @param conceptIds the optional ConceptId to set as the new ConceptId
      * @return a new VertexElement
      */

--- a/server/src/server/kb/concept/EntityImpl.java
+++ b/server/src/server/kb/concept/EntityImpl.java
@@ -23,16 +23,10 @@ import grakn.core.graql.concept.EntityType;
 import grakn.core.server.kb.structure.VertexElement;
 
 /**
- * <p>
- *     An instance of Entity Type EntityType
- * </p>
- *
- * <p>
- *     This represents an entity in the graph.
- *     Entities are objects which are defined by their Attribute and their links to
- *     other entities via Relation
- * </p>
- *
+ * An instance of Entity Type EntityType
+ * This represents an entity in the graph.
+ * Entities are objects which are defined by their Attribute and their links to
+ * other entities via Relation
  */
 public class EntityImpl extends ThingImpl<Entity, EntityType> implements Entity {
     private EntityImpl(VertexElement vertexElement) {
@@ -43,15 +37,15 @@ public class EntityImpl extends ThingImpl<Entity, EntityType> implements Entity 
         super(vertexElement, type);
     }
 
-    public static EntityImpl get(VertexElement vertexElement){
+    public static EntityImpl get(VertexElement vertexElement) {
         return new EntityImpl(vertexElement);
     }
 
-    public static EntityImpl create(VertexElement vertexElement, EntityType type){
+    public static EntityImpl create(VertexElement vertexElement, EntityType type) {
         return new EntityImpl(vertexElement, type);
     }
 
-    public static EntityImpl from(Entity entity){
+    public static EntityImpl from(Entity entity) {
         return (EntityImpl) entity;
     }
 }

--- a/server/src/server/kb/concept/EntityTypeImpl.java
+++ b/server/src/server/kb/concept/EntityTypeImpl.java
@@ -24,18 +24,11 @@ import grakn.core.graql.internal.Schema;
 import grakn.core.server.kb.structure.VertexElement;
 
 /**
- * <p>
- *     SchemaConcept used to represent categories.
- * </p>
- *
- * <p>
- *     A SchemaConcept which represents categories instances can fall within.
- *     Any instance of a EntityType is called an Entity.
- * </p>
- *
- *
+ * SchemaConcept used to represent categories.
+ * A SchemaConcept which represents categories instances can fall within.
+ * Any instance of a EntityType is called an Entity.
  */
-public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements EntityType{
+public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements EntityType {
     private EntityTypeImpl(VertexElement vertexElement) {
         super(vertexElement);
     }
@@ -44,12 +37,16 @@ public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements Enti
         super(vertexElement, type);
     }
 
-    public static EntityTypeImpl get(VertexElement vertexElement){
+    public static EntityTypeImpl get(VertexElement vertexElement) {
         return new EntityTypeImpl(vertexElement);
     }
 
-    public static EntityTypeImpl create(VertexElement vertexElement, EntityType type){
+    public static EntityTypeImpl create(VertexElement vertexElement, EntityType type) {
         return new EntityTypeImpl(vertexElement, type);
+    }
+
+    public static EntityTypeImpl from(EntityType entityType) {
+        return (EntityTypeImpl) entityType;
     }
 
     @Override
@@ -59,9 +56,5 @@ public class EntityTypeImpl extends TypeImpl<EntityType, Entity> implements Enti
 
     public Entity addEntityInferred() {
         return addInstance(Schema.BaseType.ENTITY, (vertex, type) -> vertex().tx().factory().buildEntity(vertex, type), true);
-    }
-
-    public static EntityTypeImpl from(EntityType entityType){
-        return (EntityTypeImpl) entityType;
     }
 }

--- a/server/src/server/kb/concept/RelationEdge.java
+++ b/server/src/server/kb/concept/RelationEdge.java
@@ -41,16 +41,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     Encapsulates The Relation as a EdgeElement
- * </p>
- *
- * <p>
- *     This wraps up a Relation as a EdgeElement. It is used to represent any binary Relation.
- *     This also includes the ability to automatically reify a RelationEdge into a RelationReified.
- * </p>
- *
- *
+ * Encapsulates The Relation as a EdgeElement
+ * This wraps up a Relation as a EdgeElement. It is used to represent any binary Relation.
+ * This also includes the ability to automatically reify a RelationEdge into a RelationReified.
  */
 public class RelationEdge implements RelationStructure, CacheOwner {
     private final Set<Cache> registeredCaches = new HashSet<>();
@@ -90,7 +83,7 @@ public class RelationEdge implements RelationStructure, CacheOwner {
         this.valueRole.set(valueRole);
     }
 
-    public static RelationEdge get(EdgeElement edgeElement){
+    public static RelationEdge get(EdgeElement edgeElement) {
         return new RelationEdge(edgeElement);
     }
 
@@ -98,7 +91,7 @@ public class RelationEdge implements RelationStructure, CacheOwner {
         return new RelationEdge(relationshipType, ownerRole, valueRole, edgeElement);
     }
 
-    private EdgeElement edge(){
+    private EdgeElement edge() {
         return edgeElement;
     }
 
@@ -140,13 +133,13 @@ public class RelationEdge implements RelationStructure, CacheOwner {
 
     @Override
     public Stream<Thing> rolePlayers(Role... roles) {
-        if(roles.length == 0){
+        if (roles.length == 0) {
             return Stream.of(owner(), value());
         }
 
         HashSet<Thing> result = new HashSet<>();
         for (Role role : roles) {
-            if(role.equals(ownerRole())) {
+            if (role.equals(ownerRole())) {
                 result.add(owner());
             } else if (role.equals(valueRole())) {
                 result.add(value());
@@ -155,17 +148,19 @@ public class RelationEdge implements RelationStructure, CacheOwner {
         return result.stream();
     }
 
-    public Role ownerRole(){
+    public Role ownerRole() {
         return ownerRole.get();
     }
-    public Thing owner(){
+
+    public Thing owner() {
         return owner.get();
     }
 
-    public Role valueRole(){
+    public Role valueRole() {
         return valueRole.get();
     }
-    public Thing value(){
+
+    public Thing value() {
         return value.get();
     }
 
@@ -185,7 +180,7 @@ public class RelationEdge implements RelationStructure, CacheOwner {
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return "ID [" + id() + "] Type [" + type().label() + "] Roles and Role Players: \n" +
                 "Role [" + ownerRole().label() + "] played by [" + owner().id() + "] \n" +
                 "Role [" + valueRole().label() + "] played by [" + value().id() + "] \n";

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -123,8 +123,8 @@ public class RelationImpl implements Relation, ConceptVertex, CacheOwner {
     }
 
     @Override
-    public Stream<Relation> relationships(Role... roles) {
-        return readFromReified((relationReified) -> relationReified.relationships(roles));
+    public Stream<Relation> relations(Role... roles) {
+        return readFromReified((relationReified) -> relationReified.relations(roles));
     }
 
     @Override

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -55,6 +55,10 @@ public class RelationImpl implements Relation, ConceptVertex, CacheOwner {
         return new RelationImpl(relationshipStructure);
     }
 
+    public static RelationImpl from(Relation relationship) {
+        return (RelationImpl) relationship;
+    }
+
     /**
      * Gets the RelationReified if the Relation has been reified.
      * To reify the Relation you use RelationImpl.reify().
@@ -225,10 +229,6 @@ public class RelationImpl implements Relation, ConceptVertex, CacheOwner {
     @Override
     public VertexElement vertex() {
         return reify().vertex();
-    }
-
-    public static RelationImpl from(Relation relationship) {
-        return (RelationImpl) relationship;
     }
 
     @Override

--- a/server/src/server/kb/concept/RelationReified.java
+++ b/server/src/server/kb/concept/RelationReified.java
@@ -108,7 +108,7 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
     /**
      * If the edge does not exist then it adds a Schema.EdgeLabel#ROLE_PLAYER edge from
      * this Relation to a target Thing which is playing some Role.
-         * If the edge does exist nothing is done.
+     * If the edge does exist nothing is done.
      *
      * @param role    The Role being played by the Thing in this Relation
      * @param toThing The Thing playing a Role in this Relation

--- a/server/src/server/kb/concept/RelationReified.java
+++ b/server/src/server/kb/concept/RelationReified.java
@@ -44,20 +44,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     Encapsulates The Relation as a VertexElement
- * </p>
- *
- * <p>
- *     This wraps up a Relation as a VertexElement. It is used to represent any Relation which
- *     has been reified.
- * </p>
- *
- *
+ * Encapsulates The Relation as a VertexElement
+ * This wraps up a Relation as a VertexElement. It is used to represent any Relation which
+ * has been reified.
  */
 public class RelationReified extends ThingImpl<Relation, RelationType> implements RelationStructure {
 
-    @Nullable private RelationImpl owner;
+    @Nullable
+    private RelationImpl owner;
 
     private RelationReified(VertexElement vertexElement) {
         super(vertexElement);
@@ -67,11 +61,11 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
         super(vertexElement, type);
     }
 
-    public static RelationReified get(VertexElement vertexElement){
+    public static RelationReified get(VertexElement vertexElement) {
         return new RelationReified(vertexElement);
     }
 
-    public static RelationReified create(VertexElement vertexElement, RelationType type){
+    public static RelationReified create(VertexElement vertexElement, RelationType type) {
         return new RelationReified(vertexElement, type);
     }
 
@@ -96,8 +90,8 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
         castingsRelation().filter(casting -> casting.getRole().equals(role) && casting.getRolePlayer().equals(thing)).
                 findAny().
                 ifPresent(casting -> {
-                   casting.delete();
-                   vertex().tx().cache().remove(casting);
+                    casting.delete();
+                    vertex().tx().cache().remove(casting);
                 });
     }
 
@@ -105,7 +99,7 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
         Objects.requireNonNull(role);
         Objects.requireNonNull(thing);
 
-        if(Schema.MetaSchema.isMetaLabel(role.label())) throw TransactionException.metaTypeImmutable(role.label());
+        if (Schema.MetaSchema.isMetaLabel(role.label())) throw TransactionException.metaTypeImmutable(role.label());
 
         //Do the actual put of the role and role player
         putRolePlayerEdge(role, thing);
@@ -114,10 +108,9 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
     /**
      * If the edge does not exist then it adds a {@link Schema.EdgeLabel#ROLE_PLAYER} edge from
      * this Relation to a target Thing which is playing some Role.
+         * If the edge does exist nothing is done.
      *
-     * If the edge does exist nothing is done.
-     *
-     * @param role The Role being played by the Thing in this Relation
+     * @param role    The Role being played by the Thing in this Relation
      * @param toThing The Thing playing a Role in this Relation
      */
     public void putRolePlayerEdge(Role role, Thing toThing) {
@@ -132,7 +125,7 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
                 has(Schema.VertexProperty.ID.name(), toThing.id()).
                 select("edge");
 
-        if(traversal.hasNext()){
+        if (traversal.hasNext()) {
             return;
         }
 
@@ -150,9 +143,9 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
      * @param roles The Role which the Things are playing
      * @return The Casting which unify a Role and Thing with this Relation
      */
-    public Stream<Casting> castingsRelation(Role... roles){
+    public Stream<Casting> castingsRelation(Role... roles) {
         Set<Role> roleSet = new HashSet<>(Arrays.asList(roles));
-        if(roleSet.isEmpty()){
+        if (roleSet.isEmpty()) {
             return vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ROLE_PLAYER).
                     map(edge -> Casting.withRelationship(edge, owner));
         }
@@ -170,11 +163,11 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
     }
 
     @Override
-    public String innerToString(){
+    public String innerToString() {
         StringBuilder description = new StringBuilder();
         description.append("ID [").append(id()).append("] Type [").append(type().label()).append("] Roles and Role Players: \n");
         for (Map.Entry<Role, Set<Thing>> entry : allRolePlayers().entrySet()) {
-            if(entry.getValue().isEmpty()){
+            if (entry.getValue().isEmpty()) {
                 description.append("    Role [").append(entry.getKey().label()).append("] not played by any instance \n");
             } else {
                 StringBuilder instancesString = new StringBuilder();

--- a/server/src/server/kb/concept/RelationReified.java
+++ b/server/src/server/kb/concept/RelationReified.java
@@ -106,7 +106,7 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
     }
 
     /**
-     * If the edge does not exist then it adds a {@link Schema.EdgeLabel#ROLE_PLAYER} edge from
+     * If the edge does not exist then it adds a Schema.EdgeLabel#ROLE_PLAYER edge from
      * this Relation to a target Thing which is playing some Role.
          * If the edge does exist nothing is done.
      *

--- a/server/src/server/kb/concept/RelationStructure.java
+++ b/server/src/server/kb/concept/RelationStructure.java
@@ -30,53 +30,40 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     Encapsulates The structure of a  Relation.
- * </p>
- *
- * <p>
- *     This wraps up the structure of a Relation as either a RelationReified or a
- *     RelationEdge.
- *     It contains methods which can be accessed regardless of the Relation being a represented by a
- *     VertexElement or an EdgeElement
- * </p>
- *
- *
+ * Encapsulates The structure of a  Relation.
+ * This wraps up the structure of a Relation as either a RelationReified or a
+ * RelationEdge.
+ * It contains methods which can be accessed regardless of the Relation being a represented by a
+ * VertexElement or an EdgeElement
  */
 interface RelationStructure extends CacheOwner {
 
     /**
-     *
      * @return The ConceptId of the Relation
      */
     ConceptId id();
 
     /**
-     *
      * @return The relation structure which has been reified
      */
     RelationReified reify();
 
     /**
-     *
      * @return true if the Relation has been reified meaning it can support n-ary relationships
      */
     boolean isReified();
 
     /**
-     *
      * @return The RelationType of the Relation
      */
     RelationType type();
 
     /**
-     *
      * @return All the Roles and the Things which play them
      */
     Map<Role, Set<Thing>> allRolePlayers();
 
     /**
-     *
      * @param roles The Roles which are played in this relation
      * @return The Things which play those Roles
      */
@@ -94,9 +81,9 @@ interface RelationStructure extends CacheOwner {
 
     /**
      * Used to indicate if this Relation has been created as the result of a Rule inference.
-     * @see Rule
      *
      * @return true if this Relation exists due to a rule
+     * @see Rule
      */
     boolean isInferred();
 

--- a/server/src/server/kb/concept/RelationTypeImpl.java
+++ b/server/src/server/kb/concept/RelationTypeImpl.java
@@ -33,16 +33,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     An ontological element which categorises how instances may relate to each other.
- * </p>
- *
- * <p>
- *     A relation type defines how Type may relate to one another.
- *     They are used to model and categorise n-ary relationships.
- * </p>
- *
- *
+ * An ontological element which categorises how instances may relate to each other.
+ * A relation type defines how Type may relate to one another.
+ * They are used to model and categorise n-ary relationships.
  */
 public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implements RelationType {
     private final Cache<Set<Role>> cachedRelates = Cache.createSessionCache(this, Cacheable.set(), () -> this.<Role>neighbours(Direction.OUT, Schema.EdgeLabel.RELATES).collect(Collectors.toSet()));
@@ -55,14 +48,18 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
         super(vertexElement, type);
     }
 
-    public static RelationTypeImpl get(VertexElement vertexElement){
+    public static RelationTypeImpl get(VertexElement vertexElement) {
         return new RelationTypeImpl(vertexElement);
     }
 
-    public static RelationTypeImpl create(VertexElement vertexElement, RelationType type){
+    public static RelationTypeImpl create(VertexElement vertexElement, RelationType type) {
         RelationTypeImpl relationType = new RelationTypeImpl(vertexElement, type);
         vertexElement.tx().cache().trackForValidation(relationType);
         return relationType;
+    }
+
+    public static RelationTypeImpl from(RelationType relationshipType) {
+        return (RelationTypeImpl) relationshipType;
     }
 
     @Override
@@ -80,8 +77,6 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
         vertex().tx().cache().addNewRelationship(relationship);
         return relationship;
     }
-
-
 
     @Override
     public Stream<Role> roles() {
@@ -105,7 +100,6 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
     }
 
     /**
-     *
      * @param role The Role to delete from this RelationType.
      * @return The Relation Type itself.
      */
@@ -135,7 +129,7 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
     }
 
     @Override
-    public void delete(){
+    public void delete() {
         cachedRelates.get().forEach(r -> {
             RoleImpl role = ((RoleImpl) r);
             vertex().tx().cache().trackForValidation(role);
@@ -146,43 +140,39 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
     }
 
     @Override
-    void trackRolePlayers(){
+    void trackRolePlayers() {
         instances().forEach(concept -> {
             RelationImpl relation = RelationImpl.from(concept);
-            if(relation.reified().isPresent()){
+            if (relation.reified().isPresent()) {
                 relation.reified().get().castingsRelation().forEach(rolePlayer -> vertex().tx().cache().trackForValidation(rolePlayer));
             }
         });
     }
 
     @Override
-    public Stream<Relation> instancesDirect(){
+    public Stream<Relation> instancesDirect() {
         Stream<Relation> instances = super.instancesDirect();
 
         //If the relation type is implicit then we need to get any relation edges it may have.
-        if(isImplicit()) instances = Stream.concat(instances, relationEdges());
+        if (isImplicit()) instances = Stream.concat(instances, relationEdges());
 
         return instances;
     }
 
-    private Stream<Relation> relationEdges(){
+    private Stream<Relation> relationEdges() {
         //Unfortunately this is a slow process
         return roles().
                 flatMap(Role::players).
-                flatMap(type ->{
+                flatMap(type -> {
                     //Traversal is used here to take advantage of vertex centric index
-                    return  vertex().tx().getTinkerTraversal().V().
+                    return vertex().tx().getTinkerTraversal().V().
                             has(Schema.VertexProperty.ID.name(), type.id().getValue()).
                             in(Schema.EdgeLabel.SHARD.getLabel()).
                             in(Schema.EdgeLabel.ISA.getLabel()).
                             outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()).
                             has(Schema.EdgeProperty.RELATIONSHIP_TYPE_LABEL_ID.name(), labelId().getValue()).
                             toStream().
-                            map(edge -> vertex().tx().factory().<Relation>buildConcept(edge));
+                            map(edge -> vertex().tx().factory().buildConcept(edge));
                 });
-    }
-
-    public static RelationTypeImpl from(RelationType relationshipType){
-        return (RelationTypeImpl) relationshipType;
     }
 }

--- a/server/src/server/kb/concept/RoleImpl.java
+++ b/server/src/server/kb/concept/RoleImpl.java
@@ -34,18 +34,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     An SchemaConcept which defines a Role which can be played in a RelationType.
- * </p>
- *
- * <p>
- *     This SchemaConcept defines the roles which make up a RelationType.
- *     It has some additional functionality:
- *     1. It cannot play a Role to itself.
- *     2. It is special in that it is unique to RelationTypes.
- * </p>
- *
- *
+ * An SchemaConcept which defines a Role which can be played in a RelationType.
+ * This SchemaConcept defines the roles which make up a RelationType.
+ * It has some additional functionality:
+ * 1. It cannot play a Role to itself.
+ * 2. It is special in that it is unique to RelationTypes.
  */
 public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
     private final Cache<Set<Type>> cachedDirectPlayedByTypes = Cache.createSessionCache(this, Cacheable.set(), () -> this.<Type>neighbours(Direction.IN, Schema.EdgeLabel.PLAYS).collect(Collectors.toSet()));
@@ -59,7 +52,7 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
         super(vertexElement, type);
     }
 
-    public static RoleImpl get(VertexElement vertexElement){
+    public static RoleImpl get(VertexElement vertexElement) {
         return new RoleImpl(vertexElement);
     }
 
@@ -80,7 +73,7 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
      *
      * @param newRelationshipType The new relation type to cache in the role.
      */
-    void addCachedRelationType(RelationType newRelationshipType){
+    void addCachedRelationType(RelationType newRelationshipType) {
         cachedRelationTypes.ifPresent(set -> set.add(newRelationshipType));
     }
 
@@ -90,12 +83,11 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
      *
      * @param oldRelationshipType The new relation type to cache in the role.
      */
-    void deleteCachedRelationType(RelationType oldRelationshipType){
+    void deleteCachedRelationType(RelationType oldRelationshipType) {
         cachedRelationTypes.ifPresent(set -> set.remove(oldRelationshipType));
     }
 
     /**
-     *
      * @return A list of all the Concept Types which can play this role.
      */
     @Override
@@ -103,19 +95,18 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
         return cachedDirectPlayedByTypes.get().stream().flatMap(Type::subs);
     }
 
-    void addCachedDirectPlaysByType(Type newType){
+    void addCachedDirectPlaysByType(Type newType) {
         cachedDirectPlayedByTypes.ifPresent(set -> set.add(newType));
     }
 
-    void deleteCachedDirectPlaysByType(Type oldType){
+    void deleteCachedDirectPlaysByType(Type oldType) {
         cachedDirectPlayedByTypes.ifPresent(set -> set.remove(oldType));
     }
 
     /**
-     *
      * @return Get all the roleplayers of this role type
      */
-    public Stream<Casting> rolePlayers(){
+    public Stream<Casting> rolePlayers() {
         return relationships().
                 flatMap(RelationType::instances).
                 map(relation -> RelationImpl.from(relation).reified()).
@@ -124,7 +115,7 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
     }
 
     @Override
-    boolean deletionAllowed(){
+    boolean deletionAllowed() {
         return super.deletionAllowed() &&
                 !neighbours(Direction.IN, Schema.EdgeLabel.RELATES).findAny().isPresent() && // This role is not linked t any relation type
                 !neighbours(Direction.IN, Schema.EdgeLabel.PLAYS).findAny().isPresent() && // Nothing can play this role

--- a/server/src/server/kb/concept/RoleImpl.java
+++ b/server/src/server/kb/concept/RoleImpl.java
@@ -63,7 +63,7 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
     }
 
     @Override
-    public Stream<RelationType> relationships() {
+    public Stream<RelationType> relations() {
         return cachedRelationTypes.get().stream();
     }
 
@@ -107,7 +107,7 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
      * @return Get all the roleplayers of this role type
      */
     public Stream<Casting> rolePlayers() {
-        return relationships().
+        return relations().
                 flatMap(RelationType::instances).
                 map(relation -> RelationImpl.from(relation).reified()).
                 flatMap(CommonUtil::optionalToStream).

--- a/server/src/server/kb/concept/RuleImpl.java
+++ b/server/src/server/kb/concept/RuleImpl.java
@@ -30,14 +30,8 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     An ontological element used to model and categorise different types of Rule.
- * </p>
- *
- * <p>
- *     An ontological element used to define different types of Rule.
- * </p>
- *
+ * An ontological element used to model and categorise different types of Rule.
+ * An ontological element used to define different types of Rule.
  */
 public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
     private RuleImpl(VertexElement vertexElement) {
@@ -50,7 +44,7 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
         vertex().propertyImmutable(Schema.VertexProperty.RULE_THEN, then, then(), Pattern::toString);
     }
 
-    public static RuleImpl get(VertexElement vertexElement){
+    public static RuleImpl get(VertexElement vertexElement) {
         return new RuleImpl(vertexElement);
     }
 
@@ -58,6 +52,11 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
         RuleImpl rule = new RuleImpl(vertexElement, type, when, then);
         vertexElement.tx().cache().trackForValidation(rule);
         return rule;
+    }
+
+    public static <X extends Type, Y extends Thing> RuleImpl from(Rule type) {
+        //noinspection unchecked
+        return (RuleImpl) type;
     }
 
     @Override
@@ -86,7 +85,6 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
     }
 
     /**
-     *
      * @param type The Type which this Rule applies to.
      */
     public void addHypothesis(Type type) {
@@ -94,23 +92,17 @@ public class RuleImpl extends SchemaConceptImpl<Rule> implements Rule {
     }
 
     /**
-     *
      * @param type The Type which is the conclusion of this Rule.
      */
     public void addConclusion(Type type) {
         putEdge(ConceptVertex.from(type), Schema.EdgeLabel.CONCLUSION);
     }
 
-    private Pattern parsePattern(String value){
-        if(value == null) {
+    private Pattern parsePattern(String value) {
+        if (value == null) {
             return null;
         } else {
             return Graql.parsePattern(value);
         }
-    }
-
-    public static <X extends Type, Y extends Thing> RuleImpl from(Rule type){
-        //noinspection unchecked
-        return (RuleImpl) type;
     }
 }

--- a/server/src/server/kb/concept/SchemaConceptImpl.java
+++ b/server/src/server/kb/concept/SchemaConceptImpl.java
@@ -38,23 +38,17 @@ import java.util.stream.Stream;
 import static scala.tools.scalap.scalax.rules.scalasig.NoSymbol.isAbstract;
 
 /**
- * <p>
- *     Schema Specific Concept
- * </p>
- *
- * <p>
- *     Allows you to create schema or ontological elements.
- *     These differ from normal graph constructs in two ways:
- *     1. They have a unique Label which identifies them
- *     2. You can link them together into a hierarchical structure
- * </p>
- *
+ * Schema Specific Concept
+ * Allows you to create schema or ontological elements.
+ * These differ from normal graph constructs in two ways:
+ * 1. They have a unique Label which identifies them
+ * 2. You can link them together into a hierarchical structure
  *
  * @param <T> The leaf interface of the object concept.
- *           For example an EntityType or RelationType or Role
+ *            For example an EntityType or RelationType or Role
  */
 public abstract class SchemaConceptImpl<T extends SchemaConcept> extends ConceptImpl implements SchemaConcept {
-    private final Cache<Label> cachedLabel = Cache.createPersistentCache(this, Cacheable.label(), () ->  Label.of(vertex().property(Schema.VertexProperty.SCHEMA_LABEL)));
+    private final Cache<Label> cachedLabel = Cache.createPersistentCache(this, Cacheable.label(), () -> Label.of(vertex().property(Schema.VertexProperty.SCHEMA_LABEL)));
     private final Cache<LabelId> cachedLabelId = Cache.createSessionCache(this, Cacheable.labelId(), () -> LabelId.of(vertex().property(Schema.VertexProperty.LABEL_ID)));
     private final Cache<T> cachedSuperType = Cache.createSessionCache(this, Cacheable.concept(), () -> this.<T>neighbours(Direction.OUT, Schema.EdgeLabel.SUB).findFirst().orElse(null));
     private final Cache<Set<T>> cachedDirectSubTypes = Cache.createSessionCache(this, Cacheable.set(), () -> this.<T>neighbours(Direction.IN, Schema.EdgeLabel.SUB).collect(Collectors.toSet()));
@@ -66,33 +60,36 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
 
     SchemaConceptImpl(VertexElement vertexElement, T superType) {
         this(vertexElement);
-        if(sup() == null) sup(superType);
+        if (sup() == null) sup(superType);
     }
 
-    public T label(Label label){
+    public static <X extends SchemaConcept> SchemaConceptImpl<X> from(SchemaConcept schemaConcept) {
+        //noinspection unchecked
+        return (SchemaConceptImpl<X>) schemaConcept;
+    }
+
+    public T label(Label label) {
         try {
             vertex().tx().cache().remove(this);
             vertex().propertyUnique(Schema.VertexProperty.SCHEMA_LABEL, label.getValue());
             cachedLabel.set(label);
             vertex().tx().cache().cacheConcept(this);
             return getThis();
-        } catch (PropertyNotUniqueException exception){
+        } catch (PropertyNotUniqueException exception) {
             vertex().tx().cache().cacheConcept(this);
             throw TransactionException.labelTaken(label);
         }
     }
 
     /**
-     *
      * @return The internal id which is used for fast lookups
      */
     @Override
-    public LabelId labelId(){
+    public LabelId labelId() {
         return cachedLabelId.get();
     }
 
     /**
-     *
      * @return The label of this ontological element
      */
     @Override
@@ -101,21 +98,19 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
     }
 
     /**
-     *
      * @return The super of this SchemaConcept
      */
     public T sup() {
         return cachedSuperType.get();
     }
 
-
     @Override
     public Stream<T> sups() {
-        Set<T> superSet= new HashSet<>();
+        Set<T> superSet = new HashSet<>();
 
         T superParent = getThis();
 
-        while(superParent != null && !Schema.MetaSchema.THING.getLabel().equals(superParent.label())){
+        while (superParent != null && !Schema.MetaSchema.THING.getLabel().equals(superParent.label())) {
             superSet.add(superParent);
 
             //noinspection unchecked
@@ -126,11 +121,10 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
     }
 
     /**
-     *
      * @return returns true if the type was created implicitly through the resource syntax
      */
     @Override
-    public Boolean isImplicit(){
+    public Boolean isImplicit() {
         return cachedIsImplicit.get();
     }
 
@@ -138,8 +132,8 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      * Deletes the concept as a SchemaConcept
      */
     @Override
-    public void delete(){
-        if(deletionAllowed()){
+    public void delete() {
+        if (deletionAllowed()) {
             //Force load of linked concepts whose caches need to be updated
             T superConcept = cachedSuperType.get();
 
@@ -162,17 +156,16 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
         }
     }
 
-    boolean deletionAllowed(){
+    boolean deletionAllowed() {
         checkSchemaMutationAllowed();
         return !neighbours(Direction.IN, Schema.EdgeLabel.SUB).findAny().isPresent();
     }
 
     /**
-     *
      * @return All the subs of this concept including itself
      */
     @Override
-    public Stream<T> subs(){
+    public Stream<T> subs() {
         return nextSubLevel(getThis());
     }
 
@@ -181,19 +174,18 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      *
      * @param newSubType The new subtype
      */
-    private void addCachedDirectSubType(T newSubType){
+    private void addCachedDirectSubType(T newSubType) {
         cachedDirectSubTypes.ifPresent(set -> set.add(newSubType));
     }
 
     /**
-     *
      * @param root The current SchemaConcept
      * @return All the sub children of the root. Effectively calls  the cache {@link SchemaConceptImpl#cachedDirectSubTypes} recursively
      */
     @SuppressWarnings("unchecked")
-    private Stream<T> nextSubLevel(T root){
+    private Stream<T> nextSubLevel(T root) {
         return Stream.concat(Stream.of(root),
-                SchemaConceptImpl.<T>from(root).cachedDirectSubTypes.get().stream().flatMap(this::nextSubLevel));
+                             SchemaConceptImpl.<T>from(root).cachedDirectSubTypes.get().stream().flatMap(this::nextSubLevel));
     }
 
     /**
@@ -201,9 +193,9 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      * 1. The SchemaConcept is not a meta-type
      * 2. The graph is not batch loading
      */
-    void checkSchemaMutationAllowed(){
+    void checkSchemaMutationAllowed() {
         vertex().tx().checkSchemaMutationAllowed();
-        if(Schema.MetaSchema.isMetaLabel(label())){
+        if (Schema.MetaSchema.isMetaLabel(label())) {
             throw TransactionException.metaTypeImmutable(label());
         }
     }
@@ -213,23 +205,22 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      *
      * @param oldSubType The old sub type which should not be cached anymore
      */
-    private void deleteCachedDirectedSubType(T oldSubType){
+    private void deleteCachedDirectedSubType(T oldSubType) {
         cachedDirectSubTypes.ifPresent(set -> set.remove(oldSubType));
     }
 
     /**
-     *
      * @param newSuperType This type's super type
      * @return The Type itself
      */
     public T sup(T newSuperType) {
         T oldSuperType = sup();
-        if(changingSuperAllowed(oldSuperType, newSuperType)){
+        if (changingSuperAllowed(oldSuperType, newSuperType)) {
             //Update the super type of this type in cache
             cachedSuperType.set(newSuperType);
 
             //Note the check before the actual construction
-            if(superLoops()){
+            if (superLoops()) {
                 cachedSuperType.set(oldSuperType); //Reset if the new super type causes a loop
                 throw TransactionException.loopCreated(this, newSuperType);
             }
@@ -239,7 +230,7 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
             putEdge(ConceptVertex.from(newSuperType), Schema.EdgeLabel.SUB);
 
             //Update the sub types of the old super type
-            if(oldSuperType != null) {
+            if (oldSuperType != null) {
                 //noinspection unchecked - Casting is needed to access {deleteCachedDirectedSubTypes} method
                 ((SchemaConceptImpl<T>) oldSuperType).deleteCachedDirectedSubType(getThis());
             }
@@ -249,11 +240,10 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
             ((SchemaConceptImpl<T>) newSuperType).addCachedDirectSubType(getThis());
 
             //Track any existing data if there is some
-            if(oldSuperType != null) trackRolePlayers();
+            if (oldSuperType != null) trackRolePlayers();
         }
         return getThis();
     }
-
 
     /**
      * Checks if changing the super is allowed. This passed if:
@@ -263,7 +253,7 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      * @param newSuperType the new super
      * @return true if we can set the new super
      */
-    boolean changingSuperAllowed(T oldSuperType, T newSuperType){
+    boolean changingSuperAllowed(T oldSuperType, T newSuperType) {
         checkSchemaMutationAllowed();
         return oldSuperType == null || !oldSuperType.equals(newSuperType);
     }
@@ -273,14 +263,14 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      */
     abstract void trackRolePlayers();
 
-    private boolean superLoops(){
+    private boolean superLoops() {
         //Check For Loop
         HashSet<SchemaConcept> foundTypes = new HashSet<>();
         SchemaConcept currentSuperType = sup();
-        while (currentSuperType != null){
+        while (currentSuperType != null) {
             foundTypes.add(currentSuperType);
             currentSuperType = currentSuperType.sup();
-            if(foundTypes.contains(currentSuperType)){
+            if (foundTypes.contains(currentSuperType)) {
                 return true;
             }
         }
@@ -288,7 +278,6 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
     }
 
     /**
-     *
      * @return A collection of Rule for which this SchemaConcept serves as a hypothesis
      */
     @Override
@@ -297,7 +286,6 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
     }
 
     /**
-     *
      * @return A collection of Rule for which this SchemaConcept serves as a conclusion
      */
     @Override
@@ -306,14 +294,9 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
     }
 
     @Override
-    public String innerToString(){
+    public String innerToString() {
         String message = super.innerToString();
         message = message + " - Label [" + label() + "] - Abstract [" + isAbstract() + "] ";
         return message;
-    }
-
-    public static <X extends SchemaConcept> SchemaConceptImpl<X> from(SchemaConcept schemaConcept){
-        //noinspection unchecked
-        return (SchemaConceptImpl<X>) schemaConcept;
     }
 }

--- a/server/src/server/kb/concept/SchemaConceptImpl.java
+++ b/server/src/server/kb/concept/SchemaConceptImpl.java
@@ -180,7 +180,7 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
 
     /**
      * @param root The current SchemaConcept
-     * @return All the sub children of the root. Effectively calls  the cache {@link SchemaConceptImpl#cachedDirectSubTypes} recursively
+     * @return All the sub children of the root. Effectively calls  the cache SchemaConceptImpl#cachedDirectSubTypes recursively
      */
     @SuppressWarnings("unchecked")
     private Stream<T> nextSubLevel(T root) {

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -55,21 +55,15 @@ import static grakn.core.graql.internal.Schema.EdgeProperty.ROLE_LABEL_ID;
 import static java.util.stream.Collectors.toSet;
 
 /**
- * <p>
- *     A data instance in the graph belonging to a specific Type
- * </p>
- *
- * <p>
- *     Instances represent data in the graph.
- *     Every instance belongs to a Type which serves as a way of categorising them.
- *     Instances can relate to one another via Relation
- * </p>
- *
+ * A data instance in the graph belonging to a specific Type
+ * Instances represent data in the graph.
+ * Every instance belongs to a Type which serves as a way of categorising them.
+ * Instances can relate to one another via Relation
  *
  * @param <T> The leaf interface of the object concept which extends Thing.
- *           For example Entity or Relation.
+ *            For example Entity or Relation.
  * @param <V> The type of the concept which extends Type of the concept.
- *           For example EntityType or RelationType
+ *            For example EntityType or RelationType
  */
 public abstract class ThingImpl<T extends Thing, V extends Type> extends ConceptImpl implements Thing {
     private final Cache<Label> cachedInternalType = Cache.createTxCache(this, Cacheable.label(), () -> {
@@ -102,13 +96,13 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     /**
      * This Thing gets tracked for validation only if it has keys which need to be checked.
      */
-    private void track(){
-        if(type().keys().findAny().isPresent()){
+    private void track() {
+        if (type().keys().findAny().isPresent()) {
             vertex().tx().cache().trackForValidation(this);
         }
     }
 
-    public boolean isInferred(){
+    public boolean isInferred() {
         return vertex().propertyBoolean(Schema.VertexProperty.IS_INFERRED);
     }
 
@@ -129,7 +123,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         deleteNode();
 
         relationships.forEach(relation -> {
-            if(relation.type().isImplicit()){//For now implicit relationships die
+            if (relation.type().isImplicit()) {//For now implicit relationships die
                 relation.delete();
             } else {
                 RelationImpl rel = (RelationImpl) relation;
@@ -140,9 +134,10 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
 
     /**
      * This index is used by concepts such as casting and relations to speed up internal lookups
+     *
      * @return The inner index value of some concepts.
      */
-    public String getIndex(){
+    public String getIndex() {
         return vertex().property(Schema.VertexProperty.INDEX);
     }
 
@@ -153,15 +148,15 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     }
 
     @Override
-    public Stream<Attribute<?>> keys(AttributeType... attributeTypes){
+    public Stream<Attribute<?>> keys(AttributeType... attributeTypes) {
         Set<ConceptId> attributeTypesIds = Arrays.stream(attributeTypes).map(Concept::id).collect(toSet());
         Set<ConceptId> keyTypeIds = type().keys().map(Concept::id).collect(toSet());
 
-        if(!attributeTypesIds.isEmpty()){
+        if (!attributeTypesIds.isEmpty()) {
             keyTypeIds = Sets.intersection(attributeTypesIds, keyTypeIds);
         }
 
-        if(keyTypeIds.isEmpty()) return Stream.empty();
+        if (keyTypeIds.isEmpty()) return Stream.empty();
 
         return attributes(getShortcutNeighbours(true), keyTypeIds);
     }
@@ -169,16 +164,16 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     /**
      * Helper class which filters a Stream of Attribute to those of a specific set of AttributeType.
      *
-     * @param conceptStream The Stream to filter
+     * @param conceptStream     The Stream to filter
      * @param attributeTypesIds The AttributeType ConceptIds to filter to.
      * @return the filtered stream
      */
-    private <X extends Concept> Stream<Attribute<?>> attributes(Stream<X> conceptStream, Set<ConceptId> attributeTypesIds){
+    private <X extends Concept> Stream<Attribute<?>> attributes(Stream<X> conceptStream, Set<ConceptId> attributeTypesIds) {
         Stream<Attribute<?>> attributeStream = conceptStream.
                 filter(concept -> concept.isAttribute() && !this.equals(concept)).
                 map(Concept::asAttribute);
 
-        if(!attributeTypesIds.isEmpty()){
+        if (!attributeTypesIds.isEmpty()) {
             attributeStream = attributeStream.filter(attribute -> attributeTypesIds.contains(attribute.type().id()));
         }
 
@@ -190,12 +185,12 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
      *
      * @return All the Casting which this instance is cast into the role
      */
-    Stream<Casting> castingsInstance(){
+    Stream<Casting> castingsInstance() {
         return vertex().getEdgesOfType(Direction.IN, Schema.EdgeLabel.ROLE_PLAYER).
                 map(edge -> Casting.withThing(edge, this));
     }
 
-    private Set<Integer> implicitLabelsToIds(Set<Label> labels, Set<Schema.ImplicitType> implicitTypes){
+    private Set<Integer> implicitLabelsToIds(Set<Label> labels, Set<Schema.ImplicitType> implicitTypes) {
         return labels.stream()
                 .flatMap(label -> implicitTypes.stream().map(it -> it.getLabel(label)))
                 .map(label -> vertex().tx().convertToId(label))
@@ -204,7 +199,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
                 .collect(toSet());
     }
 
-    <X extends Thing> Stream<X> getShortcutNeighbours(boolean ownerToValueOrdering, AttributeType... attributeTypes){
+    <X extends Thing> Stream<X> getShortcutNeighbours(boolean ownerToValueOrdering, AttributeType... attributeTypes) {
         Set<AttributeType> completeAttributeTypes = new HashSet<>(Arrays.asList(attributeTypes));
         if (completeAttributeTypes.isEmpty()) completeAttributeTypes.add(vertex().tx().getMetaAttributeType());
 
@@ -227,13 +222,13 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
                 ));
 
         //NB: need extra check cause it seems valid types can still produce invalid ids
-        GraphTraversal<Vertex, Vertex> shortcutTraversal = !(ownerRoleIds.isEmpty() || valueRoleIds.isEmpty())?
+        GraphTraversal<Vertex, Vertex> shortcutTraversal = !(ownerRoleIds.isEmpty() || valueRoleIds.isEmpty()) ?
                 __.inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
                         as("edge").
-                        has(ROLE_LABEL_ID.name(), P.within(ownerToValueOrdering? ownerRoleIds : valueRoleIds)).
+                        has(ROLE_LABEL_ID.name(), P.within(ownerToValueOrdering ? ownerRoleIds : valueRoleIds)).
                         outV().
                         outE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).
-                        has(ROLE_LABEL_ID.name(), P.within(ownerToValueOrdering? valueRoleIds : ownerRoleIds)).
+                        has(ROLE_LABEL_ID.name(), P.within(ownerToValueOrdering ? valueRoleIds : ownerRoleIds)).
                         where(P.neq("edge")).
                         inV()
                 :
@@ -250,11 +245,10 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         return vertex().tx().getTinkerTraversal().V().
                 has(Schema.VertexProperty.ID.name(), id().getValue()).
                 union(shortcutTraversal, attributeEdgeTraversal).toStream().
-                map(vertex -> vertex().tx().<X>buildConcept(vertex));
+                map(vertex -> vertex().tx().buildConcept(vertex));
     }
 
     /**
-     *
      * @param roles An optional parameter which allows you to specify the role of the relations you wish to retrieve.
      * @return A set of Relations which the concept instance takes part in, optionally constrained by the Role Type.
      */
@@ -263,11 +257,11 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         return Stream.concat(reifiedRelations(roles), edgeRelations(roles));
     }
 
-    private Stream<Relation> reifiedRelations(Role... roles){
+    private Stream<Relation> reifiedRelations(Role... roles) {
         GraphTraversal<Vertex, Vertex> traversal = vertex().tx().getTinkerTraversal().V().
                 has(Schema.VertexProperty.ID.name(), id().getValue());
 
-        if(roles.length == 0){
+        if (roles.length == 0) {
             traversal.in(Schema.EdgeLabel.ROLE_PLAYER.getLabel());
         } else {
             Set<Integer> roleTypesIds = Arrays.stream(roles).map(r -> r.labelId().getValue()).collect(toSet());
@@ -275,14 +269,14 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
                     has(Schema.EdgeProperty.ROLE_LABEL_ID.name(), P.within(roleTypesIds)).outV();
         }
 
-        return traversal.toStream().map(vertex -> vertex().tx().<Relation>buildConcept(vertex));
+        return traversal.toStream().map(vertex -> vertex().tx().buildConcept(vertex));
     }
 
-    private Stream<Relation> edgeRelations(Role... roles){
+    private Stream<Relation> edgeRelations(Role... roles) {
         Set<Role> roleSet = new HashSet<>(Arrays.asList(roles));
         Stream<EdgeElement> stream = vertex().getEdgesOfType(Direction.BOTH, Schema.EdgeLabel.ATTRIBUTE);
 
-        if(!roleSet.isEmpty()){
+        if (!roleSet.isEmpty()) {
             stream = stream.filter(edge -> {
                 Role roleOwner = vertex().tx().getSchemaConcept(LabelId.of(edge.property(Schema.EdgeProperty.RELATIONSHIP_ROLE_OWNER_LABEL_ID)));
                 return roleSet.contains(roleOwner);
@@ -316,13 +310,13 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     private Relation attributeRelationship(Attribute attribute, boolean isInferred) {
         Schema.ImplicitType has = Schema.ImplicitType.HAS;
         Schema.ImplicitType hasValue = Schema.ImplicitType.HAS_VALUE;
-        Schema.ImplicitType hasOwner  = Schema.ImplicitType.HAS_OWNER;
+        Schema.ImplicitType hasOwner = Schema.ImplicitType.HAS_OWNER;
 
         //Is this attribute a key to me?
-        if(type().keys().anyMatch(rt -> rt.equals(attribute.type()))){
+        if (type().keys().anyMatch(rt -> rt.equals(attribute.type()))) {
             has = Schema.ImplicitType.KEY;
             hasValue = Schema.ImplicitType.KEY_VALUE;
-            hasOwner  = Schema.ImplicitType.KEY_OWNER;
+            hasOwner = Schema.ImplicitType.KEY_OWNER;
         }
 
         Label label = attribute.type().label();
@@ -330,17 +324,17 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         Role hasAttributeOwner = vertex().tx().getSchemaConcept(hasOwner.getLabel(label));
         Role hasAttributeValue = vertex().tx().getSchemaConcept(hasValue.getLabel(label));
 
-        if(hasAttribute == null || hasAttributeOwner == null || hasAttributeValue == null || type().playing().noneMatch(play -> play.equals(hasAttributeOwner))){
+        if (hasAttribute == null || hasAttributeOwner == null || hasAttributeValue == null || type().playing().noneMatch(play -> play.equals(hasAttributeOwner))) {
             throw TransactionException.hasNotAllowed(this, attribute);
         }
 
         EdgeElement attributeEdge = addEdge(AttributeImpl.from(attribute), Schema.EdgeLabel.ATTRIBUTE);
-        if(isInferred) attributeEdge.property(Schema.EdgeProperty.IS_INFERRED, true);
+        if (isInferred) attributeEdge.property(Schema.EdgeProperty.IS_INFERRED, true);
         return vertex().tx().factory().buildRelation(attributeEdge, hasAttribute, hasAttributeOwner, hasAttributeValue);
     }
 
     @Override
-    public T unhas(Attribute attribute){
+    public T unhas(Attribute attribute) {
         Role roleHasOwner = vertex().tx().getSchemaConcept(Schema.ImplicitType.HAS_OWNER.getLabel(attribute.type().label()));
         Role roleKeyOwner = vertex().tx().getSchemaConcept(Schema.ImplicitType.KEY_OWNER.getLabel(attribute.type().label()));
 
@@ -359,12 +353,11 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     /**
      * Returns an array with all the nulls filtered out.
      */
-    private Role[] filterNulls(Role ... roles){
+    private Role[] filterNulls(Role... roles) {
         return Arrays.stream(roles).filter(Objects::nonNull).toArray(Role[]::new);
     }
 
     /**
-     *
      * @return The type of the concept casted to the correct interface
      */
     public V type() {
@@ -372,11 +365,10 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     }
 
     /**
-     *
      * @param type The type of this concept
      */
     private void type(TypeImpl type) {
-        if(type != null){
+        if (type != null) {
             //noinspection unchecked
             cachedType.set((V) type); //We cache the type early because it turns out we use it EVERY time. So this prevents many db reads
             type.currentShard().link(this);
@@ -385,20 +377,18 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     }
 
     /**
-     *
-     * @param type The type of this concept
+     * @return The id of the type of this concept. This is a shortcut used to prevent traversals.
      */
-    private void setInternalType(Type type){
-        cachedInternalType.set(type.label());
-        vertex().property(Schema.VertexProperty.THING_TYPE_LABEL_ID, type.labelId().getValue());
+    Label getInternalType() {
+        return cachedInternalType.get();
     }
 
     /**
-     *
-     * @return The id of the type of this concept. This is a shortcut used to prevent traversals.
+     * @param type The type of this concept
      */
-    Label getInternalType(){
-        return cachedInternalType.get();
+    private void setInternalType(Type type) {
+        cachedInternalType.set(type.label());
+        vertex().property(Schema.VertexProperty.THING_TYPE_LABEL_ID, type.labelId().getValue());
     }
 
 }

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -253,7 +253,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
      * @return A set of Relations which the concept instance takes part in, optionally constrained by the Role Type.
      */
     @Override
-    public Stream<Relation> relationships(Role... roles) {
+    public Stream<Relation> relations(Role... roles) {
         return Stream.concat(reifiedRelations(roles), edgeRelations(roles));
     }
 
@@ -341,7 +341,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         Role roleHasValue = vertex().tx().getSchemaConcept(Schema.ImplicitType.HAS_VALUE.getLabel(attribute.type().label()));
         Role roleKeyValue = vertex().tx().getSchemaConcept(Schema.ImplicitType.KEY_VALUE.getLabel(attribute.type().label()));
 
-        Stream<Relation> relationships = relationships(filterNulls(roleHasOwner, roleKeyOwner));
+        Stream<Relation> relationships = relations(filterNulls(roleHasOwner, roleKeyOwner));
         relationships.filter(relationship -> {
             Stream<Thing> rolePlayers = relationship.rolePlayers(filterNulls(roleHasValue, roleKeyValue));
             return rolePlayers.anyMatch(rolePlayer -> rolePlayer.equals(attribute));

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -79,6 +79,11 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         createShard();
     }
 
+    public static <X extends Type, Y extends Thing> TypeImpl<X, Y> from(Type type) {
+        //noinspection unchecked
+        return (TypeImpl<X, Y>) type;
+    }
+
     /**
      * Utility method used to create an instance of this type
      *
@@ -193,7 +198,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         return vertex().getEdgesOfType(Direction.IN, Schema.EdgeLabel.SHARD).
                 map(EdgeElement::source).
                 map(source -> vertex().tx().factory().buildShard(source)).
-                flatMap(Shard::<V>links);
+                flatMap(Shard::links);
     }
 
     @Override
@@ -236,7 +241,6 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
      * This is a temporary patch to prevent accidentally disconnecting implicit RelationTypes from their
      * RelationEdges. This Disconnection happens because RelationType.instances() depends on the
      * presence of a direct {@link Schema.EdgeLabel#PLAYS} edge between the Type and the implicit RelationType.
-     * <p>
      * When changing the super you may accidentally cause this disconnection. So we prevent it here.
      */
     //TODO: Remove this when traversing to the instances of an implicit Relationship Type is no longer done via plays edges
@@ -285,7 +289,6 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
     public T unkey(AttributeType attributeType) {
         return unlinkAttribute(attributeType, true);
     }
-
 
     /**
      * Helper method to delete a AttributeType which is possible linked to this Type.
@@ -452,10 +455,5 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         if (attributes(implicitType).anyMatch(rt -> rt.equals(attributeType))) {
             throw TransactionException.duplicateHas(this, attributeType);
         }
-    }
-
-    public static <X extends Type, Y extends Thing> TypeImpl<X, Y> from(Type type) {
-        //noinspection unchecked
-        return (TypeImpl<X, Y>) type;
     }
 }

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -27,7 +27,6 @@ import grakn.core.graql.concept.Role;
 import grakn.core.graql.concept.Thing;
 import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.Schema;
-import grakn.core.server.Transaction;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.kb.cache.Cache;
 import grakn.core.server.kb.cache.Cacheable;

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -108,7 +108,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
 
     /**
      * Checks if an Thing is allowed to be created and linked to this Type.
-     * This can fail is the {@link Transaction.Type} is read only.
+     * This can fail is the Transaction.Type is read only.
      * It can also fail when attempting to attach an Attribute to a meta type
      */
     private void preCheckForInstanceCreation() {
@@ -240,7 +240,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
     /**
      * This is a temporary patch to prevent accidentally disconnecting implicit RelationTypes from their
      * RelationEdges. This Disconnection happens because RelationType.instances() depends on the
-     * presence of a direct {@link Schema.EdgeLabel#PLAYS} edge between the Type and the implicit RelationType.
+     * presence of a direct Schema.EdgeLabel#PLAYS edge between the Type and the implicit RelationType.
      * When changing the super you may accidentally cause this disconnection. So we prevent it here.
      */
     //TODO: Remove this when traversing to the instances of an implicit Relationship Type is no longer done via plays edges

--- a/server/src/server/kb/structure/AbstractElement.java
+++ b/server/src/server/kb/structure/AbstractElement.java
@@ -17,9 +17,6 @@
  */
 package grakn.core.server.kb.structure;
 
-import grakn.core.graql.concept.Concept;
-import grakn.core.graql.internal.Schema;
-import grakn.core.server.Transaction;
 import grakn.core.server.exception.PropertyNotUniqueException;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.session.TransactionOLTP;
@@ -35,84 +32,75 @@ import java.util.function.Function;
 import static org.apache.tinkerpop.gremlin.structure.T.id;
 
 /**
- * <p>
- *     {@link Transaction} AbstractElement
- * </p>
+ * Transaction AbstractElement
+ * Base class used to represent a construct in the graph. This includes exposed constructs such as Concept
+ * and hidden constructs such as EdgeElement and Casting
  *
- * <p>
- *     Base class used to represent a construct in the graph. This includes exposed constructs such as {@link Concept}
- *     and hidden constructs such as {@link EdgeElement} and {@link Casting}
- * </p>
- *
- * @param <E> The type of the element. Either {@link VertexElement} of {@link EdgeElement}
- * @param <P> Enum indicating the allowed properties on each type. Either {@link Schema.VertexProperty} or
- *           {@link Schema.EdgeProperty}
- *
- *
+ * @param <E> The type of the element. Either VertexElement of EdgeElement
+ * @param <P> Enum indicating the allowed properties on each type. Either Schema.VertexProperty or
+ *            Schema.EdgeProperty
  */
 public abstract class AbstractElement<E extends Element, P extends Enum> {
     private final String prefix;
     private final E element;
     private final TransactionOLTP tx;
 
-    AbstractElement(TransactionOLTP tx, E element, String prefix){
+    AbstractElement(TransactionOLTP tx, E element, String prefix) {
         this.tx = tx;
         this.element = element;
         this.prefix = prefix;
     }
 
-    public E element(){
+    public E element() {
         return element;
     }
 
-    public ElementId id(){
+    public ElementId id() {
         return ElementId.of(prefix + element().id());
     }
 
     /**
      * Deletes the element from the graph
      */
-    public void delete(){
+    public void delete() {
         element().remove();
     }
 
     /**
-     *
-     * @param key The key of the property to mutate
+     * @param key   The key of the property to mutate
      * @param value The value to commit into the property
      */
-    public void property(P key, Object value){
-        if(value == null) {
+    public void property(P key, Object value) {
+        if (value == null) {
             element().property(key.name()).remove();
         } else {
             Property<Object> foundProperty = element().property(key.name());
-            if(!foundProperty.isPresent() || !foundProperty.value().equals(value)){
+            if (!foundProperty.isPresent() || !foundProperty.value().equals(value)) {
                 element().property(key.name(), value);
             }
         }
     }
 
     /**
-     *
      * @param key The key of the non-unique property to retrieve
      * @return The value stored in the property
      */
     @Nullable
-    public <X> X property(P key){
+    public <X> X property(P key) {
         Property<X> property = element().property(key.name());
-        if(property != null && property.isPresent()) {
+        if (property != null && property.isPresent()) {
             return property.value();
         }
         return null;
     }
-    public Boolean propertyBoolean(P key){
+
+    public Boolean propertyBoolean(P key) {
         Boolean value = property(key);
-        if(value == null) return false;
+        if (value == null) return false;
         return value;
     }
 
     /**
-     *
      * @return The grakn graph this concept is bound to.
      */
     public TransactionOLTP tx() {
@@ -120,7 +108,6 @@ public abstract class AbstractElement<E extends Element, P extends Enum> {
     }
 
     /**
-     *
      * @return The hash code of the underlying vertex
      */
     public int hashCode() {
@@ -128,7 +115,6 @@ public abstract class AbstractElement<E extends Element, P extends Enum> {
     }
 
     /**
-     *
      * @return true if the elements equal each other
      */
     @Override
@@ -141,16 +127,16 @@ public abstract class AbstractElement<E extends Element, P extends Enum> {
     /**
      * Sets the value of a property with the added restriction that no other vertex can have that property.
      *
-     * @param key The key of the unique property to mutate
+     * @param key   The key of the unique property to mutate
      * @param value The new value of the unique property
      */
-    public void propertyUnique(P key, String value){
+    public void propertyUnique(P key, String value) {
         GraphTraversal<Vertex, Vertex> traversal = tx().getTinkerTraversal().V().has(key.name(), value);
 
-        if(traversal.hasNext()){
+        if (traversal.hasNext()) {
             Vertex vertex = traversal.next();
-            if(!vertex.equals(element()) || traversal.hasNext()){
-                if(traversal.hasNext()) vertex = traversal.next();
+            if (!vertex.equals(element()) || traversal.hasNext()) {
+                if (traversal.hasNext()) vertex = traversal.next();
                 throw PropertyNotUniqueException.cannotChangeProperty(element(), vertex, key, value);
             }
         }
@@ -161,16 +147,16 @@ public abstract class AbstractElement<E extends Element, P extends Enum> {
     /**
      * Sets a property which cannot be mutated
      *
-     * @param property The key of the immutable property to mutate
-     * @param newValue The new value to put on the property (if the property is not set)
+     * @param property   The key of the immutable property to mutate
+     * @param newValue   The new value to put on the property (if the property is not set)
      * @param foundValue The current value of the property
-     * @param converter Helper method to ensure data is persisted in the correct format
+     * @param converter  Helper method to ensure data is persisted in the correct format
      */
-    public <X> void propertyImmutable(P property, X newValue, @Nullable X foundValue, Function<X, Object> converter){
+    public <X> void propertyImmutable(P property, X newValue, @Nullable X foundValue, Function<X, Object> converter) {
         Objects.requireNonNull(property);
 
-        if(foundValue != null){
-            if(!foundValue.equals(newValue)){
+        if (foundValue != null) {
+            if (!foundValue.equals(newValue)) {
                 throw TransactionException.immutableProperty(foundValue, newValue, property);
             }
         } else {
@@ -178,15 +164,14 @@ public abstract class AbstractElement<E extends Element, P extends Enum> {
         }
     }
 
-    public <X> void propertyImmutable(P property, X newValue, X foundValue){
+    public <X> void propertyImmutable(P property, X newValue, X foundValue) {
         propertyImmutable(property, newValue, foundValue, Function.identity());
     }
 
     /**
-     *
      * @return the label of the element in the graph.
      */
-    public String label(){
+    public String label() {
         return element().label();
     }
 

--- a/server/src/server/kb/structure/Casting.java
+++ b/server/src/server/kb/structure/Casting.java
@@ -27,7 +27,6 @@ import grakn.core.graql.internal.Schema;
 import grakn.core.server.kb.cache.Cache;
 import grakn.core.server.kb.cache.CacheOwner;
 import grakn.core.server.kb.cache.Cacheable;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -35,47 +34,41 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * <p>
- *     Represents An Thing Playing a Role
- * </p>
- *
- * <p>
- *    Wraps the {@link Schema.EdgeLabel#ROLE_PLAYER} {@link Edge} which contains the information unifying an {@link Thing},
- *    {@link Relation} and {@link Role}.
- * </p>
- *
+ * Represents An Thing Playing a Role
+ * Wraps the Schema.EdgeLabel#ROLE_PLAYER Edge which contains the information unifying an Thing,
+ * Relation and Role.
  */
-public class Casting implements CacheOwner{
+public class Casting implements CacheOwner {
     private final Set<Cache> registeredCaches = new HashSet<>();
     private final EdgeElement edgeElement;
 
     private final Cache<Role> cachedRole = Cache.createTxCache(this, Cacheable.concept(), () ->
-            (Role) edge().tx().getSchemaConcept(LabelId.of(edge().property(Schema.EdgeProperty.ROLE_LABEL_ID))));
+            edge().tx().getSchemaConcept(LabelId.of(edge().property(Schema.EdgeProperty.ROLE_LABEL_ID))));
     private final Cache<Thing> cachedInstance = Cache.createTxCache(this, Cacheable.concept(), () ->
             edge().tx().factory().<Thing>buildConcept(edge().target()));
     private final Cache<Relation> cachedRelationship = Cache.createTxCache(this, Cacheable.concept(), () ->
             edge().tx().factory().<Thing>buildConcept(edge().source()));
 
     private final Cache<RelationType> cachedRelationshipType = Cache.createTxCache(this, Cacheable.concept(), () -> {
-        if(cachedRelationship.isPresent()){
+        if (cachedRelationship.isPresent()) {
             return cachedRelationship.get().type();
         } else {
-            return (RelationType) edge().tx().getSchemaConcept(LabelId.of(edge().property(Schema.EdgeProperty.RELATIONSHIP_TYPE_LABEL_ID)));
+            return edge().tx().getSchemaConcept(LabelId.of(edge().property(Schema.EdgeProperty.RELATIONSHIP_TYPE_LABEL_ID)));
         }
     });
 
-    private Casting(EdgeElement edgeElement, @Nullable Relation relationship, @Nullable Role role, @Nullable Thing thing){
+    private Casting(EdgeElement edgeElement, @Nullable Relation relationship, @Nullable Role role, @Nullable Thing thing) {
         this.edgeElement = edgeElement;
-        if(relationship != null) this.cachedRelationship.set(relationship);
-        if(role != null) this.cachedRole.set(role);
-        if(thing != null) this.cachedInstance.set(thing);
+        if (relationship != null) this.cachedRelationship.set(relationship);
+        if (role != null) this.cachedRole.set(role);
+        if (thing != null) this.cachedInstance.set(thing);
     }
 
     public static Casting create(EdgeElement edgeElement, Relation relationship, Role role, Thing thing) {
         return new Casting(edgeElement, relationship, role, thing);
     }
 
-    public static Casting withThing(EdgeElement edgeElement, Thing thing){
+    public static Casting withThing(EdgeElement edgeElement, Thing thing) {
         return new Casting(edgeElement, null, null, thing);
     }
 
@@ -83,49 +76,44 @@ public class Casting implements CacheOwner{
         return new Casting(edgeElement, relationship, null, null);
     }
 
-    private EdgeElement edge(){
+    private EdgeElement edge() {
         return edgeElement;
     }
 
     @Override
-    public Collection<Cache> caches(){
+    public Collection<Cache> caches() {
         return registeredCaches;
     }
 
     /**
-     *
-     * @return The {@link Role} the {@link Thing} is playing
+     * @return The Role the Thing is playing
      */
-    public Role getRole(){
+    public Role getRole() {
         return cachedRole.get();
     }
 
     /**
-     *
-     * @return The {@link RelationType} the {@link Thing} is taking part in
+     * @return The RelationType the Thing is taking part in
      */
-    public RelationType getRelationshipType(){
+    public RelationType getRelationshipType() {
         return cachedRelationshipType.get();
     }
 
     /**
-     *
-     * @return The {@link Relation} which is linking the {@link Role} and the instance
+     * @return The Relation which is linking the Role and the instance
      */
-    public Relation getRelationship(){
+    public Relation getRelationship() {
         return cachedRelationship.get();
     }
 
     /**
-     *
-     * @return The {@link Thing} playing the {@link Role}
+     * @return The Thing playing the Role
      */
-    public Thing getRolePlayer(){
+    public Thing getRolePlayer() {
         return cachedInstance.get();
     }
 
     /**
-     *
      * @return The hash code of the underlying vertex
      */
     public int hashCode() {
@@ -133,14 +121,13 @@ public class Casting implements CacheOwner{
     }
 
     /**
-     * Deletes this {@link Casting} effectively removing a {@link Thing} from playing a {@link Role} in a {@link Relation}
+     * Deletes this Casting effectively removing a Thing from playing a Role in a Relation
      */
-    public void delete(){
+    public void delete() {
         edge().delete();
     }
 
     /**
-     *
      * @return true if the elements equal each other
      */
     @Override

--- a/server/src/server/kb/structure/EdgeElement.java
+++ b/server/src/server/kb/structure/EdgeElement.java
@@ -19,30 +19,23 @@
 package grakn.core.server.kb.structure;
 
 import grakn.core.graql.internal.Schema;
-import grakn.core.server.Transaction;
 import grakn.core.server.session.TransactionOLTP;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 
 /**
- * <p>
- *     Represent an {@link Edge} in a {@link Transaction}
- * </p>
- *
- * <p>
- *    Wraps a tinkerpop {@link Edge} constraining it to the Grakn Object Model.
- * </p>
- *
+ * Represent an Edge in a Transaction
+ * Wraps a tinkerpop Edge constraining it to the Grakn Object Model.
  */
 public class EdgeElement extends AbstractElement<Edge, Schema.EdgeProperty> {
 
-    public EdgeElement(TransactionOLTP graknGraph, Edge e){
+    public EdgeElement(TransactionOLTP graknGraph, Edge e) {
         super(graknGraph, e, Schema.PREFIX_EDGE);
     }
 
     /**
      * Deletes the edge between two concepts and adds both those concepts for re-validation in case something goes wrong
      */
-    public void delete(){
+    public void delete() {
         element().remove();
     }
 
@@ -61,11 +54,11 @@ public class EdgeElement extends AbstractElement<Edge, Schema.EdgeProperty> {
         return element().id().equals(edge.id());
     }
 
-    public VertexElement source(){
+    public VertexElement source() {
         return tx().factory().buildVertexElement(element().outVertex());
     }
 
-    public VertexElement target(){
+    public VertexElement target() {
         return tx().factory().buildVertexElement(element().inVertex());
     }
 }

--- a/server/src/server/kb/structure/ElementId.java
+++ b/server/src/server/kb/structure/ElementId.java
@@ -18,21 +18,13 @@
 
 package grakn.core.server.kb.structure;
 
-import grakn.core.server.Transaction;
-
 import javax.annotation.CheckReturnValue;
 import java.io.Serializable;
 
 /**
- * <p>
- *     A Concept Id
- * </p>
- *
- * <p>
- *     A class which represents an id of any {@link AbstractElement} in the {@link Transaction}.
- *     Also contains a static method for producing {@link AbstractElement} IDs from Strings.
- * </p>
- *
+ * A Concept Id
+ * A class which represents an id of any AbstractElement in the Transaction.
+ * Also contains a static method for producing AbstractElement IDs from Strings.
  */
 public class ElementId implements Serializable {
 
@@ -40,12 +32,21 @@ public class ElementId implements Serializable {
     private final String elementId;
     private int hashCode = 0;
 
-    private ElementId(String conceptId){
+    private ElementId(String conceptId) {
         this.elementId = conceptId;
     }
 
+    /**
+     * @param value The string which potentially represents a Concept
+     * @return The matching concept ID
+     */
     @CheckReturnValue
-    public String getValue(){
+    public static ElementId of(String value) {
+        return new ElementId(value);
+    }
+
+    @CheckReturnValue
+    public String getValue() {
         return elementId;
     }
 
@@ -59,24 +60,14 @@ public class ElementId implements Serializable {
 
     @Override
     public int hashCode() {
-        if (hashCode == 0 ){
+        if (hashCode == 0) {
             hashCode = elementId.hashCode();
         }
         return hashCode;
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         return getValue();
-    }
-
-    /**
-     *
-     * @param value The string which potentially represents a Concept
-     * @return The matching concept ID
-     */
-    @CheckReturnValue
-    public static ElementId of(String value){
-        return new ElementId(value);
     }
 }

--- a/server/src/server/kb/structure/Shard.java
+++ b/server/src/server/kb/structure/Shard.java
@@ -18,9 +18,7 @@
 
 package grakn.core.server.kb.structure;
 
-import grakn.core.graql.concept.Concept;
 import grakn.core.graql.concept.Thing;
-import grakn.core.graql.concept.Type;
 import grakn.core.graql.internal.Schema;
 import grakn.core.server.kb.concept.ConceptImpl;
 import org.apache.tinkerpop.gremlin.structure.Direction;
@@ -28,46 +26,38 @@ import org.apache.tinkerpop.gremlin.structure.Direction;
 import java.util.stream.Stream;
 
 /**
- * <p>
- *     Represent a Shard of a concept
- * </p>
- *
- * <p>
- *     Wraps a {@link VertexElement} which is a shard of a {@link Concept}.
- *     This is used to break supernodes apart. For example the instances of a {@link Type} are
- *     spread across several shards.
- * </p>
- *
+ * Represent a Shard of a concept
+ * Wraps a VertexElement which is a shard of a Concept.
+ * This is used to break supernodes apart. For example the instances of a Type are
+ * spread across several shards.
  */
 public class Shard {
     private final VertexElement vertexElement;
 
-    public Shard(ConceptImpl owner, VertexElement vertexElement){
+    public Shard(ConceptImpl owner, VertexElement vertexElement) {
         this(vertexElement);
         owner(owner);
     }
 
-    public Shard(VertexElement vertexElement){
+    public Shard(VertexElement vertexElement) {
         this.vertexElement = vertexElement;
     }
 
-    public VertexElement vertex(){
+    public VertexElement vertex() {
         return vertexElement;
     }
 
     /**
-     *
      * @return The id of this shard. Strings are used because shards are looked up via the string index.
      */
-    public String id(){
+    public String id() {
         return vertex().property(Schema.VertexProperty.ID);
     }
 
     /**
-     *
      * @param owner Sets the owner of this shard
      */
-    private void owner(ConceptImpl owner){
+    private void owner(ConceptImpl owner) {
         vertex().putEdge(owner.vertex(), Schema.EdgeLabel.SHARD);
     }
 
@@ -76,22 +66,20 @@ public class Shard {
      *
      * @param concept The concept to link to this shard
      */
-    public void link(ConceptImpl concept){
+    public void link(ConceptImpl concept) {
         concept.vertex().addEdge(vertex(), Schema.EdgeLabel.ISA);
     }
 
     /**
-     *
      * @return All the concept linked to this shard
      */
-    public <V extends Thing> Stream<V> links(){
-        return  vertex().getEdgesOfType(Direction.IN, Schema.EdgeLabel.ISA).
+    public <V extends Thing> Stream<V> links() {
+        return vertex().getEdgesOfType(Direction.IN, Schema.EdgeLabel.ISA).
                 map(EdgeElement::source).
-                map(vertexElement ->  vertex().tx().factory().<V>buildConcept(vertexElement));
+                map(vertexElement -> vertex().tx().factory().buildConcept(vertexElement));
     }
 
     /**
-     *
      * @return The hash code of the underlying vertex
      */
     public int hashCode() {

--- a/server/src/server/kb/structure/VertexElement.java
+++ b/server/src/server/kb/structure/VertexElement.java
@@ -18,9 +18,7 @@
 
 package grakn.core.server.kb.structure;
 
-import grakn.core.graql.concept.Concept;
 import grakn.core.graql.internal.Schema;
-import grakn.core.server.Transaction;
 import grakn.core.server.session.TransactionOLTP;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Direction;
@@ -35,16 +33,10 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * <p>
- *     Represent a {@link Vertex} in a {@link Transaction}
- * </p>
- *
- * <p>
- *    Wraps a tinkerpop {@link Vertex} constraining it to the Grakn Object Model.
- *    This is used to wrap common functionality between exposed {@link Concept} and unexposed
- *    internal vertices.
- * </p>
- *
+ * Represent a Vertex in a Transaction
+ * Wraps a tinkerpop Vertex constraining it to the Grakn Object Model.
+ * This is used to wrap common functionality between exposed Concept and unexposed
+ * internal vertices.
  */
 public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty> {
 
@@ -53,20 +45,18 @@ public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty
     }
 
     /**
-     *
      * @param direction The direction of the edges to retrieve
-     * @param label The type of the edges to retrieve
+     * @param label     The type of the edges to retrieve
      * @return A collection of edges from this concept in a particular direction of a specific type
      */
-    public Stream<EdgeElement> getEdgesOfType(Direction direction, Schema.EdgeLabel label){
+    public Stream<EdgeElement> getEdgesOfType(Direction direction, Schema.EdgeLabel label) {
         Iterable<Edge> iterable = () -> element().edges(direction, label.getLabel());
         return StreamSupport.stream(iterable.spliterator(), false).
                 map(edge -> tx().factory().buildEdgeElement(edge));
     }
 
     /**
-     *
-     * @param to the target {@link VertexElement}
+     * @param to   the target VertexElement
      * @param type the type of the edge to create
      * @return The edge created
      */
@@ -76,16 +66,16 @@ public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty
     }
 
     /**
-     * @param to the target {@link VertexElement}
+     * @param to   the target VertexElement
      * @param type the type of the edge to create
      */
-    public EdgeElement putEdge(VertexElement to, Schema.EdgeLabel type){
+    public EdgeElement putEdge(VertexElement to, Schema.EdgeLabel type) {
         GraphTraversal<Vertex, Edge> traversal = tx().getTinkerTraversal().V().
                 has(Schema.VertexProperty.ID.name(), id().getValue()).
                 outE(type.getLabel()).as("edge").otherV().
                 has(Schema.VertexProperty.ID.name(), to.id().getValue()).select("edge");
 
-        if(!traversal.hasNext()) {
+        if (!traversal.hasNext()) {
             return addEdge(to, type);
         } else {
             return tx().factory().buildEdgeElement(traversal.next());
@@ -93,22 +83,22 @@ public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty
     }
 
     /**
-     * Deletes all the edges of a specific {@link Schema.EdgeLabel} to or from a specific set of targets.
+     * Deletes all the edges of a specific Schema.EdgeLabel to or from a specific set of targets.
      * If no targets are provided then all the edges of the specified type are deleted
      *
      * @param direction The direction of the edges to delete
-     * @param label The edge label to delete
-     * @param targets An optional set of targets to delete edges from
+     * @param label     The edge label to delete
+     * @param targets   An optional set of targets to delete edges from
      */
-    public void deleteEdge(Direction direction, Schema.EdgeLabel label, VertexElement... targets){
+    public void deleteEdge(Direction direction, Schema.EdgeLabel label, VertexElement... targets) {
         Iterator<Edge> edges = element().edges(direction, label.getLabel());
-        if(targets.length == 0){
+        if (targets.length == 0) {
             edges.forEachRemaining(Edge::remove);
         } else {
             Set<Vertex> verticesToDelete = Arrays.stream(targets).map(AbstractElement::element).collect(Collectors.toSet());
             edges.forEachRemaining(edge -> {
                 boolean delete = false;
-                switch (direction){
+                switch (direction) {
                     case BOTH:
                         delete = verticesToDelete.contains(edge.inVertex()) || verticesToDelete.contains(edge.outVertex());
                         break;
@@ -120,13 +110,13 @@ public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty
                         break;
                 }
 
-                if(delete) edge.remove();
+                if (delete) edge.remove();
             });
         }
     }
 
     @Override
-    public String toString(){
+    public String toString() {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Vertex [").append(id()).append("] /n");
         element().properties().forEachRemaining(

--- a/server/src/server/rpc/ConceptMethod.java
+++ b/server/src/server/rpc/ConceptMethod.java
@@ -303,8 +303,8 @@ public class ConceptMethod {
 
                 if (sup.isEntityType()) {
                     sub.asEntityType().sup(sup.asEntityType());
-                } else if (sup.isRelationshipType()) {
-                    sub.asRelationshipType().sup(sup.asRelationshipType());
+                } else if (sup.isRelationType()) {
+                    sub.asRelationType().sup(sup.asRelationType());
                 } else if (sup.isRole()) {
                     sub.asRole().sup(sup.asRole());
                 } else if (sup.isAttributeType()) {
@@ -393,7 +393,7 @@ public class ConceptMethod {
         private class Role {
 
             private Transaction.Res relations() {
-                Stream<RelationType> concepts = concept.asRole().relationships();
+                Stream<RelationType> concepts = concept.asRole().relations();
 
                 Stream<SessionProto.Transaction.Res> responses = concepts.map(con -> {
                     ConceptProto.Method.Iter.Res res = ConceptProto.Method.Iter.Res.newBuilder()
@@ -580,7 +580,7 @@ public class ConceptMethod {
         private class RelationshipType {
 
             private Transaction.Res create() {
-                Relation relationship = concept.asRelationshipType().create();
+                Relation relationship = concept.asRelationType().create();
 
                 ConceptProto.Method.Res response = ConceptProto.Method.Res.newBuilder()
                         .setRelationTypeCreateRes(ConceptProto.RelationType.Create.Res.newBuilder()
@@ -590,7 +590,7 @@ public class ConceptMethod {
             }
 
             private Transaction.Res roles() {
-                Stream<grakn.core.graql.concept.Role> roles = concept.asRelationshipType().roles();
+                Stream<grakn.core.graql.concept.Role> roles = concept.asRelationType().roles();
 
                 Stream<SessionProto.Transaction.Res> responses = roles.map(con -> {
                     ConceptProto.Method.Iter.Res res = ConceptProto.Method.Iter.Res.newBuilder()
@@ -609,13 +609,13 @@ public class ConceptMethod {
 
             private Transaction.Res relates(ConceptProto.Concept protoRole) {
                 grakn.core.graql.concept.Role role = convert(protoRole).asRole();
-                concept.asRelationshipType().relates(role);
+                concept.asRelationType().relates(role);
                 return null;
             }
 
             private Transaction.Res unrelate(ConceptProto.Concept protoRole) {
                 grakn.core.graql.concept.Role role = convert(protoRole).asRole();
-                concept.asRelationshipType().unrelate(role);
+                concept.asRelationType().unrelate(role);
                 return null;
             }
         }
@@ -756,7 +756,7 @@ public class ConceptMethod {
                 grakn.core.graql.concept.Role[] roles = protoRoles.stream()
                         .map(rpcConcept -> convert(rpcConcept))
                         .toArray(grakn.core.graql.concept.Role[]::new);
-                Stream<Relation> concepts = concept.asThing().relationships(roles);
+                Stream<Relation> concepts = concept.asThing().relations(roles);
 
                 Stream<SessionProto.Transaction.Res> responses = concepts.map(con -> {
                     ConceptProto.Method.Iter.Res res = ConceptProto.Method.Iter.Res.newBuilder()

--- a/server/src/server/rpc/ResponseBuilder.java
+++ b/server/src/server/rpc/ResponseBuilder.java
@@ -174,13 +174,13 @@ public class ResponseBuilder {
         private static ConceptProto.Concept.BASE_TYPE getBaseType(grakn.core.graql.concept.Concept concept) {
             if (concept.isEntityType()) {
                 return ConceptProto.Concept.BASE_TYPE.ENTITY_TYPE;
-            } else if (concept.isRelationshipType()) {
+            } else if (concept.isRelationType()) {
                 return ConceptProto.Concept.BASE_TYPE.RELATION_TYPE;
             } else if (concept.isAttributeType()) {
                 return ConceptProto.Concept.BASE_TYPE.ATTRIBUTE_TYPE;
             } else if (concept.isEntity()) {
                 return ConceptProto.Concept.BASE_TYPE.ENTITY;
-            } else if (concept.isRelationship()) {
+            } else if (concept.isRelation()) {
                 return ConceptProto.Concept.BASE_TYPE.RELATION;
             } else if (concept.isAttribute()) {
                 return ConceptProto.Concept.BASE_TYPE.ATTRIBUTE;

--- a/server/src/server/rpc/SessionService.java
+++ b/server/src/server/rpc/SessionService.java
@@ -328,7 +328,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
         }
 
         private void putRelationshipType(Transaction.PutRelationType.Req request) {
-            RelationType relationshipType = tx().putRelationshipType(Label.of(request.getLabel()));
+            RelationType relationshipType = tx().putRelationType(Label.of(request.getLabel()));
             Transaction.Res response = ResponseBuilder.Transaction.putRelationshipType(relationshipType);
             onNextResponse(response);
         }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -559,7 +559,7 @@ public class TransactionOLTP implements Transaction {
     }
 
     @Override
-    public RelationType putRelationshipType(Label label) {
+    public RelationType putRelationType(Label label) {
         return putSchemaConcept(label, Schema.BaseType.RELATIONSHIP_TYPE, false,
                                 v -> factory().buildRelationshipType(v, getMetaRelationType()));
     }
@@ -694,7 +694,7 @@ public class TransactionOLTP implements Transaction {
     }
 
     @Override
-    public RelationType getRelationshipType(String label) {
+    public RelationType getRelationType(String label) {
         return getSchemaConcept(Label.of(label), Schema.BaseType.RELATIONSHIP_TYPE);
     }
 

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -132,8 +132,8 @@ public class TransactionCache {
             modifiedThings.add(concept.asThing());
         } else if (concept.isRole()) {
             modifiedRoles.add(concept.asRole());
-        } else if (concept.isRelationshipType()) {
-            modifiedRelationshipTypes.add(concept.asRelationshipType());
+        } else if (concept.isRelationType()) {
+            modifiedRelationshipTypes.add(concept.asRelationType());
         } else if (concept.isRule()) {
             modifiedRules.add(concept.asRule());
         }
@@ -144,8 +144,8 @@ public class TransactionCache {
     }
 
     public void removeFromValidation(Type type) {
-        if (type.isRelationshipType()) {
-            modifiedRelationshipTypes.remove(type.asRelationshipType());
+        if (type.isRelationType()) {
+            modifiedRelationshipTypes.remove(type.asRelationType());
         }
     }
 
@@ -191,7 +191,7 @@ public class TransactionCache {
             newAttributes.removeAll(AttributeImpl.from(concept.asAttribute()).getIndex());
         }
 
-        if (concept.isRelationship()) {
+        if (concept.isRelation()) {
             newRelationships.remove(concept.asRelation());
         }
 

--- a/server/test/graql/internal/gremlin/sets/RolePlayerFragmentSetTest.java
+++ b/server/test/graql/internal/gremlin/sets/RolePlayerFragmentSetTest.java
@@ -174,7 +174,7 @@ public class RolePlayerFragmentSetTest {
     public void whenLabelDoesNotReferToARelationType_DoNotApplyRelationTypeOptimisation() {
         Label movie = Label.of("movie");
         SchemaConcept movieConcept = mock(SchemaConcept.class);
-        when(movieConcept.isRelationshipType()).thenReturn(false);
+        when(movieConcept.isRelationType()).thenReturn(false);
         when(tx.getSchemaConcept(movie)).thenReturn(movieConcept);
         Collection<EquivalentFragmentSet> fragmentSets = Sets.newHashSet(
                 EquivalentFragmentSets.rolePlayer(null, a, b, c, null),

--- a/test-integration/graql/analytics/ConnectedComponentIT.java
+++ b/test-integration/graql/analytics/ConnectedComponentIT.java
@@ -279,7 +279,7 @@ public class ConnectedComponentIT {
             Role role2 = tx.putRole("role2");
             entityType1.plays(role1).plays(role2);
             entityType2.plays(role1).plays(role2);
-            RelationType relationshipType = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType = tx.putRelationType(related).relates(role1).relates(role2);
 
             relationshipType.create()
                     .assign(role1, entity1)

--- a/test-integration/graql/analytics/CorenessIT.java
+++ b/test-integration/graql/analytics/CorenessIT.java
@@ -107,7 +107,7 @@ public class CorenessIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             entityType.plays(role1).plays(role2);
-            tx.putRelationshipType(related)
+            tx.putRelationType(related)
                     .relates(role1).relates(role2)
                     .create()
                     .assign(role1, entity1)
@@ -116,7 +116,7 @@ public class CorenessIT {
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
             entityType.plays(role3).plays(role4);
-            tx.putRelationshipType(veryRelated)
+            tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4)
                     .create()
                     .assign(role3, entity1)
@@ -201,12 +201,12 @@ public class CorenessIT {
 
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
-            RelationType relationshipType1 = tx.putRelationshipType(related)
+            RelationType relationshipType1 = tx.putRelationType(related)
                     .relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated)
+            RelationType relationshipType2 = tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4);
 
             entityType1.plays(role1).plays(role2).plays(role3).plays(role4);
@@ -318,12 +318,12 @@ public class CorenessIT {
 
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
-            RelationType relationshipType1 = tx.putRelationshipType(related)
+            RelationType relationshipType1 = tx.putRelationType(related)
                     .relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated)
+            RelationType relationshipType2 = tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4);
 
             entityType1.plays(role1).plays(role2).plays(role3).plays(role4);

--- a/test-integration/graql/analytics/CountIT.java
+++ b/test-integration/graql/analytics/CountIT.java
@@ -183,7 +183,7 @@ public class CountIT {
             name.plays(resourceValue);
 
             RelationType relationshipType =
-                    tx.putRelationshipType(Schema.ImplicitType.HAS.getLabel(Label.of("name")))
+                    tx.putRelationType(Schema.ImplicitType.HAS.getLabel(Label.of("name")))
                             .relates(resourceOwner).relates(resourceValue);
             relationshipType.create()
                     .assign(resourceOwner, aPerson)
@@ -239,7 +239,7 @@ public class CountIT {
             name.plays(resourceValue);
 
             RelationType relationshipType =
-                    tx.putRelationshipType(Schema.ImplicitType.HAS.getLabel(Label.of("name")))
+                    tx.putRelationType(Schema.ImplicitType.HAS.getLabel(Label.of("name")))
                             .relates(resourceOwner).relates(resourceValue);
             // here relationship type is still implicit
             relationshipType.create()

--- a/test-integration/graql/analytics/DegreeIT.java
+++ b/test-integration/graql/analytics/DegreeIT.java
@@ -84,7 +84,7 @@ public class DegreeIT {
         Role role2 = tx.putRole("role2");
         thingy.plays(role1).plays(role2);
         anotherThing.plays(role1).plays(role2);
-        RelationType related = tx.putRelationshipType("related").relates(role1).relates(role2);
+        RelationType related = tx.putRelationType("related").relates(role1).relates(role2);
 
         // relate them
         related.create()
@@ -172,7 +172,7 @@ public class DegreeIT {
         EntityType animal = tx.putEntityType("animal").plays(pet);
         Entity dog = tx.putEntityType("dog").sup(animal).create();
 
-        tx.putRelationshipType("mans-best-friend").relates(pet).relates(owner)
+        tx.putRelationType("mans-best-friend").relates(pet).relates(owner)
                 .create().assign(pet, dog).assign(owner, person);
 
         List<ConceptSetMeasure> correctDegrees = new ArrayList<>();
@@ -194,7 +194,7 @@ public class DegreeIT {
         // create a simple tx
         Role pet = tx.putRole("pet");
         Role owner = tx.putRole("owner");
-        RelationType mansBestFriend = tx.putRelationshipType("mans-best-friend").relates(pet).relates(owner);
+        RelationType mansBestFriend = tx.putRelationType("mans-best-friend").relates(pet).relates(owner);
 
         EntityType person = tx.putEntityType("person").plays(owner);
         EntityType animal = tx.putEntityType("animal").plays(pet);
@@ -252,7 +252,7 @@ public class DegreeIT {
         Role pet = tx.putRole("pet");
         Role owner = tx.putRole("owner");
         Role breeder = tx.putRole("breeder");
-        RelationType mansBestFriend = tx.putRelationshipType("mans-best-friend")
+        RelationType mansBestFriend = tx.putRelationType("mans-best-friend")
                 .relates(pet).relates(owner).relates(breeder);
         EntityType person = tx.putEntityType("person").plays(owner).plays(breeder);
         EntityType animal = tx.putEntityType("animal").plays(pet);
@@ -279,14 +279,14 @@ public class DegreeIT {
 
         Role pet = tx.putRole("pet");
         Role owner = tx.putRole("owner");
-        RelationType mansBestFriend = tx.putRelationshipType("mans-best-friend").relates(pet).relates(owner);
+        RelationType mansBestFriend = tx.putRelationType("mans-best-friend").relates(pet).relates(owner);
 
         EntityType person = tx.putEntityType("person").plays(owner);
         EntityType animal = tx.putEntityType("animal").plays(pet);
 
         Role ownership = tx.putRole("ownership");
         Role ownershipResource = tx.putRole("ownership-resource");
-        RelationType hasOwnershipResource = tx.putRelationshipType("has-ownership-resource")
+        RelationType hasOwnershipResource = tx.putRelationType("has-ownership-resource")
                 .relates(ownership).relates(ownershipResource);
 
         AttributeType<String> startDate = tx.putAttributeType("start-date", AttributeType.DataType.STRING);
@@ -319,7 +319,7 @@ public class DegreeIT {
         Role productionWithCast = tx.putRole("production-with-cast");
         Role actor = tx.putRole("actor");
         Role characterBeingPlayed = tx.putRole("character-being-played");
-        RelationType hasCast = tx.putRelationshipType("has-cast")
+        RelationType hasCast = tx.putRelationType("has-cast")
                 .relates(productionWithCast)
                 .relates(actor)
                 .relates(characterBeingPlayed);
@@ -354,7 +354,7 @@ public class DegreeIT {
         Role pet = tx.putRole("pet");
         Role owner = tx.putRole("owner");
         Role breeder = tx.putRole("breeder");
-        RelationType mansBestFriend = tx.putRelationshipType("mans-best-friend")
+        RelationType mansBestFriend = tx.putRelationType("mans-best-friend")
                 .relates(pet).relates(owner).relates(breeder);
         EntityType person = tx.putEntityType("person").plays(owner).plays(breeder);
         EntityType animal = tx.putEntityType("animal").plays(pet);

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -106,7 +106,7 @@ public class GraqlComputeIT {
 
             Role degreeOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(resourceTypeId).getValue());
             Role degreeValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(resourceTypeId).getValue());
-            RelationType relationshipType = tx.putRelationshipType(Schema.ImplicitType.HAS.getLabel(resourceTypeId))
+            RelationType relationshipType = tx.putRelationType(Schema.ImplicitType.HAS.getLabel(resourceTypeId))
                     .relates(degreeOwner)
                     .relates(degreeValue);
             thingy.plays(degreeOwner);
@@ -228,7 +228,7 @@ public class GraqlComputeIT {
 
             Role resourceOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(resourceTypeId).getValue());
             Role resourceValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(resourceTypeId).getValue());
-            RelationType relationshipType = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(resourceTypeId).getValue());
+            RelationType relationshipType = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(resourceTypeId).getValue());
 
             relationshipType.create()
                     .assign(resourceOwner, theResourceOwner)
@@ -373,7 +373,7 @@ public class GraqlComputeIT {
             Role role2 = tx.putRole("role2");
             entityType1.plays(role1).plays(role2);
             entityType2.plays(role1).plays(role2);
-            RelationType relationshipType = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType = tx.putRelationType(related).relates(role1).relates(role2);
 
             relationId12 = relationshipType.create()
                     .assign(role1, entity1)

--- a/test-integration/graql/analytics/KCoreIT.java
+++ b/test-integration/graql/analytics/KCoreIT.java
@@ -107,7 +107,7 @@ public class KCoreIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             entityType.plays(role1).plays(role2);
-            tx.putRelationshipType(related)
+            tx.putRelationType(related)
                     .relates(role1).relates(role2)
                     .create()
                     .assign(role1, entity1)
@@ -116,7 +116,7 @@ public class KCoreIT {
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
             entityType.plays(role3).plays(role4);
-            tx.putRelationshipType(veryRelated)
+            tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4)
                     .create()
                     .assign(role3, entity1)
@@ -221,12 +221,12 @@ public class KCoreIT {
 
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
-            RelationType relationshipType1 = tx.putRelationshipType(related)
+            RelationType relationshipType1 = tx.putRelationType(related)
                     .relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated)
+            RelationType relationshipType2 = tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4);
 
             entityType1.plays(role1).plays(role2).plays(role3).plays(role4);
@@ -331,12 +331,12 @@ public class KCoreIT {
 
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
-            RelationType relationshipType1 = tx.putRelationshipType(related)
+            RelationType relationshipType1 = tx.putRelationType(related)
                     .relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated)
+            RelationType relationshipType2 = tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4);
 
             entityType1.plays(role1).plays(role2).plays(role3).plays(role4);

--- a/test-integration/graql/analytics/PathIT.java
+++ b/test-integration/graql/analytics/PathIT.java
@@ -191,7 +191,7 @@ public class PathIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             entityType.plays(role1).plays(role2);
-            RelationType relationshipType = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType = tx.putRelationType(related).relates(role1).relates(role2);
 
             Entity start = entityType.create();
             Entity end = entityType.create();
@@ -246,12 +246,12 @@ public class PathIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             entityType.plays(role1).plays(role2);
-            RelationType relationshipType1 = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType1 = tx.putRelationType(related).relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
             entityType.plays(role3).plays(role4);
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated).relates(role3).relates(role4);
+            RelationType relationshipType2 = tx.putRelationType(veryRelated).relates(role3).relates(role4);
 
             Entity start = entityType.create();
             Entity end = entityType.create();
@@ -307,13 +307,13 @@ public class PathIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             entityType.plays(role1).plays(role2);
-            RelationType relationshipType1 = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType1 = tx.putRelationType(related).relates(role1).relates(role2);
 
             Role role3 = tx.putRole("role3");
             Role role4 = tx.putRole("role4");
             Role role5 = tx.putRole("role5");
             entityType.plays(role3).plays(role4).plays(role5);
-            RelationType relationshipType2 = tx.putRelationshipType(veryRelated)
+            RelationType relationshipType2 = tx.putRelationType(veryRelated)
                     .relates(role3).relates(role4).relates(role5);
 
             Entity start = entityType.create();
@@ -442,7 +442,7 @@ public class PathIT {
             // manually construct the attribute relation
             Role resourceOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(Label.of("power")).getValue());
             Role resourceValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(Label.of("power")).getValue());
-            RelationType relationType = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(Label.of("power")).getValue());
+            RelationType relationType = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(Label.of("power")).getValue());
 
             Entity person1 = person.create();
             idPerson1 = person1.id();
@@ -477,7 +477,7 @@ public class PathIT {
             Role role1 = tx.putRole("role1");
             Role role2 = tx.putRole("role2");
             person.plays(role1).plays(role2);
-            RelationType relationTypePerson = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationTypePerson = tx.putRelationType(related).relates(role1).relates(role2);
             idRelationPerson1Person3 = relationTypePerson.create()
                     .assign(role1, person1)
                     .assign(role2, person3).id();
@@ -564,7 +564,7 @@ public class PathIT {
             Role role2 = tx.putRole("role2");
             entityType1.plays(role1).plays(role2);
             entityType2.plays(role1).plays(role2);
-            RelationType relationshipType = tx.putRelationshipType(related).relates(role1).relates(role2);
+            RelationType relationshipType = tx.putRelationType(related).relates(role1).relates(role2);
 
             relationId12 = relationshipType.create()
                     .assign(role1, entity1)

--- a/test-integration/graql/analytics/StatisticsIT.java
+++ b/test-integration/graql/analytics/StatisticsIT.java
@@ -520,7 +520,7 @@ public class StatisticsIT {
             Attribute power1 = power.create(1L);
             Attribute power2 = power.create(2L);
             Attribute power3 = power.create(3L);
-            RelationType relationType = tx.putRelationshipType(Schema.ImplicitType.HAS.getLabel(Label.of("power")))
+            RelationType relationType = tx.putRelationType(Schema.ImplicitType.HAS.getLabel(Label.of("power")))
                     .relates(resourceOwner).relates(resourceValue);
 
             relationType.create()
@@ -574,7 +574,7 @@ public class StatisticsIT {
             Role relation2 = tx.putRole("relation2");
             entityType1.plays(relation1).plays(relation2);
             entityType2.plays(relation1).plays(relation2);
-            RelationType related = tx.putRelationshipType("related").relates(relation1).relates(relation2);
+            RelationType related = tx.putRelationType("related").relates(relation1).relates(relation2);
 
             related.create()
                     .assign(relation1, entity1)

--- a/test-integration/graql/graph/MovieGraph.java
+++ b/test-integration/graql/graph/MovieGraph.java
@@ -77,27 +77,27 @@ public class MovieGraph {
     private static void buildSchema(Transaction tx) {
         work = tx.putRole("work");
         author = tx.putRole("author");
-        authoredBy = tx.putRelationshipType("authored-by").relates(work).relates(author);
+        authoredBy = tx.putRelationType("authored-by").relates(work).relates(author);
 
         productionBeingDirected = tx.putRole("production-being-directed").sup(work);
         director = tx.putRole("director").sup(author);
-        directedBy = tx.putRelationshipType("directed-by").sup(authoredBy)
+        directedBy = tx.putRelationType("directed-by").sup(authoredBy)
                 .relates(productionBeingDirected).relates(director);
 
         productionWithCast = tx.putRole("production-with-cast");
         actor = tx.putRole("actor");
         characterBeingPlayed = tx.putRole("character-being-played");
-        hasCast = tx.putRelationshipType("has-cast")
+        hasCast = tx.putRelationType("has-cast")
                 .relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
 
         genreOfProduction = tx.putRole("genre-of-production");
         productionWithGenre = tx.putRole("production-with-genre");
-        hasGenre = tx.putRelationshipType("has-genre")
+        hasGenre = tx.putRelationType("has-genre")
                 .relates(genreOfProduction).relates(productionWithGenre);
 
         clusterOfProduction = tx.putRole("cluster-of-production");
         productionWithCluster = tx.putRole("production-with-cluster");
-        hasCluster = tx.putRelationshipType("has-cluster")
+        hasCluster = tx.putRelationType("has-cluster")
                 .relates(clusterOfProduction).relates(productionWithCluster);
 
         title = tx.putAttributeType("title", AttributeType.DataType.STRING);

--- a/test-integration/graql/internal/IsaExplicitIT.java
+++ b/test-integration/graql/internal/IsaExplicitIT.java
@@ -76,7 +76,7 @@ public class IsaExplicitIT {
         superType1.plays(role1).plays(role2).plays(role3);
         entityType2.plays(role1).plays(role2).plays(role3);
         entityType3.plays(role1).plays(role2).plays(role3);
-        RelationType relationshipType = tx.putRelationshipType("related")
+        RelationType relationshipType = tx.putRelationType("related")
                 .relates(role1).relates(role2).relates(role3);
 
         Entity entity1 = entityType1.create();

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -467,7 +467,7 @@ public class GraqlDefineIT {
     public void whenDefiningARelationship_SubRoleDeclarationsCanBeSkipped() {
         tx.execute(Graql.define(type("marriage").sub(type(RELATIONSHIP.getLabel().getValue())).relates("husband").relates("wife")));
 
-        RelationType marriage = tx.getRelationshipType("marriage");
+        RelationType marriage = tx.getRelationType("marriage");
         Role husband = tx.getRole("husband");
         Role wife = tx.getRole("wife");
         assertThat(marriage.roles().toArray(), arrayContainingInAnyOrder(husband, wife));
@@ -482,7 +482,7 @@ public class GraqlDefineIT {
                           .relates("father", "parent")
                           .relates("son", "child")));
 
-        RelationType marriage = tx.getRelationshipType("fatherhood");
+        RelationType marriage = tx.getRelationType("fatherhood");
         Role father = tx.getRole("father");
         Role son = tx.getRole("son");
         assertThat(marriage.roles().toArray(), arrayContainingInAnyOrder(father, son));
@@ -507,7 +507,7 @@ public class GraqlDefineIT {
                 type("person").plays("husband").plays("wife")
         ));
 
-        RelationType marriage = tx.getRelationshipType("marriage");
+        RelationType marriage = tx.getRelationType("marriage");
         EntityType person = tx.getEntityType("person");
         Role husband = tx.getRole("husband");
         Role wife = tx.getRole("wife");

--- a/test-integration/graql/query/GraqlUndefineIT.java
+++ b/test-integration/graql/query/GraqlUndefineIT.java
@@ -341,7 +341,7 @@ public class GraqlUndefineIT {
         tx = session.transaction(Transaction.Type.WRITE);
 
         EntityType pokemon = tx.getEntityType("pokemon");
-        RelationType evolution = tx.getRelationshipType("evolution");
+        RelationType evolution = tx.getRelationType("evolution");
         AttributeType<Long> pokedexNo = tx.getAttributeType("pokedex-no");
         Role ancestor = tx.getRole("ancestor");
         Role descendant = tx.getRole("descendant");

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -99,9 +99,9 @@ public class QueryPlannerIT {
         superType1.plays(role1).plays(role2).plays(role3);
         entityType2.plays(role1).plays(role2).plays(role3);
         entityType3.plays(role1).plays(role2).plays(role3);
-        RelationType relationshipType1 = graph.putRelationshipType(related)
+        RelationType relationshipType1 = graph.putRelationType(related)
                 .relates(role1).relates(role2).relates(role3);
-        graph.putRelationshipType(sameAsRelated)
+        graph.putRelationType(sameAsRelated)
                 .relates(role1).relates(role2).relates(role3);
 
         Role role4 = graph.putRole("role4");
@@ -109,7 +109,7 @@ public class QueryPlannerIT {
         entityType1.plays(role4).plays(role5);
         entityType2.plays(role4).plays(role5);
         entityType4.plays(role4);
-        graph.putRelationshipType(veryRelated)
+        graph.putRelationType(veryRelated)
                 .relates(role4).relates(role5);
 
         Entity entity1 = entityType1.create();

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -114,7 +114,7 @@ public class ReasoningIT {
                 List<ConceptMap> attributeRelationSubs = tx.execute(Graql.<GraqlGet>parse("match $x sub @has-attribute; get;"));
 
                 assertEquals(attributeSubs.size(), attributeRelationSubs.size());
-                assertTrue(attributeRelationSubs.stream().map(ans -> ans.get("x")).map(Concept::asRelationshipType).allMatch(relTypes::contains));
+                assertTrue(attributeRelationSubs.stream().map(ans -> ans.get("x")).map(Concept::asRelationType).allMatch(relTypes::contains));
 
                 List<ConceptMap> baseResourceSubs = tx.execute(Graql.parse("match $x sub baseResource; get;").asGet());
                 List<ConceptMap> baseResourceRelationSubs = tx.execute(Graql.<GraqlGet>parse("match $x sub @has-baseResource; get;"));

--- a/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicRuleApplicabilityIT.java
@@ -345,7 +345,7 @@ public class AtomicRuleApplicabilityIT {
 
         assertEquals(tx.ruleCache().getRules().count(), type.getApplicableRules().count());
         assertThat(type2.getApplicableRules().collect(toSet()), empty());
-        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), type3.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationType)).count(), type3.getApplicableRules().count());
         tx.close();
     }
 
@@ -417,7 +417,7 @@ public class AtomicRuleApplicabilityIT {
         Atom relation3 = ReasonerQueries.create(conjunction(relationString3, tx), tx).getAtoms(RelationshipAtom.class).findFirst().orElse(null);
 
         assertEquals(7, relation.getApplicableRules().count());
-        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationshipType)).count(), relation2.getApplicableRules().count());
+        assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isRelationType)).count(), relation2.getApplicableRules().count());
 
         //TODO not filtered correctly
         //assertEquals(tx.ruleCache().getRules().filter(r -> r.thenTypes().allMatch(Concept::isAttributeType)).count(), relation3.getApplicableRules().count());
@@ -750,7 +750,7 @@ public class AtomicRuleApplicabilityIT {
     @Test
     public void testRuleApplicability_whenMatchingRulesForGroundAtomRedefinedViaRule_ruleIsMatched(){
         TransactionOLTP tx = ruleApplicabilitySession.transaction(Transaction.Type.READ);
-        Relation instance = tx.getRelationshipType("reifiable-relation").instances().findFirst().orElse(null);
+        Relation instance = tx.getRelationType("reifiable-relation").instances().findFirst().orElse(null);
         String queryString = "{ $r has description 'typed-reified'; $r id '" + instance.id().getValue() + "'; };";
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 
@@ -761,7 +761,7 @@ public class AtomicRuleApplicabilityIT {
     @Test
     public void testRuleApplicability_whenMatchingRulesForGroundTypeWhichIsNotRedefined_noRulesAreMatched(){
         TransactionOLTP tx = ruleApplicabilitySession.transaction(Transaction.Type.READ);
-        Relation instance = tx.getRelationshipType("binary").instances().findFirst().orElse(null);
+        Relation instance = tx.getRelationType("binary").instances().findFirst().orElse(null);
         String queryString = "{ $x isa binary; $x id '" + instance.id().getValue() + "'; };";
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 
@@ -772,7 +772,7 @@ public class AtomicRuleApplicabilityIT {
     @Test
     public void testRuleApplicability_whenMatchingRulesForASpecificRelation_noRulesAreMatched(){
         TransactionOLTP tx = ruleApplicabilitySession.transaction(Transaction.Type.READ);
-        Relation instance = tx.getRelationshipType("binary").instances().findFirst().orElse(null);
+        Relation instance = tx.getRelationType("binary").instances().findFirst().orElse(null);
         String queryString = "{ $r ($x, $y) isa binary; $r id '" + instance.id().getValue() + "'; };";
         Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 

--- a/test-integration/graql/reasoner/atomic/AtomicTypeInferenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicTypeInferenceIT.java
@@ -432,7 +432,7 @@ public class AtomicTypeInferenceIT {
     }
 
     private List<Type> allRelations(TransactionOLTP tx){
-        RelationType metaType = tx.getRelationshipType(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue());
+        RelationType metaType = tx.getRelationType(Schema.MetaSchema.RELATIONSHIP.getLabel().getValue());
         return metaType.subs().filter(t -> !t.equals(metaType)).collect(Collectors.toList());
     }
 

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -97,7 +97,7 @@ public class BenchmarkBigIT {
             assertEquals(instances.length, N);
             Role fromRole = transaction.getRole(fromRoleLabel);
             Role toRole = transaction.getRole(toRoleLabel);
-            RelationType relationType = transaction.getRelationshipType(relationLabel);
+            RelationType relationType = transaction.getRelationType(relationLabel);
 
             Random rand = new Random();
             Multimap<Integer, Integer> assignmentMap = HashMultimap.create();
@@ -164,7 +164,7 @@ public class BenchmarkBigIT {
 
                 //define N relation types
                 for (int i = 1; i <= N; i++) {
-                    transaction.putRelationshipType(genericRelationLabel + i)
+                    transaction.putRelationType(genericRelationLabel + i)
                             .relates(fromRole)
                             .relates(toRole);
                 }
@@ -210,7 +210,7 @@ public class BenchmarkBigIT {
                         .map(ans -> ans.get(entityVar.var()).id())
                         .toArray(ConceptId[]::new);
 
-                RelationType baseRelation = transaction.getRelationshipType(baseRelationLabel);
+                RelationType baseRelation = transaction.getRelationType(baseRelationLabel);
                 Role fromRole = transaction.getRole(fromRoleLabel);
                 Role toRole = transaction.getRole(toRoleLabel);
                 transaction.execute(

--- a/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
@@ -69,12 +69,12 @@ public class BenchmarkSmallIT {
             Role fromRole = tx.putRole("fromRole");
             Role toRole = tx.putRole("toRole");
 
-            RelationType relation0 = tx.putRelationshipType("relation0")
+            RelationType relation0 = tx.putRelationType("relation0")
                     .relates(fromRole)
                     .relates(toRole);
 
             for (int i = 1; i <= N; i++) {
-                tx.putRelationshipType("relation" + i)
+                tx.putRelationType("relation" + i)
                         .relates(fromRole)
                         .relates(toRole);
             }

--- a/test-integration/graql/reasoner/graph/DiagonalGraph.java
+++ b/test-integration/graql/reasoner/graph/DiagonalGraph.java
@@ -53,8 +53,8 @@ public class DiagonalGraph{
         Role relTo = tx.getRole("rel-to");
 
         EntityType entity1 = tx.getEntityType("entity1");
-        RelationType horizontal = tx.getRelationshipType("horizontal");
-        RelationType vertical = tx.getRelationshipType("vertical");
+        RelationType horizontal = tx.getRelationType("horizontal");
+        RelationType vertical = tx.getRelationType("vertical");
         ConceptId[][] instanceIds = new ConceptId[n][m];
         long inserts = 0;
         for (int i = 0; i < n; i++) {

--- a/test-integration/graql/reasoner/graph/DualLinearTransitivityMatrixGraph.java
+++ b/test-integration/graql/reasoner/graph/DualLinearTransitivityMatrixGraph.java
@@ -55,8 +55,8 @@ public class DualLinearTransitivityMatrixGraph{
 
         EntityType aEntity = tx.getEntityType("a-entity");
         EntityType bEntity = tx.getEntityType("b-entity");
-        RelationType R1 = tx.getRelationshipType("R1");
-        RelationType R2 = tx.getRelationshipType("R2");
+        RelationType R1 = tx.getRelationType("R1");
+        RelationType R2 = tx.getRelationType("R2");
 
         ConceptId[] aInstancesIds = new ConceptId[m+1];
         ConceptId[][] bInstancesIds = new ConceptId[m][n+1];

--- a/test-integration/graql/reasoner/graph/GenericSchemaGraph.java
+++ b/test-integration/graql/reasoner/graph/GenericSchemaGraph.java
@@ -62,8 +62,8 @@ public class GenericSchemaGraph {
         EntityType anotherEntityType = tx.getEntityType("anotherBaseRoleEntity");
         AttributeType<Object> resourceType = tx.getAttributeType("resource");
         AttributeType<Object> anotherResourceType = tx.getAttributeType("resource-long");
-        RelationType binary = tx.getRelationshipType("binary");
-        RelationType ternary = tx.getRelationshipType("ternary");
+        RelationType binary = tx.getRelationType("binary");
+        RelationType ternary = tx.getRelationType("ternary");
 
         Iterator<Entity> entities = entityType.instances()
                 .filter(et -> !et.type().equals(subRoleEntityType) )

--- a/test-integration/graql/reasoner/graph/GeoGraph.java
+++ b/test-integration/graql/reasoner/graph/GeoGraph.java
@@ -65,7 +65,7 @@ public class GeoGraph {
 
         geoEntity = tx.putRole("geo-entity");
         entityLocation = tx.putRole("entity-location");
-        isLocatedIn = tx.putRelationshipType("is-located-in")
+        isLocatedIn = tx.putRelationType("is-located-in")
                 .relates(geoEntity).relates(entityLocation);
 
         geographicalObject = tx.putEntityType("geoObject")

--- a/test-integration/graql/reasoner/graph/LinearTransitivityMatrixGraph.java
+++ b/test-integration/graql/reasoner/graph/LinearTransitivityMatrixGraph.java
@@ -54,7 +54,7 @@ public class LinearTransitivityMatrixGraph{
         Role Qto = tx.getRole("Q-to");
 
         EntityType aEntity = tx.getEntityType("a-entity");
-        RelationType Q = tx.getRelationshipType("Q");
+        RelationType Q = tx.getRelationType("Q");
         ConceptId[][] aInstancesIds = new ConceptId[n+1][m+1];
         Thing aInst = putEntityWithResource(tx, "a", tx.getEntityType("entity2"), key);
         for(int i = 1 ; i <= n ;i++) {

--- a/test-integration/graql/reasoner/graph/NguyenGraph.java
+++ b/test-integration/graql/reasoner/graph/NguyenGraph.java
@@ -59,9 +59,9 @@ public class NguyenGraph{
         EntityType entity = tx.getEntityType("entity2");
         EntityType aEntity = tx.getEntityType("a-entity");
         EntityType bEntity = tx.getEntityType("b-entity");
-        RelationType r = tx.getRelationshipType("R");
-        RelationType p = tx.getRelationshipType("P");
-        RelationType q = tx.getRelationshipType("Q");
+        RelationType r = tx.getRelationType("R");
+        RelationType p = tx.getRelationType("P");
+        RelationType q = tx.getRelationType("Q");
 
         ConceptId cId = putEntityWithResource(tx, "c", entity, key).id();
         ConceptId dId = putEntityWithResource(tx, "d", entity, key).id();

--- a/test-integration/graql/reasoner/graph/PathMatrixGraph.java
+++ b/test-integration/graql/reasoner/graph/PathMatrixGraph.java
@@ -57,7 +57,7 @@ public class PathMatrixGraph {
         Role arcFrom = tx.getRole("arc-from");
         Role arcTo = tx.getRole("arc-to");
 
-        RelationType arc = tx.getRelationshipType("arc");
+        RelationType arc = tx.getRelationType("arc");
         putEntityWithResource(tx, "a0", startVertex, key);
 
         for(int i = 0 ; i < n ;i++) {

--- a/test-integration/graql/reasoner/graph/PathTreeGraph.java
+++ b/test-integration/graql/reasoner/graph/PathTreeGraph.java
@@ -69,7 +69,7 @@ public class PathTreeGraph{
         EntityType vertex = tx.getEntityType("vertex");
         EntityType startVertex = tx.getEntityType("start-vertex");
 
-        RelationType arc = tx.getRelationshipType("arc");
+        RelationType arc = tx.getRelationType("arc");
         putEntityWithResource(tx, "a0", startVertex, key);
 
         int outputThreshold = 500;

--- a/test-integration/graql/reasoner/graph/ReachabilityGraph.java
+++ b/test-integration/graql/reasoner/graph/ReachabilityGraph.java
@@ -58,7 +58,7 @@ public class ReachabilityGraph {
         EntityType node = tx.getEntityType("node");
         Role from = tx.getRole("from");
         Role to = tx.getRole("to");
-        RelationType link = tx.getRelationshipType("link");
+        RelationType link = tx.getRelationType("link");
 
         //basic test variant from Green
         putEntityWithResource(tx, "aa", node, key);

--- a/test-integration/graql/reasoner/graph/TailRecursionGraph.java
+++ b/test-integration/graql/reasoner/graph/TailRecursionGraph.java
@@ -54,7 +54,7 @@ public class TailRecursionGraph{
 
         EntityType aEntity = tx.getEntityType("a-entity");
         EntityType bEntity = tx.getEntityType("b-entity");
-        RelationType q = tx.getRelationshipType("Q");
+        RelationType q = tx.getRelationType("Q");
 
         putEntityWithResource(tx, "a0", aEntity, key);
         for(int i = 1 ; i <= m + 1 ;i++) {

--- a/test-integration/graql/reasoner/graph/TransitivityChainGraph.java
+++ b/test-integration/graql/reasoner/graph/TransitivityChainGraph.java
@@ -54,7 +54,7 @@ public class TransitivityChainGraph {
         Role qto = tx.getRole("Q-to");
 
         EntityType aEntity = tx.getEntityType("a-entity");
-        RelationType q = tx.getRelationshipType("Q");
+        RelationType q = tx.getRelationType("Q");
         Thing aInst = putEntityWithResource(tx, "a", tx.getEntityType("entity2"), key);
         ConceptId[] aInstanceIds = new ConceptId[n];
         for(int i = 0 ; i < n ;i++) {

--- a/test-integration/graql/reasoner/graph/TransitivityMatrixGraph.java
+++ b/test-integration/graql/reasoner/graph/TransitivityMatrixGraph.java
@@ -54,7 +54,7 @@ public class TransitivityMatrixGraph{
         Role qto = tx.getRole("Q-to");
 
         EntityType aEntity = tx.getEntityType("a-entity");
-        RelationType q = tx.getRelationshipType("Q");
+        RelationType q = tx.getRelationType("Q");
         Thing aInst = putEntityWithResource(tx, "a", tx.getEntityType("entity2"), key);
         ConceptId[][] aInstanceIds = new ConceptId[n][m];
         for(int i = 0 ; i < n ;i++) {

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -610,7 +610,7 @@ public class NegationIT {
     }
 
     private boolean thingsRelated(Map<Thing, Role> thingMap, Label relation, Transaction tx){
-        RelationType relationshipType = tx.getRelationshipType(relation.getValue());
+        RelationType relationshipType = tx.getRelationType(relation.getValue());
         boolean inferrable = relationshipType.subs().flatMap(SchemaConcept::thenRules).findFirst().isPresent();
 
         if (!inferrable){

--- a/test-integration/graql/reasoner/query/OntologicalQueryIT.java
+++ b/test-integration/graql/reasoner/query/OntologicalQueryIT.java
@@ -198,7 +198,7 @@ public class OntologicalQueryIT {
         String specificQueryString = "match $x isa reifiable-relation;get;";
         List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
 
-        assertEquals(tx.execute(Graql.parse(specificQueryString).asGet()).size() * tx.getRelationshipType("reifiable-relation").subs().count(), answers.size());
+        assertEquals(tx.execute(Graql.parse(specificQueryString).asGet()).size() * tx.getRelationType("reifiable-relation").subs().count(), answers.size());
         assertCollectionsNonTriviallyEqual(answers, tx.execute(Graql.parse(queryString).asGet(), false));
     }
 
@@ -220,7 +220,7 @@ public class OntologicalQueryIT {
                 String queryString = "match $x isa $type; $type sub relationship; get;";
         List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
 
-        assertEquals(tx.getRelationshipType("relationship").subs().flatMap(RelationType::instances).count(), answers.size());
+        assertEquals(tx.getRelationType("relationship").subs().flatMap(RelationType::instances).count(), answers.size());
         assertCollectionsNonTriviallyEqual(answers, tx.execute(Graql.parse(queryString).asGet(), false));
     }
 
@@ -275,7 +275,7 @@ public class OntologicalQueryIT {
 
         List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
         assertEquals(
-                tx.getRelationshipType("reifying-relation").roles().collect(Collectors.toSet()),
+                tx.getRelationType("reifying-relation").roles().collect(Collectors.toSet()),
                 answers.stream().map(ans -> ans.get("x")).collect(Collectors.toSet())
         );
     }

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -84,11 +84,11 @@ public class QueryIT {
             try (TransactionOLTP tx = session.transaction(Transaction.Type.WRITE)) {
 
                 Role someRole = tx.putRole("someRole");
-                tx.putRelationshipType("relation")
+                tx.putRelationType("relation")
                         .relates(someRole);
-                RelationType inferredBase = tx.putRelationshipType("inferredBase")
+                RelationType inferredBase = tx.putRelationType("inferredBase")
                         .relates(someRole);
-                tx.putRelationshipType("inferred")
+                tx.putRelationType("inferred")
                         .relates(someRole).sup(inferredBase);
                 tx.putEntityType("genericEntity")
                         .plays(someRole);

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -193,7 +193,7 @@ public class AttributeAttachmentIT {
                     {
                         assertTrue(ans.get("x").isEntity());
                         assertTrue(ans.get("y").isAttribute());
-                        assertTrue(ans.get("z").isRelationship());
+                        assertTrue(ans.get("z").isRelation());
                     }
             );
 
@@ -202,7 +202,7 @@ public class AttributeAttachmentIT {
             assertEquals(1, answers2.size());
             answers2.forEach(ans ->
                     {
-                        assertTrue(ans.get("x").isRelationship());
+                        assertTrue(ans.get("x").isRelation());
                         assertTrue(ans.get("y").isAttribute());
                     }
             );

--- a/test-integration/graql/reasoner/reasoning/VariableRolesIT.java
+++ b/test-integration/graql/reasoner/reasoning/VariableRolesIT.java
@@ -190,7 +190,7 @@ public class VariableRolesIT {
 
     private void ternaryNaryRelationWithVariableRoles(String label, int conceptDOF){
         try(TransactionOLTP tx = variableRoleSession.transaction(Transaction.Type.WRITE)) {
-                        final int arity = (int) tx.getRelationshipType(label).roles().count();
+                        final int arity = (int) tx.getRelationType(label).roles().count();
 
             Statement resourcePattern = var("a1").has("name", "a");
 

--- a/test-integration/server/kb/RuleTest.java
+++ b/test-integration/server/kb/RuleTest.java
@@ -700,13 +700,13 @@ public class RuleTest {
                 .plays(someRole)
                 .plays(anotherRole);
 
-        tx.putRelationshipType("relation")
+        tx.putRelationType("relation")
                 .relates(someRole)
                 .relates(anotherRole)
                 .relates(singleRole)
                 .plays(someRole)
                 .plays(anotherRole);
-        tx.putRelationshipType("anotherRelation")
+        tx.putRelationType("anotherRelation")
                 .relates(singleRole);
     }
 }

--- a/test-integration/server/kb/TransactionIT.java
+++ b/test-integration/server/kb/TransactionIT.java
@@ -125,18 +125,18 @@ public class TransactionIT {
         String ruleTypeLabel = "My Rule Type";
 
         assertNull(tx.getEntityType(entityTypeLabel));
-        assertNull(tx.getRelationshipType(relationTypeLabel));
+        assertNull(tx.getRelationType(relationTypeLabel));
         assertNull(tx.getRole(roleTypeLabel));
         assertNull(tx.getAttributeType(resourceTypeLabel));
         assertNull(tx.getRule(ruleTypeLabel));
 
         EntityType entityType = tx.putEntityType(entityTypeLabel);
-        RelationType relationshipType = tx.putRelationshipType(relationTypeLabel);
+        RelationType relationshipType = tx.putRelationType(relationTypeLabel);
         Role role = tx.putRole(roleTypeLabel);
         AttributeType attributeType = tx.putAttributeType(resourceTypeLabel, AttributeType.DataType.STRING);
 
         assertEquals(entityType, tx.getEntityType(entityTypeLabel));
-        assertEquals(relationshipType, tx.getRelationshipType(relationTypeLabel));
+        assertEquals(relationshipType, tx.getRelationType(relationTypeLabel));
         assertEquals(role, tx.getRole(roleTypeLabel));
         assertEquals(attributeType, tx.getAttributeType(resourceTypeLabel));
     }
@@ -144,7 +144,7 @@ public class TransactionIT {
     @Test
     public void whenGettingSubTypesFromRootMeta_IncludeAllTypes() {
         EntityType sampleEntityType = tx.putEntityType("Sample Entity Type");
-        RelationType sampleRelationshipType = tx.putRelationshipType("Sample Relationship Type");
+        RelationType sampleRelationshipType = tx.putRelationType("Sample Relationship Type");
 
         assertThat(tx.getMetaConcept().subs().collect(toSet()), containsInAnyOrder(
                 tx.getMetaConcept(),
@@ -233,7 +233,7 @@ public class TransactionIT {
         Role r1 = tx.putRole("r1");
         Role r2 = tx.putRole("r2");
         EntityType e1 = tx.putEntityType("e1").plays(r1).plays(r2);
-        RelationType rel1 = tx.putRelationshipType("rel1").relates(r1).relates(r2);
+        RelationType rel1 = tx.putRelationType("rel1").relates(r1).relates(r2);
 
         //Purge the above concepts into the main cache
         tx.commit();
@@ -289,7 +289,7 @@ public class TransactionIT {
         tx = session.transaction(Transaction.Type.READ);
         failMutation(tx, () -> tx.putEntityType(entityType));
         failMutation(tx, () -> tx.putRole(roleType1));
-        failMutation(tx, () -> tx.putRelationshipType(relationType1));
+        failMutation(tx, () -> tx.putRelationType(relationType1));
 
         //Pass some mutations
         tx.close();

--- a/test-integration/server/kb/ValidateGlobalRulesIT.java
+++ b/test-integration/server/kb/ValidateGlobalRulesIT.java
@@ -67,7 +67,7 @@ public class ValidateGlobalRulesIT {
         EntityTypeImpl wolf = (EntityTypeImpl) tx.putEntityType("wolf");
         EntityTypeImpl creature = (EntityTypeImpl) tx.putEntityType("creature");
         EntityTypeImpl hunter = (EntityTypeImpl) tx.putEntityType("hunter");
-        RelationType hunts = tx.putRelationshipType("hunts");
+        RelationType hunts = tx.putRelationType("hunts");
         RoleImpl witcher = (RoleImpl) tx.putRole("witcher");
         RoleImpl monster = (RoleImpl) tx.putRole("monster");
         Thing geralt = hunter.create();
@@ -101,7 +101,7 @@ public class ValidateGlobalRulesIT {
     public void testValidatePlaysStructureUnique() {
         Role role1 = tx.putRole("role1");
         Role role2 = tx.putRole("role2");
-        RelationType relationshipType = tx.putRelationshipType("rt").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("rt").relates(role1).relates(role2);
 
         EntityType entityType = tx.putEntityType("et");
 
@@ -139,7 +139,7 @@ public class ValidateGlobalRulesIT {
     @Test
     public void testValidateRelationTypeRelates() {
         Role hunter = tx.putRole("hunter");
-        RelationType kills = tx.putRelationshipType("kills");
+        RelationType kills = tx.putRelationType("kills");
 
         assertTrue(ValidateGlobalRules.validateHasMinimumRoles(kills).isPresent());
         kills.relates(hunter);
@@ -150,7 +150,7 @@ public class ValidateGlobalRulesIT {
     @Test
     public void testAbstractConceptValidation(){
         Role role = tx.putRole("relates");
-        RelationType relationshipType = tx.putRelationshipType("relationTypes");
+        RelationType relationshipType = tx.putRelationType("relationTypes");
 
         assertTrue(ValidateGlobalRules.validateHasSingleIncomingRelatesEdge(role).isPresent());
         assertTrue(ValidateGlobalRules.validateHasMinimumRoles(relationshipType).isPresent());

--- a/test-integration/server/kb/ValidatorIT.java
+++ b/test-integration/server/kb/ValidatorIT.java
@@ -77,10 +77,10 @@ public class ValidatorIT {
         Role role1 = tx.putRole("my role");
         Role role2 = tx.putRole("my role 2");
 
-        RelationType abstractRelationType = tx.putRelationshipType("my abstract relation type").
+        RelationType abstractRelationType = tx.putRelationType("my abstract relation type").
                 relates(role1).
                 isAbstract(true);
-        tx.putRelationshipType("my relation type").
+        tx.putRelationType("my relation type").
                 sup(abstractRelationType).
                 relates(role2);
 
@@ -89,7 +89,7 @@ public class ValidatorIT {
 
     @Test
     public void whenCommittingGraphWhichFollowsValidationRules_Commit(){
-        RelationType cast = tx.putRelationshipType("Cast");
+        RelationType cast = tx.putRelationType("Cast");
         Role feature = tx.putRole("Feature");
         Role actor = tx.putRole("Actor");
         EntityType movie = tx.putEntityType("Movie");
@@ -100,7 +100,7 @@ public class ValidatorIT {
         Role movieOfGenre = tx.putRole("Movie of Genre");
         Role movieGenre = tx.putRole("Movie Genre");
         Thing crime = genre.create();
-        RelationType movieHasGenre = tx.putRelationshipType("Movie Has Genre");
+        RelationType movieHasGenre = tx.putRelationType("Movie Has Genre");
 
         //Construction
         cast.relates(feature);
@@ -126,7 +126,7 @@ public class ValidatorIT {
     @Test
     public void whenCommittingRelationWithoutSpecifyingSchema_ThrowOnCommit(){
         EntityType fakeType = tx.putEntityType("Fake Concept");
-        RelationType relationshipType = tx.putRelationshipType("kicks");
+        RelationType relationshipType = tx.putRelationType("kicks");
         Role kicker = tx.putRole("kicker");
         Role kickee = tx.putRole("kickee");
         Thing kyle = fakeType.create();
@@ -155,7 +155,7 @@ public class ValidatorIT {
 
     @Test
     public void whenCommittingNonAbstractRelationTypeNotLinkedToAnyRoleType_Throw(){
-        RelationType alone = tx.putRelationshipType("alone");
+        RelationType alone = tx.putRelationType("alone");
 
         expectedException.expect(InvalidKBException.class);
         expectedException.expectMessage(containsString(ErrorMessage.VALIDATION_RELATION_TYPE.getMessage(alone.label())));
@@ -168,7 +168,7 @@ public class ValidatorIT {
         Role hunter = tx.putRole("hunter");
         Role monster = tx.putRole("monster");
         EntityType stuff = tx.putEntityType("Stuff").plays(hunter).plays(monster);
-        RelationType kills = tx.putRelationshipType("kills").relates(hunter);
+        RelationType kills = tx.putRelationType("kills").relates(hunter);
 
         Entity myHunter = stuff.create();
         Entity myMonster = stuff.create();
@@ -186,7 +186,7 @@ public class ValidatorIT {
         // schema
         EntityType person = tx.putEntityType("person");
         EntityType movie = tx.putEntityType("movie");
-        RelationType cast = tx.putRelationshipType("cast");
+        RelationType cast = tx.putRelationType("cast");
         Role feature = tx.putRole("feature");
         Role actor = tx.putRole("actor");
         cast.relates(feature).relates(actor);
@@ -209,7 +209,7 @@ public class ValidatorIT {
 
         // now try to delete all assertions and then the movie
         godfather = tx.getEntityType("movie").instances().iterator().next();
-        Collection<Relation> assertions = godfather.relationships().collect(Collectors.toSet());
+        Collection<Relation> assertions = godfather.relations().collect(Collectors.toSet());
         Set<ConceptId> assertionIds = new HashSet<>();
 
         for (Relation a : assertions) {
@@ -231,7 +231,7 @@ public class ValidatorIT {
     public void whenManuallyCreatingCorrectBinaryRelation_Commit() throws InvalidKBException {
         Role characterBeingPlayed = tx.putRole("Character being played");
         Role personPlayingCharacter = tx.putRole("Person Playing Char");
-        RelationType playsChar = tx.putRelationshipType("Plays Char").relates(characterBeingPlayed).relates(personPlayingCharacter);
+        RelationType playsChar = tx.putRelationType("Plays Char").relates(characterBeingPlayed).relates(personPlayingCharacter);
 
         EntityType person = tx.putEntityType("person").plays(characterBeingPlayed).plays(personPlayingCharacter);
         EntityType character = tx.putEntityType("character").plays(characterBeingPlayed);
@@ -261,7 +261,7 @@ public class ValidatorIT {
         Role child = tx.putRole("child");
 
         //Padding to make it valid
-        tx.putRelationshipType("filler").relates(parent).relates(child).relates(father).relates(relative).relates(mother);
+        tx.putRelationType("filler").relates(parent).relates(child).relates(father).relates(relative).relates(mother);
 
         tx.commit();
     }
@@ -276,7 +276,7 @@ public class ValidatorIT {
         tx.putEntityType("person").plays(parent).plays(child);
 
         //Padding to make it valid
-        tx.putRelationshipType("filler").relates(parent).relates(child);
+        tx.putRelationType("filler").relates(parent).relates(child);
 
         tx.commit();
     }
@@ -291,7 +291,7 @@ public class ValidatorIT {
         EntityType man = tx.putEntityType("man").sup(person);
         EntityType oneEyedMan = tx.putEntityType("oneEyedMan").sup(man);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(child);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(child);
 
         Entity x = oneEyedMan.create();
         Entity y = person.create();
@@ -308,7 +308,7 @@ public class ValidatorIT {
         EntityType person = tx.putEntityType("person").plays(parent).plays(child);
         EntityType company = tx.putEntityType("company").plays(parent);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(child);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(child);
 
         Entity x = company.create();
         Entity y = person.create();
@@ -325,7 +325,7 @@ public class ValidatorIT {
         EntityType person = tx.putEntityType("person").plays(parent).plays(child);
         EntityType man = tx.putEntityType("man");
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(child);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(child);
 
         Entity x = man.create();
         Entity y = person.create();
@@ -345,7 +345,7 @@ public class ValidatorIT {
 
         EntityType person = tx.putEntityType("person").plays(child);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(child);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(child);
 
         Entity x = person.create();
         Entity y = person.create();
@@ -366,7 +366,7 @@ public class ValidatorIT {
         EntityType person = tx.putEntityType("person").plays(child);
         tx.putEntityType("man").plays(child);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(child);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(child);
 
         Entity x = person.create();
         Entity y = person.create();
@@ -391,7 +391,7 @@ public class ValidatorIT {
         Role mChild = tx.putRole("mChild").sup(pChild);
 
         //This is to bypass a specific validation rule
-        tx.putRelationshipType("filler").relates(relative);
+        tx.putRelationType("filler").relates(relative);
 
         tx.putEntityType("animal").
                 plays(relative).
@@ -402,9 +402,9 @@ public class ValidatorIT {
                 plays(fChild).
                 plays(mChild);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(pChild);
-        tx.putRelationshipType("fatherhood").sup(parenthood).relates(father).relates(fChild);
-        tx.putRelationshipType("motherhood").sup(parenthood).relates(mother).relates(mChild);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild);
+        tx.putRelationType("fatherhood").sup(parenthood).relates(father).relates(fChild);
+        tx.putRelationType("motherhood").sup(parenthood).relates(mother).relates(mChild);
 
         tx.commit();
     }
@@ -419,7 +419,7 @@ public class ValidatorIT {
         Role fmChild = tx.putRole("fChild").sup(pChild);
 
         //This is to bypass a specific validation rule
-        tx.putRelationshipType("filler").relates(relative);
+        tx.putRelationType("filler").relates(relative);
 
         tx.putEntityType("animal").
                 plays(relative).
@@ -429,8 +429,8 @@ public class ValidatorIT {
                 plays(pChild).
                 plays(fmChild);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(pChild);
-        tx.putRelationshipType("fathermotherhood").sup(parenthood).relates(father).relates(mother).relates(fmChild);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild);
+        tx.putRelationType("fathermotherhood").sup(parenthood).relates(father).relates(mother).relates(fmChild);
 
         tx.commit();
     }
@@ -449,9 +449,9 @@ public class ValidatorIT {
                 plays(pChild).
                 plays(fChild);
 
-        RelationType parentrelativehood = tx.putRelationshipType("parentrelativehood").
+        RelationType parentrelativehood = tx.putRelationType("parentrelativehood").
                 relates(relative).relates(parent).relates(pChild);
-        tx.putRelationshipType("fatherhood").sup(parentrelativehood).
+        tx.putRelationType("fatherhood").sup(parentrelativehood).
                 relates(father).relates(fChild);
 
         tx.commit();
@@ -468,8 +468,8 @@ public class ValidatorIT {
         tx.putEntityType("animal").plays(parent).plays(father).plays(pChild).plays(fChild);
         tx.putEntityType("context").plays(inContext);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(pChild);
-        RelationType fatherhood = tx.putRelationshipType("fatherhood").sup(parenthood).relates(father).relates(fChild).relates(inContext);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild);
+        RelationType fatherhood = tx.putRelationType("fatherhood").sup(parenthood).relates(father).relates(fChild).relates(inContext);
 
         expectedException.expect(InvalidKBException.class);
         expectedException.expectMessage(
@@ -489,8 +489,8 @@ public class ValidatorIT {
         tx.putEntityType("animal").plays(parent).plays(father).plays(pChild).plays(fChild);
         tx.putEntityType("context").plays(inContext);
 
-        RelationType parenthood = tx.putRelationshipType("parenthood").relates(parent).relates(pChild).relates(inContext);
-        RelationType fatherhood = tx.putRelationshipType("fatherhood").sup(parenthood).relates(father).relates(fChild);
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild).relates(inContext);
+        RelationType fatherhood = tx.putRelationType("fatherhood").sup(parenthood).relates(father).relates(fChild);
 
         expectedException.expect(InvalidKBException.class);
         expectedException.expectMessage(
@@ -504,8 +504,8 @@ public class ValidatorIT {
         Role insurer = tx.putRole("insurer");
         Role monoline = tx.putRole("monoline").sup(insurer);
         Role insured = tx.putRole("insured");
-        RelationType insure = tx.putRelationshipType("insure").relates(insurer).relates(insured);
-        tx.putRelationshipType("monoline-insure").relates(monoline).relates(insured).sup(insure);
+        RelationType insure = tx.putRelationType("insure").relates(insurer).relates(insured);
+        tx.putRelationType("monoline-insure").relates(monoline).relates(insured).sup(insure);
         tx.commit();
     }
 
@@ -513,7 +513,7 @@ public class ValidatorIT {
     public void whenARoleInARelationIsNotPlayed_TheGraphIsValid() {
         Role role1 = tx.putRole("role-1");
         Role role2 = tx.putRole("role-2");
-        RelationType relationshipType = tx.putRelationshipType("my-relation").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("my-relation").relates(role1).relates(role2);
 
         Thing thing = tx.putEntityType("my-entity").plays(role1).create();
 
@@ -526,7 +526,7 @@ public class ValidatorIT {
     public void whenARoleInARelationIsPlayedTwice_TheGraphIsValid() {
         Role role1 = tx.putRole("role-1");
         Role role2 = tx.putRole("role-2");
-        RelationType relationshipType = tx.putRelationshipType("my-relationship").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("my-relationship").relates(role1).relates(role2);
 
         EntityType entityType = tx.putEntityType("my-entity").plays(role1);
         Thing thing1 = entityType.create();
@@ -545,7 +545,7 @@ public class ValidatorIT {
     public void whenARoleInARelationIsPlayedAZillionTimes_TheGraphIsValid() {
         Role role1 = tx.putRole("role-1");
         Role role2 = tx.putRole("role-2");
-        RelationType relationshipType = tx.putRelationshipType("my-relationship").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("my-relationship").relates(role1).relates(role2);
 
         EntityType entityType = tx.putEntityType("my-entity").plays(role1);
 
@@ -568,7 +568,7 @@ public class ValidatorIT {
     @Test
     public void whenARelationTypeHasOnlyOneRole_TheGraphIsValid() {
         Role role = tx.putRole("role-1");
-        tx.putRelationshipType("my-relation").relates(role);
+        tx.putRelationType("my-relation").relates(role);
 
         tx.commit();
     }
@@ -578,7 +578,7 @@ public class ValidatorIT {
     public void whenRemovingInvalidRolePlayers_EnsureValidationPasses(){
         Role chased = tx.putRole("chased");
         Role chaser = tx.putRole("chaser");
-        RelationType chases = tx.putRelationshipType("chases").relates(chased).relates(chaser);
+        RelationType chases = tx.putRelationType("chases").relates(chased).relates(chaser);
 
         EntityType puppy = tx.putEntityType("puppy").plays(chaser);
         Entity dunstan = puppy.create();

--- a/test-integration/server/kb/concept/AttributeIT.java
+++ b/test-integration/server/kb/concept/AttributeIT.java
@@ -89,7 +89,7 @@ public class AttributeIT {
     public void whenAttachingResourcesToInstances_EnsureInstancesAreReturnedAsOwners() throws Exception {
         EntityType randomThing = tx.putEntityType("A Thing");
         AttributeType<String> attributeType = tx.putAttributeType("A Attribute Thing", AttributeType.DataType.STRING);
-        RelationType hasResource = tx.putRelationshipType("Has Attribute");
+        RelationType hasResource = tx.putRelationType("Has Attribute");
         Role resourceRole = tx.putRole("Attribute Role");
         Role actorRole = tx.putRole("Actor");
         Thing pacino = randomThing.create();
@@ -204,7 +204,7 @@ public class AttributeIT {
 
         entity.has(attribute);
 
-        RelationStructure relationshipStructure = RelationImpl.from(Iterables.getOnlyElement(entity.relationships().collect(toSet()))).structure();
+        RelationStructure relationshipStructure = RelationImpl.from(Iterables.getOnlyElement(entity.relations().collect(toSet()))).structure();
         assertThat(relationshipStructure, instanceOf(RelationEdge.class));
         assertTrue("Edge Relationship id not starting with [" + Schema.PREFIX_EDGE + "]", relationshipStructure.id().getValue().startsWith(Schema.PREFIX_EDGE));
         assertEquals(entity, attribute.owner());
@@ -219,7 +219,7 @@ public class AttributeIT {
         EntityType entityType = tx.putEntityType("My entity type").has(attributeType);
         Entity entity = entityType.create();
         entity.has(attribute);
-        RelationImpl relation = RelationImpl.from(entity.relationships().iterator().next());
+        RelationImpl relation = RelationImpl.from(entity.relations().iterator().next());
 
         //Check it's a relation edge.
         RelationStructure relationshipStructureBefore = relation.structure();
@@ -281,15 +281,15 @@ public class AttributeIT {
         Entity e1 = entityType.create();
         Entity e2 = entityType.create();
 
-        assertThat(attribute.relationships().collect(toSet()), empty());
+        assertThat(attribute.relations().collect(toSet()), empty());
 
         e1.has(attribute);
         e2.has(attribute);
 
-        Relation rel1 = Iterables.getOnlyElement(e1.relationships().collect(toSet()));
-        Relation rel2 = Iterables.getOnlyElement(e2.relationships().collect(toSet()));
+        Relation rel1 = Iterables.getOnlyElement(e1.relations().collect(toSet()));
+        Relation rel2 = Iterables.getOnlyElement(e2.relations().collect(toSet()));
 
-        assertThat(attribute.relationships().collect(toSet()), containsInAnyOrder(rel1, rel2));
+        assertThat(attribute.relations().collect(toSet()), containsInAnyOrder(rel1, rel2));
     }
 
     @Test

--- a/test-integration/server/kb/concept/EntityIT.java
+++ b/test-integration/server/kb/concept/EntityIT.java
@@ -88,7 +88,7 @@ public class EntityIT {
     public void whenDeletingInstanceInRelationShip_TheInstanceAndCastingsAreDeletedAndTheRelationRemains() throws TransactionException {
         //Schema
         EntityType type = tx.putEntityType("Concept Type");
-        RelationType relationshipType = tx.putRelationshipType("relationTypes");
+        RelationType relationshipType = tx.putRelationType("relationTypes");
         Role role1 = tx.putRole("role1");
         Role role2 = tx.putRole("role2");
         Role role3 = tx.putRole("role3");
@@ -125,7 +125,7 @@ public class EntityIT {
     @Test
     public void whenDeletingLastRolePlayerInRelation_TheRelationIsDeleted() throws TransactionException {
         EntityType type = tx.putEntityType("Concept Type");
-        RelationType relationshipType = tx.putRelationshipType("relationTypes");
+        RelationType relationshipType = tx.putRelationType("relationTypes");
         Role role1 = tx.putRole("role1");
         Thing rolePlayer1 = type.create();
 
@@ -150,7 +150,7 @@ public class EntityIT {
         Attribute attribute = attributeType.create("A attribute thing");
 
         entity.has(attribute);
-        Relation relationship = entity.relationships().iterator().next();
+        Relation relationship = entity.relations().iterator().next();
 
         checkImplicitStructure(attributeType, relationship, entity, Schema.ImplicitType.HAS, Schema.ImplicitType.HAS_OWNER, Schema.ImplicitType.HAS_VALUE);
     }
@@ -180,11 +180,11 @@ public class EntityIT {
         Attribute attribute1 = attributeType.create("A resource thing");
         Attribute attribute2 = attributeType.create("Another resource thing");
 
-        assertEquals(0, entity.relationships().count());
+        assertEquals(0, entity.relations().count());
         entity.has(attribute1);
-        assertEquals(1, entity.relationships().count());
+        assertEquals(1, entity.relations().count());
         entity.has(attribute2);
-        assertEquals(2, entity.relationships().count());
+        assertEquals(2, entity.relations().count());
 
         tx.commit();
     }
@@ -200,7 +200,7 @@ public class EntityIT {
         Attribute attribute = attributeType.create("A attribute thing");
 
         entity.has(attribute);
-        Relation relationship = entity.relationships().iterator().next();
+        Relation relationship = entity.relations().iterator().next();
 
         checkImplicitStructure(attributeType, relationship, entity, Schema.ImplicitType.KEY, Schema.ImplicitType.KEY_OWNER, Schema.ImplicitType.KEY_VALUE);
     }
@@ -297,7 +297,7 @@ public class EntityIT {
         e.has(attribute1);
         EntityImpl.from(e).attributeInferred(attribute2);
 
-        e.relationships().forEach(relationship -> {
+        e.relations().forEach(relationship -> {
             relationship.rolePlayers().forEach(roleplayer ->{
                 if(roleplayer.equals(attribute1)){
                     assertFalse(relationship.isInferred());

--- a/test-integration/server/kb/concept/EntityTypeIT.java
+++ b/test-integration/server/kb/concept/EntityTypeIT.java
@@ -295,15 +295,15 @@ public class EntityTypeIT {
                 containsInAnyOrder(tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(label).getValue())));
 
         //Check Implicit Types Follow SUB Structure
-        RelationType superRelation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()).getValue());
+        RelationType superRelation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()).getValue());
         Role superRoleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(superAttributeType.label()).getValue());
         Role superRoleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(superAttributeType.label()).getValue());
 
-        RelationType relation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
+        RelationType relation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
         Role roleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(attributeType.label()).getValue());
         Role roleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(attributeType.label()).getValue());
 
-        RelationType metaRelation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(metaType.label()).getValue());
+        RelationType metaRelation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(metaType.label()).getValue());
         Role metaRoleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(metaType.label()).getValue());
         Role metaRoleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(metaType.label()).getValue());
 
@@ -334,15 +334,15 @@ public class EntityTypeIT {
                 containsInAnyOrder(tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(label).getValue())));
 
         //Check Implicit Types Follow SUB Structure
-        RelationType superRelation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()).getValue());
+        RelationType superRelation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(superAttributeType.label()).getValue());
         Role superRoleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(superAttributeType.label()).getValue());
         Role superRoleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(superAttributeType.label()).getValue());
 
-        RelationType relation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
+        RelationType relation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
         Role roleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(attributeType.label()).getValue());
         Role roleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(attributeType.label()).getValue());
 
-        RelationType metaRelation = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(metaType.label()).getValue());
+        RelationType metaRelation = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(metaType.label()).getValue());
         Role metaRoleOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(metaType.label()).getValue());
         Role metaRoleValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(metaType.label()).getValue());
 

--- a/test-integration/server/kb/concept/RelationIT.java
+++ b/test-integration/server/kb/concept/RelationIT.java
@@ -87,7 +87,7 @@ public class RelationIT {
         role3 = (RoleImpl) tx.putRole("Role 3");
 
         type = tx.putEntityType("Main concept Type").plays(role1).plays(role2).plays(role3);
-        relationshipType = tx.putRelationshipType("Main relation type").relates(role1).relates(role2).relates(role3);
+        relationshipType = tx.putRelationType("Main relation type").relates(role1).relates(role2).relates(role3);
 
         rolePlayer1 = (ThingImpl) type.create();
         rolePlayer2 = (ThingImpl) type.create();
@@ -117,7 +117,7 @@ public class RelationIT {
 
     @Test
     public void whenCreatingAnInferredRelationship_EnsureMarkedAsInferred(){
-        RelationTypeImpl rt = RelationTypeImpl.from(tx.putRelationshipType("rt"));
+        RelationTypeImpl rt = RelationTypeImpl.from(tx.putRelationType("rt"));
         Relation relationship = rt.create();
         Relation relationshipInferred = rt.addRelationshipInferred();
         assertFalse(relationship.isInferred());
@@ -130,7 +130,7 @@ public class RelationIT {
         Role role1 = tx.putRole("Role 1");
         Role role2 = tx.putRole("Role 2");
         Role role3 = tx.putRole("Role 3");
-        tx.putRelationshipType("Rel Type").relates(role1).relates(role2).relates(role3);
+        tx.putRelationType("Rel Type").relates(role1).relates(role2).relates(role3);
         EntityType entType = tx.putEntityType("Entity Type").plays(role1).plays(role2).plays(role3);
 
         //Data
@@ -186,7 +186,7 @@ public class RelationIT {
     public void ensureRelationToStringContainsRolePlayerInformation(){
         Role role1 = tx.putRole("role type 1");
         Role role2 = tx.putRole("role type 2");
-        RelationType relationshipType = tx.putRelationshipType("A relationship Type").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("A relationship Type").relates(role1).relates(role2);
         EntityType type = tx.putEntityType("concept type").plays(role1).plays(role2);
         Thing thing1 = type.create();
         Thing thing2 = type.create();
@@ -209,7 +209,7 @@ public class RelationIT {
         EntityType entityType = tx.putEntityType("Entity Type").plays(entityRole);
         AttributeType<Long> degreeType = tx.putAttributeType("Attribute Type", AttributeType.DataType.LONG).plays(degreeRole);
 
-        RelationType hasDegree = tx.putRelationshipType("Has Degree").relates(entityRole).relates(degreeRole);
+        RelationType hasDegree = tx.putRelationType("Has Degree").relates(entityRole).relates(degreeRole);
 
         Entity entity = entityType.create();
         Attribute<Long> degree1 = degreeType.create(100L);
@@ -218,11 +218,11 @@ public class RelationIT {
         Relation relationship1 = hasDegree.create().assign(entityRole, entity).assign(degreeRole, degree1);
         hasDegree.create().assign(entityRole, entity).assign(degreeRole, degree2);
 
-        assertEquals(2, entity.relationships().count());
+        assertEquals(2, entity.relations().count());
 
         relationship1.delete();
 
-        assertEquals(1, entity.relationships().count());
+        assertEquals(1, entity.relations().count());
     }
 
 
@@ -232,7 +232,7 @@ public class RelationIT {
         Role roleB = tx.putRole("RoleB");
         Role roleC = tx.putRole("RoleC");
 
-        RelationType relation = tx.putRelationshipType("relation type").relates(roleA).relates(roleB).relates(roleC);
+        RelationType relation = tx.putRelationType("relation type").relates(roleA).relates(roleB).relates(roleC);
         EntityType type = tx.putEntityType("concept type").plays(roleA).plays(roleB).plays(roleC);
         Entity a = type.create();
         Entity b = type.create();
@@ -260,7 +260,7 @@ public class RelationIT {
         Attribute<String> attribute = attributeType.create("a real pain");
 
         EntityType entityType = tx.putEntityType("yay").has(attributeType);
-        Relation implicitRelationship = Iterables.getOnlyElement(entityType.create().has(attribute).relationships().collect(Collectors.toSet()));
+        Relation implicitRelationship = Iterables.getOnlyElement(entityType.create().has(attribute).relations().collect(Collectors.toSet()));
 
         expectedException.expect(TransactionException.class);
         expectedException.expectMessage(TransactionException.hasNotAllowed(implicitRelationship, attribute).getMessage());
@@ -274,7 +274,7 @@ public class RelationIT {
         Role role1 = tx.putRole("dark");
         Role role2 = tx.putRole("souls");
         AttributeType<Long> attributeType = tx.putAttributeType("Death Number", AttributeType.DataType.LONG);
-        RelationType relationshipType = tx.putRelationshipType("Dark Souls").relates(role1).relates(role2).key(attributeType);
+        RelationType relationshipType = tx.putRelationType("Dark Souls").relates(role1).relates(role2).key(attributeType);
         EntityType entityType = tx.putEntityType("Dead Guys").plays(role1).plays(role2);
 
         Entity e1 = entityType.create();
@@ -301,7 +301,7 @@ public class RelationIT {
     public void whenRemovingRolePlayerFromRelationship_EnsureRolePlayerIsRemoved(){
         Role role1 = tx.putRole("dark");
         Role role2 = tx.putRole("souls");
-        RelationType relationshipType = tx.putRelationshipType("Dark Souls").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("Dark Souls").relates(role1).relates(role2);
         EntityType entityType = tx.putEntityType("Dead Guys").plays(role1).plays(role2);
 
         Entity e1 = entityType.create();
@@ -326,20 +326,20 @@ public class RelationIT {
     @Test
     public void whenAttributeLinkedToRelationshipIsInferred_EnsureItIsMarkedAsInferred(){
         AttributeType attributeType = tx.putAttributeType("Another thing of sorts", AttributeType.DataType.STRING);
-        RelationType relationshipType = tx.putRelationshipType("A thing of sorts").has(attributeType);
+        RelationType relationshipType = tx.putRelationType("A thing of sorts").has(attributeType);
 
         Attribute attribute = attributeType.create("Things");
         Relation relationship = relationshipType.create();
 
         RelationImpl.from(relationship).attributeInferred(attribute);
-        assertTrue(relationship.relationships().findAny().get().isInferred());
+        assertTrue(relationship.relations().findAny().get().isInferred());
     }
 
     @Test
     public void whenAddingRelationshipWithNoRolePlayers_Throw(){
         Role role1 = tx.putRole("r1");
         Role role2 = tx.putRole("r2");
-        RelationType relationshipType = tx.putRelationshipType("A thing of sorts").relates(role1).relates(role2);
+        RelationType relationshipType = tx.putRelationType("A thing of sorts").relates(role1).relates(role2);
         Relation relationship = relationshipType.create();
 
         expectedException.expect(InvalidKBException.class);

--- a/test-integration/server/kb/concept/RelationTypeIT.java
+++ b/test-integration/server/kb/concept/RelationTypeIT.java
@@ -68,7 +68,7 @@ public class RelationTypeIT {
 
     @Test
     public void whenGettingTheRolesOfRelationTypes_AllTheRolesAreReturned() throws Exception {
-        RelationType relationshipType = tx.putRelationshipType("relationTypes");
+        RelationType relationshipType = tx.putRelationType("relationTypes");
         Role role1 = tx.putRole("role1");
         Role role2 = tx.putRole("role2");
         Role role3 = tx.putRole("role3");
@@ -78,7 +78,7 @@ public class RelationTypeIT {
 
     @Test
     public void whenMutatingRolesOfRelationType_EnsureRelationTypeRolesAreAlwaysUpdated(){
-        RelationType relationshipType = tx.putRelationshipType("c1");
+        RelationType relationshipType = tx.putRelationType("c1");
         Role role1 = tx.putRole("c2");
         Role role2 = tx.putRole("c3");
         assertThat(relationshipType.roles().collect(toSet()), empty());
@@ -98,7 +98,7 @@ public class RelationTypeIT {
         EntityType entityType = tx.putEntityType("My Special Entity Type").has(attributeType);
         Entity entity = entityType.create();
 
-        RelationType implicitRelationshipType = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
+        RelationType implicitRelationshipType = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
 
         assertNotNull(implicitRelationshipType);
         assertThat(implicitRelationshipType.instances().collect(toSet()), empty());
@@ -116,7 +116,7 @@ public class RelationTypeIT {
         EntityType entityType = tx.putEntityType("My Special Entity Type").has(attributeType);
         entityType.create().has(attribute);
 
-        RelationType implicitRelationshipType = tx.getRelationshipType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
+        RelationType implicitRelationshipType = tx.getRelationType(Schema.ImplicitType.HAS.getLabel(attributeType.label()).getValue());
 
         expectedException.expect(TransactionException.class);
         expectedException.expectMessage(TransactionException.addingInstancesToAbstractType(implicitRelationshipType).getMessage());

--- a/test-integration/server/kb/concept/RoleIT.java
+++ b/test-integration/server/kb/concept/RoleIT.java
@@ -60,7 +60,7 @@ public class RoleIT {
         session = server.sessionWithNewKeyspace();
         tx = session.transaction(Transaction.Type.WRITE);
         role = tx.putRole("My Role");
-        relationshipType = tx.putRelationshipType("RelationshipType");
+        relationshipType = tx.putRelationType("RelationshipType");
     }
 
     @After
@@ -71,9 +71,9 @@ public class RoleIT {
 
     @Test
     public void whenGettingTheRelationTypesARoleIsInvolvedIn_ReturnTheRelationTypes() {
-        assertThat(role.relationships().collect(toSet()), empty());
+        assertThat(role.relations().collect(toSet()), empty());
         relationshipType.relates(role);
-        assertThat(role.relationships().collect(toSet()), containsInAnyOrder(relationshipType));
+        assertThat(role.relations().collect(toSet()), containsInAnyOrder(relationshipType));
     }
 
     @Test
@@ -104,7 +104,7 @@ public class RoleIT {
     @Test
     public void whenDeletingRoleTypeWithRelationTypes_Throw(){
         Role role2 = tx.putRole("New Role Type");
-        tx.putRelationshipType("Thing").relates(role2).relates(role);
+        tx.putRelationType("Thing").relates(role2).relates(role);
 
         expectedException.expect(TransactionException.class);
         expectedException.expectMessage(TransactionException.cannotBeDeleted(role2).getMessage());
@@ -116,7 +116,7 @@ public class RoleIT {
     public void whenDeletingRoleTypeWithRolePlayers_Throw(){
         Role roleA = tx.putRole("roleA");
         Role roleB = tx.putRole("roleB");
-        RelationType relationshipType = tx.putRelationshipType("relationTypes").relates(roleA).relates(roleB);
+        RelationType relationshipType = tx.putRelationType("relationTypes").relates(roleA).relates(roleB);
         EntityType entityType = tx.putEntityType("entityType").plays(roleA).plays(roleB);
 
         Entity a = entityType.create();
@@ -135,11 +135,11 @@ public class RoleIT {
         Role roleA = tx.putRole("roleA");
         Role roleB = tx.putRole("roleB");
         relationshipType.relates(roleA).relates(role);
-        RelationType relationshipType2 = tx.putRelationshipType("relationshipType2").relates(roleB).relates(role);
+        RelationType relationshipType2 = tx.putRelationType("relationshipType2").relates(roleB).relates(role);
         tx.commit();
 
-        assertThat(roleA.relationships().collect(toSet()), containsInAnyOrder(relationshipType));
-        assertThat(roleB.relationships().collect(toSet()), containsInAnyOrder(relationshipType2));
-        assertThat(role.relationships().collect(toSet()), containsInAnyOrder(relationshipType, relationshipType2));
+        assertThat(roleA.relations().collect(toSet()), containsInAnyOrder(relationshipType));
+        assertThat(roleB.relations().collect(toSet()), containsInAnyOrder(relationshipType2));
+        assertThat(role.relations().collect(toSet()), containsInAnyOrder(relationshipType, relationshipType2));
     }
 }

--- a/test-integration/server/kb/concept/SchemaConceptIT.java
+++ b/test-integration/server/kb/concept/SchemaConceptIT.java
@@ -105,7 +105,7 @@ public class SchemaConceptIT {
 
         entityType.has(attributeType);
 
-        RelationType relationshipType = tx.getRelationshipType(hasResourceLabel.getValue());
+        RelationType relationshipType = tx.getRelationType(hasResourceLabel.getValue());
         Assert.assertEquals(hasResourceLabel, relationshipType.label());
 
         Set<Label> roleLabels = relationshipType.roles().map(SchemaConcept::label).collect(toSet());

--- a/test-integration/server/kb/concept/SchemaMutationIT.java
+++ b/test-integration/server/kb/concept/SchemaMutationIT.java
@@ -67,8 +67,8 @@ public class SchemaMutationIT {
         Role driver = tx.putRole("driver");
         Role driven = tx.putRole("driven");
 
-        RelationType marriage = tx.putRelationshipType("marriage").relates(husband).relates(wife);
-        RelationType drives = tx.putRelationshipType("drives").relates(driven).relates(driver);
+        RelationType marriage = tx.putRelationType("marriage").relates(husband).relates(wife);
+        RelationType drives = tx.putRelationType("drives").relates(driven).relates(driver);
 
         EntityType person = tx.putEntityType("person").plays(husband).plays(wife).plays(driver);
         EntityType man = tx.putEntityType("man").sup(person);
@@ -106,7 +106,7 @@ public class SchemaMutationIT {
 
     @Test
     public void whenDeletingRelatesUsedByExistingRelation_Throw() throws InvalidKBException {
-        RelationType marriage = tx.getRelationshipType("marriage");
+        RelationType marriage = tx.getRelationType("marriage");
         Role husband = tx.getRole("husband");
 
         marriage.unrelate(husband);
@@ -160,13 +160,13 @@ public class SchemaMutationIT {
     @Test
     public void whenDeletingRelationTypeAndLeavingRoleByItself_Throw() {
         Role role = tx.putRole("my wonderful role");
-        RelationType relation = tx.putRelationshipType("my wonderful relation").relates(role);
+        RelationType relation = tx.putRelationType("my wonderful relation").relates(role);
         relation.relates(role);
         tx.commit();
 
         //Now delete the relation
         tx = session.transaction(Transaction.Type.WRITE);
-        RelationType relationInNewTx = tx.getRelationshipType("my wonderful relation");
+        RelationType relationInNewTx = tx.getRelationType("my wonderful relation");
         relationInNewTx.delete();
 
         expectedException.expect(InvalidKBException.class);
@@ -184,7 +184,7 @@ public class SchemaMutationIT {
 
         //Create a dog which is a animal and is therefore allowed to have a name
         EntityType dog = tx.putEntityType("dog").sup(animal);
-        RelationType has_name = tx.getRelationshipType("@has-name");
+        RelationType has_name = tx.getRelationType("@has-name");
 
         //Create a dog and name it puppy
         Attribute<String> puppy = name.create("puppy");

--- a/test-integration/server/kb/structure/CastingIT.java
+++ b/test-integration/server/kb/structure/CastingIT.java
@@ -61,7 +61,7 @@ public class CastingIT {
         role2 = tx.putRole("role2");
         role3 = tx.putRole("role3");
         entityType = tx.putEntityType("Entity Type").plays(role1).plays(role2).plays(role3);
-        relationshipType = tx.putRelationshipType("Relationship Type").relates(role1).relates(role2).relates(role3);
+        relationshipType = tx.putRelationType("Relationship Type").relates(role1).relates(role2).relates(role3);
     }
 
     @After


### PR DESCRIPTION
## What is the goal of this PR?

We are in the process of refactoring client-java (PR #4926) to
a) not depend on server
b) extracted into its own repository
c) have two distributions, one for normal use and one for benchmarking

## What are the changes implemented in this PR?

Before we can complete the above PR, we needed to a lot of minor clean-ups the code of client-java and concept API:

1) Cleaned up Javadoc comments in client-java, concept-api, session and transaction classes, so that they don't create artificial dependencies to external classes/packages
2) Renamed 'relationship' to 'relation' in all classes and methods that occur in client-java and concept-api