### PR TITLE
Enable Schema Concept Cache in Transaction Cache

### DIFF
--- a/server/src/server/kb/concept/SchemaConceptImpl.java
+++ b/server/src/server/kb/concept/SchemaConceptImpl.java
@@ -143,7 +143,7 @@ public abstract class SchemaConceptImpl<T extends SchemaConcept> extends Concept
             //noinspection unchecked
             SchemaConceptImpl.from(superConcept).deleteCachedDirectedSubType(getThis());
 
-            //Clear Global Cache
+            //Clear Transaction Cache
             vertex().tx().cache().remove(this);
 
             //Clear internal caching

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -490,7 +490,8 @@ public class TransactionOLTP implements Transaction {
                 vertexElement.property(Schema.VertexProperty.IS_IMPLICIT, true);
             }
 
-            schemaConcept = SchemaConceptImpl.from(buildSchemaConcept(label, () -> newConceptFactory.apply(vertexElement)));
+            // if the schema concept is not in janus, create it here
+            schemaConcept = SchemaConceptImpl.from(newConceptFactory.apply(vertexElement));
         } else if (!baseType.equals(schemaConcept.baseType())) {
             throw labelTaken(schemaConcept);
         }
@@ -658,7 +659,12 @@ public class TransactionOLTP implements Transaction {
     private <T extends SchemaConcept> T getSchemaConcept(Label label, Schema.BaseType baseType) {
         operateOnOpenGraph(() -> null); //Makes sure the graph is open
 
-        SchemaConcept schemaConcept = buildSchemaConcept(label, () -> getSchemaConcept(convertToId(label)));
+        SchemaConcept schemaConcept;
+        if (transactionCache.isTypeCached(label)) {
+            schemaConcept = transactionCache.getCachedSchemaConcept(label);
+        } else {
+            schemaConcept = getSchemaConcept(convertToId(label));
+        }
         return validateSchemaConcept(schemaConcept, baseType, () -> null);
     }
 

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -519,20 +519,6 @@ public class TransactionOLTP implements Transaction {
         }
     }
 
-    /**
-     * A helper method which either retrieves the SchemaConcept from the cache or builds it using a provided supplier
-     *
-     * @param label     The Label of the SchemaConcept to retrieve or build
-     * @param dbBuilder A method which builds the SchemaConcept via a DB read or write
-     * @return The SchemaConcept which was either cached or built via a DB read or write
-     */
-    private SchemaConcept buildSchemaConcept(Label label, Supplier<SchemaConcept> dbBuilder) {
-//        if (transactionCache.isTypeCached(label)) {
-//            return transactionCache.getCachedSchemaConcept(label);
-//        } else {
-            return dbBuilder.get();
-//        }
-    }
 
     /**
      * @param label A unique label for the RelationType

--- a/server/src/server/session/cache/KeyspaceCache.java
+++ b/server/src/server/session/cache/KeyspaceCache.java
@@ -132,8 +132,8 @@ public class KeyspaceCache {
         }
 
         //Flush All The Internal TransactionOLTP Caches
-        transactionCache.getSchemaConceptCache().values().forEach(schemaConcept
-                -> SchemaConceptImpl.from(schemaConcept).txCacheFlush());
+//        transactionCache.getSchemaConceptCache().values().forEach(schemaConcept
+//                -> SchemaConceptImpl.from(schemaConcept).txCacheFlush());
     }
 
     /**

--- a/server/src/server/session/cache/KeyspaceCache.java
+++ b/server/src/server/session/cache/KeyspaceCache.java
@@ -46,7 +46,7 @@ public class KeyspaceCache {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     // Concept cache
-    private final Cache<Label, SchemaConcept> cachedTypes;
+//    private final Cache<Label, SchemaConcept> cachedTypes;
 
     // Label cache
     private final Map<Label, LabelId> cachedLabels;
@@ -55,10 +55,10 @@ public class KeyspaceCache {
         cachedLabels = new ConcurrentHashMap<>();
 
         int cacheTimeout = config.getProperty(ConfigKey.SESSION_CACHE_TIMEOUT_MS);
-        cachedTypes = CacheBuilder.newBuilder()
-                .maximumSize(1000)
-                .expireAfterAccess(cacheTimeout, TimeUnit.MILLISECONDS)
-                .build();
+//        cachedTypes = CacheBuilder.newBuilder()
+//                .maximumSize(1000)
+//                .expireAfterAccess(cacheTimeout, TimeUnit.MILLISECONDS)
+//                .build();
     }
 
     /**
@@ -70,13 +70,13 @@ public class KeyspaceCache {
         try {
             lock.writeLock().lock();
 
-            Map<Label, SchemaConcept> cachedSchemaSnapshot = getCachedTypes();
+//            Map<Label, SchemaConcept> cachedSchemaSnapshot = getCachedTypes();
             Map<Label, LabelId> cachedLabelsSnapshot = getCachedLabels();
 
             //Read central cache into transactionCache cloning only base concepts. Sets clones later
-            for (SchemaConcept type : cachedSchemaSnapshot.values()) {
-                transactionCache.cacheConcept(type);
-            }
+//            for (SchemaConcept type : cachedSchemaSnapshot.values()) {
+//                transactionCache.cacheConcept(type);
+//            }
 
             //Load Labels Separately. We do this because the TypeCache may have expired.
             cachedLabelsSnapshot.forEach(transactionCache::cacheLabel);
@@ -91,9 +91,9 @@ public class KeyspaceCache {
      * @param label The label of the type to cache
      * @param type  The type to cache
      */
-    void cacheType(Label label, SchemaConcept type) {
-        cachedTypes.put(label, type);
-    }
+//    void cacheType(Label label, SchemaConcept type) {
+//        cachedTypes.put(label, type);
+//    }
 
     /**
      * Caches a label so we can map type labels to type ids. This is necesssary so we can make fast
@@ -121,7 +121,7 @@ public class KeyspaceCache {
 
                 //Clear the cache
                 cachedLabels.clear();
-                cachedTypes.invalidateAll();
+//                cachedTypes.invalidateAll();
 
                 //Add a new one
                 cachedLabels.putAll(transactionCache.getLabelCache());
@@ -150,11 +150,12 @@ public class KeyspaceCache {
      *
      * @return an immutable copy of the cached schema.
      */
-    public Map<Label, SchemaConcept> getCachedTypes() {
-        return ImmutableMap.copyOf(cachedTypes.asMap());
-    }
+//    public Map<Label, SchemaConcept> getCachedTypes() {
+//        return ImmutableMap.copyOf(cachedTypes.asMap());
+//    }
 
     public boolean isEmpty(){
-        return cachedLabels.isEmpty() && (cachedTypes.size()==0);
+        return cachedLabels.isEmpty();
+        //&& (cachedTypes.size()==0);
     }
 }

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server.session.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import grakn.core.concept.Concept;
@@ -146,13 +147,6 @@ public class TransactionCache {
      */
     public Map<ConceptId, Long> getShardingCount() {
         return shardingCount;
-    }
-
-    /**
-     * @return All the types currently cached in the transaction. Used for
-     */
-    Map<Label, SchemaConcept> getSchemaConceptCache() {
-        return schemaConceptCache;
     }
 
     /**
@@ -343,6 +337,18 @@ public class TransactionCache {
         conceptCache.clear();
         schemaConceptCache.clear();
         labelCache.clear();
+    }
+
+
+
+    @VisibleForTesting
+    Map<ConceptId, Concept> getConceptCache() {
+        return conceptCache;
+    }
+
+    @VisibleForTesting
+    Map<Label, SchemaConcept> getSchemaConceptCache() {
+        return schemaConceptCache;
     }
 
 }

--- a/test-integration/server/kb/TransactionIT.java
+++ b/test-integration/server/kb/TransactionIT.java
@@ -157,32 +157,7 @@ public class TransactionIT {
         assertEquals(10000L, tx.shardingThreshold());
     }
 
-    @Test
-    public void whenClosingReadOnlyGraph_EnsureTypesAreCached() {
-        assertCacheOnlyContainsMetaTypes();
-        //noinspection ResultOfMethodCallIgnored
-        tx.getMetaConcept().subs(); //This loads some types into transaction cache
-        tx.abort();
-        assertCacheOnlyContainsMetaTypes(); //Ensure central cache is empty
 
-        tx = session.transaction().read();
-
-        Set<SchemaConcept> finalTypes = new HashSet<>();
-        finalTypes.addAll(tx.getMetaConcept().subs().collect(toSet()));
-        finalTypes.add(tx.getMetaRole());
-        finalTypes.add(tx.getMetaRule());
-
-        tx.abort();
-
-        for (SchemaConcept type : session.getKeyspaceCache().getCachedTypes().values()) {
-            assertTrue("Type [" + type + "] is missing from central cache after closing read only graph", finalTypes.contains(type));
-        }
-    }
-
-    private void assertCacheOnlyContainsMetaTypes() {
-        Set<Label> metas = Stream.of(Schema.MetaSchema.values()).map(Schema.MetaSchema::getLabel).collect(toSet());
-        session.getKeyspaceCache().getCachedTypes().keySet().forEach(cachedLabel -> assertTrue("Type [" + cachedLabel + "] is missing from central cache", metas.contains(cachedLabel)));
-    }
 
     @Test
     public void whenBuildingAConceptFromAVertex_ReturnConcept() {

--- a/test-integration/server/session/BUILD
+++ b/test-integration/server/session/BUILD
@@ -32,9 +32,22 @@ java_test(
 
 java_test(
     name = "keyspace-cache-it",
-    test_class = "grakn.core.server.session.KeyspaceCacheIT",
-    srcs = ["KeyspaceCacheIT.java"],
+    test_class = "grakn.core.server.session.cache.KeyspaceCacheIT",
+    srcs = ["cache/KeyspaceCacheIT.java"],
     deps = ["//server", "//test-integration/rule:grakn-test-server", "@graknlabs_client_java//:client-java", "//concept"],
+    classpath_resources = ["//test-integration/resources:logback-test"]
+)
+
+java_test(
+    name = "transaction-cache-it",
+    test_class = "grakn.core.server.session.cache.TransactionCacheIT",
+    srcs = ["cache/TransactionCacheIT.java"],
+    deps = [
+        "//server",
+        "//test-integration/rule:grakn-test-server",
+        "//concept",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+    ],
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
@@ -42,6 +55,7 @@ checkstyle_test(
     name = "checkstyle",
     targets = [
         ":session-it",
-        ":keyspace-cache-it"
+        ":keyspace-cache-it",
+        ":transaction-cache-it"
     ],
 )

--- a/test-integration/server/session/cache/KeyspaceCacheIT.java
+++ b/test-integration/server/session/cache/KeyspaceCacheIT.java
@@ -16,11 +16,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package grakn.core.server.session;
+package grakn.core.server.session.cache;
 
 import grakn.client.GraknClient;
 import grakn.core.concept.type.Role;
 import grakn.core.rule.GraknTestServer;
+import grakn.core.server.session.SessionImpl;
+import grakn.core.server.session.TransactionOLTP;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -1,0 +1,181 @@
+package grakn.core.server.session.cache;
+
+import grakn.core.concept.Concept;
+import grakn.core.concept.ConceptId;
+import grakn.core.concept.Label;
+import grakn.core.concept.thing.Entity;
+import grakn.core.concept.type.EntityType;
+import grakn.core.concept.type.SchemaConcept;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.session.SessionImpl;
+import grakn.core.server.session.TransactionOLTP;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+
+/**
+ *
+ * Interesting takeaways:
+ * - Creating a new type, we retrieve and cache the entire hierarchy up to `Thing` (top level meta concept)
+ * - When fetching an existing type, we only cache that single type, not the entire hierarchy
+ * - When fetching instances of a type, we cache both the instances and that type (but again, no supertypes)
+ *
+ */
+
+@SuppressWarnings("CheckReturnValue")
+public class TransactionCacheIT {
+
+    @ClassRule
+    public static final GraknTestServer server = new GraknTestServer();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+    private TransactionOLTP tx;
+    private SessionImpl session;
+
+    @Before
+    public void setUp() {
+        session = server.sessionWithNewKeyspace();
+        tx = session.transaction().write();
+    }
+
+    @After
+    public void tearDown() {
+        tx.close();
+        session.close();
+    }
+
+
+    @Test
+    public void whenOpenTransaction_ConceptCacheIsEmpty() {
+        TransactionCache transactionCache = tx.cache();
+        Map<ConceptId, Concept> conceptCache = transactionCache.getConceptCache();
+        assertEquals(0, conceptCache.size());
+    }
+
+    @Test
+    public void whenOpenTransaction_SchemaConceptCacheIsEmpty() {
+        TransactionCache transactionCache = tx.cache();
+        Map<Label, SchemaConcept> schemaConceptCache = transactionCache.getSchemaConceptCache();
+        assertEquals(0, schemaConceptCache.size());
+    }
+
+    @Test
+    public void whenQueryForConcept_ConceptCacheIsUpdated() {
+        // define and insert a concept
+        EntityType person = tx.putEntityType("person");
+        person.create();
+        tx.commit();
+
+        // examine new transaction's cache
+        tx = session.transaction().read();
+        EntityType retrievedPerson = tx.getEntityType("person");
+        Entity retrievedPersonInstance = retrievedPerson.instances().collect(Collectors.toList()).get(0);
+
+        TransactionCache transactionCache = tx.cache();
+        Map<ConceptId, Concept> conceptCache = transactionCache.getConceptCache();
+
+        // concept cache contains "person" type and "person" instance
+        assertEquals(2, conceptCache.size());
+        assertThat(conceptCache.values(), containsInAnyOrder(retrievedPerson, retrievedPersonInstance));
+    }
+
+    @Test
+    public void whenQueryForSchemaConcept_SchemaConceptCacheIsUpdated() {
+        // define and insert a concept
+        EntityType person = tx.putEntityType("person");
+        tx.commit();
+
+        // examine new transaction's cache
+        tx = session.transaction().read();
+        tx.getEntityType("person");
+
+        TransactionCache transactionCache = tx.cache();
+        Map<Label, SchemaConcept> schemaConceptCache = transactionCache.getSchemaConceptCache();
+
+        assertEquals(1, schemaConceptCache.size());
+        assertEquals("person", schemaConceptCache.values().iterator().next().label().toString());
+    }
+
+    @Test
+    public void whenCreateNewConcept_ConceptCacheIsUpdated() {
+        // define and insert a concept
+        EntityType person = tx.putEntityType("person");
+        Entity personInstance = person.create();
+
+        TransactionCache transactionCache = tx.cache();
+        Map<ConceptId, Concept> conceptCache = transactionCache.getConceptCache();
+
+        assertEquals(4, conceptCache.size());
+
+        List<String> conceptCacheLabels = conceptCache.values().stream().map(concept -> {
+            if (concept.isThing()) {
+                return concept.asThing().type().label().toString();
+            } else {
+                return concept.asType().label().toString();
+            }
+        }).collect(Collectors.toList());
+        assertThat(conceptCacheLabels, containsInAnyOrder("person", "person", "entity", "thing"));
+    }
+
+    @Test
+    public void whenCreateNewSchemaConcept_SchemaConceptCacheIsUpdated() {
+        // define a concept type
+        EntityType person = tx.putEntityType("person");
+
+        TransactionCache transactionCache = tx.cache();
+        Map<Label, SchemaConcept> schemaConceptCache = transactionCache.getSchemaConceptCache();
+
+        /*
+        Expect 3 types in the schema concept cache because:
+        1. `thing` is required to create the next type label ID
+        2. Hierarchy of supertypes is immediates retrieved and cache on new type creation
+         */
+        assertEquals(3, schemaConceptCache.size());
+        List<String> cachedSchemaConceptLabels = schemaConceptCache.values().stream().map(schemaConcept -> schemaConcept.label().toString()).collect(Collectors.toList());
+        assertThat(cachedSchemaConceptLabels, containsInAnyOrder("person", "entity", "thing"));
+    }
+
+    @Test
+    public void whenDeleteConcept_ConceptCacheIsUpdated() {
+        // define and insert a concept
+        EntityType person = tx.putEntityType("person");
+        Entity personInstance = person.create();
+
+        TransactionCache transactionCache = tx.cache();
+        Map<ConceptId, Concept> conceptCache = transactionCache.getConceptCache();
+
+        personInstance.delete();
+
+        List<String> cachedConceptLabels = conceptCache.values().stream().map(concept-> concept.asType().label().toString()).collect(Collectors.toList());
+        assertEquals(3, conceptCache.size());
+        assertThat(cachedConceptLabels,containsInAnyOrder("person", "entity", "thing"));
+    }
+
+    @Test
+    public void whenDeleteSchemaConcept_SchemaConceptCacheIsUpdated() {
+        // define and insert a concept
+        EntityType person = tx.putEntityType("person");
+
+        TransactionCache transactionCache = tx.cache();
+        Map<Label, SchemaConcept> schemaConceptCache = transactionCache.getSchemaConceptCache();
+
+        person.delete();
+
+        assertEquals(2, schemaConceptCache.size());
+        List<String> cachedSchemaConceptLabels = schemaConceptCache.values().stream().map(schemaConcept -> schemaConcept.label().toString()).collect(Collectors.toList());
+        assertThat(cachedSchemaConceptLabels, containsInAnyOrder( "entity", "thing"));
+    }
+}

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.server.session.cache;
 
 import grakn.core.concept.Concept;


### PR DESCRIPTION
## What is the goal of this PR?
Speed up access to the schema concepts via a schema concept cache at the transaction level.

## What are the changes implemented in this PR?
* Enable schema concept caching in the Transaction Cache
* Add tests for Transaction Cache
* Comment out `Flush All The Internal TransactionOLTP Caches` in the KeyspaceCache, plus all concept object caches in it - end goal removing KeyspaceCache.