### PR TITLE
Fix creation and deletion of attributes bugs

### DIFF
--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -221,6 +221,7 @@ public class TransactionOLTP implements Transaction {
     private void mergeAttributesAndCommit() {
         session.graphLock().writeLock().lock();
         try {
+            cache().getRemovedAttributes().forEach(index -> session.attributesMap().remove(index));
             cache().getNewAttributes().forEach(((labelIndexPair, conceptId) -> {
                 // If the same index is contained in attributesMap, it means
                 // another concurrent transaction inserted the same attribute, time to merge!
@@ -235,7 +236,6 @@ public class TransactionOLTP implements Transaction {
             }));
             session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
             janusTransaction.commit();
-            cache().getRemovedAttributes().forEach(index -> session.attributesMap().remove(index));
             updateAttributesMapInSession();
         } finally {
             session.graphLock().writeLock().unlock();

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -150,7 +150,7 @@ public class TransactionCache {
 
         if (concept.isAttribute()) {
             AttributeImpl attr = AttributeImpl.from(concept.asAttribute());
-            newAttributes.remove(new Pair<>(attr.type().label().toString(), attr.getIndex()));
+            newAttributes.remove(new Pair<>(attr.type().label(), attr.getIndex()));
             removedAttributes.add(Schema.generateAttributeIndex(attr.type().label(), attr.value().toString()));
         }
 

--- a/test-integration/server/session/BUILD
+++ b/test-integration/server/session/BUILD
@@ -47,6 +47,7 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//concept",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "@graknlabs_graql//java:graql"
     ],
     classpath_resources = ["//test-integration/resources:logback-test"]
 )


### PR DESCRIPTION
## What is the goal of this PR?

Resolve 2 bugs concerning creation and deletion of attributes in the same transaction.
Specifically:

- when deleting an attribute, the `newAttributes` map in `TransactionCahce` was not properly evicted
- when deleting and re-creating an attribute with same value in the same Transaction, `attributesMap` in `SessionImpl` was not updated in the correct order.

## What are the changes implemented in this PR?

- deleting attributes from `newAttributes` map now correctly creates a `Pair` containing `Label, String` instead of `String, String`
- when committing, removed deleted attributes from `attributesMap` before checking if merging is needed
- add new regression tests and update test names