### PR TITLE
Number Comparison

### DIFF
--- a/server/src/graql/gremlin/GraqlTraversal.java
+++ b/server/src/graql/gremlin/GraqlTraversal.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import grakn.core.concept.ConceptId;
 import grakn.core.graql.gremlin.fragment.Fragment;
-import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;

--- a/server/src/graql/gremlin/sets/AttributeIndexFragmentSet.java
+++ b/server/src/graql/gremlin/sets/AttributeIndexFragmentSet.java
@@ -88,8 +88,10 @@ abstract class AttributeIndexFragmentSet extends EquivalentFragmentSet {
 
             if (labels.size() == 1) {
                 Label label = Iterables.getOnlyElement(labels);
-                optimise(fragmentSets, valueSet, isaSet, label);
-                return true;
+                if (graph.getAttributeType(label.getValue()).dataType().dataClass().isInstance(valueSet.operation().value())) {
+                    optimise(fragmentSets, valueSet, isaSet, label);
+                    return true;
+                }
             }
         }
 

--- a/test-integration/graql/query/BUILD
+++ b/test-integration/graql/query/BUILD
@@ -109,10 +109,10 @@ java_test(
 )
 
 java_test(
-    name = "type-conversion-it",
+    name = "number-casting-it",
     size = "medium",
-    srcs = ["TypeConversionIT.java"],
-    test_class = "grakn.core.graql.query.TypeConversionIT",
+    srcs = ["NumberCastingIT.java"],
+    test_class = "grakn.core.graql.query.NumberCastingIT",
     deps = [
         "//concept",
         "//dependencies/maven/artifacts/com/google/guava",
@@ -216,6 +216,6 @@ checkstyle_test(
         ":query-error-it",
         ":query-planner-it",
         ":query-validity-it",
-        ":type-conversion-it",
+        ":number-casting-it",
     ],
 )

--- a/test-integration/graql/query/NumberCastingIT.java
+++ b/test-integration/graql/query/NumberCastingIT.java
@@ -28,8 +28,8 @@ import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.MatchClause;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,8 +47,8 @@ public class NumberCastingIT {
     public static final GraknTestServer graknServer = new GraknTestServer();
     public static SessionImpl session;
 
-    @BeforeClass
-    public static void newSession() {
+    @Before
+    public void newSession() {
         session = graknServer.sessionWithNewKeyspace();
         try (TransactionOLTP tx = session.transaction().write()) {
             tx.putAttributeType("attr-long", AttributeType.DataType.LONG);
@@ -58,8 +58,8 @@ public class NumberCastingIT {
         }
     }
 
-    @AfterClass
-    public static void closeSession() {
+    @After
+    public void closeSession() {
         session.close();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

At the moment, if an attribute is defined to have a certain `datatype`, then only values of that `datatype` could be evaluated in a query traversal. For example, if `score` is an `attribute` with `datatype double`, you can only query for `score` by providing decimal point values, e.g. `match $x 9.0 isa score; get;`. Querying for `match $x 9 isa score; get;` would yield no results even though there are `score`s with the value `9.0`. We have now improved the expressivity of Graql's predicate comparison to being able to compare Numerical values of arbitrary `datatype`s (at the moment just `long` and `double`). Numbers will now be evaluated to be equivalent if they have the same value regardless of their `datatype`s.

## What are the changes implemented in this PR?

1) We relax the `ATTRIBUTE_INDEX_OPTIMISATION` in `AttributeFragmentSet` to exclude the case where attribute values do not have the same `datatype` as variable's `datatype` defined in the schema.

2) We introduced a new logic to the comparison predicate `ValueExecutor.Operation.Comparison.apply()` that takes advantage of the fact that different value classes (such as subclasses of `Number`) are comparable to other multiple value classes (such as `Long` and `Double`).

3) Additionally, we also refactored the test class and test cases. The test class is now named `NumberCastingIT` to cover both `write` and `read` castings of numbers in Grakn. The test cases now have better schema names and are independent of each other by operating on a separate keyspace.

This PR fixes #3772.