### PR TITLE
Track inferred concepts separately to use them for determining persistence on commit

### DIFF
--- a/server/src/graql/executor/WriteExecutor.java
+++ b/server/src/graql/executor/WriteExecutor.java
@@ -31,27 +31,19 @@ import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.concept.Concept;
-import grakn.core.concept.Label;
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.concept.thing.Relation;
 import grakn.core.concept.thing.Thing;
-import grakn.core.concept.type.Role;
-import grakn.core.concept.type.Rule;
-import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.graql.executor.property.PropertyExecutor.Writer;
 import grakn.core.graql.util.Partition;
 import grakn.core.server.kb.Schema;
-import grakn.core.server.kb.concept.ConceptImpl;
 import grakn.core.server.kb.concept.ConceptUtils;
 import grakn.core.server.kb.concept.ConceptVertex;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-import java.util.Stack;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -296,7 +288,7 @@ public class WriteExecutor {
                 .forEach(t -> {
                     //as we are going to persist the concepts, reset the inferred flag
                     ConceptVertex.from(t).vertex().property(Schema.VertexProperty.IS_INFERRED, false);
-                    transaction.cache().inferredThingToPersist(t);
+                    transaction.cache().inferredInstanceToPersist(t);
                 });
     }
 

--- a/server/src/server/kb/concept/RelationEdge.java
+++ b/server/src/server/kb/concept/RelationEdge.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server.kb.concept;
 
+import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptId;
 import grakn.core.concept.LabelId;
 import grakn.core.concept.thing.Thing;
@@ -27,6 +28,7 @@ import grakn.core.server.kb.Schema;
 import grakn.core.server.kb.Cache;
 import grakn.core.server.kb.structure.EdgeElement;
 import grakn.core.server.kb.structure.VertexElement;
+import grakn.core.server.session.TransactionOLTP;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -158,6 +160,11 @@ public class RelationEdge implements RelationStructure {
     @Override
     public void delete() {
         if (!isDeleted()) edge().tx().statisticsDelta().decrement(type().label());
+        if (isInferred()){
+            TransactionOLTP tx = edge().tx();
+            Concept relation = tx.getConcept(id());
+            if (relation != null) tx.cache().removeInferredInstance(relation.asThing());
+        }
         edge().delete();
     }
 

--- a/server/src/server/kb/concept/RelationReified.java
+++ b/server/src/server/kb/concept/RelationReified.java
@@ -69,6 +69,7 @@ public class RelationReified extends ThingImpl<Relation, RelationType> implement
         // removing the owner as it is the real concept that gets cached.
         // trying to delete a RelationStructure will fail the concept.isRelation check leading to errors when deleting the relation from transactionCache
         vertex().tx().cache().getNewRelations().remove(owner);
+        if(isInferred()) vertex().tx().cache().removeInferredInstance(owner);
         super.delete();
     }
 

--- a/server/src/server/kb/concept/ThingImpl.java
+++ b/server/src/server/kb/concept/ThingImpl.java
@@ -342,7 +342,9 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
 
         vertex().tx().statisticsDelta().increment(hasAttribute.label());
 
-        return vertex().tx().factory().buildRelation(attributeEdge, hasAttribute, hasAttributeOwner, hasAttributeValue);
+        RelationImpl attributeRelation = vertex().tx().factory().buildRelation(attributeEdge, hasAttribute, hasAttributeOwner, hasAttributeValue);
+        if (isInferred) vertex().tx().cache().inferredInstance(attributeRelation);
+        return attributeRelation;
     }
 
     @Override

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -98,6 +98,8 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
         VertexElement instanceVertex = vertex().tx().addVertexElement(instanceBaseType);
 
         vertex().tx().ruleCache().ackTypeInstance(this);
+        vertex().tx().statisticsDelta().increment(label());
+
         if (!Schema.MetaSchema.isMetaLabel(label())) {
             vertex().tx().cache().addedInstance(id());
             if (isInferred){
@@ -111,8 +113,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
 
         V instance = producer.apply(instanceVertex, getThis());
         Preconditions.checkNotNull(instance, "producer should never return null");
-
-        vertex().tx().statisticsDelta().increment(label());
+        if(isInferred) vertex().tx().cache().cacheInferredInstance(instance);
 
         return instance;
     }

--- a/server/src/server/kb/concept/TypeImpl.java
+++ b/server/src/server/kb/concept/TypeImpl.java
@@ -113,7 +113,7 @@ public class TypeImpl<T extends Type, V extends Thing> extends SchemaConceptImpl
 
         V instance = producer.apply(instanceVertex, getThis());
         Preconditions.checkNotNull(instance, "producer should never return null");
-        if(isInferred) vertex().tx().cache().cacheInferredInstance(instance);
+        if(isInferred) vertex().tx().cache().inferredInstance(instance);
 
         return instance;
     }

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -941,7 +941,7 @@ public class TransactionOLTP implements Transaction {
     }
 
     private void removeInferredConcepts() {
-        Set<Thing> inferredThingsToDiscard = cache().getInferredThingsToDiscard().collect(Collectors.toSet());
+        Set<Thing> inferredThingsToDiscard = cache().getInferredInstancesToDiscard().collect(Collectors.toSet());
         inferredThingsToDiscard.forEach(inferred -> cache().remove(inferred));
         inferredThingsToDiscard.forEach(Concept::delete);
     }

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -153,10 +153,7 @@ public class TransactionCache {
 
         if (concept.isThing()){
             Thing instance = concept.asThing();
-            if (instance.isInferred()){
-                inferredConcepts.remove(instance);
-                inferredConceptsToPersist.remove(instance);
-            }
+            if (instance.isInferred()) removeInferredInstance(instance);
         }
 
         conceptCache.remove(concept.id());
@@ -242,11 +239,21 @@ public class TransactionCache {
         inferredConcepts.add(thing);
     }
 
+    /**
+     * Remove an inferred instance from tracking.
+     * 
+     * @param thing The inferred instance to be cached.
+     */
+    public void removeInferredInstance(Thing thing){
+        inferredConcepts.remove(thing);
+        inferredConceptsToPersist.remove(thing);
+    }
+
     public void inferredInstanceToPersist(Thing t) {
         inferredConceptsToPersist.add(t);
     }
 
-    public Stream<Thing> getInferredInstances() {
+    Stream<Thing> getInferredInstances() {
         return inferredConcepts.stream();
     }
 

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -152,7 +152,11 @@ public class TransactionCache {
         }
 
         if (concept.isThing()){
-            if (concept.asThing().isInferred()) inferredConcepts.remove(concept.id());
+            Thing instance = concept.asThing();
+            if (instance.isInferred()){
+                inferredConcepts.remove(instance);
+                inferredConceptsToPersist.remove(instance);
+            }
         }
 
         conceptCache.remove(concept.id());
@@ -179,14 +183,6 @@ public class TransactionCache {
             schemaConceptCache.put(schemaConcept.label(), schemaConcept);
             labelCache.put(schemaConcept.label(), schemaConcept.labelId());
         }
-    }
-
-    /**
-     *
-     * @param thing
-     */
-    public void cacheInferredInstance(Thing thing){
-        inferredConcepts.add(thing);
     }
 
     /**
@@ -237,20 +233,28 @@ public class TransactionCache {
         return (X) conceptCache.get(id);
     }
 
-    public void inferredThingToPersist(Thing t) {
+    /**
+     * Caches an inferred instance for possible persistence later.
+     *
+     * @param thing The inferred instance to be cached.
+     */
+    public void inferredInstance(Thing thing){
+        inferredConcepts.add(thing);
+    }
+
+    public void inferredInstanceToPersist(Thing t) {
         inferredConceptsToPersist.add(t);
+    }
+
+    public Stream<Thing> getInferredInstances() {
+        return inferredConcepts.stream();
     }
 
     /**
      * @return cached things that are inferred
      */
-    public Stream<Thing> getInferredThingsToDiscard() {
-        return /*conceptCache.values().stream()
-                .filter(Concept::isThing)
-                .map(Concept::asThing)
-                .filter(Thing::isInferred)
-                */
-        inferredConcepts.stream()
+    public Stream<Thing> getInferredInstancesToDiscard() {
+        return inferredConcepts.stream()
                 .filter(t -> !inferredConceptsToPersist.contains(t));
     }
 

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -241,7 +241,7 @@ public class TransactionCache {
 
     /**
      * Remove an inferred instance from tracking.
-     * 
+     *
      * @param thing The inferred instance to be cached.
      */
     public void removeInferredInstance(Thing thing){

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -32,6 +32,7 @@ import grakn.core.concept.type.SchemaConcept;
 import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.kb.Schema;
+import grakn.core.server.kb.concept.AttributeTypeImpl;
 import grakn.core.server.kb.concept.EntityImpl;
 import grakn.core.server.kb.concept.EntityTypeImpl;
 import grakn.core.server.kb.concept.RelationTypeImpl;
@@ -354,7 +355,6 @@ public class TransactionCacheIT {
     @Test
     public void whenInsertingAndDeletingInferredRelation_instanceIsTracked(){
         Role someRole = tx.putRole("someRole");
-        EntityType someEntity = tx.putEntityType("someEntity").plays(someRole);
         RelationType someRelation = tx.putRelationType("someRelation").relates(someRole);
         Relation relation = RelationTypeImpl.from(someRelation).addRelationInferred();
         assertTrue(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(relation)));
@@ -365,7 +365,7 @@ public class TransactionCacheIT {
     @Test
     public void whenInsertingAndDeletingInferredAttribute_instanceIsTracked(){
         AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
-        Attribute<String> attribute = attributeType.create("banana");
+        Attribute attribute = AttributeTypeImpl.from(attributeType).putAttributeInferred("banana");
         assertTrue(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(attribute)));
         attribute.delete();
         assertFalse(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(attribute)));

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -32,6 +32,8 @@ import grakn.core.concept.type.SchemaConcept;
 import grakn.core.graql.reasoner.utils.Pair;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.kb.Schema;
+import grakn.core.server.kb.concept.EntityTypeImpl;
+import grakn.core.server.kb.concept.RelationTypeImpl;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
@@ -337,5 +339,14 @@ public class TransactionCacheIT {
         // confirm we have the exact same object from Janus
         assertSame(janusVertex, relationVertex);
         assertEquals("testValue", janusVertex.property("testKey").value().toString());
+    }
+
+    @Test
+    public void whenInsertingAndDeletingInferredInstance_instanceIsTracked(){
+        EntityType someEntity = tx.putEntityType("someEntity");
+        Entity entity = EntityTypeImpl.from(someEntity).addEntityInferred();
+        assertTrue(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(entity)));
+        entity.delete();
+        assertFalse(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(entity)));
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
Previously we were using the full `conceptCache` to determine which inferred concepts to delete or persist on commit. As the concept cache can grow substantially, extra filtering for inferred concepts introduces a lot of extra overhead. In this PR, we introduce separate tracking for inferred concepts in the `TransactionCache` so that we can fetch them easily on commit.

## What are the changes implemented in this PR?
- introduce tracking of inferred instance in `TransactionCache`
