### PR TITLE
Small fix to ignore inferred concepts when deleting

### DIFF
--- a/test-integration/server/kb/concept/BUILD
+++ b/test-integration/server/kb/concept/BUILD
@@ -90,6 +90,8 @@ java_test(
          "//common:common",
          "//concept:concept",
          "//server:server",
+         "//api:api",
+         "@graknlabs_graql//java:graql",
          "//test-integration/rule:grakn-test-server",
          "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
          "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",


### PR DESCRIPTION
## What is the goal of this PR?
Prevent Grakn from failing when deleting inferred concepts (specifically found to fail when deleting inferred relationships)

Closes #4447 

## What are the changes implemented in this PR?
Add a small `if` check during the delete process of a concept so that it is silently skipped if deleting an inferred concept.