### PR TITLE
Fix logs

### DIFF
--- a/common/config/Config.java
+++ b/common/config/Config.java
@@ -41,9 +41,9 @@ public class Config {
     private final Properties prop;
 
     /**
-     * The path to the config file currently in use. Default: ./conf/grakn.properties
+     * The path to the config file currently in use. Default: ./server/conf/grakn.properties
      */
-    private static final Path DEFAULT_CONFIG_FILE = Paths.get(".", "conf", "grakn.properties");
+    private static final Path DEFAULT_CONFIG_FILE = Paths.get(".", "server", "conf", "grakn.properties");
     private static final Logger LOG = LoggerFactory.getLogger(Config.class);
     private static Config defaultConfig = null;
     private static final Path PROJECT_PATH = Config.getProjectPath();

--- a/daemon/executor/Server.java
+++ b/daemon/executor/Server.java
@@ -169,7 +169,7 @@ public class Server {
 
     private String getServerClassPath() {
         return graknHome.resolve("server").resolve("services").resolve("lib").toString() + File.separator + "*"
-                + File.pathSeparator + graknHome.resolve("conf");
+                + File.pathSeparator + graknHome.resolve("server").resolve("conf");
     }
 
     private static boolean isServerReady(String host, int port) {

--- a/test-end-to-end/distribution/DistributionE2EConstants.java
+++ b/test-end-to-end/distribution/DistributionE2EConstants.java
@@ -20,6 +20,7 @@ package grakn.core.distribution;
 
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
+import grakn.core.common.config.SystemProperty;
 import org.junit.Assert;
 import org.zeroturnaround.exec.ProcessExecutor;
 
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.concurrent.TimeoutException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,6 +60,12 @@ public class DistributionE2EConstants {
     public static void unzipGrakn() throws IOException, InterruptedException, TimeoutException {
         new ProcessExecutor()
                 .command("unzip", ZIP_FULLPATH.toString(), "-d", GRAKN_UNZIPPED_DIRECTORY.getParent().toString()).execute();
+    }
+
+    public static Path getLogsPath(){
+        Config config = Config.read(GRAKN_UNZIPPED_DIRECTORY.resolve("server").resolve("conf").resolve("grakn.properties"));
+        Path logsPath = Paths.get(config.getProperty(ConfigKey.LOG_DIR));
+        return logsPath.isAbsolute() ? logsPath : GRAKN_UNZIPPED_DIRECTORY.resolve(logsPath);
     }
 
     private static boolean isServerReady(String host, int port) {

--- a/test-end-to-end/distribution/GraknGraqlCommands_WithARunningGraknE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommands_WithARunningGraknE2E.java
@@ -27,6 +27,8 @@ import org.zeroturnaround.exec.ProcessExecutor;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
@@ -34,6 +36,7 @@ import static grakn.core.distribution.DistributionE2EConstants.GRAKN_UNZIPPED_DI
 import static grakn.core.distribution.DistributionE2EConstants.assertGraknIsNotRunning;
 import static grakn.core.distribution.DistributionE2EConstants.assertGraknIsRunning;
 import static grakn.core.distribution.DistributionE2EConstants.assertZipExists;
+import static grakn.core.distribution.DistributionE2EConstants.getLogsPath;
 import static grakn.core.distribution.DistributionE2EConstants.unzipGrakn;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -103,5 +106,16 @@ public class GraknGraqlCommands_WithARunningGraknE2E {
     public void grakn_testPrintStatus_whenCurrentlyRunning() throws IOException, InterruptedException, TimeoutException {
         String output = commandExecutor.command("./grakn", "server", "status").execute().outputUTF8();
         assertThat(output, allOf(containsString("Storage: RUNNING"), containsString("Grakn Core Server: RUNNING")));
+    }
+
+    /**
+     * make sure Grakn is properly writing logs inside grakn.log file
+     */
+    @Test
+    public void logMessagesArePrintedInLogFile() throws IOException {
+        Path logsPath = getLogsPath();
+        Path graknLogFilePath = logsPath.resolve("grakn.log");
+        String logsString = new String(Files.readAllBytes(graknLogFilePath), StandardCharsets.UTF_8);
+        assertThat(logsString, containsString("Grakn started"));
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Fix logging bug introduced with recent restructuring of `conf` folders.
Grakn stopped logging messages to the `grakn.log` file, with this PR we update the `classPath` provided to the `Grakn.class` to start Grakn Server.

## What are the changes implemented in this PR?

- update paths
- added test to verify that Grakn is actually logging
