### PR TITLE
Update dependencies with @graknlabs_graql//sync:dependency-update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,11 +145,10 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Sync docs/development to the latest Grakn version
+          name: Sync docs:development client-java:development client-python:development client-nodejs:development to the latest Grakn version
           command: |
-            mkdir docs
-            cd docs
-            python ../.circleci/grakn-docs-update.py
+            bazel run @graknlabs_grabl//sync:dependency-update -- --dependency grakn:master \
+              --user docs:development client-java:development client-python:development client-nodejs:development
   
   approve-release:
     machine: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,6 +63,9 @@ graql_dependencies()
 load("//dependencies/git:dependencies.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 
+load("//dependencies/git:dependencies.bzl", "graknlabs_grabl")
+graknlabs_grabl()
+
 #######################################
 # Load compiler dependencies for GRPC #
 #######################################

--- a/dependencies/git/dependencies.bzl
+++ b/dependencies/git/dependencies.bzl
@@ -31,3 +31,10 @@ def graknlabs_client_java():
         remote = "https://github.com/graknlabs/client-java",
         commit = "bbc8e2eaf99f8e2ecb4fe06813a47dcb36f96071",
     )
+
+def graknlabs_grabl():
+    git_repository(
+        name = "graknlabs_grabl",
+        remote = "https://github.com/graknlabs/grabl",
+        commit = "4a7abd7f79f989424c6f13f625e9ce63a08d2af6",
+    )


### PR DESCRIPTION
## What is the goal of this PR?

Completes part of #4890
`workbase` to be done after graknlabs/workbase#69 is merged
`examples` are not bazelized yet

## What are the changes implemented in this PR?

Uses new dependency updater script to bump `@graknlabs_grakn_core` version in `docs` and `client-*`
