### PR TITLE
Remove unscalable rule features

### DIFF
--- a/server/src/graql/reasoner/atom/AtomicBase.java
+++ b/server/src/graql/reasoner/atom/AtomicBase.java
@@ -111,9 +111,8 @@ public abstract class AtomicBase implements Atomic {
     /**
      * @return TransactionOLTP this atomic is defined in
      */
-    protected TransactionOLTP tx(){
-        // TODO: This cast is unsafe - ReasonerQuery should return an TransactionImpl
-        return (TransactionOLTP) getParentQuery().tx();
+    public TransactionOLTP tx(){
+        return getParentQuery().tx();
     }
 
     @Override

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -316,10 +316,6 @@ public class ReasonerQueryImpl implements ResolvableQuery {
         throw GraqlQueryException.getUnifierOfNonAtomicQuery();
     }
 
-    public GraqlGet getQuery() {
-        return Graql.match(getPattern()).get();
-    }
-
     private Stream<IsaAtom> inferEntityTypes(ConceptMap sub) {
         Set<Variable> typedVars = getAtoms(IsaAtomBase.class).map(AtomicBase::getVarName).collect(Collectors.toSet());
         return Stream.concat(

--- a/server/src/graql/reasoner/query/ResolvableQuery.java
+++ b/server/src/graql/reasoner/query/ResolvableQuery.java
@@ -25,6 +25,8 @@ import grakn.core.graql.reasoner.state.QueryStateBase;
 import grakn.core.graql.reasoner.state.ResolutionState;
 import grakn.core.graql.reasoner.unifier.Unifier;
 
+import graql.lang.Graql;
+import graql.lang.query.GraqlGet;
 import javax.annotation.CheckReturnValue;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -87,6 +89,14 @@ public interface ResolvableQuery extends ReasonerQuery {
      */
     @CheckReturnValue
     boolean requiresReiteration();
+
+    /**
+     * @return corresponding Get query
+     */
+    @CheckReturnValue
+    default GraqlGet getQuery() {
+        return Graql.match(getPattern()).get();
+    }
 
     /**
      * @return rewritten (decomposed) version of the query

--- a/server/src/graql/reasoner/rule/InferenceRule.java
+++ b/server/src/graql/reasoner/rule/InferenceRule.java
@@ -20,6 +20,7 @@ package grakn.core.graql.reasoner.rule;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.Rule;
 import grakn.core.concept.type.SchemaConcept;
@@ -93,7 +94,7 @@ public class InferenceRule {
 
     @Override
     public String toString(){
-        return  "\n" + this.body.toString() + "->\n" + this.head.toString() + "[" + resolutionPriority() +"]\n";
+        return  "\n" + this.body.toString() + "->\n" + this.head.toString() + "]\n";
     }
 
     @Override
@@ -119,7 +120,12 @@ public class InferenceRule {
         if (priority == Long.MAX_VALUE) {
             //NB: this has to be relatively lightweight as it is called on each rule
             //TODO come with a more useful metric
-            priority = getBody().isRuleResolvable()? -1 : 0;
+            boolean bodyRuleResolvable = getBody().getAtoms(Atom.class)
+                    .map(Atom::getSchemaConcept)
+                    .filter(Objects::nonNull)
+                    .map(Concept::asType)
+                    .anyMatch(t -> t.thenRules().findFirst().isPresent());
+            priority = bodyRuleResolvable? -1 : 0;
         }
         return priority;
     }


### PR DESCRIPTION
## What is the goal of this PR?

Refine features that scale poorly with the number of rules:
- rule priority - simplified it. Now we only check locally for rule resolvability (instead of looking at number of dependent rules).
- do not include priority when printing
- cached conclusion atom calculation
- avoiding composite query construction when rewriting rules