### PR TITLE
Remove obsolete use of neqPositive

### DIFF
--- a/server/src/graql/reasoner/atom/Atomic.java
+++ b/server/src/graql/reasoner/atom/Atomic.java
@@ -37,9 +37,6 @@ public interface Atomic {
     @CheckReturnValue
     Atomic copy(ReasonerQuery parent);
 
-    @CheckReturnValue
-    Atomic neqPositive();
-
     /**
      * @return variable name of this atomic
      */

--- a/server/src/graql/reasoner/atom/AtomicBase.java
+++ b/server/src/graql/reasoner/atom/AtomicBase.java
@@ -38,9 +38,6 @@ import java.util.stream.Stream;
  */
 public abstract class AtomicBase implements Atomic {
 
-    @Override
-    public Atomic neqPositive() { return this; }
-
     @Override public void checkValid(){}
 
     @Override

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -106,20 +106,6 @@ public abstract class AttributeAtom extends Binary{
     public Atomic copy(ReasonerQuery parent){ return create(this, parent);}
 
     @Override
-    public Atomic neqPositive(){
-        return create(
-                this.getPattern(),
-                this.getAttributeVariable(),
-                this.getRelationVariable(),
-                this.getPredicateVariable(),
-                this.getTypeId(),
-                this.getMultiPredicate().stream()
-                        .filter(at -> !(at.getPredicate().comparator().equals(Graql.Token.Comparator.NEQV)))
-                        .collect(Collectors.toSet()),
-                this.getParentQuery());
-    }
-
-    @Override
     public Class<? extends VarProperty> getVarPropertyClass() { return HasAttributeProperty.class;}
 
     @Override

--- a/server/src/graql/reasoner/query/CompositeQuery.java
+++ b/server/src/graql/reasoner/query/CompositeQuery.java
@@ -217,9 +217,9 @@ public class CompositeQuery implements ResolvableQuery {
     }
 
     @Override
-    public ResolvableQuery neqPositive() {
+    public ResolvableQuery constantValuePredicateQuery() {
         return new CompositeQuery(
-                getConjunctiveQuery().neqPositive(),
+                getConjunctiveQuery().constantValuePredicateQuery(),
                 getComplementQueries(),
                 tx());
     }

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -155,10 +155,9 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     }
 
     @Override
-    public ReasonerQueryImpl neqPositive(){
+    public ReasonerQueryImpl constantValuePredicateQuery(){
         return ReasonerQueries.create(
                 getAtoms().stream()
-                        .map(Atomic::neqPositive)
                         .filter(at -> !(at instanceof VariablePredicate))
                         .collect(Collectors.toSet()),
                 tx());

--- a/server/src/graql/reasoner/query/ResolvableQuery.java
+++ b/server/src/graql/reasoner/query/ResolvableQuery.java
@@ -58,10 +58,10 @@ public interface ResolvableQuery extends ReasonerQuery {
     ResolvableQuery withSubstitution(ConceptMap sub);
 
     /**
-     * @return corresponding neqPositive query (with neq predicates removed)
+     * @return corresponding query with variable predicates removed
      */
     @CheckReturnValue
-    ResolvableQuery neqPositive();
+    ResolvableQuery constantValuePredicateQuery();
 
     /**
      * @return corresponding reasoner query with inferred types

--- a/server/src/graql/reasoner/state/VariableComparisonState.java
+++ b/server/src/graql/reasoner/state/VariableComparisonState.java
@@ -64,7 +64,7 @@ public class VariableComparisonState extends QueryStateBase {
         this.variablePredicateSub = ConceptUtils.mergeAnswers(query.getSubstitution(), sub)
                 .project(this.variablePredicates.stream().flatMap(p -> p.getVarNames().stream()).collect(Collectors.toSet()));
 
-        this.complementState = query.neqPositive().subGoal(sub, u, this, subGoals);
+        this.complementState = query.constantValuePredicateQuery().subGoal(sub, u, this, subGoals);
     }
 
     @Override

--- a/test-integration/graql/reasoner/reasoning/BUILD
+++ b/test-integration/graql/reasoner/reasoning/BUILD
@@ -17,12 +17,12 @@ java_test(
 )
 
 java_test(
-    name = "variable-valuepredicate-it",
+    name = "valuepredicate-it",
     size = "medium",
-    srcs = ["VariableValuePredicateIT.java"],
+    srcs = ["ValuePredicateIT.java"],
     classpath_resources = ["//test-integration/resources:logback-test"],
     resources = ["//test-integration/graql/reasoner/stubs:reasoning-stubs"],
-    test_class = "grakn.core.graql.reasoner.reasoning.VariableValuePredicateIT",
+    test_class = "grakn.core.graql.reasoner.reasoning.ValuePredicateIT",
     deps = [
         "//concept",
         "//dependencies/maven/artifacts/com/google/guava",
@@ -139,7 +139,7 @@ checkstyle_test(
     targets = [
         ":attribute-attachment-it",
         ":neq-idpredicate-it",
-        ":variable-valuepredicate-it",
+        ":valuepredicate-it",
         ":recursion-it",
         ":type-generation-it",
         ":type-hierarchies-it",

--- a/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
+++ b/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
@@ -52,11 +52,10 @@ import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
-public class VariableValuePredicateIT {
-
-    private static String resourcePath = "test-integration/graql/reasoner/stubs/";
+public class ValuePredicateIT {
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
@@ -65,12 +64,69 @@ public class VariableValuePredicateIT {
     @BeforeClass
     public static void loadContext(){
         attributeAttachmentSession = server.sessionWithNewKeyspace();
+        String resourcePath = "test-integration/graql/reasoner/stubs/";
         loadFromFileAndCommit(resourcePath, "resourceAttachment.gql", attributeAttachmentSession);
     }
 
     @AfterClass
     public static void closeSession(){
         attributeAttachmentSession.close();
+    }
+
+    @Test
+    public void whenResolvingInferrableAttributesWithBounds_answersAreCalculatedCorrectly(){
+        SessionImpl session = server.sessionWithNewKeyspace();
+        try(TransactionOLTP tx = session.transaction().write()) {
+            tx.execute(Graql.parse("define " +
+                    "someEntity sub entity," +
+                    "has derivedResource;" +
+                    "derivedResource sub attribute, datatype long;" +
+                    "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
+                    "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};" +
+                    "rule3 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1997;};"
+
+            ).asDefine());
+            tx.execute(Graql.parse("insert " +
+                    "$x isa someEntity;" +
+                    "$y isa someEntity;"
+            ).asInsert());
+            tx.commit();
+        }
+
+        final long bound = 1667L;
+        Statement value = Graql.var("value");
+        Pattern basePattern = Graql.var("x").has("derivedResource", value);
+
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.gt(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() > bound));
+        }
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.gte(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() >= bound));
+        }
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.lt(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() < bound));
+        }
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.lte(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() <= bound));
+        }
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.eq(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() == bound));
+        }
+        try(TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.neq(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() != bound));
+        }
     }
 
     @Test
@@ -92,45 +148,53 @@ public class VariableValuePredicateIT {
             tx.commit();
         }
 
-        Pattern basePattern = Graql.parsePattern("{" +
-                "$x has derivedResource $value;" +
-                "$y has derivedResource $anotherValue;" +
-                "};");
+        Statement value = Graql.var("value");
+        Statement anotherValue = Graql.var("anotherValue");
+        Pattern basePattern = Graql.and(
+                Graql.var("x").has("derivedResource", value),
+                Graql.var("y").has("derivedResource", anotherValue)
+        );
 
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").gt(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.gt(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertTrue((long) ans.get("value").asAttribute().value() > (long) ans.get("anotherValue").asAttribute().value());
+                assertTrue((long) ans.get(value.var()).asAttribute().value() > (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").gte(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.gte(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertTrue((long) ans.get("value").asAttribute().value() >= (long) ans.get("anotherValue").asAttribute().value());
+                assertTrue((long) ans.get(value.var()).asAttribute().value() >= (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").lt(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.lt(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertTrue((long) ans.get("value").asAttribute().value() < (long) ans.get("anotherValue").asAttribute().value());
+                assertTrue((long) ans.get(value.var()).asAttribute().value() < (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").lte(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.lte(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertTrue((long) ans.get("value").asAttribute().value() <= (long) ans.get("anotherValue").asAttribute().value());
+                assertTrue((long) ans.get(value.var()).asAttribute().value() <= (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").eq(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.eq(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertEquals((long) ans.get("value").asAttribute().value(), (long) ans.get("anotherValue").asAttribute().value());
+                assertEquals((long) ans.get(value.var()).asAttribute().value(), (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("value").neq(Graql.var("anotherValue")))).get());
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, value.neq(anotherValue))).get());
+            assertFalse(answers.isEmpty());
             answers.forEach(ans -> {
-                assertTrue((long) ans.get("value").asAttribute().value() != (long) ans.get("anotherValue").asAttribute().value());
+                assertTrue((long) ans.get(value.var()).asAttribute().value() != (long) ans.get(anotherValue.var()).asAttribute().value());
             });
         }
     }
@@ -156,35 +220,43 @@ public class VariableValuePredicateIT {
         }
 
         final long bound = 1667L;
-        Pattern basePattern = Graql.parsePattern("{" +
-                "$x has derivedResource $value;" +
-                "$y has derivedResource $anotherValue;" +
-                "$value == $anotherValue;" +
-                "};");
+        Statement value = Graql.var("value");
+        Statement anotherValue = Graql.var("anotherValue");
+        Pattern basePattern = Graql.and(
+                Graql.var("x").has("derivedResource", value),
+                Graql.var("y").has("derivedResource", anotherValue),
+                value.eq(anotherValue)
+        );
 
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").gt(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() > bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.gt(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() > bound));
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").gte(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() >= bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.gte(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() >= bound));
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").lt(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() < bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.lt(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() < bound));
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").lte(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() <= bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.lte(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() <= bound));
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").eq(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() == bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.eq(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() == bound));
         }
         try(TransactionOLTP tx = session.transaction().write()) {
-            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").neq(bound))).get());
-            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() != bound));
+            List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, anotherValue.neq(bound))).get());
+            assertFalse(answers.isEmpty());
+            answers.forEach(ans -> assertTrue((long) ans.get(value.var()).asAttribute().value() != bound));
         }
     }
 
@@ -494,8 +566,8 @@ public class VariableValuePredicateIT {
             answers.forEach(ans -> {
                 Type type = ans.get("type").asType();
                 Object value = ans.get("value").asAttribute().value();
-                assertTrue(!value.equals("unattached"));
-                assertTrue(!type.equals(unwantedType));
+                assertNotEquals("unattached", value);
+                assertNotEquals(unwantedType, type);
             });
         }
     }

--- a/test-integration/graql/reasoner/reasoning/VariableValuePredicateIT.java
+++ b/test-integration/graql/reasoner/reasoning/VariableValuePredicateIT.java
@@ -184,8 +184,7 @@ public class VariableValuePredicateIT {
         }
         try(TransactionOLTP tx = session.transaction().write()) {
             List<ConceptMap> answers = tx.execute(Graql.match(Graql.and(basePattern, Graql.var("anotherValue").neq(bound))).get());
-            //TODO this currently fails
-            //answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() != bound));
+            answers.forEach(ans -> assertTrue((long) ans.get("value").asAttribute().value() != bound));
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Remove the use of `neqPositive` which is obsolete after the changes introduced in #5226. The use of `neqPositive` in the current context leads to potential issues - if a query contains `!== ` predicates with a value, they might be omitted if other variable predicates are present. This PR fixes that.

Requires #5311
## What are the changes implemented in this PR?
- remove the `neqPositive` member of `Atomic` and its uses
