### PR TITLE
Dedicated conf folder for console and server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -33,6 +33,7 @@ assemble_targz(
                "//bin:assemble-bash-targz"],
     additional_files = {
         "//server:conf/logback.xml": "conf/logback.xml",
+        "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -56,6 +57,7 @@ assemble_zip(
                "//bin:assemble-bash-targz"],
     additional_files = {
         "//server:conf/logback.xml": "conf/logback.xml",
+        "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -79,6 +81,7 @@ assemble_zip(
                "//bin:assemble-bat-targz"],
     additional_files = {
         "//server:conf/logback.xml": "conf/logback.xml",
+        "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",

--- a/BUILD
+++ b/BUILD
@@ -34,7 +34,7 @@ assemble_targz(
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt",
@@ -58,7 +58,7 @@ assemble_zip(
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt",
@@ -82,7 +82,7 @@ assemble_zip(
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt",

--- a/BUILD
+++ b/BUILD
@@ -32,7 +32,7 @@ assemble_targz(
                "//console:console-deps",
                "//bin:assemble-bash-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
@@ -56,7 +56,7 @@ assemble_zip(
                "//console:console-deps",
                "//bin:assemble-bash-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
@@ -80,7 +80,7 @@ assemble_zip(
                "//console:console-deps",
                "//bin:assemble-bat-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//console:conf/logback.xml": "console/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",

--- a/bin/grakn
+++ b/bin/grakn
@@ -65,7 +65,7 @@ elif [ "$1" = "console" ]; then
 elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
         SERVICE_LIB_CP="server/services/lib/*"
-        CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/conf/"
+        CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/server/conf/"
         java ${GRAKN_DAEMON_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" -Dstorage.javaopts="${STORAGE_JAVAOPTS}" -Dserver.javaopts="${SERVER_JAVAOPTS}" grakn.core.daemon.GraknDaemon $@
     else
         echo "Grakn Core Server is not included in this Grakn distribution."

--- a/bin/grakn
+++ b/bin/grakn
@@ -21,7 +21,7 @@
 JAVA_BIN=java
 [[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
 GRAKN_HOME=$(cd "$(dirname "${path}")" && pwd -P)
-GRAKN_CONFIG="conf/grakn.properties"
+GRAKN_CONFIG="server/conf/grakn.properties"
 
 CONSOLE_JAR_FILENAME=(${GRAKN_HOME}/console/services/lib/io-grakn-core-console*.jar)
 SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/services/lib/io-grakn-core-server*.jar)

--- a/bin/grakn
+++ b/bin/grakn
@@ -56,8 +56,8 @@ if [ -z "$1" ]; then
 elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
-        CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/conf/"
-        java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" -Dgrakn.conf="${GRAKN_HOME}/${GRAKN_CONFIG}" grakn.core.console.GraknConsole "$@"
+        CLASSPATH="${GRAKN_HOME}/${SERVICE_LIB_CP}:${GRAKN_HOME}/console/conf/"
+        java ${CONSOLE_JAVAOPTS} -cp "${CLASSPATH}" -Dgrakn.dir="${GRAKN_HOME}" grakn.core.console.GraknConsole "$@"
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."

--- a/bin/grakn.bat
+++ b/bin/grakn.bat
@@ -64,7 +64,7 @@ if exist .\console\services\lib\io-grakn-core-console-*.jar (
 
 :startserver
 
-set "G_CP=%GRAKN_HOME%\conf\;%GRAKN_HOME%\server\services\lib\*"
+set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\services\lib\*"
 if exist .\server\services\lib\io-grakn-core-server-*.jar (
   java %GRAKN_DAEMON_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" -Dstorage.javaopts="%STORAGE_JAVAOPTS%" -Dserver.javaopts="%SERVER_JAVAOPTS%" grakn.core.daemon.GraknDaemon %*
   goto exit

--- a/bin/grakn.bat
+++ b/bin/grakn.bat
@@ -20,7 +20,7 @@ REM
 SET "GRAKN_HOME=%cd%"
 
 
-SET "GRAKN_CONFIG=conf\grakn.properties"
+SET "GRAKN_CONFIG=server\conf\grakn.properties"
 
 where java >NUL 2>NUL
 if %ERRORLEVEL% GEQ 1 (

--- a/bin/grakn.bat
+++ b/bin/grakn.bat
@@ -52,9 +52,9 @@ goto exiterror
 
 :startconsole
 
-set "G_CP=%GRAKN_HOME%\conf\;%GRAKN_HOME%\console\services\lib\*"
+set "G_CP=%GRAKN_HOME%\console\conf\;%GRAKN_HOME%\console\services\lib\*"
 if exist .\console\services\lib\io-grakn-core-console-*.jar (
-  java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" grakn.core.console.GraknConsole %*
+  java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" grakn.core.console.GraknConsole %*
   goto exit
 ) else (
   echo Grakn Core Console is not included in this Grakn distribution^.

--- a/console/BUILD
+++ b/console/BUILD
@@ -56,6 +56,11 @@ checkstyle_test(
     ],
 )
 
+exports_files(
+    glob(["conf/logback.xml"]),
+    visibility = ["//visibility:public"]
+)
+
 java_binary(
     name = "console-binary",
     main_class = "grakn.core.console.GraknConsole",
@@ -76,7 +81,7 @@ assemble_targz(
     output_filename = "grakn-core-console-linux",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-        "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "console/conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -86,7 +91,7 @@ assemble_zip(
     output_filename = "grakn-core-console-mac",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-        "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "console/conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -96,7 +101,7 @@ assemble_zip(
     output_filename = "grakn-core-console-windows",
     targets = [":console-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-        "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "console/conf/logback.xml"
     },
     visibility = ["//visibility:public"]
 )
@@ -125,7 +130,7 @@ assemble_apt(
       "grakn-core-bin (={version})"
     ],
     files = {
-        "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "console/conf/logback.xml"
     },
     archives = [":console-deps"],
     installation_dir = "/opt/grakn/core/",
@@ -148,7 +153,7 @@ assemble_rpm(
     spec_file = "//config/rpm:grakn-core-console.spec",
     archives = [":console-deps"],
     files = {
-        "//console:conf/logback.xml": "conf/logback.xml"
+        "//console:conf/logback.xml": "console/conf/logback.xml"
     },
     empty_dirs = [
          "opt/grakn/core/console/services/lib/",

--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -101,7 +101,7 @@ public class GraknDaemon {
         if (!javaVersion.equals("1.8")) {
             throw new RuntimeException(ErrorMessage.UNSUPPORTED_JAVA_VERSION.getMessage(javaVersion));
         }
-        if (!graknHome.resolve("conf").toFile().exists()) {
+        if (!graknHome.resolve("server").resolve("conf").toFile().exists()) {
             throw new RuntimeException(ErrorMessage.UNABLE_TO_GET_GRAKN_HOME_FOLDER.getMessage());
         }
         if (!graknProperties.toFile().exists()) {

--- a/server/BUILD
+++ b/server/BUILD
@@ -120,7 +120,7 @@ assemble_targz(
     targets = [":server-deps", "//bin:assemble-bash-targz"],
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"
@@ -143,7 +143,7 @@ assemble_zip(
     targets = [":server-deps", "//bin:assemble-bash-targz"],
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"
@@ -166,7 +166,7 @@ assemble_zip(
     targets = [":server-deps", "//bin:assemble-bat-targz"],
     additional_files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt",
@@ -211,7 +211,7 @@ assemble_apt(
     installation_dir = "/opt/grakn/core/",
     files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"
@@ -250,7 +250,7 @@ assemble_rpm(
      ],
     files = {
         "//server:conf/logback.xml": "server/conf/logback.xml",
-        "//server:conf/grakn.properties": "conf/grakn.properties",
+        "//server:conf/grakn.properties": "server/conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
         "//server:services/grakn/grakn-core-ascii.txt": "server/services/grakn/grakn-core-ascii.txt"

--- a/server/BUILD
+++ b/server/BUILD
@@ -119,7 +119,7 @@ assemble_targz(
     output_filename = "grakn-core-server-linux",
     targets = [":server-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -142,7 +142,7 @@ assemble_zip(
     output_filename = "grakn-core-server-mac",
     targets = [":server-deps", "//bin:assemble-bash-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -165,7 +165,7 @@ assemble_zip(
     output_filename = "grakn-core-server-windows",
     targets = [":server-deps", "//bin:assemble-bat-targz"],
     additional_files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -210,7 +210,7 @@ assemble_apt(
     archives = [":server-deps"],
     installation_dir = "/opt/grakn/core/",
     files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",
@@ -249,7 +249,7 @@ assemble_rpm(
         "var/lib/grakn/db/cassandra"
      ],
     files = {
-        "//server:conf/logback.xml": "conf/logback.xml",
+        "//server:conf/logback.xml": "server/conf/logback.xml",
         "//server:conf/grakn.properties": "conf/grakn.properties",
         "//server:services/cassandra/cassandra.yaml": "server/services/cassandra/cassandra.yaml",
         "//server:services/cassandra/logback.xml": "server/services/cassandra/logback.xml",

--- a/test-end-to-end/client-java/ClientJavaE2EConstants.java
+++ b/test-end-to-end/client-java/ClientJavaE2EConstants.java
@@ -38,13 +38,13 @@ public class ClientJavaE2EConstants {
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all-mac");
 
     public static void assertGraknRunning() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknRunning() failed because ", serverReady, equalTo(true));
     }
 
     public static void assertGraknStopped() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknRunning() failed because ", serverReady, equalTo(false));
     }

--- a/test-end-to-end/deduplicator/AttributeDeduplicatorE2EConstants.java
+++ b/test-end-to-end/deduplicator/AttributeDeduplicatorE2EConstants.java
@@ -38,13 +38,13 @@ public class AttributeDeduplicatorE2EConstants {
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all-mac");
 
     public static void assertGraknRunning() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknRunning() failed because ", serverReady, equalTo(true));
     }
 
     public static void assertGraknStopped() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknRunning() failed because ", serverReady, equalTo(false));
     }

--- a/test-end-to-end/distribution/DistributionE2EConstants.java
+++ b/test-end-to-end/distribution/DistributionE2EConstants.java
@@ -38,13 +38,13 @@ public class DistributionE2EConstants {
     public static final Path GRAKN_UNZIPPED_DIRECTORY = Paths.get(GRAKN_TARGET_DIRECTORY.toString(), "distribution-test", "grakn-core-all-mac");
 
     public static void assertGraknIsRunning() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknRunning() failed because ", serverReady, equalTo(true));
     }
 
     public static void assertGraknIsNotRunning() {
-        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties"));
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
         boolean serverReady = isServerReady(config.getProperty(ConfigKey.SERVER_HOST_NAME), config.getProperty(ConfigKey.GRPC_PORT));
         assertThat("assertGraknIsNotRunning() failed because ", serverReady, equalTo(false));
     }

--- a/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommandsE2E.java
@@ -72,7 +72,7 @@ public class GraknGraqlCommandsE2E {
     public void verifyDistributionFiles() {
         // assert files exist
         final Path grakn = GRAKN_UNZIPPED_DIRECTORY.resolve("grakn");
-        final Path graknProperties = GRAKN_UNZIPPED_DIRECTORY.resolve("conf").resolve("grakn.properties");
+        final Path graknProperties = GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties");
         final Path cassandraDirectory = GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("services").resolve("cassandra");
         final Path libDirectory = GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("services").resolve("lib");
 


### PR DESCRIPTION
## What is the goal of this PR?

Create dedicated conf folder for console and server, so we now have:

 - conf folder for console in `grakn_dir/console/conf` (we store new dedicated logback file for console)
 - conf folder for server in `grakn_dir/server/conf` (we store server logback together with grakn.properties)

## What are the changes implemented in this PR?

- use dedicated folder for console so that it doesnt clash with the server `conf` folder when installing server and console using `apt` on the same machine

- changes to BUILD files to have the aforementioned structure
