### PR TITLE
Fix exposing Grakn/Cassandra logs as build artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,10 @@ jobs:
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-mac.zip --save-success
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-mac/logs/grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-mac/logs/cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   test-assembly-windows-zip:
     machine: true
@@ -154,10 +154,10 @@ jobs:
           no_output_timeout: 20m
       - store_artifacts:
           path: ./grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   test-assembly-linux-targz:
     machine: true
@@ -175,10 +175,10 @@ jobs:
       - run: RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-linux.tar.gz --save-success
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-linux/logs/grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: bazel-genfiles/grakn-core-all-linux/logs/cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   test-assembly-linux-apt:
     machine: true
@@ -201,10 +201,10 @@ jobs:
       - run: grakn server stop
       - store_artifacts:
           path: /opt/grakn/core/logs/grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: /opt/grakn/core/logs/cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   test-assembly-docker:
     machine: true
@@ -215,10 +215,10 @@ jobs:
       - run: test/assembly/docker.py
       - store_artifacts:
           path: ./grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   deploy-maven-snapshot:
     machine: true
@@ -297,10 +297,10 @@ jobs:
       - run: grakn server stop
       - store_artifacts:
           path: /opt/grakn/core/logs/grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: /opt/grakn/core/logs/cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   test-deployment-linux-rpm:
     machine: true
@@ -313,10 +313,10 @@ jobs:
       - run: test/deployment/rpm.py
       - store_artifacts:
           path: ./grakn.log
-          destination: logs/
+          destination: logs/grakn.log
       - store_artifacts:
           path: ./cassandra.log
-          destination: logs/
+          destination: logs/cassandra.log
 
   sync-dependencies-snapshot:
     machine: true

--- a/test/assembly/windows/windows-zip.py
+++ b/test/assembly/windows/windows-zip.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import os
+import platform
 import subprocess as sp
 import tempfile
 import time
@@ -39,14 +40,18 @@ def ssh(command, ssh_host, ssh_user, ssh_pass, attempts=5):
 
 
 def scp(remote, local, ssh_host, ssh_user, ssh_pass):
-    sp.check_call([
+    system = platform.system()
+    sp.check_call(filter(None, [
         'sshpass',
         '-p',
         ssh_pass,
         'scp',
+        # '-T' (suppresses strict filename check) parameter
+        # is not available on scp on macOS
+        '-T' if system == 'Linux' else None,
         '{}@{}:"{}"'.format(ssh_user, ssh_host, remote),
         local,
-    ])
+    ]))
 
 
 def wait_for_ssh(ssh_host, ssh_user, ssh_pass, timeout_mins=10):


### PR DESCRIPTION
## What is the goal of this PR?

Recent PR which introduced storing logs as build artifacts (#5247) and subsequent fix of if (#5251) had several bugs:
- `test-assembly-windows-zip` was not able to copy log files from remote instance due to strict filename checking (issue to similar to one Workbase had and which was fixed in graknlabs/workbase#93)
- when logs were uploaded successfully, latest one errorneously overwrited the first one since they were named the same (`logs/`). CircleCI seems to expect _actual_ final filename you want your artifact to be placed at.

## What are the changes implemented in this PR?

- Disable strict filename checking from `scp` invocation in Windows assembly test
- Use `logs/grakn.log` and `logs/cassandra.log` as `destination` instead of `logs/` [folder]
