### PR TITLE
Make sure we do not return duplicate played roles

### DIFF
--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -131,7 +131,8 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
                 filter(sup -> !sup.equals(this)). //We already have the plays from ourselves
                 flatMap(sup -> TypeImpl.from(sup).directPlays().keySet().stream());
 
-        return Stream.concat(allRoles, superSet);
+        //NB: use distinct as roles from different types from the hierarchy can overlap
+        return Stream.concat(allRoles, superSet).distinct();
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Ensure that we do not duplicate roles when calling `playing()` on types - we fetch roles for each type from the hierarchy which can result in duplicates (overlapping roles between types).

## What are the changes implemented in this PR?
Closes #4599.
