### PR TITLE
Fix issue with returned role variables

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -42,7 +42,6 @@ import grakn.core.graql.reasoner.rule.InferenceRule;
 import grakn.core.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.Unifier;
-import grakn.core.graql.reasoner.unifier.UnifierComparison;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import graql.lang.property.IsaProperty;
 import graql.lang.property.VarProperty;
@@ -398,7 +397,7 @@ public abstract class Atom extends AtomicBase {
      * @return corresponding unifier
      */
     @Nullable
-    public abstract Unifier getUnifier(Atom parentAtom, UnifierComparison unifierType);
+    public abstract Unifier getUnifier(Atom parentAtom, UnifierType unifierType);
 
     /**
      *
@@ -407,7 +406,7 @@ public abstract class Atom extends AtomicBase {
      * @param unifierType unifier type in question
      * @return true if predicates between this (child) and parent are compatible based on the mappings provided by unifier
      */
-    protected boolean isPredicateCompatible(Atom parentAtom, Unifier unifier, UnifierComparison unifierType){
+    protected boolean isPredicateCompatible(Atom parentAtom, Unifier unifier, UnifierType unifierType){
         //check value predicates compatibility
         return unifier.mappings().stream().allMatch(mapping -> {
             Variable childVar = mapping.getKey();
@@ -442,7 +441,7 @@ public abstract class Atom extends AtomicBase {
      * @param unifierType type of unifier to be computed
      * @return multiunifier
      */
-    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierComparison unifierType) {
+    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
         //NB only for relations we can have non-unique unifiers
         Unifier unifier = this.getUnifier(parentAtom, unifierType);
         return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -42,7 +42,6 @@ import grakn.core.graql.reasoner.cache.VariableDefinition;
 import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
 import grakn.core.graql.reasoner.unifier.Unifier;
-import grakn.core.graql.reasoner.unifier.UnifierComparison;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.server.kb.Schema;
@@ -289,7 +288,7 @@ public abstract class AttributeAtom extends Binary{
     }
 
     @Override
-    public Unifier getUnifier(Atom parentAtom, UnifierComparison unifierType) {
+    public Unifier getUnifier(Atom parentAtom, UnifierType unifierType) {
         if (!(parentAtom instanceof AttributeAtom)) {
             // in general this >= parent, hence for rule unifiers we can potentially specialise child to match parent
             if (unifierType.equals(UnifierType.RULE)) {

--- a/server/src/graql/reasoner/atom/binary/Binary.java
+++ b/server/src/graql/reasoner/atom/binary/Binary.java
@@ -32,8 +32,8 @@ import grakn.core.graql.reasoner.atom.predicate.NeqPredicate;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.unifier.Unifier;
-import grakn.core.graql.reasoner.unifier.UnifierComparison;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
+import grakn.core.graql.reasoner.unifier.UnifierType;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.IsaProperty;
@@ -178,7 +178,7 @@ public abstract class Binary extends Atom {
     }
 
     @Override
-    public Unifier getUnifier(Atom parentAtom, UnifierComparison unifierType) {
+    public Unifier getUnifier(Atom parentAtom, UnifierType unifierType) {
         boolean inferTypes = unifierType.inferTypes();
         Variable childVarName = this.getVarName();
         Variable parentVarName = parentAtom.getVarName();

--- a/server/src/graql/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/reasoner/atom/binary/IsaAtom.java
@@ -35,8 +35,8 @@ import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
 import grakn.core.graql.reasoner.unifier.Unifier;
-import grakn.core.graql.reasoner.unifier.UnifierComparison;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
+import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.server.kb.concept.ConceptUtils;
 import grakn.core.server.kb.concept.EntityTypeImpl;
 import graql.lang.pattern.Pattern;
@@ -230,7 +230,7 @@ public abstract class IsaAtom extends IsaAtomBase {
     }
 
     @Override
-    public Unifier getUnifier(Atom parentAtom, UnifierComparison unifierType) {
+    public Unifier getUnifier(Atom parentAtom, UnifierType unifierType) {
         //in general this <= parent, so no specialisation viable
         if (this.getClass() != parentAtom.getClass()) return UnifierImpl.nonExistent();
         return super.getUnifier(parentAtom, unifierType);

--- a/server/src/graql/reasoner/utils/ReasonerUtils.java
+++ b/server/src/graql/reasoner/utils/ReasonerUtils.java
@@ -35,7 +35,7 @@ import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
 import grakn.core.graql.reasoner.unifier.Unifier;
-import grakn.core.graql.reasoner.unifier.UnifierComparison;
+import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.graql.reasoner.utils.conversion.RoleConverter;
 import grakn.core.graql.reasoner.utils.conversion.SchemaConceptConverter;
 import grakn.core.graql.reasoner.utils.conversion.TypeConverter;
@@ -62,7 +62,7 @@ import static java.util.stream.Collectors.toSet;
 /**
  *
  * <p>
- * Utiliy class providing useful functionalities.
+ * Utility class providing useful functionalities.
  * </p>
  *
  *
@@ -246,7 +246,7 @@ public class ReasonerUtils {
      * @param childParentUnifier unifier to unify child with parent
      * @return combined unifier for type atoms
      */
-    public static Unifier typeUnifier(Set<TypeAtom> childTypes, Set<TypeAtom> parentTypes, Unifier childParentUnifier, UnifierComparison unifierType){
+    public static Unifier typeUnifier(Set<TypeAtom> childTypes, Set<TypeAtom> parentTypes, Unifier childParentUnifier, UnifierType unifierType){
         Unifier unifier = childParentUnifier;
         for(TypeAtom childType : childTypes){
             Variable childVarName = childType.getVarName();

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -497,6 +497,26 @@ public class AtomicQueryUnificationIT {
     }
 
     @Test
+    public void testUnification_RelationsWithVariableRolesAndPotentialTypes(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
+            String query = "{ (baseRole1: $x, baseRole2: $y);};";
+            String potentialEquivalent = "{ ($role: $u, baseRole2: $v);$role type baseRole1;};";
+
+            unification(query, potentialEquivalent, false, UnifierType.EXACT, tx);
+            unification(potentialEquivalent, query, false, UnifierType.EXACT, tx);
+
+            unification(query, potentialEquivalent, false, UnifierType.STRUCTURAL, tx);
+            unification(potentialEquivalent, query, false, UnifierType.STRUCTURAL, tx);
+
+            unification(query, potentialEquivalent, true, UnifierType.RULE, tx);
+            unification(potentialEquivalent, query, true, UnifierType.RULE, tx);
+
+            unification(query, potentialEquivalent, true, UnifierType.SUBSUMPTIVE, tx);
+            unification(potentialEquivalent, query, true, UnifierType.SUBSUMPTIVE, tx);
+        }
+    }
+
+    @Test
     public void testUnification_differentRelationVariants_EXACT(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
             unification(
@@ -922,7 +942,7 @@ public class AtomicQueryUnificationIT {
         if (unifierType.equivalence() != null) queryEquivalence(child, parent, unifierExists, unifierType.equivalence());
         MultiUnifier multiUnifier = child.getMultiUnifier(parent, unifierType);
         assertEquals("Unexpected unifier: " + multiUnifier + " between the child - parent pair:\n" + child + " :\n" + parent, unifierExists, !multiUnifier.isEmpty());
-        if (unifierExists && unifierType != UnifierType.RULE){
+        if (unifierExists && unifierType.equivalence() != null){
             MultiUnifier multiUnifierInverse = parent.getMultiUnifier(child, unifierType);
 
             assertEquals("Unexpected unifier inverse: " + multiUnifier + " of type " + unifierType.name() + " between the child - parent pair:\n" + parent + " :\n" + child, unifierExists, !multiUnifierInverse.isEmpty());


### PR DESCRIPTION
## What is the goal of this PR?

Previously two queries differing only by the fact that a role variable was returned (~userdefined) were treated as equivalent which lead to cache entries.

## What are the changes implemented in this PR?

Make sure we check whether the role variables are returned when determining compatible role players.
