### PR TITLE
Optimise QueryCache query completion acking 

### DIFF
--- a/server/src/graql/reasoner/ResolutionIterator.java
+++ b/server/src/graql/reasoner/ResolutionIterator.java
@@ -44,10 +44,8 @@ public class ResolutionIterator extends ReasonerQueryIterator {
     private long oldAns = 0;
     private final ResolvableQuery query;
     private final Set<ConceptMap> answers = new HashSet<>();
-
+    private final Set<ReasonerAtomicQuery> subGoals;
     private final Stack<ResolutionState> states = new Stack<>();
-
-    private Set<ReasonerAtomicQuery> toComplete = new HashSet<>();
 
     private ConceptMap nextAnswer = null;
     private final boolean reiterationRequired;
@@ -57,6 +55,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
     public ResolutionIterator(ResolvableQuery q, Set<ReasonerAtomicQuery> subGoals, boolean reiterate){
         this.query = q;
         this.reiterationRequired = reiterate;
+        this.subGoals = subGoals;
         states.push(query.subGoal(new ConceptMap(), new UnifierImpl(), null, subGoals));
     }
 
@@ -69,8 +68,6 @@ public class ResolutionIterator extends ReasonerQueryIterator {
             if (state.isAnswerState() && state.isTopState()) {
                 return state.getSubstitution();
             }
-
-            state.completionQueries().forEach(toComplete::add);
 
             ResolutionState newState = state.generateSubGoal();
             if (newState != null) {
@@ -111,7 +108,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
             }
         }
 
-        toComplete.forEach(query.tx().queryCache()::ackCompleteness);
+        subGoals.forEach(query.tx().queryCache()::ackCompleteness);
         query.tx().queryCache().propagateAnswers();
 
         return false;

--- a/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -215,17 +215,20 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
                 Iterators.singletonIterator(new CacheCompletionState(this, new ConceptMap(), null));
 
         Iterator<ResolutionState> subGoalIterator;
+        boolean visited = visitedSubGoals.contains(this);
         //if this is ground and exists in the db then do not resolve further
-        if(visitedSubGoals.contains(this)
+        boolean doNotResolveFurther = visited
                 || tx().queryCache().isComplete(this)
-                || (this.isGround() && dbIterator.hasNext())){
+                || (this.isGround() && dbIterator.hasNext());
+        if(doNotResolveFurther){
             subGoalIterator = Collections.emptyIterator();
         } else {
-            visitedSubGoals.add(this);
+
             subGoalIterator = getRuleStream()
                     .map(rulePair -> rulePair.getKey().subGoal(this.getAtom(), rulePair.getValue(), parent, visitedSubGoals))
                     .iterator();
         }
+        if (!visited) visitedSubGoals.add(this);
         return Iterators.concat(dbIterator, dbCompletionIterator, subGoalIterator);
     }
 

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -87,9 +87,6 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         return recordAnswer(query, answer);
     }
 
-    @Override
-    public Stream<ReasonerAtomicQuery> completionQueries(){ return Stream.of(getQuery());}
-
     /**
      * @return cache unifier if any
      */

--- a/server/src/graql/reasoner/state/ResolutionState.java
+++ b/server/src/graql/reasoner/state/ResolutionState.java
@@ -66,11 +66,6 @@ public abstract class ResolutionState {
     }
 
     /**
-     * @return stream of queries to be acked for completion when processing is finished
-     */
-    public Stream<ReasonerAtomicQuery> completionQueries(){ return Stream.empty();}
-
-    /**
      * @return parent state of this state
      */
     QueryStateBase getParentState(){ return parentState;}


### PR DESCRIPTION
## What is the goal of this PR?

Previously we were recording the information about queries to ack for completion in the main resolution loop. This is super ineffective:
- introduces extra equality check when determining set members
- this information is already available in the form of resolved subGoals,

The main resolution loop involves a huge number of calls - as a result we introduce a lot of unnecessary overhead.

## What are the changes implemented in this PR?
Use visited subGoals to know which queries should be acked for completion.
