### PR TITLE
Make //api:api public so clients can depend on it

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -39,6 +39,7 @@ java_library(
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
     ],
     tags = ["maven_coordinates=grakn.core:api:{pom_version}"],
+    visibility = ["//visibility:public"]
 )
 
 


### PR DESCRIPTION
## What is the goal of this PR?

`//api:api` is needed for `client-java` when we split it out

## What are the changes implemented in this PR?

Makes `//api:api` public