### PR TITLE
Optimise atom materialise

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -350,6 +350,12 @@ public abstract class Atom extends AtomicBase {
      */
     public Atom addType(SchemaConcept type) { return this;}
 
+    /**
+     * Materialises the atom - does an insert of the corresponding pattern.
+     * Exhibits PUT behaviour - if things are already present, nothing is inserted.
+     *
+     * @return materialised answer to this atom
+     */
     public Stream<ConceptMap> materialise() { return Stream.empty();}
 
     /**

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -333,6 +333,12 @@ public abstract class AttributeAtom extends Binary{
         return Stream.concat(super.getInnerPredicates(), getMultiPredicate().stream());
     }
 
+    /**
+     * exhibits put behaviour - attributed is attached only if the link doesn't exist already
+     * @param owner attribute owner
+     * @param attribute attribute itself
+     * @return implicit relation of the attribute
+     */
     private Relation attachAttribute(Concept owner, Attribute attribute){
         //check if link exists
         if (owner.asThing().attributes(attribute.type()).noneMatch(a -> a.equals(attribute))) {

--- a/server/src/graql/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/reasoner/atom/binary/IsaAtom.java
@@ -44,8 +44,6 @@ import graql.lang.property.IsaProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -53,6 +51,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * TypeAtom corresponding to graql a IsaProperty property.
@@ -211,10 +210,15 @@ public abstract class IsaAtom extends IsaAtomBase {
 
     @Override
     public Stream<ConceptMap> materialise(){
+        ConceptMap substitution = getParentQuery().getSubstitution();
         EntityType entityType = getSchemaConcept().asEntityType();
-        return Stream.of(ConceptUtils.mergeAnswers(
-                getParentQuery().getSubstitution(),
-                new ConceptMap(ImmutableMap.of(getVarName(), EntityTypeImpl.from(entityType).addEntityInferred()))
+
+        Concept foundConcept = substitution.get(getVarName());
+        if (foundConcept != null) return Stream.of(substitution);
+
+        Concept concept = EntityTypeImpl.from(entityType).addEntityInferred();
+        return Stream.of(
+                ConceptUtils.mergeAnswers(substitution, new ConceptMap(ImmutableMap.of(getVarName(), concept))
         ));
     }
 

--- a/server/src/graql/reasoner/atom/binary/IsaAtom.java
+++ b/server/src/graql/reasoner/atom/binary/IsaAtom.java
@@ -213,7 +213,7 @@ public abstract class IsaAtom extends IsaAtomBase {
         ConceptMap substitution = getParentQuery().getSubstitution();
         EntityType entityType = getSchemaConcept().asEntityType();
 
-        Concept foundConcept = substitution.get(getVarName());
+        Concept foundConcept = substitution.containsVar(getVarName())? substitution.get(getVarName()) : null;
         if (foundConcept != null) return Stream.of(substitution);
 
         Concept concept = EntityTypeImpl.from(entityType).addEntityInferred();

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1003,7 +1003,6 @@ public abstract class RelationAtom extends IsaAtomBase {
         //if the relation already exists, only assign roleplayers, otherwise create a new relation
         Relation relation;
         if (substitution.containsVar(getVarName())){
-            RelationTypeImpl.from(relationType).addRelationInferred();
             relation = substitution.get(getVarName()).asRelation();
         } else {
             Relation foundRelation = findRelation(substitution);

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -50,6 +50,8 @@ import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.cache.VariableDefinition;
+import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
+import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueryEquivalence;
 import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
@@ -74,8 +76,6 @@ import graql.lang.statement.Statement;
 import graql.lang.statement.StatementInstance;
 import graql.lang.statement.StatementThing;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -90,6 +90,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 import static grakn.core.server.kb.concept.ConceptUtils.bottom;
 import static grakn.core.server.kb.concept.ConceptUtils.top;
@@ -984,18 +985,32 @@ public abstract class RelationAtom extends IsaAtomBase {
         return baseDiff.merge(new SemanticDifference(diff));
     }
 
+    private Relation findRelation(ConceptMap sub){
+        ReasonerAtomicQuery query = ReasonerQueries.atomic(this).withSubstitution(sub);
+        ConceptMap answer = tx().queryCache().getAnswerStream(query).findFirst().orElse(null);
+
+        if (answer == null) tx().queryCache().ackDBCompleteness(query);
+        return answer != null? answer.get(getVarName()).asRelation() : null;
+    }
+
     @Override
     public Stream<ConceptMap> materialise(){
         RelationType relationType = getSchemaConcept().asRelationType();
         Multimap<Role, Variable> roleVarMap = getRoleVarMap();
         ConceptMap substitution = getParentQuery().getSubstitution();
 
-        //NB: if the relation is implicit, it will created as a reified relation
-
+        //NB: if the relation is implicit, it will be created as a reified relation
         //if the relation already exists, only assign roleplayers, otherwise create a new relation
-        Relation relation = substitution.containsVar(getVarName())?
-                substitution.get(getVarName()).asRelation() :
-                RelationTypeImpl.from(relationType).addRelationInferred();
+        Relation relation;
+        if (substitution.containsVar(getVarName())){
+            RelationTypeImpl.from(relationType).addRelationInferred();
+            relation = substitution.get(getVarName()).asRelation();
+        } else {
+            Relation foundRelation = findRelation(substitution);
+            relation = foundRelation != null?
+                    foundRelation :
+                    RelationTypeImpl.from(relationType).addRelationInferred();
+        }
 
         roleVarMap.asMap()
                 .forEach((key, value) -> value.forEach(var -> relation.assign(key, substitution.get(var).asThing())));

--- a/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
+++ b/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
@@ -84,7 +84,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
     @Override
     protected boolean propagateAnswers(CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> parentEntry,
                                     CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> childEntry,
-                                    boolean inferred) {
+                                    boolean propagateInferred) {
         ReasonerAtomicQuery parent = parentEntry.query();
         ReasonerAtomicQuery child = childEntry.query();
         IndexedAnswerSet parentAnswers = parentEntry.cachedElement();
@@ -105,7 +105,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
         Set<ConceptMap> newAnswers = new HashSet<>();
 
         parentAnswers.getAll().stream()
-                .filter(ans -> inferred || ans.explanation().isLookupExplanation())
+                .filter(ans -> propagateInferred || ans.explanation().isLookupExplanation())
                 .flatMap(ans -> parentToChildUnifierDelta.stream()
                                 .map(unifierDelta -> unifierDelta.getValue()
                                         .applyToAnswer(ans, partialSub, childVars, unifierDelta.getKey()))

--- a/server/src/graql/reasoner/cache/QueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/QueryCacheBase.java
@@ -103,15 +103,6 @@ public abstract class QueryCacheBase<
     }
 
     /**
-     * find specific answer to a query in the cache
-     *
-     * @param query input query
-     * @param ans   sought specific answer to the query
-     * @return found answer if any, otherwise empty answer
-     */
-    public abstract ConceptMap findAnswer(Q query, ConceptMap ans);
-
-    /**
      * @param query for which the entry is to be retrieved
      * @return corresponding cache entry if any or null
      */

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -323,15 +323,4 @@ public abstract class SemanticCache<
                 answerStreamWithUnifier.getValue()
         );
     }
-
-    @Override
-    public ConceptMap findAnswer(ReasonerAtomicQuery query, ConceptMap ans) {
-        if(ans.isEmpty()) return ans;
-        ConceptMap answer = getAnswerStreamWithUnifier(ReasonerQueries.atomic(query, ans)).getKey().findFirst().orElse(null);
-        if (answer != null) return answer;
-
-        //TODO should it create a cache entry?
-        List<ConceptMap> answers = query.tx().execute(ReasonerQueries.create(query, ans).getQuery(), false);
-        return answers.isEmpty()? new ConceptMap() : answers.iterator().next();
-    }
 }

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -23,20 +23,17 @@ import com.google.common.collect.Sets;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.SchemaConcept;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
-import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.graql.reasoner.utils.Pair;
 import graql.lang.statement.Variable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -190,7 +187,7 @@ public abstract class SemanticCache<
      * @param childMatch entry to which we want to propagate answers
      * @param inferred true if inferred answers should be propagated
      */
-    private boolean propagateAnswersToQuery(ReasonerAtomicQuery target, CacheEntry<ReasonerAtomicQuery, SE> childMatch, boolean inferred){
+    private boolean propagateAnswersToQuery(ReasonerAtomicQuery target, CacheEntry<ReasonerAtomicQuery, SE> childMatch, boolean fetchInferred){
         ReasonerAtomicQuery child = childMatch.query();
         boolean[] newAnswersFound = {false};
         boolean childGround = child.isGround();
@@ -200,7 +197,9 @@ public abstract class SemanticCache<
                     if (parentDbComplete || childGround){
                         boolean parentComplete = isComplete(keyToQuery(parent));
                         CacheEntry<ReasonerAtomicQuery, SE> parentMatch = getEntry(keyToQuery(parent));
-                        boolean newAnswers = propagateAnswers(parentMatch, childMatch, inferred || parentComplete);
+
+                        boolean propagateInferred = fetchInferred || parentComplete || child.getAtom().getVarName().isReturned();
+                        boolean newAnswers = propagateAnswers(parentMatch, childMatch, propagateInferred);
                         newAnswersFound[0] = newAnswers;
                         if (parentDbComplete || newAnswers) ackDBCompleteness(target);
                         if (parentComplete) ackCompleteness(target);

--- a/server/src/graql/reasoner/cache/SimpleQueryCache.java
+++ b/server/src/graql/reasoner/cache/SimpleQueryCache.java
@@ -142,25 +142,4 @@ public class SimpleQueryCache<Q extends ReasonerQueryImpl> extends SimpleQueryCa
                 new MultiUnifierImpl()
         );
     }
-
-    @Override
-    public ConceptMap findAnswer(Q query, ConceptMap ans) {
-        if (ans.isEmpty()) return ans;
-        CacheEntry<Q, Set<ConceptMap>> match = this.getEntry(query);
-        if (match != null) {
-            Q equivalentQuery = match.query();
-            MultiUnifier multiUnifier = equivalentQuery.getMultiUnifier(query, unifierType());
-
-            //NB: only used when checking for materialised answer duplicates
-            ConceptMap answer = match.cachedElement().stream()
-                    .flatMap(multiUnifier::apply)
-                    .filter(a -> a.containsAll(ans))
-                    .findFirst().orElse(null);
-            if (answer != null) return answer;
-        }
-
-        //TODO should it create a cache entry?
-        List<ConceptMap> answers = query.tx().execute(ReasonerQueries.create(query, ans).getQuery(), false);
-        return answers.isEmpty() ? new ConceptMap() : answers.iterator().next();
-    }
 }

--- a/test-end-to-end/client-java/ClientJavaE2E.java
+++ b/test-end-to-end/client-java/ClientJavaE2E.java
@@ -124,20 +124,21 @@ public class ClientJavaE2E {
                     type("parentship").sub("relation").relates("parent").relates("child"),
 
                     type("name").sub("attribute").datatype(Graql.Token.DataType.STRING),
-                    type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring"),
-
-                    type("infer-parentship-from-mating-and-child-bearing").sub("rule")
-                            .when(and(
-                                    var().rel("male-partner", var("male")).rel("female-partner", var("female")).isa("mating"),
-                                    var("childbearing").rel("child-bearer").rel("offspring", var("offspring")).isa("child-bearing")
-                            ))
-                            .then(and(
-                                    var().rel("parent", var("male")).rel("parent", var("female")).rel("child", var("offspring")).isa("parentship")
-                            ))
+                    type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring")
             );
+
+            GraqlDefine ruleQuery = Graql.define(type("infer-parentship-from-mating-and-child-bearing").sub("rule")
+                    .when(and(
+                            var().rel("male-partner", var("male")).rel("female-partner", var("female")).isa("mating"),
+                            var("childbearing").rel("child-bearer").rel("offspring", var("offspring")).isa("child-bearing")
+                    ))
+                    .then(and(
+                            var().rel("parent", var("male")).rel("parent", var("female")).rel("child", var("offspring")).isa("parentship")
+                    )));
             LOG.info("clientJavaE2E() - define a schema...");
             LOG.info("clientJavaE2E() - '" + defineQuery + "'");
             List<ConceptMap> answer = tx.execute(defineQuery);
+            List<ConceptMap> rule = tx.execute(ruleQuery);
             tx.commit();
             LOG.info("clientJavaE2E() - done.");
         });
@@ -227,7 +228,7 @@ public class ClientJavaE2E {
                             .rel("child", var("child"))).get();
             LOG.info("clientJavaE2E() - '" + getParentship + "'");
             List<ConceptMap> parentship = tx.execute(getParentship);
-            assertThat(parentship, hasSize(2));
+            assertThat(parentship, hasSize(1));
             LOG.info("clientJavaE2E() - done.");
         });
 


### PR DESCRIPTION
## What is the goal of this PR?
Simplifies and optimises the materialisation process for cases when it is required:
- attributes in rule heads
- relations with relation variable specifed as to be returned
- types in rule heads.

## What are the changes implemented in this PR?

- removed redundant db checks in `AtomicState` that were placed to ensure we won't create duplicates
- `Atom::materialise` now has PUT behaviour - we check for existence before inserting, if exists we do not insert anything
- removed now redundant `findAnswer` method in query cache implementations
- we track already materialised answers in `AtomicState` so that we do not recheck

