### PR TITLE
Lock graph when attribute deduplicator needs to merge attributes

### DIFF
--- a/server/src/server/deduplicator/AttributeDeduplicator.java
+++ b/server/src/server/deduplicator/AttributeDeduplicator.java
@@ -60,6 +60,7 @@ public class AttributeDeduplicator {
                 while (duplicates.hasNext()) {
                     Vertex duplicate = duplicates.next();
                     try {
+                        session.getGraphLock().writeLock().lock();
                         duplicate.vertices(Direction.IN).forEachRemaining(connectedVertex -> {
                             // merge attribute edge connecting 'duplicate' and 'connectedVertex' to 'mergeTargetV', if exists
                             GraphTraversal<Vertex, Edge> attributeEdge =
@@ -85,6 +86,8 @@ public class AttributeDeduplicator {
                         tx.statisticsDelta().decrement(keyspaceAttributeTriple.label());
                     } catch (IllegalStateException vertexAlreadyRemovedException) {
                         LOG.warn("Trying to call the method vertices(Direction.IN) on vertex {} which is already removed.", duplicate.id());
+                    } finally {
+                        session.getGraphLock().writeLock().unlock();
                     }
                 }
 

--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -165,6 +165,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     }
 
     @Override
+    @Nullable
     public Attribute<D> attribute(D value) {
         String index = Schema.generateAttributeIndex(label(), value.toString());
         return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -262,4 +262,8 @@ public class SessionImpl implements Session {
     public Config config() {
         return config;
     }
+
+    public ReadWriteLock getGraphLock(){
+        return graphLock;
+    }
 }

--- a/test-integration/server/BUILD
+++ b/test-integration/server/BUILD
@@ -30,7 +30,8 @@ java_test(
         "@graknlabs_graql//java:graql",
 
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library"],
-    size = "large"
+    size = "large",
+    classpath_resources = ["//test-integration/resources:logback-test"]
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

We introduced locking mechanism when handling multiple concurrent transactions,
with this PR we add locking to AttributeDeduplicator to avoid cases where entities end up linked to Ghost Vertices.

NOTE:
- we tried writing an additional check when committing to verify if there other attributes with the same value in the graph, but apparently JanusGraph provides isolation between transactions so tx1 cannot see the new data added to the graph after its aperture.
- in the future we might want to make AttributeDeduplicator synchronous using more granular locking

## What are the changes implemented in this PR?

 get `graphLock` and try to acquire `write` lock before merging attributes to avoid having entities linked to broken vertices

Closes https://github.com/graknlabs/grakn/issues/5118