### PR TITLE
container_push should take in file for tag

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -154,5 +154,5 @@ container_push(
     format = "Docker",
     registry = "index.docker.io",
     repository = "graknlabs/grakn-core",
-#    tag = "$(version)" # TODO: enable once we fixed the issue with having to always pass the variable during bazel build
+    tag_file = "//:VERSION"
 )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -43,5 +43,5 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "ddc4b277e977b833ea1b9cf4efc2682249b79f71", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "21d6b157337dfa626c567b2b6efc77620f056990", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )


### PR DESCRIPTION
## What is the goal of this PR?

Use same version file (`//:VERSION`) in `container_push`

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_build_tools` to include graknlabs/build-tools#32
- Use `tag_file` tag instead of `tag` in `container_push`