### PR TITLE
Explicitly set unifier type to RULE when checking materialised answers

### DIFF
--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -30,6 +30,7 @@ import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.rule.InferenceRule;
 import grakn.core.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.graql.reasoner.unifier.Unifier;
+import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.server.kb.concept.ConceptUtils;
 import graql.lang.statement.Variable;
 import java.util.Set;
@@ -99,7 +100,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
     }
 
     private MultiUnifier getRuleUnifier(InferenceRule rule) {
-        if (ruleUnifier == null) this.ruleUnifier = rule.getHead().getMultiUnifier(this.getQuery());
+        if (ruleUnifier == null) this.ruleUnifier = rule.getHead().getMultiUnifier(this.getQuery(), UnifierType.RULE);
         return ruleUnifier;
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
In #5258 we introduced  an extra check for unifier uniqueness in `AtomicState`. We were using the default `getMultiUnifier` function which uses the EXACT unifier type. Instead, we want the RULE type, otherwise the check is useless and caching the materialised answers doesn't give any performance benefits.

## What are the changes implemented in this PR?
- change fetched rule unifier type to RULE in `AtomicState`
