### PR TITLE
Refactor CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,21 +283,19 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-# TODO: revert
-#      - run: |
-#          bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
-#          --source grakn@$CIRCLE_SHA1 \
-#          --targets \
-#          client-java:master client-python:master client-nodejs:master \
-#          workbase:master docs:development examples:development
+      - run: |
+          bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
+          --source grakn@$CIRCLE_SHA1 \
+          --targets \
+          client-java:master client-python:master client-nodejs:master \
+          workbase:master docs:development examples:development
 
   release-approval:
     machine: true
     steps:
       - install-bazel-linux-rbe
       - checkout
-# TODO: revert
-#      - run: bazel run @graknlabs_build_tools//ci:release-approval
+      - run: bazel run @graknlabs_build_tools//ci:release-approval
 
   release-github-draft:
     machine: true
@@ -351,7 +349,7 @@ workflows:
       - test-assembly-mac-zip:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -364,7 +362,7 @@ workflows:
       - test-assembly-windows-zip:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -377,7 +375,7 @@ workflows:
       - test-assembly-linux-targz:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -390,7 +388,7 @@ workflows:
       - test-assembly-linux-apt:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -403,7 +401,7 @@ workflows:
       - test-assembly-linux-rpm:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -416,7 +414,7 @@ workflows:
       - test-assembly-docker:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - build
             - test-common
@@ -429,7 +427,7 @@ workflows:
       - deploy-maven-test:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -440,7 +438,7 @@ workflows:
       - deploy-apt-test:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -451,7 +449,7 @@ workflows:
       - deploy-rpm-test:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -462,19 +460,19 @@ workflows:
       - test-deployment-linux-apt:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - deploy-apt-test
       - test-deployment-linux-rpm:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - deploy-rpm-test
       - sync-dependencies:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - deploy-maven-test
             - test-deployment-linux-apt
@@ -482,7 +480,7 @@ workflows:
       - release-approval:
           filters:
             branches:
-              only: ci-fix-sync-dependency # TODO: revert
+              only: master
           requires:
             - sync-dependencies
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,19 +283,21 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: |
-          bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
-          --source grakn@$CIRCLE_SHA1 \
-          --targets \
-          client-java:master client-python:master client-nodejs:master \
-          workbase:master docs:development examples:development
+# TODO: revert
+#      - run: |
+#          bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
+#          --source grakn@$CIRCLE_SHA1 \
+#          --targets \
+#          client-java:master client-python:master client-nodejs:master \
+#          workbase:master docs:development examples:development
 
   release-approval:
     machine: true
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: bazel run @graknlabs_build_tools//ci:release-approval
+# TODO: revert
+#      - run: bazel run @graknlabs_build_tools//ci:release-approval
 
   release-github-draft:
     machine: true
@@ -349,7 +351,7 @@ workflows:
       - test-assembly-mac-zip:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -362,7 +364,7 @@ workflows:
       - test-assembly-windows-zip:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -375,7 +377,7 @@ workflows:
       - test-assembly-linux-targz:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -388,7 +390,7 @@ workflows:
       - test-assembly-linux-apt:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -401,7 +403,7 @@ workflows:
       - test-assembly-linux-rpm:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -414,7 +416,7 @@ workflows:
       - test-assembly-docker:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - build
             - test-common
@@ -427,7 +429,7 @@ workflows:
       - deploy-maven-test:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -438,7 +440,7 @@ workflows:
       - deploy-apt-test:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -449,7 +451,7 @@ workflows:
       - deploy-rpm-test:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -460,19 +462,19 @@ workflows:
       - test-deployment-linux-apt:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - deploy-apt-test
       - test-deployment-linux-rpm:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - deploy-rpm-test
       - sync-dependencies:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - deploy-maven-test
             - test-deployment-linux-apt
@@ -480,7 +482,7 @@ workflows:
       - release-approval:
           filters:
             branches:
-              only: master
+              only: ci-fix-sync-dependency # TODO: revert
           requires:
             - sync-dependencies
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,18 +122,6 @@ jobs:
       - run-bazel-rbe:
           command: bazel test //test-end-to-end:test-end-to-end --test_output=streamed --spawn_strategy=standalone
 
-  deploy-maven-test:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: echo $CIRCLE_SHA1
-      - run: bazel run //api:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
-      - run: bazel run //protocol:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
-      - run: bazel run //concept:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
-      - run: bazel run //common:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
-
   test-assembly-mac-zip:
     macos:
       xcode: "9.0"
@@ -174,42 +162,12 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: echo $(date +%s)-$(cat VERSION)-$CIRCLE_SHA1 > VERSION
-      - run: echo VERSION=$(cat VERSION)
-      - run: cat VERSION
       - run: bazel build //bin:assemble-linux-apt
       - run: bazel build //server:assemble-linux-apt
       - run: bazel build //console:assemble-linux-apt
       - run: sudo dpkg -i bazel-bin/bin/grakn-core-bin__all.deb
       - run: sudo dpkg -i bazel-bin/server/grakn-core-server__all.deb
       - run: sudo dpkg -i bazel-bin/console/grakn-core-console__all.deb
-      - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
-      - run: nohup grakn server start
-      - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
-      - run: grakn server stop
-      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //bin:deploy-apt
-      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //console:deploy-apt
-      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //server:deploy-apt
-      - run: cp VERSION VERSION.apt
-      - persist_to_workspace:
-          root: ~/grakn
-          paths:
-            - VERSION.apt
-
-  test-deployment-linux-apt:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - attach_workspace:
-          at: ~/circleci-workspace
-      - run: echo "deb [ arch=all ] https://repo.grakn.ai/repository/test-deb/ trusty main" | sudo tee -a /etc/apt/sources.list.d/grakn-core.list
-      - run: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
-      - run: sudo apt update
-      - run: mv ~/circleci-workspace/VERSION.apt VERSION
-      - run: cat VERSION
-      - run: sudo apt install grakn-core-server=$(cat VERSION) grakn-core-console=$(cat VERSION)
       - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
       - run: nohup grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
@@ -234,6 +192,82 @@ jobs:
           paths:
             - VERSION.rpm
 
+  test-assembly-docker:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: test/assembly/docker.py
+
+  deploy-maven-test:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: echo $CIRCLE_SHA1
+      - run: bazel run //api:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
+      - run: bazel run //protocol:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
+      - run: bazel run //concept:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
+      - run: bazel run //common:deploy-maven -- snapshot $CIRCLE_SHA1 $REPO_GRAKN_USERNAME $REPO_GRAKN_PASSWORD
+
+  deploy-apt-test:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: echo $(date +%s)-$(cat VERSION)-$CIRCLE_SHA1 > VERSION
+      - run: echo VERSION=$(cat VERSION)
+      - run: cat VERSION
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //bin:deploy-apt
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //console:deploy-apt
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //server:deploy-apt
+      - run: cp VERSION VERSION.apt
+      - persist_to_workspace:
+          root: ~/grakn
+          paths:
+            - VERSION.apt
+
+  deploy-rpm-test:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: sudo apt install rpm
+      - run: echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION
+      - run: sed -i -e 's/-/_/g' VERSION
+      - run: cat VERSION
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //bin:deploy-rpm
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //server:deploy-rpm
+      - run: DEPLOYMENT_REPO_TYPE=test DEPLOYMENT_USERNAME=$REPO_GRAKN_USERNAME DEPLOYMENT_PASSWORD=$REPO_GRAKN_PASSWORD bazel run //console:deploy-rpm
+      - run: cp VERSION VERSION.rpm
+      - persist_to_workspace:
+          root: ~/grakn
+          paths:
+            - VERSION.rpm
+
+  test-deployment-linux-apt:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - attach_workspace:
+          at: ~/circleci-workspace
+      - run: echo "deb [ arch=all ] https://repo.grakn.ai/repository/test-deb/ trusty main" | sudo tee -a /etc/apt/sources.list.d/grakn-core.list
+      - run: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
+      - run: sudo apt update
+      - run: mv ~/circleci-workspace/VERSION.apt VERSION
+      - run: cat VERSION
+      - run: sudo apt install grakn-core-server=$(cat VERSION) grakn-core-console=$(cat VERSION)
+      - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
+      - run: nohup grakn server start
+      - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
+      - run: grakn server stop
+
   test-deployment-linux-rpm:
     machine: true
     working_directory: ~/grakn
@@ -243,14 +277,6 @@ jobs:
           at: ~/circleci-workspace
       - run: mv ~/circleci-workspace/VERSION.rpm VERSION
       - run: test/deployment/rpm.py
-
-  test-assembly-docker:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: test/assembly/docker.py
 
   sync-dependencies:
     machine: true
@@ -320,47 +346,7 @@ workflows:
           filters:
             branches:
               ignore: grakn-core-release-branch
-      - deploy-maven-test:
-          filters:
-            branches:
-              only: master
       - test-assembly-mac-zip:
-          filters:
-            branches:
-              only: master
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only: master
-      - test-assembly-linux-targz:
-          filters:
-            branches:
-              only: master
-      - test-assembly-linux-apt:
-          filters:
-            branches:
-              only: master
-      - test-deployment-linux-apt:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-linux-apt
-      - test-assembly-linux-rpm:
-          filters:
-            branches:
-              only: master
-      - test-deployment-linux-rpm:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-linux-rpm
-      - test-assembly-docker:
-          filters:
-            branches:
-              only: master
-      - sync-dependencies:
           filters:
             branches:
               only: master
@@ -373,12 +359,124 @@ workflows:
             - test-integration-reasoner
             - test-integration-analytics
             - test-end-to-end
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-targz:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-apt:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-rpm:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-docker:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - deploy-maven-test:
+          filters:
+            branches:
+              only: master
+          requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
             - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-linux-rpm
+            - test-assembly-docker
+      - deploy-apt-test:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-linux-rpm
+            - test-assembly-docker
+      - deploy-rpm-test:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-linux-rpm
+            - test-assembly-docker
+      - test-deployment-linux-apt:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-apt-test
+      - test-deployment-linux-rpm:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-rpm-test
+      - sync-dependencies:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-maven-test
             - test-deployment-linux-apt
             - test-deployment-linux-rpm
-            - test-assembly-docker
       - release-approval:
           filters:
             branches:


### PR DESCRIPTION
## What is the goal of this PR?

Refactor CI pipeline such that :
1. test integrations are executed first
2. test assemblies are ran after only after test integrations have all passed
3. deploy-maven-test, deploy-rpm-test ,and deploy-apt-test are ran after only after test assemblies have all passed
4. test-deployments:
    - test-deployment-apt is ran after deploy-apt-test
    - test-deployment-rpm is ran after deploy-rpm-test
4. sync-dependencies is called after test-deployment-apt, test-deployment-rpm, and deploy-maven-test have all passed