### PR TITLE
Added the ability to add 'Java Options' to Console, Daemon, and Storage

### DIFF
--- a/bin/grakn
+++ b/bin/grakn
@@ -57,7 +57,7 @@ elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/conf/"
-        java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" grakn.core.console.GraknConsole "$@"
+        java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" grakn.core.console.GraknConsole "$@"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."
@@ -66,7 +66,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
         SERVICE_LIB_CP="server/services/lib/*"
         CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/conf/"
-        java -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.daemon.GraknDaemon $@
+        java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.daemon.GraknDaemon $@
     else
         echo "Grakn Core Server is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Server or Grakn Core (all)."


### PR DESCRIPTION
## What is the goal of this PR?
Right now there's only SERVER_JAVAOPTS. Being able to supply Java options to Console, the Daemon (bootup) process, and Storage will be quite useful, especially for attaching remote debuggers.

This PR adds those functionalities via these environment variables: CONSOLE_JAVAOPTS, GRAKN_DAEMON_JAVAOPTS and STORAGE_JAVAOPTS.

Usage examples:
```
env CONSOLE_JAVAOPTS="-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" ./grakn console
```
```
env GRAKN_DAEMON_JAVAOPTS="-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" ./grakn server start
```
```
env STORAGE_JAVAOPTS="-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005" ./grakn server start
```

## What are the changes implemented in this PR?
Added CONSOLE_JAVAOPTS, GRAKN_DAEMON_JAVAOPTS and STORAGE_JAVAOPTS to the `grakn` script.