### PR TITLE
Make '//console:version' visibility 'public' for use by KGMS

### DIFF
--- a/console/BUILD
+++ b/console/BUILD
@@ -31,6 +31,7 @@ genrule(
     ],
     cmd = "VERSION=`cat $(location :VERSION)`;sed -e \"s/{version}/$$VERSION/g\" $(location templates/Version.java) >> $@",
     outs = ["Version.java"],
+    visibility = ["//visibility:public"]
 )
 
 java_library(


### PR DESCRIPTION
## What is the goal of this PR?

We have made the Bazel target `//console:version` have public visibility for use by KGMS.