### PR TITLE
Remove some of the sonarcloud bugs

### DIFF
--- a/common/util/Triple.java
+++ b/common/util/Triple.java
@@ -46,16 +46,12 @@ public class Triple<A, B, C> {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
 
-        if (obj.getClass() == this.getClass()) {
-            Triple<?, ?, ?> other = (Triple) obj;
-
-            return (Objects.equals(this.first, other.first) &&
+        Triple<?, ?, ?> other = (Triple) obj;
+        return (Objects.equals(this.first, other.first) &&
                     Objects.equals(this.second, other.second) &&
                     Objects.equals(this.third, other.third));
-        }
-
-        return false;
     }
 
     public int hashCode() {

--- a/common/util/Tuple.java
+++ b/common/util/Tuple.java
@@ -40,15 +40,10 @@ public class Tuple<A, B> {
 
     public boolean equals(Object obj) {
         if (obj == this) return true;
-
-        if (obj.getClass() == this.getClass()) {
-            Tuple<?, ?> other = (Tuple) obj;
-
-            return (Objects.equals(this.first, other.first) &&
-                    Objects.equals(this.second, other.second));
-        }
-
-        return false;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Tuple<?, ?> other = (Tuple) obj;
+        return (Objects.equals(this.first, other.first) &&
+                Objects.equals(this.second, other.second));
     }
 
     public int hashCode() {

--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -389,7 +389,7 @@ public class QueryExecutor {
     public Stream<ConceptMap> get(GraqlGet query) {
         MatchClause matchClause = query.match();
         Set<Variable> variablesToGet = query.vars();
-        Stream<ConceptMap> answers = match(matchClause);
+        Stream<ConceptMap> answers = match(matchClause).distinct();
 
         if (!matchClause.getSelectedNames().equals(variablesToGet)){
             answers = answers.map(ans -> ans.project(variablesToGet));

--- a/server/src/graql/gremlin/fragment/ValueFragment.java
+++ b/server/src/graql/gremlin/fragment/ValueFragment.java
@@ -164,7 +164,7 @@ public class ValueFragment extends Fragment {
             // short circuiting can be done quickly if starting here
             return 0.0;
         } else {
-            return totalImplicitRels / totalAttributes;
+            return (double) totalImplicitRels / totalAttributes;
         }
     }
 }

--- a/server/test/graql/gremlin/NodesUtilTest.java
+++ b/server/test/graql/gremlin/NodesUtilTest.java
@@ -51,14 +51,14 @@ public class NodesUtilTest {
         Node inIsaMiddleNode = inIsaNodes.stream()
                 .filter(node -> node instanceof EdgeNode)
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(inIsaMiddleNode);
 
         InstanceNode instanceVarNode = (InstanceNode) inIsaNodes.stream()
                 .filter(node -> node instanceof InstanceNode && node.getNodeId().toString().contains("instanceVar"))
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(instanceVarNode);
 
@@ -87,14 +87,14 @@ public class NodesUtilTest {
         Node outIsaMiddleNode = outIsaNodes.stream()
                 .filter(node -> node instanceof EdgeNode)
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(outIsaMiddleNode);
 
         InstanceNode instanceVarNode = (InstanceNode) outIsaNodes.stream()
                 .filter(node -> node instanceof InstanceNode && node.getNodeId().toString().contains("instanceVar"))
                 .findAny()
-                .get();
+                .orElse(null);
 
         assertNotNull(instanceVarNode);
 

--- a/server/test/graql/gremlin/spanningtree/datastructure/FibonacciQueueTest.java
+++ b/server/test/graql/gremlin/spanningtree/datastructure/FibonacciQueueTest.java
@@ -36,6 +36,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class FibonacciQueueTest {
+
+    final private Random random = new Random();
+
     @Test
     public void testIterator() {
         // insert lots of numbers in order
@@ -52,7 +55,6 @@ public class FibonacciQueueTest {
         final FibonacciQueue<Integer> queue = FibonacciQueue.create();
         // Insert lots of random numbers.
         final ImmutableMultiset.Builder<Integer> insertedBuilder = ImmutableMultiset.builder();
-        final Random random = new Random();
         for (int i = 0; i < lots; i++) {
             int r = random.nextInt();
             insertedBuilder.add(r);

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -789,7 +789,7 @@ public class GraknClientIT {
             GraqlGet.Aggregate stdAgeQuery =
                     Graql.match(var("x").isa("person").has("age", var("y"))).get().std("y");
             int n = 2;
-            double mean = (20 + 22) / n;
+            double mean = (double) (20 + 22) / n;
             double var = (Math.pow(20 - mean, 2) + Math.pow(22 - mean, 2)) / (n - 1);
             double std = Math.sqrt(var);
             assertEquals(std, tx.execute(stdAgeQuery).get(0).number().doubleValue(), 0.0001d);

--- a/test-integration/server/kb/TransactionIT.java
+++ b/test-integration/server/kb/TransactionIT.java
@@ -284,6 +284,7 @@ public class TransactionIT {
         }
         assertNotNull(exception);
         assertThat(exception, instanceOf(TransactionException.class));
+        assertNotNull(exception);
         assertEquals(exception.getMessage(), ErrorMessage.TRANSACTION_ALREADY_OPEN.getMessage(keyspace));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

Address some of the bugs highlighted by sonarcloud, especially those concerning possible nulls, use of resources and use of Random.

## What are the changes implemented in this PR?
- updated hashcodes for `Tuple` and `Triple` to account for compared object being null
- removed `get()` calls without isPresent in `NodeUtilTest`
- added extra casts in `ValueFragment` and `GraknClientIt` to prevent from inaccurate calculations
- reused `Random` in `BenchmarkBigIT` and `FibonacciQueueIT`
- properly closed resources in `BenchmarkBigIT`
