### PR TITLE
Refactor and optimise resolution plan

### DIFF
--- a/server/src/graql/reasoner/plan/ResolutionPlan.java
+++ b/server/src/graql/reasoner/plan/ResolutionPlan.java
@@ -19,12 +19,18 @@
 package grakn.core.graql.reasoner.plan;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.AtomicBase;
 import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
-
+import graql.lang.statement.Variable;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class defining the resolution plan for a given ReasonerQueryImpl at an atom level.
@@ -32,8 +38,9 @@ import java.util.stream.Collectors;
  */
 public final class ResolutionPlan {
 
-    final private ImmutableList<Atom> plan;
-    final private ReasonerQueryImpl query;
+    private final ImmutableList<Atom> plan;
+    private final ReasonerQueryImpl query;
+    private static final Logger LOG = LoggerFactory.getLogger(ResolutionPlan.class);
 
     public ResolutionPlan(ReasonerQueryImpl q){
         this.query = q;
@@ -58,11 +65,24 @@ public final class ResolutionPlan {
         return query.selectAtoms().allMatch(plan::contains);
     }
 
+
     private void validatePlan() {
         if (!isComplete()){
             throw GraqlQueryException.incompleteResolutionPlan(query);
         }
-    }
 
+        Iterator<Atom> iterator = plan.iterator();
+        Set<Variable> vars = new HashSet<>(iterator.next().getVarNames());
+        while (iterator.hasNext()) {
+            Atom next = iterator.next();
+            Set<Variable> varNames = next.getVarNames();
+            boolean planDisconnected = Sets.intersection(varNames, vars).isEmpty();
+            if (planDisconnected) {
+                LOG.warn("Disconnected resolution plan produced:\n{}", this);
+                break;
+            }
+            vars.addAll(varNames);
+        }
+    }
 }
 

--- a/server/src/graql/reasoner/plan/ResolutionPlan.java
+++ b/server/src/graql/reasoner/plan/ResolutionPlan.java
@@ -78,7 +78,7 @@ public final class ResolutionPlan {
             Set<Variable> varNames = next.getVarNames();
             boolean planDisconnected = Sets.intersection(varNames, vars).isEmpty();
             if (planDisconnected) {
-                LOG.warn("Disconnected resolution plan produced:\n{}", this);
+                LOG.debug("Disconnected resolution plan produced:\n{}", this);
                 break;
             }
             vars.addAll(varNames);

--- a/test-integration/graql/reasoner/query/ResolutionPlanIT.java
+++ b/test-integration/graql/reasoner/query/ResolutionPlanIT.java
@@ -70,8 +70,6 @@ public class ResolutionPlanIT {
 
     private static final int repeat = 20;
 
-    private static String resourcePath = "test-integration/graql/reasoner/resources/";
-
     @Rule
     public RepeatRule repeatRule = new RepeatRule();
 
@@ -84,6 +82,7 @@ public class ResolutionPlanIT {
     @BeforeClass
     public static void loadContext(){
         planSession = server.sessionWithNewKeyspace();
+        String resourcePath = "test-integration/graql/reasoner/resources/";
         loadFromFileAndCommit(resourcePath, "resolutionPlanTest.gql", planSession);
     }
 
@@ -295,6 +294,7 @@ public class ResolutionPlanIT {
      */
     @Ignore ("should be fixed once we provide an estimate for inferred concepts count")
     @Test
+    @Repeat( times = repeat )
     public void whenRelationLinkWithSubbedEndsAndRuleRelationInTheMiddle_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
                 "$start id V123;" +
@@ -321,6 +321,7 @@ public class ResolutionPlanIT {
      *
      */
     @Test
+    @Repeat( times = repeat )
     public void whenRelationLinkWithSubbedEndsAndRuleRelationAtEnd_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
                 "$start id Vsomesampleid;" +
@@ -351,6 +352,7 @@ public class ResolutionPlanIT {
      *    anotherResource 'someValue'
      */
     @Test
+    @Repeat( times = repeat )
     public void whenRelationLinkWithEndsSharingAResource_exploitDBRelationsAndConnectivity(){
         String queryString = "{" +
                 "$start id V123;" +
@@ -417,8 +419,10 @@ public class ResolutionPlanIT {
         checkPlanSanity(queryX);
         checkPlanSanity(queryY);
 
-        assertNotEquals(new ResolutionPlan(queryX).plan().get(0), getAtomOfType(queryX, "anotherResource", tx));
-        assertNotEquals(new ResolutionPlan(queryY).plan().get(0), getAtomOfType(queryX, "resource", tx));
+        ImmutableList<Atom> xPlan = new ResolutionPlan(queryX).plan();
+        ImmutableList<Atom> yPlan = new ResolutionPlan(queryY).plan();
+        assertNotEquals(xPlan.get(0), getAtomOfType(queryX, "anotherResource", tx));
+        assertNotEquals(yPlan.get(0), getAtomOfType(queryY, "resource", tx));
     }
 
     @Test
@@ -452,9 +456,9 @@ public class ResolutionPlanIT {
 
     /**
      follows the two-branch pattern
-                                /   (d, e) - (e, f)*
-        (a, b)* - (b, c) - (c, d)*
-                                 \   (d, g) - (g, h)*
+     /   (d, e) - (e, f)*
+     (a, b)* - (b, c) - (c, d)*
+     \   (d, g) - (g, h)*
      */
     @Test
     @Ignore ("flaky - need to reintroduce inferred concept counts")

--- a/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
+++ b/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
@@ -37,7 +37,9 @@ yetAnotherRelation sub relation,
 
 derivedRelation sub relation,
     relates someRole,
-    relates otherRole;
+    relates otherRole,
+    has resource,
+    has anotherResource;
 
 anotherDerivedRelation sub relation,
     relates someRole,


### PR DESCRIPTION
## What is the goal of this PR?
To simplify and correct the behaviour of resolution planning: remove the recursion and make sure the ordering ensures atom connectedness if possible.

## What are the changes implemented in this PR?
Context: when doing resolution we need possibly need to split queries into atomic ones so that we can resolve them via rules. The entry query is split based on the plan graql produces. The split queries are then executed separately.  However graql planner does not always produce ordering optimal for resolution purposes so we introduced a refinement step - it ensures we use the information in the query (ids, specific value predicates) optimally, we start from subqueries with the most amount of information. This PR addresses some issues of the refinement step.
- remove recursion in GraqlTraversalPlanner
- make sure GraqlTraversalPlanner doesn't produce unnecessarily disconnected plans by tracking visited variables
- produce and log a warning if created resolution plan is disconnected
