### PR TITLE
Remove grakn.properties GlobalOffline Configuration Options

### DIFF
--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -68,13 +68,8 @@ storage.connection-timeout=20000
 # Enabling this option speeds up traversals by holding hot elements in memory,
 # but also increases the likelihood of reading stale data. Disabling it forces each transaction
 # to independently fetch elements from storage before reading/writing them.
+# the default cache expiration is 5 seconds, currently unmodifiable
 cache.db-cache=false
-# How long in milliseconds database-level cache will keep entries after flushing them.
-cache.db-cache-clean-wait=20
-# Default expiration time in milliseconds for entries in the database-level cache.
-# Set to 0 to disable expiration (cache entries live forever or until memory pressure
-# triggers eviction).
-cache.db-cache-time=5000
 # Size of Janus's database cache in proportion to JVM size 0 (small) to 1 (large)
 cache.db-cache-size=0.35
 cache.tx-cache-size=30000


### PR DESCRIPTION
## What is the goal of this PR?
After some experimentation, we realised that the two options `cache.db-cache-clean-wait` and `cache.db-cache-time` were not having any effect. This is because they fall under `GLOBAL_OFFLINE` configuration options (see janusgraph configuration reference https://docs.janusgraph.org/0.2.0/config-ref.html), and require a different approach for being set compared to `maskable` or `local` options.

The accepted current solution is that we fully remove the `GLOBAL_OFFLINE` options from the `grakn.properties` file until firstly, we have a good understanding of why these options are `GLOBAL_OFFLINE` and are therefore persisted to the backend and propagated to all nodes on bootup. Secondly, once we have this understanding, a full fix may end up re-exposing the `db-cache-time` etc. in a roboust way. 

One hacky, testing implementation that writes the global offline configs separately, can be found here: https://github.com/flyingsilverfin/grakn/tree/janus-global-offline-options-KEEP (see the `JanusGraphFactory` class). Might be useful as a reference in the future. It also solves an issue that was uncovered where killing the server uncleanly while a graph is open leads to extra recorded connected clients in Janus, which means the configurations can no longer be updated (see the `JanusGraphManagement.forceCloseInstance()` to remove defunct instances from the internal records)

## What are the changes implemented in this PR?
* remove GLOBAL_OFFLINE configurations `cache.db-cache-clean-wait` and `cache.db-cache-time` from `grakn.properties.