### PR TITLE
Proper use of JanusTransaction

### DIFF
--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -72,4 +72,4 @@ cache.db-cache-clean-wait=20
 cache.db-cache-time=5000
 # Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
 cache.db-cache-size=0.35
-cache.tx-cache-size=100
+cache.tx-cache-size=200

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -72,4 +72,4 @@ cache.db-cache-clean-wait=20
 cache.db-cache-time=5000
 # Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
 cache.db-cache-size=0.35
-cache.tx-cache-size=200
+cache.tx-cache-size=3000

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -72,4 +72,4 @@ cache.db-cache-clean-wait=20
 cache.db-cache-time=5000
 # Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
 cache.db-cache-size=0.35
-cache.tx-cache-size=3000
+cache.tx-cache-size=100

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -33,7 +33,7 @@ import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import grakn.core.server.session.cache.KeyspaceCache;
 import grakn.core.server.statistics.KeyspaceStatistics;
-import org.janusgraph.core.JanusGraph;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +57,7 @@ public class KeyspaceManager {
     private static final Logger LOG = LoggerFactory.getLogger(KeyspaceManager.class);
     private final Set<KeyspaceImpl> existingKeyspaces;
     private final SessionImpl systemKeyspaceSession;
-    private final JanusGraph graph;
+    private final StandardJanusGraph graph;
 
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
         KeyspaceCache keyspaceCache = new KeyspaceCache();

--- a/server/src/server/session/JanusGraphFactory.java
+++ b/server/src/server/session/JanusGraphFactory.java
@@ -102,10 +102,10 @@ final public class JanusGraphFactory {
             STORAGE_REPLICATION_FACTOR, JANUS_PREFIX + STORAGE_REPLICATION_FACTOR
     );
 
-    public synchronized JanusGraph openGraph(String keyspace) {
-        JanusGraph JanusGraph = configureGraph(keyspace, config);
-        buildJanusIndexes(JanusGraph);
-        JanusGraph.tx().onClose(org.apache.tinkerpop.gremlin.structure.Transaction.CLOSE_BEHAVIOR.ROLLBACK);
+    public synchronized StandardJanusGraph openGraph(String keyspace) {
+        StandardJanusGraph janusGraph = configureGraph(keyspace, config);
+        buildJanusIndexes(janusGraph);
+        janusGraph.tx().onClose(org.apache.tinkerpop.gremlin.structure.Transaction.CLOSE_BEHAVIOR.ROLLBACK);
         if (!strategiesApplied.getAndSet(true)) {
             TraversalStrategies strategies = TraversalStrategies.GlobalCache.getStrategies(StandardJanusGraph.class);
             strategies = strategies.clone().addStrategies(new JanusPreviousPropertyStepStrategy());
@@ -115,7 +115,7 @@ final public class JanusGraphFactory {
             TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraphTx.class, strategies);
         }
 
-        return JanusGraph;
+        return janusGraph;
     }
 
     public void drop(String keyspace) {
@@ -129,7 +129,7 @@ final public class JanusGraphFactory {
     }
 
 
-    private static JanusGraph configureGraph(String keyspace, Config config) {
+    private static StandardJanusGraph configureGraph(String keyspace, Config config) {
         org.janusgraph.core.JanusGraphFactory.Builder builder = org.janusgraph.core.JanusGraphFactory.build().
                 set(STORAGE_HOSTNAME, config.getProperty(ConfigKey.STORAGE_HOSTNAME)).
                 set(STORAGE_KEYSPACE, keyspace).
@@ -149,7 +149,7 @@ final public class JanusGraphFactory {
         });
 
         LOG.debug("Opening graph {}", keyspace);
-        return builder.open();
+        return (StandardJanusGraph) builder.open();
     }
 
 

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -28,6 +28,7 @@ import grakn.core.server.session.cache.KeyspaceCache;
 import grakn.core.server.statistics.KeyspaceStatistics;
 import grakn.core.server.util.LockManager;
 import org.janusgraph.core.JanusGraph;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -70,7 +71,7 @@ public class SessionFactory {
      */
     public SessionImpl session(KeyspaceImpl keyspace) {
         SharedKeyspaceData cacheContainer;
-        JanusGraph graph;
+        StandardJanusGraph graph;
         KeyspaceCache cache;
         KeyspaceStatistics keyspaceStatistics;
         Cache<String, ConceptId> attributesCache;
@@ -170,7 +171,7 @@ public class SessionFactory {
 
         private final KeyspaceCache keyspaceCache;
         // Graph is cached here because concurrently created sessions don't see writes to JanusGraph DB cache
-        private final JanusGraph graph;
+        private final StandardJanusGraph graph;
         // Keep track of sessions so that if a user deletes a keyspace we make sure to invalidate all associated sessions
         private final List<SessionImpl> sessions;
 
@@ -183,7 +184,7 @@ public class SessionFactory {
 
         private final ReadWriteLock graphLock;
 
-        public SharedKeyspaceData(KeyspaceCache keyspaceCache, JanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
+        public SharedKeyspaceData(KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
             this.keyspaceCache = keyspaceCache;
             this.graph = graph;
             this.sessions = new ArrayList<>();
@@ -216,7 +217,7 @@ public class SessionFactory {
             sessions.forEach(SessionImpl::invalidate);
         }
 
-        public JanusGraph graph() {
+        public StandardJanusGraph graph() {
             return graph;
         }
 

--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -33,7 +33,7 @@ import grakn.core.server.kb.structure.VertexElement;
 import grakn.core.server.keyspace.KeyspaceImpl;
 import grakn.core.server.session.cache.KeyspaceCache;
 import grakn.core.server.statistics.KeyspaceStatistics;
-import org.janusgraph.core.JanusGraph;
+import org.janusgraph.graphdb.database.StandardJanusGraph;
 
 import javax.annotation.CheckReturnValue;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -59,7 +59,7 @@ public class SessionImpl implements Session {
 
     private final KeyspaceImpl keyspace;
     private final Config config;
-    private final JanusGraph graph;
+    private final StandardJanusGraph graph;
     private final KeyspaceCache keyspaceCache;
     private final KeyspaceStatistics keyspaceStatistics;
     private final Cache<String, ConceptId> attributesCache;
@@ -75,7 +75,7 @@ public class SessionImpl implements Session {
      * @param keyspace to which keyspace the session should be bound to
      * @param config   config to be used.
      */
-    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
+    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
         this(keyspace, config, keyspaceCache, graph, keyspaceStatistics, new HadoopGraphFactory(config, keyspace), attributesCache, graphLock);
     }
 
@@ -87,7 +87,7 @@ public class SessionImpl implements Session {
      * @param config   config to be used.
      */
     // NOTE: this method is used by Grakn KGMS and should be kept public
-    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, JanusGraph graph,
+    public SessionImpl(KeyspaceImpl keyspace, Config config, KeyspaceCache keyspaceCache, StandardJanusGraph graph,
                        KeyspaceStatistics keyspaceStatistics, HadoopGraphFactory hadoopGraphFactory, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock) {
         this.keyspace = keyspace;
         this.config = config;
@@ -136,7 +136,7 @@ public class SessionImpl implements Session {
         if (localTx != null && !localTx.isClosed()) throw TransactionException.transactionOpen(localTx);
 
         // We are passing the graph to Transaction because there is the need to access graph tinkerpop traversal
-        TransactionOLTP tx = new TransactionOLTP(this, graph, keyspaceCache);
+        TransactionOLTP tx = new TransactionOLTP(this, graph.newThreadBoundTransaction(), keyspaceCache);
         tx.open(type);
         localOLTPTransactionContainer.set(tx);
 


### PR DESCRIPTION
## What is the goal of this PR?

We now use different JanusTransactions which we get from a shared StandardJanusGraph.

Before we were often reusing the same JanusTransaction for different Grakn Transactions.
This wrong behaviour was in place probably due to an ambiguous Janus documentation which doesn't shed much light on the topic.

With this change we now achieved a stable memory allocation and we don't see any more OutOfMemory exceptions when keeping the same Session open for a long time.

## What are the changes implemented in this PR?

 - use `StandardJanusGraph.newThreadBoundTransaction()` instead of `graph.tx()` which seems to reuse the same internal tx.
- don't pass graph to `TransactionOLTP` anymore and always rely on `JanusTransaction`
