### PR TITLE
Reiterate if disconnected inferrable atoms present

### DIFF
--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -557,7 +557,8 @@ public class ReasonerQueryImpl implements ResolvableQuery {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
         return RuleUtils.subGraphIsCyclical(dependentRules, tx())
-                || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules);
+                || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules)
+                || selectAtoms().filter(Atom::isDisconnected).anyMatch(Atom::isRuleResolvable);
     }
 
     public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals){

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -558,7 +558,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
         return RuleUtils.subGraphIsCyclical(dependentRules, tx())
                 || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules)
-                || selectAtoms().filter(Atom::isDisconnected).anyMatch(Atom::isRuleResolvable);
+                || selectAtoms().filter(Atom::isDisconnected).filter(Atom::isRuleResolvable).count() > 1;
     }
 
     public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals){


### PR DESCRIPTION
## What is the goal of this PR?
Due to the way query caching and reasoning works, in the case we have disconnected inferrable subqueries within the query of interest, some results might be missed if we do not reiterate. We fix that by adding an extra reiteration condition.

## What are the changes implemented in this PR?
- add an extra check for disconnected rule-resolvable atoms when determining if reiteration is needed
