### PR TITLE
Fix Docker image build issue and uncomment deploy-rpm

### DIFF
--- a/bin/BUILD
+++ b/bin/BUILD
@@ -90,8 +90,8 @@ assemble_rpm(
     },
 )
 
-#deploy_rpm(
-#    name = "deploy-rpm",
-#    target = ":assemble-rpm",
-#    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
-#)
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":assemble-rpm",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+)

--- a/bin/grakn-docker.sh
+++ b/bin/grakn-docker.sh
@@ -27,7 +27,7 @@ function cleanup() {
 
 trap cleanup SIGINT SIGTERM
 
-pushd grakn-core-all &>/dev/null
+pushd ./grakn-core-all-linux &>/dev/null
 ./grakn server start
 tail -f logs/grakn.log &
 

--- a/console/BUILD
+++ b/console/BUILD
@@ -186,11 +186,11 @@ assemble_rpm(
     ],
 )
 
-#deploy_rpm(
-#    name = "deploy-rpm",
-#    target = ":assemble-rpm",
-#    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
-#)
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":assemble-rpm",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+)
 
 test_suite(
     name = "console-test-integration",

--- a/server/BUILD
+++ b/server/BUILD
@@ -261,8 +261,8 @@ assemble_rpm(
     },
 )
 
-#deploy_rpm(
-#    name = "deploy-rpm",
-#    target = ":assemble-rpm",
-#    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
-#)
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":assemble-rpm",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+)


### PR DESCRIPTION
## What is the goal of this PR?
1. Fix an issue where the docker image won't build properly
2. Re-enable `//bin:deploy-rpm`, `//server:deploy-rpm`, `//console:deploy-rpm`

## What are the changes implemented in this PR?
1. Updated Grakn directory name in the `grakn-docker.sh` script
2. Uncomment `//bin:deploy-rpm`, `//server:deploy-rpm`, `//console:deploy-rpm`