### PR TITLE
Ensure materialised answers are in cache when checking for answer existence

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -33,9 +33,9 @@ import grakn.core.graql.reasoner.atom.binary.OntologicalAtom;
 import grakn.core.graql.reasoner.atom.binary.RelationAtom;
 import grakn.core.graql.reasoner.atom.binary.TypeAtom;
 import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
-import grakn.core.graql.reasoner.atom.predicate.VariablePredicate;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
+import grakn.core.graql.reasoner.atom.predicate.VariablePredicate;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.cache.VariableDefinition;
 import grakn.core.graql.reasoner.rule.InferenceRule;
@@ -46,14 +46,13 @@ import grakn.core.graql.reasoner.unifier.UnifierType;
 import graql.lang.property.IsaProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 import static java.util.stream.Collectors.toSet;
 

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -217,6 +217,7 @@ public abstract class SemanticCache<
 
         assert(query.isPositive());
         validateAnswer(answer, query, query.getVarNames());
+        if (query.isGround()) ackCompleteness(query);
 
         /*
          * find SE entry

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -124,9 +124,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         ConceptMap sub = ruleHead.getSubstitution();
         if(materialised.get(rule.getRule().id()).contains(sub)) return new ConceptMap();
         materialised.put(rule.getRule().id(), sub);
-
-        ReasonerAtomicQuery subbedQuery = ReasonerQueries.atomic(query, answer);
-        boolean queryEquivalentToHead = subbedQuery.isEquivalent(ruleHead);
+        
         Set<Variable> queryVars = query.getVarNames().size() < ruleHead.getVarNames().size() ?
                 unifier.keySet() :
                 ruleHead.getVarNames();
@@ -134,9 +132,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         //materialise exhibits put behaviour - duplicates won't be created
         ConceptMap materialisedSub = ruleHead.materialise(answer).findFirst().orElse(null);
         if (materialisedSub != null) {
-            if (!queryEquivalentToHead) {
-                getQuery().tx().queryCache().record(ruleHead, materialisedSub.explain(new RuleExplanation(query.getPattern(), rule.getRule().id())));
-            }
+            getQuery().tx().queryCache().record(ruleHead, materialisedSub.explain(new RuleExplanation(query.getPattern(), rule.getRule().id())));
             answer = unifier.apply(materialisedSub.project(queryVars));
         }
 

--- a/test-integration/graql/reasoner/stubs/BUILD
+++ b/test-integration/graql/reasoner/stubs/BUILD
@@ -22,6 +22,7 @@ filegroup(
     name = "reasoning-stubs",
     srcs = [
         "appendingRPs.gql",
+        "duplicateMaterialisation.gql",
         "explanations.gql",
         "freshEntityDerivation.gql",
         "freshEntityDerivationFromRelations.gql",

--- a/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
+++ b/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
@@ -1,0 +1,44 @@
+define 
+baseEntity sub entity,
+    has index,
+    has inferredAttribute,
+    has nonInferredAttribute,
+    plays someRole,
+    plays anotherRole;
+startEntity sub baseEntity;
+bulkEntity sub baseEntity;
+
+index sub attribute, datatype long;
+nonInferredAttribute sub attribute, datatype string;
+inferredAttribute sub attribute, datatype string, plays anotherRole;
+
+inferredRelation sub relation, has inferredAttribute, relates someRole, relates anotherRole;
+
+infer-attribute sub rule,
+when {
+    $p isa baseEntity;
+    not {$p has nonInferredAttribute 'start';};},
+then {
+    $p has inferredAttribute 'inferred';};
+
+infer-relation sub rule,
+when {
+    $p isa baseEntity, has index < 5;
+    $q isa baseEntity, has index < 5, has inferredAttribute $r; $r 'inferred';},
+then {
+    (someRole: $p, anotherRole: $q) isa inferredRelation;};
+
+annotate-relation sub rule,
+when {
+    $rel (someRole: $p, anotherRole: $q) isa inferredRelation;},
+then {
+    $rel has inferredAttribute 'inferredRelation';};
+
+insert
+
+$p isa startEntity, has nonInferredAttribute 'start';
+$q isa baseEntity, has index 0;
+$w isa baseEntity, has index 1;
+$r isa baseEntity, has index 2;
+$s isa baseEntity, has index 3;
+$t isa baseEntity, has index 4;


### PR DESCRIPTION
## What is the goal of this PR?
Make sure no duplicates are created when we materialise inferences. Also: fixes benchmark.

## What are the changes implemented in this PR?
After materialising, we explicitly add an entry to the cache containing the materialised query and materialised Answer.
