### PR TITLE
Expose Grakn/Cassandra logs as CI build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,12 @@ jobs:
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
       - run: bazel-genfiles/grakn-core-all-mac/grakn server stop
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-mac.zip --save-success
+      - store_artifacts:
+          path: bazel-genfiles/grakn-core-all-mac/logs/grakn.log
+          destination: logs
+      - store_artifacts:
+          path: bazel-genfiles/grakn-core-all-mac/logs/cassandra.log
+          destination: logs
 
   test-assembly-windows-zip:
     machine: true
@@ -146,6 +152,12 @@ jobs:
       - run:
           command: test/assembly/windows/windows-zip.py
           no_output_timeout: 20m
+      - store_artifacts:
+          path: ./grakn.log
+          destination: logs
+      - store_artifacts:
+          path: ./cassandra.log
+          destination: logs
 
   test-assembly-linux-targz:
     machine: true
@@ -161,6 +173,12 @@ jobs:
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
       - run: bazel-genfiles/grakn-core-all-linux/grakn server stop
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-linux.tar.gz --save-success
+      - store_artifacts:
+          path: bazel-genfiles/grakn-core-all-linux/logs/grakn.log
+          destination: logs
+      - store_artifacts:
+          path: bazel-genfiles/grakn-core-all-linux/logs/cassandra.log
+          destination: logs
 
   test-assembly-linux-apt:
     machine: true
@@ -181,6 +199,12 @@ jobs:
       - run: nohup grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
       - run: grakn server stop
+      - store_artifacts:
+          path: /opt/grakn/core/logs/grakn.log
+          destination: logs
+      - store_artifacts:
+          path: /opt/grakn/core/logs/cassandra.log
+          destination: logs
 
   test-assembly-docker:
     machine: true
@@ -189,6 +213,12 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: test/assembly/docker.py
+      - store_artifacts:
+          path: ./grakn.log
+          destination: logs
+      - store_artifacts:
+          path: ./cassandra.log
+          destination: logs
 
   deploy-maven-snapshot:
     machine: true
@@ -265,6 +295,12 @@ jobs:
       - run: nohup grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
       - run: grakn server stop
+      - store_artifacts:
+          path: /opt/grakn/core/logs/grakn.log
+          destination: logs
+      - store_artifacts:
+          path: /opt/grakn/core/logs/cassandra.log
+          destination: logs
 
   test-deployment-linux-rpm:
     machine: true
@@ -275,6 +311,12 @@ jobs:
           at: ~/circleci-workspace
       - run: mv ~/circleci-workspace/VERSION.rpm VERSION
       - run: test/deployment/rpm.py
+      - store_artifacts:
+          path: ./grakn.log
+          destination: logs
+      - store_artifacts:
+          path: ./cassandra.log
+          destination: logs
 
   sync-dependencies-snapshot:
     machine: true

--- a/test/assembly/docker.py
+++ b/test/assembly/docker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import subprocess as sp
 import sys
 import time
@@ -8,7 +9,7 @@ print('Building the image...')
 sp.check_call(['bazel', 'run', '//:assemble-docker'])
 
 print('Starting the image...')
-sp.check_call(['docker', 'run', '--name', 'grakn','-d', '--rm', '-ti', '-p', '127.0.0.1:48555:48555/tcp', 'bazel:assemble-docker'])
+sp.check_call(['docker', 'run', '-v', '{}:/grakn-core-all-linux/logs/'.format(os.getcwd()), '--name', 'grakn','-d', '--rm', '-ti', '-p', '127.0.0.1:48555:48555/tcp', 'bazel:assemble-docker'])
 print('Docker status:')
 sp.check_call(['docker', 'ps'])
 

--- a/test/assembly/windows/windows-zip.py
+++ b/test/assembly/windows/windows-zip.py
@@ -187,6 +187,13 @@ try:
     lprint('[Remote]: test finished successfully!')
 
 finally:
+    lprint('Copying logs from remote instance')
+    scp('/Users/circleci/repo/bazel-genfiles/"a directory with whitespace"/grakn-core-all-windows/logs/grakn.log',
+        'grakn.log',
+        instance_ip, 'circleci', instance_password)
+    scp('/Users/circleci/repo/bazel-genfiles/"a directory with whitespace"/grakn-core-all-windows/logs/cassandra.log',
+        'cassandra.log',
+        instance_ip, 'circleci', instance_password)
     lprint('Remove instance')
     sp.check_call([
         'gcloud', '--quiet', 'compute', 'instances',

--- a/test/deployment/rpm.py
+++ b/test/deployment/rpm.py
@@ -52,6 +52,18 @@ def gcloud_scp(instance, local, remote):
     ])
 
 
+def gcloud_scp_from_remote(instance, remote, local):
+    sp.call([
+        'gcloud',
+        'compute',
+        'scp',
+        instance + ':' + remote,
+        local,
+        '--zone=europe-west1-b',
+        '--project=grakn-dev'
+    ])
+
+
 def gcloud_instances_delete(instance):
     sp.check_call([
         'gcloud',
@@ -105,5 +117,8 @@ try:
     gcloud_ssh(instance, 'grakn server start')
     gcloud_ssh(instance, 'grakn server stop')
 finally:
+    lprint('Copying logs from CentOS instance')
+    gcloud_scp_from_remote(instance, remote='/opt/grakn/core/logs/grakn.log', local='./grakn.log')
+    gcloud_scp_from_remote(instance, remote='/opt/grakn/core/logs/cassandra.log', local='./cassandra.log')
     lprint('Deleting the CentOS instance')
     gcloud_instances_delete(instance)


### PR DESCRIPTION
## What is the goal of this PR?

Fix #5243
Previously, it was hard to debug test issues without `grakn.log` and `cassandra.log`. This PR allows to expose these log files as CircleCI Build Artifacts, simplifying the debugging.

## What are the changes implemented in this PR?

###  `grakn.log` and `cassandra.log` are exposed for following CI jobs:
* `test-assembly-mac-zip`
* `test-assembly-windows-zip`
* `test-assembly-linux-targz`
* `test-assembly-linux-apt`
* `test-assembly-docker`
* `test-deployment-linux-apt`
* `test-deployment-linux-rpm`