### PR TITLE
Include subtypes when determining fruitless rules

### DIFF
--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -135,7 +135,7 @@ public class RuleCache {
         if (checkedTypes.contains(type)) return !absentTypes.contains(type);
         checkedTypes.add(type);
         boolean instancePresent = type.instances().findFirst().isPresent()
-                || type.thenRules().anyMatch(this::isRuleMatchable);
+                || type.subs().flatMap(SchemaConcept::thenRules).anyMatch(this::isRuleMatchable);
         if (!instancePresent){
             absentTypes.add(type);
             type.whenRules().forEach(r -> unmatchableRules.add(r));


### PR DESCRIPTION
## What is the goal of this PR?
Previously in the `RuleCache` we were trying to assess whether a type has instances. To do that we were looking whether the type has instances and whether an instance could be created via a rule. When looking at possible rules to do that, we were only looking at rules of the specific type omitting it's subtypes. This PR fixes that.

## What are the changes implemented in this PR?
Additionally check subtypes when trying to find matchable rules when determining whether an instance has types.
