### PR TITLE
Statistics 1.1 - improve ValueFragment starting point cost estimate efficiency

### DIFF
--- a/server/src/graql/gremlin/fragment/ValueFragment.java
+++ b/server/src/graql/gremlin/fragment/ValueFragment.java
@@ -140,7 +140,6 @@ public class ValueFragment extends Fragment {
 
     @Override
     public double estimatedCostAsStartingPoint(TransactionOLTP tx) {
-        long startTime = System.currentTimeMillis();
         KeyspaceStatistics statistics = tx.session().keyspaceStatistics();
 
         // compute the sum of all @has-attribute implicit relations
@@ -163,7 +162,6 @@ public class ValueFragment extends Fragment {
             totalImplicitRels += statistics.count(tx, implicitAttrRelLabel.toString());
         }
 
-        System.out.println("Time for valueFragment: " + (System.currentTimeMillis() - startTime) + " ms");
         if (totalAttributes == 0) {
             // short circuiting can be done quickly if starting here
             return 0.0;

--- a/server/src/graql/gremlin/fragment/ValueFragment.java
+++ b/server/src/graql/gremlin/fragment/ValueFragment.java
@@ -36,6 +36,7 @@ import org.apache.tinkerpop.gremlin.structure.Vertex;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -139,6 +140,7 @@ public class ValueFragment extends Fragment {
 
     @Override
     public double estimatedCostAsStartingPoint(TransactionOLTP tx) {
+        long startTime = System.currentTimeMillis();
         KeyspaceStatistics statistics = tx.session().keyspaceStatistics();
 
         // compute the sum of all @has-attribute implicit relations
@@ -147,19 +149,21 @@ public class ValueFragment extends Fragment {
         // this is probably not the highest quality heuristic (plus it is a heavy operation), needs work
 
         Label attributeLabel = Label.of("attribute");
+        long totalImplicitRels = 0;
+        long totalAttributes = 0;
 
         AttributeType attributeType = tx.getSchemaConcept(attributeLabel).asAttributeType();
         Stream<AttributeType> attributeSubs = attributeType.subs();
 
-        Label implicitAttributeRelation = Schema.ImplicitType.HAS.getLabel(attributeLabel);
-        SchemaConcept implicitAttributeRelationType = tx.getSchemaConcept(implicitAttributeRelation);
-        double totalImplicitRels = 0.0;
-        if (implicitAttributeRelationType != null) {
-            Stream<RelationType> implicitSubs = implicitAttributeRelationType.asRelationType().subs();
-            totalImplicitRels = implicitSubs.map(t -> statistics.count(tx, t.label().toString())).reduce((a,b) -> a+b).orElse(1L);
+        for (Iterator<AttributeType> it = attributeSubs.iterator(); it.hasNext(); ) {
+            AttributeType attrType = it.next();
+            Label attrLabel = attrType.label();
+            Label implicitAttrRelLabel = Schema.ImplicitType.HAS.getLabel(attrLabel);
+            totalAttributes += statistics.count(tx, attrLabel.toString());
+            totalImplicitRels += statistics.count(tx, implicitAttrRelLabel.toString());
         }
 
-        double totalAttributes = attributeSubs.map(t -> statistics.count(tx, t.label().toString())).reduce((a,b) -> a+b).orElse(1L);
+        System.out.println("Time for valueFragment: " + (System.currentTimeMillis() - startTime) + " ms");
         if (totalAttributes == 0) {
             // short circuiting can be done quickly if starting here
             return 0.0;

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -31,7 +31,9 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "@graknlabs_graql//java:graql",
+         "@graknlabs_client_java//:client-java",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -49,6 +51,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -65,6 +68,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -83,6 +87,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -100,6 +105,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -115,6 +121,7 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -129,6 +136,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -143,6 +151,7 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -159,6 +168,7 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 java_test(
@@ -174,6 +184,7 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 
@@ -190,6 +201,7 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
+    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 checkstyle_test(

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -201,7 +201,6 @@ java_test(
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
-    classpath_resources = ["//test-integration/resources:logback-test"],
 )
 
 checkstyle_test(

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -85,12 +85,6 @@ public class GraqlGetIT {
         session.close();
     }
 
-
-    @Test
-    public void testing() {
-        tx.execute(Graql.parse("match $x isa person, has name \"John\"; get;").asGet());
-    }
-
     @Test
     public void testGetSort() {
         List<ConceptMap> answers = tx.execute(


### PR DESCRIPTION
## What is the goal of this PR?
Improves the efficiency of evaluating the starting point of a ValueFragment by about 50%. Previously, we were retrieving the concept for `@has-attribute` and all of its subs, then querying statistics using these labels. On top of that, we were also retrieving the entire `attribute` subs() hierarchy. Only one of these is required (`attribute` subs() are more likely to be cached) and we can convert these labels into the corresponding implicit labels, which then goes to the statistics lookup.

## What are the changes implemented in this PR?
* Add test logback files to integration tests 
* Change `ValueFragment` to not retrieve both hierarchies of `attribute`.subs() and `@has-attribute`.subs()
* remove temporary test that slipped through