### PR TITLE
Disable automatically updating docs repo when building on forks

### DIFF
--- a/.circleci/grakn-docs-update.py
+++ b/.circleci/grakn-docs-update.py
@@ -2,6 +2,16 @@ import os
 import re
 import subprocess as sp
 
+repo_url = os.getenv('CIRCLE_REPOSITORY_URL')
+building_upstream = 'graknlabs' in repo_url
+
+if not building_upstream:
+    print('Not building the upstream repo, no need to update the docs')
+    exit(0)
+elif building_upstream and 'GRABL_CREDENTIAL' not in os.environ:
+    print('[ERROR]: Building the upstream repo requires having $GRABL_CREDENTIAL env variable')
+    exit(1)
+
 # TODO: consider not making grakn_master_branch configurable
 git_username = "Grabl"
 git_email = "grabl@grakn.ai"


### PR DESCRIPTION
## What is the goal of this PR?

Currently CI on `grakn-core` forks is red because `grakn-docs-update` is failing. Moreover, it only fails because forks tend to not have `GRABL_CREDENTIAL` — and this is implicit.

## What are the changes implemented in this PR?

- checks whether CircleCI is building mainline `grakn-core`
- if we're building a fork, successfully exit prematurely
- if we're building mainline repo and we *don't* have `GRABL_CREDENTIAL` set, print out descriptive error message
