### PR TITLE
Fix issues with fetching and propagating parents in query cache

### DIFF
--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -112,7 +112,11 @@ public abstract class SemanticCache<
     final private Set<ReasonerAtomicQuery> dbCompleteQueries = new HashSet<>();
     final private Set<QE> dbCompleteEntries = new HashSet<>();
 
-    private boolean isDBComplete(ReasonerAtomicQuery query){
+    /**
+     * @param query to check
+     * @return true if this query is db complete - cache contains all db answers for this query
+     */
+    public boolean isDBComplete(ReasonerAtomicQuery query){
         return dbCompleteEntries.contains(queryToKey(query))
                 || dbCompleteQueries.contains(query);
     }
@@ -124,7 +128,7 @@ public abstract class SemanticCache<
             dbCompleteEntries.add(queryToKey(query));
         }
     }
-    
+
     private Set<QE> getParents(ReasonerAtomicQuery child){
         Set<QE> parents = this.parents.get(queryToKey(child));
         if (parents.isEmpty()) parents = computeParents(child);
@@ -272,8 +276,9 @@ public abstract class SemanticCache<
 
         //if no match but db-complete parent exists, use parent to create entry
         Set<QE> parents = getParents(query);
-        boolean fetchFromParent = !parents.isEmpty()
-                && parents.stream().anyMatch(p -> isDBComplete(keyToQuery(p)));
+        boolean fetchFromParent = parents.stream().anyMatch(p ->
+                query.isGround() || isDBComplete(keyToQuery(p))
+        );
         if (fetchFromParent){
             CacheEntry<ReasonerAtomicQuery, SE> newEntry = addEntry(createEntry(query, new HashSet<>()));
             return new Pair<>(entryToAnswerStream(newEntry), MultiUnifierImpl.trivial());

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -134,8 +134,10 @@ public abstract class SemanticCache<
 
     private Set<QE> getParents(ReasonerAtomicQuery child){
         Set<QE> parents = this.parents.get(queryToKey(child));
-        if (!parents.isEmpty()) return parents;
-        return computeParents(child);
+        if (parents.isEmpty()) parents = computeParents(child);
+        return parents.stream()
+                .filter(parent -> child.subsumes(keyToQuery(parent)))
+                .collect(toSet());
     }
 
     private Set<QE> getFamily(ReasonerAtomicQuery query){

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -175,7 +175,6 @@ public class QueryCacheIT {
             MultilevelSemanticCache cache = new MultilevelSemanticCache();
 
             ConceptId id = tx.getEntityType("subRoleEntity").instances().iterator().next().id();
-
             ConceptId dConcept = tx.stream(Graql.<GraqlGet>parse("match $d isa subSubRoleEntity, has resource 'd';get;")).iterator().next().get("d").id();
             ConceptId sConcept = tx.stream(Graql.<GraqlGet>parse("match $s isa subSubRoleEntity, has resource 's';get;")).iterator().next().get("s").id();
 
@@ -201,14 +200,15 @@ public class QueryCacheIT {
                             "};",
                     tx), tx);
 
-            Set<ConceptMap> cacheAnswers = cache.getAnswers(childQuery);
-            assertEquals(tx.stream(childQuery.getQuery(), false).collect(toSet()), cacheAnswers);
+            Set<ConceptMap> childAnswers = cache.getAnswers(childQuery);
+            assertEquals(tx.stream(childQuery.getQuery(), false).collect(toSet()), childAnswers);
 
             assertNotNull(cache.getEntry(childQuery));
-            cacheAnswers.forEach(ans -> assertTrue(ans.explanation().isRuleExplanation()));
+            childAnswers.forEach(ans -> assertTrue(ans.explanation().isRuleExplanation()));
 
-            //fetch a different query, the child should have no parents in the cache so the answer needs to be fetched from the db
-            childQuery = ReasonerQueries.atomic(conjunction(
+            //fetch a different query, the query is structurally equivalent to the child query but
+            //should have no parents in the cache so the answer needs to be fetched from the db
+            ReasonerAtomicQuery anotherChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y) isa binary;" +
                             "$x id '" + id.getValue() + "';" +
@@ -216,12 +216,80 @@ public class QueryCacheIT {
                             "};",
                     tx), tx);
 
-            cacheAnswers = cache.getAnswers(childQuery);
-            assertTrue(!cacheAnswers.isEmpty());
-            assertEquals(tx.stream(childQuery.getQuery(), false).collect(toSet()), cacheAnswers);
+            Set<ConceptMap> anotherChildAnswers = cache.getAnswers(anotherChildQuery);
+            assertTrue(!anotherChildAnswers.isEmpty());
+            assertEquals(tx.stream(anotherChildQuery.getQuery(), false).collect(toSet()), anotherChildAnswers);
 
-            assertNull(cache.getEntry(childQuery));
-            cacheAnswers.forEach(ans -> assertTrue(ans.explanation().isLookupExplanation()));
+            anotherChildAnswers.forEach(ans -> assertTrue(ans.explanation().isLookupExplanation()));
+        }
+    }
+
+    @Test
+    public void whenGettingAndMatchDoesntExist_cachedParentAvailableButNotParentOfTheQuery_childQueriesAreNotEquivalent_answersFetchedFromDB(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
+            MultilevelSemanticCache cache = new MultilevelSemanticCache();
+
+            ConceptId fConcept = tx.getEntityType("subRoleEntity").instances().iterator().next().id();
+            ConceptId mConcept = tx.stream(Graql.<GraqlGet>parse("match $m isa subSubRoleEntity, has resource 'm';get;")).iterator().next().get("m").id();
+            ConceptId dConcept = tx.stream(Graql.<GraqlGet>parse("match $d isa subSubRoleEntity, has resource 'd';get;")).iterator().next().get("d").id();
+            ConceptId sConcept = tx.stream(Graql.<GraqlGet>parse("match $s isa subSubRoleEntity, has resource 's';get;")).iterator().next().get("s").id();
+
+            /*
+            (baseRole1: $b, subRole2: $f, subSubRole3: $m) isa ternary;
+(baseRole1: $f, subRole2: $f, subSubRole3: $m) isa ternary;
+
+(subRole1: $f, subRole2: $m, subSubRole3: $d) isa ternary;
+(subRole1: $f, subRole2: $f, subSubRole3: $d) isa ternary;
+
+(subRole1: $f, subSubRole2: $m, subSubRole3: $d) isa ternary;
+(subRole1: $m, subSubRole2: $m, subSubRole3: $d) isa ternary;
+
+(subSubRole1: $m, subSubRole2: $d, subSubRole3: $s) isa ternary;
+(subSubRole1: $m, subSubRole2: $m, subSubRole3: $s) isa ternary;
+             */
+
+            ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(
+                    "{" +
+                            "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
+                            "$z id '" + dConcept.getValue() + "';" +
+                            "};",
+                    tx), tx);
+
+            //record parent, mark the answers to be explained by a rule so that we can distinguish them
+            tx.execute(parentQuery.getQuery(), false).stream()
+                    .map(ans -> ans.explain(new LookupExplanation(parentQuery.getPattern())))
+                    .forEach(ans -> cache.record(parentQuery, ans));
+            cache.ackDBCompleteness(parentQuery);
+
+            //fetch a query that subsumes parent
+            ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
+                    "{" +
+                            "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
+                            "$x id '" + fConcept.getValue() + "';" +
+                            "$z id '" + dConcept.getValue() + "';" +
+                            "};",
+                    tx), tx);
+
+            Set<ConceptMap> childAnswers = cache.getAnswers(childQuery);
+            assertEquals(tx.stream(childQuery.getQuery(), false).collect(toSet()), childAnswers);
+
+            assertNotNull(cache.getEntry(childQuery));
+
+            //fetch a different query that is not structurally equivalent to the child query,
+            //consequently the query should have no parents in the cache so the answer needs to be fetched from the db
+            ReasonerAtomicQuery anotherChildQuery = ReasonerQueries.atomic(conjunction(
+                    "{" +
+                            "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
+                            "$x id '" + mConcept.getValue() + "';" +
+                            "$y id '" + mConcept.getValue() + "';" +
+                            "$z id '" + sConcept.getValue() + "';" +
+                            "};",
+                    tx), tx);
+
+            Set<ConceptMap> anotherChildAnswers = cache.getAnswers(anotherChildQuery);
+            assertTrue(!anotherChildAnswers.isEmpty());
+            assertEquals(tx.stream(anotherChildQuery.getQuery(), false).collect(toSet()), anotherChildAnswers);
+            assertNull(cache.getEntry(anotherChildQuery));
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix following scenarios:

- parent query has an entry in the cache which is optionally dbComplete
- we query for a child query that subsumes the parent
- we query for another query which:
   a) is structurally equivalent to the child query
   b) is similar structurally although not structurally equivalent to the child query

## What are the changes implemented in this PR?

Changes to cache behaviour ensuring correct treatment of above scenarios.
