### PR TITLE
Depend on benchmark lib via bazel git_repository

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,6 +29,9 @@ graknlabs_graql()
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_client_java")
 graknlabs_client_java()
 
+load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_benchmark")
+graknlabs_benchmark()
+
 load("//dependencies/graknlabs:dependencies.bzl", "graknlabs_build_tools")
 graknlabs_build_tools()
 
@@ -90,6 +93,14 @@ antlr_dependencies()
 load("@graknlabs_graql//dependencies/maven:dependencies.bzl",
 graknlabs_graql_maven_dependencies = "maven_dependencies")
 graknlabs_graql_maven_dependencies()
+
+
+###########################
+# Load Benchmark dependencies #
+###########################
+load("@graknlabs_benchmark//dependencies/maven:dependencies.bzl",
+graknlabs_benchmark_maven_dependencies = "maven_dependencies")
+graknlabs_benchmark_maven_dependencies()
 
 
 #######################################

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -32,6 +32,13 @@ def graknlabs_client_java():
          commit = "d9091e05e61a592752da5bc487af5ed2ba518695",
      )
 
+def graknlabs_benchmark():
+    git_repository(
+        name = "graknlabs_benchmark",
+        remote = "https://github.com/graknlabs/benchmark.git",
+        commit = "ceb5a2ebb71ee526d788fb4b17a104a6669d4b70" # do not sync - changes much less frequently than repository
+    )
+
 def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",

--- a/server/BUILD
+++ b/server/BUILD
@@ -41,9 +41,10 @@ java_library(
 
         # External dependencies from @graknlabs
         "@graknlabs_graql//java:graql",
+        "@graknlabs_benchmark//lib:server-instrumentation",
 
         # External dependencies from Maven
-        "//dependencies/maven/artifacts/grakn/benchmark:lib",
+
         "//dependencies/maven/artifacts/com/datastax/cassandra:cassandra-driver-core", # PREVIOUSLY UNDECLARED
         "//dependencies/maven/artifacts/com/google/auto/value:auto-value",
         "//dependencies/maven/artifacts/com/google/code/findbugs:annotations",

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -18,7 +18,7 @@
 
 package grakn.core.server;
 
-import grakn.benchmark.lib.serverinstrumentation.ServerTracingInstrumentation;
+import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.server.deduplicator.AttributeDeduplicatorDaemon;
@@ -90,7 +90,7 @@ public class ServerFactory {
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);
 
         if (benchmark) {
-            ServerTracingInstrumentation.initInstrumentation("server-instrumentation");
+            ServerTracing.initInstrumentation("server-instrumentation");
         }
 
         io.grpc.Server serverRPC = ServerBuilder.forPort(grpcPort)

--- a/server/src/server/rpc/SessionService.java
+++ b/server/src/server/rpc/SessionService.java
@@ -22,7 +22,7 @@ import brave.ScopedSpan;
 import brave.Span;
 import brave.propagation.TraceContext;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import grakn.benchmark.lib.serverinstrumentation.ServerTracingInstrumentation;
+import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.api.Transaction.Type;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
@@ -147,9 +147,9 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
         public void onNext(Transaction.Req request) {
             // !important: this is the gRPC thread
             try {
-                if (ServerTracingInstrumentation.tracingEnabledFromMessage(request)) {
-                    TraceContext receivedTraceContext = ServerTracingInstrumentation.extractTraceContext(request);
-                    Span queueSpan = ServerTracingInstrumentation.createChildSpanWithParentContext("Server receive queue", receivedTraceContext);
+                if (ServerTracing.tracingEnabledFromMessage(request)) {
+                    TraceContext receivedTraceContext = ServerTracing.extractTraceContext(request);
+                    Span queueSpan = ServerTracing.createChildSpanWithParentContext("Server receive queue", receivedTraceContext);
                     queueSpan.start();
                     queueSpan.tag("childNumber", "0");
 
@@ -180,7 +180,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             queueSpan.finish(); // time spent in queue
 
             // create a new scoped span
-            ScopedSpan span = ServerTracingInstrumentation.startScopedChildSpanWithParentContext("Server handle request", context);
+            ScopedSpan span = ServerTracing.startScopedChildSpanWithParentContext("Server handle request", context);
             span.tag("childNumber", "1");
             handleRequest(request);
         }
@@ -300,14 +300,14 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             /* permanent tracing hooks, as performance here varies depending on query and what's in the graph */
 
             ScopedSpan span = null;
-            if (ServerTracingInstrumentation.tracingActive()) {
-                span = ServerTracingInstrumentation.createScopedChildSpan("Parsing Graql Query");
+            if (ServerTracing.tracingActive()) {
+                span = ServerTracing.startScopedChildSpan("Parsing Graql Query");
             }
             GraqlQuery query = Graql.parse(request.getQuery());
 
             if (span != null) {
                 span.finish();
-                span = ServerTracingInstrumentation.createScopedChildSpan("Creating query stream");
+                span = ServerTracing.startScopedChildSpan("Creating query stream");
             }
 
             Stream<Transaction.Res> responseStream = tx().stream(query, request.getInfer().equals(Transaction.Query.INFER.TRUE)).map(ResponseBuilder.Transaction.Iter::query);
@@ -396,8 +396,8 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
         }
 
         private void onNextResponse(Transaction.Res response) {
-            if (ServerTracingInstrumentation.tracingActive()) {
-                ServerTracingInstrumentation.currentSpan().finish();
+            if (ServerTracing.tracingActive()) {
+                ServerTracing.currentSpan().finish();
             }
             responseSender.onNext(response);
         }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -19,7 +19,7 @@
 package grakn.core.server.session;
 
 import brave.ScopedSpan;
-import grakn.benchmark.lib.serverinstrumentation.ServerTracingInstrumentation;
+import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.api.Transaction;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.common.exception.ErrorMessage;
@@ -874,8 +874,8 @@ public class TransactionOLTP implements Transaction {
 
         /* This method has permanent tracing because commits can take varying lengths of time depending on operations */
         ScopedSpan span = null;
-        if (ServerTracingInstrumentation.tracingActive()) {
-            span = ServerTracingInstrumentation.createScopedChildSpan("commitWithLogs validate");
+        if (ServerTracing.tracingActive()) {
+            span = ServerTracing.startScopedChildSpan("commitWithLogs validate");
         }
 
         checkMutationAllowed();
@@ -887,7 +887,7 @@ public class TransactionOLTP implements Transaction {
 
         if (span != null) {
             span.finish();
-            span = ServerTracingInstrumentation.createScopedChildSpan("commitWithLogs commit");
+            span = ServerTracing.startScopedChildSpan("commitWithLogs commit");
         }
 
         // lock on the keyspace cache shared between concurrent tx's to the same keyspace
@@ -902,7 +902,7 @@ public class TransactionOLTP implements Transaction {
 
             if (span != null) {
                 span.finish();
-                span = ServerTracingInstrumentation.createScopedChildSpan("commitWithLogs create log");
+                span = ServerTracing.startScopedChildSpan("commitWithLogs create log");
             }
 
             Optional logs = Optional.of(CommitLog.create(keyspace(), newInstances, newAttributes));


### PR DESCRIPTION
## What is the goal of this PR?
Implement dependency on benchmark-lib (which provides Zipkin tracing functionality) via bazel and git repository rather than maven-snapshot pushed to our test repository.

## What are the changes implemented in this PR?
* Add a new github dependency `@graknlabs_benchmark`
* Slight syntax changes to server instrumentation tracing
