### PR TITLE
CI job now waits for an existing apt process to finish before proceeding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ commands:
   install-bazel-linux-rbe:
     steps:
       - run: curl -OL https://raw.githubusercontent.com/lolski/build-tools/apt-wait/ci/apt-wait.sh
-      - run: bash ./apt-wait.sh
+      - run: bash ./apt-wait.sh && rm ./apt-wait.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-linux.sh
       - run: bash ./install-bazel-linux.sh && rm ./install-bazel-linux.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-rbe.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 commands:
   install-bazel-linux-rbe:
     steps:
-      - run: curl -OL https://github.com/lolski/build-tools/blob/apt-wait/ci/apt-wait.sh
+      - run: curl -OL https://raw.githubusercontent.com/lolski/build-tools/apt-wait/ci/apt-wait.sh
       - run: bash ./apt-wait.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-linux.sh
       - run: bash ./install-bazel-linux.sh && rm ./install-bazel-linux.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,8 @@ version: 2.1
 commands:
   install-bazel-linux-rbe:
     steps:
+      - run: curl -OL https://github.com/lolski/build-tools/blob/apt-wait/ci/apt-wait.sh
+      - run: bash ./apt-wait.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-linux.sh
       - run: bash ./install-bazel-linux.sh && rm ./install-bazel-linux.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-rbe.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ version: 2.1
 commands:
   install-bazel-linux-rbe:
     steps:
-      - run: curl -OL https://raw.githubusercontent.com/lolski/build-tools/apt-wait/ci/apt-wait.sh
+      - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/apt-wait.sh
       - run: bash ./apt-wait.sh && rm ./apt-wait.sh
       - run: curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-linux.sh
       - run: bash ./install-bazel-linux.sh && rm ./install-bazel-linux.sh


### PR DESCRIPTION
## What is the goal of this PR?

Sometimes the `apt` command in the CI would fail because there is already an existing `apt` background process started automatically by the machine. This PR uses `build-tools`'s `apt-wait.sh` to wait for it to finish before proceeding.
