### PR TITLE
Add benchmark:master to sync-dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
           --source grakn@$CIRCLE_SHA1 \
           --targets \
           client-java:master client-python:master client-nodejs:master \
-          workbase:master docs:development examples:development
+          workbase:master docs:development examples:development benchmark:master
 
   release-approval:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?
Auto-update benchmark dependencies to reflect updates to grakn core. This should lead to notifications when benchmark fails because of a breaking change rather than having to notice that the dashboard is not updating anymore.

## What are the changes implemented in this PR?
* Add benchmark:master to sync dependencies
