### PR TITLE
Make sure all inferred concept dependants are persisted when inserting

### DIFF
--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -121,7 +121,7 @@ public interface Thing extends Concept {
     boolean isInferred();
 
     /**
-     * Return concepts that are dependants of this concept - concepts required to be persisted if we persist this concept.
+     * Return concepts that are DIRECT dependants of this concept - concepts required to be persisted if we persist this concept.
      */
     default Stream<Thing> getDependentConcepts(){ return Stream.of(this);}
 

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -120,6 +120,11 @@ public interface Thing extends Concept {
      */
     boolean isInferred();
 
+    /**
+     * Return concepts that are dependants of this concept - concepts required to be persisted if we persist this concept.
+     */
+    Stream<Thing> getDependentConcepts();
+
     //------------------------------------- Other ---------------------------------
     @Deprecated
     @CheckReturnValue

--- a/concept/thing/Thing.java
+++ b/concept/thing/Thing.java
@@ -123,7 +123,7 @@ public interface Thing extends Concept {
     /**
      * Return concepts that are dependants of this concept - concepts required to be persisted if we persist this concept.
      */
-    Stream<Thing> getDependentConcepts();
+    default Stream<Thing> getDependentConcepts(){ return Stream.of(this);}
 
     //------------------------------------- Other ---------------------------------
     @Deprecated

--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -35,16 +35,21 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.thing.Relation;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Role;
+import grakn.core.concept.type.Rule;
+import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.property.PropertyExecutor.Writer;
 import grakn.core.graql.util.Partition;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.kb.concept.ConceptImpl;
+import grakn.core.server.kb.concept.ConceptUtils;
 import grakn.core.server.kb.concept.ConceptVertex;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import java.util.Stack;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -280,10 +285,12 @@ public class WriteExecutor {
     }
 
     private void markConceptsForPersistence(Collection<Concept> concepts){
-        concepts.stream()
+        Set<Thing> things = concepts.stream()
                 .filter(Concept::isThing)
                 .map(Concept::asThing)
-                .flatMap(Thing::getDependentConcepts)
+                .collect(Collectors.toSet());
+
+        ConceptUtils.getDependentConcepts(things)
                 .filter(Thing::isInferred)
                 .forEach(t -> {
                     //as we are going to persist the concepts, reset the inferred flag

--- a/server/src/server/kb/concept/AttributeImpl.java
+++ b/server/src/server/kb/concept/AttributeImpl.java
@@ -127,8 +127,8 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
         Role hasRole = vertex().tx().getRole(Schema.ImplicitType.HAS_VALUE.getLabel(typeLabel).getValue());
         Role keyRole = vertex().tx().getRole(Schema.ImplicitType.KEY_VALUE.getLabel(typeLabel).getValue());
         Stream<Thing> conceptStream = Stream.of(this);
-        if (hasRole != null) conceptStream = Stream.concat(conceptStream, relations(hasRole).flatMap(Thing::getDependentConcepts));
-        if (keyRole != null) conceptStream = Stream.concat(conceptStream, relations(keyRole).flatMap(Thing::getDependentConcepts));
+        if (hasRole != null) conceptStream = Stream.concat(conceptStream, relations(hasRole));
+        if (keyRole != null) conceptStream = Stream.concat(conceptStream, relations(keyRole));
         return conceptStream;
     }
 }

--- a/server/src/server/kb/concept/AttributeImpl.java
+++ b/server/src/server/kb/concept/AttributeImpl.java
@@ -18,9 +18,12 @@
 
 package grakn.core.server.kb.concept;
 
+import grakn.core.concept.Label;
 import grakn.core.concept.thing.Attribute;
+import grakn.core.concept.thing.Relation;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.AttributeType;
+import grakn.core.concept.type.Role;
 import grakn.core.server.exception.TransactionException;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.kb.structure.VertexElement;
@@ -116,5 +119,16 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
     @Override
     public String innerToString() {
         return super.innerToString() + "- Value [" + value() + "] ";
+    }
+
+    @Override
+    public Stream<Thing> getDependentConcepts() {
+        Label typeLabel = type().label();
+        Role hasRole = vertex().tx().getRole(Schema.ImplicitType.HAS_VALUE.getLabel(typeLabel).getValue());
+        Role keyRole = vertex().tx().getRole(Schema.ImplicitType.KEY_VALUE.getLabel(typeLabel).getValue());
+        Stream<Relation> implicitRelationStream = keyRole == null ?
+                relations(hasRole) :
+                Stream.concat(relations(hasRole), relations(keyRole));
+        return Stream.concat(Stream.of(this), implicitRelationStream.flatMap(Thing::getDependentConcepts));
     }
 }

--- a/server/src/server/kb/concept/AttributeImpl.java
+++ b/server/src/server/kb/concept/AttributeImpl.java
@@ -126,9 +126,9 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
         Label typeLabel = type().label();
         Role hasRole = vertex().tx().getRole(Schema.ImplicitType.HAS_VALUE.getLabel(typeLabel).getValue());
         Role keyRole = vertex().tx().getRole(Schema.ImplicitType.KEY_VALUE.getLabel(typeLabel).getValue());
-        Stream<Relation> implicitRelationStream = keyRole == null ?
-                relations(hasRole) :
-                Stream.concat(relations(hasRole), relations(keyRole));
-        return Stream.concat(Stream.of(this), implicitRelationStream.flatMap(Thing::getDependentConcepts));
+        Stream<Thing> conceptStream = Stream.of(this);
+        if (hasRole != null) conceptStream = Stream.concat(conceptStream, relations(hasRole).flatMap(Thing::getDependentConcepts));
+        if (keyRole != null) conceptStream = Stream.concat(conceptStream, relations(keyRole).flatMap(Thing::getDependentConcepts));
+        return conceptStream;
     }
 }

--- a/server/src/server/kb/concept/EntityImpl.java
+++ b/server/src/server/kb/concept/EntityImpl.java
@@ -19,8 +19,10 @@
 package grakn.core.server.kb.concept;
 
 import grakn.core.concept.thing.Entity;
+import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.EntityType;
 import grakn.core.server.kb.structure.VertexElement;
+import java.util.stream.Stream;
 
 /**
  * An instance of Entity Type EntityType
@@ -48,4 +50,7 @@ public class EntityImpl extends ThingImpl<Entity, EntityType> implements Entity 
     public static EntityImpl from(Entity entity) {
         return (EntityImpl) entity;
     }
+
+    @Override
+    public Stream<Thing> getDependentConcepts() { return Stream.of(this); }
 }

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -237,4 +237,9 @@ public class RelationImpl implements Relation, ConceptVertex {
     public Relation attributeInferred(Attribute attribute) {
         return reify().attributeInferred(attribute);
     }
+
+    @Override
+    public Stream<Thing> getDependentConcepts() {
+        return Stream.concat(Stream.of(this), rolePlayers().flatMap(Thing::getDependentConcepts));
+    }
 }

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -43,7 +43,7 @@ public class RelationImpl implements Relation, ConceptVertex {
     private RelationImpl(RelationStructure relationStructure) {
         this.relationStructure = relationStructure;
         if (relationStructure.isReified()) {
-            relationStructure.reify().owner(/*.flatMap(Thing::getDependentConcepts)*/this);
+            relationStructure.reify().owner(this);
         }
     }
 

--- a/server/src/server/kb/concept/RelationImpl.java
+++ b/server/src/server/kb/concept/RelationImpl.java
@@ -43,7 +43,7 @@ public class RelationImpl implements Relation, ConceptVertex {
     private RelationImpl(RelationStructure relationStructure) {
         this.relationStructure = relationStructure;
         if (relationStructure.isReified()) {
-            relationStructure.reify().owner(this);
+            relationStructure.reify().owner(/*.flatMap(Thing::getDependentConcepts)*/this);
         }
     }
 
@@ -240,6 +240,6 @@ public class RelationImpl implements Relation, ConceptVertex {
 
     @Override
     public Stream<Thing> getDependentConcepts() {
-        return Stream.concat(Stream.of(this), rolePlayers().flatMap(Thing::getDependentConcepts));
+        return Stream.concat(Stream.of(this), rolePlayers());
     }
 }

--- a/server/src/server/kb/concept/RelationReified.java
+++ b/server/src/server/kb/concept/RelationReified.java
@@ -223,4 +223,8 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
         return true;
     }
 
+    @Override
+    public Stream<Thing> getDependentConcepts() {
+        return owner != null? owner.getDependentConcepts() : Stream.empty();
+    }
 }

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -284,8 +284,12 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
 
         if (!roleSet.isEmpty()) {
             stream = stream.filter(edge -> {
-                Role roleOwner = vertex().tx().getSchemaConcept(LabelId.of(edge.property(Schema.EdgeProperty.RELATION_ROLE_OWNER_LABEL_ID)));
-                return roleSet.contains(roleOwner);
+                Set<Role> edgeRoles = new HashSet<>();
+                edgeRoles.add(vertex().tx().getSchemaConcept(LabelId.of(edge.property(Schema.EdgeProperty.RELATION_ROLE_OWNER_LABEL_ID))));
+                if (this.isAttribute()){
+                    edgeRoles.add(vertex().tx().getSchemaConcept(LabelId.of(edge.property(Schema.EdgeProperty.RELATION_ROLE_VALUE_LABEL_ID))));
+                }
+                return !Sets.intersection(roleSet, edgeRoles).isEmpty();
             });
         }
 

--- a/test-integration/server/kb/TransactionIT.java
+++ b/test-integration/server/kb/TransactionIT.java
@@ -513,8 +513,11 @@ public class TransactionIT {
         tx = session.transaction().read();
         List<ConceptMap> relationsWithInferredRolePlayerPostCommit = tx.execute(Graql.parse(
                 "match " +
-                "$rel (someRole: $p, anotherRole: $r) isa inferrableRelation;" +
-                "$rel has nonInferrableAttribute 'relation with inferred roleplayer'; get;")
+                        "$p isa someEntity;" +
+                        "$q isa someEntity, has inferrableAttribute $r; $r 'inferred';" +
+                        "$rel (someRole: $p, anotherRole: $r) isa inferrableRelation;" +
+                        "$rel has nonInferrableAttribute 'relation with inferred roleplayer';" +
+                        "get $rel, $p, $r;")
                 .asGet(), false);
 
         List<ConceptMap> inferredRelationWithAttributeAttachedPostCommit = tx.execute(Graql.parse(


### PR DESCRIPTION
## What is the goal of this PR?
When we are inserting, to ensure all required inferred concepts are marked for persistence, this includes situations:
- multiply-nested relations where children role players are inferred
- implicit relations of attributes
- when inserted relations are non-inferred but role players are possibly inferred

## What are the changes implemented in this PR?
We retrieve all dependent concepts including non-directly dependent ones when we execute an insert in `WriteExecutor`.
