### PR TITLE
Remove the use of assert

### DIFF
--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graql.executor;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -305,7 +306,7 @@ public class WriteExecutor {
 
     private Concept buildConcept(Variable var, ConceptBuilder builder) {
         Concept concept = builder.build();
-        assert concept != null : String.format("build() should never return null. var: %s", var);
+        Preconditions.checkNotNull(concept, "build() should never return null. var: %s", var);
         concepts.put(var, concept);
         return concept;
     }
@@ -409,7 +410,7 @@ public class WriteExecutor {
      */
     public Concept getConcept(Variable var) {
         var = equivalentVars.componentOf(var);
-        assert var != null;
+        Preconditions.checkNotNull(var);
 
         @Nullable Concept concept = concepts.get(var);
 

--- a/server/src/graql/gremlin/GreedyTreeTraversal.java
+++ b/server/src/graql/gremlin/GreedyTreeTraversal.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graql.gremlin;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import grakn.core.graql.gremlin.fragment.Fragment;
 import grakn.core.graql.gremlin.spanningtree.Arborescence;
@@ -66,7 +67,7 @@ public class GreedyTreeTraversal {
             Node nodeWithMinCost = reachableNodes.stream().min(Comparator.comparingDouble(node ->
                     branchWeight(node, arborescence, edgesParentToChild, edgeFragmentChildToParent))).orElse(null);
 
-            assert nodeWithMinCost != null : "reachableNodes is never empty, so there is always a minimum";
+            Preconditions.checkNotNull(nodeWithMinCost, "reachableNodes is never empty, so there is always a minimum");
 
             // add fragments without dependencies first (eg. could be the index fragments)
             nodeFragmentsWithoutDependencies(nodeWithMinCost).forEach(fragment -> {

--- a/server/src/graql/gremlin/spanningtree/datastructure/FibonacciHeap.java
+++ b/server/src/graql/gremlin/spanningtree/datastructure/FibonacciHeap.java
@@ -104,8 +104,7 @@ public class FibonacciHeap<V, P> implements Iterable<FibonacciHeap<V, P>.Entry> 
                 comparator.compare(newPriority, entry.priority) <= 0,
                 "Cannot increase priority"
         );
-
-        assert oMinEntry != null;
+        Preconditions.checkNotNull(oMinEntry);
 
         entry.priority = newPriority;
         Entry oParent = entry.oParent;
@@ -291,7 +290,7 @@ public class FibonacciHeap<V, P> implements Iterable<FibonacciHeap<V, P>.Entry> 
 
         // update parent's `oFirstChild` pointer
         Entry oFirstChild = oParent.oFirstChild;
-        assert oFirstChild != null;
+        Preconditions.checkNotNull(oFirstChild);
 
         if (oFirstChild.equals(entry)) {
             if (oParent.degree == 0) {

--- a/server/src/graql/gremlin/spanningtree/datastructure/FibonacciQueue.java
+++ b/server/src/graql/gremlin/spanningtree/datastructure/FibonacciQueue.java
@@ -18,13 +18,13 @@
 
 package grakn.core.graql.gremlin.spanningtree.datastructure;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
 
 import java.util.AbstractQueue;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.function.Function;
-import jline.internal.Preconditions;
 
 /**
  * A PriorityQueue built on top of a FibonacciHeap

--- a/server/src/graql/gremlin/spanningtree/datastructure/FibonacciQueue.java
+++ b/server/src/graql/gremlin/spanningtree/datastructure/FibonacciQueue.java
@@ -24,6 +24,7 @@ import java.util.AbstractQueue;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.function.Function;
+import jline.internal.Preconditions;
 
 /**
  * A PriorityQueue built on top of a FibonacciHeap
@@ -33,7 +34,7 @@ import java.util.function.Function;
 public class FibonacciQueue<E> extends AbstractQueue<E> {
     private final FibonacciHeap<E, E> heap;
     private final Function<FibonacciHeap<E, ?>.Entry, E> getValue = input -> {
-        assert input != null;
+        Preconditions.checkNotNull(input);
         return input.value;
     };
 

--- a/server/src/graql/gremlin/spanningtree/graph/DirectedEdge.java
+++ b/server/src/graql/gremlin/spanningtree/graph/DirectedEdge.java
@@ -20,12 +20,12 @@ package grakn.core.graql.gremlin.spanningtree.graph;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.Set;
-import jline.internal.Preconditions;
 
 /**
  * An edge in a directed graph.

--- a/server/src/graql/gremlin/spanningtree/graph/DirectedEdge.java
+++ b/server/src/graql/gremlin/spanningtree/graph/DirectedEdge.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 import java.util.Set;
+import jline.internal.Preconditions;
 
 /**
  * An edge in a directed graph.
@@ -80,7 +81,7 @@ public class DirectedEdge {
 
     public static Predicate<DirectedEdge> hasDestination(final Node node) {
         return input -> {
-            assert input != null;
+            Preconditions.checkNotNull(input);
             return input.destination.equals(node);
         };
     }
@@ -92,7 +93,7 @@ public class DirectedEdge {
         }
         final Map<Node, Node> requiredSourceByDest = requiredSourceByDestinationBuilder.build();
         return input -> {
-            assert input != null;
+            Preconditions.checkNotNull(input);
             return (requiredSourceByDest.containsKey(input.destination) &&
                     !input.source.equals(requiredSourceByDest.get(input.destination)));
         };
@@ -100,7 +101,7 @@ public class DirectedEdge {
 
     public static Predicate<DirectedEdge> isAutoCycle() {
         return input -> {
-            assert input != null;
+            Preconditions.checkNotNull(input);
             return input.source.equals(input.destination);
         };
     }

--- a/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graql.reasoner.atom.predicate;
 
+import com.google.common.base.Preconditions;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.exception.GraqlQueryException;
@@ -28,7 +29,6 @@ import graql.lang.Graql;
 import graql.lang.property.ValueProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-import jline.internal.Preconditions;
 
 /**
  * Class used to handle value predicates with a variable:

--- a/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -28,6 +28,7 @@ import graql.lang.Graql;
 import graql.lang.property.ValueProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import jline.internal.Preconditions;
 
 /**
  * Class used to handle value predicates with a variable:
@@ -51,7 +52,7 @@ public class VariableValuePredicate extends VariablePredicate {
     private VariableValuePredicate(Variable varName, Variable predicateVar, ValueProperty.Operation op, Statement pattern, ReasonerQuery parentQuery) {
         super(varName, predicateVar, pattern, parentQuery);
         //comparisons only valid for variable predicates (ones having a reference variable)
-        assert (op.innerStatement() != null);
+        Preconditions.checkNotNull(op.innerStatement());
         this.op = op;
     }
 

--- a/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -25,7 +25,6 @@ import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.executor.property.ValueExecutor;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.query.ReasonerQuery;
-import graql.lang.Graql;
 import graql.lang.property.ValueProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
@@ -51,14 +50,14 @@ public class VariableValuePredicate extends VariablePredicate {
 
     private VariableValuePredicate(Variable varName, Variable predicateVar, ValueProperty.Operation op, Statement pattern, ReasonerQuery parentQuery) {
         super(varName, predicateVar, pattern, parentQuery);
-        //comparisons only valid for variable predicates (ones having a reference variable)
-        Preconditions.checkNotNull(op.innerStatement());
         this.op = op;
     }
 
     public static VariableValuePredicate create(Variable varName, ValueProperty.Operation op, ReasonerQuery parent) {
         Statement innerStatement = op.innerStatement();
-        Variable predicateVar = innerStatement != null? innerStatement.var() : Graql.var().var().asReturnedVar();
+        //comparisons only valid for variable predicates (ones having a reference variable)
+        Preconditions.checkNotNull(innerStatement);
+        Variable predicateVar = innerStatement.var();
         Statement pattern = new Statement(varName).operation(op);
         return new VariableValuePredicate(varName, predicateVar, op, pattern, parent);
     }

--- a/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
+++ b/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
@@ -19,6 +19,7 @@
 package grakn.core.graql.reasoner.cache;
 
 import com.google.common.base.Equivalence;
+import com.google.common.base.Preconditions;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueryEquivalence;
@@ -131,7 +132,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
         ReasonerAtomicQuery equivalentQuery = entry.query();
         AnswerSet answers = entry.cachedElement();
         MultiUnifier multiUnifier = equivalentQuery.getMultiUnifier(query, unifierType());
-        assert(!multiUnifier.isEmpty());
+        Preconditions.checkState(!multiUnifier.isEmpty());
 
         return new Pair<>(
                 multiUnifier.inverse()

--- a/server/src/graql/reasoner/cache/SemanticCache.java
+++ b/server/src/graql/reasoner/cache/SemanticCache.java
@@ -238,7 +238,6 @@ public abstract class SemanticCache<
             @Nullable CacheEntry<ReasonerAtomicQuery, SE> entry,
             @Nullable MultiUnifier unifier) {
 
-        assert(query.isPositive());
         validateAnswer(answer, query, query.getVarNames());
         if (query.hasUniqueAnswer()) ackCompleteness(query);
 
@@ -274,7 +273,6 @@ public abstract class SemanticCache<
 
     @Override
     public Pair<Stream<ConceptMap>, MultiUnifier> getAnswerStreamWithUnifier(ReasonerAtomicQuery query) {
-        assert(query.isPositive());
         CacheEntry<ReasonerAtomicQuery, SE> match = getEntry(query);
         boolean queryGround = query.isGround();
 

--- a/server/src/graql/reasoner/plan/ResolutionPlan.java
+++ b/server/src/graql/reasoner/plan/ResolutionPlan.java
@@ -38,7 +38,6 @@ public final class ResolutionPlan {
     public ResolutionPlan(ReasonerQueryImpl q){
         this.query = q;
         this.plan = GraqlTraversalPlanner.plan(query);
-        assert(q.isPositive());
         validatePlan();
     }
 

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server.kb.concept;
 
+import com.google.common.base.Preconditions;
 import grakn.core.concept.Concept;
 import grakn.core.concept.Label;
 import grakn.core.concept.thing.Attribute;
@@ -109,7 +110,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         }
 
         V instance = producer.apply(instanceVertex, getThis());
-        assert instance != null : "producer should never return null";
+        Preconditions.checkNotNull(instance, "producer should never return null");
 
         vertex().tx().statisticsDelta().increment(label());
 

--- a/server/src/server/session/computer/GraknSparkComputer.java
+++ b/server/src/server/session/computer/GraknSparkComputer.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server.session.computer;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.FileConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
@@ -325,10 +326,10 @@ public final class GraknSparkComputer extends AbstractHadoopGraphComputer {
                     this.logger.debug("Partitioning the loaded graphRDD: " + partitioner);
                     loadedGraphRDD = loadedGraphRDD.partitionBy(partitioner);
                     partitioned = true;
-                    assert loadedGraphRDD.partitioner().isPresent();
+                    Preconditions.checkState(loadedGraphRDD.partitioner().isPresent());
                 } else {
                     // no easy way to test this with a test case
-                    assert skipPartitioner == !loadedGraphRDD.partitioner().isPresent();
+                    Preconditions.checkState(skipPartitioner == !loadedGraphRDD.partitioner().isPresent());
 
                     this.logger.debug("Partitioning has been skipped for the loaded graphRDD via " +
                             Constants.GREMLIN_SPARK_SKIP_PARTITIONER);
@@ -408,10 +409,7 @@ public final class GraknSparkComputer extends AbstractHadoopGraphComputer {
                                 !this.mapReducers.isEmpty()) {
                             computedGraphRDD = GraknSparkExecutor.prepareFinalGraphRDD(
                                     loadedGraphRDD, viewIncomingRDD, this.vertexProgram.getVertexComputeKeys());
-                            assert null != computedGraphRDD && computedGraphRDD != loadedGraphRDD;
-                        } else {
-                            // ensure that the computedGraphRDD was not created
-                            assert null == computedGraphRDD;
+                            Preconditions.checkState(null != computedGraphRDD && computedGraphRDD != loadedGraphRDD);
                         }
                     }
                     /////////////////
@@ -419,7 +417,7 @@ public final class GraknSparkComputer extends AbstractHadoopGraphComputer {
                     // write the computed graph to the respective output (rdd or output format)
                     if (null != outputRDD && !this.persist.equals(Persist.NOTHING)) {
                         // the logic holds that a computeGraphRDD must be created at this point
-                        assert null != computedGraphRDD;
+                        Preconditions.checkNotNull(computedGraphRDD);
 
                         outputRDD.writeGraphRDD(graphComputerConfiguration, computedGraphRDD);
                     }
@@ -475,11 +473,11 @@ public final class GraknSparkComputer extends AbstractHadoopGraphComputer {
                     }
                     // if the mapReduceRDD is not simply the computed graph, unpersist the mapReduceRDD
                     if (computedGraphCreated && !outputToSpark) {
-                        assert loadedGraphRDD != computedGraphRDD;
-                        assert mapReduceRDD != computedGraphRDD;
+                        Preconditions.checkState(loadedGraphRDD != computedGraphRDD);
+                        Preconditions.checkState(mapReduceRDD != computedGraphRDD);
                         mapReduceRDD.unpersist();
                     } else {
-                        assert mapReduceRDD == computedGraphRDD;
+                        Preconditions.checkState(mapReduceRDD == computedGraphRDD);
                     }
                 }
 


### PR DESCRIPTION
## What is the goal of this PR?

To remove the use of `assert` in the code. The motivation is that it is only meant to be used during development and it requires a VM option to be enabled during run time. Additionally, if the assert condition is false, the assert throws an AssertionError with just the message text.

## What are the changes implemented in this PR?
- Removes the use of `assert` and uses `Preconditions` in place.