### PR TITLE
Add logback file for console distribution

### DIFF
--- a/console/BUILD
+++ b/console/BUILD
@@ -76,7 +76,7 @@ assemble_targz(
     output_filename = "grakn-core-console-linux",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-           "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -95,9 +95,9 @@ assemble_zip(
     name = "assemble-windows-zip",
     output_filename = "grakn-core-console-windows",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
-        additional_files = {
-            "//console:conf/logback.xml": "conf/logback.xml"
-        },
+    additional_files = {
+        "//console:conf/logback.xml": "conf/logback.xml"
+    },
     visibility = ["//visibility:public"]
 )
 
@@ -125,8 +125,7 @@ assemble_apt(
       "grakn-core-bin (={version})"
     ],
     files = {
-        "//console:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "console/conf/grakn.properties",
+        "//console:conf/logback.xml": "conf/logback.xml"
     },
     archives = [":console-deps"],
     installation_dir = "/opt/grakn/core/",
@@ -149,8 +148,7 @@ assemble_rpm(
     spec_file = "//config/rpm:grakn-core-console.spec",
     archives = [":console-deps"],
     files = {
-        "//console:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "console/conf/grakn.properties",
+        "//console:conf/logback.xml": "conf/logback.xml"
     },
     empty_dirs = [
          "opt/grakn/core/console/services/lib/",

--- a/console/BUILD
+++ b/console/BUILD
@@ -75,18 +75,8 @@ assemble_targz(
     name = "assemble-linux-targz",
     output_filename = "grakn-core-console-linux",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
-    empty_directories = [
-        "console/db/cassandra",
-        "console/db/queue"
-    ],
     additional_files = {
-        "//server:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "console/conf/grakn.properties",
-    },
-    permissions = {
-      "console/services/cassandra/cassandra.yaml": "0777",
-      "console/db/cassandra": "0777",
-      "console/db/queue": "0777",
+           "//console:conf/logback.xml": "conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -95,18 +85,8 @@ assemble_zip(
     name = "assemble-mac-zip",
     output_filename = "grakn-core-console-mac",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
-    empty_directories = [
-        "console/db/cassandra",
-        "console/db/queue"
-    ],
     additional_files = {
-        "//server:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "console/conf/grakn.properties",
-    },
-    permissions = {
-      "console/services/cassandra/cassandra.yaml": "0777",
-      "console/db/cassandra": "0777",
-      "console/db/queue": "0777",
+        "//console:conf/logback.xml": "conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -114,20 +94,10 @@ assemble_zip(
 assemble_zip(
     name = "assemble-windows-zip",
     output_filename = "grakn-core-console-windows",
-    targets = [":console-deps", "//bin:assemble-bat-targz"],
-    empty_directories = [
-        "console/db/cassandra",
-        "console/db/queue"
-    ],
-    additional_files = {
-        "//server:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "console/conf/grakn.properties",
-    },
-    permissions = {
-      "console/services/cassandra/cassandra.yaml": "0777",
-      "console/db/cassandra": "0777",
-      "console/db/queue": "0777",
-    },
+    targets = [":console-deps", "//bin:assemble-bash-targz"],
+        additional_files = {
+            "//console:conf/logback.xml": "conf/logback.xml"
+        },
     visibility = ["//visibility:public"]
 )
 
@@ -155,7 +125,7 @@ assemble_apt(
       "grakn-core-bin (={version})"
     ],
     files = {
-        "//server:conf/logback.xml": "console/conf/logback.xml",
+        "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "console/conf/grakn.properties",
     },
     archives = [":console-deps"],
@@ -179,7 +149,7 @@ assemble_rpm(
     spec_file = "//config/rpm:grakn-core-console.spec",
     archives = [":console-deps"],
     files = {
-        "//server:conf/logback.xml": "console/conf/logback.xml",
+        "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "console/conf/grakn.properties",
     },
     empty_dirs = [

--- a/console/conf/logback.xml
+++ b/console/conf/logback.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ GRAKN.AI - THE KNOWLEDGE GRAPH
+  ~ Copyright (C) 2018 Grakn Labs Ltd
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<configuration debug="false">
+    <root level="OFF"/>
+</configuration>


### PR DESCRIPTION
## What is the goal of this PR?

Add logback file to set to `OFF` logging level when using console alone without the full distribution.

As of now when packaging `grakn-core-console.zip` the package contains unused empty folders and a very verbose logback file (comes from server) which is also misplaced and not picked up by console JVM, so we see all the DEBUG statements in the console.

## What are the changes implemented in this PR?

- remove unused folders when packaging just console
- add `logback.xml` inside `console/conf` to be packaged with console when `bazel build //console:assemble-*`
