### PR TITLE
Do not attach base attributes when infering sub attributes

### DIFF
--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -44,6 +44,7 @@ import grakn.core.graql.reasoner.cache.VariableDefinition;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
+import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
 import grakn.core.graql.reasoner.unifier.Unifier;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
@@ -60,6 +61,7 @@ import graql.lang.property.HasAttributeProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -394,8 +396,8 @@ public abstract class AttributeAtom extends Binary{
     }
 
     private ConceptMap findAnswer(ConceptMap sub){
-        AttributeAtom atom = getRelationVariable().isReturned()? this.rewriteWithRelationVariable() : this;
-        ReasonerAtomicQuery query = ReasonerQueries.atomic(atom).withSubstitution(sub);
+        //AttributeAtom atom = getRelationVariable().isReturned()? this.rewriteWithRelationVariable() : this;
+        ReasonerAtomicQuery query = ReasonerQueries.atomic(Collections.singleton(this), tx()).withSubstitution(sub);
         ConceptMap answer = tx().queryCache().getAnswerStream(query).findFirst().orElse(null);
 
         if (answer == null) tx().queryCache().ackDBCompleteness(query);
@@ -410,7 +412,7 @@ public abstract class AttributeAtom extends Binary{
      * @return inserted implicit relation if didn't exist, null otherwise
      */
     private Relation putImplicitRelation(ConceptMap sub, Concept owner, Attribute attribute){
-        ConceptMap answer = findAnswer(ConceptUtils.mergeAnswers(sub, new ConceptMap(ImmutableMap.of(getAttributeVariable(), attribute))));
+        ConceptMap answer = findAnswer(sub);
         if (answer == null) return attachAttribute(owner, attribute);
         return getRelationVariable().isReturned()? answer.get(getRelationVariable()).asRelation() : null;
     }
@@ -424,22 +426,36 @@ public abstract class AttributeAtom extends Binary{
         Variable resourceVariable = getAttributeVariable();
 
         //if the attribute already exists, only attach a new link to the owner, otherwise create a new attribute
-        Attribute attribute;
+        Attribute attribute = null;
         if(this.isValueEquality()){
             Object value = Iterables.getOnlyElement(getMultiPredicate()).getPredicate().value();
             Attribute existingAttribute = attributeType.attribute(value);
             attribute = existingAttribute == null? attributeType.putAttributeInferred(value) : existingAttribute;
         } else {
-            attribute = substitution.containsVar(resourceVariable)? substitution.get(resourceVariable).asAttribute() : null;
+            Attribute existingAttribute = substitution.containsVar(resourceVariable)? substitution.get(resourceVariable).asAttribute() : null;
+            //even if the attribute exists but is of different type (supertype for instance) we create a new one
+            //to make sure the attribute index will be different
+            if (existingAttribute != null){
+                Object value = existingAttribute.value();
+                attribute = existingAttribute;
+                if (!existingAttribute.type().equals(attributeType)){
+                    existingAttribute = attributeType.attribute(value);
+                    attribute = existingAttribute == null? attributeType.putAttributeInferred(value) : existingAttribute;
+                }
+            }
         }
 
         if (attribute != null) {
-            Relation relation = putImplicitRelation(substitution, owner, attribute);
-            ConceptMap answer = new ConceptMap(ImmutableMap.of(resourceVariable, attribute));
+            ConceptMap answer = new ConceptMap(ImmutableMap.of(
+                    getVarName(), substitution.get(getVarName()),
+                    resourceVariable, attribute));
+
+            Relation relation = putImplicitRelation(answer, owner, attribute);
+
             if (getRelationVariable().isReturned()){
                 answer = ConceptUtils.mergeAnswers(answer, new ConceptMap(ImmutableMap.of(getRelationVariable(), relation)));
             }
-            return Stream.of(ConceptUtils.mergeAnswers(substitution, answer));
+            return Stream.of(answer);
         }
         return Stream.empty();
     }

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -396,7 +396,7 @@ public abstract class AttributeAtom extends Binary{
     }
 
     private ConceptMap findAnswer(ConceptMap sub){
-        //AttributeAtom atom = getRelationVariable().isReturned()? this.rewriteWithRelationVariable() : this;
+        //NB: we are only interested in this atom and its subs, not any other constraints
         ReasonerAtomicQuery query = ReasonerQueries.atomic(Collections.singleton(this), tx()).withSubstitution(sub);
         ConceptMap answer = tx().queryCache().getAnswerStream(query).findFirst().orElse(null);
 

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1052,7 +1052,10 @@ public abstract class RelationAtom extends IsaAtomBase {
     public Stream<ConceptMap> materialise(){
         RelationType relationType = getSchemaConcept().asRelationType();
         //in case the roles are variable, we wouldn't have enough information if converted to attribute
-        if (relationType.isImplicit() && this.getRoleVariables().isEmpty()) return this.toAttributeAtom().materialise();
+        if (relationType.isImplicit()){
+            ConceptMap roleSub = getRoleSubstitution();
+            return this.toAttributeAtom().materialise().map(ans -> ConceptUtils.mergeAnswers(ans, roleSub));
+        }
         Multimap<Role, Variable> roleVarMap = getRoleVarMap();
         ConceptMap substitution = getParentQuery().getSubstitution();
 

--- a/server/src/graql/reasoner/cache/QueryCacheBase.java
+++ b/server/src/graql/reasoner/cache/QueryCacheBase.java
@@ -128,7 +128,7 @@ public abstract class QueryCacheBase<
     }
 
     static <T extends ReasonerQueryImpl> void validateAnswer(ConceptMap answer, T query, Set<Variable> expectedVars){
-        if (!answer.vars().containsAll(expectedVars)
+        if (!answer.vars().equals(expectedVars)
                 || answer.explanation() == null
                 || (
                         !answer.explanation().isRuleExplanation()

--- a/server/src/graql/reasoner/query/ReasonerQueries.java
+++ b/server/src/graql/reasoner/query/ReasonerQueries.java
@@ -152,6 +152,16 @@ public class ReasonerQueries {
     }
 
     /**
+     * create a reasoner atomic query from provided set of atomics
+     * @param as set of atomics that define the query
+     * @param tx corresponding transaction
+     * @return reasoner query defined by the provided set of atomics
+     */
+    public static ReasonerAtomicQuery atomic(Set<Atomic> as, TransactionOLTP tx){
+        return new ReasonerAtomicQuery(as, tx).inferTypes();
+    }
+
+    /**
      * create an atomic query by combining an existing atomic query and a substitution
      * @param q base query for substitution to be attached
      * @param sub (partial) substitution

--- a/server/src/graql/reasoner/rule/InferenceRule.java
+++ b/server/src/graql/reasoner/rule/InferenceRule.java
@@ -111,7 +111,7 @@ public class InferenceRule {
     /**
      * @return the priority with which the rule should be fired
      */
-    public long resolutionPriority(){
+    long resolutionPriority(){
         if (priority == Long.MAX_VALUE) {
             //NB: this has to be relatively lightweight as it is called on each rule
             //TODO come with a more useful metric
@@ -121,6 +121,8 @@ public class InferenceRule {
                     .map(Concept::asType)
                     .anyMatch(t -> t.thenRules().findFirst().isPresent());
             priority = bodyRuleResolvable? -1 : 0;
+            //resolve base types first
+            priority -= getHead().getAtom().getSchemaConcept().sups().count();
         }
         return priority;
     }

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -144,8 +144,6 @@ public class RuleUtils {
         typeSCC.successorMap().entries().forEach(e -> typeTCinverse.put(e.getValue(), e.getKey()));
 
         return typeCycles.stream().anyMatch(typeSet -> {
-            //for complicated patterns we reiterate
-            if (typeSet.size() > 1) return true;
             Set<ReasonerAtomicQuery> queries = typeSet.stream()
                     .flatMap(type -> typeTCinverse.get(type).stream())
                     .flatMap(type -> tx.queryCache().getFamily(type).stream())

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -144,6 +144,8 @@ public class RuleUtils {
         typeSCC.successorMap().entries().forEach(e -> typeTCinverse.put(e.getValue(), e.getKey()));
 
         return typeCycles.stream().anyMatch(typeSet -> {
+            //for complicated patterns we reiterate
+            if (typeSet.size() > 1) return true;
             Set<ReasonerAtomicQuery> queries = typeSet.stream()
                     .flatMap(type -> typeTCinverse.get(type).stream())
                     .flatMap(type -> tx.queryCache().getFamily(type).stream())

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -136,7 +136,7 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         }
         materialised.put(rule.getRule().id(), sub);
 
-        Set<Variable> queryVars = query.getVarNames().size() < ruleHead.getVarNames().size() ?
+        Set<Variable> headVars = query.getVarNames().size() < ruleHead.getVarNames().size() ?
                 unifier.keySet() :
                 ruleHead.getVarNames();
 
@@ -152,12 +152,13 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
                 ReasonerAtomicQuery attributeHead = ReasonerQueries.atomic(ruleHead.getAtom().toAttributeAtom());
                 getQuery().tx().queryCache().record(attributeHead, ruleAnswer.project(attributeHead.getVarNames()));
             }
-            answer = unifier.apply(materialisedSub.project(queryVars));
+            answer = unifier.apply(materialisedSub.project(headVars));
         }
         if (answer.isEmpty()) return answer;
 
         return ConceptUtils
                 .mergeAnswers(answer, query.getSubstitution())
+                .project(query.getVarNames())
                 .explain(new RuleExplanation(query.getPattern(), rule.getRule().id()));
     }
 }

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -144,12 +144,13 @@ public class AtomicState extends QueryState<ReasonerAtomicQuery> {
         ConceptMap materialisedSub = ruleHead.materialise(answer).findFirst().orElse(null);
         if (materialisedSub != null) {
             RuleExplanation ruleExplanation = new RuleExplanation(query.getPattern(), rule.getRule().id());
-            getQuery().tx().queryCache().record(ruleHead, materialisedSub.explain(ruleExplanation));
+            ConceptMap ruleAnswer = materialisedSub.explain(ruleExplanation);
+            getQuery().tx().queryCache().record(ruleHead, ruleAnswer);
             Atom ruleAtom = ruleHead.getAtom();
             //if it's an implicit relation also record it as an attribute
             if (ruleAtom.isRelation() && ruleAtom.getSchemaConcept() != null && ruleAtom.getSchemaConcept().isImplicit()) {
                 ReasonerAtomicQuery attributeHead = ReasonerQueries.atomic(ruleHead.getAtom().toAttributeAtom());
-                getQuery().tx().queryCache().record(attributeHead, materialisedSub.explain(ruleExplanation));
+                getQuery().tx().queryCache().record(attributeHead, ruleAnswer.project(attributeHead.getVarNames()));
             }
             answer = unifier.apply(materialisedSub.project(queryVars));
         }

--- a/server/src/graql/reasoner/state/RuleState.java
+++ b/server/src/graql/reasoner/state/RuleState.java
@@ -42,6 +42,7 @@ public class RuleState extends QueryStateBase{
 
     public RuleState(InferenceRule rule, ConceptMap sub, Unifier unifier, QueryStateBase parent, Set<ReasonerAtomicQuery> visitedSubGoals) {
         super(sub, unifier, parent, visitedSubGoals);
+        //NB; sub gets propagated to the body here
         this.bodyIterator = Iterators.singletonIterator(rule.getBody().subGoal(sub, unifier, this, visitedSubGoals));
         this.rule = rule;
     }

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -158,7 +158,6 @@ public class AttributeAttachmentIT {
             */
             final int baseResourceRoles = 4;
             final int subResourceRoles = 5;
-            //TODO: currently we will reify the implicit relations and have duplicate reified and non-reified versions in the answers
             assertEquals(
                     concepts.size() * baseResourceRoles +
                             subResources.size() * subResourceRoles,

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -71,7 +71,6 @@ public class AttributeAttachmentIT {
     @AfterClass
     public static void closeSession(){
         attributeAttachmentSession.close();
-
     }
 
     @Test
@@ -156,10 +155,19 @@ public class AttributeAttachmentIT {
             //TODO: currently we will reify the implicit relations and have duplicate reified and non-reified versions in the answers
             assertEquals(
                     concepts.size() * baseResourceRoles +
-                            subResources.size() * baseResourceRoles +
                             subResources.size() * subResourceRoles,
                     answers.size());
             answers.forEach(ans -> assertEquals(3, ans.size()));
+        }
+    }
+
+    @Test
+    public void whenReasoningWithAttributesWithRelationVar_ResultsAreComplete() {
+        try (TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
+            Statement has = var("x").has("reattachable-resource-string", var("y"), var("r"));
+            List<ConceptMap> answers = tx.execute(Graql.match(has).get());
+            assertEquals(5, answers.size());
+            answers.forEach(a -> assertTrue(a.vars().contains(new Variable("r"))));
         }
     }
 
@@ -203,19 +211,6 @@ public class AttributeAttachmentIT {
         try (TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
             List<ConceptMap> genericAnswers = tx.execute(Graql.parse(generalQuery).asGet());
             assertEquals(noOfGeneralAnswers, genericAnswers.size());
-        }
-    }
-
-    @Ignore
-    @Test
-    /* Flaky test */
-    public void whenReasoningWithAttributesWithRelationVar_ResultsAreComplete() {
-        try(TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
-
-            Statement has = var("x").has("reattachable-resource-string", var("y"), var("r"));
-            List<ConceptMap> answers = tx.execute(Graql.match(has).get());
-            assertEquals(5, answers.size());
-            answers.forEach(a -> assertTrue(a.vars().contains(new Variable("r"))));
         }
     }
 

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -56,8 +56,6 @@ import static org.junit.Assert.assertTrue;
 @SuppressWarnings("CheckReturnValue")
 public class AttributeAttachmentIT {
 
-    private static String resourcePath = "test-integration/graql/reasoner/stubs/";
-
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
 
@@ -65,6 +63,7 @@ public class AttributeAttachmentIT {
     @BeforeClass
     public static void loadContext(){
         attributeAttachmentSession = server.sessionWithNewKeyspace();
+        String resourcePath = "test-integration/graql/reasoner/stubs/";
         loadFromFileAndCommit(resourcePath, "resourceAttachment.gql", attributeAttachmentSession);
     }
 
@@ -83,8 +82,10 @@ public class AttributeAttachmentIT {
             String queryString2 = "match $x isa reattachable-resource-string; get;";
             List<ConceptMap> answers2 = tx.execute(Graql.parse(queryString2).asGet());
 
-            assertEquals(tx.getEntityType("genericEntity").instances().count(), answers.size());
-            assertEquals(1, answers2.size());
+            //two attributes for each entity
+            assertEquals(tx.getEntityType("genericEntity").instances().count() * 2, answers.size());
+            //one base resource, one sub
+            assertEquals(2, answers2.size());
         }
     }
 
@@ -96,8 +97,12 @@ public class AttributeAttachmentIT {
             String queryString = "match $x isa genericEntity;($x, $y); get;";
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
 
-            assertEquals(3, answers.size());
-            assertEquals(2, answers.stream().filter(answer -> answer.get("y").isAttribute()).count());
+            assertEquals(5, answers.size());
+            //two attributes for each entity
+            assertEquals(
+                    tx.getEntityType("genericEntity").instances().count() * 2,
+                    answers.stream().filter(answer -> answer.get("y").isAttribute()).count()
+            );
         }
     }
 
@@ -116,7 +121,8 @@ public class AttributeAttachmentIT {
 
             String queryString3 = "match $x isa reattachable-resource-string; $y isa subResource;get;";
             List<ConceptMap> answers3 = tx.execute(Graql.parse(queryString3).asGet());
-            assertEquals(1, answers3.size());
+            //2 RRS instances - one base, one sub hence two answers
+            assertEquals(2, answers3.size());
 
             assertTrue(answers3.iterator().next().get("x").isAttribute());
             assertTrue(answers3.iterator().next().get("y").isAttribute());
@@ -243,7 +249,8 @@ public class AttributeAttachmentIT {
 
             String queryString = "match $x isa genericEntity, has reattachable-resource-string $y; $z isa relation0; get;";
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
-            assertEquals(2, answers.size());
+            //two attributes for each entity
+            assertEquals(tx.getEntityType("genericEntity").instances().count() * 2, answers.size());
             answers.forEach(ans ->
                     {
                         assertTrue(ans.get("x").isEntity());


### PR DESCRIPTION
## What is the goal of this PR?
Previously, when inferring attributes based on existing attributes, we tried to reuse the existing concepts. This leads to unconsistencies: 
- we created an implicit relation of the base, not sub type
- we would use an inconsistent attribute index - base and sub attributes of the same value have different indices. This PR ensures if we are dealing with attribute attachments when hierarchies are involved, we explicitly create a new attribute of the specific type.

Fixes #5302
## What are the changes implemented in this PR?

- when materialising attributes, we check whether instances of specific types are present and whether the existing attribute is of the specific type. If specific instance is not found, we insert it.
- stricter answer validity check in query cache (equality instead of containment)
