### PR TITLE
Fix concurrent modification issue in query cache

### DIFF
--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -125,10 +125,9 @@ public abstract class SemanticCache<
      * propagate answers within the cache (children fetch answers from parents)
      */
     public void propagateAnswers(){
-        parents.keySet().stream()
-                .filter(c -> isComplete(keyToQuery(c)))
-                .forEach(c-> {
-                    ReasonerAtomicQuery child = keyToQuery(c);
+        queries().stream()
+                .filter(this::isComplete)
+                .forEach(child-> {
                     CacheEntry<ReasonerAtomicQuery, SE> childEntry = getEntry(child);
                     if (childEntry != null) {
                         propagateAnswersToQuery(child, childEntry, true);


### PR DESCRIPTION
## What is the goal of this PR?

When doing a post-query cache update, it was possible that we modified the `parents` hashmap whilst iterating over it - the iteration involved calls to `computeParents`that could modify the `parents` map . This PR fixes that.

## What are the changes implemented in this PR?

- ensures the collection we iterate over is not modified
