### PR TITLE
Update rule priority calculation to take into account type hierarchy

### DIFF
--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -556,8 +556,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     public boolean requiresReiteration() {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
-        return RuleUtils.subGraphIsCyclical(dependentRules, tx())||
-                RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules);
+        return RuleUtils.subGraphIsCyclical(dependentRules, tx());
     }
 
     public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals){

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -188,15 +188,6 @@ public class RuleUtils {
     }
 
     /**
-     * @param rules set of rules of interest forming a rule subgraph
-     * @return true if the rule subgraph formed from provided rules contains any rule with head satisfying the body pattern
-     */
-    public static boolean subGraphHasRulesWithHeadSatisfyingBody(Set<InferenceRule> rules){
-        return rules.stream()
-                .anyMatch(InferenceRule::headSatisfiesBody);
-    }
-
-    /**
      * @param query top query
      * @return all rules that are reachable from the entry types
      */


### PR DESCRIPTION
## What is the goal of this PR?
Update rule priority calculation to include type hierarchy information of the type of the head of the rule.

## What are the changes implemented in this PR?
- we take into account how deep in type hierarchy the head type is and prioritise base types
- removed the head satisfication check as it wasn't working as expected
