### PR TITLE
Make sure if we materialise symmetric relations we return all answer combinations

### DIFF
--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1006,9 +1006,13 @@ public abstract class RelationAtom extends IsaAtomBase {
             relation = substitution.get(getVarName()).asRelation();
         } else {
             Relation foundRelation = findRelation(substitution);
-            relation = foundRelation != null?
-                    foundRelation :
-                    RelationTypeImpl.from(relationType).addRelationInferred();
+            if (foundRelation == null) {
+                Relation insertedRelation = RelationTypeImpl.from(relationType).addRelationInferred();
+                relation = insertedRelation;
+            } else {
+                relation = foundRelation;
+            }
+
         }
 
         roleVarMap.asMap()

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -40,6 +40,9 @@ import java.util.Set;
 @SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 public class AtomicState extends QueryState<ReasonerAtomicQuery> {
 
+    //TODO: remove it once we introduce multi answer states
+    private MultiUnifier ruleUnifier = null;
+
     private MultiUnifier cacheUnifier = null;
     private CacheEntry<ReasonerAtomicQuery, IndexedAnswerSet> cacheEntry = null;
     private HashMultimap<ConceptId, ConceptMap> materialised = HashMultimap.create();
@@ -95,6 +98,11 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         return cacheUnifier;
     }
 
+    private MultiUnifier getRuleUnifier(InferenceRule rule) {
+        if (ruleUnifier == null) this.ruleUnifier = rule.getHead().getMultiUnifier(this.getQuery());
+        return ruleUnifier;
+    }
+
     private ConceptMap recordAnswer(ReasonerAtomicQuery query, ConceptMap answer) {
         if (answer.isEmpty()) return answer;
         if (cacheEntry == null) {
@@ -122,7 +130,10 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         ReasonerAtomicQuery query = getQuery();
         ReasonerAtomicQuery ruleHead = ReasonerQueries.atomic(rule.getHead(), answer);
         ConceptMap sub = ruleHead.getSubstitution();
-        if(materialised.get(rule.getRule().id()).contains(sub)) return new ConceptMap();
+        if(materialised.get(rule.getRule().id()).contains(sub)
+            && getRuleUnifier(rule).isUnique()){
+            return new ConceptMap();
+        }
         materialised.put(rule.getRule().id(), sub);
         
         Set<Variable> queryVars = query.getVarNames().size() < ruleHead.getVarNames().size() ?

--- a/test-end-to-end/client-java/ClientJavaE2E.java
+++ b/test-end-to-end/client-java/ClientJavaE2E.java
@@ -228,7 +228,8 @@ public class ClientJavaE2E {
                             .rel("child", var("child"))).get();
             LOG.info("clientJavaE2E() - '" + getParentship + "'");
             List<ConceptMap> parentship = tx.execute(getParentship);
-            assertThat(parentship, hasSize(1));
+            //2 answers - single answer for each parent
+            assertThat(parentship, hasSize(2));
             LOG.info("clientJavaE2E() - done.");
         });
 


### PR DESCRIPTION
## What is the goal of this PR?
In the case when we have multiple unifiers between the rule head and query, we make sure we don't accidentally discard any answers - all combinations are returned.

## What are the changes implemented in this PR?

- add an extra check if the multiunifier is unique so that we don't discard the answers too aggressively
