### PR TITLE
Remove ReasonerQuery from Explanation

### DIFF
--- a/server/src/graql/answer/Explanation.java
+++ b/server/src/graql/answer/Explanation.java
@@ -18,12 +18,10 @@
 
 package grakn.core.graql.answer;
 
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
-
-import javax.annotation.CheckReturnValue;
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.CheckReturnValue;
+import javax.annotation.Nullable;
 
 /**
  * Base class for explanation classes.
@@ -40,20 +38,20 @@ public interface Explanation {
     Explanation childOf(ConceptMap ans);
 
     /**
-     * @return query associated with this explanation
+     * @return query pattern associated with this explanation
      */
     @Nullable
     @CheckReturnValue
-    ReasonerQuery getQuery();
+    String getQueryPattern();
 
     /**
      * produce a new explanation with provided query set
      *
-     * @param q query this explanation should be associated with
+     * @param queryPattern query this explanation should be associated with
      * @return explanation with provided query
      */
     @CheckReturnValue
-    Explanation setQuery(ReasonerQuery q);
+    Explanation setQueryPattern(String queryPattern);
 
     /**
      * @return answers this explanation is dependent on

--- a/server/src/graql/internal/reasoner/cache/StructuralCache.java
+++ b/server/src/graql/internal/reasoner/cache/StructuralCache.java
@@ -73,13 +73,13 @@ public class StructuralCache<Q extends ReasonerQueryImpl>{
 
             return tx.executor().traversal(transformedQuery.getPattern().variables(), traversal.transform(idTransform))
                     .map(ans -> ans.unify(unifier))
-                    .map(a -> a.explain(new LookupExplanation(query)));
+                    .map(a -> a.explain(new LookupExplanation(query.getPattern().toString())));
         }
 
         GraqlTraversal traversal = GreedyTraversalPlan.createTraversal(query.getPattern(), tx);
         structCache.put(structQuery, new CacheEntry<>(query, traversal));
 
         return tx.executor().traversal(query.getPattern().variables(), traversal)
-                .map(a -> a.explain(new LookupExplanation(query)));
+                .map(a -> a.explain(new LookupExplanation(query.getPattern().toString())));
     }
 }

--- a/server/src/graql/internal/reasoner/explanation/JoinExplanation.java
+++ b/server/src/graql/internal/reasoner/explanation/JoinExplanation.java
@@ -20,12 +20,8 @@ package grakn.core.graql.internal.reasoner.explanation;
 
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
-import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
-import grakn.core.graql.internal.reasoner.query.ReasonerQueryImpl;
 import grakn.core.graql.internal.reasoner.utils.ReasonerUtils;
-
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  *
@@ -38,13 +34,8 @@ import java.util.stream.Collectors;
 public class JoinExplanation extends QueryExplanation {
 
     public JoinExplanation(List<ConceptMap> answers){ super(answers);}
-    public JoinExplanation(ReasonerQueryImpl q, ConceptMap mergedAnswer){
-        super(q, q.selectAtoms()
-                .map(at -> at.inferTypes(mergedAnswer.project(at.getVarNames())))
-                .map(ReasonerQueries::atomic)
-                .map(aq -> mergedAnswer.project(aq.getVarNames()).explain(new LookupExplanation(aq)))
-                .collect(Collectors.toList())
-        );
+    public JoinExplanation(String queryPattern, List<ConceptMap> partialAnswers){
+        super(queryPattern, partialAnswers);
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/explanation/LookupExplanation.java
+++ b/server/src/graql/internal/reasoner/explanation/LookupExplanation.java
@@ -20,8 +20,6 @@ package grakn.core.graql.internal.reasoner.explanation;
 
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
-
 import java.util.List;
 
 /**
@@ -34,19 +32,19 @@ import java.util.List;
  */
 public class LookupExplanation extends QueryExplanation {
 
-    public LookupExplanation(ReasonerQuery q){ super(q);}
-    private LookupExplanation(ReasonerQuery q, List<ConceptMap> answers){
-        super(q, answers);
+    public LookupExplanation(String queryPattern){ super(queryPattern);}
+    private LookupExplanation(String queryPattern, List<ConceptMap> answers){
+        super(queryPattern, answers);
     }
 
     @Override
-    public Explanation setQuery(ReasonerQuery q){
-        return new LookupExplanation(q);
+    public Explanation setQueryPattern(String queryPattern){
+        return new LookupExplanation(queryPattern);
     }
 
     @Override
     public Explanation childOf(ConceptMap ans) {
-        return new LookupExplanation(getQuery(), ans.explanation().getAnswers());
+        return new LookupExplanation(getQueryPattern(), ans.explanation().getAnswers());
     }
 
     @Override

--- a/server/src/graql/internal/reasoner/explanation/QueryExplanation.java
+++ b/server/src/graql/internal/reasoner/explanation/QueryExplanation.java
@@ -21,8 +21,6 @@ package grakn.core.graql.internal.reasoner.explanation;
 import com.google.common.collect.ImmutableList;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
-
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -39,31 +37,34 @@ import java.util.stream.Collectors;
  */
 public class QueryExplanation implements Explanation {
 
-    private final ReasonerQuery query;
+    private final String queryPattern;
     private final ImmutableList<ConceptMap> answers;
 
     public QueryExplanation(){
-        this.query = null;
+        this.queryPattern = null;
         this.answers = ImmutableList.of();}
-    QueryExplanation(ReasonerQuery q, List<ConceptMap> ans){
-        this.query = q;
+    QueryExplanation(String queryPattern, List<ConceptMap> ans){
+        this.queryPattern = queryPattern;
         this.answers = ImmutableList.copyOf(ans);
     }
-    QueryExplanation(ReasonerQuery q){
-        this(q, new ArrayList<>());
+    QueryExplanation(String queryPattern){
+        this(queryPattern, new ArrayList<>());
     }
     QueryExplanation(List<ConceptMap> ans){
         this(null, ans);
     }
 
     @Override
-    public Explanation setQuery(ReasonerQuery q){
-        return new QueryExplanation(q);
+    public String getQueryPattern(){ return queryPattern;}
+
+    @Override
+    public Explanation setQueryPattern(String queryPattern){
+        return new QueryExplanation(queryPattern);
     }
 
     @Override
     public Explanation childOf(ConceptMap ans) {
-        return new QueryExplanation(getQuery(), ans.explanation().getAnswers());
+        return new QueryExplanation(getQueryPattern(), ans.explanation().getAnswers());
     }
 
     @Override
@@ -92,7 +93,4 @@ public class QueryExplanation implements Explanation {
 
     @Override
     public boolean isEmpty() { return !isLookupExplanation() && !isRuleExplanation() && getAnswers().isEmpty();}
-
-    @Override
-    public ReasonerQuery getQuery(){ return query;}
 }

--- a/server/src/graql/internal/reasoner/explanation/RuleExplanation.java
+++ b/server/src/graql/internal/reasoner/explanation/RuleExplanation.java
@@ -20,10 +20,8 @@ package grakn.core.graql.internal.reasoner.explanation;
 
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
 import grakn.core.graql.internal.reasoner.rule.InferenceRule;
 import grakn.core.graql.internal.reasoner.utils.ReasonerUtils;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -39,24 +37,24 @@ public class RuleExplanation extends QueryExplanation {
 
     private final InferenceRule rule;
 
-    public RuleExplanation(ReasonerQuery q, InferenceRule rl){
-        super(q);
+    public RuleExplanation(String queryPattern, InferenceRule rl){
+        super(queryPattern);
         this.rule = rl;
     }
-    private RuleExplanation(ReasonerQuery q, List<ConceptMap> answers, InferenceRule rl){
-        super(q, answers);
+    private RuleExplanation(String queryPattern, List<ConceptMap> answers, InferenceRule rl){
+        super(queryPattern, answers);
         this.rule = rl;
     }
 
     @Override
-    public Explanation setQuery(ReasonerQuery q){
-        return new RuleExplanation(q, getRule());
+    public Explanation setQueryPattern(String queryPattern){
+        return new RuleExplanation(queryPattern, getRule());
     }
 
     @Override
     public Explanation childOf(ConceptMap ans) {
         Explanation explanation = ans.explanation();
-        return new RuleExplanation(getQuery(),
+        return new RuleExplanation(getQueryPattern(),
                 ReasonerUtils.listUnion(this.getAnswers(), explanation.isLookupExplanation()?
                         Collections.singletonList(ans) :
                         explanation.getAnswers()),

--- a/server/src/graql/internal/reasoner/explanation/RuleExplanation.java
+++ b/server/src/graql/internal/reasoner/explanation/RuleExplanation.java
@@ -20,8 +20,7 @@ package grakn.core.graql.internal.reasoner.explanation;
 
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
-import grakn.core.graql.internal.reasoner.rule.InferenceRule;
-import grakn.core.graql.internal.reasoner.utils.ReasonerUtils;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,34 +34,36 @@ import java.util.List;
  */
 public class RuleExplanation extends QueryExplanation {
 
-    private final InferenceRule rule;
+    private final String ruleId;
 
-    public RuleExplanation(String queryPattern, InferenceRule rl){
+    public RuleExplanation(String queryPattern, String ruleId){
         super(queryPattern);
-        this.rule = rl;
+        this.ruleId = ruleId;
     }
-    private RuleExplanation(String queryPattern, List<ConceptMap> answers, InferenceRule rl){
+    private RuleExplanation(String queryPattern, List<ConceptMap> answers, String ruleId){
         super(queryPattern, answers);
-        this.rule = rl;
+        this.ruleId = ruleId;
     }
 
     @Override
     public Explanation setQueryPattern(String queryPattern){
-        return new RuleExplanation(queryPattern, getRule());
+        return new RuleExplanation(queryPattern, getRuleId());
     }
 
     @Override
     public Explanation childOf(ConceptMap ans) {
         Explanation explanation = ans.explanation();
-        return new RuleExplanation(getQueryPattern(),
-                ReasonerUtils.listUnion(this.getAnswers(), explanation.isLookupExplanation()?
+        List<ConceptMap> answerList = new ArrayList<>(this.getAnswers());
+        answerList.addAll(
+                explanation.isLookupExplanation()?
                         Collections.singletonList(ans) :
-                        explanation.getAnswers()),
-                getRule());
+                        explanation.getAnswers()
+        );
+        return new RuleExplanation(getQueryPattern(), answerList, getRuleId());
     }
 
     @Override
     public boolean isRuleExplanation(){ return true;}
 
-    public InferenceRule getRule(){ return rule;}
+    public String getRuleId(){ return ruleId;}
 }

--- a/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/internal/reasoner/query/ReasonerAtomicQuery.java
@@ -205,7 +205,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     public Iterator<ResolutionState> queryStateIterator(QueryStateBase parent, Set<ReasonerAtomicQuery> visitedSubGoals, MultilevelSemanticCache cache) {
         Pair<Stream<ConceptMap>, MultiUnifier> cacheEntry = cache.getAnswerStreamWithUnifier(this);
         Iterator<AnswerState> dbIterator = cacheEntry.getKey()
-                .map(a -> a.explain(a.explanation().setQuery(this)))
+                .map(a -> a.explain(a.explanation().setQueryPattern(this.getPattern().toString())))
                 .map(ans -> new AnswerState(ans, parent.getUnifier(), parent))
                 .iterator();
 

--- a/server/src/graql/internal/reasoner/state/AtomicState.java
+++ b/server/src/graql/internal/reasoner/state/AtomicState.java
@@ -115,7 +115,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         return answer
                 .merge(query.getSubstitution())
                 .project(query.getVarNames())
-                .explain(new RuleExplanation(query.getPattern().toString(), rule));
+                .explain(new RuleExplanation(query.getPattern().toString(), rule.getRule().id().getValue()));
     }
 
     private ConceptMap materialisedAnswer(ConceptMap baseAnswer, InferenceRule rule, Unifier unifier) {
@@ -159,6 +159,8 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
 
         return answer
                 .merge(query.getSubstitution())
-                .explain(new RuleExplanation(query.getPattern().toString(), rule));
+                .explain(new RuleExplanation(
+                        query.getPattern().toString(),
+                        rule.getRule().id().getValue()));
     }
 }

--- a/server/src/graql/internal/reasoner/state/AtomicState.java
+++ b/server/src/graql/internal/reasoner/state/AtomicState.java
@@ -115,7 +115,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         return answer
                 .merge(query.getSubstitution())
                 .project(query.getVarNames())
-                .explain(new RuleExplanation(query, rule));
+                .explain(new RuleExplanation(query.getPattern().toString(), rule));
     }
 
     private ConceptMap materialisedAnswer(ConceptMap baseAnswer, InferenceRule rule, Unifier unifier) {
@@ -159,6 +159,6 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
 
         return answer
                 .merge(query.getSubstitution())
-                .explain(new RuleExplanation(query, rule));
+                .explain(new RuleExplanation(query.getPattern().toString(), rule));
     }
 }

--- a/server/src/server/rpc/ResponseBuilder.java
+++ b/server/src/server/rpc/ResponseBuilder.java
@@ -290,7 +290,7 @@ public class ResponseBuilder {
             AnswerProto.Explanation.Builder builder = AnswerProto.Explanation.newBuilder()
                     .addAllAnswers(explanation.getAnswers().stream().map(Answer::conceptMap)
                             .collect(Collectors.toList()));
-            if (explanation.getQuery() != null) builder.setPattern(explanation.getQuery().getPattern().toString());
+            if (explanation.getQueryPattern() != null) builder.setPattern(explanation.getQueryPattern());
             return builder.build();
         }
 

--- a/test-integration/graql/reasoner/query/ExplanationIT.java
+++ b/test-integration/graql/reasoner/query/ExplanationIT.java
@@ -19,18 +19,14 @@
 package grakn.core.graql.reasoner.query;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import grakn.core.graql.answer.ConceptMap;
 import grakn.core.graql.answer.Explanation;
 import grakn.core.graql.concept.Concept;
-import grakn.core.graql.internal.reasoner.query.ReasonerQueries;
-import grakn.core.graql.internal.reasoner.query.ReasonerQuery;
 import grakn.core.graql.reasoner.graph.GeoGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.Transaction;
 import grakn.core.server.session.SessionImpl;
-import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
 import graql.lang.statement.Variable;

--- a/test-integration/graql/reasoner/query/ExplanationIT.java
+++ b/test-integration/graql/reasoner/query/ExplanationIT.java
@@ -100,7 +100,7 @@ public class ExplanationIT {
 
     @Test
     public void whenExplainingTransitiveClosure_explanationsAreCorrectlyNested() {
-        try (TransactionOLTP tx = geoSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = geoSession.transaction(Transaction.Type.READ)) {
             String queryString = "match (geo-entity: $x, entity-location: $y) isa is-located-in; get;";
 
             Concept polibuda = getConcept(tx, "name", "Warsaw-Polytechnics");
@@ -114,7 +114,7 @@ public class ExplanationIT {
             ConceptMap answer4 = new ConceptMap(ImmutableMap.of(var("x").var(), polibuda, var("y").var(), europe));
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
-            testExplanation(tx, answers);
+            testExplanation(answers);
 
             ConceptMap queryAnswer1 = findAnswer(answer1, answers);
             ConceptMap queryAnswer2 = findAnswer(answer2, answers);
@@ -149,7 +149,7 @@ public class ExplanationIT {
 
     @Test
     public void whenExplainingTransitiveClosureWithSpecificResourceAndTypes_explanationsAreCorrect() {
-        try (TransactionOLTP tx = geoSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = geoSession.transaction(Transaction.Type.READ)) {
             String queryString = "match $x isa university;" +
                     "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                     "$y isa country;$y has name 'Poland'; get;";
@@ -161,7 +161,7 @@ public class ExplanationIT {
             ConceptMap answer2 = new ConceptMap(ImmutableMap.of(var("x").var(), uw, var("y").var(), poland));
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
-            testExplanation(tx, answers);
+            testExplanation(answers);
 
             ConceptMap queryAnswer1 = findAnswer(answer1, answers);
             ConceptMap queryAnswer2 = findAnswer(answer2, answers);
@@ -188,7 +188,7 @@ public class ExplanationIT {
 
     @Test
     public void whenExplainingAGroundQuery_explanationsAreCorrect(){
-        try (TransactionOLTP tx = geoSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = geoSession.transaction(Transaction.Type.READ)) {
             Concept polibuda = getConcept(tx, "name", "Warsaw-Polytechnics");
             Concept europe = getConcept(tx, "name", "Europe");
             String queryString = "match " +
@@ -205,13 +205,13 @@ public class ExplanationIT {
             assertEquals(2, answer.explanation().getAnswers().size());
             assertEquals(3, getRuleExplanations(answer).size());
             assertEquals(4, answer.explanation().explicit().size());
-            testExplanation(tx, answers);
+            testExplanation(answers);
         }
     }
 
     @Test
     public void whenExplainingConjunctiveQueryWithTwoIdPredicates_explanationsAreCorrect(){
-        try (TransactionOLTP tx = geoSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = geoSession.transaction(Transaction.Type.READ)) {
             Concept polibuda = getConcept(tx, "name", "Warsaw-Polytechnics");
             Concept masovia = getConcept(tx, "name", "Masovia");
             String queryString = "match " +
@@ -224,13 +224,13 @@ public class ExplanationIT {
             GraqlGet query = Graql.parse(queryString);
             List<ConceptMap> answers = tx.execute(query);
             assertEquals(answers.size(), 1);
-            testExplanation(tx, answers);
+            testExplanation(answers);
         }
     }
 
     @Test
     public void whenExplainingConjunctions_explanationsAreCorrect(){
-        try (TransactionOLTP tx = explanationSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = explanationSession.transaction(Transaction.Type.READ)) {
             String queryString = "match " +
                     "(role1: $x, role2: $w) isa inferredRelation;" +
                     "$x has name $xName;" +
@@ -238,13 +238,13 @@ public class ExplanationIT {
 
             GraqlGet query = Graql.parse(queryString);
             List<ConceptMap> answers = tx.execute(query);
-            testExplanation(tx, answers);
+            testExplanation(answers);
         }
     }
 
     @Test
     public void whenExplainingMixedAtomicQueries_explanationsAreCorrect(){
-        try (TransactionOLTP tx = explanationSession.transaction(Transaction.Type.READ)) {
+        try (Transaction tx = explanationSession.transaction(Transaction.Type.READ)) {
             String queryString = "match " +
                     "$x has value 'high';" +
                     "($x, $y) isa carried-relation;" +
@@ -252,7 +252,7 @@ public class ExplanationIT {
 
             GraqlGet query = Graql.parse(queryString);
             List<ConceptMap> answers = tx.execute(query);
-            testExplanation(tx, answers);
+            testExplanation(answers);
             answers.stream()
                     .filter(ans -> ans.explanations().stream().anyMatch(Explanation::isRuleExplanation))
                     .forEach(inferredAnswer -> {
@@ -265,12 +265,12 @@ public class ExplanationIT {
 
     @Test
     public void whenExplainingEquivalentPartialQueries_explanationsAreCorrect(){
-        try (TransactionOLTP tx = explanationSession.transaction(Transaction.Type.WRITE)) {
+        try (Transaction tx = explanationSession.transaction(Transaction.Type.WRITE)) {
             String queryString = "match $x isa same-tag-column-link; get;";
 
             GraqlGet query = Graql.parse(queryString);
             List<ConceptMap> answers = tx.execute(query);
-            testExplanation(tx, answers);
+            testExplanation(answers);
             answers.stream()
                     .filter(ans -> ans.explanations().stream().anyMatch(Explanation::isRuleExplanation))
                     .forEach(inferredAnswer -> {
@@ -282,12 +282,12 @@ public class ExplanationIT {
     }
 
 
-    private void testExplanation(TransactionOLTP tx, Collection<ConceptMap> answers){
-        answers.forEach(ans -> testExplanation(tx, ans));
+    private void testExplanation(Collection<ConceptMap> answers){
+        answers.forEach(ans -> testExplanation(ans));
     }
 
-    private void testExplanation(TransactionOLTP tx, ConceptMap answer){
-        answerHasConsistentExplanations(tx, answer);
+    private void testExplanation(ConceptMap answer){
+        answerHasConsistentExplanations(answer);
         checkExplanationCompleteness(answer);
         checkAnswerConnectedness(answer);
     }
@@ -312,12 +312,12 @@ public class ExplanationIT {
         });
     }
 
-    private void answerHasConsistentExplanations(TransactionOLTP tx, ConceptMap answer){
+    private void answerHasConsistentExplanations(ConceptMap answer){
         Set<ConceptMap> answers = answer.explanation().deductions().stream()
                 .filter(a -> !a.explanation().isJoinExplanation())
                 .collect(Collectors.toSet());
 
-        answers.forEach(a -> assertTrue("Answer has inconsistent explanations", explanationConsistentWithAnswer(tx, a)));
+        answers.forEach(a -> assertTrue("Answer has inconsistent explanations", explanationConsistentWithAnswer(a)));
     }
 
     private static Concept getConcept(Transaction tx, String typeLabel, String val){
@@ -340,13 +340,12 @@ public class ExplanationIT {
         return a.explanations().stream().filter(Explanation::isLookupExplanation).collect(Collectors.toSet());
     }
 
-    private boolean explanationConsistentWithAnswer(TransactionOLTP tx, ConceptMap ans){
-        ReasonerQuery query =
-                ReasonerQueries.create(
-                        Iterables.getOnlyElement(Graql.parsePattern(ans.explanation().getQueryPattern()).getDisjunctiveNormalForm().getPatterns()),
-                        tx
-                );
-        Set<Variable> vars = query != null? query.getVarNames() : new HashSet<>();
+    private boolean explanationConsistentWithAnswer(ConceptMap ans){
+        String queryPattern = ans.explanation().getQueryPattern();
+        Set<Variable> vars = new HashSet<>();
+        if (queryPattern != null){
+            Graql.parsePattern(queryPattern).statements().forEach(s -> vars.addAll(s.variables()));
+        }
         return vars.containsAll(ans.map().keySet());
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
Remove dependencies on reasoner from explanations.

## What are the changes implemented in this PR?
Store queries as pattern strings and rules as rule id strings.
