### PR TITLE
Do not print success when failing at loading file

### DIFF
--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -108,11 +108,11 @@ public class ConsoleSession implements AutoCloseable {
         try {
             String queries = readFile(filePath);
             executeQuery(queries, false);
-            commit();
+            tx.commit();
             consoleReader.println("Successful commit: " + filePath.getFileName().toString());
-        } catch (GraknClientException e) {
-            String error = "Failed to load file: " + filePath.getFileName().toString();
-            throw new GraknConsoleException(error, e);
+        } catch (RuntimeException e) {
+            printErr.println("Failed to load file:");
+            printErr.println(e.getMessage());
         } finally {
             consoleReader.flush();
         }

--- a/console/ConsoleSession.java
+++ b/console/ConsoleSession.java
@@ -20,7 +20,6 @@ package grakn.core.console;
 
 import grakn.client.GraknClient;
 import grakn.client.exception.GraknClientException;
-import grakn.core.console.exception.GraknConsoleException;
 import grakn.core.console.printer.Printer;
 import graql.lang.Graql;
 import graql.lang.query.GraqlQuery;
@@ -110,7 +109,7 @@ public class ConsoleSession implements AutoCloseable {
             executeQuery(queries, false);
             tx.commit();
             consoleReader.println("Successful commit: " + filePath.getFileName().toString());
-        } catch (RuntimeException e) {
+        } catch (GraknClientException e) {
             printErr.println("Failed to load file:");
             printErr.println(e.getMessage());
         } finally {

--- a/console/test/BUILD
+++ b/console/test/BUILD
@@ -41,7 +41,7 @@ java_test(
         "//dependencies/maven/artifacts/io/grpc:grpc-core",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
     ],
-    data = ["file-(with-parentheses).gql"],
+    data = ["file-(with-parentheses).gql", "invalid-data.cql"],
     size = "large",
     classpath_resources = ["//test-integration/resources:logback-test"]
 )

--- a/console/test/GraknConsoleIT.java
+++ b/console/test/GraknConsoleIT.java
@@ -158,6 +158,14 @@ public class GraknConsoleIT {
     }
 
     @Test
+    public void when_loadingInvalidDataFromFile_expectError() {
+        Response response = runConsoleSession("", "-f", "console/test/invalid-data.cql");
+
+        assertThat(response.err(), allOf(containsString("Failed to load file:"), containsString("A structural validation error has occurred.")));
+        assertThat(response.out(), not(containsString("Successful commit:")));
+    }
+
+    @Test
     public void when_loadingFileWithEscapes_expect_dataIsWritten() throws Exception {
         assertConsoleSessionMatches(
                 "load console/test/file-\\(with-parentheses\\).gql",

--- a/console/test/invalid-data.cql
+++ b/console/test/invalid-data.cql
@@ -1,0 +1,60 @@
+define
+
+example-id sub attribute,
+    datatype long;
+
+person sub entity,
+    has example-id,
+    plays patient,
+    plays symptomatic-patient;
+
+disease sub entity,
+    plays cause,
+    plays diagnosed-disease;
+
+diagnosis sub relation,
+    relates patient,
+    relates diagnosed-disease;
+
+candidate-diagnosis sub relation,
+    relates candidate-patient,
+    relates candidate-diagnosed-disease;
+
+where-no-diagnosis-add-candidate-diagnosis sub rule,
+    when {
+        $p isa person;
+        $d isa disease;
+        not{ (patient: $p, diagnosed-disease: $d) isa diagnosis; };
+    }, then {
+        (candidate-patient: $p, candidate-diagnosed-disease: $d) isa candidate-diagnosis;
+    };
+
+
+meningitis sub disease;
+flu sub disease;
+
+causality sub relation,
+    relates cause,
+    relates effect;
+
+symptom sub entity,
+    plays presented-symptom,
+    plays effect;
+
+light-sensitivity sub symptom;
+fever sub symptom;
+
+symptom-presentation sub relation,
+    relates presented-symptom,
+    relates symptomatic-patient;
+
+# Add elements to the Knowledge Graph that are common to all examples
+insert
+    $men isa meningitis;
+    $flu isa flu;
+    $ls isa light-sensitivity;
+    $fever isa fever;
+    $c(cause: $men, effect: $ls) isa causality;
+    $c1(cause: $men, effect: $fever) isa causality;
+    $c2(cause: $flu, effect: $ls) isa causality;
+    $c3(cause: $flu, effect: $fever) isa causality;

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -97,7 +97,6 @@ public class GraknTestServer extends ExternalResource {
             updatedCassandraConfigPath = buildCassandraConfigWithRandomPorts();
             System.setProperty("cassandra.config", "file:" + updatedCassandraConfigPath.getAbsolutePath());
             System.setProperty("cassandra-foreground", "true");
-            System.out.println("cassandraConfig.getAbsolutePath() = " + updatedCassandraConfigPath.getAbsolutePath());
             GraknStorage.main(new String[]{});
             System.out.println("Grakn Storage started");
 


### PR DESCRIPTION


## What is the goal of this PR?

We were previously printing "Successful Commit:" even when exceptions were thrown while loading data from file using console, i.e. `grakn console -f ./test.cql`.
With this PR we make sure the successful message is not printed anymore and instead we only print the exception message.


## What are the changes implemented in this PR?

- update console
- add regression test

Closes https://github.com/graknlabs/grakn/issues/5361
