### PR TITLE
Use transaction.close instead of transaction.rollback

### DIFF
--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -914,7 +914,7 @@ public class TransactionOLTP implements Transaction {
             return;
         }
         try {
-            janusTransaction.rollback();
+            janusTransaction.close();
         } finally {
             closeTransaction(closeMessage);
         }

--- a/test-end-to-end/distribution/BUILD
+++ b/test-end-to-end/distribution/BUILD
@@ -13,7 +13,6 @@ java_test(
         "@graknlabs_client_java//:client-java",
     ],
     data = ["//:assemble-mac-zip"],
-    size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
 )
 


### PR DESCRIPTION
## What is the goal of this PR?

Revert recent change and use `janusTransaction.close()` again, instead of `janusTransaction.rollback()`

## What are the changes implemented in this PR?

- also remove the size large from the test as it actually completes in 60s, so 300s should be more than enough