### PR TITLE
Add instance count estimate for inferrable concepts

### DIFF
--- a/server/src/graql/gremlin/TraversalPlanner.java
+++ b/server/src/graql/gremlin/TraversalPlanner.java
@@ -21,17 +21,10 @@ package grakn.core.graql.gremlin;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Sets;
-import grakn.core.concept.Label;
-import grakn.core.concept.type.AttributeType;
-import grakn.core.concept.type.RelationType;
-import grakn.core.concept.type.SchemaConcept;
-import grakn.core.graql.gremlin.fragment.AttributeIndexFragment;
 import grakn.core.graql.gremlin.fragment.Fragment;
-import grakn.core.graql.gremlin.fragment.IdFragment;
 import grakn.core.graql.gremlin.fragment.InIsaFragment;
 import grakn.core.graql.gremlin.fragment.InSubFragment;
 import grakn.core.graql.gremlin.fragment.LabelFragment;
-import grakn.core.graql.gremlin.fragment.ValueFragment;
 import grakn.core.graql.gremlin.spanningtree.Arborescence;
 import grakn.core.graql.gremlin.spanningtree.ChuLiuEdmonds;
 import grakn.core.graql.gremlin.spanningtree.graph.DirectedEdge;
@@ -41,17 +34,11 @@ import grakn.core.graql.gremlin.spanningtree.graph.SparseWeightedGraph;
 import grakn.core.graql.gremlin.spanningtree.util.Weighted;
 import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.exception.GraknServerException;
-import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
-import grakn.core.server.statistics.KeyspaceStatistics;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-import org.janusgraph.core.QueryException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,7 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static grakn.core.common.util.CommonUtil.toImmutableSet;
 import static grakn.core.graql.gremlin.NodesUtil.buildNodesWithDependencies;
@@ -77,9 +65,9 @@ import static grakn.core.graql.gremlin.fragment.Fragment.SHARD_LOAD_FACTOR;
  */
 public class TraversalPlanner {
 
-    protected static final Logger LOG = LoggerFactory.getLogger(TraversalPlanner.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TraversalPlanner.class);
 
-    protected static final int MAX_STARTING_POINTS = 3;
+    private static final int MAX_STARTING_POINTS = 3;
 
     /**
      * Create a traversal plan.
@@ -201,7 +189,8 @@ public class TraversalPlanner {
             Arborescence<Node> arborescence = startingNodes.stream()
                     .map(node -> ChuLiuEdmonds.getMaxArborescence(sparseWeightedGraph, node))
                     .max(Comparator.comparingDouble(tree -> tree.weight))
-                    .map(arborescenceInside -> arborescenceInside.val).orElse(Arborescence.empty());
+                    .map(arborescenceInside -> arborescenceInside.val)
+                    .orElse(Arborescence.empty());
 
             return arborescence;
         } else {
@@ -340,7 +329,7 @@ public class TraversalPlanner {
         }
     }
 
-    static Map<Node, Map<Node, Fragment>> virtualMiddleNodeToFragmentMapping(Set<Fragment> connectedFragments, Map<NodeId, Node> nodes) {
+    private static Map<Node, Map<Node, Fragment>> virtualMiddleNodeToFragmentMapping(Set<Fragment> connectedFragments, Map<NodeId, Node> nodes) {
         Map<Node, Map<Node, Fragment>> middleNodeFragmentMapping = new HashMap<>();
         for (Fragment fragment : connectedFragments) {
             Pair<Node, Node> middleNodeDirectedEdge = fragment.getMiddleNodeDirectedEdge(nodes);

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -68,7 +68,7 @@ public class RuleUtils {
                 .forEach(p -> graph.put(p.getKey(), p.getValue()));
         return graph;
     }
-    
+
     /**
      * @return a type graph (when->then) from possibly uncommited/invalid rules (no mapping to InferenceRule may exist).
      */

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -68,14 +68,7 @@ public class RuleUtils {
                 .forEach(p -> graph.put(p.getKey(), p.getValue()));
         return graph;
     }
-
-
-    public static HashMultimap<Type, Type> typeGraphInverse(TransactionOLTP tx){
-        HashMultimap<Type, Type> inverse = HashMultimap.create();
-        typeGraph(tx).entries().forEach(e -> inverse.put(e.getValue(), e.getKey()));
-        return inverse;
-    }
-
+    
     /**
      * @return a type graph (when->then) from possibly uncommited/invalid rules (no mapping to InferenceRule may exist).
      */

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -23,7 +23,10 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import grakn.core.common.util.CommonUtil;
+import grakn.core.concept.Label;
 import grakn.core.concept.type.Rule;
+import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.AtomicEquivalence;
@@ -35,6 +38,7 @@ import grakn.core.server.session.TransactionOLTP;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.Function;
@@ -65,10 +69,17 @@ public class RuleUtils {
         return graph;
     }
 
+
+    public static HashMultimap<Type, Type> typeGraphInverse(TransactionOLTP tx){
+        HashMultimap<Type, Type> inverse = HashMultimap.create();
+        typeGraph(tx).entries().forEach(e -> inverse.put(e.getValue(), e.getKey()));
+        return inverse;
+    }
+
     /**
-     * @return a type graph from possibly uncommited/invalid rules (no mapping to InferenceRule may exist).
+     * @return a type graph (when->then) from possibly uncommited/invalid rules (no mapping to InferenceRule may exist).
      */
-    private static HashMultimap<Type,Type> typeGraph(TransactionOLTP tx){
+    private static HashMultimap<Type, Type> typeGraph(TransactionOLTP tx){
         HashMultimap<Type, Type> graph = HashMultimap.create();
         tx.getMetaRule().subs()
                 .filter(rule -> !Schema.MetaSchema.isMetaLabel(rule.label()))
@@ -186,5 +197,47 @@ public class RuleUtils {
             }
         }
         return rules;
+    }
+
+    /**
+     * @param label type label for which the inferred count should be estimated
+     * @param tx transaction context
+     * @return estimated number of inferred instances of a given type
+     */
+    public static long estimateInferredTypeCount(Label label, TransactionOLTP tx){
+        SchemaConcept initialType = tx.getSchemaConcept(label);
+        if (initialType == null || !initialType.thenRules().findFirst().isPresent()) return 0;
+        long inferredEstimate = 0;
+
+        Set<SchemaConcept> visitedTypes = new HashSet<>();
+        Stack<SchemaConcept> types = new Stack<>();
+        types.push(initialType);
+        while(!types.isEmpty()) {
+            SchemaConcept type = types.pop();
+            //estimate count by assuming connectivity determined by the least populated type
+            Set<Optional<? extends Type>> dependants = type.thenRules()
+                    .map(rule ->
+                            rule.whenTypes()
+                                    .flatMap(Type::subs)
+                                    .min(Comparator.comparing(t -> tx.session().keyspaceStatistics().count(tx, t.toString())))
+                    ).collect(toSet());
+
+            if (!visitedTypes.contains(type) && !dependants.isEmpty()){
+                dependants.stream()
+                        .flatMap(CommonUtil::optionalToStream)
+                        .filter(at -> !visitedTypes.contains(at))
+                        .filter(at -> !types.contains(at))
+                        .forEach(types::add);
+                visitedTypes.add(type);
+            } else {
+                //if type is a leaf - update counts
+                Set<? extends SchemaConcept> subs = type.subs().collect(toSet());
+                for (SchemaConcept sub : subs) {
+                    long labelCount = tx.session().keyspaceStatistics().count(tx, sub.label().toString());
+                    inferredEstimate += labelCount;
+                }
+            }
+        }
+        return inferredEstimate;
     }
 }

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -166,6 +166,7 @@ java_test(
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//server",
         "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
 )

--- a/test-integration/graql/reasoner/query/ResolutionPlanIT.java
+++ b/test-integration/graql/reasoner/query/ResolutionPlanIT.java
@@ -35,6 +35,13 @@ import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -46,18 +53,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 
-import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
+import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static graql.lang.Graql.var;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.util.stream.Collectors.toSet;
@@ -73,43 +69,31 @@ public class ResolutionPlanIT {
 
     private static final int repeat = 20;
 
+    private static String resourcePath = "test-integration/graql/reasoner/resources/";
+
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
 
-    private static SessionImpl genericSchemaSession;
-
-    private static void loadFromFile(String fileName, SessionImpl session){
-        try {
-            InputStream inputStream = ResolutionPlanIT.class.getClassLoader().getResourceAsStream("test-integration/graql/reasoner/resources/"+fileName);
-            String s = new BufferedReader(new InputStreamReader(inputStream)).lines().collect(Collectors.joining("\n"));
-            TransactionOLTP tx = session.transaction().write();
-            Graql.parseList(s).forEach(tx::execute);
-            tx.commit();
-        } catch (Exception e){
-            System.err.println(e);
-            throw new RuntimeException(e);
-        }
-    }
-
+    private static SessionImpl planSession;
     private TransactionOLTP tx;
 
     @BeforeClass
     public static void loadContext(){
-        genericSchemaSession = server.sessionWithNewKeyspace();
-        loadFromFile("resolutionPlanTest.gql", genericSchemaSession);
+        planSession = server.sessionWithNewKeyspace();
+        loadFromFileAndCommit(resourcePath, "resolutionPlanTest.gql", planSession);
     }
 
     @AfterClass
     public static void closeSession(){
-        genericSchemaSession.close();
+        planSession.close();
     }
 
     @Before
     public void setUp(){
-        tx = genericSchemaSession.transaction().write();
+        tx = planSession.transaction().write();
     }
 
     @After
@@ -119,7 +103,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureDisconnectedIndexedQueriesProduceCompletePlan_indexedResource() {
+    public void whenDisconnectedIndexedQueriesPresentWithIndexedResource_completePlanIsProduced() {
         String queryString = "{" +
                 "$x isa someEntity;" +
                 "$y isa resource;$y 'value';" +
@@ -131,7 +115,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureDisconnectedIndexedQueriesProduceCompletePlan_indexedEntity() {
+    public void whenDisconnectedIndexedQueriesPresentWithIndexedEntity_completePlanIsProduced() {
         String queryString = "{" +
                 "$x isa someEntity;$x id V123;" +
                 "$y isa resource;" +
@@ -143,7 +127,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseSubbedRelationsOverNonSubbedOnes() {
+    public void whenSubstituionPresent_prioritiseSubbedRelationsOverNonSubbedOnes() {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
@@ -162,7 +146,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseSubbedResolvableRelationsOverNonSubbedNonResolvableOnes() {
+    public void whenSubstitutionPresent_prioritiseSubbedResolvableRelationsOverNonSubbedNonResolvableOnes() {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa derivedRelation;" +
@@ -179,7 +163,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseMostSubbedRelations() {
+    public void whenMultipleSubsPresent_prioritiseMostSubbedRelations() {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
@@ -197,32 +181,30 @@ public class ResolutionPlanIT {
         checkPlanSanity(query);
     }
 
-    //TODO refined plan should solve this
-    @Ignore
+    @Ignore ("atm it is a degenerate case - we need to incorporate statistics into MST calculation")
     @Test
     @Repeat( times = repeat )
-    public void prioritiseNonResolvableRelations_OnlyAtomicQueriesPresent() {
+    public void whenOnlyAtomicQueriesPresent_prioritiseNonResolvableRelations_() {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
-                "(someRole:$y, otherRole: $z) isa derivedRelation;" +
+                "(someRole:$y, otherRole: $z) isa anotherDerivedRelation;" +
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         ImmutableList<Atom> correctPlan = ImmutableList.of(
                 getAtomOfType(query, "someRelation", tx),
-                getAtomOfType(query, "derivedRelation", tx)
+                getAtomOfType(query, "anotherDerivedRelation", tx)
         );
         checkOptimalAtomPlanProduced(query, correctPlan);
         checkPlanSanity(query);
     }
 
-    //TODO refined plan should solve this
-    @Ignore
+    @Ignore ("atm it is a degenerate case - we need to incorporate statistics into MST calculation")
     @Test
     @Repeat( times = repeat )
-    public void prioritiseNonResolvableRelations_SandwichedResolvableRelation() {
+    public void whenSandwichedResolvableRelation_prioritiseNonResolvableRelations_() {
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
-                "(someRole:$y, otherRole: $z) isa derivedRelation;" +
+                "(someRole:$y, otherRole: $z) isa anotherDerivedRelation;" +
                 "(someRole:$z, otherRole: $w) isa yetAnotherRelation;" +
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
@@ -232,7 +214,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseSpecificResourcesOverRelations(){
+    public void whenSpecificResourcePresent_prioritiseSpecificResources(){
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
@@ -252,7 +234,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseSpecificResourcesOverResolvableRelationsWithGuards(){
+    public void whenSpecificResourcesAndRelationsWithGuardsPresent_prioritiseSpecificResources(){
         String queryString = "{" +
                 "$x isa baseEntity;" +
                 "(someRole:$x, otherRole: $y) isa derivedRelation;" +
@@ -270,7 +252,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void prioritiseSpecificResourcesOverNonSpecific(){
+    public void whenSpecificAndNonspecificResourcesPresent_prioritiseSpecificResources(){
 
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
@@ -293,7 +275,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void doNotPrioritiseNonSpecificResources(){
+    public void whenNonSpecificResourcesPresent_doNotPrioritiseThem(){
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa derivedRelation;" +
                 "$x has resource $xr;" +
@@ -310,13 +292,11 @@ public class ResolutionPlanIT {
      * [$start/...] ($start, $link) - ($link, $anotherlink) - ($anotherlink, $end)* [$anotherlink/...]
      *
      */
-    //TODO refined plan should solve this
-    @Ignore
     @Test
-    public void exploitDBRelationsAndConnectivity_relationLinkWithSubbedEndsAndRuleRelationInTheMiddle(){
+    public void whenRelationLinkWithSubbedEndsAndRuleRelationInTheMiddle_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
-                "$start id someSampleId;" +
-                "$end id anotherSampleId;" +
+                "$start id V123;" +
+                "$end id V456;" +
                 "(someRole: $link, otherRole: $start) isa someRelation;" +
                 "(someRole: $link, otherRole: $anotherlink) isa derivedRelation;" +
                 "(someRole: $anotherlink, otherRole: $end) isa anotherRelation;" +
@@ -329,8 +309,6 @@ public class ResolutionPlanIT {
 
         checkQueryPlanSanity(query);
         assertTrue(resolutionQueryPlan.queries().get(0).getAtoms(IdPredicate.class).findFirst().isPresent());
-        assertEquals(2, resolutionQueryPlan.queries().size());
-        //TODO still might produce disconnected plans
         checkAtomPlanSanity(query);
     }
 
@@ -340,10 +318,8 @@ public class ResolutionPlanIT {
      * [$start/...] ($start, $link) - ($link, $anotherlink) - ($anotherlink, $end)* [$anotherlink/...]
      *
      */
-    //TODO refined plan should solve this
-    //@Ignore
     @Test
-    public void exploitDBRelationsAndConnectivity_relationLinkWithSubbedEndsAndRuleRelationAtEnd(){
+    public void whenRelationLinkWithSubbedEndsAndRuleRelationAtEnd_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
                 "$start id Vsomesampleid;" +
                 "$end id Vanothersampleid;" +
@@ -361,7 +337,6 @@ public class ResolutionPlanIT {
         assertTrue(resolutionQueryPlan.queries().get(0).getAtoms(IdPredicate.class).findFirst().isPresent());
         assertTrue(!resolutionQueryPlan.queries().get(0).isAtomic());
         assertEquals(2, resolutionQueryPlan.queries().size());
-        //TODO still might produce disconnected plans
         checkAtomPlanSanity(query);
     }
 
@@ -373,12 +348,10 @@ public class ResolutionPlanIT {
      *        resource $res                                                  resource $res
      *    anotherResource 'someValue'
      */
-    //TODO flaky!
-    @Ignore
     @Test
-    public void exploitDBRelationsAndConnectivity_relationLinkWithEndsSharingAResource(){
+    public void whenRelationLinkWithEndsSharingAResource_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
-                "$start id sampleId;" +
+                "$start id V123;" +
                 "$start isa someEntity;" +
                 "$start has anotherResource 'someValue';" +
                 "$start has resource $res;" +
@@ -392,14 +365,20 @@ public class ResolutionPlanIT {
 
         checkQueryPlanSanity(query);
         assertTrue(resolutionQueryPlan.queries().get(0).getAtoms(IdPredicate.class).findFirst().isPresent());
-        assertTrue(!resolutionQueryPlan.queries().get(0).isAtomic());
+        System.out.println(resolutionQueryPlan);
+
+        List<ReasonerQueryImpl> queries = resolutionQueryPlan.queries();
+        //check that last two queries are the rule resolvable ones
+        assertTrue(queries.get(queries.size()-1).isRuleResolvable());
+        assertTrue(queries.get(queries.size()-2).isRuleResolvable());
+
         //TODO still might produce disconnected plans
         //checkAtomPlanSanity(query);
     }
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureIndirectTypeAtomsAreNotLostWhenPlanning(){
+    public void whenIndirectTypeAtomsPresent_makeSureTheyAreNotLost(){
         String queryString = "{" +
                 "$x isa baseEntity;" +
                 "$y isa baseEntity;" +
@@ -414,7 +393,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureOptimalOrderPickedWhenResourcesWithSubstitutionsArePresent() {
+    public void whenResourcesWithSubstitutionsArePresent_makeSureOptimalOrderPicked() {
         Concept concept = tx.stream(Graql.match(var("x").isa("baseEntity")).get("x"))
                 .map(ans -> ans.get("x")).findAny().orElse(null);
         String basePatternString =
@@ -442,7 +421,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureConnectednessPreservedWhenRelationsWithSameTypesPresent(){
+    public void whenRelationsWithSameTypesPresent_makeSureConnectednessPreserved(){
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
@@ -456,7 +435,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureConnectednessPreservedWhenRelationsWithSameTypesPresent_longerChain(){
+    public void whenRelationsWithSameTypesPresent_makeSureConnectednessPreserved_longerChain(){
         String queryString = "{" +
                 "(someRole:$x, otherRole: $y) isa someRelation;" +
                 "(someRole:$y, otherRole: $z) isa anotherRelation;" +
@@ -471,14 +450,14 @@ public class ResolutionPlanIT {
 
     /**
      follows the two-branch pattern
-     /   (d, e) - (e, f)*
-     (a, b)* - (b, c) - (c, d)*
-     \   (d, g) - (g, h)*
+                                /   (d, e) - (e, f)*
+        (a, b)* - (b, c) - (c, d)*
+                                 \   (d, g) - (g, h)*
      */
     @Test
-    @Ignore
+    //@Ignore
     @Repeat( times = repeat )
-    public void makeSureBranchedQueryChainsWithResolvableRelationsDoNotProduceDisconnectedPlans(){
+    public void whenBranchedQueryChainsWithResolvableRelations_disconnectedPlansAreNotProduced(){
 
         String basePatternString =
                 "($a, $b) isa derivedRelation;" +
@@ -494,6 +473,7 @@ public class ResolutionPlanIT {
         String queryString = "{" + basePatternString + "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         checkPlanSanity(query);
+
 
         String attributedQueryString = "{" +
                 "$a has resource 'someValue';" +
@@ -518,7 +498,7 @@ public class ResolutionPlanIT {
      */
     @Test
     @Repeat( times = repeat )
-    public void makeSureBranchedQueryChainsWithResolvableRelationsDoNotProduceDisconnectedPlans_anotherVariant(){
+    public void whenBranchedQueryChainsWithResolvableRelations_disconnectedPlansAreNotProduced_anotherVariant(){
         String basePatternString =
                 "($a, $b) isa someRelation;" +
                         "($b, $g) isa anotherRelation;" +
@@ -550,7 +530,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureDisconnectedQueryProducesValidPlan(){
+    public void whenQueryIsDisconnected_validPlanIsProduced(){
         String queryString = "{" +
                 "$a isa baseEntity;" +
                 "($a, $b) isa derivedRelation; $b isa someEntity;" +
@@ -567,7 +547,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureNonTrivialDisconnectedQueryProducesValidPlan(){
+    public void whenQueryIsNonTriviallyDisconnected_validPlanIsProduced(){
         String queryString = "{" +
                 "$a isa baseEntity;" +
                 "($a, $b) isa derivedRelation; $b isa someEntity;" +
@@ -590,7 +570,7 @@ public class ResolutionPlanIT {
      */
     @Test
     @Repeat( times = repeat )
-    public void makeSureDisconnectedConjunctionWithSpecificConceptsResolvedFirst(){
+    public void whenDisconnectedConjunctionWithSpecificConceptsPresent_itIsResolvedFirst(){
         String queryString = "{" +
                 "$x isa someEntity;" +
                 "$x has resource 'someValue';" +
@@ -611,7 +591,7 @@ public class ResolutionPlanIT {
      */
     @Test
     @Repeat( times = repeat )
-    public void makeSureDisconnectedConjunctionWithOntologicalAtomResolvedFirst() {
+    public void whenDisconnectedConjunctionWithOntologicalAtomPresent_itIsResolvedFirst() {
         String queryString = "{" +
                 "$x isa $type;" +
                 "$type has resource;" +
@@ -631,7 +611,7 @@ public class ResolutionPlanIT {
 
     @Test
     @Repeat( times = repeat )
-    public void makeSureAttributeResolvedBeforeConjunction(){
+    public void whenConjunctionChainWithASpecificAttribute_attributeResolvedBeforeConjunction(){
         String queryString = "{" +
                 "$f has resource 'value'; $f isa someEntity;" +
                 "($e, $f) isa derivedRelation; $e isa someOtherEntity;" +
@@ -642,7 +622,6 @@ public class ResolutionPlanIT {
                 "};";
         ReasonerQueryImpl query = ReasonerQueries.create(conjunction(queryString), tx);
         checkPlanSanity(query);
-        //todo
     }
 
     private Atom getAtomWithVariables(ReasonerQuery query, Set<Variable> vars){

--- a/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
+++ b/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
@@ -77,15 +77,17 @@ $x has anotherDerivedResource $r;
 insert
 
 $x isa someEntity, has resource 'someValue';
+$z isa someEntity;
+$c isa baseEntity;
 $y isa someOtherEntity;
 (someRole: $x, otherRole: $y) isa someRelation;
-(someRole: $x, otherRole: $y) isa someRelation;
+(someRole: $x, otherRole: $z) isa someRelation;
 (someRole: $x, otherRole: $y) isa anotherRelation;
-(someRole: $x, otherRole: $y) isa anotherRelation;
+(someRole: $x, otherRole: $z) isa anotherRelation;
+(someRole: $x, otherRole: $c) isa anotherRelation;
 (someRole: $x, otherRole: $y) isa yetAnotherRelation;
 
-$z "value1" isa anotherResource;
-$a "value2" isa anotherResource;
+$ar "someValue" isa anotherResource;
+$ar2 "anotherValue" isa anotherResource;
 
-$b isa someEntity;
-$c isa baseEntity;
+

--- a/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
+++ b/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
@@ -23,6 +23,10 @@ someRelation sub relation,
     relates someRole,
     relates otherRole;
 
+someRelationTrans sub relation,
+    relates someRole,
+    relates otherRole;
+
 anotherRelation sub relation,
     relates someRole,
     relates otherRole;
@@ -51,6 +55,19 @@ when {
 (someRole: $x, otherRole: $y) isa someRelation;},
 then {
 (someRole: $x, otherRole: $y) isa derivedRelation;};
+
+some-relation-equiv-rule
+when {
+(someRole: $x, otherRole: $y) isa someRelation;},
+then {
+(someRole: $x, otherRole: $y) isa someRelationTrans;};
+
+transitivity-rule
+when {
+(someRole: $x, otherRole: $y) isa someRelationTrans;
+(someRole: $y, otherRole: $z) isa someRelationTrans;},
+then {
+(someRole: $x, otherRole: $z) isa someRelationTrans;};
 
 another-relation-rule
 when {
@@ -82,9 +99,9 @@ $c isa baseEntity;
 $y isa someOtherEntity;
 (someRole: $x, otherRole: $y) isa someRelation;
 (someRole: $x, otherRole: $z) isa someRelation;
+(someRole: $x, otherRole: $c) isa someRelation;
 (someRole: $x, otherRole: $y) isa anotherRelation;
 (someRole: $x, otherRole: $z) isa anotherRelation;
-(someRole: $x, otherRole: $c) isa anotherRelation;
 (someRole: $x, otherRole: $y) isa yetAnotherRelation;
 
 $ar "someValue" isa anotherResource;


### PR DESCRIPTION
## What is the goal of this PR?
In one of the previous PRs we incorporated instance statistics (counts). However we haven't accounted for the fact that we can have no persisted instances with possibility to infer them. As a result we would prioritise types that have no persisted instanced but can be inferred. This PR addresses this issue. 

## What are the changes implemented in this PR?

- we introduce a simple compound count for labels: sum of persisted and inferrable concepts
- we estimate the count of inferrable concepts in the following way:
  * we use the type graph to determine possible derivation routes
  * for multiple rules we sum the contributions (counts)
  * for a single rule with multiple types, we pick the minimal count assuming it determines the connectivity
