### PR TITLE
Cleanup atomic tests

### DIFF
--- a/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -40,36 +40,26 @@ import java.io.InputStreamReader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 
 @SuppressWarnings({"CheckReturnValue", "Duplicates"})
 public class AtomicEquivalenceIT {
 
+    private static String resourcePath = "test-integration/graql/reasoner/resources/";
+
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
 
     private static SessionImpl genericSchemaSession;
-
-    private static void loadFromFile(String fileName, SessionImpl session){
-        try {
-            InputStream inputStream = AtomicEquivalenceIT.class.getClassLoader().getResourceAsStream("test-integration/graql/reasoner/resources/"+fileName);
-            String s = new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining("\n"));
-            TransactionOLTP tx = session.transaction().write();
-            Graql.parseList(s).forEach(tx::execute);
-            tx.commit();
-        } catch (Exception e){
-            System.err.println(e);
-            throw new RuntimeException(e);
-        }
-    }
 
     private TransactionOLTP tx;
 
     @BeforeClass
     public static void loadContext(){
         genericSchemaSession = server.sessionWithNewKeyspace();
-        loadFromFile("genericSchema.gql", genericSchemaSession);
+        loadFromFileAndCommit(resourcePath,"genericSchema.gql", genericSchemaSession);
     }
 
     @AfterClass

--- a/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicUnificationIT.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static grakn.core.util.GraqlTestUtil.assertCollectionsNonTriviallyEqual;
+import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static graql.lang.Graql.var;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
@@ -67,30 +68,19 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings({"CheckReturnValue", "Duplicates"})
 public class AtomicUnificationIT {
 
+    private static String resourcePath = "test-integration/graql/reasoner/resources/";
+
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
 
     private static SessionImpl genericSchemaSession;
-
-    private static void loadFromFile(String fileName, SessionImpl session){
-        try {
-            InputStream inputStream = AtomicUnificationIT.class.getClassLoader().getResourceAsStream("test-integration/graql/reasoner/resources/"+fileName);
-            String s = new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining("\n"));
-            TransactionOLTP tx = session.transaction().write();
-            Graql.parseList(s).forEach(tx::execute);
-            tx.commit();
-        } catch (Exception e){
-            System.err.println(e);
-            throw new RuntimeException(e);
-        }
-    }
 
     private TransactionOLTP tx;
 
     @BeforeClass
     public static void loadContext(){
         genericSchemaSession = server.sessionWithNewKeyspace();
-        loadFromFile("genericSchema.gql", genericSchemaSession);
+        loadFromFileAndCommit(resourcePath,"genericSchema.gql", genericSchemaSession);
     }
 
     @AfterClass

--- a/test-integration/graql/reasoner/atomic/BUILD
+++ b/test-integration/graql/reasoner/atomic/BUILD
@@ -75,6 +75,7 @@ java_test(
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//server",
         "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
 )
@@ -91,6 +92,7 @@ java_test(
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//server",
         "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
 )

--- a/test-integration/graql/reasoner/atomic/RoleInferenceIT.java
+++ b/test-integration/graql/reasoner/atomic/RoleInferenceIT.java
@@ -43,12 +43,15 @@ import java.io.InputStreamReader;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"CheckReturnValue", "Duplicates"})
 public class RoleInferenceIT {
+
+    private static String resourcePath = "test-integration/graql/reasoner/resources/";
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
@@ -57,27 +60,14 @@ public class RoleInferenceIT {
     private static SessionImpl genericSchemaSession;
     private static SessionImpl ruleApplicabilitySetSession;
 
-    private static void loadFromFile(String fileName, SessionImpl session){
-        try {
-            InputStream inputStream = RoleInferenceIT.class.getClassLoader().getResourceAsStream("test-integration/graql/reasoner/resources/"+fileName);
-            String s = new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining("\n"));
-            TransactionOLTP tx = session.transaction().write();
-            Graql.parseList(s).forEach(tx::execute);
-            tx.commit();
-        } catch (Exception e){
-            System.err.println(e);
-            throw new RuntimeException(e);
-        }
-    }
-
     @BeforeClass
     public static void loadContext(){
         roleInferenceSetSession = server.sessionWithNewKeyspace();
-        loadFromFile("roleInferenceTest.gql", roleInferenceSetSession);
+        loadFromFileAndCommit(resourcePath, "roleInferenceTest.gql", roleInferenceSetSession);
         genericSchemaSession = server.sessionWithNewKeyspace();
-        loadFromFile("genericSchema.gql", genericSchemaSession);
+        loadFromFileAndCommit(resourcePath, "genericSchema.gql", genericSchemaSession);
         ruleApplicabilitySetSession = server.sessionWithNewKeyspace();
-        loadFromFile("ruleApplicabilityTest.gql", ruleApplicabilitySetSession);
+        loadFromFileAndCommit(resourcePath,"ruleApplicabilityTest.gql", ruleApplicabilitySetSession);
     }
 
     @AfterClass


### PR DESCRIPTION
## What is the goal of this PR?

Make the atomic tests consistently use the test utils. Also to trigger a new benchmark ;p

## What are the changes implemented in this PR?

- use the `GraqlTestUtils` loading facilities instead of local functions
