### PR TITLE
Make resolution logs not output redundant info

### DIFF
--- a/server/src/graql/reasoner/state/AnswerPropagatorState.java
+++ b/server/src/graql/reasoner/state/AnswerPropagatorState.java
@@ -58,9 +58,6 @@ public abstract class AnswerPropagatorState<Q extends ResolvableQuery> extends R
     }
 
     @Override
-    public String toString(){ return super.toString() + "\n" + getQuery() + "\n"; }
-
-    @Override
     public ResolutionState generateChildState() {
         return subGoalIterator.hasNext()? subGoalIterator.next() : null;
     }

--- a/server/src/graql/reasoner/state/AtomicState.java
+++ b/server/src/graql/reasoner/state/AtomicState.java
@@ -57,6 +57,9 @@ public class AtomicState extends AnswerPropagatorState<ReasonerAtomicQuery> {
     }
 
     @Override
+    public String toString(){ return super.toString() + "\n" + getQuery() + "\n"; }
+
+    @Override
     Iterator<ResolutionState> generateChildStateIterator() {
         return getQuery().innerStateIterator(this, getVisitedSubGoals());
     }

--- a/server/src/graql/reasoner/state/ConjunctiveState.java
+++ b/server/src/graql/reasoner/state/ConjunctiveState.java
@@ -41,6 +41,9 @@ public class ConjunctiveState extends AnswerPropagatorState<ReasonerQueryImpl> {
     }
 
     @Override
+    public String toString(){ return super.toString() + "\n" + getQuery() + "\n"; }
+
+    @Override
     Iterator<ResolutionState> generateChildStateIterator() {
         return getQuery().innerStateIterator(this, getVisitedSubGoals());
     }


### PR DESCRIPTION
## What is the goal of this PR?
Previously some of the resolution states would produce string outputs with repeated information. In this PR we make sure no redundancies are present.
## What are the changes implemented in this PR?
Updated `toString()` methods for `AtomicState`, `ConjunctiveState`, `CumulativeState` and `RuleState`.

