### PR TITLE
spilt console to not depend on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,7 @@ With the expressivity of the schema, inference through OLTP and distributed algo
 
 ## Download and Running Grakn Core
 
-To run Grakn Core (which you can download from the [Download Centre](https://grakn.ai/download) or [GitHub Releases](https://github.com/graknlabs/grakn/releases)), you need:
-1. Java 8 (OpenJDK or Oracle Java)
-2. If running on Windows version prior to 10, please make sure to have [Visual Studio C++ Runtime for Visual Studio 2015](https://www.microsoft.com/en-us/download/details.aspx?id=48145) installed
+To run Grakn Core (which you can download from the [Download Centre](https://grakn.ai/download) or [GitHub Releases](https://github.com/graknlabs/grakn/releases)), you need to have Java 8 (OpenJDK or Oracle Java) installed.
 
 You can visit the [Setup Guide](https://dev.grakn.ai/docs/running-grakn/install-and-run) to help your installation.
 
@@ -69,7 +67,7 @@ Outputs to: `bazel-genfiles/grakn-core-all-windows.zip`
 
 ## Contributions
 
-Grakn Core is built using various state-of-the-art open-source Graph and Distributed Computing frameworks: [ANTLR](http://www.antlr.org), [Apache Cassandra](http://cassandra.apache.org), [Apache Hadoop](https://hadoop.apache.org), [Apache Spark](http://spark.apache.org), [Apache TinkerPop](http://tinkerpop.apache.org), [Bazel](https://bazel.build), [GRPC](https://grpc.io), [JanusGraph](http://janusgraph.org), and [RocksDB](https://rocksdb.org). Thank you!
+Grakn Core is built using various state-of-the-art open-source Graph and Distributed Computing frameworks: [ANTLR](http://www.antlr.org), [Apache Cassandra](http://cassandra.apache.org), [Apache Hadoop](https://hadoop.apache.org), [Apache Spark](http://spark.apache.org), [Apache TinkerPop](http://tinkerpop.apache.org), [Bazel](https://bazel.build), [GRPC](https://grpc.io) and [JanusGraph](http://janusgraph.org). Thank you!
 
 ## Licensing
 

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -33,6 +33,7 @@ java_library(
 
         # External dependencies from Maven
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
+        "//dependencies/maven/artifacts/com/google/code/findbugs:annotations",
     ],
     tags = ["maven_coordinates=io.grakn.core:concept:{pom_version}"],
 )

--- a/concept/printer/Printer.java
+++ b/concept/printer/Printer.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package grakn.core.graql.printer;
+package grakn.core.concept.printer;
 
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.AnswerGroup;

--- a/concept/printer/StringPrinter.java
+++ b/concept/printer/StringPrinter.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package grakn.core.graql.printer;
+package grakn.core.concept.printer;
 
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;

--- a/console/BUILD
+++ b/console/BUILD
@@ -30,13 +30,12 @@ java_library(
     deps = [
         # Grakn Core dependencies
         "//common:common",
+        "//concept",
         "@graknlabs_client_java//:client-java",
         "@graknlabs_graql//java:graql",
-        "//server:server", # NEEDS TO GO
+
 
         # External dependencies
-        "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",
-        "//dependencies/maven/artifacts/ch/qos/logback:logback-core",
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/commons-cli",
         "//dependencies/maven/artifacts/commons-lang:commons-lang", # PREVOIUSLY UNDECLARED

--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -22,7 +22,7 @@ import com.google.common.base.StandardSystemProperty;
 import grakn.client.GraknClient;
 import grakn.core.common.exception.GraknException;
 import grakn.core.console.exception.GraknConsoleException;
-import grakn.core.graql.printer.Printer;
+import grakn.core.concept.printer.Printer;
 import graql.lang.Graql;
 import graql.lang.query.GraqlQuery;
 import jline.console.ConsoleReader;

--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -50,7 +50,7 @@ public class ConsoleSession implements AutoCloseable {
 
     private static final String COPYRIGHT = "\n" +
             "Welcome to Grakn Console. You are now in Grakn Wonderland!\n" +
-            "Copyright (C) 2018 Grakn Labs Limited\n\n";
+            "Copyright (C) 2019 Grakn Labs Limited\n\n";
 
     private static final String EDITOR = "editor";
     private static final String COMMIT = "commit";

--- a/console/GraknConsole.java
+++ b/console/GraknConsole.java
@@ -18,8 +18,6 @@
 
 package grakn.core.console;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import grakn.client.GraknClient;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
@@ -31,7 +29,6 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
-import org.slf4j.LoggerFactory;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -136,10 +133,6 @@ public class GraknConsole {
      * Invocation from bash script './grakn console'
      */
     public static void main(String[] args) {
-        // Disable logging for Grakn console as we only use System.out
-        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
-        root.setLevel(Level.OFF);
-
         try {
             GraknConsole console = new GraknConsole(Arrays.copyOfRange(args, 1, args.length), System.out, System.err);
             console.run();

--- a/server/src/graql/gremlin/fragment/Fragments.java
+++ b/server/src/graql/gremlin/fragment/Fragments.java
@@ -24,7 +24,7 @@ import grakn.core.concept.ConceptId;
 import grakn.core.concept.Label;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.graql.executor.property.ValueExecutor;
-import grakn.core.graql.printer.StringPrinter;
+import grakn.core.concept.printer.StringPrinter;
 import grakn.core.server.kb.Schema;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;

--- a/server/src/graql/gremlin/fragment/IdFragment.java
+++ b/server/src/graql/gremlin/fragment/IdFragment.java
@@ -33,7 +33,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import java.util.Collection;
 import java.util.Map;
 
-import static grakn.core.graql.printer.StringPrinter.conceptId;
+import static grakn.core.concept.printer.StringPrinter.conceptId;
 
 @AutoValue
 abstract class IdFragment extends Fragment {

--- a/server/src/graql/gremlin/fragment/LabelFragment.java
+++ b/server/src/graql/gremlin/fragment/LabelFragment.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import grakn.core.concept.Label;
 import grakn.core.concept.type.SchemaConcept;
-import grakn.core.graql.printer.StringPrinter;
+import grakn.core.concept.printer.StringPrinter;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -24,7 +24,6 @@ import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.graql.graph.MovieGraph;
-import grakn.core.graql.printer.Printer;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;


### PR DESCRIPTION
## What is the goal of this PR?

Reduce the size of the final `zip` and `tar.gz` from 320MB to 180MB

Closes https://github.com/graknlabs/grakn/issues/5077

## What are the changes implemented in this PR?

Move concept printer in the `concept` module so that `console` does not depend on `server` anymore.
Also removed unused dependency on `logback` in `console` given that we print everything to standard output and we're not logging anything.
