### PR TITLE
Moves version instructions to command usage of `grakn server`

### DIFF
--- a/bin/grakn
+++ b/bin/grakn
@@ -52,7 +52,6 @@ if [ -z "$1" ]; then
     echo "Missing argument. Possible commands are:"
     echo "  Server:          grakn server [--help]"
     echo "  Console:         grakn console [--help]"
-    echo "  Version:         grakn version"
 elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
@@ -75,7 +74,6 @@ else
     echo "Invalid argument: $1. Possible commands are: "
     echo "  Server:          grakn server [--help]"
     echo "  Console:         grakn console [--help]"
-    echo "  Version:         grakn version"
 fi
 
 exit_code=$?

--- a/daemon/GraknDaemon.java
+++ b/daemon/GraknDaemon.java
@@ -197,6 +197,7 @@ public class GraknDaemon {
                                    "stop [" + SERVER + "|" + STORAGE + "]   Stop Grakn (or optionally, only one of the component)\n" +
                                    "status                         Check if Grakn is running\n" +
                                    "clean                          DANGEROUS: wipe data completely\n" +
+                                   "version                        Print version of Grakn server\n" +
                                    "\n" +
                                    "Tips:\n" +
                                    "- Start Grakn with 'grakn server start'\n" +
@@ -211,19 +212,6 @@ public class GraknDaemon {
 
     private void version() {
         System.out.println(Version.VERSION);
-    }
-
-    private void help() {
-        System.out.println("Usage: grakn COMMAND\n" +
-                                   "\n" +
-                                   "COMMAND:\n" +
-                                   "server     Manage Grakn components\n" +
-                                   "version    Print Grakn version\n" +
-                                   "help       Print this message\n" +
-                                   "\n" +
-                                   "Tips:\n" +
-                                   "- Start Grakn with 'grakn server start'\n" +
-                                   "- You can then perform queries by opening a console with 'grakn console'");
     }
 
     private void clean() {


### PR DESCRIPTION
## What is the goal of this PR?
`version` is no longer listed in the command usage instructions of `grakn`. Instead, it's now displayed as one of the `grakn server` commands.

## What are the changes implemented in this PR?
- removes `version` from instructions in `bin/grakn`
- adds `version` to list of commands in `daemon/GraknDaemon.java`
- removes outdated method, `help()` in `daemon/GraknDaemon.java`


Closes https://github.com/graknlabs/grakn/issues/5313