### PR TITLE
Fix comparisons of variable value predicates

### DIFF
--- a/server/src/graql/reasoner/atom/predicate/Predicate.java
+++ b/server/src/graql/reasoner/atom/predicate/Predicate.java
@@ -79,20 +79,16 @@ public abstract class Predicate<T> extends AtomicBase {
     public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
 
     @Override
-    public final boolean equals(Object o) {
-        if (o == this) {
-            return true;
-        }
-        if (o instanceof Predicate) {
-            Predicate that = (Predicate) o;
-            return (this.getVarName().equals(that.getVarName()))
-                    && (this.getPredicate().equals(that.getPredicate()));
-        }
-        return false;
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        Predicate that = (Predicate) obj;
+        return this.getVarName().equals(that.getVarName())
+                && this.getPredicate().equals(that.getPredicate());
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         int h = 1;
         h *= 1000003;
         h ^= this.getVarName().hashCode();

--- a/server/src/graql/reasoner/atom/predicate/ValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/ValuePredicate.java
@@ -126,13 +126,4 @@ public class ValuePredicate extends Predicate<ValueProperty.Operation> {
     public String getPredicateValue() {
         return getPattern().toString();
     }
-
-    @Override
-    public Set<Variable> getVarNames(){
-        Set<Variable> vars = super.getVarNames();
-        if (getPredicate() instanceof ValueProperty.Operation.Comparison.Variable) {
-            vars.add(((ValueProperty.Operation.Comparison.Variable) getPredicate()).value().var());
-        }
-        return vars;
-    }
 }

--- a/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -85,14 +85,11 @@ public class VariableValuePredicate extends VariablePredicate {
 
     @Override
     public int hashCode() {
-        int h = 1;
-        h *= 1000003;
-        h ^= this.getVarName().hashCode();
-        h *= 1000003;
-        h ^= this.getPredicate().hashCode();
-        h *= 1000003;
-        h ^= this.operation().hashCode();
-        return h;
+        int hashCode = 1;
+        hashCode = hashCode * 37 + this.getVarName().hashCode();
+        hashCode = hashCode * 37 + this.getPredicate().hashCode();
+        hashCode = hashCode * 37 + this.operation().hashCode();
+        return hashCode;
     }
 
     @Override

--- a/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/server/src/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -62,16 +62,92 @@ public class VariableValuePredicate extends VariablePredicate {
         return new VariableValuePredicate(varName, predicateVar, op, pattern, parent);
     }
 
-    @Override
-    public Atomic copy(ReasonerQuery parent) {
-        return create(this.getVarName(), this.operation(), parent);
-    }
-
     public static Atomic fromValuePredicate(ValuePredicate predicate){
         return create(predicate.getVarName(), predicate.getPredicate(), predicate.getParentQuery());
     }
 
     public ValueProperty.Operation operation(){ return op;}
+
+    @Override
+    public Atomic copy(ReasonerQuery parent) {
+        return create(this.getVarName(), this.operation(), parent);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        VariableValuePredicate that = (VariableValuePredicate) obj;
+        return this.getVarName().equals(that.getVarName())
+                && this.getPredicate().equals(that.getPredicate())
+                && this.operation().equals(that.operation());
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 1;
+        h *= 1000003;
+        h ^= this.getVarName().hashCode();
+        h *= 1000003;
+        h ^= this.getPredicate().hashCode();
+        h *= 1000003;
+        h ^= this.operation().hashCode();
+        return h;
+    }
+
+    @Override
+    public boolean isAlphaEquivalent(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        if (!super.isAlphaEquivalent(obj)) return false;
+        VariableValuePredicate that = (VariableValuePredicate) obj;
+        return this.operation().comparator().equals(that.operation().comparator())
+                && this.operation().value().equals(that.operation().value());
+    }
+
+    @Override
+    public int alphaEquivalenceHashCode() {
+        int hashCode = super.alphaEquivalenceHashCode();
+        hashCode = hashCode * 37 + this.operation().hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean isStructurallyEquivalent(Object obj){
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        if (!super.isStructurallyEquivalent(obj)) return false;
+        VariableValuePredicate that = (VariableValuePredicate) obj;
+        return this.operation().comparator().equals(that.operation().comparator())
+                && this.operation().value().equals(that.operation().value());
+    }
+
+    @Override
+    public int structuralEquivalenceHashCode() {
+        int hashCode = super.structuralEquivalenceHashCode();
+        hashCode = hashCode * 37 + this.operation().hashCode();
+        return hashCode;
+    }
+
+    @Override
+    public boolean isCompatibleWith(Object obj) {
+        if (this.isAlphaEquivalent(obj)) return true;
+        if (obj == null || this.getClass() != obj.getClass()) return false;
+        if (obj == this) return true;
+        VariableValuePredicate that = (VariableValuePredicate) obj;
+        return ValueOperation.of(this.operation())
+                .isCompatible(ValueOperation.of(that.operation()));
+    }
+
+    @Override
+    public boolean subsumes(Atomic atomic){
+        if (this.isAlphaEquivalent(atomic)) return true;
+        if (atomic == null || this.getClass() != atomic.getClass()) return false;
+        if (atomic == this) return true;
+        VariableValuePredicate that = (VariableValuePredicate) atomic;
+        return ValueOperation.of(this.operation())
+                .subsumes(ValueOperation.of(that.operation()));
+    }
 
     @Override
     public String toString(){


### PR DESCRIPTION
## What is the goal of this PR?

Previously when making equivalence checks for `VariableValuePredicate`s we weren't taking into account the underlying `Operation` object. This PR makes sure we include the operation in both the hashing and equality checks.

## What are the changes implemented in this PR?
- make sure we include the `Operation` in hashing and equivalence checking of `VariableValuePredicate`s


