### PR TITLE
Propagate answers in cache if query is ground

### DIFF
--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1060,7 +1060,11 @@ public abstract class RelationAtom extends IsaAtomBase {
                         new ConceptMap()
         );
 
-        return Stream.of(ConceptUtils.mergeAnswers(substitution, relationSub));
+        ConceptMap answer = ConceptUtils.mergeAnswers(substitution, relationSub);
+
+        System.out.println("materialise: " + this + " [" + answer + "]");
+
+        return Stream.of(answer);
     }
 
     /**

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1061,9 +1061,6 @@ public abstract class RelationAtom extends IsaAtomBase {
         );
 
         ConceptMap answer = ConceptUtils.mergeAnswers(substitution, relationSub);
-
-        System.out.println("materialise: " + this + " [" + answer + "]");
-
         return Stream.of(answer);
     }
 

--- a/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
+++ b/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
@@ -68,7 +68,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
     }
 
     @Override
-    protected void propagateAnswers(ReasonerAtomicQuery target,
+    protected boolean propagateAnswers(ReasonerAtomicQuery target,
                                     CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> parentEntry,
                                     CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> childEntry,
                                     boolean inferred) {
@@ -119,6 +119,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
                 .forEach(newAnswers::add);
 
         LOG.trace(newAnswers.size() + " new out of " + parentAnswersToPropagate.size() + " parent answers propagated: " + newAnswers);
+        return !newAnswers.isEmpty();
     }
 
     @Override

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -99,7 +99,7 @@ public abstract class SemanticCache<
 
     private CacheEntry<ReasonerAtomicQuery, SE> addEntry(CacheEntry<ReasonerAtomicQuery, SE> entry){
         CacheEntry<ReasonerAtomicQuery, SE> cacheEntry = putEntry(entry);
-        ReasonerAtomicQuery query = entry.query();
+        ReasonerAtomicQuery query = cacheEntry.query();
         updateFamily(query);
         computeParents(query);
         propagateAnswersToQuery(query, cacheEntry, query.isGround());

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -722,9 +722,13 @@ public class ReasoningIT {
         try(Session session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet30.gql", session);
             try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-                String queryString = "match $p isa pair, has name 'ff'; get;";
-                List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
+                String specificPairs = "match $p isa pair, has name 'ff'; get;";
+                List<ConceptMap> answers = tx.execute(Graql.parse(specificPairs).asGet());
                 assertEquals(16, answers.size());
+
+                String pairQuery = "match $p isa pair; get;";
+                List<ConceptMap> pairs = tx.execute(Graql.parse(pairQuery).asGet());
+                assertEquals(64, pairs.size());
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?
Fixes #3061.
Closes #4747.

## What are the changes implemented in this PR?
Query caching behaviour update:
If the sought query is ground (all variables have concepts mapped to them) then we try to propagate answers from parents in the hope that this will allow to avoid hitting the db.
