### PR TITLE
Add missing dependency for grakn-core-bin

### DIFF
--- a/config/rpm/grakn-core-bin.spec
+++ b/config/rpm/grakn-core-bin.spec
@@ -9,6 +9,7 @@ AutoReqProv: no
 Source0: {_grakn-core-bin-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
+Requires: which
 
 %description
 Grakn Core (server) - description


### PR DESCRIPTION
## What is the goal of this PR?

RPM package `grakn-core-bin` depends on having `which` CLI command in `$PATH` which doesn't come standard in CentOS (as tested on Docker image)

## What are the changes implemented in this PR?

Added missing dependency to `which` package