### PR TITLE
Adapt to using newest *_maven rules from bazel-distribution

### DIFF
--- a/api/BUILD
+++ b/api/BUILD
@@ -17,7 +17,7 @@
 #
 #
 
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(
@@ -37,10 +37,15 @@ java_library(
 )
 
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":api",
     package = "api",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven"
 )
 
 checkstyle_test(

--- a/common/BUILD
+++ b/common/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@com_github_google_bazel_common//tools/jarjar:jarjar.bzl", "jarjar_library")
 
 jarjar_library(
@@ -32,8 +32,13 @@ jarjar_library(
     tags = ["maven_coordinates=grakn.core:common:{pom_version}"],
 )
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":common",
     package = "common",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven",
 )

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -18,7 +18,7 @@
 #
 package(default_visibility = ["//visibility:public"])
 
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(
@@ -38,10 +38,15 @@ java_library(
 )
 
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":concept",
     package = "concept",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven"
 )
 
 checkstyle_test(

--- a/console/BUILD
+++ b/console/BUILD
@@ -17,7 +17,7 @@
 #
 
 package(default_visibility = ["//visibility:__subpackages__"])
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")
@@ -131,10 +131,15 @@ assemble_zip(
     }
 )
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":console",
     package = "console",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven"
 )
 
 assemble_apt(

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_client_java():
      git_repository(
          name = "graknlabs_client_java",
          remote = "https://github.com/graknlabs/client-java",
-         commit = "a86ad5b10f2ccb1c9b46c561040188761fd31052",
+         commit = "24ab02f3145e95f2469b72fb6bbf1850352e2314",
      )
 
 def graknlabs_build_tools():

--- a/protocol/BUILD
+++ b/protocol/BUILD
@@ -19,7 +19,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@stackb_rules_proto//java:java_grpc_compile.bzl", "java_grpc_compile")
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 
 java_grpc_compile(
     name = "protocol-java-src",
@@ -44,8 +44,13 @@ java_library(
     tags = ["maven_coordinates=grakn.core:protocol:{pom_version}", "checkstyle_ignore"],
 )
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":protocol-java",
     package = "protocol",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven"
 )

--- a/server/BUILD
+++ b/server/BUILD
@@ -18,7 +18,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//dependencies/maven:rules.bzl", "deploy_maven_jar")
+load("//dependencies/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")
@@ -182,10 +182,15 @@ assemble_zip(
     }
 )
 
-deploy_maven_jar(
-    name = "deploy-maven",
+assemble_maven(
+    name = "assemble-maven",
     target = ":server",
     package = "server",
+)
+
+deploy_maven(
+    name = "deploy-maven",
+    target = ":assemble-maven"
 )
 
 assemble_apt(


### PR DESCRIPTION
## What is the goal of this PR?

Use newest `assemble_maven`/`deploy_maven` rules

## What are the changes implemented in this PR?

Replace using `deploy_maven_jar` with a combination of `assemble_maven`+`deploy_maven`