### PR TITLE
Removing unused code in Cache

### DIFF
--- a/common/config/ConfigKey.java
+++ b/common/config/ConfigKey.java
@@ -62,8 +62,6 @@ public abstract class ConfigKey<T> {
     public static final ConfigKey<String> STORAGE_KEYSPACE = key("storage.cassandra.keyspace", STRING);
     public static final ConfigKey<Integer> STORAGE_REPLICATION_FACTOR = key("storage.cassandra.replication-factor", INT);
 
-    public static final ConfigKey<Integer> SESSION_CACHE_TIMEOUT_MS = key("knowledge-base.schema-cache-timeout-ms", INT);
-
     public static final ConfigKey<Long> SHARDING_THRESHOLD = key("knowledge-base.sharding-threshold", LONG);
     public static final ConfigKey<String> DATA_DIR = key("data-dir");
     public static final ConfigKey<String> LOG_DIR = key("log.dirs");

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -42,12 +42,6 @@ knowledge-base.default-keyspace=grakn
 # more frequently.
 knowledge-base.sharding-threshold=10000
 
-# How long, in milliseconds, knowledge base-level schema elements will be
-# cached. Longer cache timeouts means writing will be much faster, particularly for
-# batch loading. Shorter cache timeouts are better for memory usage and in some cases
-# may help avoid GC issues.
-knowledge-base.schema-cache-timeout-ms=600000
-
 ############################# Server Configuration #############################
 
 # Directory in which server data will be stored

--- a/server/src/server/kb/cache/CacheOwner.java
+++ b/server/src/server/kb/cache/CacheOwner.java
@@ -36,7 +36,7 @@ public interface CacheOwner {
     }
 
     /**
-     * @return all the caches beloning to the CacheOwner
+     * @return all the caches belonging to the CacheOwner
      */
     Collection<Cache> caches();
 
@@ -52,12 +52,5 @@ public interface CacheOwner {
      */
     default void registerCache(Cache cache) {
         caches().add(cache);
-    }
-
-    /**
-     * Flushes the internal transaction caches so they can refresh with persisted graph
-     */
-    default void txCacheFlush() {
-        caches().forEach(Cache::flush);
     }
 }

--- a/server/src/server/kb/concept/ElementFactory.java
+++ b/server/src/server/kb/concept/ElementFactory.java
@@ -288,7 +288,6 @@ public final class ElementFactory {
         Vertex vertex = graph.addVertex(baseType.name());
         String newConceptId = Schema.PREFIX_VERTEX + vertex.id().toString();
         vertex.property(Schema.VertexProperty.ID.name(), newConceptId);
-        tx.cache().writeOccurred();
         return new VertexElement(tx, vertex);
     }
 
@@ -303,7 +302,6 @@ public final class ElementFactory {
         Vertex vertex = graph.addVertex(baseType.name());
         String newConceptId = conceptId.getValue();
         vertex.property(Schema.VertexProperty.ID.name(), newConceptId);
-        tx.cache().writeOccurred();
         return new VertexElement(tx, vertex);
     }
 }

--- a/server/src/server/kb/structure/VertexElement.java
+++ b/server/src/server/kb/structure/VertexElement.java
@@ -61,7 +61,6 @@ public class VertexElement extends AbstractElement<Vertex, Schema.VertexProperty
      * @return The edge created
      */
     public EdgeElement addEdge(VertexElement to, Schema.EdgeLabel type) {
-        tx().cache().writeOccurred();
         return tx().factory().buildEdgeElement(element().addEdge(type.getLabel(), to.element()));
     }
 

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -58,7 +58,7 @@ public class KeyspaceManager {
     private final JanusGraph graph;
 
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
-        KeyspaceCache keyspaceCache = new KeyspaceCache(config);
+        KeyspaceCache keyspaceCache = new KeyspaceCache();
         this.graph = janusGraphFactory.openGraph(SYSTEM_KB_KEYSPACE.name());
         this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, new ReentrantReadWriteLock());
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -80,7 +80,7 @@ public class SessionFactory {
             } else { // If keyspace reference not cached, put keyspace in keyspace manager, open new graph and instantiate new keyspace cache
                 keyspaceManager.putKeyspace(keyspace);
                 graph = janusGraphFactory.openGraph(keyspace.name());
-                cache = new KeyspaceCache(config);
+                cache = new KeyspaceCache();
                 graphLock = new ReentrantReadWriteLock();
                 cacheContainer = new KeyspaceCacheContainer(cache, graph, graphLock);
                 keyspaceCacheMap.put(keyspace, cacheContainer);

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -56,7 +56,7 @@ public class SessionImpl implements Session {
 
     private final KeyspaceImpl keyspace;
     private final Config config;
-    private ReadWriteLock graphLock;
+    private final ReadWriteLock graphLock;
     private final JanusGraph graph;
     private final KeyspaceCache keyspaceCache;
     private Consumer<SessionImpl> onClose;
@@ -87,9 +87,9 @@ public class SessionImpl implements Session {
         if (!keyspaceHasBeenInitialised(tx)) {
             initialiseMetaConcepts(tx);
         }
-        // If keyspace cache is empty, copy schema concepts in it.
+        // If keyspace cache is empty, copy schema concept labels in it.
         if (keyspaceCache.isEmpty()) {
-            copySchemaConceptsToKeyspaceCache(tx);
+            copySchemaConceptLabelsToKeyspaceCache(tx);
         }
         tx.commit();
 
@@ -142,11 +142,11 @@ public class SessionImpl implements Session {
     }
 
     /**
-     * Copy all Schema Concepts to current KeyspaceCache
+     * Copy schema concepts labels to current KeyspaceCache
      *
      * @param tx
      */
-    private void copySchemaConceptsToKeyspaceCache(TransactionOLTP tx) {
+    private void copySchemaConceptLabelsToKeyspaceCache(TransactionOLTP tx) {
         copyToCache(tx.getMetaConcept());
         copyToCache(tx.getMetaRole());
         copyToCache(tx.getMetaRule());
@@ -161,11 +161,12 @@ public class SessionImpl implements Session {
         return keyspaceCache;
     }
 
+    /**
+     * Copy schema concept and all its subs labels to keyspace cache
+     * @param schemaConcept
+     */
     private void copyToCache(SchemaConcept schemaConcept) {
-        schemaConcept.subs().forEach(concept -> {
-            keyspaceCache.cacheLabel(concept.label(), concept.labelId());
-//            keyspaceCache.cacheType(concept.label(), concept);
-        });
+        schemaConcept.subs().forEach(concept -> keyspaceCache.cacheLabel(concept.label(), concept.labelId()));
     }
 
     private boolean keyspaceHasBeenInitialised(TransactionOLTP tx) {

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -813,7 +813,6 @@ public class TransactionOLTP implements Transaction {
         if (isClosed()) {
             return;
         }
-        transactionCache.refreshKeyspaceCache();
         closeTransaction(closeMessage);
     }
 

--- a/server/src/server/session/cache/KeyspaceCache.java
+++ b/server/src/server/session/cache/KeyspaceCache.java
@@ -18,47 +18,27 @@
 
 package grakn.core.server.session.cache;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
-import grakn.core.common.config.Config;
-import grakn.core.common.config.ConfigKey;
 import grakn.core.concept.Label;
 import grakn.core.concept.LabelId;
-import grakn.core.concept.type.SchemaConcept;
-import grakn.core.server.kb.concept.SchemaConceptImpl;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * Keyspace cache contains two caches:
- * - Schema Cache - An expiring cache that stores Concept objects across transactions
- * (currently disabled, shared concepts are not allowed)
+ * Keyspace cache contains:
  * - Label Cache - Map labels to IDs for fast lookups
  * <p>
- * These are shared across sessions and transactions to the same keyspace, and kept in sync
+ * This cache is shared across sessions and transactions to the same keyspace, and kept in sync
  * on commit.
  */
 public class KeyspaceCache {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-
-    // Concept cache
-//    private final Cache<Label, SchemaConcept> cachedTypes;
-
-    // Label cache
     private final Map<Label, LabelId> cachedLabels;
 
-    public KeyspaceCache(Config config) {
+    public KeyspaceCache() {
         cachedLabels = new ConcurrentHashMap<>();
-
-        int cacheTimeout = config.getProperty(ConfigKey.SESSION_CACHE_TIMEOUT_MS);
-//        cachedTypes = CacheBuilder.newBuilder()
-//                .maximumSize(1000)
-//                .expireAfterAccess(cacheTimeout, TimeUnit.MILLISECONDS)
-//                .build();
     }
 
     /**
@@ -69,16 +49,7 @@ public class KeyspaceCache {
     void populateSchemaTxCache(TransactionCache transactionCache) {
         try {
             lock.writeLock().lock();
-
-//            Map<Label, SchemaConcept> cachedSchemaSnapshot = getCachedTypes();
             Map<Label, LabelId> cachedLabelsSnapshot = getCachedLabels();
-
-            //Read central cache into transactionCache cloning only base concepts. Sets clones later
-//            for (SchemaConcept type : cachedSchemaSnapshot.values()) {
-//                transactionCache.cacheConcept(type);
-//            }
-
-            //Load Labels Separately. We do this because the TypeCache may have expired.
             cachedLabelsSnapshot.forEach(transactionCache::cacheLabel);
         } finally {
             lock.writeLock().unlock();
@@ -86,17 +57,7 @@ public class KeyspaceCache {
     }
 
     /**
-     * Caches a type so that we can retrieve ontological concepts without making a DB read.
-     *
-     * @param label The label of the type to cache
-     * @param type  The type to cache
-     */
-//    void cacheType(Label label, SchemaConcept type) {
-//        cachedTypes.put(label, type);
-//    }
-
-    /**
-     * Caches a label so we can map type labels to type ids. This is necesssary so we can make fast
+     * Caches a label so we can map type labels to type ids. This is necessary so we can make fast
      * indexed lookups.
      *
      * @param label The label of the type to cache
@@ -107,33 +68,23 @@ public class KeyspaceCache {
     }
 
     /**
-     * Reads the SchemaConcept and their Label currently in the transaction cache
+     * Reads the SchemaConcept labels currently in the transaction cache
      * into the keyspace cache. This happens when a commit occurs and allows us to track schema
      * mutations without having to read the graph.
      *
      * @param transactionCache The transaction cache
      */
     void readTxCache(TransactionCache transactionCache) {
-        //Check if the ontology has been changed and should be flushed into this cache
+        //Check if the schema has been changed and should be flushed into this cache
         if (!cachedLabels.equals(transactionCache.getLabelCache())) {
             try {
-                lock.readLock().lock();
-
-                //Clear the cache
+                lock.writeLock().lock();
                 cachedLabels.clear();
-//                cachedTypes.invalidateAll();
-
-                //Add a new one
                 cachedLabels.putAll(transactionCache.getLabelCache());
-//                cachedTypes.putAll(transactionCache.getSchemaConceptCache());
             } finally {
-                lock.readLock().unlock();
+                lock.writeLock().unlock();
             }
         }
-
-        //Flush All The Internal TransactionOLTP Caches
-//        transactionCache.getSchemaConceptCache().values().forEach(schemaConcept
-//                -> SchemaConceptImpl.from(schemaConcept).txCacheFlush());
     }
 
     /**
@@ -145,17 +96,8 @@ public class KeyspaceCache {
         return ImmutableMap.copyOf(cachedLabels);
     }
 
-    /**
-     * A copy of the cached schema. This is used when creating a new transaction.
-     *
-     * @return an immutable copy of the cached schema.
-     */
-//    public Map<Label, SchemaConcept> getCachedTypes() {
-//        return ImmutableMap.copyOf(cachedTypes.asMap());
-//    }
 
     public boolean isEmpty(){
         return cachedLabels.isEmpty();
-        //&& (cachedTypes.size()==0);
     }
 }

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -77,35 +77,13 @@ public class TransactionCache {
     // The index and id are directly cached to prevent unneeded reads
     private Multimap<String, ConceptId> newAttributes = ArrayListMultimap.create();
 
-    //Transaction Specific Meta Data
-    private boolean writeOccurred = false;
-
     public TransactionCache(KeyspaceCache keyspaceCache) {
         this.keyspaceCache = keyspaceCache;
-    }
-
-    /**
-     *
-     */
-    public void refreshKeyspaceCache() {
-        // This is used to prevent the keyspace cache from expiring its stored concept cache
-        // This method is NOT used to actually change things in the keyspace cache
-        if (!writeOccurred) {
-            keyspaceCache.readTxCache(this);
-        }
     }
 
     public void flushToKeyspaceCache() {
         // This method is used to actually flush to the keyspace cache
         keyspaceCache.readTxCache(this);
-    }
-
-    /**
-     * Notifies the cache that a write has occurred.
-     * This is later used to determine if it is safe to flush the transaction cache to the session cache or not.
-     */
-    public void writeOccurred() {
-        writeOccurred = true;
     }
 
     /**
@@ -338,7 +316,6 @@ public class TransactionCache {
         schemaConceptCache.clear();
         labelCache.clear();
     }
-
 
 
     @VisibleForTesting


### PR DESCRIPTION
## What is the goal of this PR?

Cleanup old code that was used when we were caching SchemaConcepts in Session and sharing them across multiple transactions.

## What are the changes implemented in this PR?

Given that we don't cache SchemaConcepts anymore we can get rid of a lot of gnarly code that was used to update global caches and refresh other amazing things.

The code deleted in this PR was not used previously so it should be a fairly safe cleanup.
There is still cleanup to be done by we prefer to make smaller PRs so that we can investigate better if something breaks.