### PR TITLE
Remove unnecessary answer projections in query executor

### DIFF
--- a/common/util/Triple.java
+++ b/common/util/Triple.java
@@ -46,16 +46,12 @@ public class Triple<A, B, C> {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
 
-        if (obj.getClass() == this.getClass()) {
-            Triple<?, ?, ?> other = (Triple) obj;
-
-            return (Objects.equals(this.first, other.first) &&
+        Triple<?, ?, ?> other = (Triple) obj;
+        return (Objects.equals(this.first, other.first) &&
                     Objects.equals(this.second, other.second) &&
                     Objects.equals(this.third, other.third));
-        }
-
-        return false;
     }
 
     public int hashCode() {

--- a/common/util/Tuple.java
+++ b/common/util/Tuple.java
@@ -40,15 +40,10 @@ public class Tuple<A, B> {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
-
-        if (obj.getClass() == this.getClass()) {
-            Tuple<?, ?> other = (Tuple) obj;
-
-            return (Objects.equals(this.first, other.first) &&
-                    Objects.equals(this.second, other.second));
-        }
-
-        return false;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Tuple<?, ?> other = (Tuple) obj;
+        return (Objects.equals(this.first, other.first) &&
+                Objects.equals(this.second, other.second));
     }
 
     public int hashCode() {

--- a/server/src/graql/gremlin/fragment/ValueFragment.java
+++ b/server/src/graql/gremlin/fragment/ValueFragment.java
@@ -164,7 +164,7 @@ public class ValueFragment extends Fragment {
             // short circuiting can be done quickly if starting here
             return 0.0;
         } else {
-            return totalImplicitRels / totalAttributes;
+            return (double) totalImplicitRels / totalAttributes;
         }
     }
 }

--- a/server/test/graql/gremlin/NodesUtilTest.java
+++ b/server/test/graql/gremlin/NodesUtilTest.java
@@ -51,14 +51,14 @@ public class NodesUtilTest {
         Node inIsaMiddleNode = inIsaNodes.stream()
                 .filter(node -> node instanceof EdgeNode)
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(inIsaMiddleNode);
 
         InstanceNode instanceVarNode = (InstanceNode) inIsaNodes.stream()
                 .filter(node -> node instanceof InstanceNode && node.getNodeId().toString().contains("instanceVar"))
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(instanceVarNode);
 
@@ -87,14 +87,14 @@ public class NodesUtilTest {
         Node outIsaMiddleNode = outIsaNodes.stream()
                 .filter(node -> node instanceof EdgeNode)
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(outIsaMiddleNode);
 
         InstanceNode instanceVarNode = (InstanceNode) outIsaNodes.stream()
                 .filter(node -> node instanceof InstanceNode && node.getNodeId().toString().contains("instanceVar"))
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(instanceVarNode);
 

--- a/server/test/graql/gremlin/spanningtree/datastructure/FibonacciQueueTest.java
+++ b/server/test/graql/gremlin/spanningtree/datastructure/FibonacciQueueTest.java
@@ -36,6 +36,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class FibonacciQueueTest {
+
+    final private Random random = new Random();
+
     @Test
     public void testIterator() {
         // insert lots of numbers in order
@@ -52,7 +55,6 @@ public class FibonacciQueueTest {
         final FibonacciQueue<Integer> queue = FibonacciQueue.create();
         // Insert lots of random numbers.
         final ImmutableMultiset.Builder<Integer> insertedBuilder = ImmutableMultiset.builder();
-        final Random random = new Random();
         for (int i = 0; i < lots; i++) {
             int r = random.nextInt();
             insertedBuilder.add(r);

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -789,7 +789,7 @@ public class GraknClientIT {
             GraqlGet.Aggregate stdAgeQuery =
                     Graql.match(var("x").isa("person").has("age", var("y"))).get().std("y");
             int n = 2;
-            double mean = (20 + 22) / n;
+            double mean = (double) (20 + 22) / n;
             double var = (Math.pow(20 - mean, 2) + Math.pow(22 - mean, 2)) / (n - 1);
             double std = Math.sqrt(var);
             assertEquals(std, tx.execute(stdAgeQuery).get(0).number().doubleValue(), 0.0001d);

--- a/test-integration/server/kb/TransactionIT.java
+++ b/test-integration/server/kb/TransactionIT.java
@@ -284,6 +284,7 @@ public class TransactionIT {
         }
         assertNotNull(exception);
         assertThat(exception, instanceOf(TransactionException.class));
+        assertNotNull(exception);
         assertEquals(exception.getMessage(), ErrorMessage.TRANSACTION_ALREADY_OPEN.getMessage(keyspace));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Remove unnecessary projection steps when returning answers in QueryExecutor. For large number of answers these introduce a lot of unnecessary work and extra overhead.

## What are the changes implemented in this PR?

- removed redundant answer projections in `QueryExecutor`
