### PR TITLE
Minor cleanup of properties/settings

### DIFF
--- a/common/config/ConfigKey.java
+++ b/common/config/ConfigKey.java
@@ -56,11 +56,10 @@ public class ConfigKey<T> {
     public static final ConfigKey<Integer> GRPC_PORT = key("grpc.port", INT);
 
     public static final ConfigKey<String> STORAGE_HOSTNAME = key("storage.hostname", STRING);
+    public static final ConfigKey<String> STORAGE_BACKEND = key("storage.backend", STRING);
     public static final ConfigKey<Integer> STORAGE_PORT = key("storage.port", INT);
     public static final ConfigKey<Integer> HADOOP_STORAGE_PORT = key("janusgraphmr.ioformat.conf.storage.port", INT);
-    public final static ConfigKey<Integer> CQL_STORAGE_PORT = ConfigKey.key("cql.storage.port", INT);
     public static final ConfigKey<Integer> STORAGE_CQL_NATIVE_PORT = key("cassandra.input.native.port", INT);
-    public static final ConfigKey<String> STORAGE_BATCH_LOADING = key("storage.batch-loading", STRING);
     public static final ConfigKey<String> STORAGE_KEYSPACE = key("storage.cql.keyspace", STRING);
     public static final ConfigKey<Integer> STORAGE_REPLICATION_FACTOR = key("storage.cql.replication-factor", INT);
 

--- a/server/resources/default-OLAP-configs.properties
+++ b/server/resources/default-OLAP-configs.properties
@@ -17,23 +17,14 @@
 #
 
 # This provides keeps a variety of configs which should not be exposed or configurable to the user,
-# but are still required when initialising Janus Based DBs.
+# but are still required when initialising OLAP Graphs (Hadoop + Spark)
+# Reference: https://docs.janusgraph.org/latest/hadoop-tp3.html
 # Note: That these default configs can be overwritten at runtime
-
-##############################################################################################
-############################### Cassandra Configuration ######################################
-##############################################################################################
-
-storage.backend=cql
 
 ##############################################################################################
 ############################# Configuration Needed For Analytics #############################
 ##############################################################################################
 
-# Janus InputFormat configuration for using hadoop
-# Not clear why these need to be set. See http://stackoverflow.com/questions/38524151/counting-vertices-on-a-titan-graph-using-sparkgraphcomputer-throws-org-apache-sp/38529076
-# for more information.
-# These two properties should be equal to the value of storage.backend and storage.hostname, respectively.
 janusgraphmr.ioformat.conf.storage.backend=cql
 janusgraphmr.ioformat.cf-name=edgestore
 

--- a/server/src/server/session/HadoopGraphFactory.java
+++ b/server/src/server/session/HadoopGraphFactory.java
@@ -24,8 +24,6 @@ import grakn.core.common.exception.ErrorMessage;
 import grakn.core.server.keyspace.KeyspaceImpl;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.apache.tinkerpop.gremlin.structure.util.GraphFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,18 +39,17 @@ import java.util.Properties;
  */
 public class HadoopGraphFactory {
 
-    private final Logger LOG = LoggerFactory.getLogger(HadoopGraphFactory.class);
     private Config config;
     //These properties are loaded in by default and can optionally be overwritten
-    private static final Properties DEFAULT_PROPERTIES;
+    private static final Properties DEFAULT_OLAP_PROPERTIES;
+    private static final String DEFAULT_OLAP_PATH = "resources/default-OLAP-configs.properties";
 
     static {
-        String DEFAULT_CONFIG = "resources/default-configs.properties";
-        DEFAULT_PROPERTIES = new Properties();
-        try (InputStream in = HadoopGraphFactory.class.getClassLoader().getResourceAsStream(DEFAULT_CONFIG)) {
-            DEFAULT_PROPERTIES.load(in);
+        DEFAULT_OLAP_PROPERTIES = new Properties();
+        try (InputStream in = HadoopGraphFactory.class.getClassLoader().getResourceAsStream(DEFAULT_OLAP_PATH)) {
+            DEFAULT_OLAP_PROPERTIES.load(in);
         } catch (IOException e) {
-            throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage(DEFAULT_CONFIG), e);
+            throw new RuntimeException(ErrorMessage.INVALID_PATH_TO_CONFIG.getMessage(DEFAULT_OLAP_PATH), e);
         }
     }
 
@@ -61,7 +58,6 @@ public class HadoopGraphFactory {
     }
 
     public synchronized HadoopGraph getGraph(KeyspaceImpl keyspace) {
-
         return (HadoopGraph) GraphFactory.open(addHadoopProperties(config, keyspace.name()).properties());
     }
 
@@ -76,7 +72,7 @@ public class HadoopGraphFactory {
 
         config.properties().setProperty(graphMrPrefixConf + hostnameConf, hostnameValue);
         //Load Defaults
-        DEFAULT_PROPERTIES.forEach((key, value) -> {
+        DEFAULT_OLAP_PROPERTIES.forEach((key, value) -> {
             if (!config.properties().containsKey(key)) {
                 config.properties().put(key, value);
             }

--- a/test-integration/server/statistics/KeyspaceStatisticsIT.java
+++ b/test-integration/server/statistics/KeyspaceStatisticsIT.java
@@ -29,20 +29,21 @@ import grakn.core.concept.type.RelationType;
 import grakn.core.concept.type.Role;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.kb.Schema;
+import grakn.core.server.keyspace.KeyspaceImpl;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
@@ -87,7 +88,7 @@ public class KeyspaceStatisticsIT {
 
     @Test
     public void sessionsToSameKeyspaceShareStatistics() {
-        SessionImpl session2 = server.session(localSession.keyspace().name());
+        SessionImpl session2 = server.session(localSession.keyspace());
         assertSame(localSession.keyspaceStatistics(), session2.keyspaceStatistics());
     }
 
@@ -227,7 +228,7 @@ public class KeyspaceStatisticsIT {
         remoteSession.close();
 
         // at this point, the graph and keyspace should be deleted from Grakn server cache
-        localSession = server.session(remoteSession.keyspace().name());
+        localSession = server.session(KeyspaceImpl.of(remoteSession.keyspace().name()));
 
         tx = localSession.transaction().write();
         long personCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("person"));


### PR DESCRIPTION
## What is the goal of this PR?

Cleanup use and location of properties and configurations used to instantiate new graphs.

## What are the changes implemented in this PR?

- remove unused config keys (`cql.storage.port` and `storage.batch-loading`)
- rename `default-configs.properties` to `default-OLAP-configs.properties` to only store OLAP related configurations which are quite low level and should not be configurable by users
- cleanup `JanusGraphFactory` which was using and reading many configs that are not needed
- removed unused `rpcPort` from `GraknTestServer`

