### PR TITLE
Deploy Grakn Docker image with latest tag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,4 @@
+build --workspace_status_command bin/workspace_status.sh
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com

--- a/BUILD
+++ b/BUILD
@@ -22,8 +22,9 @@ load("@graknlabs_bazel_distribution//brew:rules.bzl", "deploy_brew")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip", "checksum", "assemble_versioned")
 load("@graknlabs_bazel_distribution//github:rules.bzl", "deploy_github")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 assemble_targz(
     name = "assemble-linux-targz",
@@ -181,11 +182,15 @@ container_image(
     volumes = ["/server/db"]
 )
 
-container_push(
+container_bundle(
+    name = "assemble-docker-bundle",
+    images = {
+        "index.docker.io/graknlabs/grakn:{DOCKER_VERSION}": ":assemble-docker",
+        "index.docker.io/graknlabs/grakn:latest": ":assemble-docker",
+    }
+)
+
+docker_push(
     name = "deploy-docker",
-    image = ":assemble-docker",
-    format = "Docker",
-    registry = "index.docker.io",
-    repository = "graknlabs/grakn",
-    tag_file = "//:VERSION"
+    bundle = ":assemble-docker-bundle",
 )

--- a/bin/workspace_status.sh
+++ b/bin/workspace_status.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "DOCKER_VERSION $(cat VERSION)"


### PR DESCRIPTION
## What is the goal of this PR?

[Docker image of Grakn](https://hub.docker.com/r/graknlabs/grakn) will now be tagged with `latest` tag which would allow to pull `latest` image by default if no tag is specified

## What are the changes implemented in this PR?

Closes #5082
- Add `--workspace_status_command` which outputs content current `VERSION` - this makes it possible to use it in `container_bundle`
- Add `container_bundle` which allows to deploy the same image with two different tags: `latest` and one read from `VERSION`