### PR TITLE
Cleanup use of id prefixes

### DIFF
--- a/server/src/graql/gremlin/fragment/IdFragment.java
+++ b/server/src/graql/gremlin/fragment/IdFragment.java
@@ -91,6 +91,6 @@ abstract class IdFragment extends Fragment {
 
     @Override
     public boolean canOperateOnEdges() {
-        return id().getValue().startsWith(Schema.PREFIX_EDGE);
+        return Schema.isEdgeId(id());
     }
 }

--- a/server/src/server/kb/Schema.java
+++ b/server/src/server/kb/Schema.java
@@ -49,8 +49,8 @@ import static grakn.core.common.util.Collections.tuple;
  * A type enum which restricts the types of links/concepts which can be created
  */
 public final class Schema {
-    public final static String PREFIX_VERTEX = "V";
-    public final static String PREFIX_EDGE = "E";
+    private final static String PREFIX_VERTEX = "V";
+    private final static String PREFIX_EDGE = "E";
 
     private Schema() {
         throw new UnsupportedOperationException();
@@ -67,6 +67,10 @@ public final class Schema {
 
     public static String elementId(ConceptId conceptId){
         return conceptId.getValue().substring(1);
+    }
+
+    public static boolean isEdgeId(ConceptId conceptId){
+        return conceptId.getValue().startsWith(Schema.PREFIX_EDGE);
     }
 
     /**

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -660,7 +660,7 @@ public class TransactionOLTP implements Transaction {
             if (transactionCache.isConceptCached(id)) {
                 return transactionCache.getCachedConcept(id);
             } else {
-                if (id.getValue().startsWith(Schema.PREFIX_EDGE)) {
+                if (Schema.isEdgeId(id)) {
                     Optional<T> concept = getConceptEdge(id);
                     if (concept.isPresent()) return concept.get();
                 }
@@ -676,7 +676,7 @@ public class TransactionOLTP implements Transaction {
     }
 
     private <T extends Concept> Optional<T> getConceptEdge(ConceptId id) {
-        String edgeId = id.getValue().substring(1);
+        String edgeId = Schema.elementId(id);
         GraphTraversal<Edge, Edge> traversal = getTinkerTraversal().E(edgeId);
         if (traversal.hasNext()) {
             return Optional.of(factory().buildConcept(factory().buildEdgeElement(traversal.next())));

--- a/test-integration/server/kb/concept/AttributeIT.java
+++ b/test-integration/server/kb/concept/AttributeIT.java
@@ -206,7 +206,7 @@ public class AttributeIT {
 
         RelationStructure relationStructure = RelationImpl.from(Iterables.getOnlyElement(entity.relations().collect(toSet()))).structure();
         assertThat(relationStructure, instanceOf(RelationEdge.class));
-        assertTrue("Edge Relation id not starting with [" + Schema.PREFIX_EDGE + "]", relationStructure.id().getValue().startsWith(Schema.PREFIX_EDGE));
+        assertTrue("Edge Relation id not starting with edge prefix", Schema.isEdgeId(relationStructure.id()));
         assertEquals(entity, attribute.owner());
         assertThat(entity.attributes().collect(toSet()), containsInAnyOrder(attribute));
     }


### PR DESCRIPTION
## What is the goal of this PR?

Centralise the use of id prefixes to `Schema`

## What are the changes implemented in this PR?

All ConceptId prefix manipulation happens in `Schema`.
