### PR TITLE
Make sure toStrings are not called if log level inadequate

### DIFF
--- a/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
+++ b/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
@@ -91,13 +91,13 @@ public class ConnectedComponentsVertexProgram extends GraknVertexProgram<String>
 
     @Override
     public boolean terminate(final Memory memory) {
-        LOGGER.debug("Finished Iteration " + memory.getIteration());
+        LOGGER.debug("Finished Iteration {}", memory.getIteration());
         if (memory.getIteration() < 2) return false;
         if (memory.<Boolean>get(VOTE_TO_HALT)) {
             return true;
         }
         if (memory.getIteration() == MAX_ITERATION) {
-            LOGGER.debug("Reached Max Iteration: " + MAX_ITERATION + " !!!!!!!!");
+            LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
             throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 

--- a/server/src/graql/analytics/CorenessVertexProgram.java
+++ b/server/src/graql/analytics/CorenessVertexProgram.java
@@ -136,12 +136,12 @@ public class CorenessVertexProgram extends GraknVertexProgram<String> {
     @Override
     public boolean terminate(final Memory memory) {
         if (memory.isInitialIteration()) {
-            LOGGER.debug("Finished Iteration " + memory.getIteration());
+            LOGGER.debug("Finished Iteration {}", memory.getIteration());
             return false;
         }
 
         if (memory.getIteration() == MAX_ITERATION) {
-            LOGGER.debug("Reached Max Iteration: " + MAX_ITERATION + " !!!!!!!!");
+            LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
             throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
@@ -149,13 +149,13 @@ public class CorenessVertexProgram extends GraknVertexProgram<String> {
             memory.set(PERSIST_CORENESS, false);
         }
         if (!atRelations(memory)) {
-            LOGGER.debug("UpdateEntityAndAttribute... Finished Iteration " + memory.getIteration());
+            LOGGER.debug("UpdateEntityAndAttribute... Finished Iteration {}", memory.getIteration());
             if (!memory.<Boolean>get(K_CORE_EXIST)) {
-                LOGGER.debug("KCoreVertexProgram Finished !!!!!!!!");
+                LOGGER.debug("KCoreVertexProgram Finished");
                 return true;
             } else {
                 if (memory.<Boolean>get(K_CORE_STABLE)) {
-                    LOGGER.debug("Found Core Areas K = " + memory.<Long>get(K) + "\n");
+                    LOGGER.debug("Found Core Areas K = {}\n", memory.<Long>get(K));
                     memory.set(K, memory.<Long>get(K) + 1L);
                     memory.set(PERSIST_CORENESS, true);
                 } else {
@@ -165,7 +165,7 @@ public class CorenessVertexProgram extends GraknVertexProgram<String> {
                 return false;
             }
         } else {
-            LOGGER.debug("RelayOrSaveMessage...       Finished Iteration " + memory.getIteration());
+            LOGGER.debug("RelayOrSaveMessage...       Finished Iteration {}", memory.getIteration());
             return false; // can not end after relayOrSaveMessages
         }
     }

--- a/server/src/graql/analytics/CountVertexProgram.java
+++ b/server/src/graql/analytics/CountVertexProgram.java
@@ -70,7 +70,7 @@ public class CountVertexProgram extends GraknVertexProgram<Long> {
 
     @Override
     public boolean terminate(final Memory memory) {
-        LOGGER.debug("Finished Count Iteration " + memory.getIteration());
+        LOGGER.debug("Finished Count Iteration {}", memory.getIteration());
         return memory.getIteration() == 1;
     }
 }

--- a/server/src/graql/analytics/DegreeStatisticsVertexProgram.java
+++ b/server/src/graql/analytics/DegreeStatisticsVertexProgram.java
@@ -79,7 +79,7 @@ public class DegreeStatisticsVertexProgram extends DegreeVertexProgram {
 
     @Override
     public boolean terminate(final Memory memory) {
-        LOGGER.debug("Finished Degree Iteration " + memory.getIteration());
+        LOGGER.debug("Finished Degree Iteration {}", memory.getIteration());
         return memory.getIteration() == 2;
     }
 

--- a/server/src/graql/analytics/KCoreVertexProgram.java
+++ b/server/src/graql/analytics/KCoreVertexProgram.java
@@ -173,7 +173,7 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
             }
 
             if (messageCount >= memory.<Long>get(K)) {
-                LOGGER.trace("Sending msg from " + id);
+                LOGGER.trace("Sending msg from {}", id);
                 sendMessage(messenger, id);
                 memory.add(K_CORE_EXIST, true);
 
@@ -182,7 +182,7 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
                     vertex.property(MESSAGE_COUNT, messageCount);
                 }
             } else {
-                LOGGER.trace("Removing label of " + id);
+                LOGGER.trace("Removing label of {}", id);
                 vertex.property(K_CORE_LABEL).remove();
                 memory.add(K_CORE_STABLE, false);
             }
@@ -194,12 +194,12 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
         String max = IteratorUtils.reduce(messenger.receiveMessages(), currentMax,
                 (a, b) -> a.compareTo(b) > 0 ? a : b);
         if (!max.equals(currentMax)) {
-            LOGGER.trace("Cluster label of " + vertex + " changed from " + currentMax + " to " + max);
+            LOGGER.trace("Cluster label of {} changed from {} to {}", vertex, currentMax, max);
             vertex.property(K_CORE_LABEL, max);
             sendMessage(messenger, max);
             memory.add(VOTE_TO_HALT, false);
         } else {
-            LOGGER.trace("Cluster label of " + vertex + " is still " + currentMax);
+            LOGGER.trace("Cluster label of {} is still {}", vertex, currentMax);
         }
     }
 
@@ -229,17 +229,17 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
 
     @Override
     public boolean terminate(final Memory memory) {
-        LOGGER.debug("Finished Iteration " + memory.getIteration());
+        LOGGER.debug("Finished Iteration {}", memory.getIteration());
         if (memory.isInitialIteration()) return false;
 
         if (memory.getIteration() == MAX_ITERATION) {
-            LOGGER.debug("Reached Max Iteration: " + MAX_ITERATION + " !!!!!!!!");
+            LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
             throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
         if (memory.<Boolean>get(CONNECTED_COMPONENT_STARTED)) {
             if (memory.<Boolean>get(VOTE_TO_HALT)) {
-                LOGGER.debug("KCoreVertexProgram Finished !!!!!!!!");
+                LOGGER.debug("KCoreVertexProgram Finished");
                 return true; // connected component is done
             } else {
                 memory.set(VOTE_TO_HALT, true);
@@ -248,14 +248,14 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
         } else {
             if (!atRelations(memory)) {
                 if (!memory.<Boolean>get(K_CORE_EXIST)) {
-                    LOGGER.debug("KCoreVertexProgram Finished !!!!!!!!");
-                    LOGGER.debug("No Such Core Areas Found !!!!!!!!");
+                    LOGGER.debug("KCoreVertexProgram Finished");
+                    LOGGER.debug("No Such Core Areas Found");
                     throw new NoResultException();
                 } else {
                     if (memory.<Boolean>get(K_CORE_STABLE)) {
                         memory.set(CONNECTED_COMPONENT_STARTED, true);
-                        LOGGER.debug("Found Core Areas !!!!!!!!");
-                        LOGGER.debug("Starting Connected Components !!!!!!!!");
+                        LOGGER.debug("Found Core Areas");
+                        LOGGER.debug("Starting Connected Components");
                     } else {
                         memory.set(K_CORE_EXIST, false);
                         memory.set(K_CORE_STABLE, true);

--- a/server/src/graql/analytics/MedianVertexProgram.java
+++ b/server/src/graql/analytics/MedianVertexProgram.java
@@ -225,31 +225,31 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
 
     @Override
     public boolean terminate(final Memory memory) {
-        LOGGER.debug("Finished Iteration " + memory.getIteration());
+        LOGGER.debug("Finished Iteration {}", memory.getIteration());
 
         if (memory.getIteration() == 2) {
             memory.set(INDEX_START, 0L);
             memory.set(INDEX_END, memory.<Long>get(COUNT) - 1L);
             memory.set(INDEX_MEDIAN, (memory.<Long>get(COUNT) - 1L) / 2L);
 
-            LOGGER.debug("count: " + memory.<Long>get(COUNT));
-            LOGGER.debug("first pivot: " + memory.<Long>get(PIVOT));
+            LOGGER.debug("count: {}", memory.<Long>get(COUNT));
+            LOGGER.debug("first pivot: {}", memory.<Long>get(PIVOT));
 
         } else if (memory.getIteration() > 2) {
 
             long indexNegativeEnd = memory.<Long>get(INDEX_START) + memory.<Long>get(NEGATIVE_COUNT) - 1;
             long indexPositiveStart = memory.<Long>get(INDEX_END) - memory.<Long>get(POSITIVE_COUNT) + 1;
 
-            LOGGER.debug("pivot: " + memory.get(PIVOT));
+            LOGGER.debug("pivot: {}", memory.<Long>get(PIVOT));
 
-            LOGGER.debug(memory.<Long>get(INDEX_START) + ", " + indexNegativeEnd);
-            LOGGER.debug(indexPositiveStart + ", " + memory.<Long>get(INDEX_END));
+            LOGGER.debug("{}, {}", memory.<Long>get(INDEX_START), indexNegativeEnd);
+            LOGGER.debug("{}, {}", indexPositiveStart, memory.<Long>get(INDEX_END));
 
-            LOGGER.debug("negative count: " + memory.<Long>get(NEGATIVE_COUNT));
-            LOGGER.debug("positive count: " + memory.<Long>get(POSITIVE_COUNT));
+            LOGGER.debug("negative count: {}", memory.<Long>get(NEGATIVE_COUNT));
+            LOGGER.debug("positive count: {}", memory.<Long>get(POSITIVE_COUNT));
 
-            LOGGER.debug("negative pivot: " + memory.get(PIVOT_NEGATIVE));
-            LOGGER.debug("positive pivot: " + memory.get(PIVOT_POSITIVE));
+            LOGGER.debug("negative pivot: {}", memory.<Long>get(PIVOT_NEGATIVE));
+            LOGGER.debug("positive pivot: {}", memory.<Long>get(PIVOT_POSITIVE));
 
             if (indexNegativeEnd < memory.<Long>get(INDEX_MEDIAN)) {
                 if (indexPositiveStart > memory.<Long>get(INDEX_MEDIAN)) {
@@ -259,13 +259,13 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
                     memory.set(INDEX_START, indexPositiveStart);
                     memory.set(PIVOT, memory.get(PIVOT_POSITIVE));
                     memory.set(LABEL_SELECTED, memory.getIteration());
-                    LOGGER.debug("new pivot: " + memory.get(PIVOT));
+                    LOGGER.debug("new pivot: {}", memory.<Long>get(PIVOT));
                 }
             } else {
                 memory.set(INDEX_END, indexNegativeEnd);
                 memory.set(PIVOT, memory.get(PIVOT_NEGATIVE));
                 memory.set(LABEL_SELECTED, -memory.getIteration());
-                LOGGER.debug("new pivot: " + memory.get(PIVOT));
+                LOGGER.debug("new pivot: {}", memory.<Long>get(PIVOT));
             }
             memory.set(MEDIAN, memory.get(PIVOT));
 

--- a/server/src/graql/analytics/ShortestPathVertexProgram.java
+++ b/server/src/graql/analytics/ShortestPathVertexProgram.java
@@ -124,7 +124,7 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
                 List<VertexMessage> messages = messages(messenger);
                 List<MessageFromSource> incomingSourceMsg = messageFromSource(messages);
                 List<MessageFromDestination> incomingDestMsg = messageFromDestination(messages);
-                LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received the following messages: " + incomingSourceMsg + ", " + incomingDestMsg);
+                LOG.debug("Iteration {} , Vertex {}: received the following messages: {}, {}", memory.getIteration(), vertexId, incomingSourceMsg, incomingDestMsg);
                 if (!incomingSourceMsg.isEmpty() || !incomingDestMsg.isEmpty()) {
                     if (!incomingDestMsg.isEmpty()) {
                         long pathLength = incomingDestMsg.get(0).pathLength();
@@ -132,12 +132,12 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
                             recordShortestPath_AndMarkBroadcasted(vertex, memory, vertexId, incomingDestMsg, pathLength);
                         }
                         else {
-                            LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received " + incomingDestMsg + " of length " +
-                                    pathLength + ". This isn't the shortest path, which is of length " + memory.<Long>get(shortestPathLength) + ". Do nothing.");
+                            LOG.debug("Iteration {}, Vertex {}: received {} of length {}. This isn't the shortest path, which is of length {}. Do nothing.",
+                                    memory.getIteration(), vertexId, incomingDestMsg, pathLength, memory.<Long>get(shortestPathLength));
                         }
                     }
                     else {
-                        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": no message from destination yet. Do nothing");
+                        LOG.debug("Iteration {}, Vertex {}: no message from destination yet. Do nothing", memory.getIteration(), vertexId);
                     }
                 }
             }
@@ -151,7 +151,7 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
                 List<VertexMessage> messages = messages(messenger);
                 List<MessageFromSource> incomingSourceMsg = messageFromSource(messages);
                 List<MessageFromDestination> incomingDestMsg = messageFromDestination(messages);
-                LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received the following messages: " + incomingSourceMsg + ", " + incomingDestMsg);
+                LOG.debug("Iteration {} , Vertex {}: received the following messages: {}, {}", memory.getIteration(), vertexId, incomingSourceMsg, incomingDestMsg);
                 if (!incomingSourceMsg.isEmpty() || !incomingDestMsg.isEmpty()) {
                     if (!incomingSourceMsg.isEmpty()) {
                         long pathLength = incomingSourceMsg.get(0).pathLength();
@@ -159,32 +159,32 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
                             markBroadcasted_TerminateAtTheEndOfThisIeration(vertex, memory, vertexId, incomingSourceMsg, pathLength);
                         }
                         else {
-                            LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received " + incomingSourceMsg + " of length " +
-                                    pathLength + ". This isn't the shortest path, which is of length " + memory.<Long>get(shortestPathLength) + ". Do nothing.");
+                            LOG.debug("Iteration {}, Vertex {}: received {} of length {}. This isn't the shortest path, which is of length {}. Do nothing.",
+                                    memory.getIteration(), vertexId, incomingDestMsg, pathLength, memory.<Long>get(shortestPathLength));
                         }
                     }
                     else {
-                        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": no message from source yet. Do nothing");
+                        LOG.debug("Iteration {}, Vertex {}: no message from source yet. Do nothing", memory.getIteration(), vertexId);
                     }
                 }
             }
         }
         else { // if neither source nor destination vertex
             if (memory.isInitialIteration()) {
-                LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": neither a source nor destination vertex. Do nothing.");
+                LOG.debug("Iteration {}, Vertex {}: neither a source nor destination vertex. Do nothing", memory.getIteration(), vertexId);
             }
             else {
                 boolean shortestPathProcessed = this.<Boolean>get(vertex, shortestPathRecordedAndBroadcasted).orElse(false);
 
                 if (shortestPathProcessed) {
-                    LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": shortest path have been relayed. Do nothing.");
+                    LOG.debug("Iteration {}, Vertex {}: shortest path have been relayed. Do nothing", memory.getIteration(), vertexId);
                     return;
                 }
 
                 List<VertexMessage> messages = messages(messenger);
                 List<MessageFromSource> incomingSourceMsg = messageFromSource(messages);
                 List<MessageFromDestination> incomingDestMsg = messageFromDestination(messages);
-                LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received the following messages: " + incomingSourceMsg + ", " + incomingDestMsg);
+                LOG.debug("Iteration {} , Vertex {}: received the following messages: {}, {}", memory.getIteration(), vertexId, incomingSourceMsg, incomingDestMsg);
 
                 if (!incomingSourceMsg.isEmpty() || !incomingDestMsg.isEmpty()) {
                     boolean hasNewMessageToProcess = false;
@@ -202,20 +202,20 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
                         List<MessageFromSource> srcMsgs = this.<List<MessageFromSource>>get(vertex, srcMsgFromPrevIterations).get();
                         List<MessageFromDestination> destMsgs = this.<List<MessageFromDestination>>get(vertex, destMsgFromPrevIterations).get();
                         long pathLength = srcMsgs.get(0).pathLength() + destMsgs.get(0).pathLength();
-                        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": Path between source and destination with length " + pathLength + " found here.");
+                        LOG.debug("Iteration {}, Vertex {}: Path between source and destination with length {} found here.", memory.getIteration(), vertexId, pathLength );
 
                         if (memory.<Long>get(shortestPathLength) == SHORTEST_PATH_LENGTH_NOT_YET_SET || pathLength == memory.<Long>get(shortestPathLength)) {
                             recordShortestPath_AndMarkBroadcasted(vertex, memory, vertexId, destMsgs, pathLength);
                         }
                         else {
-                            LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": is not the shortest path. Do nothing.");
+                            LOG.debug("Iteration {}, Vertex {}: is not the shortest path. Do nothing", memory.getIteration(), vertexId);
                             set(vertex, pathFoundButIsNotTheShortest, true);
                         }
                     }
                     memory.add(atLeastOneVertexActive, hasNewMessageToProcess);
                 }
                 else {
-                    LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": receives no message. Do nothing.");
+                    LOG.debug("Iteration {}, Vertex {}: receives no message. Do nothing", memory.getIteration(), vertexId);
                 }
             }
         }
@@ -240,7 +240,7 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
         memory.add(SHORTEST_PATH, msg);
         memory.add(shortestPathLength, pathLength);
         set(vertex, shortestPathRecordedAndBroadcasted, true);
-        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": is the shortest path. Record(" + msg + ")");
+        LOG.debug("Iteration {}, Vertex {}: is the shortest path. Record({})", memory.getIteration(), vertexId, msg);
         return msg;
     }
 
@@ -251,19 +251,19 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
         memory.add(shortestPathLength, pathLength);
         set(vertex, shortestPathRecordedAndBroadcasted, true);
         memory.add(allShortestPathsFound_TerminateAtTheEndOfThisIteration, true);
-        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": received " + msg + ". 'compute new-path' finished. Terminating...");
+        LOG.debug("Iteration {}, Vertex {}: received {}. 'compute new-path' finished. Terminating...", memory.getIteration(), vertexId, msg);
     }
 
     private void broadcastInitialDestinationMessage(Messenger<VertexMessage> messenger, Memory memory, String vertexId) {
         MessageFromDestination initialOutgoingDestMsg = new MessageFromDestination(vertexId,1L);
-        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": I am the destination vertex [" + vertexId + "]. Sending message " + initialOutgoingDestMsg + " to neighbors");
+        LOG.debug("Iteration {}, Vertex {}: I am the destination vertex [{}]. Sending message {} to neighbors", memory.getIteration(), vertexId, vertexId, initialOutgoingDestMsg);
         broadcastToNeighbors(messenger, initialOutgoingDestMsg);
     }
 
     private void broadcastInitialSourceMessage(Messenger<VertexMessage> messenger, Memory memory, String vertexId) {
         MessageFromSource initialOutgoingSrcMsg = new MessageFromSource(vertexId,1L);
         broadcastToNeighbors(messenger, initialOutgoingSrcMsg);
-        LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": I am the source vertex [" + vertexId + "]. Sending message " + initialOutgoingSrcMsg + " to neighbors");
+        LOG.debug("Iteration {}, Vertex {}: I am the source vertex [{}]. Sending message {} to neighbors", memory.getIteration(), vertexId, vertexId, initialOutgoingSrcMsg);
     }
 
     private void broadcastDestinationMessages(Messenger<VertexMessage> messenger, Memory memory, String vertexId, List<MessageFromDestination> incomingDestMsg) {
@@ -271,7 +271,7 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
             MessageFromDestination msg = incomingDestMsg.get(0);
             MessageFromDestination outgoingDstMsg = new MessageFromDestination(vertexId, msg.pathLength() + 1);
             broadcastToNeighbors(messenger, outgoingDstMsg);
-            LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": Relaying message " + outgoingDstMsg + ".");
+            LOG.debug("Iteration {}, Vertex {}: Relaying message {}", memory.getIteration(), vertexId, outgoingDstMsg);
         }
     }
 
@@ -280,7 +280,7 @@ public class ShortestPathVertexProgram extends GraknVertexProgram<ShortestPathVe
             MessageFromSource msg = incomingSourceMsg.get(0);
             MessageFromSource outgoingSrcMsg = new MessageFromSource(vertexId, msg.pathLength() + 1);
             broadcastToNeighbors(messenger, outgoingSrcMsg);
-            LOG.debug("Iteration " + memory.getIteration() + ", Vertex " + vertexId + ": Relaying message " + outgoingSrcMsg + ".");
+            LOG.debug("Iteration {}, Vertex {}: Relaying message {}.", memory.getIteration(), vertexId, outgoingSrcMsg);
         }
     }
 

--- a/server/src/graql/executor/ComputeExecutor.java
+++ b/server/src/graql/executor/ComputeExecutor.java
@@ -215,12 +215,12 @@ class ComputeExecutor {
 
         if (query.method().equals(MEDIAN)) {
             Number result = computerResult.memory().get(MedianVertexProgram.MEDIAN);
-            LOG.debug("Median = " + result);
+            LOG.debug("Median = {}", result);
             return (S) result;
         }
 
         Map<Serializable, S> resultMap = computerResult.memory().get(mapReduce.getClass().getName());
-        LOG.debug("Result = " + resultMap.get(MapReduce.NullObject.instance()));
+        LOG.debug("Result = {}", resultMap.get(MapReduce.NullObject.instance()));
         return resultMap.get(MapReduce.NullObject.instance());
     }
 
@@ -321,7 +321,7 @@ class ComputeExecutor {
             finalCount += count.get(GraknMapReduce.RESERVED_TYPE_LABEL_KEY);
         }
 
-        LOG.debug("Count = " + finalCount);
+        LOG.debug("Count = {}", finalCount);
         return Stream.of(new Numeric(finalCount));
     }
 

--- a/server/src/graql/gremlin/GreedyTraversalPlan.java
+++ b/server/src/graql/gremlin/GreedyTraversalPlan.java
@@ -190,7 +190,7 @@ public class GreedyTraversalPlan {
 
         // add disconnected fragment set with no edge fragment
         addUnvisitedNodeFragments(plan, allNodes, allNodes.values());
-        LOG.trace("Greedy Plan = " + plan);
+        LOG.trace("Greedy Plan = {}", plan);
         return plan;
     }
 

--- a/server/src/graql/reasoner/ResolutionIterator.java
+++ b/server/src/graql/reasoner/ResolutionIterator.java
@@ -66,7 +66,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
         while(!states.isEmpty()) {
             ResolutionState state = states.pop();
 
-            LOG.trace("state: " + state);
+            LOG.trace("state: {}", state);
 
             if (state.isAnswerState() && state.isTopState()) {
                 return state.getSubstitution();
@@ -103,7 +103,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
         if (reiterationRequired) {
             long dAns = answers.size() - oldAns;
             if (dAns != 0 || iter == 0) {
-                LOG.debug("iter: " + iter + " answers: " + answers.size() + " dAns = " + dAns);
+                LOG.debug("iter: {} answers: {} dAns = {}", iter, answers.size(), dAns);
                 iter++;
                 states.push(query.subGoal(new ConceptMap(), new UnifierImpl(), null, new HashSet<>(), cache));
                 oldAns = answers.size();

--- a/server/src/server/GraknStorage.java
+++ b/server/src/server/GraknStorage.java
@@ -55,7 +55,7 @@ public class GraknStorage {
             writer.print(pidString);
             writer.close();
         } catch (IOException e) {
-            LOG.error("Error persisting storage PID:" + e.getMessage());
+            LOG.error("Error persisting storage PID:{}", e.getMessage());
         }
     }
 }

--- a/server/src/server/deduplicator/AttributeDeduplicator.java
+++ b/server/src/server/deduplicator/AttributeDeduplicator.java
@@ -83,7 +83,7 @@ public class AttributeDeduplicator {
                         });
                         duplicate.remove();
                     } catch (IllegalStateException vertexAlreadyRemovedException) {
-                        LOG.warn("Trying to call the method vertices(Direction.IN) on vertex " + duplicate.id() + " which is already removed.");
+                        LOG.warn("Trying to call the method vertices(Direction.IN) on vertex {} which is already removed.", duplicate.id());
                     }
                 }
 

--- a/server/src/server/deduplicator/AttributeDeduplicatorDaemon.java
+++ b/server/src/server/deduplicator/AttributeDeduplicatorDaemon.java
@@ -82,7 +82,7 @@ public class AttributeDeduplicatorDaemon {
      */
     public void markForDeduplication(KeyspaceImpl keyspace, String index, ConceptId conceptId) {
         Attribute attribute = Attribute.create(keyspace, index, conceptId);
-        LOG.trace("insert(" + attribute + ")");
+        LOG.trace("insert({})",  attribute);
         queue.insert(attribute);
     }
 
@@ -100,7 +100,7 @@ public class AttributeDeduplicatorDaemon {
                 try {
                     List<Attribute> attributes = queue.read(QUEUE_GET_BATCH_MAX);
 
-                    LOG.trace("starting a new batch to process these new attributes: " + attributes);
+                    LOG.trace("starting a new batch to process these new attributes: {}", attributes);
 
                     // group the attributes into a set of unique (keyspace -> value) pair
                     Set<KeyspaceIndexPair> uniqueKeyValuePairs = attributes.stream()

--- a/server/src/server/kb/concept/RelationEdge.java
+++ b/server/src/server/kb/concept/RelationEdge.java
@@ -102,7 +102,7 @@ public class RelationEdge implements RelationStructure, CacheOwner {
 
     @Override
     public RelationReified reify() {
-        LOG.debug("Reifying concept [" + id() + "]");
+        LOG.debug("Reifying concept [{}]", id());
         //Build the Relation Vertex
         VertexElement relationVertex = edge().tx().addVertexElement(Schema.BaseType.RELATION, id());
         RelationReified relationReified = edge().tx().factory().buildRelationReified(relationVertex, type());


### PR DESCRIPTION
## What is the goal of this PR?

With string concatenation used when logging, the `toString` methods are can still be called even if the actual logging doesn't take place. Hence, we remove the concatenation and use printf style printing.