### PR TITLE
Handle benchmark flag when parsing start command

### DIFF
--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -44,6 +44,8 @@ public class GraknDaemon {
     private static final String SERVER = "server";
     private static final String STORAGE = "storage";
     private static final String EMPTY_STRING = "";
+    private static final String BENCHMARK_FLAG = "--benchmark";
+
 
     private final Storage storageExecutor;
     private final Server serverExecutor;
@@ -183,6 +185,7 @@ public class GraknDaemon {
             case STORAGE:
                 storageExecutor.startIfNotRunning();
                 break;
+            case BENCHMARK_FLAG:
             case EMPTY_STRING:
                 storageExecutor.startIfNotRunning();
                 serverExecutor.startIfNotRunning(arg);

--- a/test-end-to-end/distribution/DistributionE2EConstants.java
+++ b/test-end-to-end/distribution/DistributionE2EConstants.java
@@ -46,7 +46,7 @@ public class DistributionE2EConstants {
     public static void assertGraknIsNotRunning() {
         Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
-        assertThat("assertGraknRunning() failed because ", serverReady, equalTo(false));
+        assertThat("assertGraknIsNotRunning() failed because ", serverReady, equalTo(false));
     }
 
     public static void assertZipExists() {

--- a/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
@@ -97,7 +97,7 @@ public class GraknGraqlCommandsE2E {
     }
 
     /**
-     * test 'grakn server start' and 'grakn server stop'
+     * test 'grakn server start --benchmark'
      */
     @Test
     public void grakn_shouldBeAbleToStartWithBenchmarkOption() throws IOException, InterruptedException, TimeoutException {

--- a/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
@@ -97,6 +97,16 @@ public class GraknGraqlCommandsE2E {
     }
 
     /**
+     * test 'grakn server start' and 'grakn server stop'
+     */
+    @Test
+    public void grakn_shouldBeAbleToStartWithBenchmarkOption() throws IOException, InterruptedException, TimeoutException {
+        commandExecutor.command("./grakn", "server", "start", "--benchmark").execute();
+        assertGraknIsRunning();
+        commandExecutor.command("./grakn", "server", "stop").execute();
+    }
+
+    /**
      * test 'grakn server help'
      */
     @Test


### PR DESCRIPTION
## What is the goal of this PR?

We recently introduced a stricter check on `grakn server start` command to explicitly reject wrong strings such as `grakn server start storage`.
This change broke the also valid command `grakn server start --benchmark`, this PR fixes that.

## What are the changes implemented in this PR?

Add a case in `GraknDaemon` so that if the arg is equal to `--benchmark` we still start Grakn without printing any error
