### PR TITLE
grakn-core-all RPM package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: sudo apt install rpm
-      - run: echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION && sed -i -e 's/-/_/g' VERSION && cat VERSION
+      - run: echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: |
           export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           bazel run //bin:deploy-rpm -- snapshot
           bazel run //server:deploy-rpm -- snapshot
           bazel run //console:deploy-rpm -- snapshot
-        # bazel run //:deploy-rpm -- snapshot  TODO: we need to deploy grakn-server-all for RPM
+          bazel run //:deploy-rpm -- snapshot
       - run: cp VERSION VERSION.rpm
       - persist_to_workspace:
           root: ~/grakn

--- a/BUILD
+++ b/BUILD
@@ -124,6 +124,19 @@ assemble_zip(
     visibility = ["//visibility:public"]
 )
 
+assemble_rpm(
+    name = "assemble-linux-rpm",
+    package_name = "grakn-core-all",
+    version_file = "//:VERSION",
+    spec_file = "//config/rpm:grakn-core-all.spec",
+)
+
+deploy_rpm(
+    name = "deploy-rpm",
+    target = ":assemble-linux-rpm",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+)
+
 container_image(
     name = "assemble-docker",
     base = "@openjdk_image//image",

--- a/config/rpm/BUILD
+++ b/config/rpm/BUILD
@@ -16,4 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["grakn-core-bin.spec", "grakn-core-console.spec", "grakn-core-server.spec"])
+exports_files(["grakn-core-bin.spec", "grakn-core-console.spec", "grakn-core-server.spec", "grakn-core-all.spec"])

--- a/config/rpm/grakn-core-all.spec
+++ b/config/rpm/grakn-core-all.spec
@@ -1,0 +1,22 @@
+Name: grakn-core-all
+Version: devel
+Release: 1
+Summary: Grakn Core (all)
+URL: https://grakn.ai
+License: Apache License, v2.0
+AutoReqProv: no
+
+Requires: grakn-core-server = %{version}
+Requires: grakn-core-console = %{version}
+
+%description
+Grakn Core (all) - virtual package which installs both Grakn Core Server and Grakn Core Console
+
+%prep
+
+%build
+
+%install
+
+%files
+

--- a/config/rpm/grakn-core-console.spec
+++ b/config/rpm/grakn-core-console.spec
@@ -9,7 +9,7 @@ AutoReqProv: no
 Source0: {_grakn-core-console-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
-Requires: grakn-core-bin
+Requires: grakn-core-bin = %{version}
 
 %description
 Grakn Core (server) - description

--- a/config/rpm/grakn-core-server.spec
+++ b/config/rpm/grakn-core-server.spec
@@ -9,7 +9,7 @@ AutoReqProv: no
 Source0: {_grakn-core-server-rpm-tar.tar.gz}
 
 Requires: java-1.8.0-openjdk-headless
-Requires: grakn-core-bin
+Requires: grakn-core-bin = %{version}
 
 %description
 Grakn Core (server) - description

--- a/test/deployment/rpm.py
+++ b/test/deployment/rpm.py
@@ -100,9 +100,7 @@ try:
     lprint('Installing RPM packages. Grakn will be available system-wide')
     gcloud_ssh(instance, 'sudo yum-config-manager --add-repo https://repo.grakn.ai/repository/meta/rpm-snapshot.repo')
     gcloud_ssh(instance, 'sudo yum -y update')
-    gcloud_ssh(instance, 'sudo yum -y install grakn-core-bin-$(cat VERSION)')
-    gcloud_ssh(instance, 'sudo yum -y install grakn-core-server-$(cat VERSION)')
-    gcloud_ssh(instance, 'sudo yum -y install grakn-core-console-$(cat VERSION)')
+    gcloud_ssh(instance, 'sudo yum -y install grakn-core-all-$(cat VERSION)')
 
     gcloud_ssh(instance, 'grakn server start')
     gcloud_ssh(instance, 'grakn server stop')


### PR DESCRIPTION
## What is the goal of this PR?

Adds `grakn-core-all` (`bazel build //:assemble-linux-rpm`) : virtual package to install both `server` and `console`

## What are the changes implemented in this PR?

- Adds `//:assemble-linux-rpm` and `//:deploy-rpm` targets
- Adds `.spec` file to build `grakn-core-all`
- Introduces exact version dependencies between `console`/`server` and `bin`
- Deploys and installs `grakn-core-all` on `test-deployment`