### PR TITLE
Remove unimplemented KeyspaceService method

### DIFF
--- a/server/src/server/rpc/KeyspaceService.java
+++ b/server/src/server/rpc/KeyspaceService.java
@@ -50,11 +50,6 @@ public class KeyspaceService extends KeyspaceServiceGrpc.KeyspaceServiceImplBase
     }
 
     @Override
-    public void create(KeyspaceProto.Keyspace.Create.Req request, StreamObserver<KeyspaceProto.Keyspace.Create.Res> response) {
-        response.onError(new StatusRuntimeException(Status.UNIMPLEMENTED));
-    }
-
-    @Override
     public void retrieve(KeyspaceProto.Keyspace.Retrieve.Req request, StreamObserver<KeyspaceProto.Keyspace.Retrieve.Res> response) {
         try {
             Iterable<String> list = keyspaceManager.keyspaces().stream().map(KeyspaceImpl::name)


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/protocol#7 obsoletes `create` RPC method from `KeyspaceService`. This PR prepares Grakn Core for this change.

## What are the changes implemented in this PR?

Remove dummy method implementation 
