### PR TITLE
Update cache behaviour for queries with a unique answer

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -127,6 +127,11 @@ public abstract class Atom extends AtomicBase {
     }
 
     /**
+     * @return true if the query corresponding to this atom has a unique (single) answer if any
+     */
+    public boolean hasUniqueAnswer(){ return isGround();}
+
+    /**
      * @return true if this atom is bounded - via substitution/specific resource or schema
      */
     public boolean isBounded() {

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -256,6 +256,21 @@ public abstract class AttributeAtom extends Binary{
     public boolean isValueEquality(){ return getMultiPredicate().stream().anyMatch(p -> p.getPredicate().isValueEquality());}
 
     @Override
+    public boolean hasUniqueAnswer(){
+        ConceptMap sub = getParentQuery().getSubstitution();
+        if (sub.vars().containsAll(getVarNames())) return true;
+
+        SchemaConcept type = getSchemaConcept();
+        if (type == null) return false;
+
+        boolean isBottomType = !type.subs().anyMatch(t -> !t.equals(type));
+        boolean relationVarMapped = !getRelationVariable().isReturned() || sub.containsVar(getRelationVariable());
+        return isBottomType
+                && isValueEquality() && sub.containsVar(getVarName())
+                && relationVarMapped;
+    }
+
+    @Override
     public boolean requiresMaterialisation(){ return true;}
 
     @Override

--- a/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
@@ -61,6 +61,7 @@ public abstract class AtomicQueryCacheBase<
     }
 
     public void ackCompleteness(ReasonerAtomicQuery query) {
+        ackDBCompleteness(query);
         if (query.getAtom().getPredicates(IdPredicate.class).findFirst().isPresent()) {
             completeQueries.add(query);
         } else {

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -220,7 +220,7 @@ public abstract class SemanticCache<
 
         assert(query.isPositive());
         validateAnswer(answer, query, query.getVarNames());
-        if (query.isGround()) ackCompleteness(query);
+        if (query.hasUniqueAnswer()) ackCompleteness(query);
 
         /*
          * find SE entry

--- a/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -105,6 +105,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     @Override
     public boolean isAtomic(){ return true;}
 
+    public boolean hasUniqueAnswer(){ return getAtom().hasUniqueAnswer();}
+
     /**
      * Determines whether the subsumption relation between this (C) and provided query (P) holds,
      * i. e. determines if:

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -285,6 +285,11 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     }
 
     /**
+     * @return true if this query has a unique (single) answer if any
+     */
+    public boolean hasUniqueAnswer(){ return isGround();}
+
+    /**
      * @return true if this query contains disconnected atoms that are unbounded
      */
     public boolean isBoundlesslyDisconnected(){

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -30,7 +30,6 @@ import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
 import grakn.core.rule.GraknTestServer;
-import grakn.core.server.kb.Schema;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
@@ -594,16 +593,61 @@ public class QueryCacheIT {
     }
 
     @Test
-    public void whenResolvingQueryWithVariableRoles_roleExpansionAnswersAreCached(){
+    public void whenRecordingQueryWithUniqueAnswer_weAckCompleteness(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
-            ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction("($r: $x) isa binary-symmetric;"), tx);
+            MultilevelSemanticCache cache = tx.queryCache();
+            ReasonerQueryImpl baseQuery = ReasonerQueries.create(conjunction("{$x has resource $r via $rel;};"), tx);
+            Set<ConceptMap> answers = baseQuery.resolve().collect(toSet());
 
-            Set<ConceptMap> answers = query.resolve().collect(toSet());
-            Set<ConceptMap> cachedAnswers = tx.queryCache().getAnswers(query);
-            assertTrue(answers.stream().anyMatch(ans -> ans.explanation().isRuleExplanation()));
-            assertTrue(answers.stream().anyMatch(ans -> Schema.MetaSchema.isMetaLabel(ans.get("r").asRole().label())));
-            assertEquals(answers,cachedAnswers);
+            ConceptMap answer = answers.iterator().next();
+            Concept owner = answer.get("x");
+            Concept attribute = answer.get("r");
+            Concept relation = answer.get("rel");
+            Object value = attribute.asAttribute().value();
+
+            ReasonerAtomicQuery ownerMapped = ReasonerQueries.atomic(conjunction("{$x has resource $r;$x id " + owner.id() + ";};"), tx);
+            ReasonerAtomicQuery ownerAndValueMapped = ReasonerQueries.atomic(conjunction("{$x has resource '" + value + "';$x id " + owner.id() +";};"), tx);
+            ReasonerAtomicQuery ownerAndValueMappedBaseType = ReasonerQueries.atomic(conjunction("{$x has attribute '" + value + "';$x id " + owner.id() +";};"), tx);
+            ReasonerAtomicQuery ownerMappedWithRelVariable = ReasonerQueries.atomic(conjunction("{$x has resource $r via $rel;$x id " + owner.id() + ";};"), tx);
+            ReasonerAtomicQuery ownerAndValueMappedWithRelVariable = ReasonerQueries.atomic(conjunction("{" +
+                    "$x has resource '" + value + "' via $rel;" +
+                    "$x id " + owner.id() + ";" +
+                    "};"
+            ), tx);
+            ReasonerAtomicQuery ownerAndRelationMapped = ReasonerQueries.atomic(conjunction("{" +
+                    "$x has resource $r via $rel;" +
+                    "$x id " + owner.id() + ";" +
+                    "$rel id " + relation.id() + ";" +
+                    "};"
+            ), tx);
+            ReasonerAtomicQuery allMapped = ReasonerQueries.atomic(conjunction("{" +
+                    "$x has resource $r;" +
+                    "$x id " + owner.id() + ";" +
+                    "$r id " + attribute.id() + ";" +
+                    "};"
+            ), tx);
+
+            assertTrue(ownerAndValueMapped.hasUniqueAnswer());
+            assertTrue(allMapped.hasUniqueAnswer());
+            assertFalse(ownerMapped.hasUniqueAnswer());
+            assertFalse(ownerAndValueMappedBaseType.hasUniqueAnswer());
+            assertFalse(ownerMappedWithRelVariable.hasUniqueAnswer());
+            assertFalse(ownerAndValueMappedWithRelVariable.hasUniqueAnswer());
+            assertFalse(ownerAndRelationMapped.hasUniqueAnswer());
+
+            ownerAndValueMapped.resolve()
+                    .map(ans -> ans.explain(new LookupExplanation(ownerAndValueMapped.getPattern())))
+                    .forEach(ans -> cache.record(ownerAndValueMapped, ans));
+            allMapped.resolve()
+                    .map(ans -> ans.explain(new LookupExplanation(allMapped.getPattern())))
+                    .forEach(ans -> cache.record(allMapped, ans));
+
+            assertTrue(cache.isComplete(ownerAndValueMapped));
+            assertTrue(cache.isDBComplete(ownerAndValueMapped));
+            assertTrue(cache.isComplete(allMapped));
+            assertTrue(cache.isDBComplete(allMapped));
         }
+
     }
 
     private Set<ConceptMap> getCacheContent(TransactionOLTP tx){


### PR DESCRIPTION
## What is the goal of this PR?

Previously we didn't  acknowledge completion for queries that need to have a unique answer based on our data model. Now we do this for attribute queries. 

## What are the changes implemented in this PR?

- attribute queries which have a bottom type (most specific), have specific value and owner need to have a unique answer - we acknowledge their completion when recording an answer
- when acknowledging completion we also acknowledge db completion
