### PR TITLE
Implemented case-insensitive 'contains' predicate

### DIFF
--- a/server/src/graql/executor/property/ValueExecutor.java
+++ b/server/src/graql/executor/property/ValueExecutor.java
@@ -403,11 +403,27 @@ public class ValueExecutor implements PropertyExecutor.Insertable {
             }
 
             static Function<java.lang.String, P<java.lang.String>> containsPredicate() {
-                return v -> new P<>(java.lang.String::contains, v);
+                return v -> new P<>(Comparison::containsIgnoreCase, v);
             }
 
             static Function<java.lang.String, P<java.lang.String>> regexPredicate() {
                 return v -> new P<>((value, regex) -> Pattern.matches(regex, value), v);
+            }
+
+            static boolean containsIgnoreCase(java.lang.String str1, java.lang.String str2) {
+                final int len2 = str2.length();
+                if (len2 == 0) return true; // Empty string is contained
+
+                final char first2L = Character.toLowerCase(str2.charAt(0));
+                final char first2U = Character.toUpperCase(str2.charAt(0));
+
+                for (int i = 0; i <= str1.length() - len2; i++) {
+                    // Quick check before calling the more expensive regionMatches() method:
+                    final char first1 = str1.charAt(i);
+                    if (first1 != first2L && first1 != first2U) continue;
+                    if (str1.regionMatches(true, i, str2, 0, len2)) return true;
+                }
+                return false;
             }
 
             @Override

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -145,15 +145,22 @@ public class GraqlGetIT {
                 Graql.match(var("x").isa("name")).get().sort("x").limit(5)
         );
 
-        for(ConceptMap answer : answers) {
-            System.out.println(Printer.stringPrinter(false).toString(answer));
-        }
         assertEquals(5, answers.size());
         assertEquals("0", answers.get(0).get("x").asAttribute().value());
         assertEquals("1", answers.get(1).get("x").asAttribute().value());
         assertEquals("action", answers.get(2).get("x").asAttribute().value());
         assertEquals("Al Pacino", answers.get(3).get("x").asAttribute().value());
         assertEquals("Benjamin L. Willard", answers.get(4).get("x").asAttribute().value());
+    }
+
+    @Test
+    public void testGetContainsStringIgnoreCase() {
+        List<ConceptMap> answers = tx.execute(
+                Graql.match(var("x").isa("name").contains("jess")).get()
+        );
+
+        assertEquals(1, answers.size());
+        assertEquals("Sarah Jessica Parker", answers.get(0).get("x").asAttribute().value());
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?

As reported by issue #4831, the `contains` predicate at the moment is not case-insensitive, which is not very useful when searching for text flexibly.

## What are the changes implemented in this PR?

Fixes #4831: We've implemented a `containsIgnoreCase(String str1, String str2)` method in `ValueExecutor` that compares two strings regardless of their case. This implementation is a more efficient implementation, which is important given that this method will be called at every iteration of a stream consumption of the predicate. I.e. it can get really expensive really quickly if not implemented efficiently. 

This implementation uses `str1.regionMatches(str2)` from a specific position in `str1`, while the other two alternatives are:
- `(str1, str1) -> str1.toLowerCase().contains(str2.toLowerCase())`
- several variations of using `java.util.regex.Pattern`