### PR TITLE
Statistics - track total Thing count

### DIFF
--- a/server/src/graql/gremlin/spanningtree/graph/InstanceNode.java
+++ b/server/src/graql/gremlin/spanningtree/graph/InstanceNode.java
@@ -19,6 +19,7 @@
 package grakn.core.graql.gremlin.spanningtree.graph;
 
 import grakn.core.concept.Label;
+import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 
 public class InstanceNode extends Node {
@@ -34,8 +35,7 @@ public class InstanceNode extends Node {
     @Override
     public long matchingElementsEstimate(TransactionOLTP tx) {
         if (instanceTypeLabel == null) {
-            // upper bound for now until we can efficiently retrieve the total of all things efficiently
-            return 100000L;
+            return tx.session().keyspaceStatistics().count(tx, Schema.MetaSchema.THING.getLabel());
         } else {
             return tx.session().keyspaceStatistics().count(tx, instanceTypeLabel);
         }

--- a/server/src/server/statistics/KeyspaceStatistics.java
+++ b/server/src/server/statistics/KeyspaceStatistics.java
@@ -39,6 +39,10 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * On cache miss, we read from JanusGraph schema vertices, which only have the INSTANCE_COUNT property if the
  * count is non-zero or has been non-zero in the past. No such property means instance count is 0.
+ *
+ * We also store the total count of all concepts the same was as any other schema concept, but on the `Thing` meta
+ * concept. Note that this is different from the other instance counts as it DOES include counts of all subtypes. The
+ * other counts on user-defined schema concepts are for for that concrete type only
  */
 public class KeyspaceStatistics {
 

--- a/test-integration/server/statistics/KeyspaceStatisticsIT.java
+++ b/test-integration/server/statistics/KeyspaceStatisticsIT.java
@@ -114,12 +114,14 @@ public class KeyspaceStatisticsIT {
         long ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         long friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
         assertEquals(2, personCount);
         assertEquals(1, ageCount);
         assertEquals(1, friendshipCount);
         assertEquals(3, implicitAgeCount);
+        assertEquals(personCount + ageCount + friendshipCount + implicitAgeCount, thingCount);
 
         tx = localSession.transaction().write();
         tx.execute(Graql.parse("match $x isa friendship; delete $x;").asDelete());
@@ -130,12 +132,14 @@ public class KeyspaceStatisticsIT {
         ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
         assertEquals(2, personCount);
         assertEquals(1, ageCount);
         assertEquals(0, friendshipCount);
         assertEquals(3, implicitAgeCount);
+        assertEquals(personCount + ageCount + friendshipCount + implicitAgeCount, thingCount);
 
         tx = localSession.transaction().write();
         tx.execute(Graql.parse("match $x isa thing; delete $x;").asDelete());
@@ -145,12 +149,14 @@ public class KeyspaceStatisticsIT {
         ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
         assertEquals(0, personCount);
         assertEquals(0, ageCount);
         assertEquals(0, friendshipCount);
         assertEquals(0, implicitAgeCount);
+        assertEquals(0, thingCount);
     }
 
     @Test
@@ -212,6 +218,7 @@ public class KeyspaceStatisticsIT {
         long ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         long friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
         localSession.close();
@@ -225,12 +232,14 @@ public class KeyspaceStatisticsIT {
         long ageCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         long friendshipCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        long thingCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
-        TestCase.assertEquals(personCount, personCountReopened);
-        TestCase.assertEquals(ageCount, ageCountReopened);
-        TestCase.assertEquals(friendshipCount, friendshipCountReopened);
-        TestCase.assertEquals(implicitAgeCount, implicitAgeCountReopened);
+        assertEquals(personCount, personCountReopened);
+        assertEquals(ageCount, ageCountReopened);
+        assertEquals(friendshipCount, friendshipCountReopened);
+        assertEquals(implicitAgeCount, implicitAgeCountReopened);
+        assertEquals(thingCount, thingCountReopened);
     }
 
     @Test
@@ -289,9 +298,11 @@ public class KeyspaceStatisticsIT {
         tx = localSession.transaction().write();
         long personCount = localSession.keyspaceStatistics().count(tx, Label.of("person"));
         long ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
+        long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
         tx.close();
 
         assertEquals(2L, personCount - personCountStart);
         assertEquals(3L, ageCount - ageCountStart);
+        assertEquals(personCount + ageCount, thingCount);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
Maintain a count of the total number of Things committed to the graph (this includes implicit relations). This should be equal to the number of concepts counted by an aggregate count in a new transaction. This means that retrieving the total number of things persisted no longer requires traversing all the `subs()` of `Thing` and adding the counts of each of these, as this can be an expensive operation if the schema is large.

## What are the changes implemented in this PR?
* On commit, we sum the total of the concrete instance types changed and add them to the label `Thing`, which is persisted into the meta `Thing` concept just like any other schema concept would be handled.
* Tests updated to check the count of `Thing`
* Replace hardcoded upper bound in `InstanceNode` to use the `Thing` count from statistics (it was too expensive to do all the `subs()` before --  see above)