### PR TITLE
Cleanup query executor and negation it

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -100,9 +100,6 @@ public class QueryExecutor {
         ResolvableQuery query = ReasonerQueries.resolvable(conj, tx).rewrite();
         query.checkValid();
 
-        //TODO
-        // - handling of empty query is a hack, need to solve in another PR
-        // - atom parsing doesn't recognise nested statements so we do not resolve if possible
         boolean doNotResolve = query.getAtoms().isEmpty()
                 || (query.isPositive() && !query.isRuleResolvable());
         return doNotResolve?

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -47,7 +47,6 @@ import java.util.stream.Collectors;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
@@ -109,6 +108,22 @@ public class NegationIT {
                                 "not {" +
                                     "$i isa entity;" +
                                 "};" +
+                            "};" +
+                            "};"
+            );
+            ReasonerQueries.composite(Iterables.getOnlyElement(pattern.getNegationDNF().getPatterns()), tx);
+        }
+    }
+
+    @Test (expected = GraqlQueryException.class)
+    public void whenNegationBlockContainsDisjunction_exceptionIsThrown(){
+        try(TransactionOLTP tx = negationSession.transaction().write()) {
+            Pattern pattern = Graql.parsePattern(
+                    "{" +
+                            "$x isa someType;" +
+                            "not {" +
+                                "{$x has resource-string 'value';} or " +
+                                "{$x has resource-string 'someString';};" +
                             "};" +
                             "};"
             );
@@ -422,7 +437,7 @@ public class NegationIT {
                             "};" +
                         "};" +
                     "};" +
-                    "get $r;"
+                    "get;"
             )).collect(Collectors.toList());
 
             assertEquals(recipesContainingAllergens, doubleNegationEquivalent);
@@ -450,7 +465,7 @@ public class NegationIT {
                         "$i isa allergenic-ingredient;" +
                     "};" +
                     "};" +
-                    "get $r;"
+                    "get;"
             )).collect(Collectors.toList());
             assertEquals(ReasonerUtils.listDifference(allRecipes, recipesContainingAllergens), recipesWithoutAllergenIngredients);
         }
@@ -497,7 +512,7 @@ public class NegationIT {
                             "};" +
                         "};" +
                     "};" +
-                    "get $r;"
+                    "get;"
             ));
 
             List<ConceptMap> recipesWithAllIngredientsAvailable = tx.execute(Graql.<GraqlGet>parse("match " +
@@ -508,7 +523,7 @@ public class NegationIT {
                              "not {$i isa available-ingredient;};" +
                         "};" +
                     "};" +
-                    "get $r;"
+                    "get;"
             ));
 
             assertCollectionsNonTriviallyEqual(recipesWithAllIngredientsAvailableExplicit, recipesWithAllIngredientsAvailable);

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -437,7 +437,7 @@ public class NegationIT {
                             "};" +
                         "};" +
                     "};" +
-                    "get;"
+                    "get $r;"
             )).collect(Collectors.toList());
 
             assertEquals(recipesContainingAllergens, doubleNegationEquivalent);


### PR DESCRIPTION
## What is the goal of this PR?
Little cleanup:
- remove the TODO from QueryExecutor as it is no longer valid
- make the get queries in `NegationIT` use default sets of variables - to highlight the default behaviour
- add an extra test checking for disjunction support

