### PR TITLE
Catch idNotFound exceptions and resume execution

### DIFF
--- a/server/src/graql/exception/GraqlCheckedException.java
+++ b/server/src/graql/exception/GraqlCheckedException.java
@@ -1,0 +1,34 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.exception;
+
+import grakn.core.common.exception.ErrorMessage;
+import grakn.core.concept.ConceptId;
+import graql.lang.exception.GraqlException;
+
+public class GraqlCheckedException extends GraqlException {
+
+    private GraqlCheckedException(String error) {
+        super(error);
+    }
+
+    public static GraqlCheckedException idNotFound(ConceptId id) {
+        return new GraqlCheckedException(ErrorMessage.ID_NOT_FOUND.getMessage(id));
+    }
+}

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -70,10 +70,6 @@ public class GraqlQueryException extends GraknException {
         return new GraqlQueryException(String.format(formatString, args));
     }
 
-    public static GraqlQueryException idNotFound(ConceptId id) {
-        return new GraqlQueryException(ErrorMessage.ID_NOT_FOUND.getMessage(id));
-    }
-
     public static GraqlQueryException labelNotFound(Label label) {
         return new GraqlQueryException(ErrorMessage.LABEL_NOT_FOUND.getMessage(label));
     }

--- a/server/src/graql/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/reasoner/atom/binary/Binary.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Sets;
 import grakn.core.concept.ConceptId;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
+import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.reasoner.atom.Atom;
@@ -80,7 +81,7 @@ public abstract class Binary extends Atom {
     public SchemaConcept getSchemaConcept(){
         if (type == null && getTypeId() != null) {
             SchemaConcept concept = tx().getConcept(getTypeId());
-            if (concept == null) throw GraqlQueryException.idNotFound(getTypeId());
+            if (concept == null) throw GraqlCheckedException.idNotFound(getTypeId());
             type = concept;
         }
         return type;

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -41,6 +41,7 @@ import grakn.core.concept.type.Role;
 import grakn.core.concept.type.Rule;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
+import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.reasoner.atom.Atom;
@@ -846,7 +847,7 @@ public abstract class RelationAtom extends IsaAtomBase {
                     IdPredicate rolePredicate = getIdPredicate(rolePattern.var());
                     if (rolePredicate != null){
                         Role r = graph.getConcept(rolePredicate.getPredicate());
-                        if (r == null) throw GraqlQueryException.idNotFound(rolePredicate.getPredicate());
+                        if (r == null) throw GraqlCheckedException.idNotFound(rolePredicate.getPredicate());
                         role = r;
                     }
                 }

--- a/server/src/graql/reasoner/atom/predicate/IdPredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/IdPredicate.java
@@ -22,6 +22,7 @@ import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
 import grakn.core.concept.Label;
 import grakn.core.concept.type.SchemaConcept;
+import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -108,7 +109,7 @@ public class IdPredicate extends Predicate<ConceptId> {
     public void checkValid() {
         ConceptId conceptId = getPredicate();
         if (tx().getConcept(conceptId) == null) {
-            throw GraqlQueryException.idNotFound(conceptId);
+            throw GraqlCheckedException.idNotFound(conceptId);
         }
     }
 

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -27,6 +27,7 @@ import grakn.core.concept.ConceptId;
 import grakn.core.concept.Label;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.Type;
+import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.reasoner.ResolutionIterator;
@@ -441,7 +442,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
             HashMap<Variable, Concept> answerMap = new HashMap<>();
             predicates.forEach(p -> {
                 Concept concept = tx().getConcept(p.getPredicate());
-                if (concept == null) throw GraqlQueryException.idNotFound(p.getPredicate());
+                if (concept == null) throw GraqlCheckedException.idNotFound(p.getPredicate());
                 answerMap.put(p.getVarName(), concept);
             });
             substitution = new ConceptMap(answerMap);
@@ -455,7 +456,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
                 .flatMap(RelationAtom::getRolePredicates)
                 .forEach(p -> {
                     Concept concept = tx().getConcept(p.getPredicate());
-                    if (concept == null) throw GraqlQueryException.idNotFound(p.getPredicate());
+                    if (concept == null) throw GraqlCheckedException.idNotFound(p.getPredicate());
                     roleSub.put(p.getVarName(), concept);
                 });
         return new ConceptMap(roleSub);

--- a/test-integration/graql/reasoner/query/QueryValidityIT.java
+++ b/test-integration/graql/reasoner/query/QueryValidityIT.java
@@ -75,28 +75,28 @@ public class QueryValidityIT {
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentConceptId_emptyResultReturned() throws GraqlQueryException{
+    @Test
+    public void whenQueryingForInexistentConceptId_emptyResultReturned(){
         String queryString = "match $x id 'V1337'; $y id 'V456'; ($x, $y); get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentEntityTypeId_emptyResultReturned() throws GraqlQueryException{
+    @Test
+    public void whenQueryingForInexistentEntityTypeId_emptyResultReturned(){
         String queryString = "match $x isa $type; $type id 'V1337'; get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentRelationTypeId_emptyResultReturned() throws GraqlQueryException{
+    @Test
+    public void whenQueryingForInexistentRelationTypeId_emptyResultReturned(){
         String queryString = "match ($x, $y) isa $type; $type id 'V1337'; get;";
         String queryString2 = "match $r ($x, $y) isa $type; $r id 'V1337'; get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
         assertThat(tx.execute(Graql.parse(queryString2).asGet()), empty());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentResourceId_emptyResultReturned() throws GraqlQueryException{
+    @Test
+    public void whenQueryingForInexistentResourceId_emptyResultReturned(){
         String queryString = "match $x has name $y; $x id 'V1337'; get;";
         String queryString2 = "match $x has name $y; $y id 'V1337'; get;";
         String queryString3 = "match $x has name $y via $r; $r id 'V1337'; get;";


### PR DESCRIPTION
## What is the goal of this PR?

Revert the behaviour of throwing an exception when an id is invalid - too aggressive in certain scenarios.
Instead we catch the exception, log it and return empty stream.

