### PR TITLE
Fix issue with unattaching attributes from relations

### DIFF
--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Encapsulates relations between Thing
@@ -61,6 +62,7 @@ public class RelationImpl implements Relation, ConceptVertex {
      *
      * @return The RelationReified if the Relation has been reified
      */
+    @Nullable
     public RelationReified reified() {
         if (relationStructure.isReified()) return relationStructure.reify();
         return null;

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -27,9 +27,7 @@ import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
 import grakn.core.server.kb.structure.VertexElement;
-
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -63,13 +61,13 @@ public class RelationImpl implements Relation, ConceptVertex {
      *
      * @return The RelationReified if the Relation has been reified
      */
-    public Optional<RelationReified> reified() {
-        if (!relationStructure.isReified()) return Optional.empty();
-        return Optional.of(relationStructure.reify());
+    public RelationReified reified() {
+        if (relationStructure.isReified()) return relationStructure.reify();
+        return null;
     }
 
     /**
-     * Reifys and returns the RelationReified
+     * Reifies and returns the RelationReified
      */
     private RelationReified reify() {
         if (relationStructure.isReified()) return relationStructure.reify();
@@ -111,7 +109,8 @@ public class RelationImpl implements Relation, ConceptVertex {
 
     @Override
     public Stream<Attribute<?>> keys(AttributeType[] attributeTypes) {
-        return reified().map(relationReified -> relationReified.attributes(attributeTypes)).orElseGet(Stream::empty);
+        RelationReified relationReified = reified();
+        return relationReified != null? relationReified.attributes(attributeTypes) : Stream.empty();
     }
 
     @Override
@@ -134,7 +133,8 @@ public class RelationImpl implements Relation, ConceptVertex {
      * Stream is returned.
      */
     private <X> Stream<X> readFromReified(Function<RelationReified, Stream<X>> producer) {
-        return reified().map(producer).orElseGet(Stream::empty);
+        RelationReified relationReified = reified();
+        return relationReified != null? producer.apply(relationReified) : Stream.empty();
     }
 
     /**
@@ -168,7 +168,8 @@ public class RelationImpl implements Relation, ConceptVertex {
 
     @Override
     public Relation unhas(Attribute attribute) {
-        reified().ifPresent(rel -> rel.unhas(attribute));
+        RelationReified relationReified = reified();
+        if (relationReified != null) relationReified.unhas(attribute);
         return this;
     }
 
@@ -179,7 +180,10 @@ public class RelationImpl implements Relation, ConceptVertex {
 
     @Override
     public void unassign(Role role, Thing player) {
-        reified().ifPresent(relationReified -> relationReified.removeRolePlayer(role, player));
+        RelationReified relationReified = reified();
+        if (relationReified != null){
+            relationReified.removeRolePlayer(role, player);
+        }
     }
 
     /**

--- a/server/src/server/kb/concept/RelationTypeImpl.java
+++ b/server/src/server/kb/concept/RelationTypeImpl.java
@@ -142,8 +142,9 @@ public class RelationTypeImpl extends TypeImpl<RelationType, Relation> implement
     void trackRolePlayers() {
         instances().forEach(concept -> {
             RelationImpl relation = RelationImpl.from(concept);
-            if (relation.reified().isPresent()) {
-                relation.reified().get().castingsRelation().forEach(rolePlayer -> vertex().tx().cache().trackForValidation(rolePlayer));
+            RelationReified reifedRelation = relation.reified();
+            if (reifedRelation != null) {
+                reifedRelation.castingsRelation().forEach(rolePlayer -> vertex().tx().cache().trackForValidation(rolePlayer));
             }
         });
     }

--- a/server/src/server/kb/concept/RoleImpl.java
+++ b/server/src/server/kb/concept/RoleImpl.java
@@ -18,7 +18,6 @@
 
 package grakn.core.server.kb.concept;
 
-import grakn.core.common.util.CommonUtil;
 import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
 import grakn.core.concept.type.Type;
@@ -26,11 +25,11 @@ import grakn.core.server.kb.Schema;
 import grakn.core.server.kb.cache.Cache;
 import grakn.core.server.kb.structure.Casting;
 import grakn.core.server.kb.structure.VertexElement;
-import org.apache.tinkerpop.gremlin.structure.Direction;
-
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.tinkerpop.gremlin.structure.Direction;
 
 /**
  * An SchemaConcept which defines a Role which can be played in a RelationType.
@@ -106,11 +105,11 @@ public class RoleImpl extends SchemaConceptImpl<Role> implements Role {
      * @return Get all the roleplayers of this role type
      */
     public Stream<Casting> rolePlayers() {
-        return relations().
-                flatMap(RelationType::instances).
-                map(relation -> RelationImpl.from(relation).reified()).
-                flatMap(CommonUtil::optionalToStream).
-                flatMap(relation -> relation.castingsRelation(this));
+        return relations()
+                .flatMap(RelationType::instances)
+                .map(relation -> RelationImpl.from(relation).reified())
+                .filter(Objects::nonNull)
+                .flatMap(relation -> relation.castingsRelation(this));
     }
 
     @Override

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -340,7 +340,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
             return rolePlayers.anyMatch(rolePlayer -> rolePlayer.equals(attribute));
         }).forEach(Concept::delete);
 
-        return getThis();
+        return (T) this;
     }
 
     /**

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -340,7 +340,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
             return rolePlayers.anyMatch(rolePlayer -> rolePlayer.equals(attribute));
         }).forEach(Concept::delete);
 
-        return (T) this;
+        return getThis();
     }
 
     /**

--- a/test-integration/server/kb/ValidateGlobalRulesIT.java
+++ b/test-integration/server/kb/ValidateGlobalRulesIT.java
@@ -75,7 +75,7 @@ public class ValidateGlobalRulesIT {
 
         RelationImpl assertion = (RelationImpl) hunts.create().
                 assign(witcher, geralt).assign(monster, werewolf);
-        assertion.reified().get().castingsRelation().forEach(rolePlayer ->
+        assertion.reified().castingsRelation().forEach(rolePlayer ->
                 assertFalse(ValidateGlobalRules.validatePlaysAndRelatesStructure(rolePlayer).isEmpty()));
 
         hunter.plays(witcher);
@@ -83,7 +83,7 @@ public class ValidateGlobalRulesIT {
         boolean [] flags = {false, false};
         int count = 0;
 
-        for (Casting casting : assertion.reified().get().castingsRelation().collect(Collectors.toSet())) {
+        for (Casting casting : assertion.reified().castingsRelation().collect(Collectors.toSet())) {
             flags[count] = !ValidateGlobalRules.validatePlaysAndRelatesStructure(casting).isEmpty();
             count++;
         }
@@ -92,7 +92,7 @@ public class ValidateGlobalRulesIT {
         wolf.sup(creature);
         creature.plays(monster);
 
-        for (Casting casting : assertion.reified().get().castingsRelation().collect(Collectors.toSet())) {
+        for (Casting casting : assertion.reified().castingsRelation().collect(Collectors.toSet())) {
             assertFalse(ValidateGlobalRules.validatePlaysAndRelatesStructure(casting).isEmpty());
         }
     }
@@ -117,19 +117,19 @@ public class ValidateGlobalRulesIT {
                 .assign(role2, other1).assign(role1, entity);
 
         // Valid with only a single relation
-        relation1.reified().get().castingsRelation().forEach(rolePlayer ->
+        relation1.reified().castingsRelation().forEach(rolePlayer ->
                 assertTrue(ValidateGlobalRules.validatePlaysAndRelatesStructure(rolePlayer).isEmpty()));
 
         RelationImpl relation2 = (RelationImpl) relationType.create()
                 .assign(role2, other2).assign(role1, entity);
 
         // Invalid with multiple relations
-        relation1.reified().get().castingsRelation().forEach(rolePlayer -> {
+        relation1.reified().castingsRelation().forEach(rolePlayer -> {
             if (rolePlayer.getRole().equals(role1)) {
                 assertFalse(ValidateGlobalRules.validatePlaysAndRelatesStructure(rolePlayer).isEmpty());
             }
         });
-        relation2.reified().get().castingsRelation().forEach(rolePlayer -> {
+        relation2.reified().castingsRelation().forEach(rolePlayer -> {
             if (rolePlayer.getRole().equals(role1)) {
                 assertFalse(ValidateGlobalRules.validatePlaysAndRelatesStructure(rolePlayer).isEmpty());
             }

--- a/test-integration/server/kb/concept/EntityIT.java
+++ b/test-integration/server/kb/concept/EntityIT.java
@@ -111,14 +111,14 @@ public class EntityIT {
         Casting rp2 = rolePlayer2.castingsInstance().findAny().get();
         Casting rp3 = rolePlayer3.castingsInstance().findAny().get();
 
-        assertThat(relation.reified().get().castingsRelation().collect(toSet()), containsInAnyOrder(rp1, rp2, rp3));
+        assertThat(relation.reified().castingsRelation().collect(toSet()), containsInAnyOrder(rp1, rp2, rp3));
 
         //Delete And Check Again
         ConceptId idOfDeleted = rolePlayer1.id();
         rolePlayer1.delete();
 
         assertNull(tx.getConcept(idOfDeleted));
-        assertThat(relation.reified().get().castingsRelation().collect(toSet()), containsInAnyOrder(rp2, rp3));
+        assertThat(relation.reified().castingsRelation().collect(toSet()), containsInAnyOrder(rp2, rp3));
     }
 
     @Test

--- a/test-integration/server/kb/concept/RelationIT.java
+++ b/test-integration/server/kb/concept/RelationIT.java
@@ -40,8 +40,10 @@ import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
-import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -50,10 +52,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -354,9 +352,34 @@ public class RelationIT {
         tx.commit();
     }
 
+    @Test
+    public void whenUnattachingAttributeFromRelation_operationSucceeds(){
+
+        Role member = tx.putRole("member");
+        Role member_of = tx.putRole("member_of");
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        RelationType membership = tx.putRelationType("membership")
+                .relates(member)
+                .relates(member_of)
+                .has(name);
+        EntityType group = tx.putEntityType("group").plays(member_of);
+        EntityType person = tx.putEntityType("person").plays(member);
+
+        Entity personInst = person.create();
+        Entity groupInst = group.create();
+
+        Attribute<String> attr = name.create("founder");
+        Relation membershipInst = membership.create()
+                .assign(member, personInst)
+                .assign(member_of, groupInst)
+                .has(attr);
+
+        membershipInst.unhas(attr);
+        assertFalse(membershipInst.attributes().findFirst().isPresent());
+    }
 
     @Test
-    public void whenDeletingInferredRelationship_NoErrorIsThrow() {
+    public void whenDeletingInferredRelationship_NoErrorIsThrown() {
         /*
         The exact behavior is up for debate, but at the very least we should not
         throw an exception when deleting an inferred concept, otherwise there is no way to delete

--- a/test-integration/server/kb/structure/CastingIT.java
+++ b/test-integration/server/kb/structure/CastingIT.java
@@ -76,7 +76,7 @@ public class CastingIT {
         RelationImpl relation = (RelationImpl) relationType.create().
                 assign(role1, e1);
 
-        Set<Casting> castings = relation.reified().get().castingsRelation().collect(Collectors.toSet());
+        Set<Casting> castings = relation.reified().castingsRelation().collect(Collectors.toSet());
 
         castings.forEach(rolePlayer -> {
             assertEquals(e1, rolePlayer.getRolePlayer());
@@ -94,16 +94,16 @@ public class CastingIT {
         RelationImpl relation = (RelationImpl) relationType.create().
                 assign(role1, e1);
 
-        Set<Thing> things = relation.reified().get().castingsRelation().map(Casting::getRolePlayer).collect(Collectors.toSet());
-        Set<Role> roles = relation.reified().get().castingsRelation().map(Casting::getRole).collect(Collectors.toSet());
+        Set<Thing> things = relation.reified().castingsRelation().map(Casting::getRolePlayer).collect(Collectors.toSet());
+        Set<Role> roles = relation.reified().castingsRelation().map(Casting::getRole).collect(Collectors.toSet());
         assertThat(things, containsInAnyOrder(e1));
         assertThat(roles, containsInAnyOrder(role1));
 
         //Now Update
         relation.assign(role2, e1).assign(role3, e3);
 
-        things = relation.reified().get().castingsRelation().map(Casting::getRolePlayer).collect(Collectors.toSet());
-        roles = relation.reified().get().castingsRelation().map(Casting::getRole).collect(Collectors.toSet());
+        things = relation.reified().castingsRelation().map(Casting::getRolePlayer).collect(Collectors.toSet());
+        roles = relation.reified().castingsRelation().map(Casting::getRole).collect(Collectors.toSet());
         assertThat(things, containsInAnyOrder(e1, e3));
         assertThat(roles, containsInAnyOrder(role1, role2, role3));
     }


### PR DESCRIPTION
## What is the goal of this PR?

Fix problem with unattaching attributes from relations - due to casting exception. The exception was thrown due to a implicit casting happening when executing a lambda - lambda tries to silently cast the result to return.

## What are the changes implemented in this PR?
- Avoid calling the return.
- change 'reified()` return value from Optional to a Nullable 
- Closes #4670.