### PR TITLE
Make e2e test large instead of medium

### DIFF
--- a/test-end-to-end/distribution/BUILD
+++ b/test-end-to-end/distribution/BUILD
@@ -13,6 +13,7 @@ java_test(
         "@graknlabs_client_java//:client-java",
     ],
     data = ["//:assemble-mac-zip"],
+    size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

Make `grakn-graql-command-e2e` to be `large` instead of `medium` as sometimes it would timeout.

## What are the changes implemented in this PR?

- add `size: large` to `grakn-graql-command-e2e`
