### PR TITLE
Proto metadata cleanup and permanent Tracing points

### DIFF
--- a/protocol/session/Session.proto
+++ b/protocol/session/Session.proto
@@ -37,6 +37,7 @@ service SessionService {
 message Session {
     message Open {
         message Req {
+            map<string, string> metadata = 1000;
             string Keyspace = 1;
         }
         message Res {
@@ -46,9 +47,11 @@ message Session {
 
     message Close {
         message Req {
+            map<string, string> metadata = 1000;
             string sessionId = 1;
         }
-        message Res {}
+        message Res {
+        }
     }
 }
 
@@ -73,7 +76,6 @@ message Transaction {
         }
     }
     message Res {
-        map<string, string> metadata = 1000;
         oneof res {
             Open.Res open_res = 1;
             Commit.Res commit_res = 2;

--- a/server/src/server/rpc/SessionService.java
+++ b/server/src/server/rpc/SessionService.java
@@ -122,8 +122,6 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
         private final Map<String, SessionImpl> openSessions;
         private final Iterators iterators = Iterators.create();
 
-        private TraceContext receivedTraceContext;
-
         @Nullable
         private TransactionOLTP tx = null;
 

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -149,26 +149,18 @@ public class TransactionOLTP implements Transaction {
 
         createdInCurrentThread.set(true);
 
-        ScopedSpan span = null;
-        if (ServerTracingInstrumentation.tracingActive()) { span = ServerTracingInstrumentation.createScopedChildSpan("TransactionOLTP constructor"); }
-
         this.session = session;
         this.janusGraph = janusGraph;
 
-        if (span != null) { span.annotate("Creating janusGraph Tx"); }
-
         this.janusTransaction = janusGraph.tx();
 
-        if (span != null) { span.annotate("Creating ElementFactory"); }
         this.elementFactory = new ElementFactory(this, janusGraph);
 
-        if (span != null) { span.annotate("Creating RuleCache"); }
         this.ruleCache = new RuleCache(this);
 
         this.keyspaceCache = keyspaceCache;
         this.transactionCache = new TransactionCache(keyspaceCache);
 
-        if (span != null) { span.finish(); }
     }
 
     void open(Type type) {


### PR DESCRIPTION
## What is the goal of this PR?
Clean up `metadata` field in proto files, and add permanent tracing a few portions of the server.

## What are the changes implemented in this PR?
* Clean up metadata field, only put it into request messages for session and transaction
* Remove old tracing from TransactionOLTP
* Add permanent tracing to `commit` and `query`