### PR TITLE
Do not flush completeness when inserting inferred concepts

### DIFF
--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -556,7 +556,8 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     public boolean requiresReiteration() {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
-        return RuleUtils.subGraphIsCyclical(dependentRules, tx());
+        return RuleUtils.subGraphIsCyclical(dependentRules, tx())
+                || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules);
     }
 
     public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals){

--- a/server/src/graql/reasoner/rule/InferenceRule.java
+++ b/server/src/graql/reasoner/rule/InferenceRule.java
@@ -141,6 +141,20 @@ public class InferenceRule {
     private boolean hasDisconnectedHead(){
         return Sets.intersection(body.getVarNames(), head.getVarNames()).isEmpty();
     }
+
+    /**
+     * @return true if head satisfies the pattern specified in the body of the rule
+     */
+    boolean headSatisfiesBody(){
+        if (!getBody().isAtomic()) return false;
+        Set<Atomic> atoms = new HashSet<>(getHead().getAtoms());
+        Set<Variable> headVars = getHead().getVarNames();
+        getBody().getAtoms(TypeAtom.class)
+                .filter(t -> !t.isRelation())
+                .filter(t -> !Sets.intersection(t.getVarNames(), headVars).isEmpty())
+                .forEach(atoms::add);
+        return ReasonerQueries.create(atoms, tx).isEquivalent(getBody());
+    }
     
     /**
      * rule requires materialisation in the context of resolving parent atom

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -188,6 +188,15 @@ public class RuleUtils {
     }
 
     /**
+     * @param rules set of rules of interest forming a rule subgraph
+     * @return true if the rule subgraph formed from provided rules contains any rule with head satisfying the body pattern
+     */
+    public static boolean subGraphHasRulesWithHeadSatisfyingBody(Set<InferenceRule> rules){
+        return rules.stream()
+                .anyMatch(InferenceRule::headSatisfiesBody);
+    }
+
+    /**
      * @param query top query
      * @return all rules that are reachable from the entry types
      */

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -99,8 +99,11 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         vertex().tx().ruleCache().ackTypeInstance(this);
         if (!Schema.MetaSchema.isMetaLabel(label())) {
             vertex().tx().cache().addedInstance(id());
-            vertex().tx().queryCache().ackInsertion();
-            if (isInferred) instanceVertex.property(Schema.VertexProperty.IS_INFERRED, true);
+            if (isInferred){
+                instanceVertex.property(Schema.VertexProperty.IS_INFERRED, true);
+            } else {
+                vertex().tx().queryCache().ackInsertion();
+            }
         }
 
         V instance = producer.apply(instanceVertex, getThis());

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -102,6 +102,8 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
             if (isInferred){
                 instanceVertex.property(Schema.VertexProperty.IS_INFERRED, true);
             } else {
+                //creation of inferred concepts is an integral part of reasoning
+                //hence we only acknowledge non-inferred insertions
                 vertex().tx().queryCache().ackInsertion();
             }
         }


### PR DESCRIPTION
## What is the goal of this PR?

Previously (#5300) we introduced cache flushing mechanism for insertions and deletions. The added behaviour flushes too often however - the completion is flushed on insertion of inferred concepts. Insertion of inferred concepts is an integral part of the reasoning and it doesn't require any extra mechanisms to ensure the query cache is up to date. As a result of flushing on insertion of inferred concepts we potentially need to do extra db checks to guarantee answer completion.

## What are the changes implemented in this PR?
- we do not ack a concept insertion in the query cache if the concept is inferred
- we reinstate the extra head satisfiability check
