### PR TITLE
CI: sync-dependencies now syncs to grakn-kgms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,9 +280,9 @@ jobs:
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source grakn@$CIRCLE_SHA1 \
           --targets \
+          grakn-kgms:master benchmark:master workbase:master \
           client-java:master client-python:master client-nodejs:master \
-          workbase:master docs:development examples:development \
-          benchmark:master grakn-kgms:master
+          docs:development examples:development
 
   release-approval:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,8 @@ jobs:
           --source grakn@$CIRCLE_SHA1 \
           --targets \
           client-java:master client-python:master client-nodejs:master \
-          workbase:master docs:development examples:development benchmark:master
+          workbase:master docs:development examples:development \
+          benchmark:master grakn-kgms:master
 
   release-approval:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

`sync-dependencies` now syncs to grakn-kgms.

Additionally, the ordering of the arguments has been tidied up: the first line contains the top-level products, the second line contains the client drivers, and the third documentations.