### PR TITLE
Fix ghost vertex in concurrent insertions

### DIFF
--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -72,7 +72,7 @@ cache.db-cache-clean-wait=20
 # Default expiration time in milliseconds for entries in the database-level cache.
 # Set to 0 to disable expiration (cache entries live forever or until memory pressure
 # triggers eviction).
-cache.db-cache-time=180000
+cache.db-cache-time=5000
 # Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
 cache.db-cache-size=0.35
 cache.tx-cache-size=3000

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -243,35 +243,31 @@ public class TransactionOLTP implements Transaction {
     }
 
     private static void merge(GraphTraversalSource tinkerTraversal, ConceptId duplicateId, ConceptId targetId) {
-        try {
-            Vertex duplicate = tinkerTraversal.V(Schema.elementId(duplicateId)).next();
-            Vertex mergeTargetV = tinkerTraversal.V(Schema.elementId(targetId)).next();
+        Vertex duplicate = tinkerTraversal.V(Schema.elementId(duplicateId)).next();
+        Vertex mergeTargetV = tinkerTraversal.V(Schema.elementId(targetId)).next();
 
-            duplicate.vertices(Direction.IN).forEachRemaining(connectedVertex -> {
-                // merge attribute edge connecting 'duplicate' and 'connectedVertex' to 'mergeTargetV', if exists
-                GraphTraversal<Vertex, Edge> attributeEdge =
-                        tinkerTraversal.V(duplicate).inE(Schema.EdgeLabel.ATTRIBUTE.getLabel()).filter(__.outV().is(connectedVertex));
-                if (attributeEdge.hasNext()) {
-                    mergeAttributeEdge(mergeTargetV, connectedVertex, attributeEdge);
-                }
+        duplicate.vertices(Direction.IN).forEachRemaining(connectedVertex -> {
+            // merge attribute edge connecting 'duplicate' and 'connectedVertex' to 'mergeTargetV', if exists
+            GraphTraversal<Vertex, Edge> attributeEdge =
+                    tinkerTraversal.V(duplicate).inE(Schema.EdgeLabel.ATTRIBUTE.getLabel()).filter(__.outV().is(connectedVertex));
+            if (attributeEdge.hasNext()) {
+                mergeAttributeEdge(mergeTargetV, connectedVertex, attributeEdge);
+            }
 
-                // merge role-player edge connecting 'duplicate' and 'connectedVertex' to 'mergeTargetV', if exists
-                GraphTraversal<Vertex, Edge> rolePlayerEdge =
-                        tinkerTraversal.V(duplicate).inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).filter(__.outV().is(connectedVertex));
-                if (rolePlayerEdge.hasNext()) {
-                    mergeRolePlayerEdge(mergeTargetV, rolePlayerEdge);
-                }
-                try {
-                    attributeEdge.close();
-                    rolePlayerEdge.close();
-                } catch (Exception e) {
-                    LOG.warn("Error closing the merging traversals", e);
-                }
-            });
-            duplicate.remove();
-        } catch (NoSuchElementException e) {
-            e.printStackTrace();
-        }
+            // merge role-player edge connecting 'duplicate' and 'connectedVertex' to 'mergeTargetV', if exists
+            GraphTraversal<Vertex, Edge> rolePlayerEdge =
+                    tinkerTraversal.V(duplicate).inE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()).filter(__.outV().is(connectedVertex));
+            if (rolePlayerEdge.hasNext()) {
+                mergeRolePlayerEdge(mergeTargetV, rolePlayerEdge);
+            }
+            try {
+                attributeEdge.close();
+                rolePlayerEdge.close();
+            } catch (Exception e) {
+                LOG.warn("Error closing the merging traversals", e);
+            }
+        });
+        duplicate.remove();
     }
 
     private static void mergeRolePlayerEdge(Vertex mergeTargetV, GraphTraversal<Vertex, Edge> rolePlayerEdge) {

--- a/test-end-to-end/distribution/ConcurrencyE2E.java
+++ b/test-end-to-end/distribution/ConcurrencyE2E.java
@@ -30,6 +30,7 @@ import static grakn.core.distribution.DistributionE2EConstants.assertGraknIsRunn
 import static grakn.core.distribution.DistributionE2EConstants.assertZipExists;
 import static grakn.core.distribution.DistributionE2EConstants.unzipGrakn;
 import static java.util.stream.Collectors.toSet;
+import static junit.framework.TestCase.assertEquals;
 
 public class ConcurrencyE2E {
 
@@ -65,14 +66,16 @@ public class ConcurrencyE2E {
     public void concurrentInsertionOfDuplicateAttributes_doesNotCreateGhostVertices() throws ExecutionException, InterruptedException {
         String[] names = new String[]{"Marco", "James", "Ganesh", "Haikal", "Kasper", "Tomas", "Joshua", "Max", "Syed", "Soroush"};
         String[] surnames = new String[]{"Surname1", "Surname2", "Surname3", "Surname4", "Surname5", "Surname6", "Surname7", "Surname8", "Surname9", "Surname10"};
+        int[] ages = new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
         GraknClient graknClient = new GraknClient("localhost:48555");
         GraknClient.Session session = graknClient.session("concurrency");
         GraknClient.Transaction tx = session.transaction().write();
         tx.execute(Graql.parse("define " +
-                "person sub entity, has name, has surname; " +
+                "person sub entity, has name, has surname, has age; " +
                 "name sub attribute, datatype string;" +
-                "surname sub attribute, datatype string;").asDefine());
+                "surname sub attribute, datatype string;" +
+                "age sub attribute, datatype long;").asDefine());
 
         tx.commit();
         ExecutorService executorService = Executors.newFixedThreadPool(36);
@@ -80,15 +83,16 @@ public class ConcurrencyE2E {
         List<CompletableFuture<Void>> asyncInsertions = new ArrayList<>();
         // We need a good amount of parallelism to have a good chance to spot possible issues. Don't use smaller values.
         int numberOfConcurrentTransactions = 56;
-        int batchSize = 200;
+        int batchSize = 50;
         for (int i = 0; i < numberOfConcurrentTransactions; i++) {
             CompletableFuture<Void> asyncInsert = CompletableFuture.supplyAsync(() -> {
                 Random random = new Random();
                 GraknClient.Transaction threadTx = session.transaction().write();
                 for (int j = 0; j < batchSize; j++) {
-                    threadTx.execute(Graql.parse("insert $x isa person, has name \"" + names[random.nextInt(10)] + "\";").asInsert());
-                    threadTx.execute(Graql.parse("insert $x isa person, has surname \"" + surnames[random.nextInt(10)] + "\";").asInsert());
-                }
+                    threadTx.execute(Graql.parse("insert $x isa person, has name \"" + names[random.nextInt(10)] + "\"," +
+                            "has surname \"" + surnames[random.nextInt(10)] + "\"," +
+                            "has age " + ages[random.nextInt(10)] + ";").asInsert());
+                    }
                 threadTx.commit();
 
                 return null;
@@ -113,5 +117,16 @@ public class ConcurrencyE2E {
             });
         });
         tx.close();
+
+
+        tx = session.transaction().write();
+        int numOfNames = tx.execute(Graql.parse("match $x isa name; get; count;").asGetAggregate()).get(0).number().intValue();
+        int numOfSurnames = tx.execute(Graql.parse("match $x isa surname; get; count;").asGetAggregate()).get(0).number().intValue();
+        int numOfAges = tx.execute(Graql.parse("match $x isa age; get; count;").asGetAggregate()).get(0).number().intValue();
+        tx.close();
+
+        assertEquals(10, numOfNames);
+        assertEquals(10, numOfSurnames);
+        assertEquals(10, numOfAges);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

Add read lock when executing PUT of attributes, as JanusGraph commit does not seem to be fully atomic.

## What are the changes implemented in this PR?

- add readLock when checking for attribute existence in the graph
- reset cache timeout to default value, as 3 minutes is definitely too long (OOM exception)
