### PR TITLE
Differentiate semantic and query exceptions

### DIFF
--- a/console/test/GraknConsoleIT.java
+++ b/console/test/GraknConsoleIT.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.core.common.util.GraknVersion;
 import grakn.core.console.GraknConsole;
-import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import io.grpc.Status;

--- a/server/src/graql/analytics/ConnectedComponentVertexProgram.java
+++ b/server/src/graql/analytics/ConnectedComponentVertexProgram.java
@@ -19,17 +19,16 @@
 package grakn.core.graql.analytics;
 
 import grakn.core.concept.ConceptId;
-import grakn.core.graql.exception.GraqlSemanticException;
+import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.server.kb.Schema;
+import java.util.Collections;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
 import org.apache.tinkerpop.gremlin.process.computer.Messenger;
 import org.apache.tinkerpop.gremlin.process.computer.VertexComputeKey;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import java.util.Collections;
-import java.util.Set;
 
 import static grakn.core.graql.analytics.ConnectedComponentsVertexProgram.CLUSTER_LABEL;
 
@@ -103,7 +102,7 @@ public class ConnectedComponentVertexProgram extends GraknVertexProgram<Boolean>
         }
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: " + MAX_ITERATION + " !!!!!!!!");
-            throw GraqlSemanticException.maxIterationsReached(this.getClass());
+            throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
         memory.set(VOTE_TO_HALT, true);

--- a/server/src/graql/analytics/ConnectedComponentVertexProgram.java
+++ b/server/src/graql/analytics/ConnectedComponentVertexProgram.java
@@ -19,7 +19,7 @@
 package grakn.core.graql.analytics;
 
 import grakn.core.concept.ConceptId;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.server.kb.Schema;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
@@ -103,7 +103,7 @@ public class ConnectedComponentVertexProgram extends GraknVertexProgram<Boolean>
         }
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: " + MAX_ITERATION + " !!!!!!!!");
-            throw GraqlQueryException.maxIterationsReached(this.getClass());
+            throw GraqlSemanticException.maxIterationsReached(this.getClass());
         }
 
         memory.set(VOTE_TO_HALT, true);

--- a/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
+++ b/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.analytics;
 
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
@@ -96,7 +96,7 @@ public class ConnectedComponentsVertexProgram extends GraknVertexProgram<String>
         }
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlQueryException.maxIterationsReached(this.getClass());
+            throw GraqlSemanticException.maxIterationsReached(this.getClass());
         }
 
         memory.set(VOTE_TO_HALT, true);

--- a/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
+++ b/server/src/graql/analytics/ConnectedComponentsVertexProgram.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.analytics;
 
-import grakn.core.graql.exception.GraqlSemanticException;
+import grakn.core.graql.exception.GraqlQueryException;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
@@ -96,7 +96,7 @@ public class ConnectedComponentsVertexProgram extends GraknVertexProgram<String>
         }
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlSemanticException.maxIterationsReached(this.getClass());
+            throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
         memory.set(VOTE_TO_HALT, true);

--- a/server/src/graql/analytics/CorenessVertexProgram.java
+++ b/server/src/graql/analytics/CorenessVertexProgram.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.analytics;
 
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
 import org.apache.tinkerpop.gremlin.process.computer.Messenger;
@@ -142,7 +142,7 @@ public class CorenessVertexProgram extends GraknVertexProgram<String> {
 
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlQueryException.maxIterationsReached(this.getClass());
+            throw GraqlSemanticException.maxIterationsReached(this.getClass());
         }
 
         if (memory.<Boolean>get(PERSIST_CORENESS)) {

--- a/server/src/graql/analytics/CorenessVertexProgram.java
+++ b/server/src/graql/analytics/CorenessVertexProgram.java
@@ -18,15 +18,14 @@
 
 package grakn.core.graql.analytics;
 
-import grakn.core.graql.exception.GraqlSemanticException;
+import grakn.core.graql.exception.GraqlQueryException;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
 import org.apache.tinkerpop.gremlin.process.computer.Messenger;
 import org.apache.tinkerpop.gremlin.process.computer.VertexComputeKey;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
-
-import java.util.Set;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static grakn.core.graql.analytics.KCoreVertexProgram.IMPLICIT_MESSAGE_COUNT;
@@ -142,7 +141,7 @@ public class CorenessVertexProgram extends GraknVertexProgram<String> {
 
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlSemanticException.maxIterationsReached(this.getClass());
+            throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
         if (memory.<Boolean>get(PERSIST_CORENESS)) {

--- a/server/src/graql/analytics/KCoreVertexProgram.java
+++ b/server/src/graql/analytics/KCoreVertexProgram.java
@@ -19,8 +19,9 @@
 package grakn.core.graql.analytics;
 
 import com.google.common.collect.Iterators;
-import grakn.core.graql.exception.GraqlSemanticException;
+import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.server.kb.Schema;
+import java.util.Set;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
 import org.apache.tinkerpop.gremlin.process.computer.Messenger;
@@ -28,8 +29,6 @@ import org.apache.tinkerpop.gremlin.process.computer.VertexComputeKey;
 import org.apache.tinkerpop.gremlin.process.traversal.Operator;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.util.iterator.IteratorUtils;
-
-import java.util.Set;
 
 import static com.google.common.collect.Sets.newHashSet;
 
@@ -234,7 +233,7 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
 
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlSemanticException.maxIterationsReached(this.getClass());
+            throw GraqlQueryException.maxIterationsReached(this.getClass());
         }
 
         if (memory.<Boolean>get(CONNECTED_COMPONENT_STARTED)) {

--- a/server/src/graql/analytics/KCoreVertexProgram.java
+++ b/server/src/graql/analytics/KCoreVertexProgram.java
@@ -19,7 +19,7 @@
 package grakn.core.graql.analytics;
 
 import com.google.common.collect.Iterators;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.server.kb.Schema;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.MemoryComputeKey;
@@ -234,7 +234,7 @@ public class KCoreVertexProgram extends GraknVertexProgram<String> {
 
         if (memory.getIteration() == MAX_ITERATION) {
             LOGGER.debug("Reached Max Iteration: {}", MAX_ITERATION);
-            throw GraqlQueryException.maxIterationsReached(this.getClass());
+            throw GraqlSemanticException.maxIterationsReached(this.getClass());
         }
 
         if (memory.<Boolean>get(CONNECTED_COMPONENT_STARTED)) {

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -41,6 +41,10 @@ public class GraqlQueryException  extends GraknException {
     @Override
     public String getName() { return NAME; }
 
+    public static GraqlQueryException maxIterationsReached(Class<?> clazz) {
+        return new GraqlQueryException(ErrorMessage.MAX_ITERATION_REACHED.getMessage(clazz.toString()));
+    }
+
     public static GraqlQueryException ambiguousType(Variable var, Set<Type> types) {
         return new GraqlQueryException(ErrorMessage.AMBIGUOUS_TYPE.getMessage(var, types));
     }

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -36,7 +36,7 @@ public class GraqlQueryException  extends GraknException {
 
     private final String NAME = "GraqlQueryException";
 
-    private GraqlQueryException(String error) { super(error, null, false, false); }
+    private GraqlQueryException(String error) { super(error, null); }
 
     @Override
     public String getName() { return NAME; }

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -1,241 +1,29 @@
-/*
- * GRAKN.AI - THE KNOWLEDGE GRAPH
- * Copyright (C) 2018 Grakn Labs Ltd
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package grakn.core.graql.exception;
 
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
-import grakn.core.concept.Concept;
-import grakn.core.concept.Label;
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.concept.type.AttributeType;
-import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
-import grakn.core.graql.reasoner.query.ResolvableQuery;
-import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import java.time.format.DateTimeParseException;
-import java.util.Collection;
 import java.util.Set;
 
-import static grakn.core.common.exception.ErrorMessage.INSERT_ABSTRACT_NOT_TYPE;
-import static grakn.core.common.exception.ErrorMessage.INSERT_RECURSIVE;
-import static grakn.core.common.exception.ErrorMessage.INSERT_UNDEFINED_VARIABLE;
-import static grakn.core.common.exception.ErrorMessage.INVALID_VALUE;
-import static grakn.core.common.exception.ErrorMessage.NEGATIVE_OFFSET;
-import static grakn.core.common.exception.ErrorMessage.NON_POSITIVE_LIMIT;
-import static grakn.core.common.exception.ErrorMessage.UNEXPECTED_RESULT;
-
 /**
- * Graql Query Exception
- * Occurs when the query is syntactically correct but semantically incorrect.
- * For example limiting the results of a query -1
+ * Runtime exception signalling illegal states of the system encountered during query processing.
  */
-public class GraqlQueryException extends GraknException {
+public class GraqlQueryException  extends GraknException {
 
     private final String NAME = "GraqlQueryException";
 
-    private GraqlQueryException(String error) {
-        super(error, null, false, false);
-    }
-
-    private GraqlQueryException(String error, Exception cause) {
-        super(error, cause, false, false);
-    }
+    private GraqlQueryException(String error) { super(error, null, false, false); }
 
     @Override
-    public String getName() {
-        return NAME;
-    }
-
-    public static GraqlQueryException create(String formatString, Object... args) {
-        return new GraqlQueryException(String.format(formatString, args));
-    }
-
-    public static GraqlQueryException labelNotFound(Label label) {
-        return new GraqlQueryException(ErrorMessage.LABEL_NOT_FOUND.getMessage(label));
-    }
-
-    public static GraqlQueryException attributeWithNonAttributeType(Label attributeType) {
-        return new GraqlQueryException(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage(attributeType));
-    }
-
-    public static GraqlQueryException relationWithNonRelationType(Label label) {
-        return new GraqlQueryException(ErrorMessage.NOT_A_RELATION_TYPE.getMessage(label));
-    }
-
-    public static GraqlQueryException invalidRoleLabel(Label label) {
-        return new GraqlQueryException(ErrorMessage.NOT_A_ROLE_TYPE.getMessage(label, label));
-    }
-
-    public static GraqlQueryException matchWithoutAnyProperties(Statement statement) {
-        return create("Require statement to have at least one property: `%s`", statement);
-    }
-
-    public static GraqlQueryException unboundComparisonVariables(Set<Variable> unboundVariables) {
-        return GraqlQueryException.create("Variables used in comparisons cannot be unbounded %s", unboundVariables.toString());
-    }
-
-    public static GraqlQueryException kCoreOnRelationType(Label label) {
-        return create("cannot compute coreness of relation type %s.", label.getValue());
-    }
-
-    public static GraqlQueryException deleteSchemaConcept(SchemaConcept schemaConcept) {
-        return create("cannot delete schema concept %s. Use `undefine` instead.", schemaConcept);
-    }
-
-    public static GraqlQueryException insertUnsupportedProperty(String propertyName) {
-        return GraqlQueryException.create("inserting property '%s' is not supported, try `define`", propertyName);
-    }
-
-    public static GraqlQueryException defineUnsupportedProperty(String propertyName) {
-        return GraqlQueryException.create("defining property '%s' is not supported, try `insert`", propertyName);
-    }
-
-    public static GraqlQueryException mustBeAttributeType(Label attributeType) {
-        return new GraqlQueryException(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage(attributeType));
-    }
-
-    public static GraqlQueryException cannotGetInstancesOfNonType(Label label) {
-        return GraqlQueryException.create("%s is not a type and so does not have instances", label);
-    }
-
-    public static GraqlQueryException insertPredicate() {
-        return new GraqlQueryException(ErrorMessage.INSERT_PREDICATE.getMessage());
-    }
-
-    public static GraqlQueryException insertRecursive(Statement var) {
-        return new GraqlQueryException(INSERT_RECURSIVE.getMessage(var.getPrintableName()));
-    }
-
-    public static GraqlQueryException insertUndefinedVariable(Statement var) {
-        return new GraqlQueryException(INSERT_UNDEFINED_VARIABLE.getMessage(var.getPrintableName()));
-    }
-
-    public static GraqlQueryException createInstanceOfMetaConcept(Variable var, Type type) {
-        return new GraqlQueryException(var + " cannot be an instance of meta-type " + type.label());
-    }
-
-    /**
-     * Thrown when a concept is inserted with multiple properties when it can only have one.
-     * <p>
-     * For example: {@code insert $x isa movie; $x isa person;}
-     * </p>
-     */
-    public static GraqlQueryException insertMultipleProperties(
-            Statement varPattern, String property, Object value1, Object value2
-    ) {
-        String message = "a concept `%s` cannot have multiple properties `%s` and `%s` for `%s`";
-        return create(message, varPattern, value1, value2, property);
-    }
-
-    /**
-     * Thrown when a property is inserted on a concept that already exists and that property can't be overridden.
-     * <p>
-     * For example: {@code match $x isa name; insert $x val "Bob";}
-     * </p>
-     */
-    public static GraqlQueryException insertPropertyOnExistingConcept(String property, Object value, Concept concept) {
-        return create("cannot insert property `%s %s` on existing concept `%s`", property, value, concept);
-    }
-
-    /**
-     * Thrown when a property is inserted on a concept that doesn't support that property.
-     * <p>
-     * For example, an entity with a value: {@code insert $x isa movie, val "The Godfather";}
-     * </p>
-     */
-    public static GraqlQueryException insertUnexpectedProperty(String property, Object value, Concept concept) {
-        return create("unexpected property `%s %s` for concept `%s`", property, value, concept);
-    }
-
-    /**
-     * Thrown when a concept does not have all expected properties required to insert it.
-     * <p>
-     * For example, an attribute without a value: {@code insert $x isa name;}
-     * </p>
-     */
-    public static GraqlQueryException insertNoExpectedProperty(String property, Statement var) {
-        return create("missing expected property `%s` in `%s`", property, var);
-    }
-
-
-
-    /**
-     * Thrown when attempting to insert a concept that already exists.
-     * <p>
-     * For example: {@code match $x isa movie; insert $x isa name, val "Bob";}
-     * </p>
-     */
-    public static GraqlQueryException insertExistingConcept(Statement pattern, Concept concept) {
-        return create("cannot overwrite properties `%s` on  concept `%s`", pattern, concept);
-    }
-
-    public static GraqlQueryException nonPositiveLimit(long limit) {
-        return new GraqlQueryException(NON_POSITIVE_LIMIT.getMessage(limit));
-    }
-
-    public static GraqlQueryException negativeOffset(long offset) {
-        return new GraqlQueryException(NEGATIVE_OFFSET.getMessage(offset));
-    }
-
-    public static GraqlQueryException invalidValueClass(Object value) {
-        return new GraqlQueryException(INVALID_VALUE.getMessage(value.getClass()));
-    }
-
-    public static GraqlQueryException unknownAggregate(String name) {
-        return new GraqlQueryException(ErrorMessage.UNKNOWN_AGGREGATE.getMessage(name));
-    }
-
-    public static GraqlQueryException maxIterationsReached(Class<?> clazz) {
-        return new GraqlQueryException(ErrorMessage.MAX_ITERATION_REACHED.getMessage(clazz.toString()));
-    }
-
-    public static GraqlQueryException statisticsAttributeTypesNotSpecified() {
-        return new GraqlQueryException(ErrorMessage.ATTRIBUTE_TYPE_NOT_SPECIFIED.getMessage());
-    }
-
-    public static GraqlQueryException instanceDoesNotExist() {
-        return new GraqlQueryException(ErrorMessage.INSTANCE_DOES_NOT_EXIST.getMessage());
-    }
-
-    public static GraqlQueryException kValueSmallerThanTwo() {
-        return new GraqlQueryException(ErrorMessage.K_SMALLER_THAN_TWO.getMessage());
-    }
-
-    public static GraqlQueryException attributeMustBeANumber(AttributeType.DataType dataType, Label attributeType) {
-        return new GraqlQueryException(attributeType + " must have data type of `long` or `double`, but was " + dataType.name());
-    }
-
-    public static GraqlQueryException attributesWithDifferentDataTypes(Collection<String> attributeTypes) {
-        return new GraqlQueryException("resource types " + attributeTypes + " have different data types");
-    }
+    public String getName() { return NAME; }
 
     public static GraqlQueryException ambiguousType(Variable var, Set<Type> types) {
         return new GraqlQueryException(ErrorMessage.AMBIGUOUS_TYPE.getMessage(var, types));
-    }
-
-    public static GraqlQueryException nonGroundNeqPredicate(ReasonerQuery query) {
-        return new GraqlQueryException(ErrorMessage.NON_GROUND_NEQ_PREDICATE.getMessage(query));
     }
 
     public static GraqlQueryException incompleteResolutionPlan(ReasonerQuery reasonerQuery) {
@@ -262,52 +50,11 @@ public class GraqlQueryException extends GraknException {
         return new GraqlQueryException("Attempted to obtain unifiers on non-atomic queries.");
     }
 
-    public static GraqlQueryException unsafeNegationBlock(ResolvableQuery query) {
-        return new GraqlQueryException(ErrorMessage.UNSAFE_NEGATION_BLOCK.getMessage(query));
-    }
-
-    public static GraqlQueryException usingNegationWithReasoningOff(Pattern pattern) {
-        return new GraqlQueryException(ErrorMessage.USING_NEGATION_WITH_REASONING_OFF.getMessage(pattern));
-    }
-
-    public static GraqlQueryException disjunctiveNegationBlock() {
-        return new GraqlQueryException(ErrorMessage.DISJUNCTIVE_NEGATION_BLOCK.getMessage());
-    }
-
     public static GraqlQueryException invalidQueryCacheEntry(ReasonerQuery query, ConceptMap answer) {
         return new GraqlQueryException(ErrorMessage.INVALID_CACHE_ENTRY.getMessage(query.toString(), answer.toString()));
-    }
-
-    public static GraqlQueryException conceptNotAThing(Object value) {
-        return new GraqlQueryException(ErrorMessage.CONCEPT_NOT_THING.getMessage(value));
     }
 
     public static GraqlQueryException nonRoleIdAssignedToRoleVariable(Statement var) {
         return new GraqlQueryException(ErrorMessage.ROLE_ID_IS_NOT_ROLE.getMessage(var.toString()));
     }
-
-    public static GraqlQueryException cannotParseDateFormat(String originalFormat) {
-        return new GraqlQueryException("Cannot parse date format " + originalFormat + ". See DateTimeFormatter#ofPattern");
-    }
-
-    public static GraqlQueryException cannotParseDateString(String originalDate, String originalFormat, DateTimeParseException cause) {
-        throw new GraqlQueryException("Cannot parse date value " + originalDate + " with format " + originalFormat, cause);
-    }
-
-    public static GraqlQueryException noLabelSpecifiedForHas(Variable var) {
-        return create("'has' argument '%s' requires a label", var);
-    }
-
-    public static GraqlQueryException insertRolePlayerWithoutRoleType() {
-        return new GraqlQueryException(ErrorMessage.INSERT_RELATION_WITHOUT_ROLE_TYPE.getMessage());
-    }
-
-    public static GraqlQueryException insertAbstractOnNonType(SchemaConcept concept) {
-        return new GraqlQueryException(INSERT_ABSTRACT_NOT_TYPE.getMessage(concept.label()));
-    }
-
-    public static GraqlQueryException unexpectedResult(Variable var) {
-        return new GraqlQueryException(UNEXPECTED_RESULT.getMessage(var.name()));
-    }
-
 }

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -36,7 +36,7 @@ public class GraqlQueryException  extends GraknException {
 
     private final String NAME = "GraqlQueryException";
 
-    private GraqlQueryException(String error) { super(error, null); }
+    private GraqlQueryException(String error) { super(error); }
 
     @Override
     public String getName() { return NAME; }

--- a/server/src/graql/exception/GraqlQueryException.java
+++ b/server/src/graql/exception/GraqlQueryException.java
@@ -1,3 +1,22 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
 package grakn.core.graql.exception;
 
 import grakn.core.common.exception.ErrorMessage;

--- a/server/src/graql/exception/GraqlSemanticException.java
+++ b/server/src/graql/exception/GraqlSemanticException.java
@@ -1,0 +1,268 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2018 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.graql.exception;
+
+import grakn.core.common.exception.ErrorMessage;
+import grakn.core.common.exception.GraknException;
+import grakn.core.concept.Concept;
+import grakn.core.concept.Label;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.SchemaConcept;
+import grakn.core.concept.type.Type;
+import grakn.core.graql.reasoner.atom.Atomic;
+import grakn.core.graql.reasoner.query.ReasonerQuery;
+import grakn.core.graql.reasoner.query.ResolvableQuery;
+import graql.lang.pattern.Pattern;
+import graql.lang.statement.Statement;
+import graql.lang.statement.Variable;
+
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.Set;
+
+import static grakn.core.common.exception.ErrorMessage.INSERT_ABSTRACT_NOT_TYPE;
+import static grakn.core.common.exception.ErrorMessage.INSERT_RECURSIVE;
+import static grakn.core.common.exception.ErrorMessage.INSERT_UNDEFINED_VARIABLE;
+import static grakn.core.common.exception.ErrorMessage.INVALID_VALUE;
+import static grakn.core.common.exception.ErrorMessage.NEGATIVE_OFFSET;
+import static grakn.core.common.exception.ErrorMessage.NON_POSITIVE_LIMIT;
+import static grakn.core.common.exception.ErrorMessage.UNEXPECTED_RESULT;
+
+/**
+ * Graql Semantic Exception
+ * Occurs when the query is syntactically correct but semantically incorrect.
+ * For example limiting the results of a query -1
+ */
+public class GraqlSemanticException extends GraknException {
+
+    private final String NAME = "GraqlSemanticException";
+
+    private GraqlSemanticException(String error) {
+        super(error, null, false, false);
+    }
+
+    private GraqlSemanticException(String error, Exception cause) {
+        super(error, cause, false, false);
+    }
+
+    @Override
+    public String getName() {
+        return NAME;
+    }
+
+    public static GraqlSemanticException create(String formatString, Object... args) {
+        return new GraqlSemanticException(String.format(formatString, args));
+    }
+
+    public static GraqlSemanticException labelNotFound(Label label) {
+        return new GraqlSemanticException(ErrorMessage.LABEL_NOT_FOUND.getMessage(label));
+    }
+
+    public static GraqlSemanticException attributeWithNonAttributeType(Label attributeType) {
+        return new GraqlSemanticException(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage(attributeType));
+    }
+
+    public static GraqlSemanticException relationWithNonRelationType(Label label) {
+        return new GraqlSemanticException(ErrorMessage.NOT_A_RELATION_TYPE.getMessage(label));
+    }
+
+    public static GraqlSemanticException invalidRoleLabel(Label label) {
+        return new GraqlSemanticException(ErrorMessage.NOT_A_ROLE_TYPE.getMessage(label, label));
+    }
+
+    public static GraqlSemanticException matchWithoutAnyProperties(Statement statement) {
+        return create("Require statement to have at least one property: `%s`", statement);
+    }
+
+    public static GraqlSemanticException unboundComparisonVariables(Set<Variable> unboundVariables) {
+        return GraqlSemanticException.create("Variables used in comparisons cannot be unbounded %s", unboundVariables.toString());
+    }
+
+    public static GraqlSemanticException kCoreOnRelationType(Label label) {
+        return create("cannot compute coreness of relation type %s.", label.getValue());
+    }
+
+    public static GraqlSemanticException deleteSchemaConcept(SchemaConcept schemaConcept) {
+        return create("cannot delete schema concept %s. Use `undefine` instead.", schemaConcept);
+    }
+
+    public static GraqlSemanticException insertUnsupportedProperty(String propertyName) {
+        return GraqlSemanticException.create("inserting property '%s' is not supported, try `define`", propertyName);
+    }
+
+    public static GraqlSemanticException defineUnsupportedProperty(String propertyName) {
+        return GraqlSemanticException.create("defining property '%s' is not supported, try `insert`", propertyName);
+    }
+
+    public static GraqlSemanticException mustBeAttributeType(Label attributeType) {
+        return new GraqlSemanticException(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage(attributeType));
+    }
+
+    public static GraqlSemanticException cannotGetInstancesOfNonType(Label label) {
+        return GraqlSemanticException.create("%s is not a type and so does not have instances", label);
+    }
+
+    public static GraqlSemanticException insertPredicate() {
+        return new GraqlSemanticException(ErrorMessage.INSERT_PREDICATE.getMessage());
+    }
+
+    public static GraqlSemanticException insertRecursive(Statement var) {
+        return new GraqlSemanticException(INSERT_RECURSIVE.getMessage(var.getPrintableName()));
+    }
+
+    public static GraqlSemanticException insertUndefinedVariable(Statement var) {
+        return new GraqlSemanticException(INSERT_UNDEFINED_VARIABLE.getMessage(var.getPrintableName()));
+    }
+
+    public static GraqlSemanticException createInstanceOfMetaConcept(Variable var, Type type) {
+        return new GraqlSemanticException(var + " cannot be an instance of meta-type " + type.label());
+    }
+
+    /**
+     * Thrown when a concept is inserted with multiple properties when it can only have one.
+     * <p>
+     * For example: {@code insert $x isa movie; $x isa person;}
+     * </p>
+     */
+    public static GraqlSemanticException insertMultipleProperties(
+            Statement varPattern, String property, Object value1, Object value2
+    ) {
+        String message = "a concept `%s` cannot have multiple properties `%s` and `%s` for `%s`";
+        return create(message, varPattern, value1, value2, property);
+    }
+
+    /**
+     * Thrown when a property is inserted on a concept that already exists and that property can't be overridden.
+     * <p>
+     * For example: {@code match $x isa name; insert $x val "Bob";}
+     * </p>
+     */
+    public static GraqlSemanticException insertPropertyOnExistingConcept(String property, Object value, Concept concept) {
+        return create("cannot insert property `%s %s` on existing concept `%s`", property, value, concept);
+    }
+
+    /**
+     * Thrown when a property is inserted on a concept that doesn't support that property.
+     * <p>
+     * For example, an entity with a value: {@code insert $x isa movie, val "The Godfather";}
+     * </p>
+     */
+    public static GraqlSemanticException insertUnexpectedProperty(String property, Object value, Concept concept) {
+        return create("unexpected property `%s %s` for concept `%s`", property, value, concept);
+    }
+
+    /**
+     * Thrown when a concept does not have all expected properties required to insert it.
+     * <p>
+     * For example, an attribute without a value: {@code insert $x isa name;}
+     * </p>
+     */
+    public static GraqlSemanticException insertNoExpectedProperty(String property, Statement var) {
+        return create("missing expected property `%s` in `%s`", property, var);
+    }
+
+
+    /**
+     * Thrown when attempting to insert a concept that already exists.
+     * <p>
+     * For example: {@code match $x isa movie; insert $x isa name, val "Bob";}
+     * </p>
+     */
+    public static GraqlSemanticException insertExistingConcept(Statement pattern, Concept concept) {
+        return create("cannot overwrite properties `%s` on  concept `%s`", pattern, concept);
+    }
+
+    public static GraqlSemanticException nonPositiveLimit(long limit) {
+        return new GraqlSemanticException(NON_POSITIVE_LIMIT.getMessage(limit));
+    }
+
+    public static GraqlSemanticException negativeOffset(long offset) {
+        return new GraqlSemanticException(NEGATIVE_OFFSET.getMessage(offset));
+    }
+
+    public static GraqlSemanticException invalidValueClass(Object value) {
+        return new GraqlSemanticException(INVALID_VALUE.getMessage(value.getClass()));
+    }
+
+    public static GraqlSemanticException unknownAggregate(String name) {
+        return new GraqlSemanticException(ErrorMessage.UNKNOWN_AGGREGATE.getMessage(name));
+    }
+
+    public static GraqlSemanticException maxIterationsReached(Class<?> clazz) {
+        return new GraqlSemanticException(ErrorMessage.MAX_ITERATION_REACHED.getMessage(clazz.toString()));
+    }
+
+    public static GraqlSemanticException statisticsAttributeTypesNotSpecified() {
+        return new GraqlSemanticException(ErrorMessage.ATTRIBUTE_TYPE_NOT_SPECIFIED.getMessage());
+    }
+
+    public static GraqlSemanticException instanceDoesNotExist() {
+        return new GraqlSemanticException(ErrorMessage.INSTANCE_DOES_NOT_EXIST.getMessage());
+    }
+
+    public static GraqlSemanticException kValueSmallerThanTwo() {
+        return new GraqlSemanticException(ErrorMessage.K_SMALLER_THAN_TWO.getMessage());
+    }
+
+    public static GraqlSemanticException attributeMustBeANumber(AttributeType.DataType dataType, Label attributeType) {
+        return new GraqlSemanticException(attributeType + " must have data type of `long` or `double`, but was " + dataType.name());
+    }
+
+    public static GraqlSemanticException attributesWithDifferentDataTypes(Collection<String> attributeTypes) {
+        return new GraqlSemanticException("resource types " + attributeTypes + " have different data types");
+    }
+
+    public static GraqlSemanticException unsafeNegationBlock(ResolvableQuery query) {
+        return new GraqlSemanticException(ErrorMessage.UNSAFE_NEGATION_BLOCK.getMessage(query));
+    }
+
+    public static GraqlSemanticException usingNegationWithReasoningOff(Pattern pattern) {
+        return new GraqlSemanticException(ErrorMessage.USING_NEGATION_WITH_REASONING_OFF.getMessage(pattern));
+    }
+
+    public static GraqlSemanticException disjunctiveNegationBlock() {
+        return new GraqlSemanticException(ErrorMessage.DISJUNCTIVE_NEGATION_BLOCK.getMessage());
+    }
+
+    public static GraqlSemanticException cannotParseDateFormat(String originalFormat) {
+        return new GraqlSemanticException("Cannot parse date format " + originalFormat + ". See DateTimeFormatter#ofPattern");
+    }
+
+    public static GraqlSemanticException cannotParseDateString(String originalDate, String originalFormat, DateTimeParseException cause) {
+        throw new GraqlSemanticException("Cannot parse date value " + originalDate + " with format " + originalFormat, cause);
+    }
+
+    public static GraqlSemanticException noLabelSpecifiedForHas(Variable var) {
+        return create("'has' argument '%s' requires a label", var);
+    }
+
+    public static GraqlSemanticException insertRolePlayerWithoutRoleType() {
+        return new GraqlSemanticException(ErrorMessage.INSERT_RELATION_WITHOUT_ROLE_TYPE.getMessage());
+    }
+
+    public static GraqlSemanticException insertAbstractOnNonType(SchemaConcept concept) {
+        return new GraqlSemanticException(INSERT_ABSTRACT_NOT_TYPE.getMessage(concept.label()));
+    }
+
+    public static GraqlSemanticException unexpectedResult(Variable var) {
+        return new GraqlSemanticException(UNEXPECTED_RESULT.getMessage(var.name()));
+    }
+
+}

--- a/server/src/graql/exception/GraqlSemanticException.java
+++ b/server/src/graql/exception/GraqlSemanticException.java
@@ -205,10 +205,6 @@ public class GraqlSemanticException extends GraknException {
         return new GraqlSemanticException(ErrorMessage.UNKNOWN_AGGREGATE.getMessage(name));
     }
 
-    public static GraqlSemanticException maxIterationsReached(Class<?> clazz) {
-        return new GraqlSemanticException(ErrorMessage.MAX_ITERATION_REACHED.getMessage(clazz.toString()));
-    }
-
     public static GraqlSemanticException statisticsAttributeTypesNotSpecified() {
         return new GraqlSemanticException(ErrorMessage.ATTRIBUTE_TYPE_NOT_SPECIFIED.getMessage());
     }

--- a/server/src/graql/executor/ComputeExecutor.java
+++ b/server/src/graql/executor/ComputeExecutor.java
@@ -60,7 +60,7 @@ import grakn.core.graql.analytics.StatisticsMapReduce;
 import grakn.core.graql.analytics.StdMapReduce;
 import grakn.core.graql.analytics.SumMapReduce;
 import grakn.core.graql.analytics.Utility;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
@@ -234,18 +234,18 @@ class ComputeExecutor {
         AttributeType.DataType<?> dataType = null;
         for (Type type : targetTypes(query)) {
             // check if the selected type is a attribute type
-            if (!type.isAttributeType()) throw GraqlQueryException.mustBeAttributeType(type.label());
+            if (!type.isAttributeType()) throw GraqlSemanticException.mustBeAttributeType(type.label());
             AttributeType<?> attributeType = type.asAttributeType();
             if (dataType == null) {
                 // check if the attribute type has data-type LONG or DOUBLE
                 dataType = attributeType.dataType();
                 if (!dataType.equals(AttributeType.DataType.LONG) && !dataType.equals(AttributeType.DataType.DOUBLE)) {
-                    throw GraqlQueryException.attributeMustBeANumber(dataType, attributeType.label());
+                    throw GraqlSemanticException.attributeMustBeANumber(dataType, attributeType.label());
                 }
             } else {
                 // check if all the attribute types have the same data-type
                 if (!dataType.equals(attributeType.dataType())) {
-                    throw GraqlQueryException.attributesWithDifferentDataTypes(query.of());
+                    throw GraqlSemanticException.attributesWithDifferentDataTypes(query.of());
                 }
             }
         }
@@ -334,7 +334,7 @@ class ComputeExecutor {
         ConceptId fromID = ConceptId.of(query.from());
         ConceptId toID = ConceptId.of(query.to());
 
-        if (!scopeContainsInstances(query, fromID, toID)) throw GraqlQueryException.instanceDoesNotExist();
+        if (!scopeContainsInstances(query, fromID, toID)) throw GraqlSemanticException.instanceDoesNotExist();
         if (fromID.equals(toID)) return Stream.of(new ConceptList(ImmutableList.of(fromID)));
 
         Set<LabelId> scopedLabelIds = convertLabelsToIds(scopeTypeLabels(query));
@@ -389,7 +389,7 @@ class ComputeExecutor {
                     .flatMap(t -> {
                         Label typeLabel = Label.of(t);
                         Type type = tx.getSchemaConcept(typeLabel);
-                        if (type == null) throw GraqlQueryException.labelNotFound(typeLabel);
+                        if (type == null) throw GraqlSemanticException.labelNotFound(typeLabel);
                         return type.subs();
                     })
                     .map(SchemaConcept::label)
@@ -423,7 +423,7 @@ class ComputeExecutor {
     private Stream<ConceptSetMeasure> runComputeCoreness(GraqlCompute.Centrality query) {
         long k = query.where().minK().get();
 
-        if (k < 2L) throw GraqlQueryException.kValueSmallerThanTwo();
+        if (k < 2L) throw GraqlSemanticException.kValueSmallerThanTwo();
 
         Set<Label> targetTypeLabels;
 
@@ -435,8 +435,8 @@ class ComputeExecutor {
                     .flatMap(t -> {
                         Label typeLabel = Label.of(t);
                         Type type = tx.getSchemaConcept(typeLabel);
-                        if (type == null) throw GraqlQueryException.labelNotFound(typeLabel);
-                        if (type.isRelationType()) throw GraqlQueryException.kCoreOnRelationType(typeLabel);
+                        if (type == null) throw GraqlSemanticException.labelNotFound(typeLabel);
+                        if (type.isRelationType()) throw GraqlSemanticException.kCoreOnRelationType(typeLabel);
                         return type.subs();
                     })
                     .map(SchemaConcept::label)
@@ -489,7 +489,7 @@ class ComputeExecutor {
         if (query.where().contains().isPresent()) {
             ConceptId conceptId = ConceptId.of(query.where().contains().get());
             if (!scopeContainsInstances(query, conceptId)) {
-                throw GraqlQueryException.instanceDoesNotExist();
+                throw GraqlSemanticException.instanceDoesNotExist();
             }
             vertexProgram = new ConnectedComponentVertexProgram(conceptId);
         } else {
@@ -520,7 +520,7 @@ class ComputeExecutor {
     private Stream<ConceptSet> runComputeKCore(GraqlCompute.Cluster query) {
         long k = query.where().k().get();
 
-        if (k < 2L) throw GraqlQueryException.kValueSmallerThanTwo();
+        if (k < 2L) throw GraqlSemanticException.kValueSmallerThanTwo();
 
         if (!scopeContainsInstance(query)) {
             return Stream.empty();
@@ -656,15 +656,15 @@ class ComputeExecutor {
      */
     private ImmutableSet<Type> targetTypes(Computable.Targetable<?> query) {
         if (query.of().isEmpty()) {
-            throw GraqlQueryException.statisticsAttributeTypesNotSpecified();
+            throw GraqlSemanticException.statisticsAttributeTypesNotSpecified();
         }
 
         return query.of().stream()
                 .map(t -> {
                     Label label = Label.of(t);
                     Type type = tx.getSchemaConcept(label);
-                    if (type == null) throw GraqlQueryException.labelNotFound(label);
-                    if (!type.isAttributeType()) throw GraqlQueryException.mustBeAttributeType(type.label());
+                    if (type == null) throw GraqlSemanticException.labelNotFound(label);
+                    if (!type.isAttributeType()) throw GraqlSemanticException.mustBeAttributeType(type.label());
                     return type;
                 })
                 .flatMap(Type::subs)
@@ -745,7 +745,7 @@ class ComputeExecutor {
             Stream<Type> subTypes = query.in().stream().map(t -> {
                 Label label = Label.of(t);
                 Type type = tx.getType(label);
-                if (type == null) throw GraqlQueryException.labelNotFound(label);
+                if (type == null) throw GraqlSemanticException.labelNotFound(label);
                 return type;
             }).flatMap(Type::subs);
 

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -31,7 +31,7 @@ import grakn.core.concept.answer.ConceptSet;
 import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.graql.exception.GraqlCheckedException;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.property.PropertyExecutor;
 import grakn.core.graql.gremlin.GraqlTraversal;
 import grakn.core.graql.gremlin.TraversalPlanner;
@@ -152,7 +152,7 @@ public class QueryExecutor {
                 .filter(statement -> statement.properties().size() == 0)
                 .collect(toList());
         if (statementsWithoutProperties.size() != 0) {
-            throw GraqlQueryException.matchWithoutAnyProperties(statementsWithoutProperties.get(0));
+            throw GraqlSemanticException.matchWithoutAnyProperties(statementsWithoutProperties.get(0));
         }
 
         validateVarVarComparisons(negationDNF);
@@ -166,7 +166,7 @@ public class QueryExecutor {
                     .flatMap(p -> p.getPatterns().stream())
                     .anyMatch(Pattern::isNegation);
             if (containsNegation) {
-                throw GraqlQueryException.usingNegationWithReasoningOff(matchClause.getPatterns());
+                throw GraqlSemanticException.usingNegationWithReasoningOff(matchClause.getPatterns());
             }
         }
     }
@@ -200,7 +200,7 @@ public class QueryExecutor {
         // ensure variables used in var-var comparisons are used elsewhere too
         Set<Variable> unboundComparisonVariables = Sets.difference(varVarComparisons, notVarVarComparisons);
         if (!unboundComparisonVariables.isEmpty()) {
-            throw GraqlQueryException.unboundComparisonVariables(unboundComparisonVariables);
+            throw GraqlSemanticException.unboundComparisonVariables(unboundComparisonVariables);
         }
     }
 
@@ -231,7 +231,7 @@ public class QueryExecutor {
         for (Variable var : vars) {
             Element element = elements.get(var.symbol());
             if (element == null) {
-                throw GraqlQueryException.unexpectedResult(var);
+                throw GraqlSemanticException.unexpectedResult(var);
             } else {
                 Concept result;
                 if (element instanceof Vertex) {
@@ -362,7 +362,7 @@ public class QueryExecutor {
         conceptsToDelete.forEach(concept -> {
             // a concept is either a schema concept or a thing
             if (concept.isSchemaConcept()) {
-                throw GraqlQueryException.deleteSchemaConcept(concept.asSchemaConcept());
+                throw GraqlSemanticException.deleteSchemaConcept(concept.asSchemaConcept());
             } else if (concept.isThing()) {
                 try {
                     // if it's not inferred, we can delete it

--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -31,7 +31,7 @@ import com.google.common.collect.Sets;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.property.PropertyExecutor.Writer;
 import grakn.core.graql.util.Partition;
 import grakn.core.server.session.TransactionOLTP;
@@ -319,7 +319,7 @@ public class WriteExecutor {
         if (!dependencies.isEmpty()) {
             // This means there must have been a loop. Pick an arbitrary remaining var to display
             Variable var = dependencies.keys().iterator().next().var();
-            throw GraqlQueryException.insertRecursive(printableRepresentation(var));
+            throw GraqlSemanticException.insertRecursive(printableRepresentation(var));
         }
 
         return sorted.build();
@@ -333,12 +333,12 @@ public class WriteExecutor {
      * response to PropertyExecutor#producedVars().
      * For example, a property may call {@code executor.builder(var).isa(type);} in order to provide a type for a var.
      *
-     * @throws GraqlQueryException if the concept in question has already been created
+     * @throws GraqlSemanticException if the concept in question has already been created
      */
     public ConceptBuilder getBuilder(Variable var) {
         return tryBuilder(var).orElseThrow(() -> {
             Concept concept = concepts.get(equivalentVars.componentOf(var));
-            return GraqlQueryException.insertExistingConcept(printableRepresentation(var), concept);
+            return GraqlSemanticException.insertExistingConcept(printableRepresentation(var), concept);
         });
     }
 
@@ -395,7 +395,7 @@ public class WriteExecutor {
 
         LOG.debug("Could not build concept for {}\nconcepts = {}\nconceptBuilders = {}", var, concepts, conceptBuilders);
 
-        throw GraqlQueryException.insertUndefinedVariable(printableRepresentation(var));
+        throw GraqlSemanticException.insertUndefinedVariable(printableRepresentation(var));
     }
 
     Statement printableRepresentation(Variable var) {

--- a/server/src/graql/executor/property/AbstractExecutor.java
+++ b/server/src/graql/executor/property/AbstractExecutor.java
@@ -21,7 +21,7 @@ package grakn.core.graql.executor.property;
 import com.google.common.collect.ImmutableSet;
 import grakn.core.concept.Concept;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -93,7 +93,7 @@ public class AbstractExecutor implements PropertyExecutor.Definable {
             if (concept.isType()) {
                 concept.asType().isAbstract(true);
             } else {
-                throw GraqlQueryException.insertAbstractOnNonType(concept.asSchemaConcept());
+                throw GraqlSemanticException.insertAbstractOnNonType(concept.asSchemaConcept());
             }
         }
     }

--- a/server/src/graql/executor/property/HasAttributeTypeExecutor.java
+++ b/server/src/graql/executor/property/HasAttributeTypeExecutor.java
@@ -24,7 +24,7 @@ import grakn.core.concept.Label;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -66,7 +66,7 @@ public class HasAttributeTypeExecutor implements PropertyExecutor.Definable {
 
         // TODO: this may the cause of issue #4664
         String type = attributeType.getType().orElseThrow(
-                () -> GraqlQueryException.noLabelSpecifiedForHas(attributeType.var())
+                () -> GraqlSemanticException.noLabelSpecifiedForHas(attributeType.var())
         );
 
         Statement role = Graql.type(Graql.Token.Type.ROLE);

--- a/server/src/graql/executor/property/PropertyExecutor.java
+++ b/server/src/graql/executor/property/PropertyExecutor.java
@@ -19,7 +19,7 @@
 package grakn.core.graql.executor.property;
 
 import com.google.common.collect.ImmutableSet;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -117,7 +117,7 @@ public interface PropertyExecutor {
         if (executor instanceof Definable) {
             return (Definable) executor;
         } else {
-            throw GraqlQueryException.defineUnsupportedProperty(property.keyword());
+            throw GraqlSemanticException.defineUnsupportedProperty(property.keyword());
         }
     }
 
@@ -127,7 +127,7 @@ public interface PropertyExecutor {
         if (executor instanceof Insertable) {
             return (Insertable) executor;
         } else {
-            throw GraqlQueryException.insertUnsupportedProperty(property.keyword());
+            throw GraqlSemanticException.insertUnsupportedProperty(property.keyword());
         }
     }
 

--- a/server/src/graql/executor/property/RelationExecutor.java
+++ b/server/src/graql/executor/property/RelationExecutor.java
@@ -27,6 +27,7 @@ import grakn.core.concept.thing.Relation;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Role;
 import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.gremlin.sets.EquivalentFragmentSets;
@@ -202,7 +203,7 @@ public class RelationExecutor implements PropertyExecutor.Insertable {
         }
 
         private Statement getRole(RelationProperty.RolePlayer relationPlayer) {
-            return relationPlayer.getRole().orElseThrow(GraqlQueryException::insertRolePlayerWithoutRoleType);
+            return relationPlayer.getRole().orElseThrow(GraqlSemanticException::insertRolePlayerWithoutRoleType);
         }
     }
 }

--- a/server/src/graql/executor/property/ThenExecutor.java
+++ b/server/src/graql/executor/property/ThenExecutor.java
@@ -19,7 +19,7 @@
 package grakn.core.graql.executor.property;
 
 import com.google.common.collect.ImmutableSet;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -59,7 +59,7 @@ public class ThenExecutor implements PropertyExecutor.Definable {
     @Override
     public Set<PropertyExecutor.Writer> undefineExecutors() {
         // TODO: Fix this so that Undefining ThenProperty behaves symmetrically to Defining ThenProperty
-        throw GraqlQueryException.defineUnsupportedProperty(property.keyword());
+        throw GraqlSemanticException.defineUnsupportedProperty(property.keyword());
     }
 
     private class DefineThen implements PropertyExecutor.Writer {

--- a/server/src/graql/executor/property/TypeExecutor.java
+++ b/server/src/graql/executor/property/TypeExecutor.java
@@ -21,7 +21,7 @@ package grakn.core.graql.executor.property;
 import com.google.common.collect.ImmutableSet;
 import grakn.core.concept.Label;
 import grakn.core.concept.type.SchemaConcept;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.gremlin.sets.EquivalentFragmentSets;
@@ -53,7 +53,7 @@ public class TypeExecutor implements PropertyExecutor.Referrable {
     @Override
     public Atomic atomic(ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
         SchemaConcept schemaConcept = parent.tx().getSchemaConcept(Label.of(property.name()));
-        if (schemaConcept == null) throw GraqlQueryException.labelNotFound(Label.of(property.name()));
+        if (schemaConcept == null) throw GraqlSemanticException.labelNotFound(Label.of(property.name()));
         return IdPredicate.create(var.asReturnedVar(), Label.of(property.name()), parent);
     }
 

--- a/server/src/graql/executor/property/ValueExecutor.java
+++ b/server/src/graql/executor/property/ValueExecutor.java
@@ -20,7 +20,7 @@ package grakn.core.graql.executor.property;
 
 import com.google.common.collect.ImmutableSet;
 import grakn.core.concept.type.AttributeType;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.gremlin.sets.EquivalentFragmentSets;
@@ -104,7 +104,7 @@ public class ValueExecutor implements PropertyExecutor.Insertable {
         @Override
         public void execute(WriteExecutor executor) {
             if (!(operation instanceof Operation.Assignment)) {
-                throw GraqlQueryException.insertPredicate();
+                throw GraqlSemanticException.insertPredicate();
             } else {
                 executor.getBuilder(var).value(operation.value());
             }

--- a/server/src/graql/executor/property/WhenExecutor.java
+++ b/server/src/graql/executor/property/WhenExecutor.java
@@ -19,7 +19,7 @@
 package grakn.core.graql.executor.property;
 
 import com.google.common.collect.ImmutableSet;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.WriteExecutor;
 import grakn.core.graql.gremlin.EquivalentFragmentSet;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -59,7 +59,7 @@ public class WhenExecutor implements PropertyExecutor.Definable {
     @Override
     public Set<PropertyExecutor.Writer> undefineExecutors() {
         // TODO: Fix this so that Undefining WhenProperty behaves symmetrically to Defining WhenProperty
-        throw GraqlQueryException.defineUnsupportedProperty(property.keyword());
+        throw GraqlSemanticException.defineUnsupportedProperty(property.keyword());
     }
 
     private class DefineWhen implements PropertyExecutor.Writer {

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -31,6 +31,7 @@ import grakn.core.concept.type.Rule;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.atom.AtomicEquivalence;
@@ -203,7 +204,7 @@ public abstract class AttributeAtom extends Binary{
         super.checkValid();
         SchemaConcept type = getSchemaConcept();
         if (type != null && !type.isAttributeType()) {
-            throw GraqlQueryException.attributeWithNonAttributeType(type.label());
+            throw GraqlSemanticException.attributeWithNonAttributeType(type.label());
         }
     }
 

--- a/server/src/graql/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/reasoner/atom/binary/IsaAtom.java
@@ -29,7 +29,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
@@ -106,7 +106,7 @@ public abstract class IsaAtom extends IsaAtomBase {
         super.checkValid();
         SchemaConcept type = getSchemaConcept();
         if (type != null && !type.isType()) {
-            throw GraqlQueryException.cannotGetInstancesOfNonType(type.label());
+            throw GraqlSemanticException.cannotGetInstancesOfNonType(type.label());
         }
     }
 

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -44,6 +44,7 @@ import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
@@ -172,7 +173,7 @@ public abstract class RelationAtom extends IsaAtomBase {
                 .forEach(roleId -> {
                     SchemaConcept schemaConcept = tx().getSchemaConcept(roleId);
                     if (schemaConcept == null || !schemaConcept.isRole()) {
-                        throw GraqlQueryException.invalidRoleLabel(roleId);
+                        throw GraqlSemanticException.invalidRoleLabel(roleId);
                     }
                 });
     }
@@ -182,7 +183,7 @@ public abstract class RelationAtom extends IsaAtomBase {
         super.checkValid();
         SchemaConcept type = getSchemaConcept();
         if (type != null && !type.isRelationType()){
-            throw GraqlQueryException.relationWithNonRelationType(type.label());
+            throw GraqlSemanticException.relationWithNonRelationType(type.label());
         }
         checkPattern();
     }

--- a/server/src/graql/reasoner/atom/predicate/IdPredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/IdPredicate.java
@@ -23,7 +23,7 @@ import grakn.core.concept.ConceptId;
 import grakn.core.concept.Label;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.graql.exception.GraqlCheckedException;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
 import grakn.core.server.session.TransactionOLTP;
@@ -68,7 +68,7 @@ public class IdPredicate extends Predicate<ConceptId> {
 
     private static Statement createIdVar(Variable varName, Label label, TransactionOLTP graph) {
         SchemaConcept schemaConcept = graph.getSchemaConcept(label);
-        if (schemaConcept == null) throw GraqlQueryException.labelNotFound(label);
+        if (schemaConcept == null) throw GraqlSemanticException.labelNotFound(label);
         return new Statement(varName).id(schemaConcept.id().getValue());
     }
 

--- a/server/src/graql/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/reasoner/query/CompositeQuery.java
@@ -26,7 +26,7 @@ import grakn.core.concept.Label;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.Rule;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.ResolutionIterator;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -70,7 +70,7 @@ public class CompositeQuery implements ResolvableQuery {
     final private Set<ResolvableQuery> complementQueries;
     final private TransactionOLTP tx;
 
-    CompositeQuery(Conjunction<Pattern> pattern, TransactionOLTP tx) throws GraqlQueryException{
+    CompositeQuery(Conjunction<Pattern> pattern, TransactionOLTP tx) throws GraqlSemanticException {
         Conjunction<Statement> positiveConj = Graql.and(
                 pattern.getPatterns().stream()
                         .filter(p -> !p.isNegation())
@@ -86,7 +86,7 @@ public class CompositeQuery implements ResolvableQuery {
                 .collect(Collectors.toSet());
 
         if (!isNegationSafe()){
-            throw GraqlQueryException.unsafeNegationBlock(this);
+            throw GraqlSemanticException.unsafeNegationBlock(this);
         }
     }
 
@@ -161,7 +161,7 @@ public class CompositeQuery implements ResolvableQuery {
                 .map(p -> {
                     Set<Conjunction<Pattern>> patterns = p.getNegationDNF().getPatterns();
                     if (p.getNegationDNF().getPatterns().size() != 1){
-                        throw GraqlQueryException.disjunctiveNegationBlock();
+                        throw GraqlSemanticException.disjunctiveNegationBlock();
                     }
                     return Iterables.getOnlyElement(patterns);
                 })
@@ -188,7 +188,7 @@ public class CompositeQuery implements ResolvableQuery {
             if(!body.isPositive() && complementQueries.stream().noneMatch(ReasonerQuery::isPositive)){
                 errors.add(ErrorMessage.VALIDATION_RULE_NESTED_NEGATION.getMessage(rule.label()));
             }
-        } catch (GraqlQueryException e) {
+        } catch (GraqlSemanticException e) {
             errors.add(ErrorMessage.VALIDATION_RULE_INVALID.getMessage(rule.label(), e.getMessage()));
         }
         return errors;

--- a/server/src/server/rpc/ResponseBuilder.java
+++ b/server/src/server/rpc/ResponseBuilder.java
@@ -29,7 +29,7 @@ import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Explanation;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.type.AttributeType;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.protocol.AnswerProto;
 import grakn.core.protocol.ConceptProto;
 import grakn.core.protocol.SessionProto;
@@ -388,7 +388,7 @@ public class ResponseBuilder {
                 return exception(Status.INTERNAL, message);
             } else if (e instanceof PropertyNotUniqueException) {
                 return exception(Status.ALREADY_EXISTS, message);
-            } else if (e instanceof TransactionException | e instanceof GraqlQueryException |
+            } else if (e instanceof TransactionException | e instanceof GraqlSemanticException |
                     e instanceof GraqlException | e instanceof InvalidKBException) {
                 return exception(Status.INVALID_ARGUMENT, message);
             }

--- a/test-integration/graql/analytics/ConnectedComponentIT.java
+++ b/test-integration/graql/analytics/ConnectedComponentIT.java
@@ -27,7 +27,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.kb.Schema;
@@ -97,7 +97,7 @@ public class ConnectedComponentIT {
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testSourceDoesNotExistInSubGraph() {
         addSchemaAndEntities();
         try (TransactionOLTP tx = session.transaction().read()) {

--- a/test-integration/graql/analytics/CorenessIT.java
+++ b/test-integration/graql/analytics/CorenessIT.java
@@ -26,7 +26,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.session.SessionImpl;
@@ -72,7 +72,7 @@ public class CorenessIT {
     @After
     public void closeSession() { session.close(); }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testKSmallerThan2_ThrowsException() {
         try (TransactionOLTP tx = session.transaction().read()) {
             tx.execute(Graql.compute().centrality().using(K_CORE).where(min_k(1)));

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -30,7 +30,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.kb.Schema;
@@ -128,8 +128,8 @@ public class GraqlComputeIT {
 
     @Test
     public void testSubgraphContainingRuleDoesNotBreakAnalytics() {
-        expectedEx.expect(GraqlQueryException.class);
-        expectedEx.expectMessage(GraqlQueryException.labelNotFound(Label.of("rule")).getMessage());
+        expectedEx.expect(GraqlSemanticException.class);
+        expectedEx.expectMessage(GraqlSemanticException.labelNotFound(Label.of("rule")).getMessage());
         try (TransactionOLTP tx = session.transaction().read()) {
             tx.execute(Graql.compute().count().in("rule", "thing"));
         }
@@ -137,8 +137,8 @@ public class GraqlComputeIT {
 
     @Test
     public void testSubgraphContainingRoleDoesNotBreakAnalytics() {
-        expectedEx.expect(GraqlQueryException.class);
-        expectedEx.expectMessage(GraqlQueryException.labelNotFound(Label.of("role")).getMessage());
+        expectedEx.expect(GraqlSemanticException.class);
+        expectedEx.expectMessage(GraqlSemanticException.labelNotFound(Label.of("role")).getMessage());
         try (TransactionOLTP tx = session.transaction().read()) {
             tx.execute(Graql.compute().count().in("role"));
         }
@@ -201,14 +201,14 @@ public class GraqlComputeIT {
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testInvalidTypeWithStatistics() {
         try (TransactionOLTP tx = session.transaction().write()) {
             tx.execute(Graql.parse("compute sum of thingy;").asComputeStatistics());
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testInvalidTypeWithDegree() {
         try (TransactionOLTP tx = session.transaction().write()) {
             tx.execute(Graql.parse("compute centrality of thingy, using degree;").asComputeCentrality());
@@ -304,7 +304,7 @@ public class GraqlComputeIT {
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testNonResourceTypeAsSubgraphForAnalytics() throws InvalidKBException {
         try (TransactionOLTP tx = session.transaction().write()) {
             tx.putEntityType(thingy);

--- a/test-integration/graql/analytics/KCoreIT.java
+++ b/test-integration/graql/analytics/KCoreIT.java
@@ -26,7 +26,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.session.SessionImpl;
@@ -72,7 +72,7 @@ public class KCoreIT {
     @After
     public void closeSession() { session.close(); }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testKSmallerThan2_ThrowsException() {
         try (TransactionOLTP tx = session.transaction().read()) {
             tx.execute(Graql.compute().cluster().using(K_CORE).where(k(1L)));

--- a/test-integration/graql/analytics/PathIT.java
+++ b/test-integration/graql/analytics/PathIT.java
@@ -28,7 +28,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.kb.Schema;
@@ -80,7 +80,7 @@ public class PathIT {
     @After
     public void closeSession() { session.close(); }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testShortestPathExceptionIdNotFound() {
         // test on an empty tx
         try (TransactionOLTP tx = session.transaction().read()) {
@@ -88,7 +88,7 @@ public class PathIT {
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testShortestPathExceptionIdNotFoundSubgraph() {
         addSchemaAndEntities();
         try (TransactionOLTP tx = session.transaction().read()) {

--- a/test-integration/graql/analytics/StatisticsIT.java
+++ b/test-integration/graql/analytics/StatisticsIT.java
@@ -28,7 +28,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
 import grakn.core.server.kb.Schema;
@@ -147,7 +147,7 @@ public class StatisticsIT {
         boolean exceptionThrown = false;
         try {
             tx.execute(query);
-        } catch (GraqlQueryException | GraqlException e) {
+        } catch (GraqlSemanticException | GraqlException e) {
             exceptionThrown = true;
         }
         assertTrue(exceptionThrown);

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -27,8 +27,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
@@ -39,7 +38,6 @@ import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.MatchClause;
 import graql.lang.statement.Statement;
-import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -317,7 +315,7 @@ public class GraqlDefineIT {
 
     @Test
     public void testErrorResourceTypeWithoutDataType() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
                 allOf(containsString("my-resource"), containsString("datatype"), containsString("resource"))
         );
@@ -326,21 +324,21 @@ public class GraqlDefineIT {
 
     @Test
     public void testErrorRecursiveType() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("thingy"), containsString("itself")));
         tx.execute(Graql.define(type("thingy").sub("thingy")));
     }
 
     @Test
     public void whenDefiningAnOntologyConceptWithoutALabel_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("entity"), containsString("type")));
         tx.execute(Graql.define(var().sub("entity")));
     }
 
     @Test
     public void testErrorWhenNonExistentResource() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("nothing");
         tx.execute(Graql.define(type("blah this").sub("entity").has("nothing")));
     }
@@ -356,9 +354,9 @@ public class GraqlDefineIT {
     public void whenSpecifyingExistingTypeWithIncorrectDataType_Throw() {
         AttributeType name = tx.getAttributeType("name");
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                GraqlQueryException.insertPropertyOnExistingConcept("datatype", AttributeType.DataType.BOOLEAN, name).getMessage()
+                GraqlSemanticException.insertPropertyOnExistingConcept("datatype", AttributeType.DataType.BOOLEAN, name).getMessage()
         );
 
         tx.execute(Graql.define(type("name").datatype(Graql.Token.DataType.BOOLEAN)));
@@ -366,7 +364,7 @@ public class GraqlDefineIT {
 
     @Test
     public void whenSpecifyingDataTypeOnAnEntityType_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
                 allOf(containsString("unexpected property"), containsString("datatype"), containsString("my-type"))
         );
@@ -376,14 +374,14 @@ public class GraqlDefineIT {
 
     @Test
     public void whenDefiningRuleWithoutWhen_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("rule"), containsString("movie"), containsString("when")));
         tx.execute(Graql.define(type("a-rule").sub(Graql.Token.Type.RULE).then(var("x").isa("movie"))));
     }
 
     @Test
     public void whenDefiningRuleWithoutThen_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("rule"), containsString("movie"), containsString("then")));
         tx.execute(Graql.define(type("a-rule").sub(Graql.Token.Type.RULE).when(var("x").isa("movie"))));
     }
@@ -392,12 +390,12 @@ public class GraqlDefineIT {
     public void whenDefiningANonRuleWithAWhenPattern_Throw() {
         Statement rule = type("yes").sub(Graql.Token.Type.ENTITY).when(var("x").isa("yes"));
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(anyOf(
                 // Either we see "entity" and an unexpected "when"...
                 allOf(containsString("unexpected property"), containsString("when")),
                 // ...or we see "when" and don't find the expected "then"
-                containsString(GraqlQueryException.insertNoExpectedProperty("then", rule).getMessage()))
+                containsString(GraqlSemanticException.insertNoExpectedProperty("then", rule).getMessage()))
         );
 
         tx.execute(Graql.define(rule));
@@ -407,12 +405,12 @@ public class GraqlDefineIT {
     public void whenDefiningANonRuleWithAThenPattern_Throw() {
         Statement rule = type("some-type").sub(Graql.Token.Type.ENTITY).then(var("x").isa("some-type"));
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(anyOf(
                 // Either we see "entity" and an unexpected "when"...
                 allOf(containsString("unexpected property"), containsString("then")),
                 // ...or we see "when" and don't find the expected "then"
-                containsString(GraqlQueryException.insertNoExpectedProperty("when", rule).getMessage()))
+                containsString(GraqlSemanticException.insertNoExpectedProperty("when", rule).getMessage()))
         );
 
         tx.execute(Graql.define(rule));
@@ -420,8 +418,8 @@ public class GraqlDefineIT {
 
     @Test
     public void whenDefiningAThing_Throw() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.defineUnsupportedProperty(Graql.Token.Property.ISA.toString()).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.defineUnsupportedProperty(Graql.Token.Property.ISA.toString()).getMessage());
 
         tx.execute(Graql.define(var("x").isa("movie")));
     }
@@ -430,10 +428,10 @@ public class GraqlDefineIT {
     public void whenModifyingAThingInADefineQuery_Throw() {
         ConceptId id = tx.getEntityType("movie").instances().iterator().next().id();
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(anyOf(
-                is(GraqlQueryException.defineUnsupportedProperty(Graql.Token.Property.HAS.toString()).getMessage()),
-                is(GraqlQueryException.defineUnsupportedProperty(Graql.Token.Property.VALUE.toString()).getMessage())
+                is(GraqlSemanticException.defineUnsupportedProperty(Graql.Token.Property.HAS.toString()).getMessage()),
+                is(GraqlSemanticException.defineUnsupportedProperty(Graql.Token.Property.VALUE.toString()).getMessage())
         ));
 
         tx.execute(Graql.define(var().id(id.getValue()).has("title", "Bob")));
@@ -530,7 +528,7 @@ public class GraqlDefineIT {
                 exist = !tx.execute(Graql.match(var)).isEmpty();
                 if (!exist) break;
             }
-        } catch(GraqlQueryException e){
+        } catch(GraqlSemanticException e){
             exist = false;
         }
         return exist;

--- a/test-integration/graql/query/GraqlDeleteIT.java
+++ b/test-integration/graql/query/GraqlDeleteIT.java
@@ -22,7 +22,7 @@ import grakn.core.concept.ConceptId;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.ConceptSet;
 import grakn.core.concept.type.SchemaConcept;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.kb.Schema;
@@ -246,7 +246,7 @@ public class GraqlDeleteIT {
         boolean exists;
         try{
             exists = !tx.execute(Graql.match(var().id(id.getValue()))).isEmpty();
-        } catch (GraqlQueryException e){
+        } catch (GraqlSemanticException e){
             exists = false;
         }
         return exists;
@@ -322,8 +322,8 @@ public class GraqlDeleteIT {
     public void whenDeletingASchemaConcept_Throw() {
         SchemaConcept newType = tx.execute(Graql.define(x.type("new-type").sub(ENTITY))).get(0).get(x.var()).asSchemaConcept();
 
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.deleteSchemaConcept(newType).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.deleteSchemaConcept(newType).getMessage());
         tx.execute(Graql.match(x.type("new-type")).delete(x.var()));
     }
 

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -23,7 +23,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.AttributeType;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
@@ -430,7 +430,7 @@ public class GraqlGetIT {
 
     @Test
     public void testEmptyMatchThrows() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(Matchers.containsString("at least one property"));
         tx.execute(Graql.match(var()).get());
     }

--- a/test-integration/graql/query/GraqlInsertIT.java
+++ b/test-integration/graql/query/GraqlInsertIT.java
@@ -32,7 +32,7 @@ import grakn.core.concept.thing.Relation;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.Role;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
@@ -42,7 +42,6 @@ import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.IsaProperty;
-import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
@@ -248,7 +247,7 @@ public class GraqlInsertIT {
 
     @Test
     public void testErrorWhenInsertWithPredicate() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("predicate");
         tx.execute(Graql.insert(var().id("123").gt(3)));
     }
@@ -264,10 +263,10 @@ public class GraqlInsertIT {
     public void whenInsertingAResourceWithMultipleValues_Throw() {
         Statement varPattern = var().val("123").val("456").isa("title");
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(isOneOf(
-                GraqlQueryException.insertMultipleProperties(varPattern, "", "123", "456").getMessage(),
-                GraqlQueryException.insertMultipleProperties(varPattern, "", "456", "123").getMessage()
+                GraqlSemanticException.insertMultipleProperties(varPattern, "", "123", "456").getMessage(),
+                GraqlSemanticException.insertMultipleProperties(varPattern, "", "456", "123").getMessage()
         ));
 
         tx.execute(Graql.insert(varPattern));
@@ -395,7 +394,7 @@ public class GraqlInsertIT {
 
     @Test
     public void testErrorWhenInsertRelationWithEmptyRolePlayer() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
                 allOf(containsString("$y"), containsString("id"), containsString("isa"), containsString("sub"))
         );
@@ -407,7 +406,7 @@ public class GraqlInsertIT {
 
     @Test
     public void testErrorWhenAddingInstanceOfConcept() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
                 allOf(containsString("meta-type"), containsString("my-thing"), containsString(Graql.Token.Type.THING.toString()))
         );
@@ -416,7 +415,7 @@ public class GraqlInsertIT {
 
     @Test
     public void whenInsertingAResourceWithoutAValue_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("name")));
         tx.execute(Graql.insert(var("x").isa("name")));
     }
@@ -481,7 +480,7 @@ public class GraqlInsertIT {
 
     @Test
     public void testInsertInstanceWithoutType() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("isa")));
         tx.execute(Graql.insert(var().has("name", "Bob")));
     }
@@ -583,10 +582,10 @@ public class GraqlInsertIT {
         );
 
         // We don't know in what order the message will be
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(isOneOf(
-                GraqlQueryException.insertMultipleProperties(varPattern, "isa", movie, person).getMessage(),
-                GraqlQueryException.insertMultipleProperties(varPattern, "isa", person, movie).getMessage()
+                GraqlSemanticException.insertMultipleProperties(varPattern, "isa", movie, person).getMessage(),
+                GraqlSemanticException.insertMultipleProperties(varPattern, "isa", person, movie).getMessage()
         ));
 
         tx.execute(Graql.insert(var("x").isa("movie"), var("x").isa("person")));
@@ -599,24 +598,24 @@ public class GraqlInsertIT {
 
         Concept aMovie = movie.instances().iterator().next();
 
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.insertPropertyOnExistingConcept("isa", person, aMovie).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.insertPropertyOnExistingConcept("isa", person, aMovie).getMessage());
 
         tx.execute(Graql.insert(var("x").id(aMovie.id().getValue()).isa("person")));
     }
 
     @Test
     public void whenInsertingASchemaConcept_Throw() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(Graql.Token.Property.SUB.toString()).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.insertUnsupportedProperty(Graql.Token.Property.SUB.toString()).getMessage());
 
         tx.execute(Graql.insert(type("new-type").sub(Graql.Token.Type.ENTITY)));
     }
 
     @Test
     public void whenModifyingASchemaConceptInAnInsertQuery_Throw() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.insertUnsupportedProperty(Graql.Token.Property.PLAYS.toString()).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.insertUnsupportedProperty(Graql.Token.Property.PLAYS.toString()).getMessage());
 
         tx.execute(Graql.insert(type("movie").plays("actor")));
     }

--- a/test-integration/graql/query/GraqlUndefineIT.java
+++ b/test-integration/graql/query/GraqlUndefineIT.java
@@ -26,7 +26,7 @@ import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.TransactionException;
@@ -431,8 +431,8 @@ public class GraqlUndefineIT {
     public void whenUndefiningAnInstanceProperty_Throw() {
         Concept movie = tx.execute(Graql.insert(x.isa("movie"))).get(0).get(x.var());
 
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.defineUnsupportedProperty(Graql.Token.Property.ISA.toString()).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.defineUnsupportedProperty(Graql.Token.Property.ISA.toString()).getMessage());
 
         tx.execute(Graql.undefine(var().id(movie.id().getValue()).isa("movie")));
     }

--- a/test-integration/graql/query/QueryBuilderIT.java
+++ b/test-integration/graql/query/QueryBuilderIT.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
@@ -96,7 +96,7 @@ public class QueryBuilderIT {
         assertNotExists(tx, var().has("title", "123"));
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenBuildingUndefineQueryWithGraphLast_ItExecutes() {
         tx.execute(Graql.define(type("yes").sub("entity")));
 
@@ -117,7 +117,7 @@ public class QueryBuilderIT {
 
     @Test
     public void whenGraphIsProvidedAndQueryExecutedWithNonexistentType_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(x.isa("not-a-thing")));
     }

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -23,7 +23,7 @@ import grakn.core.concept.Concept;
 import grakn.core.concept.Label;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Type;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.exception.InvalidKBException;
@@ -86,7 +86,7 @@ public class QueryErrorIT {
 
     @Test
     public void testErrorNonExistentConceptType() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("film");
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var("x").isa("film")));
@@ -94,7 +94,7 @@ public class QueryErrorIT {
 
     @Test
     public void testErrorNotARole() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(containsString("role"), containsString("person"), containsString("isa person")));
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var("x").isa("movie"), var().rel("person", "y").rel("x")));
@@ -102,27 +102,27 @@ public class QueryErrorIT {
 
     @Test
     public void testErrorNonExistentResourceType() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("thingy");
         tx.execute(Graql.match(var("x").has("thingy", "value")).delete("x"));
     }
 
     @Test @Ignore // TODO: enable this properly after fixing issue #4664
     public void whenMatchingWildcardHas_Throw() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         tx.execute(Graql.match(type("thing").has(var("x"))).get());
     }
 
     @Test
     public void whenMatchingHasWithNonExistentType_Throw() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.labelNotFound(Label.of("heffalump")).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.labelNotFound(Label.of("heffalump")).getMessage());
         tx.execute(Graql.match(var("x").has("heffalump", "foo")).get());
     }
 
     @Test
     public void testErrorNotARelation() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(
                 containsString("relation"), containsString("movie"), containsString("separate"), containsString(";")));
         //noinspection ResultOfMethodCallIgnored
@@ -131,7 +131,7 @@ public class QueryErrorIT {
 
     @Test
     public void testErrorInvalidNonExistentRole() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(ErrorMessage.NOT_A_ROLE_TYPE.getMessage("character-in-production", "character-in-production"));
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var().isa("has-cast").rel("character-in-production", "x")));
@@ -149,7 +149,7 @@ public class QueryErrorIT {
 
     @Test
     public void whenSpecifyingMultipleSubs_ThrowIncludingInformationAboutTheConceptAndBothSupers() {
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(allOf(
                 containsString("abc"), containsString("sub"), containsString("person"), containsString("has-cast")
         ));
@@ -159,7 +159,7 @@ public class QueryErrorIT {
     @Test
     public void testErrorHasGenreQuery() {
         // 'has genre' is not allowed because genre is an entity type
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(ErrorMessage.MUST_BE_ATTRIBUTE_TYPE.getMessage("genre"));
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var("x").isa("movie").has("genre", "Drama")));
@@ -202,16 +202,16 @@ public class QueryErrorIT {
 
     @Test
     public void testExceptionInstanceOfRoleType() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.cannotGetInstancesOfNonType(Label.of("actor")).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.cannotGetInstancesOfNonType(Label.of("actor")).getMessage());
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var("x").isa("actor")));
     }
 
     @Test
     public void testExceptionInstanceOfRule() {
-        exception.expect(GraqlQueryException.class);
-        exception.expectMessage(GraqlQueryException.cannotGetInstancesOfNonType(Label.of("rule")).getMessage());
+        exception.expect(GraqlSemanticException.class);
+        exception.expectMessage(GraqlSemanticException.cannotGetInstancesOfNonType(Label.of("rule")).getMessage());
         //noinspection ResultOfMethodCallIgnored
         tx.stream(Graql.match(var("x").isa("rule")));
     }
@@ -241,7 +241,7 @@ public class QueryErrorIT {
         Thing movie = tx.getEntityType("movie").instances().iterator().next();
         Type person = tx.getEntityType("person");
 
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage(containsString("person"));
 
         tx.execute(Graql.match(var("x").id(movie.id().getValue())).insert(var("x").isa(type(person.label().getValue()))));

--- a/test-integration/graql/query/QueryValidityIT.java
+++ b/test-integration/graql/query/QueryValidityIT.java
@@ -18,7 +18,7 @@
 
 package grakn.core.graql.query;
 
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
@@ -29,7 +29,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.Assert.assertThat;
 
@@ -113,50 +112,50 @@ public class QueryValidityIT {
         assertThat(tx.execute(Graql.parse(queryString3).asGet()), empty());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentRelationTypeLabelViaVariable_emptyResultReturned() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForInexistentRelationTypeLabelViaVariable_emptyResultReturned() throws GraqlSemanticException {
         String queryString = "match ($x, $y) isa $type; $type type jakas-relacja; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentEntityTypeLabelViaVariable_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForInexistentEntityTypeLabelViaVariable_Throws() throws GraqlSemanticException {
         String queryString = "match $x isa $type; $type type polok; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentEntityTypeLabel_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForInexistentEntityTypeLabel_Throws() throws GraqlSemanticException {
         String queryString = "match $x isa polok; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForMismatchedResourceTypeLabel_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForMismatchedResourceTypeLabel_Throws() throws GraqlSemanticException {
         String queryString = "match $x has binary $r; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForInexistentRelationTypeLabel_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForInexistentRelationTypeLabel_Throws() throws GraqlSemanticException {
         String queryString = "match ($x, $y) isa jakas-relacja; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForMismatchedRelationTypeLabel_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForMismatchedRelationTypeLabel_Throws() throws GraqlSemanticException {
         String queryString = "match ($x, $y) isa name; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
-    @Test (expected = GraqlQueryException.class)
-    public void whenQueryingForRelationWithNonExistentRoles_Throws() throws GraqlQueryException{
+    @Test (expected = GraqlSemanticException.class)
+    public void whenQueryingForRelationWithNonExistentRoles_Throws() throws GraqlSemanticException {
         String queryString = "match (rola: $x, rola: $y) isa relation; get;";
         tx.execute(Graql.parse(queryString).asGet());
     }
 
     // this should be caught at the parser level
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenQueryingForRelationWithNonRoleRoles_Throws() throws GraqlException {
         String queryString = "match (entity: $x, entity: $y) isa relation; get;";
         tx.execute(Graql.parse(queryString).asGet());

--- a/test-integration/graql/query/pattern/PatternIT.java
+++ b/test-integration/graql/query/pattern/PatternIT.java
@@ -21,7 +21,7 @@ package grakn.core.graql.query.pattern;
 import com.google.common.collect.Sets;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
@@ -283,7 +283,7 @@ public class PatternIT {
     @Test
     public void testStatementsWithoutPropertyThrows() {
         // empty `match $x; get;` not allowed
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("Require statement to have at least one property");
         List<ConceptMap> answers = tx.execute(Graql.match(var("x")).get());
     }
@@ -297,12 +297,12 @@ public class PatternIT {
     @Test
     public void testUnboundComparisonThrows() {
         // value comparison
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("Variables used in comparisons cannot be unbound");
         List<ConceptMap> answers = tx.execute(Graql.match(var("x").neq(var("y"))).get());
 
         // concept comparison
-        exception.expect(GraqlQueryException.class);
+        exception.expect(GraqlSemanticException.class);
         exception.expectMessage("Variables used in comparisons cannot be unbound");
         answers = tx.execute(Graql.match( var("y").not("x")).get());
     }

--- a/test-integration/graql/reasoner/query/AtomicQueryIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryIT.java
@@ -23,8 +23,7 @@ import com.google.common.collect.Iterables;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.thing.Attribute;
-import grakn.core.graql.exception.GraqlQueryException;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.graph.GeoGraph;
 import grakn.core.graql.reasoner.unifier.MultiUnifier;
@@ -87,7 +86,7 @@ public class AtomicQueryIT {
         }
     }
 
-    @Test(expected = GraqlQueryException.class)
+    @Test(expected = GraqlSemanticException.class)
     public void testWhenCreatingQueryWithNonexistentType_ExceptionIsThrown() {
         try (TransactionOLTP tx = geoGraphSession.transaction().write()) {
             String patternString = "{ $x isa someType; };";

--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -29,7 +29,7 @@ import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
 import grakn.core.concept.type.SchemaConcept;
-import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.reasoner.graph.ReachabilityGraph;
 import grakn.core.graql.reasoner.utils.ReasonerUtils;
 import grakn.core.rule.GraknTestServer;
@@ -88,7 +88,7 @@ public class NegationIT {
     @org.junit.Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenNegatingSinglePattern_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -98,7 +98,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenExecutingUnboundNegationPattern_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -108,7 +108,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenIncorrectlyBoundNestedNegationBlock_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -126,7 +126,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenExecutingIncorrectlyBoundNestedNegationBlock_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -144,7 +144,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenNegationBlockContainsDisjunction_exceptionIsThrown(){
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -160,7 +160,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenExecutingNegationBlockContainingDisjunction_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(
@@ -176,7 +176,7 @@ public class NegationIT {
         }
     }
 
-    @Test (expected = GraqlQueryException.class)
+    @Test (expected = GraqlSemanticException.class)
     public void whenExecutingNegationQueryWithReasoningOff_exceptionIsThrown () {
         try(TransactionOLTP tx = negationSession.transaction().write()) {
             Pattern pattern = Graql.parsePattern(


### PR DESCRIPTION
## What is the goal of this PR?

Separate different exception types so that we handle them in a way that's more informative (for users) and faster to debug (for devs).

## What are the changes implemented in this PR?

- majority of our old exceptions are `GraqlSemanticException`s as they deal with query semantics
- we differentiate from our old exceptions `GraqlQueryException` which have nothing to do with semantics and instead occur during processing when graql enters an invalid state
