### PR TITLE
Synchronized method in findUnsusedLocalPort in TestServer

### DIFF
--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -180,7 +180,7 @@ public class GraknTestServer extends ExternalResource {
         return copyName.toFile();
     }
 
-    protected static int findUnusedLocalPort() throws IOException {
+    protected synchronized static int findUnusedLocalPort() throws IOException {
         try (ServerSocket serverSocket = new ServerSocket(0)) {
             return serverSocket.getLocalPort();
         }


### PR DESCRIPTION
## What is the goal of this PR?

Synchronise method that provides random unused ports to `GraknTestServer`,
this is we currently have concurrent tests that might fail due to receiving both the same port and therefore trying to bind to the same port.

## What are the changes implemented in this PR?

 - add `synchronize` to static method `findUnusedPort()` in `GraknTestServer`
