### PR TITLE
Remove stacktrace from GraqlQueryException

### DIFF
--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -33,5 +33,9 @@ public abstract class GraknException extends RuntimeException {
         super(error, e);
     }
 
+    protected GraknException(String error, Exception e, boolean enableSuppression, boolean writableStackTrace) {
+        super(error, e, enableSuppression, writableStackTrace);
+    }
+
     public abstract String getName();
 }

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -21,7 +21,6 @@ package grakn.core.graql.exception;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.Concept;
-import grakn.core.concept.ConceptId;
 import grakn.core.concept.Label;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.AttributeType;
@@ -33,6 +32,7 @@ import grakn.core.graql.reasoner.query.ResolvableQuery;
 import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.Set;
@@ -55,11 +55,11 @@ public class GraqlQueryException extends GraknException {
     private final String NAME = "GraqlQueryException";
 
     private GraqlQueryException(String error) {
-        super(error);
+        super(error, null, false, false);
     }
 
     private GraqlQueryException(String error, Exception cause) {
-        super(error, cause);
+        super(error, cause, false, false);
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

`GraqQueryException` is thrown when queries are semantically invalid, therefore the stacktrace does not bring any useful additional information to the user.

## What are the changes implemented in this PR?

Don't print stacktrace when `GraqlQueryException` is thrown, making the exception easier to read.
