### PR TITLE
Do not persist inferred concepts

### DIFF
--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -33,6 +33,7 @@ import grakn.core.concept.answer.ConceptSet;
 import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.thing.Attribute;
+import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
@@ -835,6 +836,7 @@ public class TransactionOLTP implements Transaction {
         }
         try {
             checkMutationAllowed();
+            removeInferredConcepts();
             validateGraph();
             // lock on the keyspace cache shared between concurrent tx's to the same keyspace
             // force serialization & atomic updates, keeping Janus and our KeyspaceCache in sync
@@ -889,6 +891,7 @@ public class TransactionOLTP implements Transaction {
 
 
         checkMutationAllowed();
+        removeInferredConcepts();
         validateGraph();
 
         Map<ConceptId, Long> newInstances = transactionCache.getShardingCount();
@@ -921,6 +924,12 @@ public class TransactionOLTP implements Transaction {
         }
 
         return Optional.empty();
+    }
+
+    private void removeInferredConcepts(){
+        Set<Thing> inferredThings = cache().getInferredConcepts().collect(Collectors.toSet());
+        inferredThings.forEach(inferred -> cache().remove(inferred));
+        inferredThings.forEach(Concept::delete);
     }
 
     private void validateGraph() throws InvalidKBException {

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * Caches TransactionOLTP specific data this includes:
@@ -225,6 +226,16 @@ public class TransactionCache {
     public <X extends Concept> X getCachedConcept(ConceptId id) {
         //noinspection unchecked
         return (X) conceptCache.get(id);
+    }
+
+    /**
+     * @return cached things that are inferred
+     */
+    public Stream<Thing> getInferredConcepts(){
+        return conceptCache.values().stream()
+                .filter(Concept::isThing)
+                .map(Concept::asThing)
+                .filter(Thing::isInferred);
     }
 
     /**


### PR DESCRIPTION
## What is the goal of this PR?
Remove the unexpected behaviour of inferred concepts being silently persisted if we commit a transaction that creates them.

## What are the changes implemented in this PR?
Explicitly delete the inferred concepts from the graph before commiting a transaction.
Closes #5136.