### PR TITLE
Refactor role compatibility checking when unifying relations

### DIFF
--- a/server/src/graql/reasoner/unifier/UnifierComparison.java
+++ b/server/src/graql/reasoner/unifier/UnifierComparison.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graql.reasoner.unifier;
 
+import grakn.core.concept.type.Role;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -54,6 +55,14 @@ public interface UnifierComparison {
      * @return true if both types are compatible in terms of type directness
      */
     boolean typeDirectednessCompatibility(Atomic parent, Atomic child);
+
+    /**
+     *
+     * @param parent
+     * @param child
+     * @return
+     */
+    boolean roleCompatibility(Role parent, Role child);
 
     /**
      * @param parent {@link SchemaConcept} of parent expression

--- a/server/src/graql/reasoner/unifier/UnifierComparison.java
+++ b/server/src/graql/reasoner/unifier/UnifierComparison.java
@@ -57,14 +57,19 @@ public interface UnifierComparison {
     boolean typeDirectednessCompatibility(Atomic parent, Atomic child);
 
     /**
+     * Does compatibility comparison between a parent-child role pair.
+     * NB: in contrast to typeCompatibility, roles in rules have INSERT semantics - have strict direct types.
      *
-     * @param parent
-     * @param child
-     * @return
+     * @param parent role
+     * @param child role
+     * @return true if {@link Type}s are compatible
      */
     boolean roleCompatibility(Role parent, Role child);
 
     /**
+     * Does compatibility comparison between a parent-child type set pair.
+     * NB: Because types are defined in the when part, types have MATCH semantics - their types include relevant hierarchy parts.
+     *
      * @param parent {@link SchemaConcept} of parent expression
      * @param child  {@link SchemaConcept} of child expression
      * @return true if {@link Type}s are compatible

--- a/server/src/graql/reasoner/unifier/UnifierType.java
+++ b/server/src/graql/reasoner/unifier/UnifierType.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graql.reasoner.unifier;
 
+import grakn.core.concept.type.Role;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -62,6 +63,12 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
         @Override
         public boolean typeDirectednessCompatibility(Atomic parent, Atomic child) {
             return parent.isDirect() == child.isDirect();
+        }
+
+        @Override
+        public boolean roleCompatibility(Role parent, Role child) {
+            return parent == null && child == null
+                    || parent != null && parent.equals(child);
         }
 
         @Override
@@ -114,6 +121,12 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
         @Override
         public boolean typeDirectednessCompatibility(Atomic parent, Atomic child) {
             return parent.isDirect() == child.isDirect();
+        }
+
+        @Override
+        public boolean roleCompatibility(Role parent, Role child) {
+            return parent == null && child == null
+                    || parent != null && parent.equals(child);
         }
 
         @Override
@@ -176,6 +189,13 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
 
         @Override
         public boolean typeDirectednessCompatibility(Atomic parent, Atomic child) { return true; }
+
+        @Override
+        public boolean roleCompatibility(Role parent, Role child) {
+            // p:    someRole
+            // child $r
+            return parent == null || parent.subs().anyMatch(sub -> sub.equals(child));
+        }
 
         @Override
         public boolean typePlayability(ReasonerQuery query, Variable var, Type type) {
@@ -253,6 +273,11 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
         public boolean typeDirectednessCompatibility(Atomic parent, Atomic child) {
             //we require equal directedness as we can't always check the type in the answer (e.g. if we have a relation without rel var)
             return (parent.isDirect() == child.isDirect());
+        }
+
+        @Override
+        public boolean roleCompatibility(Role parent, Role child) {
+            return parent == null || parent.subs().anyMatch(sub -> sub.equals(child));
         }
 
         @Override

--- a/server/src/graql/reasoner/unifier/UnifierType.java
+++ b/server/src/graql/reasoner/unifier/UnifierType.java
@@ -192,8 +192,6 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
 
         @Override
         public boolean roleCompatibility(Role parent, Role child) {
-            // p:    someRole
-            // child $r
             return parent == null || parent.subs().anyMatch(sub -> sub.equals(child));
         }
 

--- a/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
@@ -112,21 +112,21 @@ public class AtomicUnificationIT {
     public void testUnification_RelationWithRolesExchanged(){
         String relation = "{ (baseRole1: $x, baseRole2: $y) isa binary; };";
         String relation2 = "{ (baseRole1: $y, baseRole2: $x) isa binary; };";
-        exactUnification(relation, relation2, true, true, tx);
+        unification(relation, relation2, UnifierType.EXACT,true, true, tx);
     }
 
     @Test
     public void testUnification_RelationWithMetaRole(){
         String relation = "{ (baseRole1: $x, role: $y) isa binary; };";
         String relation2 = "{ (baseRole1: $y, role: $x) isa binary; };";
-        exactUnification(relation, relation2, true, true, tx);
+        unification(relation, relation2, UnifierType.EXACT,true, true, tx);
     }
 
     @Test
     public void testUnification_RelationWithRelationVar(){
         String relation = "{ $x (baseRole1: $r, baseRole2: $z) isa binary; };";
         String relation2 = "{ $r (baseRole1: $x, baseRole2: $y) isa binary; };";
-        exactUnification(relation, relation2, true, true, tx);
+        unification(relation, relation2,UnifierType.EXACT, true, true, tx);
     }
 
     @Test
@@ -136,9 +136,9 @@ public class AtomicUnificationIT {
         String relation2 = "{ (role: $z, role: $v) isa binary; $z id " + instance.id().getValue() + "; };";
         String relation3 = "{ (role: $z, role: $v) isa binary; $v id " + instance.id().getValue() + "; };";
 
-        exactUnification(relation, relation2, true, true, tx);
-        exactUnification(relation, relation3, true, true, tx);
-        exactUnification(relation2, relation3, true, true, tx);
+        unification(relation, relation2, UnifierType.EXACT,true, true, tx);
+        unification(relation, relation3, UnifierType.EXACT, true, true, tx);
+        unification(relation2, relation3, UnifierType.EXACT,true, true, tx);
     }
 
     @Test
@@ -150,10 +150,10 @@ public class AtomicUnificationIT {
         String specialisedRelation4 = "{ (subSubRole1: $y, subSubRole2: $x); };";
         String specialisedRelation5 = "{ (subRole1: $u, anotherSubRole1: $v); };";
 
-        exactUnification(parentRelation, specialisedRelation, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
+        unification(parentRelation, specialisedRelation, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation5, tx);
     }
 
@@ -167,10 +167,10 @@ public class AtomicUnificationIT {
         String specialisedRelation5 = "{ (subSubRole1: $u, baseRole3: $v); };";
         String specialisedRelation6 = "{ (baseRole1: $u, baseRole2: $v); };";
 
-        exactUnification(parentRelation, specialisedRelation, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
+        unification(parentRelation, specialisedRelation, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation5, tx);
         nonExistentUnifier(parentRelation, specialisedRelation6, tx);
     }
@@ -184,10 +184,10 @@ public class AtomicUnificationIT {
         String specialisedRelation4 = "{ (subRole1: $y, subRole2: $z, subSubRole3: $x); };";
         String specialisedRelation5 = "{ (subRole1: $u, subRole1: $v, subSubRole3: $q); };";
 
-        exactUnification(parentRelation, specialisedRelation, false, true, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, true, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
+        unification(parentRelation, specialisedRelation, UnifierType.RULE,false, true, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, true, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation5, tx);
     }
 
@@ -202,10 +202,10 @@ public class AtomicUnificationIT {
         String specialisedRelation6 = "{ (subRole1: $u, subRole1: $v, subSubRole3: $q); };";
 
         nonExistentUnifier(parentRelation, specialisedRelation, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation5, false, false, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation5, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation6, tx);
     }
 
@@ -218,10 +218,10 @@ public class AtomicUnificationIT {
         String specialisedRelation4 = "{ (subRole1: $y, subRole2: $y, subSubRole3: $x); };";
         String specialisedRelation5 = "{ (subRole1: $u, subRole1: $u, subSubRole3: $q); };";
 
-        exactUnification(parentRelation, specialisedRelation, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
+        unification(parentRelation, specialisedRelation, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE, false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation5, tx);
     }
 
@@ -234,10 +234,10 @@ public class AtomicUnificationIT {
         String specialisedRelation4 = "{ (subRole1: $y, subRole2: $y, subSubRole3: $x); };";
         String specialisedRelation5 = "{ (subRole1: $u, subRole1: $v, subSubRole3: $q); };";
 
-        exactUnification(parentRelation, specialisedRelation, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation2, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation3, false, false, tx);
-        exactUnification(parentRelation, specialisedRelation4, false, false, tx);
+        unification(parentRelation, specialisedRelation, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation2, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation3, UnifierType.RULE,false, false, tx);
+        unification(parentRelation, specialisedRelation4, UnifierType.RULE,false, false, tx);
         nonExistentUnifier(parentRelation, specialisedRelation5, tx);
     }
 
@@ -248,10 +248,15 @@ public class AtomicUnificationIT {
         String resource3 = "{ $r has resource 'f'; };";
         String resource4 = "{ $x has resource $y via $r;$y 'f'; };";
         String resource5 = "{ $y has resource $r via $x;$r 'f'; };";
-        exactUnification(resource, resource2, true, true, tx);
-        exactUnification(resource, resource3, true, true, tx);
-        exactUnification(resource2, resource3, true, true, tx);
-        exactUnification(resource4, resource5, true, true, tx);
+        unification(resource, resource2, UnifierType.RULE,true, true, tx);
+        unification(resource, resource3, UnifierType.RULE,true, true, tx);
+        unification(resource2, resource3, UnifierType.RULE,true, true, tx);
+        unification(resource4, resource5, UnifierType.RULE,true, true, tx);
+
+        unification(resource, resource2, UnifierType.EXACT,true, true, tx);
+        unification(resource, resource3, UnifierType.EXACT,true, true, tx);
+        unification(resource2, resource3, UnifierType.EXACT,true, true, tx);
+        unification(resource4, resource5, UnifierType.EXACT,true, true, tx);
     }
 
     @Test
@@ -261,10 +266,13 @@ public class AtomicUnificationIT {
         String userDefinedType = "{ $y isa $x;$x type baseRoleEntity; };";
         String userDefinedType2 = "{ $u isa $v;$v type baseRoleEntity; };";
 
-        exactUnification(type, type2, true, true, tx);
-        exactUnification(userDefinedType, userDefinedType2, true, true, tx);
+        unification(type, type2, UnifierType.EXACT, true, true, tx);
+        unification(userDefinedType, userDefinedType2, UnifierType.EXACT, true, true, tx);
+
+        unification(type, type2, UnifierType.RULE, true, true, tx);
+        unification(userDefinedType, userDefinedType2, UnifierType.RULE, true, true, tx);
         //TODO user defined-generated test
-        //exactUnification(type, userDefinedType, true, true, tx);
+        //unification(type, userDefinedType, true, true, tx);
     }
 
     @Test
@@ -414,9 +422,9 @@ public class AtomicUnificationIT {
                                 "$R1 type subRole1;" +
                                 "$R2 type subSubRole2; };"
                         , tx), tx);
-        exactUnification(parentQuery, childQuery, true, true);
-        exactUnification(baseQuery, parentQuery, true, true);
-        exactUnification(baseQuery, childQuery, true, true);
+        unification(parentQuery, childQuery, UnifierType.EXACT, true, true);
+        unification(baseQuery, parentQuery, UnifierType.EXACT, true, true);
+        unification(baseQuery, childQuery, UnifierType.EXACT, true, true);
     }
 
     @Test
@@ -438,9 +446,9 @@ public class AtomicUnificationIT {
                                 "$R1 type subRole1;" +
                                 "$R2 type subSubRole2; };"
                         , tx), tx);
-        exactUnification(parentQuery, childQuery, true, true);
-        exactUnification(baseQuery, parentQuery, true, true);
-        exactUnification(baseQuery, childQuery, true, true);
+        unification(parentQuery, childQuery, UnifierType.EXACT, true, true);
+        unification(baseQuery, parentQuery, UnifierType.EXACT, true, true);
+        unification(baseQuery, childQuery, UnifierType.EXACT, true, true);
     }
 
     private void roleInference(String patternString, ImmutableSetMultimap<Role, Variable> expectedRoleMAp, TransactionOLTP tx){
@@ -475,11 +483,12 @@ public class AtomicUnificationIT {
      * @param checkInverse flag specifying whether the inverse equality u^{-1}=u(parent, child) of the unifier u(child, parent) should be checked
      * @param checkEquality if true the parent and child answers will be checked for equality, otherwise they are checked for containment of child answers in parent
      */
-    private void exactUnification(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery, boolean checkInverse, boolean checkEquality){
+    private void unification(ReasonerAtomicQuery parentQuery, ReasonerAtomicQuery childQuery, 
+                             UnifierType unifierType, boolean checkInverse, boolean checkEquality){
         Atom childAtom = childQuery.getAtom();
         Atom parentAtom = parentQuery.getAtom();
 
-        Unifier unifier = childAtom.getMultiUnifier(parentAtom, UnifierType.EXACT).getUnifier();
+        Unifier unifier = childAtom.getMultiUnifier(parentAtom, unifierType).getUnifier();
 
         List<ConceptMap> childAnswers = tx.execute(childQuery.getQuery(), false);
         List<ConceptMap> unifiedAnswers = childAnswers.stream()
@@ -489,7 +498,7 @@ public class AtomicUnificationIT {
         List<ConceptMap> parentAnswers = tx.execute(parentQuery.getQuery(), false);
 
         if (checkInverse) {
-            Unifier unifier2 = parentAtom.getUnifier(childAtom, UnifierType.EXACT);
+            Unifier unifier2 = parentAtom.getUnifier(childAtom, unifierType);
             assertEquals(unifier.inverse(), unifier2);
             assertEquals(unifier, unifier2.inverse());
         }
@@ -508,10 +517,12 @@ public class AtomicUnificationIT {
         }
     }
 
-    private void exactUnification(String parentPatternString, String childPatternString, boolean checkInverse, boolean checkEquality, TransactionOLTP tx){
-        exactUnification(
+    private void unification(String parentPatternString, String childPatternString, 
+                             UnifierType unifierType, boolean checkInverse, boolean checkEquality, TransactionOLTP tx){
+        unification(
                 ReasonerQueries.atomic(conjunction(parentPatternString, tx), tx),
                 ReasonerQueries.atomic(conjunction(childPatternString, tx), tx),
+                unifierType,
                 checkInverse,
                 checkEquality);
     }

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -480,20 +480,6 @@ public class AtomicQueryUnificationIT {
     }
 
     @Test
-    public void test() {
-        try (TransactionOLTP tx = genericSchemaSession.transaction().read()) {
-            String child = "{ (baseRole1: $x, subRole1: $y); };";
-            String parent = "{ (baseRole1: $y, subRole1: $z);};";
-
-            ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(child), tx);
-            ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(parent), tx);
-
-            MultiUnifier u = childQuery.getMultiUnifier(parentQuery, UnifierType.RULE);
-            MultiUnifier u2 = parentQuery.getMultiUnifier(childQuery, UnifierType.RULE);
-        }
-    }
-
-    @Test
     public void testUnification_RULE_BinaryRelationWithRoleAndTypeHierarchy_BaseRoleParent_middleTypes(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
             String parentRelation = "{ (baseRole1: $x, baseRole2: $y); $x isa subRoleEntity; $y isa subRoleEntity; };";

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -480,6 +480,20 @@ public class AtomicQueryUnificationIT {
     }
 
     @Test
+    public void test() {
+        try (TransactionOLTP tx = genericSchemaSession.transaction().read()) {
+            String child = "{ (baseRole1: $x, subRole1: $y); };";
+            String parent = "{ (baseRole1: $y, subRole1: $z);};";
+
+            ReasonerAtomicQuery childQuery = ReasonerQueries.atomic(conjunction(child), tx);
+            ReasonerAtomicQuery parentQuery = ReasonerQueries.atomic(conjunction(parent), tx);
+
+            MultiUnifier u = childQuery.getMultiUnifier(parentQuery, UnifierType.RULE);
+            MultiUnifier u2 = parentQuery.getMultiUnifier(childQuery, UnifierType.RULE);
+        }
+    }
+
+    @Test
     public void testUnification_RULE_BinaryRelationWithRoleAndTypeHierarchy_BaseRoleParent_middleTypes(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
             String parentRelation = "{ (baseRole1: $x, baseRole2: $y); $x isa subRoleEntity; $y isa subRoleEntity; };";

--- a/test-integration/graql/reasoner/query/SubsumptionIT.java
+++ b/test-integration/graql/reasoner/query/SubsumptionIT.java
@@ -36,6 +36,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -114,6 +115,18 @@ public class SubsumptionIT {
             assertFalse(child2.subsumes(parent));
         }
     }
+
+    @Test
+    public void test() {
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            ReasonerAtomicQuery child = ReasonerQueries.atomic(conjunction("(baseRole1: $x, $r2: $y);"), tx);
+            ReasonerAtomicQuery parent = ReasonerQueries.atomic(conjunction("($r1: $x, $r2: $y);"), tx);
+
+            assertFalse(parent.subsumes(child));
+            assertTrue(child.subsumes(parent));
+        }
+    }
+
 
     @Test
     public void testSubsumption_differentReflexiveRelationVariants(){

--- a/test-integration/graql/reasoner/query/SubsumptionIT.java
+++ b/test-integration/graql/reasoner/query/SubsumptionIT.java
@@ -36,7 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import static java.util.stream.Collectors.toSet;
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -106,7 +105,6 @@ public class SubsumptionIT {
             String id = tx.getEntityType("baseRoleEntity").instances().iterator().next().id().getValue();
             ReasonerAtomicQuery child = ReasonerQueries.atomic(conjunction("(baseRole1: $x, baseRole2: $y);"), tx);
             ReasonerAtomicQuery child2 = ReasonerQueries.atomic(conjunction("{(baseRole1: $x, baseRole2: $y); $y id " + id + ";};"), tx);
-
             ReasonerAtomicQuery parent = ReasonerQueries.atomic(conjunction("(baseRole1: $x, baseRole2: $x);"), tx);
 
             assertFalse(child.subsumes(parent));
@@ -115,18 +113,6 @@ public class SubsumptionIT {
             assertFalse(child2.subsumes(parent));
         }
     }
-
-    @Test
-    public void test() {
-        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
-            ReasonerAtomicQuery child = ReasonerQueries.atomic(conjunction("(baseRole1: $x, $r2: $y);"), tx);
-            ReasonerAtomicQuery parent = ReasonerQueries.atomic(conjunction("($r1: $x, $r2: $y);"), tx);
-
-            assertFalse(parent.subsumes(child));
-            assertTrue(child.subsumes(parent));
-        }
-    }
-
 
     @Test
     public void testSubsumption_differentReflexiveRelationVariants(){
@@ -158,6 +144,103 @@ public class SubsumptionIT {
                     genericSchemaGraph.differentReflexiveRelationVariants().patterns(),
                     genericSchemaGraph.differentReflexiveRelationVariants().patterns(),
                     subsumptionMatrix, tx);
+        }
+    }
+
+    @Test
+    public void testSubsumption_differentRelationVariantsWithVariableRoles() {
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentRelationVariantsWithVariableRoles = genericSchemaGraph.differentRelationVariantsWithVariableRoles();
+
+            int[][] subsumptionMatrix = new int[][]{
+                    //0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17
+                    {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//0
+                    {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+                    {1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//4
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+
+                    {1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//7
+
+                    {1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0},
+
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},//11
+                    {1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0},
+
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},//15
+                    {1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0},
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1}
+            };
+
+            subsumption(
+                    differentRelationVariantsWithVariableRoles.patterns(),
+                    differentRelationVariantsWithVariableRoles.patterns(),
+                    subsumptionMatrix,
+                    tx
+            );
+        }
+    }
+
+    @Test
+    public void testSubsumption_differentRelationVariants_differentRelationVariantsWithVariableRoles() {
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
+            QueryPattern differentRelationVariantsWithVariableRoles = genericSchemaGraph.differentRelationVariantsWithVariableRoles();
+
+            int[][] subsumptionMatrix = new int[][]{
+                    //0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17
+                    {1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//0
+                    {1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+
+                    {1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//4
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},
+
+                    {1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},//7
+                    {1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0},
+
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0},//11
+                    {1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0},
+
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0},//15
+                    {1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0},
+                    {1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 0},
+                    {1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1}
+            };
+            subsumption(
+                    differentRelationVariants.patterns(),
+                    differentRelationVariantsWithVariableRoles.patterns(),
+                    subsumptionMatrix,
+                    tx
+            );
+        }
+    }
+
+    @Test
+    public void testSubsumption_differentRelationVariantsWithVariableRoles_differentRelationVariants() {
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
+            QueryPattern differentRelationVariantsWithVariableRoles = genericSchemaGraph.differentRelationVariantsWithVariableRoles();
+            subsumption(
+                    differentRelationVariantsWithVariableRoles.patterns(),
+                    differentRelationVariants.patterns(),
+                    QueryPattern.zeroMatrix(differentRelationVariantsWithVariableRoles.size(), differentRelationVariants.size()),
+                    tx
+            );
         }
     }
 
@@ -244,6 +327,21 @@ public class SubsumptionIT {
     }
 
     @Test
+    public void testSubsumption_differentRelationVariantsWithMetaRoles_differentRelationVariants(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
+            QueryPattern differentRelationVariantsWithMetaRoles = genericSchemaGraph.differentRelationVariantsWithMetaRoles();
+
+            subsumption(
+                    differentRelationVariantsWithMetaRoles.patterns(),
+                    differentRelationVariants.patterns(),
+                    QueryPattern.zeroMatrix(differentRelationVariantsWithMetaRoles.size(),differentRelationVariants.size()),
+                    tx
+            );
+        }
+    }
+
+    @Test
     public void testSubsumption_differentRelationVariants_differentRelationVariantsWithRelationVariable(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
             QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
@@ -286,6 +384,21 @@ public class SubsumptionIT {
     }
 
     @Test
+    public void testSubsumption_differentRelationVariantsWithRelationVariable_differentRelationVariants(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
+            QueryPattern differentRelationVariantsWithRelationVariable = genericSchemaGraph.differentRelationVariantsWithRelationVariable();
+
+            subsumption(
+                    differentRelationVariantsWithRelationVariable.patterns(),
+                    differentRelationVariants.patterns(),
+                    QueryPattern.zeroMatrix(differentRelationVariantsWithRelationVariable.size(), differentRelationVariants.size()),
+                    tx
+            );
+        }
+    }
+
+    @Test
     public void testSubsumption_differentTypeRelationVariants_differentRelationVariants(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
             QueryPattern differentTypeRelationVariants = genericSchemaGraph.differentTypeRelationVariants();
@@ -295,6 +408,21 @@ public class SubsumptionIT {
                     differentTypeRelationVariants.patterns(),
                     differentRelationVariants.patterns(),
                     QueryPattern.zeroMatrix(differentTypeRelationVariants.size(), differentRelationVariants.size()),
+                    tx
+            );
+        }
+    }
+
+    @Test
+    public void testSubsumption_differentRelationVariants_differentTypeRelationVariants(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            QueryPattern differentTypeRelationVariants = genericSchemaGraph.differentTypeRelationVariants();
+            QueryPattern differentRelationVariants = genericSchemaGraph.differentRelationVariants();
+
+            subsumption(
+                    differentRelationVariants.patterns(),
+                    differentTypeRelationVariants.patterns(),
+                    QueryPattern.zeroMatrix(differentRelationVariants.size(), differentTypeRelationVariants.size()),
                     tx
             );
         }
@@ -499,6 +627,7 @@ public class SubsumptionIT {
         int j = 0;
         for (String child : children) {
             for (String parent : parents) {
+                System.out.println("(i, j) = " + i + " " + j);
                 subsumption(child, parent, resultMatrix[i][j] == 1, tx);
                 j++;
             }
@@ -512,6 +641,11 @@ public class SubsumptionIT {
         ReasonerAtomicQuery parent = ReasonerQueries.atomic(conjunction(parentString), tx);
         UnifierType unifierType = UnifierType.SUBSUMPTIVE;
 
+        /*
+        if ( subsumes != child.subsumes(parent)){
+            System.out.println("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n");
+        }
+        */
         assertEquals("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n", subsumes, child.subsumes(parent));
         MultiUnifier multiUnifier = child.getMultiUnifier(parent, unifierType);
         if (subsumes){


### PR DESCRIPTION
## What is the goal of this PR?

Refactor the way we handle roles when determining role player mappings during unification of relations - make it cleaner and easier to follow - less branching and conditionals.
## What are the changes implemented in this PR?

- introduce a new compatibility check - `roleCompatibility` - which is defined for each unifier type
