### PR TITLE
Limited cache

### DIFF
--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -19,6 +19,7 @@
 package grakn.core.server.keyspace;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.cache.CacheBuilder;
 import grakn.core.common.config.Config;
 import grakn.core.concept.Label;
 import grakn.core.concept.thing.Attribute;
@@ -61,7 +62,7 @@ public class KeyspaceManager {
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
         KeyspaceCache keyspaceCache = new KeyspaceCache();
         this.graph = janusGraphFactory.openGraph(SYSTEM_KB_KEYSPACE.name());
-        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, new KeyspaceStatistics(), new ConcurrentHashMap<>(), new ReentrantReadWriteLock());
+        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, new KeyspaceStatistics(), CacheBuilder.newBuilder().build(), new ReentrantReadWriteLock());
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
     }
 

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -36,7 +36,6 @@ import grakn.core.server.statistics.KeyspaceStatistics;
 import org.janusgraph.core.JanusGraph;
 
 import javax.annotation.CheckReturnValue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.function.Consumer;
 
@@ -63,7 +62,7 @@ public class SessionImpl implements Session {
     private final JanusGraph graph;
     private final KeyspaceCache keyspaceCache;
     private final KeyspaceStatistics keyspaceStatistics;
-    private final Cache<String, ConceptId> attributesMap;
+    private final Cache<String, ConceptId> attributesCache;
     private final ReadWriteLock graphLock;
     private Consumer<SessionImpl> onClose;
 
@@ -76,8 +75,8 @@ public class SessionImpl implements Session {
      * @param keyspace to which keyspace the session should be bound to
      * @param config   config to be used.
      */
-    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesMap, ReadWriteLock graphLock) {
-        this(keyspace, config, keyspaceCache, graph, keyspaceStatistics, new HadoopGraphFactory(config, keyspace), attributesMap, graphLock);
+    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
+        this(keyspace, config, keyspaceCache, graph, keyspaceStatistics, new HadoopGraphFactory(config, keyspace), attributesCache, graphLock);
     }
 
     /**
@@ -89,7 +88,7 @@ public class SessionImpl implements Session {
      */
     // NOTE: this method is used by Grakn KGMS and should be kept public
     public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph,
-                       KeyspaceStatistics keyspaceStatistics, HadoopGraphFactory hadoopGraphFactory, Cache<String, ConceptId> attributesMap, ReadWriteLock graphLock) {
+                       KeyspaceStatistics keyspaceStatistics, HadoopGraphFactory hadoopGraphFactory, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
         this.keyspace = keyspace;
         this.config = config;
         // Only save a reference to the factory rather than opening an Hadoop graph immediately because that can be
@@ -100,7 +99,7 @@ public class SessionImpl implements Session {
 
         this.keyspaceCache = keyspaceCache;
         this.keyspaceStatistics = keyspaceStatistics;
-        this.attributesMap = attributesMap;
+        this.attributesCache = attributesCache;
         this.graphLock = graphLock;
 
         TransactionOLTP tx = this.transaction(Transaction.Type.WRITE);
@@ -274,7 +273,7 @@ public class SessionImpl implements Session {
         return config;
     }
 
-    public Cache<String, ConceptId> attributesMap() {
-        return attributesMap;
+    public Cache<String, ConceptId> attributesCache() {
+        return attributesCache;
     }
 }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -93,7 +93,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
@@ -185,7 +184,7 @@ public class TransactionOLTP implements Transaction {
     /**
      * This method handles 3 committing scenarios:
      * - use a lock to serialise all commits that are trying to create new attributes, so that we can merge real-time
-     * - use a lock to serialise commits that are removing attributes, so concurrent txs dont use outdate attribute IDs from attributesMap
+     * - use a lock to serialise commits that are removing attributes, so concurrent txs dont use outdate attribute IDs from attributesCache
      * - don't lock when added or removed attributes are not involved
      */
     private void commitInternal() {
@@ -195,14 +194,14 @@ public class TransactionOLTP implements Transaction {
                 mergeAttributesAndCommit();
             } else if (!cache().getRemovedAttributes().isEmpty()) {
                 // In this case we need to lock, so that other concurrent Transactions
-                // that are trying to create new attributes will read an updated version of attributesMap
-                // Not locking here might lead to concurrent transactions reading the attributesMap that still
+                // that are trying to create new attributes will read an updated version of attributesCache
+                // Not locking here might lead to concurrent transactions reading the attributesCache that still
                 // contains attributes that we are removing in this transaction.
                 session.graphLock().writeLock().lock();
                 try {
                     session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
                     janusTransaction.commit();
-                    cache().getRemovedAttributes().forEach(index -> session.attributesMap().invalidate(index));
+                    cache().getRemovedAttributes().forEach(index -> session.attributesCache().invalidate(index));
                 } finally {
                     session.graphLock().writeLock().unlock();
                 }
@@ -221,19 +220,19 @@ public class TransactionOLTP implements Transaction {
     private void mergeAttributesAndCommit() {
         session.graphLock().writeLock().lock();
         try {
-            cache().getRemovedAttributes().forEach(index -> session.attributesMap().invalidate(index));
+            cache().getRemovedAttributes().forEach(index -> session.attributesCache().invalidate(index));
             cache().getNewAttributes().forEach(((labelIndexPair, conceptId) -> {
-                // If the same index is contained in attributesMap, it means
+                // If the same index is contained in attributesCache, it means
                 // another concurrent transaction inserted the same attribute, time to merge!
-                // NOTE: we still need to rely on attributesMap instead of checking in the graph
+                // NOTE: we still need to rely on attributesCache instead of checking in the graph
                 // if the index exists, because apparently JanusGraph does not make indexes available
                 // in a Read Committed fashion
-                ConceptId targetId = session.attributesMap().getIfPresent(labelIndexPair.getValue());
+                ConceptId targetId = session.attributesCache().getIfPresent(labelIndexPair.getValue());
                 if (targetId != null) {
                     merge(getTinkerTraversal(), conceptId, targetId);
                     statisticsDelta().decrement(labelIndexPair.getKey());
-                }else {
-                    session.attributesMap().put(labelIndexPair.getValue(), conceptId);
+                } else {
+                    session.attributesCache().put(labelIndexPair.getValue(), conceptId);
                 }
             }));
             session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -76,7 +76,7 @@ public class TransactionCache {
     //New attributes are tracked so that we can merge any duplicate attributes at commit time.
     // The label, index and id are directly cached to prevent unneeded reads
     private Map<Pair<Label, String>, ConceptId> newAttributes = new HashMap<>();
-    // Track the removed attributes so that we can evict old attribute indexes from attributesMap in session
+    // Track the removed attributes so that we can evict old attribute indexes from attributesCache in session
     // after commit
     private Set<String> removedAttributes = new HashSet<>();
 


### PR DESCRIPTION
## What is the goal of this PR?

Change attributesMap to attributesCache and make it a Cache with limited size instead of a ConcurrentHashMap which could potentially grow out of memory.

## What are the changes implemented in this PR?

The new cache is limited to `10000` attributes and each key in the cache expires after 2 minutes.
We rely on the fact that after 2 minutes JanusGraph should correctly report as committed any attribute that has been in the graph for 2 minutes. This still require further investigation on Janus guarantees after committing an attribute with `INDEX` set. 

- change name `attributesMap` to `attributesCache`
- change implementation from `ConcurrentHashMap` to  Guava `Cache`
