### PR TITLE
Deprioritise implicit labels

### DIFF
--- a/console/printer/Printer.java
+++ b/console/printer/Printer.java
@@ -51,7 +51,7 @@ public abstract class Printer<Builder> {
      * @param attributeTypes list of attribute types that should be included in the String output
      * @return a new StringPrinter object
      */
-    public static grakn.core.console.printer.StringPrinter stringPrinter(boolean colorize, AttributeType... attributeTypes) {
+    public static StringPrinter stringPrinter(boolean colorize, AttributeType... attributeTypes) {
         return new StringPrinter(colorize, attributeTypes);
     }
 

--- a/server/src/graql/reasoner/state/VariableComparisonState.java
+++ b/server/src/graql/reasoner/state/VariableComparisonState.java
@@ -18,7 +18,6 @@
 
 package grakn.core.graql.reasoner.state;
 
-//import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.atom.predicate.VariablePredicate;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
@@ -46,7 +45,6 @@ import java.util.stream.Collectors;
  * predicates to ans(Q').
  *
  */
-//@SuppressFBWarnings("BC_UNCONFIRMED_CAST_OF_RETURN_VALUE")
 public class VariableComparisonState extends QueryStateBase {
 
     private final ResolutionState complementState;


### PR DESCRIPTION
## What is the goal of this PR?

We reinstate the previous behaviour when we assigned smaller priority to label fragments which correspond to implicit relations. This is due to the fact that in general and by default they correspond to edges (are non-reified).

## What are the changes implemented in this PR?

Differentiate between high- and low- priority starting point fragments - we define the label fragments to be low priority starting points.
