### PR TITLE
Fix exposing Grakn logs as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,10 @@ jobs:
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-mac.zip --save-success
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-mac/logs/grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-mac/logs/cassandra.log
-          destination: logs
+          destination: logs/
 
   test-assembly-windows-zip:
     machine: true
@@ -154,10 +154,10 @@ jobs:
           no_output_timeout: 20m
       - store_artifacts:
           path: ./grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs
+          destination: logs/
 
   test-assembly-linux-targz:
     machine: true
@@ -175,10 +175,10 @@ jobs:
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-linux.tar.gz --save-success
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-linux/logs/grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-linux/logs/cassandra.log
-          destination: logs
+          destination: logs/
 
   test-assembly-linux-apt:
     machine: true
@@ -201,10 +201,10 @@ jobs:
       - run: grakn server stop
       - store_artifacts:
           path: /opt/grakn/core/logs/grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: /opt/grakn/core/logs/cassandra.log
-          destination: logs
+          destination: logs/
 
   test-assembly-docker:
     machine: true
@@ -215,10 +215,10 @@ jobs:
       - run: test/assembly/docker.py
       - store_artifacts:
           path: ./grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs
+          destination: logs/
 
   deploy-maven-snapshot:
     machine: true
@@ -297,10 +297,10 @@ jobs:
       - run: grakn server stop
       - store_artifacts:
           path: /opt/grakn/core/logs/grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: /opt/grakn/core/logs/cassandra.log
-          destination: logs
+          destination: logs/
 
   test-deployment-linux-rpm:
     machine: true
@@ -313,10 +313,10 @@ jobs:
       - run: test/deployment/rpm.py
       - store_artifacts:
           path: ./grakn.log
-          destination: logs
+          destination: logs/
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs
+          destination: logs/
 
   sync-dependencies-snapshot:
     machine: true

--- a/test/assembly/windows/windows-zip.py
+++ b/test/assembly/windows/windows-zip.py
@@ -188,10 +188,10 @@ try:
 
 finally:
     lprint('Copying logs from remote instance')
-    scp('/Users/circleci/repo/bazel-genfiles/"a directory with whitespace"/grakn-core-all-windows/logs/grakn.log',
+    scp('/Users/circleci/repo/bazel-genfiles/a directory with whitespace/grakn-core-all-windows/logs/grakn.log',
         'grakn.log',
         instance_ip, 'circleci', instance_password)
-    scp('/Users/circleci/repo/bazel-genfiles/"a directory with whitespace"/grakn-core-all-windows/logs/cassandra.log',
+    scp('/Users/circleci/repo/bazel-genfiles/a directory with whitespace/grakn-core-all-windows/logs/cassandra.log',
         'cassandra.log',
         instance_ip, 'circleci', instance_password)
     lprint('Remove instance')


### PR DESCRIPTION
## What is the goal of this PR?

Recent PR which introduced storing logs as build artifacts (#5247) had several bugs:
- `test-assembly-windows-zip` was not able to copy log files from remote instance due to incorrectly-placed quotes
- when logs were uploaded successfully, latest one errorneously overwrited the first one since they were named the same (`logs`). 

## What are the changes implemented in this PR?

- Remove quotes from `scp` invocation in Windows assembly test
- Use `logs/` [folder] as `destination` instead of `logs` [filename]
