### PR TITLE
Reasoner usable in READ transactions

### DIFF
--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -98,6 +98,7 @@ public class WriteExecutor {
     }
 
     static WriteExecutor create(TransactionOLTP transaction, ImmutableSet<Writer> writers) {
+        transaction.checkMutationAllowed();
         /*
             We build several many-to-many relations, indicated by a `Multimap<X, Y>`. These are used to represent
             the dependencies between properties and variables.

--- a/server/src/server/kb/Validator.java
+++ b/server/src/server/kb/Validator.java
@@ -36,11 +36,11 @@ import java.util.Set;
  * type of the concept.
  */
 public class Validator {
-    private final TransactionOLTP graknGraph;
+    private final TransactionOLTP transaction;
     private final List<String> errorsFound = new ArrayList<>();
 
-    public Validator(TransactionOLTP graknGraph) {
-        this.graknGraph = graknGraph;
+    public Validator(TransactionOLTP transaction) {
+        this.transaction = transaction;
     }
 
     /**
@@ -55,25 +55,25 @@ public class Validator {
      */
     public boolean validate() {
         //Validate Things
-        graknGraph.cache().getModifiedThings().forEach(this::validateThing);
+        transaction.cache().getModifiedThings().forEach(this::validateThing);
 
         //Validate Relations
-        graknGraph.cache().getNewRelations().forEach(this::validateRelation);
+        transaction.cache().getNewRelations().forEach(this::validateRelation);
 
         //Validate RoleTypes
-        graknGraph.cache().getModifiedRoles().forEach(this::validateRole);
+        transaction.cache().getModifiedRoles().forEach(this::validateRole);
         //Validate Role Players
-        graknGraph.cache().getModifiedCastings().forEach(this::validateCasting);
+        transaction.cache().getModifiedCastings().forEach(this::validateCasting);
 
         //Validate Relation Types
-        graknGraph.cache().getModifiedRelationTypes().forEach(this::validateRelationType);
+        transaction.cache().getModifiedRelationTypes().forEach(this::validateRelationType);
 
         //Validate Rules
-        graknGraph.cache().getModifiedRules().forEach(rule -> validateRule(graknGraph, rule));
+        transaction.cache().getModifiedRules().forEach(rule -> validateRule(transaction, rule));
 
         //Validate rule type graph
-        if (!graknGraph.cache().getModifiedRules().isEmpty()) {
-            errorsFound.addAll(ValidateGlobalRules.validateRuleStratifiability(graknGraph));
+        if (!transaction.cache().getModifiedRules().isEmpty()) {
+            errorsFound.addAll(ValidateGlobalRules.validateRuleStratifiability(transaction));
         }
 
         return errorsFound.size() == 0;

--- a/server/src/server/kb/concept/SchemaConceptImpl.java
+++ b/server/src/server/kb/concept/SchemaConceptImpl.java
@@ -194,7 +194,6 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
      * 2. The graph is not batch loading
      */
     void checkSchemaMutationAllowed() {
-        vertex().tx().checkSchemaMutationAllowed();
         if (Schema.MetaSchema.isMetaLabel(label())) {
             throw TransactionException.metaTypeImmutable(label());
         }

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -111,8 +111,6 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
      * It can also fail when attempting to attach an Attribute to a meta type
      */
     private void preCheckForInstanceCreation() {
-        vertex().tx().checkMutationAllowed();
-
         if (Schema.MetaSchema.isMetaLabel(label())) {
             throw TransactionException.metaTypeImmutable(label());
         }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -417,10 +417,6 @@ public class TransactionOLTP implements Transaction {
         return concepts;
     }
 
-    public void checkSchemaMutationAllowed() {
-        checkMutationAllowed();
-    }
-
     public void checkMutationAllowed() {
         if (Type.READ.equals(type())) throw TransactionException.transactionReadOnly(this);
     }
@@ -487,8 +483,6 @@ public class TransactionOLTP implements Transaction {
      * @return a new or existing SchemaConcept
      */
     private <T extends SchemaConcept> T putSchemaConcept(Label label, Schema.BaseType baseType, boolean isImplicit, Function<VertexElement, T> newConceptFactory) {
-        checkSchemaMutationAllowed();
-
         //Get the type if it already exists otherwise build a new one
         SchemaConceptImpl schemaConcept = getSchemaConcept(convertToId(label));
         if (schemaConcept == null) {
@@ -813,6 +807,7 @@ public class TransactionOLTP implements Transaction {
             return;
         }
         try {
+            checkMutationAllowed();
             validateGraph();
             // lock on the keyspace cache shared between concurrent tx's to the same keyspace
             // force serialization & atomic updates, keeping Janus and our KeyspaceCache in sync
@@ -858,6 +853,7 @@ public class TransactionOLTP implements Transaction {
     }
 
     private Optional<CommitLog> commitWithLogs() throws InvalidKBException {
+        checkMutationAllowed();
         validateGraph();
 
         Map<ConceptId, Long> newInstances = transactionCache.getShardingCount();

--- a/test-integration/graql/reasoner/BUILD
+++ b/test-integration/graql/reasoner/BUILD
@@ -19,16 +19,14 @@ java_test(
         "//dependencies/maven/artifacts/org/apache/commons:commons-math3",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
     name = "geo-inference-it",
     size = "medium",
     srcs = ["GeoInferenceIT.java"],
-    classpath_resources = [
-        "//test-integration/resources:logback-test",
-        "//test-integration/resources:cassandra-embedded",
-    ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.graql.reasoner.GeoInferenceIT",
     deps = [
         "//concept:concept",

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -106,7 +106,7 @@ public class ReasoningIT {
     public void resourceHierarchiesAreRespected() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "resourceHierarchy.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 Set<RelationType> relTypes = tx.getMetaRelationType().subs().collect(toSet());
@@ -137,7 +137,7 @@ public class ReasoningIT {
     public void resourceOwnershipNotPropagatedWithinRelation() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "resourceOwnership.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 String attributeName = "name";
@@ -168,7 +168,7 @@ public class ReasoningIT {
     public void unificationOfReflexiveRelations() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "reflexiveRelation.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (role1:$x, role2:$x) isa relation1; get;";
                 String queryString2 = "match (role1:$x, role2:$y) isa relation1; get;";
@@ -191,7 +191,7 @@ public class ReasoningIT {
     public void unificationOfReflexiveSymmetricRelations() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "reflexiveSymmetricRelation.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (symmetricRole: $x, symmetricRole: $x) isa symmetricRelation; get;";
                 String queryString2 = "match (symmetricRole: $x, symmetricRole: $y) isa symmetricRelation; get;";
@@ -211,7 +211,7 @@ public class ReasoningIT {
     public void distinctLimitedAnswersOfInfinitelyGeneratingRule() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet7.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 
                 String queryString = "match $x isa relation1; get; limit 10;";
@@ -226,7 +226,7 @@ public class ReasoningIT {
     public void roleUnificationWithRepeatingRoleTypes() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet9.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String doubleRpQuery = "match (role1:$x, role1:$y) isa relation2; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(doubleRpQuery).asGet());
@@ -247,7 +247,7 @@ public class ReasoningIT {
     public void transRelationWithEntityGuardsAtBothEnds() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet10.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (role1: $x, role2: $y) isa relation2; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -260,7 +260,7 @@ public class ReasoningIT {
     public void transRelationWithRelationGuardsAtBothEnds() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet11.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (role1:$x, role2:$y) isa relation3; get;";
                 assertEquals(1, tx.execute(Graql.parse(queryString).asGet()).size());
@@ -272,7 +272,7 @@ public class ReasoningIT {
     public void circularRuleDependencies() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet12.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (role1:$x, role2:$y) isa relation3; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -285,7 +285,7 @@ public class ReasoningIT {
     public void resourcesAsRolePlayers() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "resourcesAsRolePlayers.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 String queryString = "match $x 'partial bad flag' isa resource; ($x, resource-owner: $y) isa resource-relation; get;";
@@ -325,7 +325,7 @@ public class ReasoningIT {
     public void resourcesAsRolePlayers_vpPropagationTest() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "resourcesAsRolePlayers.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 String queryString = "match $x 'partial bad flag' isa resource; ($x, resource-owner: $y) isa another-resource-relation; get;";
@@ -363,7 +363,7 @@ public class ReasoningIT {
     public void reasoningWithRepeatingRoles(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet22.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (friend:$x1, friend:$x2) isa knows-trans; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -376,7 +376,7 @@ public class ReasoningIT {
     public void reasoningWithLimitHigherThanNumberOfResults_ReturnsConsistentResults(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet23.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (friend1:$x1, friend2:$x2) isa knows-trans; get; limit 60;";
                 List<ConceptMap> oldAnswers = tx.execute(Graql.parse(queryString).asGet());
@@ -393,7 +393,7 @@ public class ReasoningIT {
     public void reasoningWithEntityTypes() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet24.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String reflexiveQuery = "match (role1:$x1, role2:$x2) isa reflexiveRelation; get;";
                 List<ConceptMap> reflexive = tx.execute(Graql.parse(reflexiveQuery).asGet());
@@ -410,7 +410,7 @@ public class ReasoningIT {
     public void reasoningWithResourceValueComparison() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet25.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (predecessor:$x1, successor:$x2) isa message-succession; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -424,7 +424,7 @@ public class ReasoningIT {
     public void reasoningWithReifiedRelations() {
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet26.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match (role1: $x1, role2: $x2) isa relation2; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
@@ -453,7 +453,7 @@ public class ReasoningIT {
     public void whenReasoningWithRelationConjunctions_duplicatesNotProducesAndTypesInferredCorrectly(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet28.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryWithTypes = "match " +
                         "(role1: $x, role2: $y);" +
@@ -477,7 +477,7 @@ public class ReasoningIT {
     public void relationTypesAreCorrectlyInferredInConjunction_TypesAreAbsent(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet28b.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String queryString = "match " +
                         "$a isa entity1;" +
@@ -496,7 +496,7 @@ public class ReasoningIT {
     public void relationTypesAreCorrectlyInferredInConjunction_TypesAreAbsent_DisconnectedQuery(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet28b.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 String pattern = "{$a isa entity1;($a, $b); $b isa entity3;};";
@@ -533,7 +533,7 @@ public class ReasoningIT {
     public void relationTypesAreCorrectlyInferredInConjunction_TypesAreAbsent_WithRelationWithoutAnyBounds(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet28b.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
                 String entryPattern = "{" +
                         "$a isa entity1;" +
@@ -567,7 +567,7 @@ public class ReasoningIT {
     public void whenAppendingRolePlayers_queryIsRewrittenCorrectly(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "appendingRPs.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 List<ConceptMap> persistedRelations = tx.execute(Graql.parse("match $r isa relation0; get;").asGet(), false);
 
                 List<ConceptMap> answers = tx.execute(Graql.<GraqlGet>parse("match (someRole: $x, anotherRole: $y, anotherRole: $z, inferredRole: $z); $y != $z;get;"));
@@ -604,7 +604,7 @@ public class ReasoningIT {
     public void whenAppendingRolePlayers_noNewRelationsAreCreated(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "appendingRPs.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
 
                 List<ConceptMap> persistedRelations = tx.execute(Graql.parse("match $r isa relation0; get;").asGet(), false);
                 List<ConceptMap> inferredRelations = tx.execute(Graql.parse("match $r isa relation0; get;").asGet());
@@ -636,7 +636,7 @@ public class ReasoningIT {
     public void inferrableRelationWithRolePlayersSharingResource(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet29.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()){
+            try (TransactionOLTP tx = session.transaction().read()){
                 
                 String queryString = "match " +
                         "(role1: $x, role2: $y) isa binary-base;" +
@@ -680,7 +680,7 @@ public class ReasoningIT {
     public void ternaryRelationsRequiryingDifferentMultiunifiers(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet29.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 
 
                 String queryString = "match " +
@@ -721,7 +721,7 @@ public class ReasoningIT {
     public void mutuallyRecursiveRelationAndResource_queryForAttributedType(){
         try(SessionImpl session = server.sessionWithNewKeyspace()) {
             loadFromFileAndCommit(resourcePath, "testSet30.gql", session);
-            try (TransactionOLTP tx = session.transaction().write()) {
+            try (TransactionOLTP tx = session.transaction().read()) {
                 String specificPairs = "match $p isa pair, has name 'ff'; get;";
                 List<ConceptMap> answers = tx.execute(Graql.parse(specificPairs).asGet());
                 assertEquals(16, answers.size());


### PR DESCRIPTION
## What is the goal of this PR?

Reasoner was not usable via READ transaction.

## What are the changes implemented in this PR?

`checkMutationAllowed();` is invoked at commit time (when `tx.commit()`)
So for now we have a "lazy" check for Concept APIs. 

The check is moved also in `WriteExecutor.create()` so that all 
insert queries can fail immediately when used inside a `READ` tx

Closes #4338
