### PR TITLE
Correctly acknowledge role expansion answers

### DIFF
--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -63,7 +63,8 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         if (answer.isEmpty()) return null;
 
         if (state.getRule() != null && query.getAtom().requiresRoleExpansion()) {
-            return new RoleExpansionState(answer, getUnifier(), query.getAtom().getRoleExpansionVariables(), getParentState());
+            //NB: we set the parent state as this AtomicState, otherwise we won't acknowledge expanded answers (won't cache)
+            return new RoleExpansionState(answer, getUnifier(), query.getAtom().getRoleExpansionVariables(), this);
         }
         return new AnswerState(answer, getUnifier(), getParentState());
     }

--- a/test-integration/graql/reasoner/ReasoningIT.java
+++ b/test-integration/graql/reasoner/ReasoningIT.java
@@ -711,6 +711,12 @@ public class ReasoningIT {
                 assertEquals(12, answers3.size());
 
                 List<ConceptMap> answers4 = tx.execute(Graql.parse(queryString4).asGet());
+                assertEquals(answers3.stream()
+                        .filter(ans -> ans.get("a").asThing()
+                                .attributes(tx.getAttributeType("name"))
+                                .anyMatch(at -> at.value().equals("b")))
+                        .count(),
+                        answers4.size());
                 assertEquals(4, answers4.size());
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

Previously, if we had a query with variable roles: `($role: $x) isa someRelation;`, then for inferred answers the answers coming from `RoleExpansionState` wouldn't be cached. We make sure they are in this PR.

## What are the changes implemented in this PR?

- the parent state of the `RoleExpansionState` is the `AtomicState` it is created by so that all answers are consumed.
