### PR TITLE
Do not use keyspace stats for determining instance existence

### DIFF
--- a/server/src/server/session/cache/RuleCache.java
+++ b/server/src/server/session/cache/RuleCache.java
@@ -131,15 +131,10 @@ public class RuleCache {
                 .peek(rule -> ruleMap.put(type, rule));
     }
 
-    private boolean instancePresent(Type type){
-        return type.subs()
-                .anyMatch(t -> tx.session().keyspaceStatistics().count(tx, t.label()) != 0);
-    }
-
     private boolean typeHasInstances(Type type){
         if (checkedTypes.contains(type)) return !absentTypes.contains(type);
         checkedTypes.add(type);
-        boolean instancePresent = instancePresent(type)
+        boolean instancePresent = type.instances().findFirst().isPresent()
                 || type.subs().flatMap(SchemaConcept::thenRules).anyMatch(this::isRuleMatchable);
         if (!instancePresent){
             absentTypes.add(type);


### PR DESCRIPTION
## What is the goal of this PR?
After a long and tedious discussion we decided that using keyspace statistics to determine whether a type has instances in the `RuleCache` adds a lot of extra risk for little gain. Hence we revert.

## What are the changes implemented in this PR?
Use concept api to check whether instances exist in the `RuleCache`
.
