### PR TITLE
Refactor keyspace service to allow extension

### DIFF
--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -23,8 +23,10 @@ import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.server.keyspace.KeyspaceManager;
+import grakn.core.server.rpc.KeyspaceRequestsHandler;
 import grakn.core.server.rpc.KeyspaceService;
 import grakn.core.server.rpc.OpenRequest;
+import grakn.core.server.rpc.ServerKeyspaceRequestsHandler;
 import grakn.core.server.rpc.ServerOpenRequest;
 import grakn.core.server.rpc.SessionService;
 import grakn.core.server.session.HadoopGraphFactory;
@@ -95,11 +97,14 @@ public class ServerFactory {
 
         SessionService sessionService = new SessionService(requestOpener);
 
+        KeyspaceRequestsHandler requestsHandler = new ServerKeyspaceRequestsHandler(
+                keyspaceManager, sessionFactory, janusGraphFactory);
+
         Runtime.getRuntime().addShutdownHook(new Thread(sessionService::shutdown, "session-service-shutdown"));
 
         return ServerBuilder.forPort(grpcPort)
                 .addService(sessionService)
-                .addService(new KeyspaceService(keyspaceManager, sessionFactory, janusGraphFactory))
+                .addService(new KeyspaceService(requestsHandler))
                 .build();
     }
 

--- a/server/src/server/rpc/KeyspaceRequestsHandler.java
+++ b/server/src/server/rpc/KeyspaceRequestsHandler.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.server.rpc;
 
 import grakn.protocol.keyspace.KeyspaceProto;

--- a/server/src/server/rpc/KeyspaceRequestsHandler.java
+++ b/server/src/server/rpc/KeyspaceRequestsHandler.java
@@ -1,0 +1,8 @@
+package grakn.core.server.rpc;
+
+import grakn.protocol.keyspace.KeyspaceProto;
+
+public interface KeyspaceRequestsHandler {
+    Iterable<String> retrieve(KeyspaceProto.Keyspace.Retrieve.Req request);
+    void delete(KeyspaceProto.Keyspace.Delete.Req request);
+}

--- a/server/src/server/rpc/ServerKeyspaceRequestsHandler.java
+++ b/server/src/server/rpc/ServerKeyspaceRequestsHandler.java
@@ -1,3 +1,21 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package grakn.core.server.rpc;
 
 import grakn.core.server.exception.GraknServerException;

--- a/server/src/server/rpc/ServerKeyspaceRequestsHandler.java
+++ b/server/src/server/rpc/ServerKeyspaceRequestsHandler.java
@@ -1,0 +1,43 @@
+package grakn.core.server.rpc;
+
+import grakn.core.server.exception.GraknServerException;
+import grakn.core.server.keyspace.KeyspaceImpl;
+import grakn.core.server.keyspace.KeyspaceManager;
+import grakn.core.server.session.JanusGraphFactory;
+import grakn.core.server.session.SessionFactory;
+import grakn.protocol.keyspace.KeyspaceProto;
+
+import java.util.stream.Collectors;
+
+public class ServerKeyspaceRequestsHandler implements KeyspaceRequestsHandler {
+    private final KeyspaceManager keyspaceManager;
+    private final SessionFactory sessionFactory;
+    private final JanusGraphFactory janusGraphFactory;
+
+
+    public ServerKeyspaceRequestsHandler(KeyspaceManager keyspaceManager, SessionFactory sessionFactory, JanusGraphFactory janusGraphFactory) {
+        this.keyspaceManager = keyspaceManager;
+        this.sessionFactory = sessionFactory;
+        this.janusGraphFactory = janusGraphFactory;
+    }
+
+    @Override
+    public Iterable<String> retrieve(KeyspaceProto.Keyspace.Retrieve.Req request) {
+        return this.keyspaceManager.keyspaces().stream().map(KeyspaceImpl::name).collect(Collectors.toSet());
+    }
+
+    @Override
+    public void delete(KeyspaceProto.Keyspace.Delete.Req request) {
+        KeyspaceImpl keyspace = KeyspaceImpl.of(request.getName());
+
+        if (!keyspaceManager.keyspaces().contains(keyspace)) {
+            throw GraknServerException.create("It is not possible to delete keyspace [" + keyspace.name() + "] as it does not exist.");
+        }
+        else {
+            // removing references to open keyspaces JanusGraph instances
+            sessionFactory.deleteKeyspace(keyspace);
+            // actually remove the keyspace
+            janusGraphFactory.drop(keyspace.name());
+        }
+    }
+}

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -26,8 +26,10 @@ import grakn.core.server.Server;
 import grakn.core.server.ServerFactory;
 import grakn.core.server.keyspace.KeyspaceImpl;
 import grakn.core.server.keyspace.KeyspaceManager;
+import grakn.core.server.rpc.KeyspaceRequestsHandler;
 import grakn.core.server.rpc.KeyspaceService;
 import grakn.core.server.rpc.OpenRequest;
+import grakn.core.server.rpc.ServerKeyspaceRequestsHandler;
 import grakn.core.server.rpc.ServerOpenRequest;
 import grakn.core.server.rpc.SessionService;
 import grakn.core.server.session.HadoopGraphFactory;
@@ -212,9 +214,12 @@ public class GraknTestServer extends ExternalResource {
 
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);
 
+        KeyspaceRequestsHandler requestsHandler = new ServerKeyspaceRequestsHandler(
+                keyspaceManager, sessionFactory, janusGraphFactory);
+
         io.grpc.Server serverRPC = ServerBuilder.forPort(grpcPort)
                 .addService(new SessionService(requestOpener))
-                .addService(new KeyspaceService(keyspaceManager, sessionFactory, janusGraphFactory))
+                .addService(new KeyspaceService(requestsHandler))
                 .build();
 
         return ServerFactory.createServer(serverRPC);


### PR DESCRIPTION
## What is the goal of this PR?

In order to support authenticated operations in `KeyspaceService` in enterprise version, it should be refactored.

## What are the changes implemented in this PR?

* Extract interface for operations with keyspaces: `KeyspaceRequestsHandler`
* Implement extracted interface in Grakn Core: `ServerKeyspaceRequestsHandler`
* Refactor gRPC service to use extracted interface
