### PR TITLE
Split version command

### DIFF
--- a/console/GraknConsole.java
+++ b/console/GraknConsole.java
@@ -55,7 +55,6 @@ public class GraknConsole {
     private static final String URI = "r";
     private static final String NO_INFER = "n";
     private static final String HELP = "h";
-    private static final String VERSION = "v";
 
     private final Options options = getOptions();
     private final CommandLine commandLine;
@@ -87,7 +86,6 @@ public class GraknConsole {
         options.addOption(URI, "address", true, "Grakn Server address");
         options.addOption(NO_INFER, "no_infer", false, "do not perform inference on results");
         options.addOption(HELP, "help", false, "print usage message");
-        options.addOption(VERSION, "version", false, "print version");
 
         return options;
     }
@@ -96,10 +94,6 @@ public class GraknConsole {
         // Print usage guidelines for Grakn Console
         if (commandLine.hasOption(HELP) || !commandLine.getArgList().isEmpty()) {
             printHelp(printOut);
-        }
-        // Print Grakn Console version
-        else if (commandLine.hasOption(VERSION)) {
-            printOut.println(GraknVersion.VERSION);
         }
         // Start a Console Session to load some Graql file(s)
         else if (commandLine.hasOption(FILE)) {
@@ -136,11 +130,16 @@ public class GraknConsole {
      * Invocation from bash script './grakn console'
      */
     public static void main(String[] args) {
+        String action = args.length > 1 ? args[1] : "";
+        if(action.equals("version")){
+            System.out.println(GraknVersion.VERSION);
+            System.exit(0);
+        }
+
         try {
             GraknConsole console = new GraknConsole(Arrays.copyOfRange(args, 1, args.length), System.out, System.err);
             console.run();
             System.exit(0);
-
         } catch (GraknConsoleException e) {
             System.err.println(e.getMessage());
             System.err.println("Cause: " + e.getCause().getClass().getName());

--- a/console/test/GraknConsoleIT.java
+++ b/console/test/GraknConsoleIT.java
@@ -116,12 +116,6 @@ public class GraknConsoleIT {
     }
 
     @Test
-    public void when_startingConsoleWithOptionVersion_expect_printVersion() {
-        String result = runConsoleSessionWithoutExpectingErrors("", "--version");
-        assertThat(result, containsString(GraknVersion.VERSION));
-    }
-
-    @Test
     public void when_writingToDefaultKeyspace_expect_successReadFromDefaultKeyspace() throws Exception {
         runConsoleSessionWithoutExpectingErrors("define im-in-the-default-keyspace sub entity;\ncommit\n");
 

--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -48,7 +48,6 @@ public class GraknDaemon {
     private static final String VERSION_LABEL = "Version: ";
 
 
-
     private final Storage storageExecutor;
     private final Server serverExecutor;
 
@@ -62,10 +61,7 @@ public class GraknDaemon {
         try {
             Path graknHome = Paths.get(Objects.requireNonNull(SystemProperty.CURRENT_DIRECTORY.value()));
             Path graknProperties = Paths.get(Objects.requireNonNull(SystemProperty.CONFIGURATION_FILE.value()));
-
             assertEnvironment(graknHome, graknProperties);
-
-            printGraknLogo();
 
             Executor bootupProcessExecutor = new Executor();
             GraknDaemon daemon = new GraknDaemon(
@@ -132,35 +128,26 @@ public class GraknDaemon {
      *             option may be eg., `--benchmark`
      */
     public void run(String[] args) {
-        String context = args.length > 0 ? args[0] : "";
         String action = args.length > 1 ? args[1] : "";
         String option = args.length > 2 ? args[2] : "";
-
-        switch (context) {
-            case "server":
-                server(action, option);
-                break;
-            case "version":
-                version();
-                break;
-            default:
-                help();
-        }
-    }
-
-    private void server(String action, String option) {
         switch (action) {
             case "start":
+                printGraknLogo();
                 serverStart(option);
                 break;
             case "stop":
+                printGraknLogo();
                 serverStop(option);
                 break;
             case "status":
+                printGraknLogo();
                 serverStatus();
                 break;
             case "clean":
                 clean();
+                break;
+            case "version":
+                version();
                 break;
             default:
                 serverHelp();

--- a/test-end-to-end/distribution/GraknGraqlCommands_WithARunningGraknE2E.java
+++ b/test-end-to-end/distribution/GraknGraqlCommands_WithARunningGraknE2E.java
@@ -18,7 +18,9 @@
 
 package grakn.core.distribution;
 
+import grakn.core.common.util.GraknVersion;
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -117,5 +119,17 @@ public class GraknGraqlCommands_WithARunningGraknE2E {
         Path graknLogFilePath = logsPath.resolve("grakn.log");
         String logsString = new String(Files.readAllBytes(graknLogFilePath), StandardCharsets.UTF_8);
         assertThat(logsString, containsString("Grakn started"));
+    }
+
+    @Test
+    public void graknServerVersion_shouldPrintCurrentVersion() throws InterruptedException, TimeoutException, IOException {
+        String output = commandExecutor.command("./grakn", "server", "version").execute().outputUTF8();
+        assertThat(output, containsString(GraknVersion.VERSION));
+    }
+
+    @Test
+    public void graknConsoleVersion_shouldPrintCurrentVersion() throws InterruptedException, TimeoutException, IOException {
+        String output = commandExecutor.command("./grakn", "console", "version").execute().outputUTF8();
+        assertThat(output, containsString(GraknVersion.VERSION));
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Remove ambiguous `grakn version` command and instead create specific version commands:

- `grakn server version`
- `grakn console version` 

![image](https://user-images.githubusercontent.com/6430514/58333122-0b590900-7e3d-11e9-97a3-951294cc7f5e.png)


## What are the changes implemented in this PR?

- removed `--version` option from console, use `grakn console version` instead
- removed `context` variable in `GraknDaemon` as the class will only be invoked with `grakn server *`
- moved call to `printGraknLogo()` inside `start`, `stop` and `status` commands, so we don't end up printing the grakn logo which contains the version right before printing the version 

Closes https://github.com/graknlabs/grakn/issues/5214
