### PR TITLE
GitHub release should be titled properly

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -156,6 +156,8 @@ checksum(
 deploy_github(
     name = "deploy-github",
     deployment_properties = "//:deployment.properties",
+    title = "Grakn Core",
+    title_append_version = True,
     release_description = "//:RELEASE_TEMPLATE.md",
     archive = ":assemble-versioned-all",
     version_file = "//:VERSION"


### PR DESCRIPTION
## What is the goal of this PR?

Previously, we would have to manually enter title an version when doing a release of Grakn Core. This PR automates the process.

## What are the changes implemented in this PR?

Add `title` and `title_append_version` to `deploy_github` (support introduced in graknlabs/bazel-distribution#141)
