### PR TITLE
Add retrieve() functionality to client-java

### DIFF
--- a/client-java/GraknClient.java
+++ b/client-java/GraknClient.java
@@ -20,6 +20,7 @@
 package grakn.core.client;
 
 import com.google.common.collect.AbstractIterator;
+import com.google.common.collect.ImmutableList;
 import grakn.benchmark.lib.clientinstrumentation.ClientTracingInstrumentationInterceptor;
 import grakn.core.client.concept.RemoteConcept;
 import grakn.core.client.exception.GraknClientException;
@@ -68,6 +69,7 @@ import io.grpc.ManagedChannelBuilder;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -142,7 +144,7 @@ public final class GraknClient implements AutoCloseable {
         private final String keyspace;
         private final SessionServiceGrpc.SessionServiceBlockingStub sessionStub;
         private final String sessionId;
-        private boolean isOpen = false;
+        private boolean isOpen;
 
         private Session(String keyspace) {
             if (!Validator.isValidKeyspaceName(keyspace)) {
@@ -191,6 +193,11 @@ public final class GraknClient implements AutoCloseable {
             }
             KeyspaceProto.Keyspace.Delete.Req request = RequestBuilder.Keyspace.delete(name);
             keyspaceBlockingStub.delete(request);
+        }
+
+        public List<String> retrieve(){
+            KeyspaceProto.Keyspace.Retrieve.Req request = RequestBuilder.Keyspace.retrieve();
+            return ImmutableList.copyOf(keyspaceBlockingStub.retrieve(request).getNamesList().iterator());
         }
     }
 

--- a/client-java/rpc/RequestBuilder.java
+++ b/client-java/rpc/RequestBuilder.java
@@ -273,5 +273,9 @@ public class RequestBuilder {
         public static KeyspaceProto.Keyspace.Delete.Req delete(String name) {
             return KeyspaceProto.Keyspace.Delete.Req.newBuilder().setName(name).build();
         }
+
+        public static KeyspaceProto.Keyspace.Retrieve.Req retrieve() {
+            return KeyspaceProto.Keyspace.Retrieve.Req.newBuilder().build();
+        }
     }
 }

--- a/client-java/test/GraknClientIT.java
+++ b/client-java/test/GraknClientIT.java
@@ -1134,4 +1134,35 @@ public class GraknClientIT {
             assertEquals(date, dateAttribute.value());
         }
     }
+
+    @Test
+    public void retrievingExistingKeyspaces_onlyRemoteSessionKeyspaceIsReturned(){
+        List<String> keyspaces = graknClient.keyspaces().retrieve();
+        assertEquals(1, keyspaces.size());
+        assertEquals(remoteSession.keyspace().getName(), keyspaces.get(0));
+    }
+
+    @Test
+    public void whenCreatingNewKeyspace_itIsVisibileInListOfExistingKeyspaces(){
+        graknClient.session("newkeyspace").transaction(Transaction.Type.WRITE).close();
+        List<String> keyspaces = graknClient.keyspaces().retrieve();
+
+        assertEquals(2, keyspaces.size());
+        assertTrue(keyspaces.contains("newkeyspace"));
+    }
+
+    @Test
+    public void whenDeletingKeyspace_notListedInExistingKeyspaces(){
+        graknClient.session("newkeyspace").transaction(Transaction.Type.WRITE).close();
+        List<String> keyspaces = graknClient.keyspaces().retrieve();
+
+        assertEquals(2, keyspaces.size());
+        assertTrue(keyspaces.contains("newkeyspace"));
+
+        graknClient.keyspaces().delete("newkeyspace");
+        List<String> keyspacesNoNew = graknClient.keyspaces().retrieve();
+
+        assertEquals(1, keyspacesNoNew.size());
+        assertFalse(keyspacesNoNew.contains("newkeyspace"));
+    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Add missing functionality to GraknClient to retrieve list of existing keyspaces.

## What are the changes implemented in this PR?

- Update `RequestBuilder` to build `Keyspace.Retrieve.Req`
- Update `GraknClient.keyspaces()` to expose `retrieve()` method
- Add tests to verify functionality


closes https://github.com/graknlabs/grakn/issues/4675
