### PR TITLE
Order deletes - remove relations first

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -323,7 +323,7 @@ public class QueryExecutor {
                     }
                 } catch (IllegalStateException janusVertexDeleted) {
                     if (janusVertexDeleted.getMessage().contains("was removed")) {
-                        // Tinkerpop throws this exception if we try to operate on a vertex that was already deleted
+                        // Tinkerpop throws this exception if we try to operate (including check `isInferred()`) on a vertex that was already deleted
                         // With the ordering of deletes, this edge case should only be hit when relations play roles in relations
                         LOG.debug("Trying to deleted concept that was already removed", janusVertexDeleted);
                     } else {

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -307,6 +307,7 @@ public class QueryExecutor {
         // Stream.distinct() will then work properly when it calls ConceptImpl.equals()
         List<Concept> conceptsToDelete = answers
                 .flatMap(answer -> answer.concepts().stream())
+                // delete relations first: if the RPs are deleted, the relation is removed, so null by the time we try to delete it here
                 .sorted(Comparator.comparing(concept -> !concept.isRelation()))
                 .collect(Collectors.toList());
 

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -30,6 +30,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.ConceptSet;
 import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Numeric;
+import grakn.core.concept.thing.Relation;
 import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.executor.property.PropertyExecutor;
@@ -304,9 +305,10 @@ public class QueryExecutor {
 
         // TODO: We should not need to collect toSet, once we fix ConceptId.id() to not use cache.
         // Stream.distinct() will then work properly when it calls ConceptImpl.equals()
-        Set<Concept> conceptsToDelete = answers
+        List<Concept> conceptsToDelete = answers
                 .flatMap(answer -> answer.concepts().stream())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .sorted(Comparator.comparing(concept -> !concept.isRelation()))
+                .collect(Collectors.toList());
 
         conceptsToDelete.forEach(concept -> {
             // a concept is either a schema concept or a thing


### PR DESCRIPTION
## What is the goal of this PR?
Fix issue when deleting multiple concepts in one query, where some of them are concepts that are role players and others are the relations relating these RPs. When we delete concepts playing roles, if the relations they are in have 0 role players, we delete them too. This means that sometimes when deleting RPs and relations, the relation is already gone by the time we want to delete it explicitly.

Solution: always delete relations before other concepts. This may still hit an edge case and cause an exception when deleting relations that are role players in other relations. To solve this, a try/catch was added and the event is logged.

## What are the changes implemented in this PR?
* Add an ordering to delete relations first
* Try/Catch around deleting concepts already deleted - should only occur when deleting RPs that are relations.