### PR TITLE
Use keyspace statistics for determining whether a type has instances

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -230,7 +230,7 @@ public abstract class Atom extends AtomicBase {
         if (applicableRules == null) {
             applicableRules = new HashSet<>();
             getPotentialRules()
-                    .map(rule -> tx().ruleCache().getRule(rule, () -> new InferenceRule(rule, tx())))
+                    .map(rule -> tx().ruleCache().getRule(rule))
                     .filter(this::isRuleApplicable)
                     .map(r -> r.rewrite(this))
                     .forEach(applicableRules::add);
@@ -253,7 +253,7 @@ public abstract class Atom extends AtomicBase {
      */
     public boolean requiresDecomposition() {
         return this.getPotentialRules()
-                .map(r -> tx().ruleCache().getRule(r, () -> new InferenceRule(r, tx())))
+                .map(r -> tx().ruleCache().getRule(r))
                 .anyMatch(InferenceRule::appendsRolePlayers);
     }
 

--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -279,7 +279,7 @@ public abstract class AttributeAtom extends Binary{
         if(getMultiPredicate().isEmpty()) {
             Variable attrVar = getAttributeVariable();
             AttributeType.DataType<Object> dataType = getSchemaConcept().asAttributeType().dataType();
-            ResolvableQuery body = tx().ruleCache().getRule(rule, () -> new InferenceRule(rule, tx())).getBody();
+            ResolvableQuery body = tx().ruleCache().getRule(rule).getBody();
             ErrorMessage incompatibleValuesMsg = ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES;
             body.getAtoms(AttributeAtom.class)
                     .filter(at -> at.getAttributeVariable().equals(attrVar))

--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toSet;

--- a/test-integration/graql/reasoner/cache/RuleCacheIT.java
+++ b/test-integration/graql/reasoner/cache/RuleCacheIT.java
@@ -81,10 +81,10 @@ public class RuleCacheIT {
             assertEquals(2, rulesWithTernary.size());
 
             rulesWithBinary.stream()
-                    .map(r -> ruleCache.getRule(r, () -> new InferenceRule(r, tx)))
+                    .map(ruleCache::getRule)
                     .forEach(r -> assertEquals(reifyingRelation, r.getHead().getAtom().getSchemaConcept()));
             rulesWithTernary.stream()
-                    .map(r -> ruleCache.getRule(r, () -> new InferenceRule(r, tx)))
+                    .map(ruleCache::getRule)
                     .forEach(r -> assertEquals(ternary, r.getHead().getAtom().getSchemaConcept()));
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?
Use keyspace statistics for determining whether a type has instances (instead of using concept api). Additionally we simplify rule fetching.

## What are the changes implemented in this PR?
- use keyspace statistics to find out whether any type instances exist
- simplify rule fetching - after architecture refactor we do not need the supplier anymore

