### PR TITLE
Synchronize Graql - Extended Label grammar and renamed `asUserDefined`

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/flyingsilverfin/graql",
-         commit = "d41192350e74e0bd1d0f9a6912f03dc4543034d5",
+         commit = "6f02381058c540b021bbe5dbcf1339442ec7b62b",
      )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,8 +28,8 @@ def graknlabs_build_tools():
 def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
-         remote = "https://github.com/flyingsilverfin/graql",
-         commit = "6f02381058c540b021bbe5dbcf1339442ec7b62b",
+         remote = "https://github.com/graknlabs/graql",
+         commit = "4909270feeb9ca2951e001b26325d4c3f1d481b5",
      )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,8 +28,8 @@ def graknlabs_build_tools():
 def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
-         remote = "https://github.com/graknlabs/graql",
-         tag = "1.0.0",
+         remote = "https://github.com/flyingsilverfin/graql",
+         commit = "d41192350e74e0bd1d0f9a6912f03dc4543034d5",
      )
 
 def graknlabs_client_java():

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -211,7 +211,7 @@ public class QueryExecutor {
      * @return resulting answer stream
      */
     public Stream<ConceptMap> traversal(Set<Variable> commonVars, GraqlTraversal graqlTraversal) {
-        Set<Variable> vars = Sets.filter(commonVars, Variable::isUserDefinedName);
+        Set<Variable> vars = Sets.filter(commonVars, Variable::isReturned);
 
         GraphTraversal<Vertex, Map<String, Element>> traversal = graqlTraversal.getGraphTraversal(transaction, vars);
 

--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -263,7 +263,7 @@ public class WriteExecutor {
             allConcepts.put(var, concepts.get(equivalentVars.componentOf(var)));
         }
 
-        Map<Variable, Concept> namedConcepts = Maps.filterKeys(allConcepts.build(), Variable::isUserDefinedName);
+        Map<Variable, Concept> namedConcepts = Maps.filterKeys(allConcepts.build(), Variable::isReturned);
         return new ConceptMap(namedConcepts);
     }
 

--- a/server/src/graql/executor/property/HasAttributeExecutor.java
+++ b/server/src/graql/executor/property/HasAttributeExecutor.java
@@ -86,10 +86,10 @@ public class HasAttributeExecutor implements PropertyExecutor.Insertable {
     @Override
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         //NB: HasAttributeProperty always has (type) label specified
-        Variable varName = var.asUserDefined();
+        Variable varName = var.asReturnedVar();
 
         //NB: we always make the attribute variable explicit
-        Variable attributeVariable = property.attribute().var().asUserDefined();
+        Variable attributeVariable = property.attribute().var().asReturnedVar();
         Variable relationVariable = property.relation().var();
         Variable predicateVariable = new Variable();
         Set<ValuePredicate> predicates = getValuePredicates(attributeVariable, property.attribute(), otherStatements, parent).collect(Collectors.toSet());
@@ -100,7 +100,7 @@ public class HasAttributeExecutor implements PropertyExecutor.Insertable {
         ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
 
         //add resource atom
-        Statement resVar = relationVariable.isUserDefinedName() ?
+        Statement resVar = relationVariable.isReturned() ?
                 new Statement(varName).has(property.type(), new Statement(attributeVariable), new Statement(relationVariable)) :
                 new Statement(varName).has(property.type(), new Statement(attributeVariable));
         return AttributeAtom.create(resVar, attributeVariable, relationVariable,

--- a/server/src/graql/executor/property/HasAttributeTypeExecutor.java
+++ b/server/src/graql/executor/property/HasAttributeTypeExecutor.java
@@ -135,7 +135,7 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
     @Override
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         //NB: HasResourceType is a special case and it doesn't allow variables as resource types
-        Variable varName = var.asUserDefined();
+        Variable varName = var.asReturnedVar();
         String label = property.attributeType().getType().orElse(null);
 
         Variable predicateVar = new Variable();

--- a/server/src/graql/executor/property/IsaExecutor.java
+++ b/server/src/graql/executor/property/IsaExecutor.java
@@ -68,7 +68,7 @@ public class IsaExecutor implements PropertyExecutor.Insertable {
         //IsaProperty is unique within a var, so skip if this is a relation
         if (statement.hasProperty(RelationProperty.class)) return null;
 
-        Variable varName = var.asUserDefined();
+        Variable varName = var.asReturnedVar();
         Variable typeVar = property.type().var();
 
         IdPredicate predicate = getIdPredicate(typeVar, property.type(), otherStatements, parent);

--- a/server/src/graql/executor/property/PlaysExecutor.java
+++ b/server/src/graql/executor/property/PlaysExecutor.java
@@ -61,7 +61,7 @@ public class PlaysExecutor implements PropertyExecutor.Definable {
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         IdPredicate predicate = getIdPredicate(property.role().var(), property.role(), otherStatements, parent);
         ConceptId predicateId = predicate == null ? null : predicate.getPredicate();
-        return PlaysAtom.create(var.asUserDefined(), property.role().var(), predicateId, parent);
+        return PlaysAtom.create(var.asReturnedVar(), property.role().var(), predicateId, parent);
     }
 
     @Override

--- a/server/src/graql/executor/property/RelatesExecutor.java
+++ b/server/src/graql/executor/property/RelatesExecutor.java
@@ -66,7 +66,7 @@ public class RelatesExecutor implements PropertyExecutor.Definable {
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         IdPredicate predicate = getIdPredicate(property.role().var(), property.role(), otherStatements, parent);
         ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
-        return RelatesAtom.create(var.asUserDefined(), property.role().var(), predicateId, parent);
+        return RelatesAtom.create(var.asReturnedVar(), property.role().var(), predicateId, parent);
     }
 
     @Override

--- a/server/src/graql/executor/property/RelationExecutor.java
+++ b/server/src/graql/executor/property/RelationExecutor.java
@@ -106,7 +106,7 @@ public class RelationExecutor implements PropertyExecutor.Insertable {
         boolean isReified = statement.properties().stream()
                 .filter(prop -> !RelationProperty.class.isInstance(prop))
                 .anyMatch(prop -> !IsaProperty.class.isInstance(prop));
-        Statement relVar = isReified ? new Statement(var.asUserDefined()) : new Statement(var);
+        Statement relVar = isReified ? new Statement(var.asReturnedVar()) : new Statement(var);
 
         for (RelationProperty.RolePlayer rp : property.relationPlayers()) {
             Statement rolePattern = rp.getRole().orElse(null);
@@ -150,8 +150,8 @@ public class RelationExecutor implements PropertyExecutor.Insertable {
         }
         ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
         relVar = isaProp != null && isaProp.isExplicit() ?
-                relVar.isaX(new Statement(typeVariable.asUserDefined())) :
-                relVar.isa(new Statement(typeVariable.asUserDefined()));
+                relVar.isaX(new Statement(typeVariable.asReturnedVar())) :
+                relVar.isa(new Statement(typeVariable.asReturnedVar()));
         return RelationAtom.create(relVar, typeVariable, predicateId, parent);
     }
 

--- a/server/src/graql/executor/property/SubExecutor.java
+++ b/server/src/graql/executor/property/SubExecutor.java
@@ -60,7 +60,7 @@ public class SubExecutor implements PropertyExecutor.Definable {
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         IdPredicate predicate = getIdPredicate(property.type().var(), property.type(), otherStatements, parent);
         ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
-        return SubAtom.create(var.asUserDefined(), property.type().var(), predicateId, parent);
+        return SubAtom.create(var.asReturnedVar(), property.type().var(), predicateId, parent);
     }
 
     @Override

--- a/server/src/graql/executor/property/TypeExecutor.java
+++ b/server/src/graql/executor/property/TypeExecutor.java
@@ -54,7 +54,7 @@ public class TypeExecutor implements PropertyExecutor.Referrable {
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         SchemaConcept schemaConcept = parent.tx().getSchemaConcept(Label.of(property.name()));
         if (schemaConcept == null) throw GraqlQueryException.labelNotFound(Label.of(property.name()));
-        return IdPredicate.create(var.asUserDefined(), Label.of(property.name()), parent);
+        return IdPredicate.create(var.asReturnedVar(), Label.of(property.name()), parent);
     }
 
     @Override

--- a/server/src/graql/gremlin/sets/LabelFragmentSet.java
+++ b/server/src/graql/gremlin/sets/LabelFragmentSet.java
@@ -87,8 +87,8 @@ abstract class LabelFragmentSet extends EquivalentFragmentSet {
 
         for (LabelFragmentSet labelSet : labelFragments) {
 
-            boolean hasUserDefinedVar = labelSet.var().isUserDefinedName();
-            if (hasUserDefinedVar) continue;
+            boolean hasReturnedVarVar = labelSet.var().isReturned();
+            if (hasReturnedVarVar) continue;
 
             boolean existsInGraph = labelSet.labels().stream().anyMatch(label -> graph.getSchemaConcept(label) != null);
             if (!existsInGraph) continue;

--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -371,8 +371,8 @@ public abstract class Atom extends AtomicBase {
      * @return rewritten atom
      */
     public Atom rewriteWithTypeVariable(Atom parentAtom) {
-        if (parentAtom.getPredicateVariable().isUserDefinedName()
-                && !this.getPredicateVariable().isUserDefinedName()
+        if (parentAtom.getPredicateVariable().isReturned()
+                && !this.getPredicateVariable().isReturned()
                 && this.getClass() == parentAtom.getClass()) {
             return rewriteWithTypeVariable();
         }

--- a/server/src/graql/reasoner/atom/AtomicBase.java
+++ b/server/src/graql/reasoner/atom/AtomicBase.java
@@ -53,7 +53,7 @@ public abstract class AtomicBase implements Atomic {
 
     boolean containsVar(Variable name){ return getVarNames().contains(name);}
 
-    public boolean isUserDefined(){ return getVarName().isUserDefinedName();}
+    public boolean isUserDefined(){ return getVarName().isReturned();}
 
     /**
      * @return set of predicates relevant to this atomic
@@ -93,7 +93,7 @@ public abstract class AtomicBase implements Atomic {
     @Override
     public Set<Variable> getVarNames(){
         Variable varName = getVarName();
-        return varName.isUserDefinedName()? Sets.newHashSet(varName) : Collections.emptySet();
+        return varName.isReturned()? Sets.newHashSet(varName) : Collections.emptySet();
     }
 
     protected Pattern createCombinedPattern(){ return getPattern();}

--- a/server/src/graql/reasoner/atom/AtomicFactory.java
+++ b/server/src/graql/reasoner/atom/AtomicFactory.java
@@ -115,9 +115,9 @@ public class AtomicFactory {
         Object value = operation.innerStatement() == null? operation.value() : null;
         return buildNeq?
                 (allowNeq?
-                        NeqValuePredicate.create(var.asUserDefined(), predicateVar, value, parent) :
-                        ValuePredicate.neq(var.asUserDefined(), predicateVar, value, parent)) :
-                ValuePredicate.create(var.asUserDefined(), operation, parent);
+                        NeqValuePredicate.create(var.asReturnedVar(), predicateVar, value, parent) :
+                        ValuePredicate.neq(var.asReturnedVar(), predicateVar, value, parent)) :
+                ValuePredicate.create(var.asReturnedVar(), operation, parent);
     }
 }
 

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -153,7 +153,7 @@ public abstract class AttributeAtom extends Binary{
                 getMultiPredicate().stream().map(Predicate::getPredicate).collect(Collectors.toSet()).toString();
         return getVarName() + " has " + getSchemaConcept().label() + " " +
                 multiPredicateString +
-                (getRelationVariable().isUserDefinedName()? "(" + getRelationVariable() + ")" : "");
+                (getRelationVariable().isReturned()? "(" + getRelationVariable() + ")" : "");
     }
 
     @Override
@@ -277,7 +277,7 @@ public abstract class AttributeAtom extends Binary{
     public Set<Variable> getVarNames() {
         Set<Variable> varNames = super.getVarNames();
         varNames.add(getAttributeVariable());
-        if (getRelationVariable().isUserDefinedName()) varNames.add(getRelationVariable());
+        if (getRelationVariable().isReturned()) varNames.add(getRelationVariable());
         return varNames;
     }
 
@@ -297,14 +297,14 @@ public abstract class AttributeAtom extends Binary{
         //unify attribute vars
         Variable childAttributeVarName = this.getAttributeVariable();
         Variable parentAttributeVarName = parent.getAttributeVariable();
-        if (parentAttributeVarName.isUserDefinedName()){
+        if (parentAttributeVarName.isReturned()){
             unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(childAttributeVarName, parentAttributeVarName)));
         }
 
         //unify relation vars
         Variable childRelationVarName = this.getRelationVariable();
         Variable parentRelationVarName = parent.getRelationVariable();
-        if (parentRelationVarName.isUserDefinedName()){
+        if (parentRelationVarName.isReturned()){
             unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(childRelationVarName, parentRelationVarName)));
         }
 
@@ -377,14 +377,14 @@ public abstract class AttributeAtom extends Binary{
      * @return rewritten atom
      */
     private AttributeAtom rewriteWithRelationVariable(Atom parentAtom){
-        if (parentAtom.isResource() && ((AttributeAtom) parentAtom).getRelationVariable().isUserDefinedName()) return rewriteWithRelationVariable();
+        if (parentAtom.isResource() && ((AttributeAtom) parentAtom).getRelationVariable().isReturned()) return rewriteWithRelationVariable();
         return this;
     }
 
     @Override
     public AttributeAtom rewriteWithRelationVariable(){
         Variable attributeVariable = getAttributeVariable();
-        Variable relationVariable = getRelationVariable().asUserDefined();
+        Variable relationVariable = getRelationVariable().asReturnedVar();
         Statement newVar = new Statement(getVarName())
                 .has(getSchemaConcept().label().getValue(), new Statement(attributeVariable), new Statement(relationVariable));
         return create(newVar, attributeVariable, relationVariable, getPredicateVariable(), getTypeId(), getMultiPredicate(), getParentQuery());
@@ -392,7 +392,7 @@ public abstract class AttributeAtom extends Binary{
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getPattern(), getAttributeVariable(), getRelationVariable(), getPredicateVariable().asUserDefined(), getTypeId(), getMultiPredicate(), getParentQuery());
+        return create(getPattern(), getAttributeVariable(), getRelationVariable(), getPredicateVariable().asReturnedVar(), getTypeId(), getMultiPredicate(), getParentQuery());
     }
 
     @Override

--- a/server/src/graql/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/reasoner/atom/binary/Binary.java
@@ -128,7 +128,7 @@ public abstract class Binary extends Atom {
 
     private boolean equivalenceBase(Binary that){
         return (this.isUserDefined() == that.isUserDefined())
-                && (this.getPredicateVariable().isUserDefinedName() == that.getPredicateVariable().isUserDefinedName())
+                && (this.getPredicateVariable().isReturned() == that.getPredicateVariable().isReturned())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeId(), that.getTypeId());
     }
@@ -167,8 +167,8 @@ public abstract class Binary extends Atom {
     @Override
     public Set<Variable> getVarNames() {
         Set<Variable> vars = new HashSet<>();
-        if (getVarName().isUserDefinedName()) vars.add(getVarName());
-        if (getPredicateVariable().isUserDefinedName()) vars.add(getPredicateVariable());
+        if (getVarName().isReturned()) vars.add(getVarName());
+        if (getPredicateVariable().isReturned()) vars.add(getPredicateVariable());
         return vars;
     }
 
@@ -201,10 +201,10 @@ public abstract class Binary extends Atom {
 
         Multimap<Variable, Variable> varMappings = HashMultimap.create();
 
-        if (parentVarName.isUserDefinedName()) {
+        if (parentVarName.isReturned()) {
             varMappings.put(childVarName, parentVarName);
         }
-        if (parentPredicateVarName.isUserDefinedName()) {
+        if (parentPredicateVarName.isReturned()) {
             varMappings.put(childPredicateVarName, parentPredicateVarName);
         }
 

--- a/server/src/graql/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/reasoner/atom/binary/IsaAtom.java
@@ -132,14 +132,14 @@ public abstract class IsaAtom extends IsaAtomBase {
     public String toString(){
         String typeString = (getSchemaConcept() != null? getSchemaConcept().label() : "") + "(" + getVarName() + ")";
         return typeString +
-                (getPredicateVariable().isUserDefinedName()? "(" + getPredicateVariable() + ")" : "") +
+                (getPredicateVariable().isReturned()? "(" + getPredicateVariable() + ")" : "") +
                 (isDirect()? "!" : "") +
                 getPredicates().map(Predicate::toString).collect(Collectors.joining(""));
     }
 
     @Override
     protected Pattern createCombinedPattern(){
-        if (getPredicateVariable().isUserDefinedName()) return super.createCombinedPattern();
+        if (getPredicateVariable().isReturned()) return super.createCombinedPattern();
         return getSchemaConcept() == null?
                 new Statement(getVarName()).isa(new Statement(getPredicateVariable())) :
                 isDirect()?
@@ -219,7 +219,7 @@ public abstract class IsaAtom extends IsaAtomBase {
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getVarName(), getPredicateVariable().asUserDefined(), getTypeId(), this.isDirect(), getParentQuery());
+        return create(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), this.isDirect(), getParentQuery());
     }
 
     @Override

--- a/server/src/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/server/src/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -71,13 +71,13 @@ public abstract class OntologicalAtom extends TypeAtom {
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return createSelf(getVarName(), getPredicateVariable().asUserDefined(), getTypeId(), getParentQuery());
+        return createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), getParentQuery());
     }
 
     @Override
     public Atom rewriteToUserDefined(Atom parentAtom) {
-        return parentAtom.getPredicateVariable().isUserDefinedName()?
-                createSelf(getVarName(), getPredicateVariable().asUserDefined(), getTypeId(), getParentQuery()) :
+        return parentAtom.getPredicateVariable().isReturned()?
+                createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), getParentQuery()) :
                 this;
     }
 

--- a/server/src/graql/reasoner/atom/predicate/IdPredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/IdPredicate.java
@@ -47,11 +47,11 @@ public class IdPredicate extends Predicate<ConceptId> {
     }
 
     public static IdPredicate create(Variable varName, Label label, ReasonerQuery parent) {
-        return create(createIdVar(varName.asUserDefined(), label, parent.tx()), parent);
+        return create(createIdVar(varName.asReturnedVar(), label, parent.tx()), parent);
     }
 
     public static IdPredicate create(Variable varName, ConceptId id, ReasonerQuery parent) {
-        return create(createIdVar(varName.asUserDefined(), id), parent);
+        return create(createIdVar(varName.asReturnedVar(), id), parent);
     }
 
     private static IdPredicate create(IdPredicate a, ReasonerQuery parent) {

--- a/server/src/graql/reasoner/atom/predicate/NeqValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/NeqValuePredicate.java
@@ -39,7 +39,7 @@ public class NeqValuePredicate extends NeqPredicate {
     }
 
     public static NeqValuePredicate create(Variable varName, @Nullable Variable var, @Nullable Object value, ReasonerQuery parent){
-        Variable predicateVar = var != null? var : Graql.var().var().asUserDefined();
+        Variable predicateVar = var != null? var : Graql.var().var().asReturnedVar();
         ValueProperty.Operation.Comparison<?> op = ValueProperty.Operation.Comparison.of(Graql.Token.Comparator.NEQV, value != null ? value : Graql.var(predicateVar));
         Statement pattern = new Statement(varName).operation(op);
         return new NeqValuePredicate(varName, predicateVar, value, pattern, parent);
@@ -47,7 +47,7 @@ public class NeqValuePredicate extends NeqPredicate {
 
     public static NeqValuePredicate create(Variable varName, ValueProperty.Operation op, ReasonerQuery parent) {
         Statement innerStatement = op.innerStatement();
-        Variable var = innerStatement != null? innerStatement.var() : Graql.var().var().asUserDefined();
+        Variable var = innerStatement != null? innerStatement.var() : Graql.var().var().asReturnedVar();
         Object value = var == null? op.value() : null;
         return create(varName, var, value, parent);
     }

--- a/server/src/graql/reasoner/atom/predicate/ValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/ValuePredicate.java
@@ -54,7 +54,7 @@ public class ValuePredicate extends Predicate<ValueProperty.Operation> {
     }
 
     public static ValuePredicate neq(Variable varName, @Nullable Variable var, @Nullable Object value, ReasonerQuery parent){
-        Variable predicateVar = var != null? var : Graql.var().var().asUserDefined();
+        Variable predicateVar = var != null? var : Graql.var().var().asReturnedVar();
         ValueProperty.Operation.Comparison<?> op = ValueProperty.Operation.Comparison.of(Graql.Token.Comparator.NEQV, value != null ? value : Graql.var(predicateVar));
         return create(varName, op, parent);
     }

--- a/server/src/graql/reasoner/rule/InferenceRule.java
+++ b/server/src/graql/reasoner/rule/InferenceRule.java
@@ -301,11 +301,11 @@ public class InferenceRule {
         Atom headAtom = getHead().getAtom();
         SchemaConcept headType = headAtom.getSchemaConcept();
         if (headType.isRelationType()
-                && headAtom.getVarName().isUserDefinedName()) {
+                && headAtom.getVarName().isReturned()) {
             RelationAtom bodyAtom = getBody().getAtoms(RelationAtom.class)
                     .filter(at -> Objects.nonNull(at.getSchemaConcept()))
                     .filter(at -> at.getSchemaConcept().equals(headType))
-                    .filter(at -> at.getVarName().isUserDefinedName())
+                    .filter(at -> at.getVarName().isReturned())
                     .findFirst().orElse(null);
             return bodyAtom != null;
         }

--- a/server/src/graql/reasoner/utils/ReasonerUtils.java
+++ b/server/src/graql/reasoner/utils/ReasonerUtils.java
@@ -99,7 +99,7 @@ public class ReasonerUtils {
     public static IdPredicate getIdPredicate(Variable typeVariable, Statement typeVar, Set<Statement> vars, ReasonerQuery parent){
         IdPredicate predicate = null;
         //look for id predicate among vars
-        if(typeVar.var().isUserDefinedName()) {
+        if(typeVar.var().isReturned()) {
             predicate = getUserDefinedIdPredicate(typeVariable, vars, parent);
         } else {
             TypeProperty nameProp = typeVar.getProperty(TypeProperty.class).orElse(null);
@@ -147,7 +147,7 @@ public class ReasonerUtils {
      * @return stream of mapped ValuePredicates
      */
     public static Stream<ValuePredicate> getValuePredicates(Variable valueVariable, Statement statement, Set<Statement> fullContext, ReasonerQuery parent){
-        Stream<Statement> context = statement.var().isUserDefinedName()?
+        Stream<Statement> context = statement.var().isReturned()?
                 fullContext.stream().filter(v -> v.var().equals(valueVariable)) :
                 Stream.of(statement);
         Set<ValuePredicate> vps = context

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -86,7 +86,7 @@ public class BenchmarkBigIT {
     private void loadEntities(String entityLabel, int N, GraknClient.Session session) {
         try (GraknClient.Transaction transaction = session.transaction().write()) {
             for (int i = 0; i < N; i++) {
-                GraqlInsert entityInsert = Graql.insert(new Statement(new Variable().asUserDefined()).isa(entityLabel));
+                GraqlInsert entityInsert = Graql.insert(new Statement(new Variable().asReturnedVar()).isa(entityLabel));
                 transaction.execute(entityInsert);
             }
             transaction.commit();
@@ -96,7 +96,7 @@ public class BenchmarkBigIT {
     private void loadRandomisedRelationInstances(String entityLabel, String fromRoleLabel, String toRoleLabel,
                                                  String relationLabel, int N, GraknClient.Session session) {
         try (GraknClient.Transaction transaction = session.transaction().write()) {
-            Statement entity = new Statement(new Variable().asUserDefined());
+            Statement entity = new Statement(new Variable().asReturnedVar());
             ConceptId[] instances = transaction.stream(Graql.match(entity.isa(entityLabel)).get())
                     .map(ans -> ans.get(entity.var()).id())
                     .toArray(ConceptId[]::new);
@@ -113,8 +113,8 @@ public class BenchmarkBigIT {
                 int to = rand.nextInt(N - 1);
                 while (to == from && assignmentMap.get(from).contains(to)) to = rand.nextInt(N - 1);
 
-                Statement fromRolePlayer = new Statement(new Variable().asUserDefined());
-                Statement toRolePlayer = new Statement(new Variable().asUserDefined());
+                Statement fromRolePlayer = new Statement(new Variable().asReturnedVar());
+                Statement toRolePlayer = new Statement(new Variable().asReturnedVar());
                 Pattern relationInsert = Graql.and(
                         var().rel(Graql.type(fromRole.label().getValue()), fromRolePlayer)
                                 .rel(Graql.type(toRole.label().getValue()), toRolePlayer)
@@ -178,9 +178,9 @@ public class BenchmarkBigIT {
 
                 //define N rules
                 for (int i = 2; i <= N; i++) {
-                    Statement fromVar = new Statement(new Variable().asUserDefined());
-                    Statement intermedVar = new Statement(new Variable().asUserDefined());
-                    Statement toVar = new Statement(new Variable().asUserDefined());
+                    Statement fromVar = new Statement(new Variable().asReturnedVar());
+                    Statement intermedVar = new Statement(new Variable().asReturnedVar());
+                    Statement toVar = new Statement(new Variable().asReturnedVar());
                     Statement rulePattern = Graql
                             .type("rule" + i)
                             .when(
@@ -212,7 +212,7 @@ public class BenchmarkBigIT {
             loadEntities(entityLabel, N + 1, session);
 
             try (GraknClient.Transaction transaction = session.transaction().write()) {
-                Statement entityVar = new Statement(new Variable().asUserDefined());
+                Statement entityVar = new Statement(new Variable().asReturnedVar());
                 ConceptId[] instances = transaction.stream(Graql.match(entityVar.isa(entityLabel)).get())
                         .map(ans -> ans.get(entityVar.var()).id())
                         .toArray(ConceptId[]::new);
@@ -222,7 +222,7 @@ public class BenchmarkBigIT {
                 Role toRole = transaction.getRole(toRoleLabel);
                 transaction.execute(
                         Graql.insert(
-                                new Statement(new Variable().asUserDefined())
+                                new Statement(new Variable().asReturnedVar())
                                         .has(attributeLabel, "first")
                                         .id(instances[0].getValue())
                                         .statements()
@@ -230,8 +230,8 @@ public class BenchmarkBigIT {
                 );
 
                 for (int i = 1; i < instances.length; i++) {
-                    Statement fromRolePlayer = new Statement(new Variable().asUserDefined());
-                    Statement toRolePlayer = new Statement(new Variable().asUserDefined());
+                    Statement fromRolePlayer = new Statement(new Variable().asReturnedVar());
+                    Statement toRolePlayer = new Statement(new Variable().asReturnedVar());
 
                     Pattern relationInsert = Graql.and(
                             var().rel(Graql.type(fromRole.label().getValue()), fromRolePlayer)
@@ -242,7 +242,7 @@ public class BenchmarkBigIT {
                     );
                     transaction.execute(Graql.insert(relationInsert.statements()));
 
-                    Pattern resourceInsert = new Statement(new Variable().asUserDefined())
+                    Pattern resourceInsert = new Statement(new Variable().asReturnedVar())
                             .has(attributeLabel, String.valueOf(i))
                             .id(instances[i].getValue());
                     transaction.execute(Graql.insert(resourceInsert.statements()));

--- a/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
@@ -90,8 +90,8 @@ public class BenchmarkSmallIT {
                     .assign(toRole, toEntity);
 
             for (int i = 1; i <= N; i++) {
-                Statement fromVar = new Statement(new Variable().asUserDefined());
-                Statement toVar = new Statement(new Variable().asUserDefined());
+                Statement fromVar = new Statement(new Variable().asReturnedVar());
+                Statement toVar = new Statement(new Variable().asReturnedVar());
                 Statement rulePattern = Graql
                         .type("rule" + i)
                         .when(

--- a/test-integration/graql/reasoner/pattern/RelationPattern.java
+++ b/test-integration/graql/reasoner/pattern/RelationPattern.java
@@ -89,13 +89,13 @@ public abstract class RelationPattern extends QueryPattern {
     private static List<Pattern> generateRelationPatterns(
             Multimap<Label, Pair<Label, List<ConceptId>>> spec,
             List<ConceptId> relationIds){
-        Statement relationVar = !relationIds.isEmpty()? new Statement(new Variable().asUserDefined()) : Graql.var();
+        Statement relationVar = !relationIds.isEmpty()? new Statement(new Variable().asReturnedVar()) : Graql.var();
         Statement[] basePattern = {relationVar};
         List<List<Pattern>> rpTypePatterns = new ArrayList<>();
         List<List<Pattern>> rpIdPatterns = new ArrayList<>();
         Multimap<Label, Statement> rps = HashMultimap.create();
         spec.entries().forEach(entry -> {
-            Statement rolePlayer = new Statement(new Variable().asUserDefined());
+            Statement rolePlayer = new Statement(new Variable().asReturnedVar());
             Label role = entry.getKey();
             Label type = entry.getValue().getKey();
             List<ConceptId> ids = entry.getValue().getValue();


### PR DESCRIPTION
## What is the goal of this PR?
Synchronize with a new version of Graql, which supports extended character sets for labels and implicit labels, and renames `asUserDefined` to `asReturnedVar` no `Variable` objects.
 
## What are the changes implemented in this PR?
Synchronize with changes in the Graql repository. Code had to be updated in various places to rename `var.asUserDefined()` and `var.isUserDefinedName()` to `var.asReturnedVar()` and `var.isReturned()`.