### PR TITLE
 Fix `test-assembly-mac-zip` and `test-assembly-windows-zip` CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ commands:
     steps:
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-mac.sh
       - run: bash ./install-bazel-mac.sh && rm ./install-bazel-mac.sh
+      - run: brew cask install homebrew/cask-versions/adoptopenjdk8
 
   install-rpm:
     steps:
@@ -124,7 +125,7 @@ jobs:
 
   test-assembly-mac-zip:
     macos:
-      xcode: "9.0"
+      xcode: "10.2.1"
     working_directory: ~/grakn
     steps:
       - install-bazel-mac
@@ -437,7 +438,7 @@ workflows:
       - test-assembly-mac-zip:
           filters:
             branches:
-              only: master
+              only: fix-ci # TODO(vmax): reset back to master
           requires:
             - build
             - test-common
@@ -450,7 +451,7 @@ workflows:
       - test-assembly-windows-zip:
           filters:
             branches:
-              only: master
+              only: fix-ci # TODO(vmax): reset back to master
           requires:
             - build
             - test-common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,7 +438,7 @@ workflows:
       - test-assembly-mac-zip:
           filters:
             branches:
-              only: fix-ci # TODO(vmax): reset back to master
+              only: master
           requires:
             - build
             - test-common
@@ -451,7 +451,7 @@ workflows:
       - test-assembly-windows-zip:
           filters:
             branches:
-              only: fix-ci # TODO(vmax): reset back to master
+              only: master
           requires:
             - build
             - test-common

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,6 @@ commands:
     steps:
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-mac.sh
       - run: bash ./install-bazel-mac.sh && rm ./install-bazel-mac.sh
-      - run: brew cask install homebrew/cask-versions/adoptopenjdk8
 
   install-rpm:
     steps:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "07b926e538dfcf25dc820c4d95db0995a0e67ff1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "1f5e567c803c865be59d8cf39c519ce7001de613", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_graql():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "1f5e567c803c865be59d8cf39c519ce7001de613", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "b5014777d50d35ef39ebf1aafe53d3d4254d2b63", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_graql():


### PR DESCRIPTION
## What is the goal of this PR?

- Fix `test-assembly-mac-zip` which was broken because of upgrading `bazel` to latest version in #5211

- Fix `test-assembly-windows-zip` which was broken by a recent introduction of custom java toolchain in #5208

This pull request addresses both of these problems which enables us to continue testing Grakn Core on Mac and Windows platforms.

## What are the changes implemented in this PR?

* `test-assembly-mac-zip`: upgrading XCode to latest version and explicitly installing JDK8 (bazelbuild/bazel#7304): resolved in graknlabs/build-tools#54
* `test-assembly-windows-zip`'s failure is resolved in graknlabs/build-tools#53, upgraded link to latest `@graknlabs_build_tools` manually.