### PR TITLE
Look for non-trivial instance loops when determining whether reiteration is needed

### DIFF
--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -150,6 +150,7 @@ public class RuleUtils {
 
         typeSCC.successorMap().entries().forEach(e -> typeTCinverse.put(e.getValue(), e.getKey()));
 
+        //for each cycle in the type dependency graph, check for cycles in the instances
         return typeCycles.stream().anyMatch(typeSet -> {
             Set<ReasonerAtomicQuery> queries = typeSet.stream()
                     .flatMap(type -> typeTCinverse.get(type).stream())

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -162,19 +162,18 @@ public class RuleUtils {
             if (!queries.stream().allMatch(q -> tx.queryCache().isDBComplete(q))) return true;
 
             HashMultimap<Concept, Concept> conceptMap = HashMultimap.create();
-            return queries.stream().anyMatch(q -> {
+            queries.forEach(q -> {
                 RelationAtom relationAtom = q.getAtom().toRelationAtom();
                 Set<Pair<Variable, Variable>> varPairs = relationAtom.varDirectionality();
                 IndexedAnswerSet answers = tx.queryCache().getEntry(q).cachedElement();
-                return answers.stream().anyMatch(ans ->
-                        varPairs.stream().anyMatch(p -> {
+                answers.forEach(ans ->
+                        varPairs.forEach(p -> {
                             Concept from = ans.get(p.getKey());
                             Concept to = ans.get(p.getValue());
-                            if (conceptMap.get(to).contains(from)) return true;
                             conceptMap.put(from, to);
-                            return false;
                         }));
             });
+            return !new TarjanSCC<>(conceptMap).getCycles().isEmpty();
         });
     }
 

--- a/server/src/graql/reasoner/rule/RuleUtils.java
+++ b/server/src/graql/reasoner/rule/RuleUtils.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import grakn.core.concept.Concept;
+import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.Rule;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.reasoner.atom.Atom;
@@ -163,17 +164,19 @@ public class RuleUtils {
             if (!queries.stream().allMatch(q -> tx.queryCache().isDBComplete(q))) return true;
 
             HashMultimap<Concept, Concept> conceptMap = HashMultimap.create();
-            queries.forEach(q -> {
+            for (ReasonerAtomicQuery q : queries) {
                 RelationAtom relationAtom = q.getAtom().toRelationAtom();
                 Set<Pair<Variable, Variable>> varPairs = relationAtom.varDirectionality();
                 IndexedAnswerSet answers = tx.queryCache().getEntry(q).cachedElement();
-                answers.forEach(ans ->
-                        varPairs.forEach(p -> {
-                            Concept from = ans.get(p.getKey());
-                            Concept to = ans.get(p.getValue());
-                            conceptMap.put(from, to);
-                        }));
-            });
+                for (ConceptMap ans : answers) {
+                    for (Pair<Variable, Variable> p : varPairs) {
+                        Concept from = ans.get(p.getKey());
+                        Concept to = ans.get(p.getValue());
+                        if (conceptMap.get(to).contains(from)) return true;
+                        conceptMap.put(from, to);
+                    }
+                }
+            }
             return !new TarjanSCC<>(conceptMap).getCycles().isEmpty();
         });
     }


### PR DESCRIPTION
## What is the goal of this PR?
When trying to determine whether a resolution reiteration is needed, we check for cycles in the type dependency graph and later in the relation instances. Previously when looking for cycles among relations, we were looking at direct neighbours only. This would lead finishing the processing too early in some cases. Now we look for non-trivial (transitive) cycles.
## What are the changes implemented in this PR?
Uses Tarjan's algo to determine reachable neighbours when looking for cycles in relation instances. 
Fixes #5355