### PR TITLE
Caches cleanup part 3

### DIFF
--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -65,14 +65,6 @@ import static java.util.stream.Collectors.toSet;
  *            For example EntityType or RelationType
  */
 public abstract class ThingImpl<T extends Thing, V extends Type> extends ConceptImpl implements Thing {
-    private final Cache<Label> cachedInternalType = new Cache<>(() -> {
-        int typeId = vertex().property(Schema.VertexProperty.THING_TYPE_LABEL_ID);
-        Type type = vertex().tx().getConcept(Schema.VertexProperty.LABEL_ID, typeId);
-        if (type == null) {
-            throw TransactionException.missingType(id());
-        }
-        return type.label();
-    });
 
     private final Cache<V> cachedType = new Cache<>(() -> {
         Optional<V> type = vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ISA).
@@ -374,23 +366,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
             //noinspection unchecked
             cachedType.set((V) type); //We cache the type early because it turns out we use it EVERY time. So this prevents many db reads
             type.currentShard().link(this);
-            setInternalType(type);
         }
-    }
-
-    /**
-     * @return The id of the type of this concept. This is a shortcut used to prevent traversals.
-     */
-    Label getInternalType() {
-        return cachedInternalType.get();
-    }
-
-    /**
-     * @param type The type of this concept
-     */
-    private void setInternalType(Type type) {
-        cachedInternalType.set(type.label());
-        vertex().property(Schema.VertexProperty.THING_TYPE_LABEL_ID, type.labelId().getValue());
     }
 
 }

--- a/test-integration/server/kb/cache/BUILD
+++ b/test-integration/server/kb/cache/BUILD
@@ -1,0 +1,22 @@
+load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
+
+java_test(
+     name = "concept-caches-it",
+     srcs = ["ConceptCachesIT.java"],
+     test_class = "grakn.core.server.kb.cache.ConceptCachesIT",
+     deps = [
+         "//concept:concept",
+         "//server:server",
+         "//test-integration/rule:grakn-test-server",
+     ],
+     classpath_resources = ["//test-integration/resources:logback-test"],
+     size = "small",
+)
+
+
+checkstyle_test(
+    name = "checkstyle",
+    targets = [
+        ":concept-caches-it",
+    ]
+)

--- a/test-integration/server/kb/cache/ConceptCachesIT.java
+++ b/test-integration/server/kb/cache/ConceptCachesIT.java
@@ -1,3 +1,22 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
 package grakn.core.server.kb.cache;
 
 import grakn.core.concept.thing.Attribute;

--- a/test-integration/server/kb/cache/ConceptCachesIT.java
+++ b/test-integration/server/kb/cache/ConceptCachesIT.java
@@ -1,0 +1,46 @@
+package grakn.core.server.kb.cache;
+
+import grakn.core.concept.thing.Attribute;
+import grakn.core.concept.type.AttributeType;
+import grakn.core.rule.GraknTestServer;
+import grakn.core.server.session.SessionImpl;
+import grakn.core.server.session.TransactionOLTP;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConceptCachesIT {
+
+    @ClassRule
+    public static final GraknTestServer server = new GraknTestServer();
+
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    private TransactionOLTP tx;
+    private SessionImpl session;
+
+    @Before
+    public void setUp() {
+        session = server.sessionWithNewKeyspace();
+        tx = session.transaction().write();
+    }
+
+    @After
+    public void tearDown() {
+        tx.close();
+        session.close();
+    }
+
+    @Test
+    public void whenCreatingResource_EnsureTheResourcesDataTypeIsTheSameAsItsType() throws Exception {
+        AttributeType<String> attributeType = tx.putAttributeType("attributeType", AttributeType.DataType.STRING);
+        Attribute attribute = attributeType.create("resource");
+        assertEquals(AttributeType.DataType.STRING, attribute.dataType());
+    }
+}

--- a/test-integration/server/kb/concept/EntityIT.java
+++ b/test-integration/server/kb/concept/EntityIT.java
@@ -253,13 +253,6 @@ public class EntityIT {
     }
 
     @Test
-    public void whenAddingEntity_EnsureInternalTypeIsTheSameAsRealType(){
-        EntityType et = tx.putEntityType("et");
-        EntityImpl e = (EntityImpl) et.create();
-        assertEquals(et.label(), e.getInternalType());
-    }
-
-    @Test
     public void whenCreatingAnInferredEntity_EnsureMarkedAsInferred(){
         EntityTypeImpl et = EntityTypeImpl.from(tx.putEntityType("et"));
         Entity entity = et.create();


### PR DESCRIPTION
## What is the goal of this PR?

{ Please describe the goal of this PR, why they are valuable to achieve, and reference the related GitHub issues. }

## What are the changes implemented in this PR?

Remove `cachedInteralType` from `ThingImpl` as it was added here to be used in the `relations(Role... roles)` method: 
https://github.com/graknlabs/grakn/commit/de5fe363f471182da0c65317f8b967709b923903#diff-2e88dd0366a3e9c7c750e38e3b80ce30L146

but then the `relations(Role... roles)` has been refactored to not use it at all.