### PR TITLE
Fix possible missing ValuePredicate vars in attribute atoms

### DIFF
--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -286,6 +286,7 @@ public abstract class AttributeAtom extends Binary{
         Set<Variable> varNames = super.getVarNames();
         varNames.add(getAttributeVariable());
         if (getRelationVariable().isReturned()) varNames.add(getRelationVariable());
+        getMultiPredicate().forEach(p -> varNames.addAll(p.getVarNames()));
         return varNames;
     }
 

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -127,6 +127,7 @@ java_test(
         "//test-integration/graql/reasoner/graph:geo-graph",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
+        "@com-google-guava-guava//jar",
         "@graknlabs_graql//java:graql",
     ],
 )


### PR DESCRIPTION
## What is the goal of this PR?

It was possible that if an attribute contained a comparison, the reference variable in the comparison would be omitted when fetching the variables of the query/atom. This resulted in potential validation errors and unoptimal processing.

## What are the changes implemented in this PR?

- we explicitly add variables from value predicates to the attribute atom
