### PR TITLE
Update query cache behaviour on insertions and deletions

### DIFF
--- a/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
@@ -77,13 +77,34 @@ public abstract class AtomicQueryCacheBase<
         }
     }
 
-    @Override
-    public void clear(){
-        super.clear();
+    public void unackCompleteness(ReasonerAtomicQuery query) {
+        unackDBCompleteness(query);
+        if (query.getAtom().getPredicates(IdPredicate.class).findFirst().isPresent()) {
+            completeQueries.remove(query);
+        } else {
+            completeEntries.remove(queryToKey(query));
+        }
+    }
+
+    public void unackDBCompleteness(ReasonerAtomicQuery query){
+        if (query.getAtom().getPredicates(IdPredicate.class).findFirst().isPresent()) {
+            dbCompleteQueries.remove(query);
+        } else {
+            dbCompleteEntries.remove(queryToKey(query));
+        }
+    }
+
+    public void clearCompleteness(){
         dbCompleteQueries.clear();
         dbCompleteEntries.clear();
 
         completeQueries.clear();
         completeEntries.clear();
+    }
+
+    @Override
+    public void clear(){
+        super.clear();
+        clearCompleteness();
     }
 }

--- a/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/AtomicQueryCacheBase.java
@@ -77,7 +77,7 @@ public abstract class AtomicQueryCacheBase<
         }
     }
 
-    public void unackCompleteness(ReasonerAtomicQuery query) {
+    void unackCompleteness(ReasonerAtomicQuery query) {
         unackDBCompleteness(query);
         if (query.getAtom().getPredicates(IdPredicate.class).findFirst().isPresent()) {
             completeQueries.remove(query);
@@ -86,7 +86,7 @@ public abstract class AtomicQueryCacheBase<
         }
     }
 
-    public void unackDBCompleteness(ReasonerAtomicQuery query){
+    private void unackDBCompleteness(ReasonerAtomicQuery query){
         if (query.getAtom().getPredicates(IdPredicate.class).findFirst().isPresent()) {
             dbCompleteQueries.remove(query);
         } else {
@@ -94,7 +94,12 @@ public abstract class AtomicQueryCacheBase<
         }
     }
 
-    public void clearCompleteness(){
+    void clearQueryCompleteness(){
+        dbCompleteQueries.clear();
+        completeQueries.clear();
+    }
+
+    void clearCompleteness(){
         dbCompleteQueries.clear();
         dbCompleteEntries.clear();
 

--- a/server/src/graql/reasoner/cache/QueryCache.java
+++ b/server/src/graql/reasoner/cache/QueryCache.java
@@ -46,24 +46,6 @@ public interface QueryCache<
         SE extends Collection<ConceptMap>> {
 
     /**
-     * record answer iterable for a specific query and retrieve the updated answers
-     *
-     * @param query   to be recorded
-     * @param answers to this query
-     * @return updated entry
-     */
-    CacheEntry<Q, SE> record(Q query, S answers);
-
-    /**
-     * record answer stream for a specific query and retrieve the updated stream
-     *
-     * @param query   to be recorded
-     * @param answers answer stream of the query
-     * @return updated entry
-     */
-    CacheEntry<Q, SE> record(Q query, Stream<ConceptMap> answers);
-
-    /**
      * record single answer to a specific query
      *
      * @param query  of interest
@@ -73,8 +55,6 @@ public interface QueryCache<
     CacheEntry<Q, SE> record(Q query, ConceptMap answer);
 
     CacheEntry<Q, SE> record(Q query, ConceptMap answer, @Nullable CacheEntry<Q, SE> entry, @Nullable MultiUnifier unifier);
-
-    CacheEntry<Q, SE> record(Q query, ConceptMap answer, @Nullable MultiUnifier unifier);
 
     /**
      * retrieve (possibly) cached answers for provided query

--- a/server/src/graql/reasoner/cache/QueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/QueryCacheBase.java
@@ -24,8 +24,6 @@ import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
 import grakn.core.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,11 +75,6 @@ public abstract class QueryCacheBase<
     }
 
     @Override
-    public CacheEntry<Q, SE> record(Q query, ConceptMap answer, @Nullable MultiUnifier unifier) {
-        return record(query, answer, null, unifier);
-    }
-
-    @Override
     public R getAnswers(Q query) { return getAnswersWithUnifier(query).getKey(); }
 
     @Override
@@ -108,6 +101,14 @@ public abstract class QueryCacheBase<
      */
     public CacheEntry<Q, SE> getEntry(Q query) {
         return cache.get(queryToKey(query));
+    }
+
+    /**
+     * @param query for which the entry is to be removed
+     * @return corresponding cache entry to which this map previously associated the key or null
+     */
+    CacheEntry<Q, SE> removeEntry(Q query) {
+        return cache.remove(queryToKey(query));
     }
 
     /**

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -122,11 +122,15 @@ public abstract class SemanticCache<
     }
 
     public void ackInsertion(){
-        //NB: we do a full completion flush to not add too much overhead
+        //NB: we do a full completion flush to not add too much overhead to inserts
         clearCompleteness();
     }
 
     public void ackDeletion(Type type){
+        //flush db complete queries
+        clearQueryCompleteness();
+
+        //evict entries of the type and those that might be affected by the type
         RuleUtils.getDependentTypes(type).stream()
                 .flatMap(Type::sups)
                 .flatMap(t -> getFamily(t).stream())

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -223,4 +223,28 @@ public class RuleUtils {
         return rules;
     }
 
+    /**
+     * @param entryType type of interest
+     * @return all types that are dependent on the entryType - deletion of which triggers possible retraction of inferences
+     */
+    public static Set<Type> getDependentTypes(Type entryType){
+        Set<Type> types = new HashSet<>();
+        types.add(entryType);
+        Set<Type> visitedTypes = new HashSet<>();
+        Stack<Type> typeStack = new Stack<>();
+        typeStack.add(entryType);
+        while(!typeStack.isEmpty()) {
+            Type type = typeStack.pop();
+            if (!visitedTypes.contains(type) && type != null){
+                type.whenRules()
+                        .flatMap(Rule::thenTypes)
+                        .peek(types::add)
+                        .filter(at -> !visitedTypes.contains(at))
+                        .forEach(typeStack::add);
+                visitedTypes.add(type);
+            }
+        }
+        return types;
+    }
+
 }

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -123,6 +123,7 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
         this.edgeRelations().forEach(Concept::delete);
 
         vertex().tx().cache().removedInstance(type().id());
+        vertex().tx().queryCache().ackDeletion(type());
         deleteNode();
 
         relations.forEach(relation -> {

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -99,6 +99,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         vertex().tx().ruleCache().ackTypeInstance(this);
         if (!Schema.MetaSchema.isMetaLabel(label())) {
             vertex().tx().cache().addedInstance(id());
+            vertex().tx().queryCache().ackInsertion();
             if (isInferred) instanceVertex.property(Schema.VertexProperty.IS_INFERRED, true);
         }
 

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Sets;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.thing.Entity;
+import grakn.core.concept.thing.Relation;
 import grakn.core.graql.reasoner.atom.binary.RelationAtom;
 import grakn.core.graql.reasoner.explanation.LookupExplanation;
 import grakn.core.graql.reasoner.explanation.RuleExplanation;
@@ -38,6 +40,7 @@ import graql.lang.query.GraqlGet;
 import graql.lang.statement.Statement;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -593,6 +596,65 @@ public class QueryCacheIT {
     }
 
     @Test
+    public void whenInstancesAreInserted_weUpdateCompleteness(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
+            MultilevelSemanticCache cache = tx.queryCache();
+            ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(
+                    "{" +
+                            "(symmetricRole: $x, symmetricRole: $y) isa binary-trans;" +
+                            "};"
+            ), tx);
+
+            List<ConceptMap> answers = tx.execute(query.getQuery());
+            assertTrue(cache.isComplete(query));
+            assertTrue(cache.isDBComplete(query));
+
+            Entity entity = tx.getEntityType("anotherBaseRoleEntity").instances().iterator().next();
+
+            tx.getRelationType("binary").create()
+                    .assign(tx.getRole("baseRole1"), entity)
+                    .assign(tx.getRole("baseRole2"), entity);
+
+            assertFalse(cache.isComplete(query));
+            assertFalse(cache.isDBComplete(query));
+
+            ConceptMap answer = new ConceptMap(ImmutableMap.of(Graql.var("x").var(), entity, Graql.var("y").var(), entity));
+            List<ConceptMap> requeriedAnswers = tx.execute(query.getQuery());
+            assertTrue(requeriedAnswers.contains(answer));
+        }
+    }
+
+    @Test
+    public void whenInstancesAreDeleted_weUpdateCompleteness(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
+            MultilevelSemanticCache cache = tx.queryCache();
+            ReasonerAtomicQuery query = ReasonerQueries.atomic(conjunction(
+                    "{" +
+                            "(symmetricRole: $x, symmetricRole: $y) isa binary-trans;" +
+                            "};"
+            ), tx);
+
+            Entity entity = tx.getEntityType("anotherBaseRoleEntity").instances().iterator().next();
+            Relation relation = tx.getRelationType("binary").create()
+                    .assign(tx.getRole("baseRole1"), entity)
+                    .assign(tx.getRole("baseRole2"), entity);
+
+            List<ConceptMap> answers = tx.execute(query.getQuery());
+            assertTrue(cache.isComplete(query));
+            assertTrue(cache.isDBComplete(query));
+
+            relation.delete();
+
+            assertFalse(cache.isComplete(query));
+            assertFalse(cache.isDBComplete(query));
+
+            ConceptMap answer = new ConceptMap(ImmutableMap.of(Graql.var("x").var(), entity, Graql.var("y").var(), entity));
+            List<ConceptMap> requeriedAnswers = tx.execute(query.getQuery());
+            assertFalse(requeriedAnswers.contains(answer));
+        }
+    }
+
+    @Test
     public void whenRecordingQueryWithUniqueAnswer_weAckCompleteness(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().read()) {
             MultilevelSemanticCache cache = tx.queryCache();
@@ -656,7 +718,6 @@ public class QueryCacheIT {
                 .flatMap(e -> e.cachedElement().getAll().stream())
                 .collect(toSet());
     }
-
 
     private Conjunction<Statement> conjunction(String patternString) {
         Set<Statement> vars = Graql.parsePattern(patternString)


### PR DESCRIPTION
## What is the goal of this PR?
To make the query cache acknowledge updates - respond to insertions and deletions of concepts. That is to ensure that the inserted information is included in the result and the deleted information is excluded from the results.

## What are the changes implemented in this PR?
- we make the query cache acknowledge insertions of concepts - if a concept gets inserted, we flush all query completions. That ensures that the new concept will be captured when queried after the insertion.
- we make the query cache acknowledge deletion of concepts - if a concept gets deleted, all entries linked to its type as well as dependent types get flushed. Additionally we clear query completeness. That ensures that any mentions of the deleted concept are removed from the cache.
