### PR TITLE
Fix ghost vertices issue with concurrent insertions

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -74,7 +74,7 @@ java_library(
         "//dependencies/maven/artifacts/org/scala-lang:scala-library", # PREVIOUSLY UNDECLARED
         "//dependencies/maven/artifacts/org/scala-lang:scalap", # PREVIOUSLY UNDECLARED
         "//dependencies/maven/artifacts/org/sharegov:mjson", # PREVIOUSLY UNDECLARED
-        "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
+        "//dependencies/maven/artifacts/org/slf4j:slf4j-api"
     ],
     runtime_deps = [
         "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",

--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -67,7 +67,7 @@ public class WriteExecutor {
     // A mutable map associating each `Var` to the `Concept` in the graph it refers to.
     private final Map<Variable, Concept> concepts = new HashMap<>();
 
-    // A set of concepts to be deleted at the end of a write exeuction
+    // A set of concepts to be deleted at the end of a write execution
     private final Set<Concept> conceptsToDelete = new HashSet<>();
 
     // A mutable map of concepts "under construction" that require more information before they can be built

--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -167,7 +167,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Override
     public Attribute<D> attribute(D value) {
         String index = Schema.generateAttributeIndex(label(), value.toString());
-        return vertex().tx().<Attribute<D>>getConcept(Schema.VertexProperty.INDEX, index).orElse(null);
+        return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);
     }
 
     /**

--- a/server/src/server/kb/concept/ElementFactory.java
+++ b/server/src/server/kb/concept/ElementFactory.java
@@ -145,16 +145,15 @@ public final class ElementFactory {
     }
 
     public <X extends Concept> X buildConcept(VertexElement vertexElement) {
-        Schema.BaseType type;
-
-        try {
-            type = getBaseType(vertexElement);
-        } catch (IllegalStateException e) {
-            throw TemporaryWriteException.indexOverlap(vertexElement.element(), e);
-        }
 
         ConceptId conceptId = ConceptId.of(vertexElement.property(Schema.VertexProperty.ID));
         if (!tx.cache().isConceptCached(conceptId)) {
+            Schema.BaseType type;
+            try {
+                type = getBaseType(vertexElement);
+            } catch (IllegalStateException e) {
+                throw TemporaryWriteException.indexOverlap(vertexElement.element(), e);
+            }
             Concept concept;
             switch (type) {
                 case RELATION:

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -68,8 +68,11 @@ import static java.util.stream.Collectors.toSet;
 public abstract class ThingImpl<T extends Thing, V extends Type> extends ConceptImpl implements Thing {
     private final Cache<Label> cachedInternalType = Cache.createTxCache(this, Cacheable.label(), () -> {
         int typeId = vertex().property(Schema.VertexProperty.THING_TYPE_LABEL_ID);
-        Optional<Type> type = vertex().tx().getConcept(Schema.VertexProperty.LABEL_ID, typeId);
-        return type.orElseThrow(() -> TransactionException.missingType(id())).label();
+        Type type = vertex().tx().getConcept(Schema.VertexProperty.LABEL_ID, typeId);
+        if (type == null){
+            throw TransactionException.missingType(id());
+        }
+        return type.label();
     });
 
     private final Cache<V> cachedType = Cache.createTxCache(this, Cacheable.concept(), () -> {

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -37,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
@@ -59,7 +60,7 @@ public class KeyspaceManager {
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
         KeyspaceCache keyspaceCache = new KeyspaceCache(config);
         this.graph = janusGraphFactory.openGraph(SYSTEM_KB_KEYSPACE.name());
-        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, null);
+        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, new ReentrantReadWriteLock());
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
     }
 

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -59,7 +59,7 @@ public class KeyspaceManager {
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
         KeyspaceCache keyspaceCache = new KeyspaceCache(config);
         this.graph = janusGraphFactory.openGraph(SYSTEM_KB_KEYSPACE.name());
-        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph);
+        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, null);
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
     }
 

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -34,6 +34,7 @@ import grakn.core.server.session.cache.KeyspaceCache;
 import org.janusgraph.core.JanusGraph;
 
 import javax.annotation.CheckReturnValue;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Consumer;
 
 /**
@@ -56,6 +57,7 @@ public class SessionImpl implements Session {
 
     private final KeyspaceImpl keyspace;
     private final Config config;
+    private ReadWriteLock readWriteLock;
     private final JanusGraph graph;
     private final KeyspaceCache keyspaceCache;
     private Consumer<SessionImpl> onClose;
@@ -69,9 +71,10 @@ public class SessionImpl implements Session {
      * @param keyspace to which keyspace the session should be bound to
      * @param config   config to be used.
      */
-    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph) {
+    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph, ReadWriteLock readWriteLock) {
         this.keyspace = keyspace;
         this.config = config;
+        this.readWriteLock = readWriteLock;
         // Only save a reference to the factory rather than opening an Hadoop graph immediately because that can be
         // be an expensive operation TODO: refactor in the future
         this.hadoopGraphFactory = new HadoopGraphFactory(this);
@@ -110,7 +113,7 @@ public class SessionImpl implements Session {
         if (localTx != null && !localTx.isClosed()) throw TransactionException.transactionOpen(localTx);
 
         // We are passing the graph to Transaction because there is the need to access graph tinkerpop traversal
-        TransactionOLTP tx = new TransactionOLTP(this, graph, keyspaceCache);
+        TransactionOLTP tx = new TransactionOLTP(this, graph, keyspaceCache, readWriteLock);
         tx.open(type);
         localOLTPTransactionContainer.set(tx);
 

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -19,7 +19,6 @@
 package grakn.core.server.session;
 
 import brave.ScopedSpan;
-import brave.Span;
 import grakn.benchmark.lib.serverinstrumentation.ServerTracingInstrumentation;
 import grakn.core.api.Transaction;
 import grakn.core.common.config.ConfigKey;
@@ -185,8 +184,18 @@ public class TransactionOLTP implements Transaction {
         });
     }
 
-    public VertexElement addVertexElement(Schema.BaseType baseType, ConceptId... conceptIds) {
-        return executeLockingMethod(() -> factory().addVertexElement(baseType, conceptIds));
+    public VertexElement addVertexElement(Schema.BaseType baseType) {
+        return executeLockingMethod(() -> factory().addVertexElement(baseType));
+    }
+
+    /**
+     * This is only used when reifying a Relation
+     * @param baseType Concept BaseType which will become the VertexLabel
+     * @param conceptId ConceptId to be set on the vertex
+     * @return just created Vertex
+     */
+    public VertexElement addVertexElement(Schema.BaseType baseType, ConceptId conceptId) {
+        return executeLockingMethod(() -> factory().addVertexElement(baseType, conceptId));
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?

Resolve exception `TemporaryWriteException: Index overlap has led to the accidental sharing of a partially complete vertex {v[...]}`
which is often occurring when migrating (inserting) a lot of attributes into Grakn using multiple concurrent threads.

## What are the changes implemented in this PR?

In this PR we serialise the `commit`s to Janus to avoid sharing incomplete vertices between concurrent transactions.
Apparently Janus makes indices immediately available to all transactions while committing,
even to transactions that were already open before starting the `commit` process.

Example
Scenario: two concurrent transactions are trying to insert an attribute instance `name=Marco`

- Before inserting the attribute, Transaction A will do a Janus lookup by `INDEX` property (`hasProperty(INDEX, "ATTRIBUTE-name-Marco")`)
- This will return null, so Transaction A will proceed to create the attribute Vertex and add the property `INDEX` onto the vertex
- While Transaction A is committing, Transaction B executes the same lookup by `INDEX` property,
at this point Janus will return the vertex (as `CacheVertex`) that Transaction A is committing
- Transaction B then will try to access `BASE_TYPE` vertex label or any other property of the vertex, but they are all NULL -> Exception is thrown because it looks like we are handling a ghost vertex here

The above is an educated guess, further investigation is needed.

For the time being we are solving the issue by using a ReadWriteLock so that concurrent transaction will never be able to end up in the situation described in the example.
Each transaction will acquire a read lock (non exclusive) when looking up any vertex by property (properties on vertices are all indexed) and will acquire a write lock (exclusive) when committing to Janus.
