### PR TITLE
Persist inferred concepts if we explicitly ask to do so

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -303,7 +303,8 @@ public class QueryExecutor {
 
             Stream<ConceptMap> answers = transaction.stream(match.get(projectedVars), infer);
             answerStream = answers
-                    .map(answer -> WriteExecutor.create(transaction, executors.build()).write(answer));
+                    .map(answer -> WriteExecutor.create(transaction, executors.build()).write(answer))
+                    .collect(toList()).stream();
         } else {
             answerStream = Stream.of(WriteExecutor.create(transaction, executors.build()).write(new ConceptMap()));
         }

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -168,7 +168,7 @@ public class QueryExecutor {
         }
     }
 
-    public void validateVarVarComparisons(Disjunction<Conjunction<Pattern>> negationDNF) {
+    private void validateVarVarComparisons(Disjunction<Conjunction<Pattern>> negationDNF) {
         // comparisons between two variables (ValueProperty and NotEqual, similar to !== and !=)
         // must only use variables that are also used outside of comparisons
 
@@ -296,15 +296,14 @@ public class QueryExecutor {
         if (query.match() != null) {
             MatchClause match = query.match();
             Set<Variable> matchVars = match.getSelectedNames();
-            Set<Variable> insertVars = statements.stream().map(statement -> statement.var()).collect(ImmutableSet.toImmutableSet());
+            Set<Variable> insertVars = statements.stream().map(Statement::var).collect(ImmutableSet.toImmutableSet());
 
             LinkedHashSet<Variable> projectedVars = new LinkedHashSet<>(matchVars);
             projectedVars.retainAll(insertVars);
 
             Stream<ConceptMap> answers = transaction.stream(match.get(projectedVars), infer);
-            answerStream = answers.map(answer -> WriteExecutor
-                    .create(transaction, executors.build()).write(answer))
-                    .collect(toList()).stream();
+            answerStream = answers
+                    .map(answer -> WriteExecutor.create(transaction, executors.build()).write(answer));
         } else {
             answerStream = Stream.of(WriteExecutor.create(transaction, executors.build()).write(new ConceptMap()));
         }

--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Sets;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.thing.Thing;
 import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.property.PropertyExecutor.Writer;
 import grakn.core.graql.util.Partition;
@@ -264,6 +265,14 @@ public class WriteExecutor {
         }
 
         Map<Variable, Concept> namedConcepts = Maps.filterKeys(allConcepts.build(), Variable::isReturned);
+
+        //mark inferred concepts for persistence explicitly
+        namedConcepts.values().stream()
+                .filter(Concept::isThing)
+                .map(Concept::asThing)
+                .filter(Thing::isInferred)
+                .forEach(t -> transaction.cache().inferredThingToPersist(t));
+
         return new ConceptMap(namedConcepts);
     }
 

--- a/server/src/graql/executor/property/IsaExecutor.java
+++ b/server/src/graql/executor/property/IsaExecutor.java
@@ -129,8 +129,7 @@ public class IsaExecutor implements PropertyExecutor.Insertable {
                     // however, non-attribute still throw exceptions
                     throw GraqlSemanticException.insertExistingConcept(executor.printableRepresentation(var), concept);
                 } else if ((type instanceof AttributeType)) {
-                    //
-                    if (! type.subs().map(SchemaConcept::label).collect(Collectors.toSet()).contains(concept.asThing().type().label())) {
+                    if (type.subs().map(SchemaConcept::label).noneMatch(label -> label.equals(concept.asThing().type().label()))) {
                         //downcasting is bad
                         throw GraqlSemanticException.attributeDowncast(concept.asThing().type(), type);
                     }

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -66,6 +66,8 @@ import static java.util.stream.Collectors.toSet;
  */
 public abstract class ThingImpl<T extends Thing, V extends Type> extends ConceptImpl implements Thing {
 
+    private Boolean isInferred = null;
+
     private final Cache<V> cachedType = new Cache<>(() -> {
         Optional<V> type = vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ISA).
                 map(EdgeElement::target).
@@ -97,7 +99,11 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
     }
 
     public boolean isInferred() {
-        return vertex().propertyBoolean(Schema.VertexProperty.IS_INFERRED);
+        //NB: might be over the top to cache it
+        if (isInferred == null) {
+            isInferred = vertex().propertyBoolean(Schema.VertexProperty.IS_INFERRED);
+        }
+        return isInferred;
     }
 
     /**

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -69,21 +69,6 @@ import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlUndefine;
 import graql.lang.query.MatchClause;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
-import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.janusgraph.core.JanusGraph;
-import org.janusgraph.core.JanusGraphElement;
-import org.janusgraph.core.JanusGraphException;
-import org.janusgraph.diskstorage.locking.PermanentLockingException;
-import org.janusgraph.diskstorage.locking.TemporaryLockingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -98,6 +83,20 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.verification.ReadOnlyStrategy;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.janusgraph.core.JanusGraph;
+import org.janusgraph.core.JanusGraphElement;
+import org.janusgraph.core.JanusGraphException;
+import org.janusgraph.diskstorage.locking.PermanentLockingException;
+import org.janusgraph.diskstorage.locking.TemporaryLockingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A TransactionOLTP using JanusGraph as a vendor backend.
@@ -936,9 +935,9 @@ public class TransactionOLTP implements Transaction {
     }
 
     private void removeInferredConcepts(){
-        Set<Thing> inferredThings = cache().getInferredConcepts().collect(Collectors.toSet());
-        inferredThings.forEach(inferred -> cache().remove(inferred));
-        inferredThings.forEach(Concept::delete);
+        Set<Thing> inferredThingsToDiscard = cache().getInferredThingsToDiscard().collect(Collectors.toSet());
+        inferredThingsToDiscard.forEach(inferred -> cache().remove(inferred));
+        inferredThingsToDiscard.forEach(Concept::delete);
     }
 
     private void validateGraph() throws InvalidKBException {

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -35,7 +35,6 @@ import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.server.kb.concept.AttributeImpl;
 import grakn.core.server.kb.structure.Casting;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -69,6 +68,7 @@ public class TransactionCache {
     private final Set<RelationType> modifiedRelationTypes = new HashSet<>();
 
     private final Set<Rule> modifiedRules = new HashSet<>();
+    private final Set<Thing> inferredConceptsToPersist = new HashSet<>();
 
     //We Track the number of concept connections which have been made which may result in a new shard
     private final Map<ConceptId, Long> shardingCount = new HashMap<>();
@@ -230,14 +230,17 @@ public class TransactionCache {
         return (X) conceptCache.get(id);
     }
 
+    public void inferredThingToPersist(Thing t){ inferredConceptsToPersist.add(t); }
+
     /**
      * @return cached things that are inferred
      */
-    public Stream<Thing> getInferredConcepts(){
+    public Stream<Thing> getInferredThingsToDiscard(){
         return conceptCache.values().stream()
                 .filter(Concept::isThing)
                 .map(Concept::asThing)
-                .filter(Thing::isInferred);
+                .filter(Thing::isInferred)
+                .filter(t -> !inferredConceptsToPersist.contains(t));
     }
 
     /**

--- a/test-integration/server/kb/BUILD
+++ b/test-integration/server/kb/BUILD
@@ -7,14 +7,12 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.server.kb.ValidatorIT",
     deps = [
-        "//common:common",
-        "//concept:concept",
-        "//server:server",
-        "//test-integration/rule:grakn-test-server",
-
-        "@graknlabs_graql//java:graql",
-
+        "//common",
+        "//concept",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//server",
+        "//test-integration/rule:grakn-test-server",
+        "@graknlabs_graql//java:graql",
     ],
 )
 
@@ -25,8 +23,8 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.server.kb.ValidateGlobalRulesIT",
     deps = [
-        "//concept:concept",
-        "//server:server",
+        "//concept",
+        "//server",
         "//test-integration/rule:grakn-test-server",
     ],
 )
@@ -38,13 +36,13 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.server.kb.TransactionIT",
     deps = [
-        "//common:common",
-        "//concept:concept",
-        "//server:server",
-        "//test-integration/rule:grakn-test-server",
-
+        "//common",
+        "//concept",
         "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//server",
+        "//test-integration/rule:grakn-test-server",
+        "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
     ],
 )
@@ -56,15 +54,13 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.server.kb.RuleIT",
     deps = [
-        "//common:common",
-        "//concept:concept",
-        "//server:server",
-
-        "@graknlabs_graql//java:graql",
-
+        "//common",
+        "//concept",
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//server",
         "//test-integration/rule:grakn-test-server",
+        "@graknlabs_graql//java:graql",
     ],
 )
 


### PR DESCRIPTION
## What is the goal of this PR?
Previously we defined the commit behaviour of inferred concepts for MATCH queries (#5142). Now we define a commit behaviour for INSERT queries:

Inferred concepts will be persisted provided they occur in an explicitly executed insert (or insert-match) query.

## What are the changes implemented in this PR?

- on write we mark inferred concepts for persistence
- based on those concepts and all tracked inferred concepts, we only discard those not marked for persistence