### PR TITLE
Correct implicit type label check

### DIFF
--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -257,6 +257,7 @@ public class ConsoleSession implements AutoCloseable {
     public final void close() throws IOException {
         tx.close();
         session.close();
+        client.close();
         historyFile.flush();
     }
 

--- a/server/src/server/kb/Schema.java
+++ b/server/src/server/kb/Schema.java
@@ -44,7 +44,6 @@ import static grakn.core.common.util.Collections.tuple;
 
 /**
  * A type enum which restricts the types of links/concepts which can be created
- *
  */
 public final class Schema {
     public final static String PREFIX_VERTEX = "V";
@@ -106,7 +105,7 @@ public final class Schema {
         }
 
         @CheckReturnValue
-        public LabelId getId(){
+        public LabelId getId() {
             return id;
         }
 
@@ -117,7 +116,7 @@ public final class Schema {
 
         @Nullable
         @CheckReturnValue
-        public static MetaSchema valueOf(Label label){
+        public static MetaSchema valueOf(Label label) {
             for (MetaSchema metaSchema : MetaSchema.values()) {
                 if (metaSchema.getLabel().equals(label)) return metaSchema;
             }
@@ -149,12 +148,12 @@ public final class Schema {
 
         private final Class classType;
 
-        BaseType(Class classType){
+        BaseType(Class classType) {
             this.classType = classType;
         }
 
         @CheckReturnValue
-        public Class getClassType(){
+        public Class getClassType() {
             return classType;
         }
     }
@@ -284,7 +283,7 @@ public final class Schema {
         }
 
         @CheckReturnValue
-        public String getValue(){
+        public String getValue() {
             return label;
         }
 
@@ -295,13 +294,15 @@ public final class Schema {
          * @return The original label which was used to build this type
          */
         @CheckReturnValue
-        public static Label explicitLabel(Label implicitType){
-            if(!implicitType.getValue().startsWith("key") && implicitType.getValue().startsWith("has")){
+        public static Label explicitLabel(Label implicitType) {
+            if (!(implicitType.getValue().startsWith("@key") || implicitType.getValue().startsWith("@has"))) {
                 throw new IllegalArgumentException(INVALID_IMPLICIT_TYPE.getMessage(implicitType));
             }
 
             int endIndex = implicitType.getValue().length();
-            if(implicitType.getValue().endsWith("-value") || implicitType.getValue().endsWith("-owner")) {
+            // We need to exclude the scenario where the user literally names their attributes 'value' or 'owner'
+            // which will result in @has-value, @has-owner, @key-value, @key-owner as legitimate implicit-relation names
+            if (implicitType.getValue().length() > 10 && (implicitType.getValue().endsWith("-value") || implicitType.getValue().endsWith("-owner"))) {
                 endIndex = implicitType.getValue().lastIndexOf("-");
             }
 
@@ -311,13 +312,12 @@ public final class Schema {
     }
 
     /**
-     *
      * @param label The AttributeType label
      * @param value The value of the Attribute
      * @return A unique id for the Attribute
      */
     @CheckReturnValue
-    public static String generateAttributeIndex(Label label, String value){
+    public static String generateAttributeIndex(Label label, String value) {
         return Schema.BaseType.ATTRIBUTE.name() + "-" + label + "-" + value;
     }
 }

--- a/test-integration/server/kb/concept/AttributeTypeIT.java
+++ b/test-integration/server/kb/concept/AttributeTypeIT.java
@@ -20,10 +20,12 @@ package grakn.core.server.kb.concept;
 
 import grakn.core.concept.thing.Attribute;
 import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.EntityType;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
+import graql.lang.Graql;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Before;
@@ -189,5 +191,36 @@ public class AttributeTypeIT {
                 assertEquals(rightNow, databaseTime);
             }
         }
+    }
+
+
+    @Test
+    public void whenNamingAttributeTypeValue_NoErrorsThrown() {
+        AttributeType<String> valueAttributeType = tx.putAttributeType("value", AttributeType.DataType.STRING);
+
+        Attribute<String> attribute = valueAttributeType.create("testing");
+        EntityType person = tx.putEntityType("person").has(valueAttributeType);
+        person.create().has(attribute);
+        tx.commit();
+
+        tx = session.transaction().read();
+        tx.execute(Graql.parse("match $x isa @has-attribute; get;").asGet());
+        tx.execute(Graql.parse("match $x isa @has-value; get;").asGet());
+        tx.execute(Graql.parse("match (@has-value-value: $attr, @has-value-owner: $person) isa @has-value; get;").asGet());
+    }
+
+    @Test
+    public void whenNamingAttributeTypeOwner_NoErrorsThrown() {
+        AttributeType<String> ownerAttributeType = tx.putAttributeType("owner", AttributeType.DataType.STRING);
+
+        Attribute<String> attribute = ownerAttributeType.create("testing");
+        EntityType person = tx.putEntityType("person").has(ownerAttributeType);
+        person.create().has(attribute);
+        tx.commit();
+
+        tx = session.transaction().read();
+        tx.execute(Graql.parse("match $x isa @has-attribute; get;").asGet());
+        tx.execute(Graql.parse("match $x isa @has-owner; get;").asGet());
+        tx.execute(Graql.parse("match (@has-owner-value: $attr, @has-owner-owner: $person) isa @has-owner; get;").asGet());
     }
 }

--- a/test-integration/server/kb/concept/BUILD
+++ b/test-integration/server/kb/concept/BUILD
@@ -22,6 +22,7 @@ java_test(
      deps = [
          "//concept:concept",
          "//server:server",
+         "@graknlabs_graql//java:graql",
          "//test-integration/rule:grakn-test-server",
          "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library"
      ],


### PR DESCRIPTION
## What is the goal of this PR?
Prevent breakage when naming attributes `value` or `owner`.

## What are the changes implemented in this PR?
* Adds `client.close()` to console (minor)
* Correct the conversion from implicit label to explicit type -- defensive check was corrected and made change to allow naming attribute types `value` and `owner` which caused errors before.