### PR TITLE
Query planner refactor 2

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -18,7 +18,6 @@
 
 package grakn.core.graql.executor;
 
-import brave.ScopedSpan;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;

--- a/server/src/graql/gremlin/ArborescenceToPlan.java
+++ b/server/src/graql/gremlin/ArborescenceToPlan.java
@@ -17,7 +17,7 @@ import java.util.Set;
 
 import static grakn.core.graql.gremlin.NodesUtil.nodeToPlanFragments;
 
-public class GreedyTreeToPlan {
+public class ArborescenceToPlan {
 
     // standard tree traversal from the root node
     // always visit the branch/node with smaller cost

--- a/server/src/graql/gremlin/ArborescenceToPlan.java
+++ b/server/src/graql/gremlin/ArborescenceToPlan.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.gremlin;
 
 import com.google.common.collect.Sets;

--- a/server/src/graql/gremlin/GreedyTraversalPlan.java
+++ b/server/src/graql/gremlin/GreedyTraversalPlan.java
@@ -18,10 +18,8 @@
 
 package grakn.core.graql.gremlin;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
-import grakn.core.concept.type.Type;
 import grakn.core.graql.gremlin.fragment.Fragment;
 import grakn.core.graql.gremlin.fragment.InIsaFragment;
 import grakn.core.graql.gremlin.fragment.InSubFragment;
@@ -97,7 +95,7 @@ public class GreedyTraversalPlan {
         final Set<Fragment> allFragments = query.getEquivalentFragmentSets().stream()
                 .flatMap(EquivalentFragmentSet::stream).collect(Collectors.toSet());
 
-        // if role p[ayers' types are known, we can infer the types of the relation, adding label fragments
+        // if role players' types are known, we can infer the types of the relation, adding label fragments
         Set<Fragment> inferredFragments = inferRelationTypes(tx, allFragments);
         allFragments.addAll(inferredFragments);
 
@@ -197,7 +195,7 @@ public class GreedyTraversalPlan {
         // TODO extract this out of the Node objects themselves
         allFragments.forEach(fragment -> {
             if (fragment.end() == null && fragment.dependencies().isEmpty()) {
-                // process fragments that are have fixed cost
+                // process fragments that have fixed cost
                 Node start = allNodes.get(NodeId.of(NodeId.NodeType.VAR, fragment.start()));
                 //fragments that should be done when a node has been visited
                 start.getFragmentsWithoutDependency().add(fragment);

--- a/server/src/graql/gremlin/GreedyTraversalPlan.java
+++ b/server/src/graql/gremlin/GreedyTraversalPlan.java
@@ -107,109 +107,118 @@ public class GreedyTraversalPlan {
         // these are valid conjunctions
         Collection<Set<Fragment>> connectedFragmentSets = getConnectedFragmentSets(allFragments);
 
-//        for (Set<Fragment> connectedFragments : connectedFragmentSets) {
-//
-//            Map<NodeId, Node> nodes = new HashMap<>();
-//            Set<Node> connectedNodes = new HashSet<>();
-//            Map<Node, Map<Node, Fragment>> edges = new HashMap<>();
-//            for (Fragment fragment : connectedFragments) {
-//                Set<Node> fragmentNodes = fragment.getNodes();
-//                fragmentNodes.forEach(node -> nodes.put(node.getNodeId(), node));
-//                connectedNodes.addAll(fragmentNodes);
-//            }
-//            for (Fragment fragment: connectedFragments) {
-//                Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(nodes);
-//                if (middleNodeDirectedEdge != null) {
-//                    edges.putIfAbsent(middleNodeDirectedEdge.getKey(), new HashMap<>());
-//                    edges.get(middleNodeDirectedEdge.getKey()).put(middleNodeDirectedEdge.getValue(), fragment);
-//                }
-//            }
-//
-//            Arborescence<Node> subgraphArborescence = computeArborescence(connectedFragments, nodes);
-//            if (subgraphArborescence != null) {
-//                List<Fragment> subplan = greedyTraversal(subgraphArborescence, nodes, edges);
-//                plan.addAll(subplan);
-//            }
-//            List<Fragment> subplan = addUnvisitedNodeFragments(nodes, connectedNodes);
-//            plan.addAll(subplan);
-//        }
+        Map<NodeId, Node> allNodes = new HashMap<>();
+
+        // build a query plan for each query subgraph (connected fragment set) separately
+        for (Set<Fragment> connectedFragments : connectedFragmentSets) {
+
+            // collect all nodes
+            Map<NodeId, Node> nodes = new HashMap<>();
+            for (Fragment fragment : connectedFragments) {
+                Set<Node> fragmentNodes = fragment.getNodes();
+                fragmentNodes.forEach(node -> nodes.put(node.getNodeId(), node));
+                fragmentNodes.forEach(node -> allNodes.put(node.getNodeId(), node));
+            }
+
+            // collect the mapping from directed bedge back to fragments -- inverse operation of creating virtual middle nodes
+            Map<Node, Map<Node, Fragment>> middleNodeFragmentMapping = new HashMap<>();
+            for (Fragment fragment: connectedFragments) {
+                Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(nodes);
+                if (middleNodeDirectedEdge != null) {
+                    middleNodeFragmentMapping.putIfAbsent(middleNodeDirectedEdge.getKey(), new HashMap<>());
+                    middleNodeFragmentMapping.get(middleNodeDirectedEdge.getKey()).put(middleNodeDirectedEdge.getValue(), fragment);
+                }
+            }
+
+            // compute a minimum spanning tree, if we can
+            Arborescence<Node> subgraphArborescence = computeArborescence(connectedFragments, nodes);
+            // if we have a valid tree, perform the greedy traversal
+            if (subgraphArborescence != null) {
+                List<Fragment> subplan = greedyTraversal(subgraphArborescence, nodes, middleNodeFragmentMapping);
+                plan.addAll(subplan);
+            }
+            // add the unvisited node fragments
+            List<Fragment> subplan = addUnvisitedNodeFragments(nodes, nodes.values());
+            plan.addAll(subplan);
+        }
+        plan.addAll(addUnvisitedNodeFragments(allNodes, allNodes.values()));
 
 
         // initialise all the nodes for the spanning tree
-        final Map<NodeId, Node> allNodes = new HashMap<>();
-        final Map<Node, Double> nodesWithFixedCost = new HashMap<>();
-        final Set<Node> connectedNodes = new HashSet<>();
-
-        for (Fragment fragment : allFragments) {
-            Set<Node> nodes = fragment.getNodes();
-            nodes.forEach(node -> allNodes.put(node.getNodeId(), node));
-            connectedNodes.addAll(nodes);
-            if (fragment.hasFixedFragmentCost()) {
-// add indexed, fast operations to the plan immediately TODO figure out if this is the right call
-// plan.add(fragment);
-                // a single indexed node (eg. label, value etc.) therefore cannot be an edge, so must correspond to a single node
-                Node startNode = Iterators.getOnlyElement(nodes.iterator());
-                nodesWithFixedCost.put(startNode, getLogInstanceCount(tx, fragment));
-                startNode.setFixedFragmentCost(fragment.fragmentCost());
-            }
-        }
-
-        buildDependenciesBetweenNodes(allFragments, allNodes);
-
-        // process sub fragments here as we probably need to break the query tree
-        updateSubsReachableByIndex(allNodes, nodesWithFixedCost, allFragments);
+//        final Map<NodeId, Node> allNodes = new HashMap<>();
+//        final Map<Node, Double> nodesWithFixedCost = new HashMap<>();
+//        final Set<Node> connectedNodes = new HashSet<>();
+//
+//        for (Fragment fragment : allFragments) {
+//            Set<Node> nodes = fragment.getNodes();
+//            nodes.forEach(node -> allNodes.put(node.getNodeId(), node));
+//            connectedNodes.addAll(nodes);
+//            if (fragment.hasFixedFragmentCost()) {
+//// add indexed, fast operations to the plan immediately TODO figure out if this is the right call
+//// plan.add(fragment);
+//                // a single indexed node (eg. label, value etc.) therefore cannot be an edge, so must correspond to a single node
+//                Node startNode = Iterators.getOnlyElement(nodes.iterator());
+//                nodesWithFixedCost.put(startNode, getLogInstanceCount(tx, fragment));
+//                startNode.setFixedFragmentCost(fragment.fragmentCost());
+//            }
+//        }
+//
+//        buildDependenciesBetweenNodes(allFragments, allNodes);
+//
+//        // process sub fragments here as we probably need to break the query tree
+//        updateSubsReachableByIndex(allNodes, nodesWithFixedCost, allFragments);
 
 
         // generate plan for each connected set of fragments
         // since each set is independent, order of the set doesn't matter
-        connectedFragmentSets.forEach(fragmentSet -> {
-
-            // from a start Node to an end Node, the Fragment that corresponds to that traversal step, these are directed
-            // later we use the direction to find corresponding Fragments
-            final Map<Node, Map<Node, Fragment>> edges = new HashMap<>();
-            fragmentSet.forEach(fragment -> {
-                Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(allNodes);
-                if (middleNodeDirectedEdge != null) {
-                    edges.putIfAbsent(middleNodeDirectedEdge.getKey(), new HashMap<>());
-                    edges.get(middleNodeDirectedEdge.getKey()).put(middleNodeDirectedEdge.getValue(), fragment);
-                }
-            });
+//        connectedFragmentSets.forEach(fragmentSet -> {
+//
+//            // from a start Node to an end Node, the Fragment that corresponds to that traversal step, these are directed
+//            // later we use the direction to find corresponding Fragments
+//            final Map<Node, Map<Node, Fragment>> edges = new HashMap<>();
+//            fragmentSet.forEach(fragment -> {
+//                Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(allNodes);
+//                if (middleNodeDirectedEdge != null) {
+//                    edges.putIfAbsent(middleNodeDirectedEdge.getKey(), new HashMap<>());
+//                    edges.get(middleNodeDirectedEdge.getKey()).put(middleNodeDirectedEdge.getValue(), fragment);
+//                }
+//            });
 
             // fragments that represent Janus edges
-            final Set<Fragment> edgeFragmentSet = new HashSet<>();
-
-            // save the fragments corresponding to edges, and updates some costs if we can via shard count
-            for (Fragment fragment : fragmentSet) {
-                if (fragment.end() != null) {
-                    edgeFragmentSet.add(fragment);
-                    updateFragmentCost(allNodes, nodesWithFixedCost, fragment);
-                }
-            }
-
-            // convert fragments to a connected graph
-            Set<Weighted<DirectedEdge>> weightedGraph = buildWeightedGraph(allNodes, edgeFragmentSet);
-
-            if (!weightedGraph.isEmpty()) {
-                // sparse graph for better performance
-                SparseWeightedGraph sparseWeightedGraph = SparseWeightedGraph.from(weightedGraph);
-                Set<Node> startingNodes = chooseStartingNodes(fragmentSet, allNodes, sparseWeightedGraph);
-
-                // find the minimum spanning tree for each root
-                // then get the tree with minimum weight
-                Arborescence<Node> arborescence = startingNodes.stream()
-                        .map(node -> ChuLiuEdmonds.getMaxArborescence(sparseWeightedGraph, node))
-                        .max(Comparator.comparingDouble(tree -> tree.weight))
-                        .map(arborescenceInside -> arborescenceInside.val).orElse(Arborescence.empty());
-                List<Fragment> subplan = greedyTraversal(arborescence, allNodes, edges);
-                plan.addAll(subplan);
-            }
-            List<Fragment> subplan = addUnvisitedNodeFragments(allNodes, connectedNodes);
-            plan.addAll(subplan);
-        });
+//            final Set<Fragment> edgeFragmentSet = new HashSet<>();
+//
+//            // save the fragments corresponding to edges, and updates some costs if we can via shard count
+//            for (Fragment fragment : fragmentSet) {
+//                if (fragment.end() != null) {
+//                    edgeFragmentSet.add(fragment);
+//                    updateFragmentCost(allNodes, nodesWithFixedCost, fragment);
+//                }
+//            }
+//
+//            // convert fragments to a connected graph
+//            Set<Weighted<DirectedEdge>> weightedGraph = buildWeightedGraph(allNodes, edgeFragmentSet);
+//
+//            if (!weightedGraph.isEmpty()) {
+//                // sparse graph for better performance
+//                SparseWeightedGraph sparseWeightedGraph = SparseWeightedGraph.from(weightedGraph);
+//                Set<Node> startingNodes = chooseStartingNodes(fragmentSet, allNodes, sparseWeightedGraph);
+//
+//                // find the minimum spanning tree for each root
+//                // then get the tree with minimum weight
+//                Arborescence<Node> arborescence = startingNodes.stream()
+//                        .map(node -> ChuLiuEdmonds.getMaxArborescence(sparseWeightedGraph, node))
+//                        .max(Comparator.comparingDouble(tree -> tree.weight))
+//                        .map(arborescenceInside -> arborescenceInside.val).orElse(Arborescence.empty());
+//                List<Fragment> subplan = greedyTraversal(arborescence, allNodes, edges);
+//                plan.addAll(subplan);
+//            }
+//            List<Fragment> subplan = addUnvisitedNodeFragments(allNodes, connectedNodes);
+//            plan.addAll(subplan);
+//        });
 
         // add disconnected fragment set with no edge fragment
-        List<Fragment> subplan = addUnvisitedNodeFragments(allNodes, allNodes.values());
-        plan.addAll(subplan);
+//        List<Fragment> subplan = addUnvisitedNodeFragments(allNodes, allNodes.values());
+//        plan.addAll(subplan);
         LOG.trace("Greedy Plan = {}", plan);
         return plan;
     }

--- a/server/src/graql/gremlin/GreedyTreeToPlan.java
+++ b/server/src/graql/gremlin/GreedyTreeToPlan.java
@@ -1,0 +1,124 @@
+package grakn.core.graql.gremlin;
+
+import com.google.common.collect.Sets;
+import grakn.core.graql.gremlin.fragment.Fragment;
+import grakn.core.graql.gremlin.spanningtree.Arborescence;
+import grakn.core.graql.gremlin.spanningtree.graph.Node;
+import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
+
+import javax.annotation.Nullable;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static grakn.core.graql.gremlin.NodesUtil.nodeToPlanFragments;
+
+public class GreedyTreeToPlan {
+
+    // standard tree traversal from the root node
+    // always visit the branch/node with smaller cost
+    static List<Fragment> greedyTraversal(Arborescence<Node> arborescence,
+                                                  Map<NodeId, Node> nodes,
+                                                  Map<Node, Map<Node, Fragment>> edgeFragmentChildToParent) {
+
+        List<Fragment> plan = new LinkedList<>();
+
+        Map<Node, Set<Node>> edgesParentToChild = new HashMap<>();
+        arborescence.getParents().forEach((child, parent) -> {
+            if (!edgesParentToChild.containsKey(parent)) {
+                edgesParentToChild.put(parent, new HashSet<>());
+            }
+            edgesParentToChild.get(parent).add(child);
+        });
+
+        Node root = arborescence.getRoot();
+
+        Set<Node> reachableNodes = Sets.newHashSet(root);
+        // expanding from the root until all nodes have been visited
+        while (!reachableNodes.isEmpty()) {
+
+            Node nodeWithMinCost = reachableNodes.stream().min(Comparator.comparingDouble(node ->
+                    branchWeight(node, arborescence, edgesParentToChild, edgeFragmentChildToParent))).orElse(null);
+
+            assert nodeWithMinCost != null : "reachableNodes is never empty, so there is always a minimum";
+
+            // add edge fragment first, then node fragments
+            Fragment fragment = getEdgeFragment(nodeWithMinCost, arborescence, edgeFragmentChildToParent);
+            if (fragment != null) plan.add(fragment);
+
+            plan.addAll(nodeToPlanFragments(nodeWithMinCost, nodes, true));
+
+            reachableNodes.remove(nodeWithMinCost);
+            if (edgesParentToChild.containsKey(nodeWithMinCost)) {
+                reachableNodes.addAll(edgesParentToChild.get(nodeWithMinCost));
+            }
+        }
+
+        return plan;
+    }
+
+    // recursively compute the weight of a branch
+    private static double branchWeight(Node node, Arborescence<Node> arborescence,
+                                       Map<Node, Set<Node>> edgesParentToChild,
+                                       Map<Node, Map<Node, Fragment>> edgeFragmentChildToParent) {
+
+        Double nodeWeight = node.getNodeWeight();
+
+        if (nodeWeight == null) {
+            nodeWeight = getEdgeFragmentCost(node, arborescence, edgeFragmentChildToParent) + nodeFragmentWeight(node);
+            node.setNodeWeight(nodeWeight);
+        }
+
+        Double branchWeight = node.getBranchWeight();
+
+        if (branchWeight == null) {
+            final double[] weight = {nodeWeight};
+            if (edgesParentToChild.containsKey(node)) {
+                edgesParentToChild.get(node).forEach(child ->
+                        weight[0] += branchWeight(child, arborescence, edgesParentToChild, edgeFragmentChildToParent));
+            }
+            branchWeight = weight[0];
+            node.setBranchWeight(branchWeight);
+        }
+
+        return branchWeight;
+    }
+
+    // compute the total cost of a node
+    private static double nodeFragmentWeight(Node node) {
+        double costFragmentsWithoutDependency = node.getFragmentsWithoutDependency().stream()
+                .mapToDouble(Fragment::fragmentCost).sum();
+        double costFragmentsWithDependencyVisited = node.getFragmentsWithDependencyVisited().stream()
+                .mapToDouble(Fragment::fragmentCost).sum();
+        double costFragmentsWithDependency = node.getFragmentsWithDependency().stream()
+                .mapToDouble(Fragment::fragmentCost).sum();
+        return costFragmentsWithoutDependency + node.getFixedFragmentCost() +
+                (costFragmentsWithDependencyVisited + costFragmentsWithDependency) / 2D;
+    }
+
+    // get edge fragment cost in order to map branch cost
+    private static double getEdgeFragmentCost(Node node, Arborescence<Node> arborescence,
+                                              Map<Node, Map<Node, Fragment>> edgeToFragment) {
+
+        Fragment fragment = getEdgeFragment(node, arborescence, edgeToFragment);
+        if (fragment != null) return fragment.fragmentCost();
+
+        return 0D;
+    }
+
+    @Nullable
+    private static Fragment getEdgeFragment(Node node, Arborescence<Node> arborescence,
+                                            Map<Node, Map<Node, Fragment>> edgeToFragment) {
+        if (edgeToFragment.containsKey(node) &&
+                edgeToFragment.get(node).containsKey(arborescence.getParents().get(node))) {
+            return edgeToFragment.get(node).get(arborescence.getParents().get(node));
+        }
+        return null;
+    }
+
+
+}

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.graql.gremlin;
 
 import com.google.common.collect.ImmutableMap;

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -1,0 +1,112 @@
+package grakn.core.graql.gremlin;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import grakn.core.graql.gremlin.fragment.Fragment;
+import grakn.core.graql.gremlin.fragment.ValueFragment;
+import grakn.core.graql.gremlin.spanningtree.graph.Node;
+import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
+import grakn.core.graql.reasoner.utils.Pair;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class NodesUtil {
+
+    static Map<Node, Map<Node, Fragment>> virtualMiddleNodeToFragmentMapping(Set<Fragment> connectedFragments, Map<NodeId, Node> nodes) {
+        Map<Node, Map<Node, Fragment>> middleNodeFragmentMapping = new HashMap<>();
+        for (Fragment fragment : connectedFragments) {
+            Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(nodes);
+            if (middleNodeDirectedEdge != null) {
+                middleNodeFragmentMapping.putIfAbsent(middleNodeDirectedEdge.getKey(), new HashMap<>());
+                middleNodeFragmentMapping.get(middleNodeDirectedEdge.getKey()).put(middleNodeDirectedEdge.getValue(), fragment);
+            }
+        }
+        return middleNodeFragmentMapping;
+
+    }
+
+    static ImmutableMap<NodeId, Node> buildNodesWithDependencies(Set<Fragment> fragments) {
+        // TODO handling building the dependencies in each connected subgraph doesn't work, because dependencies can step across disconnected fragment sets
+        ImmutableMap.Builder<NodeId, Node> nodeBuilder = ImmutableMap.builder();
+
+        fragments.forEach(fragment ->
+                fragment.getNodes().forEach(node -> nodeBuilder.put(node.getNodeId(), node))
+        );
+
+        ImmutableMap<NodeId, Node> nodes = nodeBuilder.build();
+
+        // build the dependencies between nodes for use between disconnected fragment sets too
+        buildDependenciesBetweenNodes(fragments, nodes);
+        return nodes;
+    }
+
+    private static void buildDependenciesBetweenNodes(Set<Fragment> allFragments, Map<NodeId, Node> allNodes) {
+        // build dependencies between nodes
+        // TODO extract this out of the Node objects themselves, if we want to keep at all
+        allFragments.forEach(fragment -> {
+            if (fragment.end() == null && fragment.dependencies().isEmpty()) {
+                // process fragments that have fixed cost
+                Node start = allNodes.get(NodeId.of(NodeId.NodeType.VAR, fragment.start()));
+                //fragments that should be done when a node has been visited
+                start.getFragmentsWithoutDependency().add(fragment);
+            }
+            if (!fragment.dependencies().isEmpty()) {
+                // process fragments that have ordering dependencies
+
+                // it's either neq or value fragment
+                Node start = allNodes.get(NodeId.of(NodeId.NodeType.VAR, fragment.start()));
+                Node other = allNodes.get(NodeId.of(NodeId.NodeType.VAR, Iterators.getOnlyElement(fragment.dependencies().iterator())));
+
+                start.getFragmentsWithDependency().add(fragment);
+                other.getDependants().add(fragment);
+
+                // check whether it's value fragment
+                if (fragment instanceof ValueFragment) {
+                    // as value fragment is not symmetric, we need to add it again
+                    other.getFragmentsWithDependency().add(fragment);
+                    start.getDependants().add(fragment);
+                }
+            }
+        });
+    }
+
+    // adding a node's fragments to plan, updating dependants' dependency map
+    static List<Fragment> nodeToPlanFragments(Node node, Map<NodeId, Node> nodes, boolean visited) {
+        List<Fragment> subplan = new LinkedList<>();
+        if (!visited) {
+            node.getFragmentsWithoutDependency().stream()
+                    .min(Comparator.comparingDouble(Fragment::fragmentCost))
+                    .ifPresent(firstNodeFragment -> {
+                        subplan.add(firstNodeFragment);
+                        node.getFragmentsWithoutDependency().remove(firstNodeFragment);
+                    });
+        }
+        node.getFragmentsWithoutDependency().addAll(node.getFragmentsWithDependencyVisited());
+        subplan.addAll(node.getFragmentsWithoutDependency().stream()
+                .sorted(Comparator.comparingDouble(Fragment::fragmentCost))
+                .collect(Collectors.toList()));
+
+        node.getFragmentsWithoutDependency().clear();
+        node.getFragmentsWithDependencyVisited().clear();
+
+        // telling their dependants that they have been visited
+        node.getDependants().forEach(fragment -> {
+            Node otherNode = nodes.get(NodeId.of(NodeId.NodeType.VAR, fragment.start()));
+            if (node.equals(otherNode)) {
+                otherNode = nodes.get(NodeId.of(NodeId.NodeType.VAR, fragment.dependencies().iterator().next()));
+            }
+            otherNode.getDependants().remove(fragment.getInverse());
+            otherNode.getFragmentsWithDependencyVisited().add(fragment);
+
+        });
+        node.getDependants().clear();
+
+        return subplan;
+    }
+}

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -76,7 +76,7 @@ public class NodesUtil {
         });
     }
 
-    // adding a node's fragments to plan, updating dependants' dependency map
+    // convert a Node to a sub-plan, updating dependants' dependency map
     static List<Fragment> nodeToPlanFragments(Node node, Map<NodeId, Node> nodes, boolean visited) {
         List<Fragment> subplan = new LinkedList<>();
         if (!visited) {

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -32,16 +32,19 @@ public class NodesUtil {
     }
 
     static ImmutableMap<NodeId, Node> buildNodesWithDependencies(Set<Fragment> fragments) {
-        // TODO handling building the dependencies in each connected subgraph doesn't work, because dependencies can step across disconnected fragment sets
-        Map<NodeId, Node> nodes = new HashMap<>();
+        // NOTE handling building the dependencies in each connected subgraph doesn't work,
+        //  because dependencies can step across disconnected fragment sets, eg  `$x; $y; $x == $y`
 
+        // build in a map using a map to squash duplicates
+        Map<NodeId, Node> nodes = new HashMap<>();
         fragments.forEach(fragment ->
                 fragment.getNodes().forEach(node -> nodes.put(node.getNodeId(), node))
         );
 
+        // convert to immutable map
         ImmutableMap<NodeId, Node> immutableNodes = ImmutableMap.copyOf(nodes);
 
-        // build the dependencies between nodes for use between disconnected fragment sets too
+        // build the dependencies between nodes
         buildDependenciesBetweenNodes(fragments, immutableNodes);
         return immutableNodes;
     }

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -33,17 +33,17 @@ public class NodesUtil {
 
     static ImmutableMap<NodeId, Node> buildNodesWithDependencies(Set<Fragment> fragments) {
         // TODO handling building the dependencies in each connected subgraph doesn't work, because dependencies can step across disconnected fragment sets
-        ImmutableMap.Builder<NodeId, Node> nodeBuilder = ImmutableMap.builder();
+        Map<NodeId, Node> nodes = new HashMap<>();
 
         fragments.forEach(fragment ->
-                fragment.getNodes().forEach(node -> nodeBuilder.put(node.getNodeId(), node))
+                fragment.getNodes().forEach(node -> nodes.put(node.getNodeId(), node))
         );
 
-        ImmutableMap<NodeId, Node> nodes = nodeBuilder.build();
+        ImmutableMap<NodeId, Node> immutableNodes = ImmutableMap.copyOf(nodes);
 
         // build the dependencies between nodes for use between disconnected fragment sets too
-        buildDependenciesBetweenNodes(fragments, nodes);
-        return nodes;
+        buildDependenciesBetweenNodes(fragments, immutableNodes);
+        return immutableNodes;
     }
 
     private static void buildDependenciesBetweenNodes(Set<Fragment> allFragments, Map<NodeId, Node> allNodes) {

--- a/server/src/graql/gremlin/RelationTypeInference.java
+++ b/server/src/graql/gremlin/RelationTypeInference.java
@@ -141,7 +141,7 @@ public class RelationTypeInference {
 
     private static Multimap<Variable, Variable> getRelationRolePlayerMap(
             Set<Fragment> allFragments, Multimap<Variable, Type> instanceVarTypeMap) {
-        // relation vars and its role player vars
+        // get all relation vars and its role player vars
         Multimap<Variable, Variable> relationRolePlayerMap = HashMultimap.create();
         allFragments.stream().filter(OutRolePlayerFragment.class::isInstance)
                 .forEach(fragment -> relationRolePlayerMap.put(fragment.start(), fragment.end()));
@@ -167,29 +167,6 @@ public class RelationTypeInference {
                     }
                 });
 
-        // find all the relation requiring type inference
-        Iterator<Variable> iterator = relationRolePlayerMap.keySet().iterator();
-        while (iterator.hasNext()) {
-            Variable relation = iterator.next();
-
-            // the relation should have at least 2 known role players so we can infer something useful
-            if (instanceVarTypeMap.containsKey(relation) ||
-                    relationRolePlayerMap.get(relation).size() < 2) {
-                iterator.remove();
-            } else {
-                int numRolePlayersHaveType = 0;
-                for (Variable rolePlayer : relationRolePlayerMap.get(relation)) {
-                    if (instanceVarTypeMap.containsKey(rolePlayer)) {
-                        numRolePlayersHaveType++;
-                    }
-                }
-                if (numRolePlayersHaveType < 2) {
-                    iterator.remove();
-                }
-            }
-        }
-
-        assert inferrableRelationsRolePlayerMap.size() == relationRolePlayerMap.size() : "New alg doesn't work";
         return relationRolePlayerMap;
     }
 

--- a/server/src/graql/gremlin/RelationTypeInference.java
+++ b/server/src/graql/gremlin/RelationTypeInference.java
@@ -167,7 +167,7 @@ public class RelationTypeInference {
                     }
                 });
 
-        return relationRolePlayerMap;
+        return inferrableRelationsRolePlayerMap;
     }
 
     private static void addAllPossibleRelations(Multimap<Type, RelationType> relationMap, Type metaType) {

--- a/server/src/graql/gremlin/fragment/AbstractRolePlayerFragment.java
+++ b/server/src/graql/gremlin/fragment/AbstractRolePlayerFragment.java
@@ -26,6 +26,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
@@ -97,8 +98,15 @@ public abstract class AbstractRolePlayerFragment extends Fragment {
     }
 
     @Override
-    public final Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = nodes.get(NodeId.of(NodeId.NodeType.VAR, edge()));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public final Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
 
         // this is a somewhat special case, where the middle node being converted to a vertex
         // may be addressed by a variable
@@ -107,11 +115,6 @@ public abstract class AbstractRolePlayerFragment extends Fragment {
         Node end = nodes.get(NodeId.of(NodeId.NodeType.VAR, end()));
         Node middle = nodes.get(NodeId.of(NodeId.NodeType.VAR, edge()));
         middle.setInvalidStartingPoint();
-
-        if (!edges.containsKey(middle)) {
-            edges.put(middle, new HashMap<>());
-        }
-        edges.get(middle).put(start, this);
 
         return Sets.newHashSet(
                 weighted(DirectedEdge.from(start).to(middle), -fragmentCost()),

--- a/server/src/graql/gremlin/fragment/Fragment.java
+++ b/server/src/graql/gremlin/fragment/Fragment.java
@@ -158,7 +158,12 @@ public abstract class Fragment {
     }
 
     /**
-     * TODO
+     * Some fragments represent Edges in JanusGraph. Similar to `getNodes()`, a fake node is added
+     * in the middle for the query planning step. These middle nodes are connected with a directed edge uniquely to another node -
+     * this directed edge is therefore the mapping from (node,node) directed edge to the Fragment. This is used to
+     * convert the fake middle node back into a Fragment after query planning is complete.
+     * For pairs of nodes we may have two edges (node1, node2) and (node2, node1). These stem from the two
+     * fragments that are `Equivalent` in EquivalentFragmentSet - directionality is used to disambiguate which choice to use
      * @param nodes
      * @return
      */

--- a/server/src/graql/gremlin/fragment/Fragment.java
+++ b/server/src/graql/gremlin/fragment/Fragment.java
@@ -26,6 +26,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
@@ -157,20 +158,26 @@ public abstract class Fragment {
     }
 
     /**
+     * TODO
+     * @param nodes
+     * @return
+     */
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        return null;
+    }
+
+    /**
      * Convert the fragment to a set of weighted edges for query planning
      *
      * @param nodes all nodes in the query
-     * @param edges a mapping from edge(child, parent) to its corresponding fragment
      * @return a set of edges
      */
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                     Map<Node, Map<Node, Fragment>> edges) {
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
         return Collections.emptySet();
     }
 
-    final Set<Weighted<DirectedEdge>> directedEdges(NodeId.NodeType nodeType,
-                                                    Map<NodeId, Node> nodes,
-                                                    Map<Node, Map<Node, Fragment>> edgeToFragment) {
+
+    final Set<Weighted<DirectedEdge>> directedEdges(NodeId.NodeType nodeType, Map<NodeId, Node> nodes) {
 
         // this call to `directedEdges` handles converting janus edges that the user cannot address
         // (ie. not role edges), into edges with a middle node to force the query planner to traverse to this middle
@@ -182,17 +189,9 @@ public abstract class Fragment {
         Node end = nodes.get(NodeId.of(NodeId.NodeType.VAR, end()));
         Node middle = nodes.get(NodeId.of(nodeType, Sets.newHashSet(start(), end())));
 
-        addEdgeToFragmentMapping(middle, start, edgeToFragment);
         return Sets.newHashSet(
                 weighted(DirectedEdge.from(start).to(middle), -fragmentCost()),
                 weighted(DirectedEdge.from(middle).to(end), 0));
-    }
-
-    private void addEdgeToFragmentMapping(Node child, Node parent, Map<Node, Map<Node, Fragment>> edgeToFragment) {
-        if (!edgeToFragment.containsKey(child)) {
-            edgeToFragment.put(child, new HashMap<>());
-        }
-        edgeToFragment.get(child).put(parent, this);
     }
 
 

--- a/server/src/graql/gremlin/fragment/InIsaFragment.java
+++ b/server/src/graql/gremlin/fragment/InIsaFragment.java
@@ -25,6 +25,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
@@ -149,8 +150,15 @@ public abstract class InIsaFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.ISA, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.ISA, nodes);
     }
 }

--- a/server/src/graql/gremlin/fragment/InPlaysFragment.java
+++ b/server/src/graql/gremlin/fragment/InPlaysFragment.java
@@ -24,6 +24,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
@@ -84,8 +85,15 @@ abstract class InPlaysFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.PLAYS, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.PLAYS, nodes);
     }
 }

--- a/server/src/graql/gremlin/fragment/InPlaysFragment.java
+++ b/server/src/graql/gremlin/fragment/InPlaysFragment.java
@@ -87,7 +87,7 @@ abstract class InPlaysFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.PLAYS, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/InRelatesFragment.java
+++ b/server/src/graql/gremlin/fragment/InRelatesFragment.java
@@ -73,7 +73,7 @@ abstract class InRelatesFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.RELATES, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/InRelatesFragment.java
+++ b/server/src/graql/gremlin/fragment/InRelatesFragment.java
@@ -24,6 +24,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -70,8 +71,15 @@ abstract class InRelatesFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.RELATES, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.RELATES, nodes);
     }
 }

--- a/server/src/graql/gremlin/fragment/InSubFragment.java
+++ b/server/src/graql/gremlin/fragment/InSubFragment.java
@@ -88,7 +88,7 @@ public abstract class InSubFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.SUB, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/InSubFragment.java
+++ b/server/src/graql/gremlin/fragment/InSubFragment.java
@@ -24,6 +24,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -85,9 +86,16 @@ public abstract class InSubFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.SUB, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.SUB, nodes);
     }
 }
 

--- a/server/src/graql/gremlin/fragment/OutIsaFragment.java
+++ b/server/src/graql/gremlin/fragment/OutIsaFragment.java
@@ -24,6 +24,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -87,9 +88,16 @@ public abstract class OutIsaFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.ISA, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.ISA, nodes);
     }
 
     @Override

--- a/server/src/graql/gremlin/fragment/OutPlaysFragment.java
+++ b/server/src/graql/gremlin/fragment/OutPlaysFragment.java
@@ -23,6 +23,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
@@ -83,8 +84,15 @@ abstract class OutPlaysFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.PLAYS, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.PLAYS, nodes);
     }
 }

--- a/server/src/graql/gremlin/fragment/OutPlaysFragment.java
+++ b/server/src/graql/gremlin/fragment/OutPlaysFragment.java
@@ -86,7 +86,7 @@ abstract class OutPlaysFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.PLAYS, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/OutRelatesFragment.java
+++ b/server/src/graql/gremlin/fragment/OutRelatesFragment.java
@@ -74,7 +74,7 @@ abstract class OutRelatesFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.RELATES, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/OutRelatesFragment.java
+++ b/server/src/graql/gremlin/fragment/OutRelatesFragment.java
@@ -24,6 +24,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -71,8 +72,15 @@ abstract class OutRelatesFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.RELATES, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.RELATES, nodes);
     }
 }

--- a/server/src/graql/gremlin/fragment/OutSubFragment.java
+++ b/server/src/graql/gremlin/fragment/OutSubFragment.java
@@ -87,7 +87,7 @@ public abstract class OutSubFragment extends Fragment {
     @Override
     public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
         Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
-        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.SUB, new HashSet<>(Arrays.asList(start(), end()))));
         // directed edge: middle -> start
         return new Pair<>(middle, start);
     }

--- a/server/src/graql/gremlin/fragment/OutSubFragment.java
+++ b/server/src/graql/gremlin/fragment/OutSubFragment.java
@@ -23,6 +23,7 @@ import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
 import grakn.core.graql.gremlin.spanningtree.graph.Node;
 import grakn.core.graql.gremlin.spanningtree.graph.NodeId;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
+import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -84,8 +85,15 @@ public abstract class OutSubFragment extends Fragment {
     }
 
     @Override
-    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes,
-                                                           Map<Node, Map<Node, Fragment>> edges) {
-        return directedEdges(NodeId.NodeType.SUB, nodes, edges);
+    public Pair<Node, Node> getMiddleNodeDirectedEdge(Map<NodeId, Node> nodes) {
+        Node start = nodes.get(NodeId.of(NodeId.NodeType.VAR, start()));
+        Node middle = new Node(NodeId.of(NodeId.NodeType.ISA, new HashSet<>(Arrays.asList(start(), end()))));
+        // directed edge: middle -> start
+        return new Pair<>(middle, start);
+    }
+
+    @Override
+    public Set<Weighted<DirectedEdge>> directedEdges(Map<NodeId, Node> nodes) {
+        return directedEdges(NodeId.NodeType.SUB, nodes);
     }
 }

--- a/server/test/graql/gremlin/spanningtree/BUILD
+++ b/server/test/graql/gremlin/spanningtree/BUILD
@@ -3,7 +3,7 @@ load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 java_test(
     name = "chu-liu-edmonds-test",
     test_class = "grakn.core.graql.gremlin.spanningtree.ChuLiuEdmondsTest",
-    srcs = ["ChuLiuEdmondsTest.java"],
+    srcs = ["ChuLiuEdmondsTest.java", "graph/DenseWeightedGraph.java"],
     deps = [
         "@graknlabs_graql//java:graql",
         "//server:server",

--- a/server/test/graql/gremlin/spanningtree/graph/DenseWeightedGraph.java
+++ b/server/test/graql/gremlin/spanningtree/graph/DenseWeightedGraph.java
@@ -16,14 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package grakn.core.graql.gremlin.spanningtree.datastructure;
+package grakn.core.graql.gremlin.spanningtree.graph;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
-import grakn.core.graql.gremlin.spanningtree.graph.Node;
-import grakn.core.graql.gremlin.spanningtree.graph.WeightedGraph;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
 
 import java.util.ArrayList;

--- a/server/test/graql/gremlin/spanningtree/graph/DenseWeightedGraph.java
+++ b/server/test/graql/gremlin/spanningtree/graph/DenseWeightedGraph.java
@@ -16,12 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package grakn.core.graql.gremlin.spanningtree.graph;
+package grakn.core.graql.gremlin.spanningtree.datastructure;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
+import grakn.core.graql.gremlin.spanningtree.graph.Node;
+import grakn.core.graql.gremlin.spanningtree.graph.WeightedGraph;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
 
 import java.util.ArrayList;
@@ -29,10 +31,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-
-import static com.google.common.collect.DiscreteDomain.integers;
-import static com.google.common.collect.Range.closedOpen;
 
 /**
  * Used for testing


### PR DESCRIPTION
## What is the goal of this PR?
Continue splitting down the `GreedyTraversalPlan` to make more readable and maintainable code.

## What are the changes implemented in this PR?
* Move class used for tests only into `test` folder (`DenseWeighedGraph`)
* Rewrite `RelationTypeInference` to build correct map in the first place, rather than deleting from iterators
* Plan components are returned and concatened, rather than writing directly to the plan from within function calls
* The mapping from middle nodes (virtual nodes corresponding to Janus Edges) to Fragments is explicitly created in a new method in each `Fragment` type (`getMiddleNodeDirectedEdge`)
* Nodes are created in an ImmutableMap to ensure read-only usage
* `GreedyTraversalPlan` is split into three files: 
  * `GreedyTraversalPlan` - consumes Pattern, splits into disconnected conjunections, for each then: builds a query graph, computes Minimum Spanning Tree (ie. Arborescence), then converts these into a plan
  * `ArborescenceToPlan` - executes the greedy traversal on the Arborescence to produce an ordered list of Fragments that is a plan
  * `NodeUtils` - static methods for building nodes, their inter-dependencies, and converting them to plan components (TODO better naming for the class)
* Various refactoring to split large functions into several smaller ones