### PR TITLE
Make sure we do not discard rules if negation block contains types without instances

### DIFF
--- a/test-integration/graql/reasoner/query/NegationIT.java
+++ b/test-integration/graql/reasoner/query/NegationIT.java
@@ -56,6 +56,7 @@ import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 
 public class NegationIT {
@@ -188,6 +189,22 @@ public class NegationIT {
                             "};"
             );
             tx.execute(Graql.match(pattern), false);
+        }
+    }
+
+    @Test
+    public void whenATypeInRuleNegationBlockIsAbsent_theRuleIsMatched() {
+        try (TransactionOLTP tx = negationSession.transaction().write()) {
+            assertFalse(tx.getAttributeType("absent-resource").instances().findFirst().isPresent());
+
+            List<ConceptMap> answers = tx.execute(Graql.<GraqlGet>parse(
+                    "match " +
+                            "$x has derived-resource-string 'no absent-resource attached';" +
+                            "get;"
+            ));
+            List<ConceptMap> explicitAnswers = tx.execute(Graql.<GraqlGet>parse("match $x isa someType;get;"));
+
+            assertCollectionsNonTriviallyEqual(explicitAnswers,answers);
         }
     }
 

--- a/test-integration/graql/reasoner/stubs/negation.gql
+++ b/test-integration/graql/reasoner/stubs/negation.gql
@@ -5,6 +5,7 @@ baseType sub entity,
     has resource-long,
     has derived-resource-string,
     has derived-resource-boolean,
+    has absent-resource,
     plays someRole,
     plays anotherRole,
     plays otherRole;
@@ -37,6 +38,7 @@ derived-ternary sub relation,
 #Resources
 resource-string sub attribute, datatype string;
 resource-long sub attribute, datatype long;
+absent-resource sub attribute, datatype string;
 
 derived-resource-string sub attribute, datatype string;
 derived-resource-boolean sub attribute, datatype boolean;
@@ -78,8 +80,6 @@ binaryTransitivity sub rule,
         (someRole:$x, otherRole:$y) isa derived-binary;
     };
 
-
-
 ternaryDefinition sub rule,
     when {
         (someRole:$x, otherRole:$z) isa binary;
@@ -104,6 +104,15 @@ typeDerivation sub rule,
     },
     then {
         $x isa derived-type;
+    };
+
+negationRuleWithAbsentType sub rule,
+    when {
+        $x isa someType;
+        not { $x has absent-resource $val;};
+    },
+    then {
+        $x has derived-resource-string "no absent-resource attached";
     };
 
 insert


### PR DESCRIPTION
## What is the goal of this PR?
In the `RuleCache`, as rules are being assessed for matchability, we scan the types for possible absence of instances which allows us to discard rules that yield no answers. However! If a rule has negation blocks in it, absence of instances yields results! Therefore we correct the pruning behaviour to take into account rules with negation.

## What are the changes implemented in this PR?
Scanning types for absence of instances when determining rule matchability is done only for positive types - ones that are present in non-negated blocks of the `when` part.
