### PR TITLE
Use custom java toolchain from @graknlabs_build_tools

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,4 @@
-build --workspace_status_command bin/workspace_status.sh
+build --workspace_status_command bin/workspace_status.sh --java_toolchain @graknlabs_build_tools//bazel:java-toolchain
 build:rbe --project_id=grakn-dev
 build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=remotebuildexecution.googleapis.com


### PR DESCRIPTION
## What is the goal of this PR?

Due to usage of Java custom toolchain (defined in [`graknlabs/build-tools`](graknlabs/build-tools)), "Go to implementation" (**Cmd+Click** on class name) action in IntelliJ IDEA now correctly takes developer to source code (`*.java` files). Previously, such action would result in going to `*.class` files, which hampered developers' productivity.

## What are the changes implemented in this PR?

Fixes graknlabs/grakn#4851
