### PR TITLE
Prefixed artifact IDs of Maven packages with 'grakn-'

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source grakn@$(cat VERSION) \
           --targets \
-          grakn-kgms:master benchmark:master workbase:master \
+          grakn-kgms:master benchmark:master workbase:master biograkn:master \
           client-java:master client-python:master client-nodejs:master \
           docs:master examples:master
 

--- a/api/BUILD
+++ b/api/BUILD
@@ -32,7 +32,7 @@ java_library(
         # External dependencies from Maven
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
     ],
-    tags = ["maven_coordinates=io.grakn.core:api:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-api:{pom_version}"],
     visibility = ["//visibility:public"]
 )
 

--- a/bin/grakn
+++ b/bin/grakn
@@ -23,8 +23,8 @@ JAVA_BIN=java
 GRAKN_HOME=$(cd "$(dirname "${path}")" && pwd -P)
 GRAKN_CONFIG="server/conf/grakn.properties"
 
-CONSOLE_JAR_FILENAME=(${GRAKN_HOME}/console/services/lib/io-grakn-core-console*.jar)
-SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/services/lib/io-grakn-core-server*.jar)
+CONSOLE_JAR_FILENAME=(${GRAKN_HOME}/console/services/lib/io-grakn-core-grakn-console*.jar)
+SERVER_JAR_FILENAME=(${GRAKN_HOME}/server/services/lib/io-grakn-core-grakn-server*.jar)
 
 # ================================================
 # common helper functions

--- a/bin/grakn.bat
+++ b/bin/grakn.bat
@@ -53,7 +53,7 @@ goto exiterror
 :startconsole
 
 set "G_CP=%GRAKN_HOME%\console\conf\;%GRAKN_HOME%\console\services\lib\*"
-if exist .\console\services\lib\io-grakn-core-console-*.jar (
+if exist .\console\services\lib\io-grakn-core-grakn-console-*.jar (
   java %CONSOLE_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" grakn.core.console.GraknConsole %*
   goto exit
 ) else (
@@ -65,7 +65,7 @@ if exist .\console\services\lib\io-grakn-core-console-*.jar (
 :startserver
 
 set "G_CP=%GRAKN_HOME%\server\conf\;%GRAKN_HOME%\server\services\lib\*"
-if exist .\server\services\lib\io-grakn-core-server-*.jar (
+if exist .\server\services\lib\io-grakn-core-grakn-server-*.jar (
   java %GRAKN_DAEMON_JAVAOPTS% -cp "%G_CP%" -Dgrakn.dir="%GRAKN_HOME%" -Dgrakn.conf="%GRAKN_HOME%\%GRAKN_CONFIG%" -Dstorage.javaopts="%STORAGE_JAVAOPTS%" -Dserver.javaopts="%SERVER_JAVAOPTS%" grakn.core.daemon.GraknDaemon %*
   goto exit
 ) else (

--- a/common/BUILD
+++ b/common/BUILD
@@ -31,7 +31,7 @@ java_library(
         "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
     ],
     visibility = ["//visibility:public"],
-    tags = ["maven_coordinates=io.grakn.core:common:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-common:{pom_version}"],
 )
 
 assemble_maven(

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -34,7 +34,7 @@ java_library(
         # External dependencies from Maven
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
     ],
-    tags = ["maven_coordinates=io.grakn.core:concept:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-concept:{pom_version}"],
 )
 
 

--- a/console/BUILD
+++ b/console/BUILD
@@ -53,7 +53,7 @@ java_library(
     visibility = ["//visibility:public"],
     resources = ["LICENSE"],
     resource_strip_prefix = "console",
-    tags = ["maven_coordinates=io.grakn.core:console:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-console:{pom_version}"],
 )
 
 checkstyle_test(

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -41,7 +41,7 @@ java_library(
     resources = ["LICENSE"],
     resource_strip_prefix = "daemon",
     visibility = ["//visibility:public"],
-    tags = ["maven_coordinates=io.grakn.core:daemon:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-daemon:{pom_version}"],
 )
 
 assemble_maven(

--- a/server/BUILD
+++ b/server/BUILD
@@ -83,7 +83,7 @@ java_library(
     ],
     resources = ["LICENSE"] + glob(["resources/*"]),
     resource_strip_prefix = "server",
-    tags = ["maven_coordinates=io.grakn.core:server:{pom_version}"],
+    tags = ["maven_coordinates=io.grakn.core:grakn-server:{pom_version}"],
     javacopts = ["-XepDisableAllChecks"], # TODO: THIS NEEDS TO BE REMOVED
     visibility = ["//visibility:public"]
 


### PR DESCRIPTION
## What is the goal of this PR?

When deploying Maven JARs to Sonatype, the JARs are renamed to be `artifact-id-version.jar`, without the `group-id`. This is done in Sonatype because the JARs are organised into folders where the folder names represent the Group IDs. However, in certain build systems, e.g. Gradle, the JARs are collected under one directory, which means the JAR names are not unique enough to disambiguate itself from each other. We have now renamed the artifact ID of our Maven packages to be prefixed with `grakn-` to solve this problem.

## What are the changes implemented in this PR?

Prefixed artifact IDs of Maven packages with 'grakn-' (fixes #5127, fixes https://github.com/graknlabs/bazel-distribution/issues/112).