### PR TITLE
Cache pattern and vars for query and optimise conditional in RelationAtom

### DIFF
--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -907,14 +907,14 @@ public abstract class RelationAtom extends IsaAtomBase {
             //NB: if two atoms are equal and their rp mappings are complete we return the identity unifier
             //this is important for cases like unifying ($r1: $x, $r2: $y) with itself
             //this is only for cached queries to ensure they do not produce spurious answers
-            if (ReasonerQueryEquivalence.Equality.equivalent(this.getParentQuery(), parent.getParentQuery())
-                    && containsRoleVariables
+            if (containsRoleVariables
                     && unifierType != UnifierType.RULE
                     //for subsumptive unifiers we need a meaningful (with actual variables) inverse
                     && unifierType != UnifierType.SUBSUMPTIVE
                     && !rpMappings.isEmpty()
                     && rpMappings.stream().allMatch(mapping -> mapping.size() == getRelationPlayers().size())){
-                return MultiUnifierImpl.trivial();
+                boolean queriesEqual = ReasonerQueryEquivalence.Equality.equivalent(this.getParentQuery(), parent.getParentQuery());
+                if (queriesEqual) return MultiUnifierImpl.trivial();
             }
 
             rpMappings

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -94,6 +94,8 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     private ConceptMap substitution = null;
     private ImmutableSetMultimap<Variable, Type> varTypeMap = null;
     private ResolutionPlan resolutionPlan = null;
+    private Conjunction<Pattern> pattern = null;
+    private Set<Variable> varNames = null;
 
     ReasonerQueryImpl(Conjunction<Statement> pattern, TransactionOLTP tx) {
         this.tx = tx;
@@ -221,12 +223,15 @@ public class ReasonerQueryImpl implements ResolvableQuery {
 
     @Override
     public Conjunction<Pattern> getPattern() {
-        return Graql.and(
-                getAtoms().stream()
-                        .map(Atomic::getCombinedPattern)
-                        .flatMap(p -> p.statements().stream())
-                        .collect(Collectors.toSet())
-        );
+        if (pattern == null) {
+            pattern = Graql.and(
+                    getAtoms().stream()
+                            .map(Atomic::getCombinedPattern)
+                            .flatMap(p -> p.statements().stream())
+                            .collect(Collectors.toSet())
+            );
+        }
+        return pattern;
     }
 
     @Override
@@ -301,9 +306,12 @@ public class ReasonerQueryImpl implements ResolvableQuery {
 
     @Override
     public Set<Variable> getVarNames() {
-        Set<Variable> vars = new HashSet<>();
-        getAtoms().forEach(atom -> vars.addAll(atom.getVarNames()));
-        return vars;
+        if (varNames == null) {
+            Set<Variable> vars = new HashSet<>();
+            getAtoms().forEach(atom -> vars.addAll(atom.getVarNames()));
+            varNames = vars;
+        }
+        return varNames;
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

After some thoughtful and tedious profiling, we have recognised that it might be beneficial to cache the `getPattern()` and `getVarNames()` functions in `ReasonerQuery`. This PR introduces these changes.
## What are the changes implemented in this PR?

- `getPattern()` and `getVarNames()` are now cached
- optimised the ordering of conditions in `RelationAtom` to shortcircuit it more effectively
