### PR TITLE
Core Bugfixes

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.concept.Concept;
+import grakn.core.concept.ConceptId;
 import grakn.core.concept.answer.Answer;
 import grakn.core.concept.answer.AnswerGroup;
 import grakn.core.concept.answer.ConceptList;
@@ -71,6 +72,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collector;
@@ -356,19 +358,18 @@ public class QueryExecutor {
                 .sorted(Comparator.comparing(concept -> !concept.isRelation()))
                 .collect(Collectors.toList());
 
-        conceptsToDelete.forEach(concept -> {
+        Set<ConceptId> deletedConceptIds = conceptsToDelete.stream().map(concept -> {
             // a concept is either a schema concept or a thing
             if (concept.isSchemaConcept()) {
                 throw GraqlSemanticException.deleteSchemaConcept(concept.asSchemaConcept());
             } else if (concept.isThing()) {
                 try {
-                    // if it's not inferred, we can delete it
-                    if (!concept.asThing().isInferred()) {
-                        concept.delete();
-                    }
+                    ConceptId id = concept.id();
+                    concept.delete();
+                    return id;
                 } catch (IllegalStateException janusVertexDeleted) {
                     if (janusVertexDeleted.getMessage().contains("was removed")) {
-                        // Tinkerpop throws this exception if we try to operate (including check `isInferred()`) on a vertex that was already deleted
+                        // Tinkerpop throws this exception if we try to operate on a vertex that was already deleted
                         // With the ordering of deletes, this edge case should only be hit when relations play roles in relations
                         LOG.debug("Trying to deleted concept that was already removed", janusVertexDeleted);
                     } else {
@@ -378,10 +379,12 @@ public class QueryExecutor {
             } else {
                 throw GraknServerException.create("Unhandled concept type isn't a schema concept or a thing");
             }
-        });
+            // TODO rewrite to either throw or return an ID
+            return null; // we shouldn't be hitting this case without throwing an exception
+        }).filter(Objects::nonNull).collect(Collectors.toSet());
 
         // TODO: return deleted Concepts instead of ConceptIds
-        return new ConceptSet(conceptsToDelete.stream().map(Concept::id).collect(toSet()));
+        return new ConceptSet(deletedConceptIds);
     }
 
     public Stream<ConceptMap> get(GraqlGet query) {

--- a/server/src/graql/gremlin/GraqlTraversal.java
+++ b/server/src/graql/gremlin/GraqlTraversal.java
@@ -109,22 +109,14 @@ public abstract class GraqlTraversal {
      */
     private GraphTraversal<Vertex, Map<String, Element>> getConjunctionTraversal(
             TransactionOLTP tx, GraphTraversal<Vertex, Vertex> traversal, Set<Variable> vars,
-            ImmutableList<Fragment> fragmentList
-    ) {
-        GraphTraversal<Vertex, ? extends Element> newTraversal = traversal;
+            ImmutableList<Fragment> fragmentList) {
 
-        // If the first fragment can operate on edges, then we have to navigate all edges as well
-        if (fragmentList.get(0).canOperateOnEdges()) {
-            newTraversal = traversal.union(__.identity(), __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()));
-        }
-
-        return applyFragments(tx, vars, fragmentList, newTraversal);
+        return applyFragments(tx, vars, fragmentList, traversal);
     }
 
     private GraphTraversal<Vertex, Map<String, Element>> applyFragments(
             TransactionOLTP tx, Set<Variable> vars, ImmutableList<Fragment> fragmentList,
-            GraphTraversal<Vertex, ? extends Element> traversal
-    ) {
+            GraphTraversal<Vertex, ? extends Element> traversal) {
         Set<Variable> foundVars = new HashSet<>();
 
         // Apply fragments in order into one single traversal

--- a/server/src/graql/gremlin/fragment/Fragment.java
+++ b/server/src/graql/gremlin/fragment/Fragment.java
@@ -284,13 +284,6 @@ public abstract class Fragment {
         return this;
     }
 
-    /**
-     * Indicates whether the fragment can be used on an {@link org.apache.tinkerpop.gremlin.structure.Edge} as well as
-     * a {@link org.apache.tinkerpop.gremlin.structure.Vertex}.
-     */
-    public boolean canOperateOnEdges() {
-        return false;
-    }
 
     /**
      * Get all variables in the fragment including the start and end (if present)

--- a/server/src/graql/gremlin/fragment/IdFragment.java
+++ b/server/src/graql/gremlin/fragment/IdFragment.java
@@ -56,7 +56,11 @@ public abstract class IdFragment extends Fragment {
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, TransactionOLTP graph, Collection<Variable> vars) {
         if (canOperateOnEdges()) {
-            // Handle both edges and vertices
+            // if the ID may be for an edge,
+            // we must extend the traversal that normally just operates on vertices
+            // to operate on both edges and vertices
+            traversal = traversal.union(__.identity(), __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()));
+
             return traversal.or(
                     edgeTraversal(),
                     vertexTraversal(__.identity())
@@ -94,8 +98,7 @@ public abstract class IdFragment extends Fragment {
         return true;
     }
 
-    @Override
-    public boolean canOperateOnEdges() {
+    private boolean canOperateOnEdges() {
         return Schema.isEdgeId(id());
     }
 

--- a/server/src/graql/gremlin/fragment/OutIsaFragment.java
+++ b/server/src/graql/gremlin/fragment/OutIsaFragment.java
@@ -89,9 +89,4 @@ public abstract class OutIsaFragment extends EdgeFragment {
     protected NodeId getMiddleNodeId() {
         return NodeId.of(NodeId.Type.ISA, new HashSet<>(Arrays.asList(start(), end())));
     }
-
-    @Override
-    public boolean canOperateOnEdges() {
-        return true;
-    }
 }

--- a/server/src/graql/gremlin/fragment/OutRolePlayerFragment.java
+++ b/server/src/graql/gremlin/fragment/OutRolePlayerFragment.java
@@ -76,6 +76,7 @@ public abstract class OutRolePlayerFragment extends AbstractRolePlayerFragment {
 
     private GraphTraversal<Element, Vertex> edgeRelationTraversal(
             TransactionOLTP tx, Direction direction, Schema.EdgeProperty roleProperty, Collection<Variable> vars) {
+
         GraphTraversal<Element, Edge> edgeTraversal = Fragments.isEdge(__.identity());
 
         // Filter by any provided type labels
@@ -99,10 +100,5 @@ public abstract class OutRolePlayerFragment extends AbstractRolePlayerFragment {
     @Override
     public double internalFragmentCost() {
         return roleLabels() != null ? COST_ROLE_PLAYERS_PER_ROLE : COST_ROLE_PLAYERS_PER_RELATION;
-    }
-
-    @Override
-    public boolean canOperateOnEdges() {
-        return true;
     }
 }

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -18,11 +18,15 @@
 
 package grakn.core.graql.query;
 
+import grakn.core.concept.Concept;
+import grakn.core.concept.ConceptId;
 import grakn.core.concept.answer.AnswerGroup;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.EntityType;
+import grakn.core.concept.type.Role;
 import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.graph.MovieGraph;
 import grakn.core.rule.GraknTestServer;
@@ -30,7 +34,9 @@ import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import graql.lang.exception.GraqlException;
+import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlGet;
+import graql.lang.statement.StatementThing;
 import graql.lang.statement.Variable;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -43,8 +49,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static graql.lang.Graql.var;
 import static graql.lang.exception.ErrorMessage.VARIABLE_OUT_OF_SCOPE;
@@ -462,5 +471,36 @@ public class GraqlGetIT {
         exception.expect(GraqlException.class);
         exception.expectMessage(VARIABLE_OUT_OF_SCOPE.getMessage(new Variable("z")));
         tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().sort("z"));
+    }
+
+
+    @Test
+    /**
+     * This tests ensures that queries that match both vertices and edges in the query operate correctly
+     */
+    public void whenMatchingEdgeAndVertex_AnswerIsNotEmpty() {
+        Role work = tx.putRole("work");
+        EntityType somework = tx.putEntityType("somework").plays(work);
+        Role author = tx.putRole("author");
+        EntityType person = tx.putEntityType("person").plays(author);
+        AttributeType<Long> year = tx.putAttributeType("year", AttributeType.DataType.LONG);
+        tx.putRelationType("authored-by").relates(work).relates(author).has(year);
+
+        Stream<ConceptMap> answers = tx.stream(Graql.parse("insert $x isa person;" +
+                "$y isa somework; " +
+                "$a isa year; $a 2019; " +
+                "$r (author: $x, work: $y) isa authored-by; $r has year $a via $imp;").asInsert());
+
+        List<ConceptId> insertedIds = answers.flatMap(conceptMap -> conceptMap.concepts().stream().map(Concept::id)).collect(Collectors.toList());
+        tx.commit();
+        newTransaction();
+
+        List<Pattern> idPatterns = new ArrayList<>();
+        for (int i = 0; i < insertedIds.size(); i++) {
+            StatementThing id = var("v" + i).id(insertedIds.get(i).toString());
+            idPatterns.add(id);
+        }
+        List<ConceptMap> answersById = tx.execute(Graql.match(idPatterns).get());
+        assertEquals(answersById.size(), 1);
     }
 }

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -502,5 +502,9 @@ public class GraqlGetIT {
         }
         List<ConceptMap> answersById = tx.execute(Graql.match(idPatterns).get());
         assertEquals(answersById.size(), 1);
+
+        // clean up, delete the IDs we inserted for this test
+        tx.execute(Graql.match(idPatterns).delete(idPatterns.stream().flatMap(pattern -> pattern.variables().stream()).collect(Collectors.toList())));
+        tx.commit();
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
Fix and add tests for:
* querying for nonreified implicit attribute ownership and the owner in the same query not returning any concepts fixed by moving an edge traversal step into `IdFragment`
* remove check for deleting inferred concepts (undoing #5054, the added tests in that PR still passes)
* return deleted concepts' IDs without re-querying deleted Janus element (was causing vertex already deleted bugs with reified relations)

## What are the changes implemented in this PR?
* Bugfixes for above small issues and some relevant tests