### PR TITLE
Re-add grakn-core-specific deployment.properties file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["VERSION"], visibility = ["//visibility:public"])
+exports_files(["VERSION", "deployment.properties"], visibility = ["//visibility:public"])
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip", "checksum")
@@ -28,7 +28,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 deploy_github(
     name = "deploy-github-zip",
     target = ":assemble-mac-zip",
-    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+    deployment_properties = "//:deployment.properties",
     version_file = "//:VERSION"
 )
 

--- a/deployment.properties
+++ b/deployment.properties
@@ -1,0 +1,20 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+repo.github.organisation=graknlabs
+repo.github.repository=grakn


### PR DESCRIPTION
## What is the goal of this PR?

After removing relevant keys in graknlabs/build-tools#26, we need to restore `deploy_github` functionality for this repo

## What are the changes implemented in this PR?

Re-add `deployment.properties` to this repo