### PR TITLE
Enable Error Prone

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -95,7 +95,6 @@ java_library(
     resources = ["LICENSE"] + glob(["resources/*"]),
     resource_strip_prefix = "server",
     tags = ["maven_coordinates=io.grakn.core:grakn-server:{pom_version}"],
-    javacopts = ["-XepDisableAllChecks"], # TODO: THIS NEEDS TO BE REMOVED
     visibility = ["//visibility:public"]
 
 )

--- a/server/src/server/session/TransactionOLAP.java
+++ b/server/src/server/session/TransactionOLAP.java
@@ -110,14 +110,14 @@ public class TransactionOLAP {
 
         Traversal<Vertex, Edge> edgeFilter;
         if (filterAllEdges) {
-            edgeFilter = __.<Vertex>bothE().limit(0);
+            edgeFilter = __.bothE().limit(0);
         } else {
             edgeFilter = includesRolePlayerEdge ?
                     __.union(
-                            __.<Vertex>bothE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()),
-                            __.<Vertex>bothE(Schema.EdgeLabel.ATTRIBUTE.getLabel())
+                            __.bothE(Schema.EdgeLabel.ROLE_PLAYER.getLabel()),
+                            __.bothE(Schema.EdgeLabel.ATTRIBUTE.getLabel())
                                     .has(Schema.EdgeProperty.RELATION_TYPE_LABEL_ID.name(), P.within(labelIds))) :
-                    __.<Vertex>bothE(Schema.EdgeLabel.ATTRIBUTE.getLabel())
+                    __.bothE(Schema.EdgeLabel.ATTRIBUTE.getLabel())
                             .has(Schema.EdgeProperty.RELATION_TYPE_LABEL_ID.name(), P.within(labelIds));
         }
 

--- a/server/src/server/session/optimisation/JanusPreviousPropertyStepStrategy.java
+++ b/server/src/server/session/optimisation/JanusPreviousPropertyStepStrategy.java
@@ -45,8 +45,8 @@ import java.util.Optional;
  * steps together.
  *
  */
-public class JanusPreviousPropertyStepStrategy
-        extends AbstractTraversalStrategy<ProviderOptimizationStrategy> implements ProviderOptimizationStrategy {
+@SuppressWarnings("ComparableType")
+public class JanusPreviousPropertyStepStrategy extends AbstractTraversalStrategy<ProviderOptimizationStrategy> implements ProviderOptimizationStrategy {
 
     private static final long serialVersionUID = 6888929702831948298L;
 


### PR DESCRIPTION
## What is the goal of this PR?

Enable Google's `Error Prone` (https://errorprone.info/index) to enable static analysis of code

## What are the changes implemented in this PR?

- remove `javacopts = ["-XepDisableAllChecks"]` from `BUILD` file
- remove unnecessary types in `TransactionOLTP` as suggested by Error Prone
- added `SuppressWarning` (https://errorprone.info/bugpattern/ComparableType) is class that cannot be fixed without modifying Janus 
