### PR TITLE
Deploy brew

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,12 +19,11 @@
 exports_files(["VERSION"], visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//brew:rules.bzl", "deploy_brew")
-load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip")
+load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip", "checksum")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_push")
-
 
 deploy_github(
     name = "deploy-github-zip",
@@ -33,6 +32,18 @@ deploy_github(
     version_file = "//:VERSION"
 )
 
+deploy_brew(
+    name = "deploy-brew",
+    checksum = "//:checksum",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+    formula = "//config/brew:grakn-core.rb",
+    version_file = "//:VERSION"
+)
+
+checksum(
+    name = "checksum",
+    target = ":assemble-mac-zip"
+)
 
 assemble_targz(
     name = "assemble-linux-targz",
@@ -103,11 +114,6 @@ assemble_zip(
     visibility = ["//visibility:public"]
 )
 
-deploy_brew(
-    name = "deploy-brew",
-    version_file = "//:VERSION"
-)
-
 container_image(
     name = "assemble-docker",
     base = "@openjdk_image//image",
@@ -118,7 +124,6 @@ container_image(
     volumes = ["/server/db"]
 )
 
-
 container_push(
     name = "deploy-docker",
     image = ":assemble-docker",
@@ -126,7 +131,6 @@ container_push(
     registry = "index.docker.io",
     repository = "graknlabs/grakn-core",
 )
-
 
 # When a Bazel build or test is executed with RBE, it will be executed using the following platform.
 # The platform is based on the standard rbe_ubuntu1604 from @bazel_toolchains,

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,19 +29,11 @@ graknlabs_graql()
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 
-#load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
-#graknlabs_build_tools()
-local_repository(
-    name = "graknlabs_build_tools",
-    path = "/Users/lolski/grakn.ai/build-tools"
-)
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
+graknlabs_build_tools()
 
-#load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
-#graknlabs_bazel_distribution()
-local_repository(
-    name = "graknlabs_bazel_distribution",
-    path = "/Users/lolski/grakn.ai/bazel-distribution"
-)
+load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
+graknlabs_bazel_distribution()
 
 ###########################
 # Load Bazel dependencies #

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,12 +29,19 @@ graknlabs_graql()
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 
-load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
-graknlabs_build_tools()
+#load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
+#graknlabs_build_tools()
+local_repository(
+    name = "graknlabs_build_tools",
+    path = "/Users/lolski/grakn.ai/build-tools"
+)
 
-load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
-graknlabs_bazel_distribution()
-
+#load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
+#graknlabs_bazel_distribution()
+local_repository(
+    name = "graknlabs_bazel_distribution",
+    path = "/Users/lolski/grakn.ai/bazel-distribution"
+)
 
 ###########################
 # Load Bazel dependencies #

--- a/config/brew/BUILD
+++ b/config/brew/BUILD
@@ -1,0 +1,1 @@
+exports_files(["grakn-core.rb"])

--- a/config/brew/grakn-core.rb
+++ b/config/brew/grakn-core.rb
@@ -1,0 +1,20 @@
+class GraknCore < Formula
+  desc "Grakn Core: The Knowledge Graph"
+  homepage "https://grakn.ai"
+  url "https://github.com/graknlabs/grakn/releases/download/v{version}/grakn-core-all-mac-{version}.zip"
+  sha256 "{sha256}"
+
+  bottle :unneeded
+
+  depends_on :java => "1.8"
+
+  def install
+    libexec.install Dir["*"]
+    bin.install libexec/"grakn"
+    bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
+  end
+
+  test do
+    assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
+  end
+end

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,5 +36,5 @@ def graknlabs_build_tools():
      git_repository(
          name = "graknlabs_build_tools",
          remote = "https://github.com/graknlabs/build-tools",
-         commit = "f15f9817872a931b9d9924682803adcaa4de6a1d", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+         commit = "d350513b965d01b094e936c368fba7454e9cd054", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
      )


### PR DESCRIPTION
Don't merge this PR yet! Merge these first:
- https://github.com/graknlabs/bazel-distribution/pull/79/files
- https://github.com/graknlabs/build-tools/pull/20

## What is the goal of this PR?
Enable Grakn to be deployed to our own brew test tap and release tap.

## What are the changes implemented in this PR?
1. Added a `//:deploy-brew` target
2. Added a Brew formula definition