### PR TITLE
Add implicit relation info if needed when materialising attributes

### DIFF
--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -229,7 +229,6 @@ public class RelationImpl implements Relation, ConceptVertex {
     }
 
     public Relation attributeInferred(Attribute attribute) {
-        reify().attributeInferred(attribute);
-        return this;
+        return reify().attributeInferred(attribute);
     }
 }

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -291,9 +291,8 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         return getThis();
     }
 
-    public T attributeInferred(Attribute attribute) {
-        attributeRelation(attribute, true);
-        return getThis();
+    public Relation attributeInferred(Attribute attribute) {
+        return attributeRelation(attribute, true);
     }
 
     @Override

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -27,14 +27,12 @@ import graql.lang.Graql;
 import graql.lang.query.GraqlGet;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import java.util.List;
+import java.util.Set;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.Set;
 
 import static grakn.core.server.kb.Schema.ImplicitType.HAS;
 import static grakn.core.server.kb.Schema.ImplicitType.HAS_OWNER;
@@ -146,12 +144,9 @@ public class AttributeAttachmentIT {
         }
     }
 
-    //TODO leads to cache inconsistency
-    @Ignore
     @Test
     public void whenReasoningWithAttributesWithRelationVar_ResultsAreComplete() {
         try(TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
-
             Statement has = var("x").has("reattachable-resource-string", var("y"), var("r"));
             List<ConceptMap> answers = tx.execute(Graql.match(has).get());
             assertEquals(3, answers.size());


### PR DESCRIPTION
## What is the goal of this PR?

To close #4512.
When resolving queries like `$x has resource $y via $r;` when the attribute is inferred, 
previously we didn't add the information about the implicit relation to an answer when we materialised an attribute. This could result in cache entries missing mappings for the relation variable.

## What are the changes implemented in this PR?

When we materialise attributes, if the relation variable is defined as to be returned, we include the implicit relation information in the answer - either by recording the inserted implicit relation or by fetching it if it exists already.
