### PR TITLE
Fixed usage of CI helper scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,14 +148,15 @@ jobs:
       - run:
           name: Sync docs:development workbase:master client-java:master client-python:master client-nodejs:master to the latest Grakn version
           command: |
-            bazel run @graknlabs_grabl//ci:update-dependency -- --dependency grakn:master \
+            bazel run @graknlabs_grabl//ci:dependency-update -- --dependency grakn:master \
               --user docs:development workbase:master client-java:master client-python:master client-nodejs:master
   
-  approve-release:
+  release-approve:
     machine: true
     steps:
       - checkout
-      - run: bazel run @graknlabs_grabl//ci:approve-release
+      - bazel_install
+      - run: bazel run @graknlabs_grabl//ci:release-approval
 
   release-cleanup:
     machine: true
@@ -230,7 +231,7 @@ workflows:
 
       # wait for an approval for Grakn to be released
       # triggers 'ci-release' workflow by creating a branch 'grakn-core-release-branch' in graknlabs/grakn
-      - approve-release:
+      - release-approve:
           filters:
             branches:
               only: master
@@ -240,7 +241,7 @@ workflows:
   # the 'ci-release' workflow is triggered by the creation of 'grakn-core-release-branch' branch in graknlabs/grakn
   # it consists of jobs which:
   # - publishes Grakn by creating a Github release
-  # - cleans up the 'grakn-core-release-branch' branch which was created by the approve-release job
+  # - cleans up the 'grakn-core-release-branch' branch which was created by the release-approve job
   grakn-core-release:
     jobs:
       - publish-github-draft:

--- a/dependencies/git/dependencies.bzl
+++ b/dependencies/git/dependencies.bzl
@@ -36,5 +36,5 @@ def graknlabs_grabl():
     git_repository(
         name = "graknlabs_grabl",
         remote = "https://github.com/graknlabs/grabl",
-        commit = "5294d9831fec8e246e73f6afb5f7bcd9cd8364da",
+        commit = "ad79f87f869d25694fe11196e16be42a80e95d14",
     )


### PR DESCRIPTION
## What is the goal of this PR?

Use the latest CI helper scripts

## What are the changes implemented in this PR?

- Bump `@graknlabs_grabl` version
- Adapt to newest naming in scripts
- Rename `approve-release` -> `release-approve` CI job
- Install missing `bazel` on `release-approve` stage