### PR TITLE
Terminate console gracefully on ctrl + c

### DIFF
--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -254,11 +254,17 @@ public class ConsoleSession implements AutoCloseable {
     }
 
     @Override
-    public final void close() throws IOException {
+    public final void close() {
         tx.close();
         session.close();
         client.close();
-        historyFile.flush();
+        try {
+            historyFile.flush();
+        } catch (IOException e) {
+            // Print stacktrace to any available stream
+            // nothing more to do here
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/console/GraknConsole.java
+++ b/console/GraknConsole.java
@@ -105,6 +105,8 @@ public class GraknConsole {
         // Start a Console Session to load some Graql file(s)
         else if (commandLine.hasOption(FILE)) {
             try (ConsoleSession consoleSession = new ConsoleSession(serverAddress, keyspace, infer, printOut, printErr)) {
+                //Intercept Ctrl+C and gracefully terminate connection with server
+                Runtime.getRuntime().addShutdownHook(new Thread(consoleSession::close, "grakn-console-shutdown"));
                 String[] paths = commandLine.getOptionValues(FILE);
                 List<Path> filePaths = Stream.of(paths).map(Paths::get).collect(toImmutableList());
                 for (Path file : filePaths) consoleSession.load(file);
@@ -113,6 +115,8 @@ public class GraknConsole {
         // Start a live Console Session for the user to interact with Grakn
         else {
             try (ConsoleSession consoleSession = new ConsoleSession(serverAddress, keyspace, infer, printOut, printErr)) {
+                //Intercept Ctrl+C and gracefully terminate connection with server
+                Runtime.getRuntime().addShutdownHook(new Thread(consoleSession::close, "grakn-console-shutdown"));
                 consoleSession.run();
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

Gracefully terminate connection with server when exiting console using `Ctrl + C`

## What are the changes implemented in this PR?

Add shutdown hook to `GraknConsole` so that we can properly invoke `close()` method on `GraknSession` and therefore terminate gracefully connection without having the usual `connection close before receiving half-closed` in the logs
