### PR TITLE
Restrict the token patterns for type labels and ID values

### DIFF
--- a/concept/printer/StringPrinter.java
+++ b/concept/printer/StringPrinter.java
@@ -40,8 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static graql.lang.util.StringUtil.escapeLabelOrId;
-
 /**
  * Default printer that prints results in Graql syntax
  *
@@ -64,7 +62,7 @@ public class StringPrinter extends Printer<StringBuilder> {
      * then it will be returned as-is, otherwise it will be quoted and escaped.
      */
     public static String conceptId(ConceptId id) {
-        return escapeLabelOrId(id.getValue());
+        return id.getValue();
     }
 
     /**
@@ -75,7 +73,7 @@ public class StringPrinter extends Printer<StringBuilder> {
      * then it will be returned as-is, otherwise it will be quoted and escaped.
      */
     public static String label(Label label) {
-        return escapeLabelOrId(label.getValue());
+        return label.getValue();
     }
 
     @Override

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "6772dab83f6e2c086786e9d9c5a3e2b04cd100ff", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "56f792ce5d0edd007c28d202d348057dfe6e795c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_graql():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,8 +28,8 @@ def graknlabs_build_tools():
 def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
-         remote = "https://github.com/haikalpribadi/graql",
-         commit = "95462c29853045a0e220b72114b87c242f064c01",
+         remote = "https://github.com/graknlabs/graql",
+         commit = "1af73102b3763400570eccd95b0371fcf0c37eae",
      )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -28,8 +28,8 @@ def graknlabs_build_tools():
 def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
-         remote = "https://github.com/graknlabs/graql",
-         commit = "4909270feeb9ca2951e001b26325d4c3f1d481b5",
+         remote = "https://github.com/haikalpribadi/graql",
+         commit = "29d268ec416672075d7c68f791286f7d316a29cf",
      )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/haikalpribadi/graql",
-         commit = "29d268ec416672075d7c68f791286f7d316a29cf",
+         commit = "95462c29853045a0e220b72114b87c242f064c01",
      )
 
 def graknlabs_client_java():

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -154,7 +154,7 @@ public class GraqlComputeIT {
         queryList.add("compute cluster using k-core;");
         queryList.add("compute centrality using degree;");
         queryList.add("compute centrality using k-core;");
-        queryList.add("compute path from \"" + entityId1 + "\", to \"" + entityId4 + "\";");
+        queryList.add("compute path from " + entityId1 + ", to " + entityId4 + ";");
 
         List<?> result = queryList.parallelStream().map(query -> {
             try (TransactionOLTP tx = session.transaction().read()) {
@@ -277,7 +277,7 @@ public class GraqlComputeIT {
         addSchemaAndEntities();
 
         try (TransactionOLTP tx = session.transaction().write()) {
-            GraqlCompute.Path query = Graql.parse("compute path from '" + entityId1 + "', to '" + entityId2 + "';").asComputePath();
+            GraqlCompute.Path query = Graql.parse("compute path from " + entityId1 + ", to " + entityId2 + ";").asComputePath();
             List<ConceptList> paths = tx.execute(query);
 
             List<ConceptId> path = Collections.emptyList();
@@ -294,7 +294,7 @@ public class GraqlComputeIT {
         addSchemaAndEntities();
 
         try (TransactionOLTP tx = session.transaction().write()) {
-            GraqlCompute.Path query = Graql.parse("compute path from '" + entityId1 + "', to '" + entityId2 + "';").asComputePath();
+            GraqlCompute.Path query = Graql.parse("compute path from " + entityId1 + ", to " + entityId2 + ";").asComputePath();
             List<ConceptList> paths = tx.execute(query);
             assertEquals(1, paths.size());
             List<String> result = paths.get(0).list().stream().map(ConceptId::getValue).collect(Collectors.toList());

--- a/test-integration/graql/query/QueryValidityIT.java
+++ b/test-integration/graql/query/QueryValidityIT.java
@@ -85,29 +85,29 @@ public class QueryValidityIT {
 
     @Test
     public void whenQueryingForInexistentConceptId_emptyResultReturned(){
-        String queryString = "match $x id 'V1337'; $y id 'V456'; ($x, $y); get;";
+        String queryString = "match $x id V1337; $y id V456; ($x, $y); get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
     }
 
     @Test
     public void whenQueryingForInexistentEntityTypeId_emptyResultReturned(){
-        String queryString = "match $x isa $type; $type id 'V1337'; get;";
+        String queryString = "match $x isa $type; $type id V1337; get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
     }
 
     @Test
     public void whenQueryingForInexistentRelationTypeId_emptyResultReturned(){
-        String queryString = "match ($x, $y) isa $type; $type id 'V1337'; get;";
-        String queryString2 = "match $r ($x, $y) isa $type; $r id 'V1337'; get;";
+        String queryString = "match ($x, $y) isa $type; $type id V1337; get;";
+        String queryString2 = "match $r ($x, $y) isa $type; $r id V1337; get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
         assertThat(tx.execute(Graql.parse(queryString2).asGet()), empty());
     }
 
     @Test
     public void whenQueryingForInexistentResourceId_emptyResultReturned(){
-        String queryString = "match $x has name $y; $x id 'V1337'; get;";
-        String queryString2 = "match $x has name $y; $y id 'V1337'; get;";
-        String queryString3 = "match $x has name $y via $r; $r id 'V1337'; get;";
+        String queryString = "match $x has name $y; $x id V1337; get;";
+        String queryString2 = "match $x has name $y; $y id V1337; get;";
+        String queryString3 = "match $x has name $y via $r; $r id V1337; get;";
         assertThat(tx.execute(Graql.parse(queryString).asGet()), empty());
         assertThat(tx.execute(Graql.parse(queryString2).asGet()), empty());
         assertThat(tx.execute(Graql.parse(queryString3).asGet()), empty());

--- a/test-integration/graql/reasoner/GeoInferenceIT.java
+++ b/test-integration/graql/reasoner/GeoInferenceIT.java
@@ -181,11 +181,11 @@ public class GeoInferenceIT {
             Concept europe = getConcept(tx, "name", "Europe");
             String queryString = "match " +
                     "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
-                    "$y id '" + poland.id().getValue() + "'; get;";
+                    "$y id " + poland.id().getValue() + "; get;";
 
             String queryString2 = "match " +
                     "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
-                    "$y id '" + europe.id().getValue() + "'; get;";
+                    "$y id " + europe.id().getValue() + "; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
             answers.forEach(ans -> assertEquals(2, ans.size()));
@@ -207,12 +207,12 @@ public class GeoInferenceIT {
             Concept masovia = getConcept(tx, "name", "Masovia");
             String queryString = "match " +
                     "($x, $y) isa is-located-in;" +
-                    "$y id '" + masovia.id().getValue() + "'; get;";
+                    "$y id " + masovia.id().getValue() + "; get;";
 
             String queryString2 = "match " +
                     "{ (geo-entity: $x, entity-location: $y) isa is-located-in; } or " +
                     "{ (geo-entity: $y, entity-location: $x) isa is-located-in; };" +
-                    "$y id '" + masovia.id().getValue() + "'; get;";
+                    "$y id " + masovia.id().getValue() + "; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
             answers.forEach(ans -> assertEquals(2, ans.size()));
@@ -230,7 +230,7 @@ public class GeoInferenceIT {
             Concept masovia = getConcept(tx, "name", "Masovia");
             String queryString = "match " +
                     "($r1: $x, $r2: $y) isa is-located-in;" +
-                    "$y id '" + masovia.id().getValue() + "'; get;";
+                    "$y id " + masovia.id().getValue() + "; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
 
@@ -281,7 +281,7 @@ public class GeoInferenceIT {
             Concept masovia = getConcept(tx, "name", "Masovia");
             String queryString = "match " +
                     "$x ($r1: $x1, $r2: $x2) isa is-located-in;" +
-                    "$x2 id '" + masovia.id().getValue() + "'; get;";
+                    "$x2 id " + masovia.id().getValue() + "; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
             assertEquals(20, answers.size());
@@ -323,7 +323,7 @@ public class GeoInferenceIT {
             Concept masovia = getConcept(tx, "name", "Masovia");
             String queryString = "match " +
                     "($x, $r2: $y) isa is-located-in;" +
-                    "$y id '" + masovia.id().getValue() + "'; get;";
+                    "$y id " + masovia.id().getValue() + "; get;";
 
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
 

--- a/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
@@ -132,9 +132,9 @@ public class AtomicUnificationIT {
     @Test
     public void testUnification_RelationWithMetaRolesAndIds(){
         Concept instance = tx.execute(Graql.parse("match $x isa subRoleEntity; get;").asGet()).iterator().next().get("x");
-        String relation = "{ (role: $x, role: $y) isa binary; $y id '" + instance.id().getValue() + "'; };";
-        String relation2 = "{ (role: $z, role: $v) isa binary; $z id '" + instance.id().getValue() + "'; };";
-        String relation3 = "{ (role: $z, role: $v) isa binary; $v id '" + instance.id().getValue() + "'; };";
+        String relation = "{ (role: $x, role: $y) isa binary; $y id " + instance.id().getValue() + "; };";
+        String relation2 = "{ (role: $z, role: $v) isa binary; $z id " + instance.id().getValue() + "; };";
+        String relation3 = "{ (role: $z, role: $v) isa binary; $v id " + instance.id().getValue() + "; };";
 
         exactUnification(relation, relation2, true, true, tx);
         exactUnification(relation, relation3, true, true, tx);
@@ -258,8 +258,8 @@ public class AtomicUnificationIT {
     public void testUnification_VariousTypeAtoms(){
         String type = "{ $x isa baseRoleEntity; };";
         String type2 = "{ $y isa baseRoleEntity; };";
-        String userDefinedType = "{ $y isa $x;$x type 'baseRoleEntity'; };";
-        String userDefinedType2 = "{ $u isa $v;$v type 'baseRoleEntity'; };";
+        String userDefinedType = "{ $y isa $x;$x type baseRoleEntity; };";
+        String userDefinedType2 = "{ $u isa $v;$v type baseRoleEntity; };";
 
         exactUnification(type, type2, true, true, tx);
         exactUnification(userDefinedType, userDefinedType2, true, true, tx);
@@ -316,7 +316,7 @@ public class AtomicUnificationIT {
         ReasonerAtomicQuery resourceQuery2 = ReasonerQueries.atomic(conjunction(resource2, tx), tx);
         ReasonerAtomicQuery resourceQuery3 = ReasonerQueries.atomic(conjunction(resource3, tx), tx);
 
-        String type = "{ $x isa resource;$x id '" + tx.execute(resourceQuery.getQuery(), false).iterator().next().get("r").id().getValue()  + "'; };";
+        String type = "{ $x isa resource;$x id " + tx.execute(resourceQuery.getQuery(), false).iterator().next().get("r").id().getValue()  + "; };";
         ReasonerAtomicQuery typeQuery = ReasonerQueries.atomic(conjunction(type, tx), tx);
         Atom typeAtom = typeQuery.getAtom();
 
@@ -405,14 +405,14 @@ public class AtomicUnificationIT {
         ReasonerAtomicQuery childQuery = ReasonerQueries
                 .atomic(conjunction(
                         "{($r1: $x1, $r2: $x2) isa binary;" +
-                                "$r1 type 'subRole1';" +
-                                "$r2 type 'subSubRole2'; };"
+                                "$r1 type subRole1;" +
+                                "$r2 type subSubRole2; };"
                         , tx), tx);
         ReasonerAtomicQuery parentQuery = ReasonerQueries
                 .atomic(conjunction(
                         "{ ($R1: $x, $R2: $y) isa binary;" +
-                                "$R1 type 'subRole1';" +
-                                "$R2 type 'subSubRole2'; };"
+                                "$R1 type subRole1;" +
+                                "$R2 type subSubRole2; };"
                         , tx), tx);
         exactUnification(parentQuery, childQuery, true, true);
         exactUnification(baseQuery, parentQuery, true, true);
@@ -429,14 +429,14 @@ public class AtomicUnificationIT {
         ReasonerAtomicQuery childQuery = ReasonerQueries
                 .atomic(conjunction(
                         "{ ($r1: $x1, $r2: $x2); " +
-                                "$r1 type 'subRole1';" +
-                                "$r2 type 'subSubRole2'; };"
+                                "$r1 type subRole1;" +
+                                "$r2 type subSubRole2; };"
                         , tx), tx);
         ReasonerAtomicQuery parentQuery = ReasonerQueries
                 .atomic(conjunction(
                         "{ ($R1: $x, $R2: $y); " +
-                                "$R1 type 'subRole1';" +
-                                "$R2 type 'subSubRole2'; };"
+                                "$R1 type subRole1;" +
+                                "$R2 type subSubRole2; };"
                         , tx), tx);
         exactUnification(parentQuery, childQuery, true, true);
         exactUnification(baseQuery, parentQuery, true, true);

--- a/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
@@ -522,7 +522,7 @@ public class RuleApplicabilityIT {
             Concept concept = getConcept(tx, "name", "noRoleEntity");
             String relationString = "{" +
                     "($x, $y) isa ternary;" +
-                    "$x id '" + concept.id().getValue() + "';" +
+                    "$x id " + concept.id().getValue() + ";" +
                     "};";
             Atom relation = ReasonerQueries.atomic(conjunction(relationString, tx), tx).getAtom();
             assertThat(relation.getApplicableRules().collect(toSet()), empty());
@@ -535,7 +535,7 @@ public class RuleApplicabilityIT {
             Concept concept = getConcept(tx, "name", "noRoleEntity");
             String relationString = "{" +
                     "($x, $y);" +
-                    "$x id '" + concept.id().getValue() + "';" +
+                    "$x id " + concept.id().getValue() + ";" +
                     "};";
 
             Atom relation = ReasonerQueries.atomic(conjunction(relationString, tx), tx).getAtom();
@@ -769,7 +769,7 @@ public class RuleApplicabilityIT {
     public void testRuleApplicability_whenMatchingRulesForGroundAtomRedefinedViaRule_ruleIsMatched(){
         try(TransactionOLTP tx = ruleApplicabilitySession.transaction().read()) {
             Relation instance = tx.getRelationType("reifiable-relation").instances().findFirst().orElse(null);
-            String queryString = "{ $r has description 'typed-reified'; $r id '" + instance.id().getValue() + "'; };";
+            String queryString = "{ $r has description 'typed-reified'; $r id " + instance.id().getValue() + "; };";
             Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 
             assertTrue(atom.getApplicableRules().findFirst().isPresent());
@@ -780,7 +780,7 @@ public class RuleApplicabilityIT {
     public void testRuleApplicability_whenMatchingRulesForGroundTypeWhichIsNotRedefined_noRulesAreMatched(){
         try(TransactionOLTP tx = ruleApplicabilitySession.transaction().read()) {
             Relation instance = tx.getRelationType("binary").instances().findFirst().orElse(null);
-            String queryString = "{ $x isa binary; $x id '" + instance.id().getValue() + "'; };";
+            String queryString = "{ $x isa binary; $x id " + instance.id().getValue() + "; };";
             Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 
             assertThat(atom.getApplicableRules().collect(toSet()), empty());
@@ -791,7 +791,7 @@ public class RuleApplicabilityIT {
     public void testRuleApplicability_whenMatchingRulesForASpecificRelation_noRulesAreMatched(){
         try(TransactionOLTP tx = ruleApplicabilitySession.transaction().read()) {
             Relation instance = tx.getRelationType("binary").instances().findFirst().orElse(null);
-            String queryString = "{ $r ($x, $y) isa binary; $r id '" + instance.id().getValue() + "'; };";
+            String queryString = "{ $r ($x, $y) isa binary; $r id " + instance.id().getValue() + "; };";
             Atom atom = ReasonerQueries.atomic(conjunction(queryString, tx), tx).getAtom();
 
             assertThat(atom.getApplicableRules().collect(toSet()), empty());

--- a/test-integration/graql/reasoner/atomic/TypeInferenceIT.java
+++ b/test-integration/graql/reasoner/atomic/TypeInferenceIT.java
@@ -100,16 +100,16 @@ public class TypeInferenceIT {
 
         //parent of all roles so all relations possible
         String patternString = "{ $x isa noRoleEntity; ($x, $y); };";
-        String subbedPatternString = "{ $x id '" + conceptId(tx, "noRoleEntity") + "';($x, $y); };";
+        String subbedPatternString = "{ $x id " + conceptId(tx, "noRoleEntity") + ";($x, $y); };";
 
         //SRE -> rel2
         //sub(SRE)=TRE -> rel3
         String patternString2 = "{ $x isa singleRoleEntity; ($x, $y); };";
-        String subbedPatternString2 = "{ $x id '" + conceptId(tx, "singleRoleEntity") + "';($x, $y); };";
+        String subbedPatternString2 = "{ $x id " + conceptId(tx, "singleRoleEntity") + ";($x, $y); };";
 
         //TRE -> rel3
         String patternString3 = "{ $x isa twoRoleEntity; ($x, $y); };";
-        String subbedPatternString3 = "{ $x id '" + conceptId(tx, "twoRoleEntity") + "';($x, $y); };";
+        String subbedPatternString3 = "{ $x id " + conceptId(tx, "twoRoleEntity") + ";($x, $y); };";
 
         List<Type> possibleTypes = Lists.newArrayList(
                 tx.getType(Label.of("anotherTwoRoleBinary")),
@@ -129,20 +129,20 @@ public class TypeInferenceIT {
         //{rel2, rel3} ^ {rel1, rel2, rel3} = {rel2, rel3}
         String patternString = "{ $x isa singleRoleEntity; ($x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString = "{($x, $y);" +
-                "$x id '" + conceptId(tx, "singleRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "singleRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         //{rel2, rel3} ^ {rel1, rel2, rel3} = {rel2, rel3}
         String patternString2 = "{ $x isa twoRoleEntity; ($x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString2 = "{($x, $y);" +
-                "$x id '" + conceptId(tx, "twoRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "twoRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         //{rel1} ^ {rel1, rel2, rel3} = {rel1}
         String patternString3 = "{ $x isa yetAnotherSingleRoleEntity; ($x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString3 = "{($x, $y);" +
-                "$x id '" + conceptId(tx, "yetAnotherSingleRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "yetAnotherSingleRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         List<Type> possibleTypes = Lists.newArrayList(
                 tx.getType(Label.of("anotherTwoRoleBinary")),
@@ -191,15 +191,15 @@ public class TypeInferenceIT {
         //{rel1, rel2, rel3} ^ {rel2, rel3}
         String patternString = "{ (role2: $x, $y); $y isa singleRoleEntity; };";
         String subbedPatternString = "{(role2: $x, $y);" +
-                "$y id '" + conceptId(tx, "singleRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "singleRoleEntity") + ";};";
         //{rel1, rel2, rel3} ^ {rel2, rel3}
         String patternString2 = "{ (role2: $x, $y); $y isa twoRoleEntity; };";
         String subbedPatternString2 = "{(role2: $x, $y);" +
-                "$y id '" + conceptId(tx, "twoRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "twoRoleEntity") + ";};";
         //{rel1} ^ {rel1, rel2, rel3}
         String patternString3 = "{ (role1: $x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString3 = "{(role1: $x, $y);" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") + ";};";
 
         List<Type> possibleTypes = Lists.newArrayList(
                 tx.getType(Label.of("anotherTwoRoleBinary")),
@@ -219,11 +219,11 @@ public class TypeInferenceIT {
         //{rel3} ^ {rel2, rel3}
         String patternString = "{ (subRole2: $x, $y); $y isa twoRoleEntity; };";
         String subbedPatternString = "{(subRole2: $x, $y);" +
-                "$y id '" + conceptId(tx, "twoRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "twoRoleEntity") + ";};";
         //{rel3} ^ {rel1, rel2, rel3}
         String patternString2 = "{ (subRole2: $x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString2 = "{(subRole2: $x, $y);" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") + ";};";
 
         typeInference(Collections.singletonList(tx.getSchemaConcept(Label.of("threeRoleBinary"))), patternString, subbedPatternString, tx);
         typeInference(Collections.singletonList(tx.getSchemaConcept(Label.of("threeRoleBinary"))), patternString2, subbedPatternString2, tx);
@@ -237,10 +237,10 @@ public class TypeInferenceIT {
         //{rel1} ^ {rel2}
         String patternString = "{ (role1: $x, $y); $y isa singleRoleEntity; };";
         String subbedPatternString = "{(role1: $x, $y);" +
-                "$y id '" + conceptId(tx, "singleRoleEntity") + "';};";
+                "$y id " + conceptId(tx, "singleRoleEntity") + ";};";
         String patternString2 = "{ (role1: $x, $y); $x isa singleRoleEntity; };";
         String subbedPatternString2 = "{(role1: $x, $y);" +
-                "$x id '" + conceptId(tx, "singleRoleEntity") + "';};";
+                "$x id " + conceptId(tx, "singleRoleEntity") + ";};";
 
         typeInference(Collections.emptyList(), patternString, subbedPatternString, tx);
         typeInference(Collections.emptyList(), patternString2, subbedPatternString2, tx);
@@ -253,8 +253,8 @@ public class TypeInferenceIT {
         //{rel2, rel3} ^ {rel1, rel2, rel3} ^ {rel1, rel2, rel3}
         String patternString = "{ $x isa singleRoleEntity;(role2: $x, $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString = "{(role2: $x, $y);" +
-                "$x id '" + conceptId(tx, "singleRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "singleRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         List<Type> possibleTypes = Lists.newArrayList(
                 tx.getType(Label.of("anotherTwoRoleBinary")),
@@ -271,14 +271,14 @@ public class TypeInferenceIT {
         //{rel1, rel2, rel3} ^ {rel3} ^ {rel2, rel3} ^ {rel1, rel2, rel3}
         String patternString = "{ $x isa threeRoleEntity;(subRole2: $x, role3: $y); $y isa threeRoleEntity; };";
         String subbedPatternString = "{(subRole2: $x, role3: $y);" +
-                "$x id '" + conceptId(tx, "threeRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "threeRoleEntity") + "';};";
+                "$x id " + conceptId(tx, "threeRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "threeRoleEntity") + ";};";
 
         //{rel1, rel2, rel3} ^ {rel1, rel2, rel3} ^ {rel2, rel3} ^ {rel1, rel2, rel3}
         String patternString2 = "{ $x isa threeRoleEntity;(role2: $x, role3: $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString2 = "{(role2: $x, role3: $y);" +
-                "$x id '" + conceptId(tx, "threeRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "threeRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         typeInference(Collections.singletonList(tx.getSchemaConcept(Label.of("threeRoleBinary"))), patternString, subbedPatternString, tx);
 
@@ -297,14 +297,14 @@ public class TypeInferenceIT {
         //{rel2, rel3} ^ {rel1} ^ {rel1, rel2, rel3} ^ {rel1, rel2, rel3}
         String patternString = "{ $x isa singleRoleEntity;(role1: $x, role2: $y); $y isa anotherTwoRoleEntity; };";
         String subbedPatternString = "{(role1: $x, role2: $y);" +
-                "$x id '" + conceptId(tx, "singleRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherTwoRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "singleRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherTwoRoleEntity") +";};";
 
         //{rel2, rel3} ^ {rel1} ^ {rel1, rel2, rel3} ^ {rel1, rel2, rel3}
         String patternString2 = "{ $x isa singleRoleEntity;(role1: $x, role2: $y); $y isa anotherSingleRoleEntity; };";
         String subbedPatternString2 = "{(role1: $x, role2: $y);" +
-                "$x id '" + conceptId(tx, "singleRoleEntity") + "';" +
-                "$y id '" + conceptId(tx, "anotherSingleRoleEntity") +"';};";
+                "$x id " + conceptId(tx, "singleRoleEntity") + ";" +
+                "$y id " + conceptId(tx, "anotherSingleRoleEntity") +";};";
 
         typeInference(Collections.emptyList(), patternString, subbedPatternString, tx);
         typeInference(Collections.emptyList(), patternString2, subbedPatternString2, tx);

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -271,10 +271,10 @@ public class BenchmarkBigIT {
                 String queryPattern = "(P-from: $x, P-to: $y) isa P;";
                 String queryString = "match " + queryPattern + " get;";
                 String subbedQueryString = "match " + queryPattern +
-                        " $x id '" + entityId.getValue() + "';" +
+                        " $x id " + entityId.getValue() + ";" +
                         " get;";
                 String subbedQueryString2 = "match " + queryPattern +
-                        " $y id '" + entityId.getValue() + "';" +
+                        " $y id " + entityId.getValue() + ";" +
                         " get;";
                 String limitedQueryString = "match " + queryPattern +
                         " get; limit " + limit + ";";
@@ -315,11 +315,11 @@ public class BenchmarkBigIT {
                 String queryString = "match " + queryPattern + " get;";
                 String subbedQueryString = "match " +
                         queryPattern +
-                        " $x id '" + entityId.getValue() + "';" +
+                        " $x id " + entityId.getValue() + ";" +
                         " get;";
                 String subbedQueryString2 = "match " +
                         queryPattern +
-                        " $y id '" + entityId.getValue() + "';" +
+                        " $y id " + entityId.getValue() + ";" +
                         " get;";
                 String limitedQueryString = "match " + queryPattern +
                         " get; limit " + limit + ";";
@@ -356,10 +356,10 @@ public class BenchmarkBigIT {
                 String queryPattern = "(fromRole: $x, toRole: $y) isa relation" + N + ";";
                 String queryString = "match " + queryPattern + " get;";
                 String subbedQueryString = "match " + queryPattern +
-                        "$x id '" + firstId.getValue() + "';" +
+                        "$x id " + firstId.getValue() + ";" +
                         "get;";
                 String subbedQueryString2 = "match " + queryPattern +
-                        "$y id '" + lastId.getValue() + "';" +
+                        "$y id " + lastId.getValue() + ";" +
                         "get;";
                 String limitedQueryString = "match " + queryPattern +
                         "get; limit 1;";

--- a/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkSmallIT.java
@@ -265,7 +265,7 @@ public class BenchmarkSmallIT {
 
         //with substitution
         Concept id = tx.execute(Graql.parse("match $x has index 'a'; get;").asGet()).iterator().next().get("x");
-        String queryString3 = "match (Q-from: $x, Q-to: $y) isa Q;$x id '" + id.id().getValue() + "'; get;";
+        String queryString3 = "match (Q-from: $x, Q-to: $y) isa Q;$x id " + id.id().getValue() + "; get;";
         GraqlGet query3 = Graql.parse(queryString3).asGet();
 
         executeQuery(query, tx, "full");

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -111,8 +111,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(subRole1: $x, subRole2: $y) isa binary;" +
-                            "$x id '" + mConcept.id().getValue() + "';" +
-                            "$y id '" + sConcept.id().getValue() + "';" +
+                            "$x id " + mConcept.id().getValue() + ";" +
+                            "$y id " + sConcept.id().getValue() + ";" +
                             "};"),
                     tx);
 
@@ -184,7 +184,7 @@ public class QueryCacheIT {
             ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y) isa binary;" +
-                            "$y id '" + dConcept.getValue() + "';" +
+                            "$y id " + dConcept.getValue() + ";" +
                     "};"),
                     tx);
 
@@ -200,8 +200,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y) isa binary;" +
-                            "$x id '" + id.getValue() + "';" +
-                            "$y id '" + dConcept.getValue() + "';" +
+                            "$x id " + id.getValue() + ";" +
+                            "$y id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -217,8 +217,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery anotherChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y) isa binary;" +
-                            "$x id '" + id.getValue() + "';" +
-                            "$y id '" + sConcept.getValue() + "';" +
+                            "$x id " + id.getValue() + ";" +
+                            "$y id " + sConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -245,7 +245,7 @@ public class QueryCacheIT {
             ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$z id '" + dConcept.getValue() + "';" +
+                            "$z id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -259,8 +259,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$x id '" + fConcept.getValue() + "';" +
-                            "$z id '" + dConcept.getValue() + "';" +
+                            "$x id " + fConcept.getValue() + ";" +
+                            "$z id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -275,9 +275,9 @@ public class QueryCacheIT {
             ReasonerAtomicQuery anotherChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$x id '" + mConcept.getValue() + "';" +
-                            "$y id '" + mConcept.getValue() + "';" +
-                            "$z id '" + sConcept.getValue() + "';" +
+                            "$x id " + mConcept.getValue() + ";" +
+                            "$y id " + mConcept.getValue() + ";" +
+                            "$z id " + sConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -302,7 +302,7 @@ public class QueryCacheIT {
             ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$z id '" + dConcept.getValue() + "';" +
+                            "$z id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -315,8 +315,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$x id '" + fConcept.getValue() + "';" +
-                            "$z id '" + dConcept.getValue() + "';" +
+                            "$x id " + fConcept.getValue() + ";" +
+                            "$z id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -333,9 +333,9 @@ public class QueryCacheIT {
             ReasonerAtomicQuery anotherChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
-                            "$x id '" + fConcept.getValue() + "';" +
-                            "$y id '" + mConcept.getValue() + "';" +
-                            "$z id '" + dConcept.getValue() + "';" +
+                            "$x id " + fConcept.getValue() + ";" +
+                            "$y id " + mConcept.getValue() + ";" +
+                            "$z id " + dConcept.getValue() + ";" +
                             "};"),
                     tx);
 
@@ -415,8 +415,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery preChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(subRole1: $x, subRole2: $y) isa binary;" +
-                            "$x id '" + fConcept.id().getValue() + "';" +
-                            "$y id '" + sConcept.id().getValue() + "';" +
+                            "$x id " + fConcept.id().getValue() + ";" +
+                            "$y id " + sConcept.id().getValue() + ";" +
                             "};"),
                     tx);
             tx.stream(preChildQuery.getQuery())
@@ -427,8 +427,8 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                     "(subRole1: $x, subRole2: $y) isa binary;" +
-                                "$x id '" + mConcept.id().getValue() + "';" +
-                                "$y id '" + sConcept.id().getValue() + "';" +
+                                "$x id " + mConcept.id().getValue() + ";" +
+                                "$y id " + sConcept.id().getValue() + ";" +
                             "};"),
                     tx);
 
@@ -457,7 +457,7 @@ public class QueryCacheIT {
             ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(subRole1: $x, subRole2: $y) isa binary;" +
-                            "$x id '" + mConcept.id().getValue() + "';" +
+                            "$x id " + mConcept.id().getValue() + ";" +
                             "};"),
                     tx);
 
@@ -478,7 +478,7 @@ public class QueryCacheIT {
             ReasonerAtomicQuery preChildQuery = ReasonerQueries.atomic(conjunction(
                     "{" +
                             "(subRole1: $x, subRole2: $y) isa binary;" +
-                            "$x id '" + fConcept.id().getValue() + "';" +
+                            "$x id " + fConcept.id().getValue() + ";" +
                             "};")
                     , tx);
             tx.stream(preChildQuery.getQuery())

--- a/test-integration/graql/reasoner/pattern/AttributePattern.java
+++ b/test-integration/graql/reasoner/pattern/AttributePattern.java
@@ -42,16 +42,16 @@ public class AttributePattern extends QueryPattern {
                 "{ $xd has attribute 'someValue'; };",
 
                 //5-6
-                "{ $x1a has " + resource + " $r1a; $x1a id '" + entityId + "'; };",
-                "{ $x1b has " + resource + " $r1b; $x1b id '" + anotherEntityId + "'; };",
+                "{ $x1a has " + resource + " $r1a; $x1a id " + entityId + "; };",
+                "{ $x1b has " + resource + " $r1b; $x1b id " + anotherEntityId + "; };",
 
                 //7-8
-                "{ $x1c has " + resource + " 'someValue'; $x1c id '" + entityId + "'; };",
-                "{ $x1d has " + resource + " 'someOtherValue'; $x1d id '" + anotherEntityId + "'; };",
+                "{ $x1c has " + resource + " 'someValue'; $x1c id " + entityId + "; };",
+                "{ $x1d has " + resource + " 'someOtherValue'; $x1d id " + anotherEntityId + "; };",
 
                 //9-10
-                "{ $x2a has " + resource + " $r2a; $r2a id '" + resourceId + "'; };",
-                "{ $x2b has " + resource + " $r2b; $r2b id '" + anotherResourceId + "'; };",
+                "{ $x2a has " + resource + " $r2a; $r2a id " + resourceId + "; };",
+                "{ $x2b has " + resource + " $r2b; $r2b id " + anotherResourceId + "; };",
 
                 //11-14
                 "{ $x3a has " + resource + " 'someValue'; };",
@@ -91,7 +91,7 @@ public class AttributePattern extends QueryPattern {
 
                 //33-35
                 //contradiction between attribute concept and provided value
-                "{ $x8b has " + resource + " $r8b; $r8b id '" + anotherResourceId + "'; $r8b 'someValue'; };",
+                "{ $x8b has " + resource + " $r8b; $r8b id " + anotherResourceId + "; $r8b 'someValue'; };",
                 //contradicting value predicates
                 "{ $x8c isa " + type + "; $x8c has " + anotherResource + " $r8c; $r8c > 27; $r8c < 23; };"
 
@@ -100,9 +100,9 @@ public class AttributePattern extends QueryPattern {
                 //TODO
                 //18-22
                 //"{ $x6a has " + resource + " $r6a; $r6a != $r2_6a; };",
-                //"{ $x6b has " + resource + " $r6b; $r6b != $r2_6b; $r2_6b id '" + resourceId + "'; };",
+                //"{ $x6b has " + resource + " $r6b; $r6b != $r2_6b; $r2_6b id " + resourceId + "; };",
                 //"{ $x6c has " + resource + " $r6c; $x6c != $x2_6c; };",
-                //"{ $x6d has " + resource + " $r6d; $x6d != $x2_6d; $x2_6d id '" + resourceId + "'; };",
+                //"{ $x6d has " + resource + " $r6d; $x6d != $x2_6d; $x2_6d id " + resourceId + "; };",
                 //"{ $x6e has " + resource + " $r6e; $x6e != $r6e; };",
         );
     }

--- a/test-integration/graql/reasoner/pattern/TypePattern.java
+++ b/test-integration/graql/reasoner/pattern/TypePattern.java
@@ -40,9 +40,9 @@ public class TypePattern extends QueryPattern {
                 "{ $xf isa " + metaType + "; };",
 
                 //6-8
-                "{ $x1a isa " + type + "; $x1a id '" + conceptId + "'; };",
-                "{ $x1b isa " + type + "; $x1b id '" + anotherConceptId + "'; };",
-                "{ $x1c isa $type1; $type1 type " + type + ";$x1c id '" + anotherConceptId + "'; };",
+                "{ $x1a isa " + type + "; $x1a id " + conceptId + "; };",
+                "{ $x1b isa " + type + "; $x1b id " + anotherConceptId + "; };",
+                "{ $x1c isa $type1; $type1 type " + type + ";$x1c id " + anotherConceptId + "; };",
 
                 //9-12
                 "{ $x2a isa " + type + "; $x2a == 'someValue'; };",
@@ -64,8 +64,8 @@ public class TypePattern extends QueryPattern {
                 //16-18
                 //TODO
                 //"{ $x5a isa resource ; $x5a != $f; };",
-                //"{ $x5b isa resource ; $x5b != $fb; $x5b id '" + resourceId + "'; };",
-                //"{ $x5c isa resource ; $x5c != $fc; $fc id '" + resourceId + "'; };"
+                //"{ $x5b isa resource ; $x5b != $fb; $x5b id " + resourceId + "; };",
+                //"{ $x5c isa resource ; $x5c != $fc; $fc id " + resourceId + "; };"
         );
     }
 

--- a/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
@@ -245,19 +245,19 @@ public class AtomicQueryEquivalenceIT {
 
     @Test
     public void testEquivalence_RelationsWithSubstitution(){
-        String query = "{ (role: $x, role: $y);$x id 'V666'; };";
-        String queryb = "{ (role: $x, role: $y);$y id 'V666'; };";
+        String query = "{ (role: $x, role: $y);$x id V666; };";
+        String queryb = "{ (role: $x, role: $y);$y id V666; };";
 
         String query2 = "{ (role: $x, role: $y);$x != $y; };";
-        String query3 = "{ (role: $x, role: $y);$x != $y;$y id 'V667'; };";
+        String query3 = "{ (role: $x, role: $y);$x != $y;$y id V667; };";
 
-        String query4 = "{ (role: $x, role: $y);$x id 'V666';$y id 'V667'; };";
-        String query4b = "{ (role: $x, role: $y);$y id 'V666';$x id 'V667'; };";
+        String query4 = "{ (role: $x, role: $y);$x id V666;$y id V667; };";
+        String query4b = "{ (role: $x, role: $y);$y id V666;$x id V667; };";
 
-        String query7 = "{ (role: $x, role: $y);$x id 'V666';$y id 'V666'; };";
+        String query7 = "{ (role: $x, role: $y);$x id V666;$y id V666; };";
 
-        String query5 = "{ (baseRole1: $x, baseRole2: $y);$x id 'V666';$y id 'V667'; };";
-        String query6 = "{ (baseRole1: $x, baseRole2: $y);$y id 'V666';$x id 'V667'; };";
+        String query5 = "{ (baseRole1: $x, baseRole2: $y);$x id V666;$y id V667; };";
+        String query6 = "{ (baseRole1: $x, baseRole2: $y);$y id V666;$x id V667; };";
 
         ArrayList<String> queries = Lists.newArrayList(query, queryb, query2, query3, query4, query4b, query5, query6, query7);
 
@@ -291,17 +291,17 @@ public class AtomicQueryEquivalenceIT {
 
     @Test
     public void testEquivalence_RelationsWithSubstitution_differentRolesMapped(){
-        String query = "{ (baseRole1: $x, baseRole2: $y);$x id 'V666'; };";
-        String query2 = "{ (baseRole1: $x, baseRole2: $y);$x id 'V667'; };";
-        String query3 = "{ (baseRole1: $x, baseRole2: $y);$y id 'V666'; };";
-        String query4 = "{ (baseRole1: $x, baseRole2: $y);$y id 'V667'; };";
+        String query = "{ (baseRole1: $x, baseRole2: $y);$x id V666; };";
+        String query2 = "{ (baseRole1: $x, baseRole2: $y);$x id V667; };";
+        String query3 = "{ (baseRole1: $x, baseRole2: $y);$y id V666; };";
+        String query4 = "{ (baseRole1: $x, baseRole2: $y);$y id V667; };";
 
         String query5 = "{ (baseRole1: $x, baseRole2: $y);$x != $y; };";
         String query6 = "{ (baseRole1: $x, baseRole2: $y);$x != $x2; };";
-        String query7 = "{ (baseRole1: $x, baseRole2: $y);$x != $x2;$x2 id 'V667'; };";
+        String query7 = "{ (baseRole1: $x, baseRole2: $y);$x != $x2;$x2 id V667; };";
 
-        String query8 = "{ (baseRole1: $x, baseRole2: $y);$x id 'V666';$y id 'V667'; };";
-        String query9 = "{ (baseRole1: $x, baseRole2: $y);$y id 'V666';$x id 'V667'; };";
+        String query8 = "{ (baseRole1: $x, baseRole2: $y);$x id V666;$y id V667; };";
+        String query9 = "{ (baseRole1: $x, baseRole2: $y);$y id V666;$x id V667; };";
         ArrayList<String> queries = Lists.newArrayList(query, query2, query3, query4, query5, query6, query7, query9, query9);
 
         equivalence(query, queries, new ArrayList<>(), ReasonerQueryEquivalence.AlphaEquivalence, tx);
@@ -374,13 +374,13 @@ public class AtomicQueryEquivalenceIT {
 
     @Test
     public void testEquivalence_RelationsWithVariableAndSubstitution(){
-        String query = "{ $r (baseRole1: $x);$x id 'V666'; };";
-        String query2 = "{ $a (baseRole1: $x);$x id 'V667'; };";
-        String query3 = "{ $b (baseRole2: $y);$y id 'V666'; };";
+        String query = "{ $r (baseRole1: $x);$x id V666; };";
+        String query2 = "{ $a (baseRole1: $x);$x id V667; };";
+        String query3 = "{ $b (baseRole2: $y);$y id V666; };";
         String query4 = "{ $c (baseRole1: $a);$a != $b; };";
         String query4b = "{ $r (baseRole1: $x);$x != $y; };";
-        String query5 = "{ $e (baseRole1: $a);$a != $b;$b id 'V666'; };";
-        String query5b = "{ $r (baseRole1: $x);$x != $y;$y id 'V666'; };";
+        String query5 = "{ $e (baseRole1: $a);$a != $b;$b id V666; };";
+        String query5b = "{ $r (baseRole1: $x);$x != $y;$y id V666; };";
         ArrayList<String> queries = Lists.newArrayList(query, query2, query3, query4, query4b, query5, query5b);
 
         equivalence(query, queries, new ArrayList<>(), ReasonerQueryEquivalence.AlphaEquivalence, tx);

--- a/test-integration/graql/reasoner/query/ExplanationIT.java
+++ b/test-integration/graql/reasoner/query/ExplanationIT.java
@@ -191,8 +191,8 @@ public class ExplanationIT {
             Concept europe = getConcept(tx, "name", "Europe");
             String queryString = "match " +
                     "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
-                    "$x id '" + polibuda.id() + "';" +
-                    "$y id '" + europe.id() + "'; get;";
+                    "$x id " + polibuda.id() + ";" +
+                    "$y id " + europe.id() + "; get;";
 
             GraqlGet query = Graql.parse(queryString);
             List<ConceptMap> answers = tx.execute(query);
@@ -215,8 +215,8 @@ public class ExplanationIT {
             String queryString = "match " +
                     "(geo-entity: $x, entity-location: $y) isa is-located-in;" +
                     "(geo-entity: $y, entity-location: $z) isa is-located-in;" +
-                    "$x id '" + polibuda.id() + "';" +
-                    "$z id '" + masovia.id() + "';" +
+                    "$x id " + polibuda.id() + ";" +
+                    "$z id " + masovia.id() + ";" +
                     "get $y;";
 
             GraqlGet query = Graql.parse(queryString);

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -467,8 +467,8 @@ public class NegationIT {
             List<ConceptMap> answers = tx.execute(Graql.<GraqlGet>parse(
                     "match " +
                             "not {($x, $y) isa derived-binary;};" +
-                            "$x id '" + start.id().getValue() + "';" +
-                            "$y id '" + end.id().getValue() + "';" +
+                            "$x id " + start.id().getValue() + ";" +
+                            "$y id " + end.id().getValue() + ";" +
                             "get;"
             ));
             assertTrue(answers.isEmpty());

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -218,9 +218,9 @@ public class QueryIT {
     public void testAlphaEquivalence_nonMatchingTypes() {
         try(TransactionOLTP tx = geoSession.transaction().write()) {
             String polandId = getConcept(tx, "name", "Poland").id().getValue();
-            String patternString = "{ $y id '" + polandId + "'; $y isa country; (geo-entity: $y1, entity-location: $y) isa is-located-in; };";
-            String patternString2 = "{ $x1 id '" + polandId + "'; $y isa country; (geo-entity: $x1, entity-location: $x2) isa is-located-in; };";
-            String patternString3 = "{ $y id '" + polandId + "'; $x isa city; (geo-entity: $x, entity-location: $y) isa is-located-in; $y isa country; };";
+            String patternString = "{ $y id " + polandId + "; $y isa country; (geo-entity: $y1, entity-location: $y) isa is-located-in; };";
+            String patternString2 = "{ $x1 id " + polandId + "; $y isa country; (geo-entity: $x1, entity-location: $x2) isa is-located-in; };";
+            String patternString3 = "{ $y id " + polandId + "; $x isa city; (geo-entity: $x, entity-location: $y) isa is-located-in; $y isa country; };";
             String patternString4 = "{ $x isa city; (entity-location: $y1, geo-entity: $x) isa is-located-in; };";
             String patternString5 = "{ (geo-entity: $y1, entity-location: $y2) isa is-located-in; };";
 
@@ -258,13 +258,13 @@ public class QueryIT {
     @Test
     public void testAlphaEquivalence_RelationsWithSubstitution(){
         try(TransactionOLTP tx = geoSession.transaction().write()) {
-            String patternString = "{ (role: $x, role: $y);$x id 'V666'; };";
-            String patternString2 = "{ (role: $x, role: $y);$y id 'V666'; };";
-            String patternString3 = "{ (role: $x, role: $y);$x id 'V666';$y id 'V667'; };";
-            String patternString4 = "{ (role: $x, role: $y);$y id 'V666';$x id 'V667'; };";
-            String patternString5 = "{ (entity-location: $x, geo-entity: $y);$x id 'V666';$y id 'V667'; };";
-            String patternString6 = "{ (entity-location: $x, geo-entity: $y);$y id 'V666';$x id 'V667'; };";
-            String patternString7 = "{ (role: $x, role: $y);$x id 'V666';$y id 'V666'; };";
+            String patternString = "{ (role: $x, role: $y);$x id V666; };";
+            String patternString2 = "{ (role: $x, role: $y);$y id V666; };";
+            String patternString3 = "{ (role: $x, role: $y);$x id V666;$y id V667; };";
+            String patternString4 = "{ (role: $x, role: $y);$y id V666;$x id V667; };";
+            String patternString5 = "{ (entity-location: $x, geo-entity: $y);$x id V666;$y id V667; };";
+            String patternString6 = "{ (entity-location: $x, geo-entity: $y);$y id V666;$x id V667; };";
+            String patternString7 = "{ (role: $x, role: $y);$x id V666;$y id V666; };";
             Conjunction<Statement> pattern = conjunction(patternString, tx);
             Conjunction<Statement> pattern2 = conjunction(patternString2, tx);
             Conjunction<Statement> pattern3 = conjunction(patternString3, tx);

--- a/test-integration/graql/reasoner/query/ResolutionPlanIT.java
+++ b/test-integration/graql/reasoner/query/ResolutionPlanIT.java
@@ -133,7 +133,7 @@ public class ResolutionPlanIT {
     @Repeat( times = repeat )
     public void makeSureDisconnectedIndexedQueriesProduceCompletePlan_indexedEntity() {
         String queryString = "{" +
-                "$x isa someEntity;$x id 'V123';" +
+                "$x isa someEntity;$x id V123;" +
                 "$y isa resource;" +
                 "$z isa someRelation;" +
                 "};";
@@ -148,7 +148,7 @@ public class ResolutionPlanIT {
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
                 "(someRole:$z, otherRole: $w) isa yetAnotherRelation;" +
-                "$w id 'sampleId';" +
+                "$w id Vsampleid;" +
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         ImmutableList<Atom> correctPlan = ImmutableList.of(
@@ -166,7 +166,7 @@ public class ResolutionPlanIT {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa derivedRelation;" +
-                "$z id 'sampleId';" +
+                "$z id Vsampleid;" +
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         ImmutableList<Atom> correctPlan = ImmutableList.of(
@@ -184,8 +184,8 @@ public class ResolutionPlanIT {
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
                 "(someRole:$z, otherRole: $w) isa yetAnotherRelation;" +
-                "$z id 'sampleId';" +
-                "$w id 'sampleId2';" +
+                "$z id Vsampleid;" +
+                "$w id Vsampleid2;" +
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         ImmutableList<Atom> correctPlan = ImmutableList.of(
@@ -314,8 +314,8 @@ public class ResolutionPlanIT {
     @Test
     public void exploitDBRelationsAndConnectivity_relationLinkWithSubbedEndsAndRuleRelationInTheMiddle(){
         String queryString = "{" +
-                "$start id 'someSampleId';" +
-                "$end id 'anotherSampleId';" +
+                "$start id someSampleId;" +
+                "$end id anotherSampleId;" +
                 "(someRole: $link, otherRole: $start) isa someRelation;" +
                 "(someRole: $link, otherRole: $anotherlink) isa derivedRelation;" +
                 "(someRole: $anotherlink, otherRole: $end) isa anotherRelation;" +
@@ -344,8 +344,8 @@ public class ResolutionPlanIT {
     @Test
     public void exploitDBRelationsAndConnectivity_relationLinkWithSubbedEndsAndRuleRelationAtEnd(){
         String queryString = "{" +
-                "$start id 'someSampleId';" +
-                "$end id 'anotherSampleId';" +
+                "$start id Vsomesampleid;" +
+                "$end id Vanothersampleid;" +
                 "(someRole: $link, otherRole: $start) isa someRelation;" +
                 "(someRole: $anotherlink, otherRole: $link) isa anotherRelation;" +
                 "(someRole: $end, otherRole: $anotherlink) isa derivedRelation;" +
@@ -377,7 +377,7 @@ public class ResolutionPlanIT {
     @Test
     public void exploitDBRelationsAndConnectivity_relationLinkWithEndsSharingAResource(){
         String queryString = "{" +
-                "$start id 'sampleId';" +
+                "$start id sampleId;" +
                 "$start isa someEntity;" +
                 "$start has anotherResource 'someValue';" +
                 "$start has resource $res;" +
@@ -422,11 +422,11 @@ public class ResolutionPlanIT {
                         "$y has anotherResource 'that';";
 
         String xPatternString = "{" +
-                "$x id '" + concept.id() + "';" +
+                "$x id " + concept.id() + ";" +
                 basePatternString +
                 "};";
         String yPatternString = "{" +
-                "$y id '" + concept.id() + "';" +
+                "$y id " + concept.id() + ";" +
                 basePatternString +
                 "};";
         ReasonerQueryImpl queryX = ReasonerQueries.create(conjunction(xPatternString), tx);

--- a/test-integration/graql/reasoner/reasoning/VariableRolesIT.java
+++ b/test-integration/graql/reasoner/reasoning/VariableRolesIT.java
@@ -86,7 +86,7 @@ public class VariableRolesIT {
 
             String equivalentQueryString2 = "match " +
                     "($r1: $a, $r2: $b) isa binary-base; " +
-                    "$r1 type 'role' ;" +
+                    "$r1 type role;" +
                     "get $a, $b, $r2;";
 
             GraqlGet query2 = Graql.parse(queryString2).asGet();

--- a/test-integration/graql/reasoner/resources/recursion/same-generation.gql
+++ b/test-integration/graql/reasoner/resources/recursion/same-generation.gql
@@ -4,25 +4,25 @@ define
 ####################Schema######################
 #################################################
 
-"person" sub entity,
+person sub entity,
       has name;
 
-"parent" sub role;
-"child" sub role;
-"Parent" sub relation, relates parent, relates child;
+parent sub role;
+child sub role;
+Parent sub relation, relates parent, relates child;
 person plays parent, plays child;
 
-"sibA" sub role;
-"sibB" sub role;
-"Sibling" sub relation, relates sibA, relates sibB;
+sibA sub role;
+sibB sub role;
+Sibling sub relation, relates sibA, relates sibB;
 person plays sibA, plays sibB;
 
-"SG-role-A" sub role;
-"SG-role-B" sub role;
-"SameGen" sub relation, relates SG-role-A, relates SG-role-B;
+SG-role-A sub role;
+SG-role-B sub role;
+SameGen sub relation, relates SG-role-A, relates SG-role-B;
 person plays SG-role-A, plays SG-role-B;
 
-"name" sub attribute, datatype string;
+name sub attribute, datatype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
+++ b/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
@@ -4,22 +4,22 @@ define
 ####################Schema######################
 #################################################
 
-"entity2" sub entity,
+entity2 sub entity,
     has index;
-"a-entity" sub entity2;
-"b-entity" sub entity2;
+a-entity sub entity2;
+b-entity sub entity2;
 
-"P-from" sub role;
-"P-to" sub role;
-"P" sub relation, relates P-from, relates P-to;
+P-from sub role;
+P-to sub role;
+P sub relation, relates P-from, relates P-to;
 entity2 plays P-from, plays P-to;
 
-"Q-from" sub role;
-"Q-to" sub role;
-"Q" sub relation, relates Q-from, relates Q-to;
+Q-from sub role;
+Q-to sub role;
+Q sub relation, relates Q-from, relates Q-to;
 entity2 plays Q-from, plays Q-to;
 
-"index" sub attribute, datatype string;
+index sub attribute, datatype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/transitivity.gql
+++ b/test-integration/graql/reasoner/resources/recursion/transitivity.gql
@@ -4,35 +4,35 @@ define
 ########################Schema######################
 #######################################################
 
-"entity2" sub entity,
+entity2 sub entity,
     has index;
 
-"R-role-A" sub role;
-"R-role-B" sub role;
-"R" sub relation, relates R-role-A, relates R-role-B;
+R-role-A sub role;
+R-role-B sub role;
+R sub relation, relates R-role-A, relates R-role-B;
 entity2 plays R-role-A, plays R-role-B;
 
-"E-role-A" sub role;
-"E-role-B" sub role;
-"E" sub relation, relates E-role-A, relates E-role-B;
+E-role-A sub role;
+E-role-B sub role;
+E sub relation, relates E-role-A, relates E-role-B;
 entity2 plays E-role-A, plays E-role-B;
 
-"F-role-A" sub role;
-"F-role-B" sub role;
-"F" sub relation, relates F-role-A, relates F-role-B;
+F-role-A sub role;
+F-role-B sub role;
+F sub relation, relates F-role-A, relates F-role-B;
 entity2 plays F-role-A, plays F-role-B;
 
-"G-role-A" sub role;
-"G-role-B" sub role;
-"G" sub relation, relates G-role-A, relates G-role-B;
+G-role-A sub role;
+G-role-B sub role;
+G sub relation, relates G-role-A, relates G-role-B;
 entity2 plays G-role-A, plays G-role-B;
 
-"H-role-A" sub role;
-"H-role-B" sub role;
-"H" sub relation, relates H-role-A, relates H-role-B;
+H-role-A sub role;
+H-role-B sub role;
+H sub relation, relates H-role-A, relates H-role-B;
 entity2 plays H-role-A, plays H-role-B;
 
-"index" sub attribute, datatype string;
+index sub attribute, datatype string;
 
 insert
 

--- a/test-integration/graql/reasoner/stubs/explanations.gql
+++ b/test-integration/graql/reasoner/stubs/explanations.gql
@@ -28,7 +28,7 @@ inferredRelation sub relation,
 
 #Resources
 
-"name" sub attribute, datatype string;
+name sub attribute, datatype string;
 
 rule-1 sub rule,
     when {

--- a/test-integration/server/kb/RuleIT.java
+++ b/test-integration/server/kb/RuleIT.java
@@ -300,7 +300,7 @@ public class RuleIT {
     public void whenAddingRuleWithIllegalAtomicInHead_Predicate_Throw() throws InvalidKBException {
         validateIllegalHead(
                 Graql.parsePattern("(someRole: $x, anotherRole: $y) isa some-relation;"),
-                Graql.parsePattern("$x id 'V123';"),
+                Graql.parsePattern("$x id V123;"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalHead(


### PR DESCRIPTION
## What is the goal of this PR?

Graql now restricts the use of type labels and IDs in queries to no longer accept and string value, which could be arbitrary. To comply with this change, we've made sure that Grakn uses and implements this language behaviour appropriately, which predominantly changes the way tests are written in the codebase.

## What are the changes implemented in this PR?

- `StringPrinter` for type labels and ID values no longer output the values in quotes (`"` or `'`)
- Integration tests for Graql (query, analytics and reasoner) are updated to comply with the new syntax