### PR TITLE
Simplify the architecture by removing the 'graknsystem' keyspace

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -56,7 +56,7 @@ java_library(
         "@graknlabs_benchmark//lib:server-instrumentation",
 
         # External dependencies from Maven
-
+        "//dependencies/maven/artifacts/com/datastax/cassandra:cassandra-driver-core",
         "//dependencies/maven/artifacts/com/google/auto/value:auto-value",
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
         "//dependencies/maven/artifacts/com/google/guava:guava",

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -56,6 +56,7 @@ log.level=INFO
 ############################# Persisted Knowledge Base Configuration #############################
 # The hostname or comma-separated list of hostnames of storage backend servers
 storage.hostname=127.0.0.1
+storage.port=9042
 # Timeout in milliseconds when connecting to storage backend
 storage.connection-timeout=20000
 

--- a/server/src/server/Grakn.java
+++ b/server/src/server/Grakn.java
@@ -63,13 +63,12 @@ public class Grakn {
             Stopwatch timer = Stopwatch.createStarted();
             boolean benchmark = parseBenchmarkArg(args);
             Server server = ServerFactory.createServer(benchmark);
-            Runtime.getRuntime().addShutdownHook(new Thread(server::close));
             server.start();
             LOG.info("Grakn started in {}", timer.stop());
             try {
-                server.block();
+                server.awaitTermination();
             } catch (InterruptedException e) {
-                //
+                server.close();
             }
         } catch (RuntimeException | IOException e) {
             LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getMessage()), e);

--- a/server/src/server/Grakn.java
+++ b/server/src/server/Grakn.java
@@ -63,9 +63,14 @@ public class Grakn {
             Stopwatch timer = Stopwatch.createStarted();
             boolean benchmark = parseBenchmarkArg(args);
             Server server = ServerFactory.createServer(benchmark);
+            Runtime.getRuntime().addShutdownHook(new Thread(server::close));
             server.start();
-
             LOG.info("Grakn started in {}", timer.stop());
+            try {
+                server.block();
+            } catch (InterruptedException e) {
+                //
+            }
         } catch (RuntimeException | IOException e) {
             LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getMessage()), e);
             System.err.println(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getMessage()));

--- a/server/src/server/Grakn.java
+++ b/server/src/server/Grakn.java
@@ -68,6 +68,7 @@ public class Grakn {
             try {
                 server.awaitTermination();
             } catch (InterruptedException e) {
+                // grakn server stop is called
                 server.close();
             }
         } catch (RuntimeException | IOException e) {

--- a/server/src/server/Grakn.java
+++ b/server/src/server/Grakn.java
@@ -70,6 +70,7 @@ public class Grakn {
             } catch (InterruptedException e) {
                 // grakn server stop is called
                 server.close();
+                Thread.currentThread().interrupt();
             }
         } catch (RuntimeException | IOException e) {
             LOG.error(ErrorMessage.UNCAUGHT_EXCEPTION.getMessage(e.getMessage()), e);

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -43,7 +43,6 @@ public class Server implements AutoCloseable {
     }
 
     public void start() throws IOException {
-        initialiseSystemSchema();
         serverRPC.start();
     }
 

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -41,7 +41,8 @@ public class Server implements AutoCloseable {
         serverRPC.start();
     }
 
-    public void block() throws InterruptedException {
+    // NOTE: this method is used by Grakn KGMS and should be kept public
+    public void awaitTermination() throws InterruptedException {
         serverRPC.awaitTermination();
     }
 

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -44,6 +44,12 @@ public class Server implements AutoCloseable {
 
     public void start() throws IOException {
         serverRPC.start();
+        try {
+            serverRPC.awaitTermination();
+        }
+        catch (InterruptedException e) {
+            close();
+        }
     }
 
     @Override

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -57,10 +57,4 @@ public class Server implements AutoCloseable {
             Thread.currentThread().interrupt();
         }
     }
-
-    private void initialiseSystemSchema() {
-        LOG.info("{} is checking the system schema", this.serverID);
-        keyspaceStore.loadSystemSchema();
-    }
 }
-

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -30,16 +30,11 @@ import java.io.IOException;
 public class Server implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(Server.class);
 
-    private final ServerID serverID;
     private final io.grpc.Server serverRPC;
 
-    private final KeyspaceManager keyspaceStore;
-
-    public Server(ServerID serverID, io.grpc.Server serverRPC, KeyspaceManager keyspaceStore) {
+    public Server(io.grpc.Server serverRPC) {
         // Lock provider
-        this.keyspaceStore = keyspaceStore;
         this.serverRPC = serverRPC;
-        this.serverID = serverID;
     }
 
     public void start() throws IOException {

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -39,12 +39,10 @@ public class Server implements AutoCloseable {
 
     public void start() throws IOException {
         serverRPC.start();
-        try {
-            serverRPC.awaitTermination();
-        }
-        catch (InterruptedException e) {
-            close();
-        }
+    }
+
+    public void block() throws InterruptedException {
+        serverRPC.awaitTermination();
     }
 
     @Override

--- a/server/src/server/Server.java
+++ b/server/src/server/Server.java
@@ -55,7 +55,6 @@ public class Server implements AutoCloseable {
     @Override
     public void close() {
         try {
-            keyspaceStore.closeStore();
             serverRPC.shutdown();
             serverRPC.awaitTermination();
         } catch (InterruptedException e) {

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -52,7 +52,7 @@ public class ServerFactory {
         // locks
         LockManager lockManager = new LockManager();
 
-        KeyspaceManager keyspaceStore = new KeyspaceManager(janusGraphFactory, config);
+        KeyspaceManager keyspaceStore = new KeyspaceManager();
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(config);
 
         // session factory

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -37,7 +37,6 @@ import io.grpc.ServerBuilder;
  * This is a factory class which contains methods for instantiating a Server in different ways.
  */
 public class ServerFactory {
-    private static final int STORAGE_NATIVE_TRANSPORT_PORT = 9042;
 
     /**
      * Create a Server configured for Grakn Core.
@@ -53,7 +52,7 @@ public class ServerFactory {
         // locks
         LockManager lockManager = new LockManager();
 
-        KeyspaceManager keyspaceStore = new KeyspaceManager(STORAGE_NATIVE_TRANSPORT_PORT);
+        KeyspaceManager keyspaceStore = new KeyspaceManager(config.getProperty(ConfigKey.STORAGE_PORT));
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(config);
 
         // session factory

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server;
 
+import com.datastax.driver.core.Cluster;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
@@ -52,7 +53,8 @@ public class ServerFactory {
         // locks
         LockManager lockManager = new LockManager();
 
-        KeyspaceManager keyspaceStore = new KeyspaceManager(config.getProperty(ConfigKey.STORAGE_PORT));
+        KeyspaceManager keyspaceStore = new KeyspaceManager(Cluster.builder().addContactPoint(
+                config.getProperty(ConfigKey.STORAGE_HOSTNAME)).withPort(config.getProperty(ConfigKey.STORAGE_PORT)).build());
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(config);
 
         // session factory

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -66,7 +66,7 @@ public class ServerFactory {
         // create gRPC server
         io.grpc.Server serverRPC = createServerRPC(config, sessionFactory, keyspaceStore, janusGraphFactory);
 
-        return createServer(serverID, serverRPC, keyspaceStore);
+        return createServer(serverRPC);
     }
 
     /**
@@ -75,8 +75,8 @@ public class ServerFactory {
      * @return a Server instance
      */
 
-    public static Server createServer(ServerID serverID, io.grpc.Server rpcServer, KeyspaceManager keyspaceStore) {
-        Server server = new Server(serverID, rpcServer, keyspaceStore);
+    public static Server createServer(io.grpc.Server rpcServer) {
+        Server server = new Server(rpcServer);
 
         Runtime.getRuntime().addShutdownHook(new Thread(server::close, "grakn-server-shutdown"));
 

--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -37,6 +37,8 @@ import io.grpc.ServerBuilder;
  * This is a factory class which contains methods for instantiating a Server in different ways.
  */
 public class ServerFactory {
+    private static final int STORAGE_NATIVE_TRANSPORT_PORT = 9042;
+
     /**
      * Create a Server configured for Grakn Core.
      *
@@ -44,7 +46,6 @@ public class ServerFactory {
      */
     public static Server createServer(boolean benchmark) {
         // Grakn Server configuration
-        ServerID serverID = ServerID.me();
         Config config = Config.create();
 
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(config);
@@ -52,7 +53,7 @@ public class ServerFactory {
         // locks
         LockManager lockManager = new LockManager();
 
-        KeyspaceManager keyspaceStore = new KeyspaceManager();
+        KeyspaceManager keyspaceStore = new KeyspaceManager(STORAGE_NATIVE_TRANSPORT_PORT);
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(config);
 
         // session factory

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -33,8 +33,8 @@ public class KeyspaceManager {
     private final Cluster storage;
     private final Set<String> internals = new HashSet<>(Arrays.asList("system_traces", "system", "system_distributed", "system_schema", "system_auth"));
     
-    public KeyspaceManager() {
-        storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build(); // TODO: don't hardcode ip and port
+    public KeyspaceManager(int storageNativeTransportPort) {
+        storage = Cluster.builder().addContactPoint("localhost").withPort(storageNativeTransportPort).build(); // TODO: don't hardcode ip and port
     }
 
     public Set<KeyspaceImpl> keyspaces() {

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -56,7 +56,7 @@ public class KeyspaceManager {
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
         Cluster storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build();
         LOG.info("listing keyspaces...");
-        List<Row> keyspaces = storage.connect().execute("DESCRIBE KEYSPACES").all();
+        List<Row> keyspaces = storage.connect().execute("DESCRIBE KEYSPACES;").all();
         for (Row keyspace: keyspaces) {
             LOG.info("- " + keyspace);
         }

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -67,6 +67,7 @@ public class KeyspaceManager {
      *
      * @param keyspace The new KeyspaceImpl we have just created
      */
+    // TODO: rewrite
     public void putKeyspace(KeyspaceImpl keyspace) {
         if (containsKeyspace(keyspace)) return;
 
@@ -91,6 +92,7 @@ public class KeyspaceManager {
         this.graph.close();
     }
 
+    // TODO: rewrite
     private boolean containsKeyspace(KeyspaceImpl keyspace) {
         //Check local cache
         if (existingKeyspaces.contains(keyspace)) {
@@ -104,6 +106,7 @@ public class KeyspaceManager {
         }
     }
 
+    // TODO: rewrite
     public void deleteKeyspace(KeyspaceImpl keyspace) {
         if (keyspace.equals(SYSTEM_KB_KEYSPACE)) {
             throw GraknServerException.create("It is not possible to delete the Grakn system keyspace.");
@@ -127,6 +130,7 @@ public class KeyspaceManager {
         }
     }
 
+    // TODO: rewrite: describe keyspaces
     public Set<KeyspaceImpl> keyspaces() {
         try (TransactionOLTP graph = systemKeyspaceSession.transaction().write()) {
             AttributeType<String> keyspaceName = graph.getSchemaConcept(KEYSPACE_RESOURCE);
@@ -139,6 +143,7 @@ public class KeyspaceManager {
         }
     }
 
+    // TODO: rewrite
     public void loadSystemSchema() {
         Stopwatch timer = Stopwatch.createStarted();
         try (TransactionOLTP tx = systemKeyspaceSession.transaction().write()) {

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -52,13 +52,8 @@ public class KeyspaceManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(KeyspaceManager.class);
     private final Set<KeyspaceImpl> existingKeyspaces;
-    private final SessionImpl systemKeyspaceSession;
-    private final StandardJanusGraph graph;
 
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
-        KeyspaceCache keyspaceCache = new KeyspaceCache();
-        this.graph = janusGraphFactory.openGraph(SYSTEM_KB_KEYSPACE.name());
-        this.systemKeyspaceSession = new SessionImpl(SYSTEM_KB_KEYSPACE, config, keyspaceCache, graph, new KeyspaceStatistics(), CacheBuilder.newBuilder().build(), new ReentrantReadWriteLock());
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
     }
 
@@ -75,8 +70,6 @@ public class KeyspaceManager {
     }
 
     public void closeStore() {
-        this.systemKeyspaceSession.close();
-        this.graph.close();
     }
 
     // TODO: rewrite

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -19,6 +19,7 @@
 package grakn.core.server.keyspace;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
 import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
 import grakn.core.common.config.Config;
@@ -38,6 +39,7 @@ import org.janusgraph.graphdb.database.StandardJanusGraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -52,8 +54,13 @@ public class KeyspaceManager {
 
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
-        Cluster storage = Cluster.builder().addContactPoint("localhost").build();
-        storage.connect().execute("DESCRIBE KEYSPACES");
+        Cluster storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build();
+        LOG.info("listing keyspaces...");
+        List<Row> keyspaces = storage.connect().execute("DESCRIBE KEYSPACES").all();
+        for (Row keyspace: keyspaces) {
+            LOG.info("- " + keyspace);
+        }
+        LOG.info("keyspaces listed.");
     }
 
     /**

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -32,8 +32,8 @@ public class KeyspaceManager {
     private final Cluster storage;
     private final Set<String> internals = new HashSet<>(Arrays.asList("system_traces", "system", "system_distributed", "system_schema", "system_auth"));
     
-    public KeyspaceManager(int storageNativeTransportPort) {
-        storage = Cluster.builder().addContactPoint("localhost").withPort(storageNativeTransportPort).build(); // TODO: don't hardcode ip and port
+    public KeyspaceManager(Cluster storage) {
+        this.storage = storage;
     }
 
     public Set<KeyspaceImpl> keyspaces() {

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -67,7 +67,7 @@ public class KeyspaceManager {
 
     // TODO: rewrite
     public void deleteKeyspace(KeyspaceImpl keyspace) {
-
+        storage.connect().execute("drop keyspace " + keyspace.name());
     }
 
     // TODO: rewrite: describe keyspaces

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -19,6 +19,7 @@
 package grakn.core.server.keyspace;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.KeyspaceMetadata;
 import com.datastax.driver.core.Row;
 import com.google.common.base.Stopwatch;
 import com.google.common.cache.CacheBuilder;
@@ -56,9 +57,9 @@ public class KeyspaceManager {
         this.existingKeyspaces = ConcurrentHashMap.newKeySet();
         Cluster storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build();
         LOG.info("listing keyspaces...");
-        List<Row> keyspaces = storage.connect().execute("DESCRIBE KEYSPACES;").all();
-        for (Row keyspace: keyspaces) {
-            LOG.info("- " + keyspace);
+        List<KeyspaceMetadata> keyspaces = storage.connect().getCluster().getMetadata().getKeyspaces();
+        for (KeyspaceMetadata keyspace: keyspaces) {
+            LOG.info("- " + keyspace.getName());
         }
         LOG.info("keyspaces listed.");
     }

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -20,45 +20,20 @@ package grakn.core.server.keyspace;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.KeyspaceMetadata;
-import com.datastax.driver.core.Row;
-import com.google.common.base.Stopwatch;
-import com.google.common.cache.CacheBuilder;
-import grakn.core.common.config.Config;
-import grakn.core.concept.Label;
-import grakn.core.concept.thing.Attribute;
-import grakn.core.concept.thing.Thing;
-import grakn.core.concept.type.AttributeType;
-import grakn.core.concept.type.EntityType;
-import grakn.core.server.exception.GraknServerException;
-import grakn.core.server.exception.InvalidKBException;
-import grakn.core.server.session.JanusGraphFactory;
-import grakn.core.server.session.SessionImpl;
-import grakn.core.server.session.TransactionOLTP;
-import grakn.core.server.session.cache.KeyspaceCache;
-import grakn.core.server.statistics.KeyspaceStatistics;
-import org.janusgraph.graphdb.database.StandardJanusGraph;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
  * KeyspaceManager used to store all existing keyspaces inside Grakn system keyspace.
  */
 public class KeyspaceManager {
-    private static final Logger LOG = LoggerFactory.getLogger(KeyspaceManager.class);
     private final Cluster storage;
     private final Set<String> internals = new HashSet<>(Arrays.asList("system_traces", "system", "system_distributed", "system_schema", "system_auth"));
-
-
-    public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
+    
+    public KeyspaceManager() {
         storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build(); // TODO: don't hardcode ip and port
     }
 

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -19,7 +19,6 @@
 package grakn.core.server.keyspace;
 
 import com.datastax.driver.core.Cluster;
-import com.datastax.driver.core.KeyspaceMetadata;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -38,9 +37,10 @@ public class KeyspaceManager {
     }
 
     public Set<KeyspaceImpl> keyspaces() {
-        Set<String> result = storage.connect().getCluster().getMetadata().getKeyspaces().stream()
-                .map(KeyspaceMetadata::getName).collect(Collectors.toSet());
-        result.removeAll(internals);
-        return result.stream().map(KeyspaceImpl::of).collect(Collectors.toSet());
+        Set<KeyspaceImpl> result = storage.connect().getCluster().getMetadata().getKeyspaces().stream()
+                .map(keyspaceMetadata -> KeyspaceImpl.of(keyspaceMetadata.getName()))
+                .filter(keyspace -> !internals.contains(keyspace.name()))
+                .collect(Collectors.toSet());
+        return result;
     }
 }

--- a/server/src/server/keyspace/KeyspaceManager.java
+++ b/server/src/server/keyspace/KeyspaceManager.java
@@ -59,18 +59,9 @@ public class KeyspaceManager {
 
 
     public KeyspaceManager(JanusGraphFactory janusGraphFactory, Config config) {
-        storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build();
+        storage = Cluster.builder().addContactPoint("localhost").withPort(9042).build(); // TODO: don't hardcode ip and port
     }
 
-    public void closeStore() {
-    }
-
-    // TODO: rewrite
-    public void deleteKeyspace(KeyspaceImpl keyspace) {
-        storage.connect().execute("drop keyspace " + keyspace.name());
-    }
-
-    // TODO: rewrite: describe keyspaces
     public Set<KeyspaceImpl> keyspaces() {
         Set<String> result = storage.connect().getCluster().getMetadata().getKeyspaces().stream()
                 .map(KeyspaceMetadata::getName).collect(Collectors.toSet());

--- a/server/src/server/rpc/KeyspaceService.java
+++ b/server/src/server/rpc/KeyspaceService.java
@@ -72,8 +72,6 @@ public class KeyspaceService extends KeyspaceServiceGrpc.KeyspaceServiceImplBase
             KeyspaceImpl keyspace = KeyspaceImpl.of(request.getName());
             // removing references to open keyspaces JanusGraph instances
             sessionFactory.deleteKeyspace(keyspace);
-            // remove the keyspace from the system keyspace
-            keyspaceStore.deleteKeyspace(keyspace);
             // actually remove the keyspace
             janusGraphFactory.drop(keyspace.name());
 

--- a/server/src/server/rpc/KeyspaceService.java
+++ b/server/src/server/rpc/KeyspaceService.java
@@ -39,12 +39,12 @@ import java.util.stream.Collectors;
 public class KeyspaceService extends KeyspaceServiceGrpc.KeyspaceServiceImplBase {
     private final Logger LOG = LoggerFactory.getLogger(KeyspaceService.class);
 
-    private final KeyspaceManager keyspaceStore;
+    private final KeyspaceManager keyspaceManager;
     private SessionFactory sessionFactory;
     private JanusGraphFactory janusGraphFactory;
 
-    public KeyspaceService(KeyspaceManager keyspaceStore, SessionFactory sessionFactory, JanusGraphFactory janusGraphFactory) {
-        this.keyspaceStore = keyspaceStore;
+    public KeyspaceService(KeyspaceManager keyspaceManager, SessionFactory sessionFactory, JanusGraphFactory janusGraphFactory) {
+        this.keyspaceManager = keyspaceManager;
         this.sessionFactory = sessionFactory;
         this.janusGraphFactory = janusGraphFactory;
     }
@@ -57,7 +57,7 @@ public class KeyspaceService extends KeyspaceServiceGrpc.KeyspaceServiceImplBase
     @Override
     public void retrieve(KeyspaceProto.Keyspace.Retrieve.Req request, StreamObserver<KeyspaceProto.Keyspace.Retrieve.Res> response) {
         try {
-            Iterable<String> list = keyspaceStore.keyspaces().stream().map(KeyspaceImpl::name)
+            Iterable<String> list = keyspaceManager.keyspaces().stream().map(KeyspaceImpl::name)
                     .collect(Collectors.toSet());
             response.onNext(KeyspaceProto.Keyspace.Retrieve.Res.newBuilder().addAllNames(list).build());
             response.onCompleted();
@@ -72,7 +72,7 @@ public class KeyspaceService extends KeyspaceServiceGrpc.KeyspaceServiceImplBase
         try {
             KeyspaceImpl keyspace = KeyspaceImpl.of(request.getName());
 
-            if (!keyspaceStore.keyspaces().contains(keyspace)) {
+            if (!keyspaceManager.keyspaces().contains(keyspace)) {
                 throw GraknServerException.create("It is not possible to delete keyspace [" + keyspace.name() + "] as it does not exist.");
             }
             else {

--- a/server/src/server/session/HadoopGraphFactory.java
+++ b/server/src/server/session/HadoopGraphFactory.java
@@ -70,8 +70,7 @@ public class HadoopGraphFactory {
         });
     }
 
-    // Keep visibility to public as this is used by KGMS
-    public synchronized HadoopGraph getGraph(KeyspaceImpl keyspace) {
+    synchronized HadoopGraph getGraph(KeyspaceImpl keyspace) {
         return (HadoopGraph) GraphFactory.open(addHadoopProperties(keyspace.name()).properties());
     }
 
@@ -80,8 +79,7 @@ public class HadoopGraphFactory {
      * @param keyspaceName keyspace value to add as a property
      * @return new copy of configuration, specific for current keyspace
      */
-    // Keep visibility to public as this is used by KGMS
-    protected Config addHadoopProperties(String keyspaceName) {
+    private Config addHadoopProperties(String keyspaceName) {
         Config localConfig = Config.of(config.properties());
         localConfig.properties().setProperty(JANUSGRAPHMR_IOFORMAT_CONF + STORAGE_KEYSPACE, keyspaceName);
         return localConfig;

--- a/server/src/server/session/HadoopGraphFactory.java
+++ b/server/src/server/session/HadoopGraphFactory.java
@@ -70,7 +70,8 @@ public class HadoopGraphFactory {
         });
     }
 
-    synchronized HadoopGraph getGraph(KeyspaceImpl keyspace) {
+    // Keep visibility to public as this is used by KGMS
+    public synchronized HadoopGraph getGraph(KeyspaceImpl keyspace) {
         return (HadoopGraph) GraphFactory.open(addHadoopProperties(keyspace.name()).properties());
     }
 
@@ -79,7 +80,8 @@ public class HadoopGraphFactory {
      * @param keyspaceName keyspace value to add as a property
      * @return new copy of configuration, specific for current keyspace
      */
-    private Config addHadoopProperties(String keyspaceName) {
+    // Keep visibility to public as this is used by KGMS
+    protected Config addHadoopProperties(String keyspaceName) {
         Config localConfig = Config.of(config.properties());
         localConfig.properties().setProperty(JANUSGRAPHMR_IOFORMAT_CONF + STORAGE_KEYSPACE, keyspaceName);
         return localConfig;

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -58,7 +58,8 @@ public class SessionFactory {
     // Keep visibility to protected as this is used by KGMS
     protected final LockManager lockManager;
 
-    private final Map<KeyspaceImpl, SharedKeyspaceData> sharedKeyspaceDataMap;
+    // Keep visibility to protected as this is used by KGMS
+    protected final Map<KeyspaceImpl, SharedKeyspaceData> sharedKeyspaceDataMap;
 
     public SessionFactory(LockManager lockManager, JanusGraphFactory janusGraphFactory, HadoopGraphFactory hadoopGraphFactory, KeyspaceManager keyspaceManager, Config config) {
         this.janusGraphFactory = janusGraphFactory;
@@ -156,7 +157,8 @@ public class SessionFactory {
      *
      * @param session SessionImpl that is being closed
      */
-    private void onSessionClose(SessionImpl session) {
+    // Keep visibility to public as this is used by KGMS
+    public void onSessionClose(SessionImpl session) {
         Lock lock = lockManager.getLock(session.keyspace().name());
         lock.lock();
         try {
@@ -180,7 +182,7 @@ public class SessionFactory {
      * Helper class used to hold in memory a reference to a graph together with its schema cache
      * and a reference to all sessions open to the graph.
      */
-    private class SharedKeyspaceData {
+    public class SharedKeyspaceData {
 
         private final KeyspaceCache keyspaceCache;
         // Graph is cached here because concurrently created sessions don't see writes to JanusGraph DB cache
@@ -198,7 +200,7 @@ public class SessionFactory {
 
         private final ReadWriteLock graphLock;
 
-        private SharedKeyspaceData(KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock, HadoopGraph hadoopGraph) {
+        public SharedKeyspaceData(KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock, HadoopGraph hadoopGraph) {
             this.keyspaceCache = keyspaceCache;
             this.graph = graph;
             this.hadoopGraph = hadoopGraph;
@@ -208,11 +210,13 @@ public class SessionFactory {
             this.graphLock = graphLock;
         }
 
-        private ReadWriteLock graphLock() {
+        // Keep visibility to public as this is used by KGMS
+        public ReadWriteLock graphLock() {
             return graphLock;
         }
 
-        private KeyspaceCache cache() {
+        // Keep visibility to public as this is used by KGMS
+        public KeyspaceCache cache() {
             return keyspaceCache;
         }
 
@@ -220,7 +224,8 @@ public class SessionFactory {
             return sessions.size();
         }
 
-        private void addSessionReference(SessionImpl session) {
+        // Keep visibility to public as this is used by KGMS
+        public void addSessionReference(SessionImpl session) {
             sessions.add(session);
         }
 
@@ -232,19 +237,23 @@ public class SessionFactory {
             sessions.forEach(SessionImpl::invalidate);
         }
 
-        private StandardJanusGraph graph() {
+        // Keep visibility to public as this is used by KGMS
+        public StandardJanusGraph graph() {
             return graph;
         }
 
-        private KeyspaceStatistics keyspaceStatistics() {
+        // Keep visibility to public as this is used by KGMS
+        public KeyspaceStatistics keyspaceStatistics() {
             return keyspaceStatistics;
         }
 
-        private Cache<String, ConceptId> attributesCache() {
+        // Keep visibility to public as this is used by KGMS
+        public Cache<String, ConceptId> attributesCache() {
             return attributesCache;
         }
 
-        private HadoopGraph hadoopGraph(){ return hadoopGraph; }
+        // Keep visibility to public as this is used by KGMS
+        public HadoopGraph hadoopGraph(){ return hadoopGraph; }
 
     }
 

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -100,7 +100,6 @@ public class SessionFactory {
                 hadoopGraph = cacheContainer.hadoopGraph();
 
             } else { // If keyspace reference not cached, put keyspace in keyspace manager, open new graph and instantiate new keyspace cache
-                keyspaceManager.putKeyspace(keyspace);
                 graph = janusGraphFactory.openGraph(keyspace.name());
                 hadoopGraph = hadoopGraphFactory.getGraph(keyspace);
                 cache = new KeyspaceCache();

--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -58,8 +58,7 @@ public class SessionFactory {
     // Keep visibility to protected as this is used by KGMS
     protected final LockManager lockManager;
 
-    // Keep visibility to protected as this is used by KGMS
-    protected final Map<KeyspaceImpl, SharedKeyspaceData> sharedKeyspaceDataMap;
+    private final Map<KeyspaceImpl, SharedKeyspaceData> sharedKeyspaceDataMap;
 
     public SessionFactory(LockManager lockManager, JanusGraphFactory janusGraphFactory, HadoopGraphFactory hadoopGraphFactory, KeyspaceManager keyspaceManager, Config config) {
         this.janusGraphFactory = janusGraphFactory;
@@ -157,8 +156,7 @@ public class SessionFactory {
      *
      * @param session SessionImpl that is being closed
      */
-    // Keep visibility to public as this is used by KGMS
-    public void onSessionClose(SessionImpl session) {
+    private void onSessionClose(SessionImpl session) {
         Lock lock = lockManager.getLock(session.keyspace().name());
         lock.lock();
         try {
@@ -182,7 +180,7 @@ public class SessionFactory {
      * Helper class used to hold in memory a reference to a graph together with its schema cache
      * and a reference to all sessions open to the graph.
      */
-    public class SharedKeyspaceData {
+    private class SharedKeyspaceData {
 
         private final KeyspaceCache keyspaceCache;
         // Graph is cached here because concurrently created sessions don't see writes to JanusGraph DB cache
@@ -200,7 +198,7 @@ public class SessionFactory {
 
         private final ReadWriteLock graphLock;
 
-        public SharedKeyspaceData(KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock, HadoopGraph hadoopGraph) {
+        private SharedKeyspaceData(KeyspaceCache keyspaceCache, StandardJanusGraph graph, KeyspaceStatistics keyspaceStatistics, Cache<String, ConceptId> attributesCache, ReadWriteLock graphLock, HadoopGraph hadoopGraph) {
             this.keyspaceCache = keyspaceCache;
             this.graph = graph;
             this.hadoopGraph = hadoopGraph;
@@ -210,13 +208,11 @@ public class SessionFactory {
             this.graphLock = graphLock;
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public ReadWriteLock graphLock() {
+        private ReadWriteLock graphLock() {
             return graphLock;
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public KeyspaceCache cache() {
+        private KeyspaceCache cache() {
             return keyspaceCache;
         }
 
@@ -224,8 +220,7 @@ public class SessionFactory {
             return sessions.size();
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public void addSessionReference(SessionImpl session) {
+        private void addSessionReference(SessionImpl session) {
             sessions.add(session);
         }
 
@@ -237,23 +232,19 @@ public class SessionFactory {
             sessions.forEach(SessionImpl::invalidate);
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public StandardJanusGraph graph() {
+        private StandardJanusGraph graph() {
             return graph;
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public KeyspaceStatistics keyspaceStatistics() {
+        private KeyspaceStatistics keyspaceStatistics() {
             return keyspaceStatistics;
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public Cache<String, ConceptId> attributesCache() {
+        private Cache<String, ConceptId> attributesCache() {
             return attributesCache;
         }
 
-        // Keep visibility to public as this is used by KGMS
-        public HadoopGraph hadoopGraph(){ return hadoopGraph; }
+        private HadoopGraph hadoopGraph(){ return hadoopGraph; }
 
     }
 

--- a/test-integration/rule/BUILD
+++ b/test-integration/rule/BUILD
@@ -28,6 +28,7 @@ java_library(
         "//dependencies/maven/artifacts/junit:junit",
         "//dependencies/maven/artifacts/org/slf4j:slf4j-api",
         "//dependencies/maven/artifacts/io/grpc:grpc-core",
+        "//dependencies/maven/artifacts/com/datastax/cassandra:cassandra-driver-core",
         "//dependencies/maven/artifacts/commons-io:commons-io",
         "//dependencies/maven/artifacts/commons-lang:commons-lang",
         "//dependencies/maven/artifacts/org/apache/cassandra:cassandra-all",

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -204,7 +204,7 @@ public class GraknTestServer extends ExternalResource {
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(serverConfig);
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(serverConfig);
 
-        keyspaceStore = new KeyspaceManager(janusGraphFactory, serverConfig);
+        keyspaceStore = new KeyspaceManager();
         sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, keyspaceStore, serverConfig);
 
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -116,7 +116,6 @@ public class GraknTestServer extends ExternalResource {
     @Override
     protected void after() {
         try {
-            keyspaceStore.closeStore();
             graknServer.close();
             FileUtils.deleteDirectory(dataDirTmp.toFile());
             updatedCassandraConfigPath.delete();

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -18,6 +18,7 @@
 
 package grakn.core.rule;
 
+import com.datastax.driver.core.Cluster;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.server.GraknStorage;
@@ -202,7 +203,8 @@ public class GraknTestServer extends ExternalResource {
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(serverConfig);
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(serverConfig);
 
-        keyspaceManager = new KeyspaceManager(nativeTransportPort);
+        keyspaceManager = new KeyspaceManager(Cluster.builder().addContactPoint(
+                serverConfig.getProperty(ConfigKey.STORAGE_HOSTNAME)).withPort(nativeTransportPort).build());
         sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, keyspaceManager, serverConfig);
 
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -214,6 +214,6 @@ public class GraknTestServer extends ExternalResource {
                 .addService(new KeyspaceService(keyspaceStore, sessionFactory, janusGraphFactory))
                 .build();
 
-        return ServerFactory.createServer(id, serverRPC, keyspaceStore);
+        return ServerFactory.createServer(serverRPC);
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?

We have removed the `graknsystem` keyspace. It is not needed and the removal leads to a simpler architecture and faster load time.

## What are the changes implemented in this PR?

- Remove the `graknsystem` keyspace. The keyspace stores a list of keyspaces that exist. This functionality is replaced by simply querying Cassandra using CQL
- We've been depending on JanusGraph's behaviour of maintaining main thread to run, by accident. This behaviour is lost as `KeyspaceManager` no longer opens a graph. Therefore we're adding similar functionality: `Server::awaitTermination`.
- Some small refactors and removal of dead-codes
- Modify visibility modifiers of various classes as needed by KGMS