### PR TITLE
Fix issues when calculating semantic difference when roles are variable

### DIFF
--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -985,12 +985,17 @@ public abstract class RelationAtom extends IsaAtomBase {
             Set<Role> parentRoles = parentVarRoleMap.get(parentVar);
             Role role = null;
             if(parentRoleVars.contains(parentVar)){
-                Set<Label> roleLabel = this.getRelationPlayers().stream()
-                        .filter(rp -> rp.getRole().isPresent())
-                        .filter(rp -> rp.getRole().get().var().equals(childVar))
-                        .map(rp -> Label.of(rp.getRole().get().getType().get()))
+                Set<Label> roleLabels = this.getRelationPlayers().stream()
+                        .map(RelationProperty.RolePlayer::getRole)
+                        .flatMap(CommonUtil::optionalToStream)
+                        .filter(roleStatement -> roleStatement.var().equals(childVar))
+                        .map(Statement::getType)
+                        .flatMap(CommonUtil::optionalToStream)
+                        .map(Label::of)
                         .collect(toSet());
-                role = tx().getRole(Iterables.getOnlyElement(roleLabel).getValue());
+                if (!roleLabels.isEmpty()){
+                    role = tx().getRole(Iterables.getOnlyElement(roleLabels).getValue());
+                }
             }
             diff.add(new VariableDefinition(childVar,null, role, bottom(Sets.difference(childRoles, parentRoles)), new HashSet<>()));
         });


### PR DESCRIPTION
## What is the goal of this PR?

We didn't cater for a case when we calculate semantic difference between relations and roles are variable. E.g. semantic difference between:
Child: `(someRole: $x) isa relation;`
Parent: `($role: $x) isa relation;`

The `$role` statement  doesn't have a label which we silently expected which results in an `ElementNotFoundException` thrown. This PR fixes that.

## What are the changes implemented in this PR?

Make sure we correctly recognise the variable role pattern and do not try to fetch it's type.
