### PR TITLE
Make sure PID stored in pid files is actually bound to a Grakn process

### DIFF
--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -148,7 +148,7 @@ public class GraknDaemon {
                 serverStop(option);
                 break;
             case "status":
-                serverStatus(option);
+                serverStatus();
                 break;
             case "clean":
                 clean();
@@ -207,15 +207,9 @@ public class GraknDaemon {
                                    "- Start Grakn with Zipkin-enabled benchmarking with `grakn server start --benchmark`");
     }
 
-    private void serverStatus(String verboseFlag) {
+    private void serverStatus() {
         storageExecutor.status();
         serverExecutor.status();
-
-        if (verboseFlag.equals("--verbose")) {
-            System.out.println("======== Failure Diagnostics ========");
-            storageExecutor.statusVerbose();
-            serverExecutor.statusVerbose();
-        }
     }
 
     private void version() {

--- a/daemon/executor/Executor.java
+++ b/daemon/executor/Executor.java
@@ -150,7 +150,6 @@ public class Executor {
                 Result command = executeAndWait(getGraknPIDArgsCommand(processPid), null);
 
                 if (command.exitCode() != 0) {
-                    System.out.println(command.stderr());
                     return false;
                 }
                 return command.stdout().contains(className);

--- a/daemon/executor/Executor.java
+++ b/daemon/executor/Executor.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 
@@ -57,8 +56,9 @@ public class Executor {
         public abstract int exitCode();
     }
 
-    public static final long WAIT_INTERVAL_SECOND = 2;
-    public static final String SH = "/bin/sh";
+    static final long WAIT_INTERVAL_SECOND = 2;
+    private static final String SH = "/bin/sh";
+
 
     public CompletableFuture<Result> executeAsync(List<String> command, File workingDirectory) {
         return CompletableFuture.supplyAsync(() -> executeAndWait(command, workingDirectory));
@@ -81,23 +81,6 @@ public class Executor {
         } catch (IOException | InterruptedException | TimeoutException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public Optional<String> getPidFromFile(Path fileName) {
-        String pid = null;
-        if (fileName.toFile().exists()) {
-            try {
-                pid = new String(Files.readAllBytes(fileName), StandardCharsets.UTF_8).trim();
-            } catch (IOException e) {
-                // DO NOTHING
-            }
-        }
-        return Optional.ofNullable(pid);
-    }
-
-    public String getPidFromPsOf(String processName) {
-        return executeAndWait(
-                Arrays.asList(SH, "-c", "ps -ef | grep " + processName + " | grep -v grep | awk '{print $2}' "), null).stdout();
     }
 
     public String retrievePid(Path pidFile) {
@@ -134,13 +117,44 @@ public class Executor {
                 if (processPid.trim().isEmpty()) {
                     return false;
                 }
-                Result command =
-                        executeAndWait(checkPIDRunningCommand(processPid), null);
+                Result command = executeAndWait(checkPIDRunningCommand(processPid), null);
 
                 if (command.exitCode() != 0) {
                     System.out.println(command.stderr());
                 }
                 return command.exitCode() == 0;
+            } catch (NumberFormatException | IOException e) {
+                return false;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Method used to check whether the pid contained in the pid file actually corresponds
+     * to a Grakn(Storage) process.
+     * This method is to be used
+     *
+     * @param pidFile path to pid file
+     * @param className name of Class associated to the given pid (e.g. grakn.core.server.Grakn)
+     * @return true if PID is associated to the GraknStorage process, false otherwise.
+     */
+    public boolean isAGraknProcess(Path pidFile, String className) {
+        String processPid;
+        if (pidFile.toFile().exists()) {
+            try {
+                processPid = new String(Files.readAllBytes(pidFile), StandardCharsets.UTF_8);
+                if (processPid.trim().isEmpty()) {
+                    return false;
+                }
+                Result command = executeAndWait(getGraknPIDArgsCommand(processPid), null);
+
+                if (command.exitCode() != 0) {
+                    System.out.println(command.stderr());
+                    return false;
+                }
+                return command.stdout().contains(className);
             } catch (NumberFormatException | IOException e) {
                 return false;
             }
@@ -156,6 +170,14 @@ public class Executor {
         }
     }
 
+    private List<String> getGraknPIDArgsCommand(String pid) {
+        if (isWindows()) {
+            return Arrays.asList("cmd", "/c", "wmic process where processId='" + pid.trim() + "' get Commandline | findstr Grakn");
+        } else {
+            return Arrays.asList(SH, "-c", "ps -p " + pid.trim() + " | awk '{print $NF}' | grep Grakn");
+        }
+    }
+
     public void stopProcessIfRunning(Path pidFile, String programName) {
         System.out.print("Stopping " + programName + "...");
         System.out.flush();
@@ -168,8 +190,8 @@ public class Executor {
 
     }
 
-    public void processStatus(Path storagePid, String name) {
-        if (isProcessRunning(storagePid)) {
+    public void processStatus(Path pidFile, String name, String className) {
+        if (isProcessRunning(pidFile) && isAGraknProcess(pidFile, className)) {
             System.out.println(name + ": RUNNING");
         } else {
             System.out.println(name + ": NOT RUNNING");
@@ -191,7 +213,9 @@ public class Executor {
         }
     }
 
-    private void kill(String pid) { executeAndWait(killProcessCommand(pid), null); }
+    private void kill(String pid) {
+        executeAndWait(killProcessCommand(pid), null);
+    }
 
     private boolean isWindows() {
         return System.getProperty("os.name").toLowerCase().contains("win");

--- a/daemon/executor/Executor.java
+++ b/daemon/executor/Executor.java
@@ -134,10 +134,9 @@ public class Executor {
     /**
      * Method used to check whether the pid contained in the pid file actually corresponds
      * to a Grakn(Storage) process.
-     * This method is to be used
      *
      * @param pidFile path to pid file
-     * @param className name of Class associated to the given pid (e.g. grakn.core.server.Grakn)
+     * @param className name of Class associated to the given pid (e.g. "grakn.core.server.Grakn")
      * @return true if PID is associated to the a Grakn process, false otherwise.
      */
     public boolean isAGraknProcess(Path pidFile, String className) {

--- a/daemon/executor/Executor.java
+++ b/daemon/executor/Executor.java
@@ -138,7 +138,7 @@ public class Executor {
      *
      * @param pidFile path to pid file
      * @param className name of Class associated to the given pid (e.g. grakn.core.server.Grakn)
-     * @return true if PID is associated to the GraknStorage process, false otherwise.
+     * @return true if PID is associated to the a Grakn process, false otherwise.
      */
     public boolean isAGraknProcess(Path pidFile, String className) {
         String processPid;
@@ -174,7 +174,7 @@ public class Executor {
         if (isWindows()) {
             return Arrays.asList("cmd", "/c", "wmic process where processId='" + pid.trim() + "' get Commandline | findstr Grakn");
         } else {
-            return Arrays.asList(SH, "-c", "ps -p " + pid.trim() + " | awk '{print $NF}' | grep Grakn");
+            return Arrays.asList(SH, "-c", "ps -p " + pid.trim() + " -o command | awk '{print $NF}' | grep Grakn");
         }
     }
 

--- a/daemon/executor/Server.java
+++ b/daemon/executor/Server.java
@@ -23,6 +23,7 @@ import grakn.core.common.config.ConfigKey;
 import grakn.core.common.config.SystemProperty;
 import grakn.core.daemon.exception.GraknDaemonException;
 import grakn.core.server.Grakn;
+import grakn.core.server.GraknStorage;
 
 import java.io.File;
 import java.io.IOException;
@@ -72,8 +73,10 @@ public class Server {
     }
 
     public void startIfNotRunning(String benchmarkFlag) {
-        boolean isServerRunning = executor.isProcessRunning(SERVER_PIDFILE);
-        if (isServerRunning) {
+        boolean isProcessRunning = executor.isProcessRunning(SERVER_PIDFILE);
+        boolean isGraknProcess = executor.isAGraknProcess(SERVER_PIDFILE, Grakn.class.getName());
+
+        if (isProcessRunning && isGraknProcess) {
             System.out.println(DISPLAY_NAME + " is already running");
         } else {
             start(benchmarkFlag);
@@ -85,11 +88,7 @@ public class Server {
     }
 
     public void status() {
-        executor.processStatus(SERVER_PIDFILE, DISPLAY_NAME);
-    }
-
-    public void statusVerbose() {
-        System.out.println(DISPLAY_NAME + " pid = '" + executor.getPidFromFile(SERVER_PIDFILE).orElse("") + "' (from " + SERVER_PIDFILE + "), '" + executor.getPidFromPsOf(getServerMainClass().getName()) + "' (from ps -ef)");
+        executor.processStatus(SERVER_PIDFILE, DISPLAY_NAME, Grakn.class.getName());
     }
 
     public void clean() {

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -92,7 +92,8 @@ public class Storage {
     private void initialiseConfig() {
         try {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
-            TypeReference<Map<String, Object>> reference = new TypeReference<Map<String, Object>>() {};
+            TypeReference<Map<String, Object>> reference = new TypeReference<Map<String, Object>>() {
+            };
             ByteArrayOutputStream outputstream = new ByteArrayOutputStream();
 
             // Read the original Cassandra config from services/cassandra/cassandra.yaml into a String
@@ -195,23 +196,24 @@ public class Storage {
 
         LocalDateTime timeout = LocalDateTime.now().plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
 
-        try {
-            while (LocalDateTime.now().isBefore(timeout) && !result.isDone()) {
-                System.out.print(".");
-                System.out.flush();
+        while (LocalDateTime.now().isBefore(timeout) && !result.isDone()) {
+            System.out.print(".");
+            System.out.flush();
 
-                if (storageStatus().equals("running") && result.get().success()) {
-                    System.out.println("SUCCESS");
-                    return;
-                }
-
-                try {
-                    Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
+            if (storageStatus().equals("running")) {
+                System.out.println("SUCCESS");
+                return;
             }
 
+            try {
+                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+
+        try {
             System.out.println("FAILED!");
             System.err.println("Unable to start " + DISPLAY_NAME + ".");
             String errorMessage = "Process exited with code '" + result.get().exitCode() + "': '" + result.get().stderr() + "'";

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -92,8 +92,7 @@ public class Storage {
     private void initialiseConfig() {
         try {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
-            TypeReference<Map<String, Object>> reference = new TypeReference<Map<String, Object>>() {
-            };
+            TypeReference<Map<String, Object>> reference = new TypeReference<Map<String, Object>>() {};
             ByteArrayOutputStream outputstream = new ByteArrayOutputStream();
 
             // Read the original Cassandra config from services/cassandra/cassandra.yaml into a String

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -62,7 +62,6 @@ import static grakn.core.daemon.executor.Executor.WAIT_INTERVAL_SECOND;
 public class Storage {
 
     private static final String DISPLAY_NAME = "Storage";
-    private static final String STORAGE_PROCESS_NAME = "CassandraDaemon";
     private static final long STORAGE_STARTUP_TIMEOUT_SECOND = 60;
     private static final Path STORAGE_PIDFILE = Paths.get(System.getProperty("java.io.tmpdir"), "grakn-storage.pid");
     private static final Path STORAGE_DATA = Paths.get("server", "db", "cassandra");
@@ -124,7 +123,7 @@ public class Storage {
                             inputConfig.properties().getProperty(key)
                     ));
 
-            // Write the new Cassandra config into the original file:services/cassandra/cassandra.yaml
+            // Write the new Cassandra config into the original file: services/cassandra/cassandra.yaml
             mapper.writeValue(outputstream, newConfigMap);
             String newConfigStr = outputstream.toString(StandardCharsets.UTF_8.name());
             Files.write(Paths.get(STORAGE_CONFIG_PATH, STORAGE_CONFIG_NAME), newConfigStr.getBytes(StandardCharsets.UTF_8));
@@ -138,8 +137,9 @@ public class Storage {
      * Attempt to start Storage if it is not already running
      */
     public void startIfNotRunning() {
-        boolean isStorageRunning = daemonExecutor.isProcessRunning(STORAGE_PIDFILE);
-        if (isStorageRunning) {
+        boolean isProcessRunning = daemonExecutor.isProcessRunning(STORAGE_PIDFILE);
+        boolean isGraknStorageProcess = daemonExecutor.isAGraknProcess(STORAGE_PIDFILE, GraknStorage.class.getName());
+        if (isProcessRunning && isGraknStorageProcess) {
             System.out.println(DISPLAY_NAME + " is already running");
         } else {
             FileUtils.deleteQuietly(STORAGE_PIDFILE.toFile()); // delete dangling STORAGE_PIDFILE, if any
@@ -152,12 +152,7 @@ public class Storage {
     }
 
     public void status() {
-        daemonExecutor.processStatus(STORAGE_PIDFILE, DISPLAY_NAME);
-    }
-
-    public void statusVerbose() {
-        System.out.println(DISPLAY_NAME + " pid = '" + daemonExecutor.getPidFromFile(STORAGE_PIDFILE).orElse("") +
-                                   "' (from " + STORAGE_PIDFILE + "), '" + daemonExecutor.getPidFromPsOf(STORAGE_PROCESS_NAME) + "' (from ps -ef)");
+        daemonExecutor.processStatus(STORAGE_PIDFILE, DISPLAY_NAME, GraknStorage.class.getName());
     }
 
     public void clean() {
@@ -200,25 +195,25 @@ public class Storage {
 
         LocalDateTime timeout = LocalDateTime.now().plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
 
-        while (LocalDateTime.now().isBefore(timeout) && !result.isDone()) {
-            System.out.print(".");
-            System.out.flush();
-
-            if (storageStatus().equals("running")) {
-                System.out.println("SUCCESS");
-                return;
-            }
-
-            try {
-                Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        System.out.println("FAILED!");
-        System.err.println("Unable to start " + DISPLAY_NAME + ".");
         try {
+            while (LocalDateTime.now().isBefore(timeout) && !result.isDone()) {
+                System.out.print(".");
+                System.out.flush();
+
+                if (storageStatus().equals("running") && result.get().success()) {
+                    System.out.println("SUCCESS");
+                    return;
+                }
+
+                try {
+                    Thread.sleep(WAIT_INTERVAL_SECOND * 1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            System.out.println("FAILED!");
+            System.err.println("Unable to start " + DISPLAY_NAME + ".");
             String errorMessage = "Process exited with code '" + result.get().exitCode() + "': '" + result.get().stderr() + "'";
             System.err.println(errorMessage);
             throw new GraknDaemonException(errorMessage);
@@ -263,7 +258,6 @@ public class Storage {
         return Arrays.asList(
                 "java", "-cp", classpath,
                 "-Dlogback.configurationFile=" + logback,
-                //TODO: this needs to be removed or find lighter cassandra deps
                 NodeTool.class.getCanonicalName(),
                 "statusthrift"
         );


### PR DESCRIPTION
## What is the goal of this PR?

We now make sure that any PID stored inside temp files `grakn-server.pid` and `grakn-storage.pid` is currently running AND it is also bound to a Grakn/GraknStorage process.

This is because it might happen that Grakn does not terminate gracefully (e.g. restart machine), in which case the `.pid` files won't be deleted. 
Before this PR Grakn would try to start reading PIDs from those files and in case the OS reassigned the PIDs to new processes, Grakn would be tricked into believing that other Grakn processes are already running. 

## What are the changes implemented in this PR?

- on top of checking if PID stored in file is running make sure that the `Command` that started the associated process contains the string `core.grakn.server.Grakn` / `core.grakn.server.GraknServer`

- remove unused functions and variables

Closes https://github.com/graknlabs/grakn/issues/5175