### PR TITLE
Remove redundant answer projection

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -387,16 +387,13 @@ public class QueryExecutor {
     }
 
     public Stream<ConceptMap> get(GraqlGet query) {
-        MatchClause matchClause = query.match();
-        Set<Variable> variablesToGet = query.vars();
-        Stream<ConceptMap> answers = match(matchClause).distinct();
+        //NB: we need distinct as projection can produce duplicates
+        Stream<ConceptMap> answers = match(query.match()).map(ans -> ans.project(query.vars())).distinct();
 
-        if (!matchClause.getSelectedNames().equals(variablesToGet)){
-            answers = answers.map(ans -> ans.project(variablesToGet));
-        }
         answers = filter(query, answers);
 
-        return answers;
+
+        return answers.distinct();
     }
 
     public Stream<Numeric> aggregate(GraqlGet.Aggregate query) {

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -393,7 +393,7 @@ public class QueryExecutor {
         answers = filter(query, answers);
 
 
-        return answers.distinct();
+        return answers;
     }
 
     public Stream<Numeric> aggregate(GraqlGet.Aggregate query) {

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -389,7 +389,7 @@ public class QueryExecutor {
     public Stream<ConceptMap> get(GraqlGet query) {
         MatchClause matchClause = query.match();
         Set<Variable> variablesToGet = query.vars();
-        Stream<ConceptMap> answers = match(matchClause);
+        Stream<ConceptMap> answers = match(matchClause).distinct();
 
         if (!matchClause.getSelectedNames().equals(variablesToGet)){
             answers = answers.map(ans -> ans.project(variablesToGet));

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -391,8 +391,7 @@ public class QueryExecutor {
         Stream<ConceptMap> answers = match(query.match()).map(ans -> ans.project(query.vars())).distinct();
 
         answers = filter(query, answers);
-
-
+        
         return answers;
     }
 

--- a/server/src/graql/reasoner/ReasonerQueryIterator.java
+++ b/server/src/graql/reasoner/ReasonerQueryIterator.java
@@ -31,7 +31,7 @@ public abstract class ReasonerQueryIterator implements Iterator<ConceptMap> {
 
     public Stream<ConceptMap> hasStream() {
         Iterable<ConceptMap> iterable = () -> this;
-        return StreamSupport.stream(iterable.spliterator(), false).distinct();
+        return StreamSupport.stream(iterable.spliterator(), false);
     }
 }
 


### PR DESCRIPTION
## What is the goal of this PR?

Remove unnecessary answer projection and distinct stream operations. These are redundant and introduce overhead for larger numbers of answers.

## What are the changes implemented in this PR?
- removed redundant projection step in `QueryExecutor`
- removed redundant `distinct` stream operation in ReasonerQueryIterator
