### PR TITLE
Make the Graql dependency available for dependency-update by declaring it directly in WORKSPACE

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -45,8 +45,11 @@ maven_dependencies()
 # Load Graql dependencies #
 ###########################
 
-load("//dependencies/git:dependencies.bzl", "graknlabs_graql")
-graknlabs_graql()
+git_repository(
+    name = "graknlabs_graql",
+    remote = "https://github.com/graknlabs/graql",
+    commit = "8b21baff544db206443cc953c22767563e42dd99", # grabl-marker: do not remove this comment, this is used for dependency-update by @graknlabs_graql
+)
 
 # Load ANTLR dependencies for Bazel
 load("@graknlabs_graql//dependencies/compilers:dependencies.bzl", "antlr_dependencies")

--- a/dependencies/git/dependencies.bzl
+++ b/dependencies/git/dependencies.bzl
@@ -18,13 +18,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
-def graknlabs_graql():
-    git_repository(
-        name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        commit = "8b21baff544db206443cc953c22767563e42dd99",
-    )
-
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",


### PR DESCRIPTION
## What is the goal of this PR?

Make the Graql dependency available for dependency-update by declaring it directly in WORKSPACE.

## What are the changes implemented in this PR?

Make the Graql dependency available for dependency-update by declaring it directly in WORKSPACE. Don't forget to merge https://github.com/graknlabs/graql/pull/23 after you merge this PR.
