### PR TITLE
grakn-core-all DEB package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ jobs:
       - run: mv ~/circleci-workspace/VERSION.apt VERSION
       - run: cat VERSION
       - run: sudo apt install grakn-core-server=$(cat VERSION) grakn-core-console=$(cat VERSION)
-      # - run: sudo apt install grakn-core-all=$(cat VERSION)  TODO: we need to install grakn-core-all, which installs the rests
+      - run: sudo apt install grakn-core-all=$(cat VERSION)
       - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
       - run: nohup grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
@@ -308,6 +308,7 @@ jobs:
           bazel run //bin:deploy-apt -- release
           bazel run //console:deploy-apt -- release
           bazel run //server:deploy-apt -- release
+          bazel run //:deploy-apt -- release
 
   deploy-rpm:
     machine: true
@@ -323,6 +324,7 @@ jobs:
           bazel run //bin:deploy-rpm -- release
           bazel run //server:deploy-rpm -- release
           bazel run //console:deploy-rpm -- release
+          bazel run //:deploy-rpm -- release
 
   deploy-brew:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,6 @@ jobs:
       - run: sudo apt update
       - run: mv ~/circleci-workspace/VERSION.apt VERSION
       - run: cat VERSION
-      - run: sudo apt install grakn-core-server=$(cat VERSION) grakn-core-console=$(cat VERSION)
       - run: sudo apt install grakn-core-all=$(cat VERSION)
       - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
       - run: nohup grakn server start

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
           bazel run //bin:deploy-apt -- snapshot
           bazel run //console:deploy-apt -- snapshot
           bazel run //server:deploy-apt -- snapshot
-        # bazel run //:deploy-apt -- snapshot  TODO: we need to deploy grakn-server-all for APT
+          bazel run //:deploy-apt -- snapshot
       - run: cp VERSION VERSION.apt
       - persist_to_workspace:
           root: ~/grakn

--- a/BUILD
+++ b/BUILD
@@ -132,9 +132,29 @@ assemble_rpm(
     spec_file = "//config/rpm:grakn-core-all.spec",
 )
 
+
+assemble_apt(
+    name = "assemble-linux-apt",
+    package_name = "grakn-core-all",
+    maintainer = "Grakn Labs <community@grakn.ai>",
+    description = "Grakn Core (all)",
+    version_file = "//:VERSION",
+    depends = [
+        "openjdk-8-jre",
+        "grakn-core-server (={version})",
+        "grakn-core-console (={version})",
+    ],
+)
+
 deploy_rpm(
     name = "deploy-rpm",
     target = ":assemble-linux-rpm",
+    deployment_properties = "@graknlabs_build_tools//:deployment.properties",
+)
+
+deploy_apt(
+    name = "deploy-apt",
+    target = ":assemble-linux-apt",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",
 )
 

--- a/console/BUILD
+++ b/console/BUILD
@@ -156,7 +156,7 @@ assemble_apt(
     version_file = "//:VERSION",
     depends = [
       "openjdk-8-jre",
-      "grakn-core-bin"
+      "grakn-core-bin (={version})"
     ],
     files = {
         "//server:conf/logback.xml": "console/conf/logback.xml",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,14 +22,14 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         commit = "55de69e993c7ffce48454872a2834b62a64abd11",
+         commit = "cc9bafaf6c96ebdbbba250e6d9b30047b7849e46",
      )
 
 def graknlabs_client_java():
      git_repository(
          name = "graknlabs_client_java",
          remote = "https://github.com/graknlabs/client-java",
-         commit = "f03cfec0389005b02ad9f0097279eca7045d67dc",
+         commit = "c3a804326927519508d1fe2250aac79b5709db89",
      )
 
 def graknlabs_benchmark():

--- a/server/BUILD
+++ b/server/BUILD
@@ -207,7 +207,7 @@ assemble_apt(
     version_file = "//:VERSION",
     depends = [
       "openjdk-8-jre",
-      "grakn-core-bin"
+      "grakn-core-bin (={version})"
     ],
     archives = [":server-deps"],
     installation_dir = "/opt/grakn/core/",


### PR DESCRIPTION
## What is the goal of this PR?

Adds `grakn-core-all` (`bazel build //:assemble-linux-deb`) : virtual package to install both `server` and `console`

## What are the changes implemented in this PR?

- Adds `//:assemble-linux-deb` and `//:deploy-deb` targets
- Introduces exact version dependencies between `console`/`server` and `bin`
- Deploys and installs `grakn-core-all` on `test-deployment`
- Bump `@graknlabs_graql` and `@graknlabs_client_java`