### PR TITLE
Dont start|stop server with wrong specific command

### DIFF
--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -43,6 +43,7 @@ public class GraknDaemon {
 
     private static final String SERVER = "server";
     private static final String STORAGE = "storage";
+    private static final String EMPTY_STRING = "";
 
     private final Storage storageExecutor;
     private final Server serverExecutor;
@@ -165,9 +166,12 @@ public class GraknDaemon {
             case STORAGE:
                 storageExecutor.stop();
                 break;
-            default:
+            case EMPTY_STRING:
                 serverExecutor.stop();
                 storageExecutor.stop();
+                break;
+            default:
+                serverHelp();
         }
     }
 
@@ -179,9 +183,12 @@ public class GraknDaemon {
             case STORAGE:
                 storageExecutor.startIfNotRunning();
                 break;
-            default:
+            case EMPTY_STRING:
                 storageExecutor.startIfNotRunning();
                 serverExecutor.startIfNotRunning(arg);
+                break;
+            default:
+                serverHelp();
         }
     }
 

--- a/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
@@ -169,6 +169,18 @@ public class GraknGraqlCommandsE2E {
         assertThat(output, containsString("Invalid argument:"));
     }
 
+
+    /**
+     * test 'grakn <some-invalid-command>'
+     */
+    @Test
+    public void grakn_whenReceivingInvalidServerCommand_shouldPrintHelp() throws IOException, InterruptedException, TimeoutException {
+        String output = commandExecutor.command("./grakn", "server", "start", "storag").execute().outputUTF8();
+        assertThat(output, containsString("Usage: grakn server COMMAND\n"));
+    }
+
+
+
     /**
      * Grakn should stop correctly when there are client connections still open
      */


### PR DESCRIPTION
## What is the goal of this PR?

Don't start or stop Grakn when the specific command is wrong.

For example:
`grakn server start storag` should not start anything - currently it starts both storage and server

## What are the changes implemented in this PR?

add `EMPTY_STRING` case and move default to print help message

Closes graknlabs/grakn#2903