### PR TITLE
Re-add Gremlin indexed nodes steps first

### DIFF
--- a/server/src/graql/gremlin/GreedyTreeTraversal.java
+++ b/server/src/graql/gremlin/GreedyTreeTraversal.java
@@ -66,7 +66,10 @@ public class GreedyTreeTraversal {
             assert nodeWithMinCost != null : "reachableNodes is never empty, so there is always a minimum";
 
             // add fragments without dependencies first (eg. could be the index fragments)
-            plan.addAll(nodeFragmentsWithoutDependencies(nodeWithMinCost));
+            nodeFragmentsWithoutDependencies(nodeWithMinCost).forEach(fragment -> {
+                if (fragment.hasFixedFragmentCost()) { plan.add(0, fragment); }
+                else { plan.add(fragment); }
+            });
             nodeWithMinCost.getFragmentsWithoutDependency().clear();
 
             // add edge fragment first
@@ -74,7 +77,10 @@ public class GreedyTreeTraversal {
             if (fragment != null) plan.add(fragment);
 
             // add node's dependant fragments
-            plan.addAll(nodeVisitedDependenciesFragments(nodeWithMinCost, nodes));
+            nodeVisitedDependenciesFragments(nodeWithMinCost, nodes).forEach(frag -> {
+                if (frag.hasFixedFragmentCost()) { plan.add(0, frag); }
+                else { plan.add(fragment); }
+            });
 
             reachableNodes.remove(nodeWithMinCost);
             if (edgesParentToChild.containsKey(nodeWithMinCost)) {

--- a/server/src/graql/gremlin/GreedyTreeTraversal.java
+++ b/server/src/graql/gremlin/GreedyTreeTraversal.java
@@ -33,7 +33,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static grakn.core.graql.gremlin.NodesUtil.nodeToPlanFragments;
+import static grakn.core.graql.gremlin.NodesUtil.nodeVisitedDependenciesFragments;
+import static grakn.core.graql.gremlin.NodesUtil.nodeFragmentsWithoutDependencies;
 
 public class GreedyTreeTraversal {
 
@@ -64,11 +65,16 @@ public class GreedyTreeTraversal {
 
             assert nodeWithMinCost != null : "reachableNodes is never empty, so there is always a minimum";
 
-            // add edge fragment first, then node fragment
+            // add fragments without dependencies first (eg. could be the index fragments)
+            plan.addAll(nodeFragmentsWithoutDependencies(nodeWithMinCost));
+            nodeWithMinCost.getFragmentsWithoutDependency().clear();
+
+            // add edge fragment first
             Fragment fragment = getEdgeFragment(nodeWithMinCost, arborescence, edgeFragmentChildToParent);
             if (fragment != null) plan.add(fragment);
 
-            plan.addAll(nodeToPlanFragments(nodeWithMinCost, nodes, true));
+            // add node's dependant fragments
+            plan.addAll(nodeVisitedDependenciesFragments(nodeWithMinCost, nodes));
 
             reachableNodes.remove(nodeWithMinCost);
             if (edgesParentToChild.containsKey(nodeWithMinCost)) {

--- a/server/src/graql/gremlin/GreedyTreeTraversal.java
+++ b/server/src/graql/gremlin/GreedyTreeTraversal.java
@@ -79,7 +79,7 @@ public class GreedyTreeTraversal {
             // add node's dependant fragments
             nodeVisitedDependenciesFragments(nodeWithMinCost, nodes).forEach(frag -> {
                 if (frag.hasFixedFragmentCost()) { plan.add(0, frag); }
-                else { plan.add(fragment); }
+                else { plan.add(frag); }
             });
 
             reachableNodes.remove(nodeWithMinCost);

--- a/server/src/graql/gremlin/NodesUtil.java
+++ b/server/src/graql/gremlin/NodesUtil.java
@@ -97,17 +97,16 @@ public class NodesUtil {
         });
     }
 
+    static List<Fragment> nodeFragmentsWithoutDependencies(Node node) {
+        return node.getFragmentsWithoutDependency().stream()
+                .sorted(Comparator.comparingDouble(Fragment::fragmentCost))
+                .collect(Collectors.toList());
+    }
+
     // convert a Node to a sub-plan, updating dependants' dependency map
-    static List<Fragment> nodeToPlanFragments(Node node, Map<NodeId, Node> nodes, boolean visited) {
+    static List<Fragment> nodeVisitedDependenciesFragments(Node node, Map<NodeId, Node> nodes) {
         List<Fragment> subplan = new LinkedList<>();
-        if (!visited) {
-            node.getFragmentsWithoutDependency().stream()
-                    .min(Comparator.comparingDouble(Fragment::fragmentCost))
-                    .ifPresent(firstNodeFragment -> {
-                        subplan.add(firstNodeFragment);
-                        node.getFragmentsWithoutDependency().remove(firstNodeFragment);
-                    });
-        }
+
         node.getFragmentsWithoutDependency().addAll(node.getFragmentsWithDependencyVisited());
         subplan.addAll(node.getFragmentsWithoutDependency().stream()
                 .sorted(Comparator.comparingDouble(Fragment::fragmentCost))

--- a/server/src/graql/gremlin/TraversalPlanner.java
+++ b/server/src/graql/gremlin/TraversalPlanner.java
@@ -57,7 +57,7 @@ import java.util.stream.Collectors;
 
 import static grakn.core.common.util.CommonUtil.toImmutableSet;
 import static grakn.core.graql.gremlin.NodesUtil.buildNodesWithDependencies;
-import static grakn.core.graql.gremlin.NodesUtil.nodeToPlanFragments;
+import static grakn.core.graql.gremlin.NodesUtil.nodeVisitedDependenciesFragments;
 import static grakn.core.graql.gremlin.RelationTypeInference.inferRelationTypes;
 import static grakn.core.graql.gremlin.fragment.Fragment.SHARD_LOAD_FACTOR;
 
@@ -127,7 +127,7 @@ public class TraversalPlanner {
                if (unhandledNodes.size() != 1) {
                    throw GraknServerException.create("Query planner exception - expected one unhandled node, found " + unhandledNodes.size());
                }
-               plan.addAll(nodeToPlanFragments(Iterators.getOnlyElement(unhandledNodes.iterator()), queryGraphNodes, false));
+               plan.addAll(nodeVisitedDependenciesFragments(Iterators.getOnlyElement(unhandledNodes.iterator()), queryGraphNodes));
             }
         }
 

--- a/server/src/graql/gremlin/TraversalPlanner.java
+++ b/server/src/graql/gremlin/TraversalPlanner.java
@@ -238,7 +238,7 @@ public class TraversalPlanner {
                         !node.getFragmentsWithDependencyVisited().isEmpty())
                 .collect(Collectors.toSet());
         while (!nodeWithFragment.isEmpty()) {
-            nodeWithFragment.forEach(node -> subplan.addAll(nodeToPlanFragments(node, allNodes, false)));
+            nodeWithFragment.forEach(node -> subplan.addAll(nodeVisitedDependenciesFragments(node, allNodes)));
             nodeWithFragment = connectedNodes.stream()
                     .filter(node -> !node.getFragmentsWithoutDependency().isEmpty() ||
                             !node.getFragmentsWithDependencyVisited().isEmpty())

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -420,7 +420,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(x.var(), plan.get(1).end());
+        assertEquals(x.var(), plan.get(3).end());
         assertEquals(3L, plan.stream().filter(fragment -> fragment instanceof NeqFragment).count());
 
         //TODO: should uncomment the following after updating cost of out-isa fragment
@@ -435,7 +435,7 @@ public class QueryPlannerIT {
                 y.isa(thingy2),
                 var().rel(x).rel(y));
         plan = getPlan(pattern);
-        assertEquals(x.var(), plan.get(2).end());
+        assertEquals(x.var(), plan.get(3).end());
 
         pattern = and(
                 x.isa(thingy),
@@ -443,7 +443,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(x.var(), plan.get(2).end());
+        assertEquals(x.var(), plan.get(4).end());
 
         pattern = and(
                 x.isa(superType),
@@ -453,7 +453,7 @@ public class QueryPlannerIT {
                 z.isa(subType),
                 var().rel(x).rel(y));
         plan = getPlan(pattern);
-        assertEquals(z.var(), plan.get(10).end());
+        assertEquals(z.var(), plan.get(5).end());
 
         tx.shard(tx.getEntityType(thingy1).id());
         tx.shard(tx.getEntityType(thingy1).id());
@@ -466,7 +466,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(y.var(), plan.get(1).end());
+        assertEquals(y.var(), plan.get(3).end());
 
         pattern = and(
                 x.isa(thingy1),
@@ -474,7 +474,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(x.var(), plan.get(1).end());
+        assertEquals(x.var(), plan.get(3).end());
 
         tx.shard(tx.getEntityType(thingy1).id());
         tx.shard(tx.getEntityType(thingy1).id());
@@ -486,7 +486,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(y.var(), plan.get(1).end());
+        assertEquals(y.var(), plan.get(3).end());
 
         pattern = and(
                 x.isa(thingy1),
@@ -494,7 +494,7 @@ public class QueryPlannerIT {
                 z.isa(thingy3),
                 var().rel(x).rel(y).rel(z));
         plan = getPlan(pattern);
-        assertEquals(y.var(), plan.get(1).end());
+        assertEquals(y.var(), plan.get(3).end());
     }
 
     private ImmutableList<Fragment> getPlan(Pattern pattern) {

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -325,10 +325,9 @@ public class QueryPlannerIT {
                 priorFragmentHasFixedCost = false;
             } else {
                 // if the current fragment is fixed cost
-                // and the prior one was not, throw and fail the test
-                if (!priorFragmentHasFixedCost) {
-                    throw new RuntimeException("Found a fixed cost fragment after a non fixed cost fragment");
-                }
+                // and the prior one was, it's ok.
+                // if it wasn't, fail the test
+                assertTrue(priorFragmentHasFixedCost);
             }
         }
     }

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -453,7 +453,7 @@ public class QueryPlannerIT {
                 z.isa(subType),
                 var().rel(x).rel(y));
         plan = getPlan(pattern);
-        assertEquals(z.var(), plan.get(5).end());
+        assertEquals(z.var(), plan.get(10).end());
 
         tx.shard(tx.getEntityType(thingy1).id());
         tx.shard(tx.getEntityType(thingy1).id());


### PR DESCRIPTION
## What is the goal of this PR?
During the QP refactors done previously, indexed fragments were sometimes ordered after the variable's first occurence in the plan, which may have resulted in some slower plans. Now we explicltly put the indexed fragments at the start of the query plan again. Further investigation on the Janus level is required to see if this is strictly faster.

## What are the changes implemented in this PR?
* When encountering a fixed cost fragment such as any indexed fragment, add it right to the start of the query plan instead of just appending it with other fragments
* remove special case in `nodeToPlanFragments` for visited/unvisited switch that was only being used in one place, move this code up into the caller.
