### PR TITLE
Always infer types in queries

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -109,7 +109,7 @@ public class QueryExecutor {
 
                 answerStream = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream()
                         .map(p -> ReasonerQueries.create(p, transaction))
-                        .flatMap(q -> transaction.stream(q.getQuery()));
+                        .flatMap(q -> transaction.stream(q.getQuery(), false));
 
                 ServerTracing.closeScopedChildSpan(traversalToStreamSpanId);
             } else {

--- a/server/src/graql/reasoner/cache/StructuralCache.java
+++ b/server/src/graql/reasoner/cache/StructuralCache.java
@@ -71,7 +71,7 @@ public class StructuralCache<Q extends ReasonerQueryImpl>{
 
             ReasonerQueryImpl transformedQuery = equivalentQuery.transformIds(idTransform);
 
-            return tx.executor().traversal(transformedQuery.getPattern().variables(), traversal.transform(idTransform))
+            return tx.executor().traversal(transformedQuery.getPattern(), traversal.transform(idTransform))
                     .map(unifier::apply)
                     .map(a -> a.explain(new LookupExplanation(query.getPattern())));
         }
@@ -79,7 +79,7 @@ public class StructuralCache<Q extends ReasonerQueryImpl>{
         GraqlTraversal traversal = TraversalPlanner.createTraversal(query.getPattern(), tx);
         structCache.put(structQuery, new CacheEntry<>(query, traversal));
 
-        return tx.executor().traversal(query.getPattern().variables(), traversal)
+        return tx.executor().traversal(query.getPattern(), traversal)
                 .map(a -> a.explain(new LookupExplanation(query.getPattern())));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
Previously we were only inferring types (roles, relation types) in queries when the reasoning was set to on. Now all queries, regardless of the reasoning setting, shall benefit from the type inference.

## What are the changes implemented in this PR?
Closes #5146 
