### PR TITLE
Use persisted values when materialising attributes

### DIFF
--- a/server/src/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/server/src/graql/reasoner/atom/binary/AttributeAtom.java
@@ -34,6 +34,7 @@ import grakn.core.concept.type.SchemaConcept;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlQueryException;
 import grakn.core.graql.exception.GraqlSemanticException;
+import grakn.core.graql.executor.property.value.ValueOperation;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
 import grakn.core.graql.reasoner.atom.AtomicEquivalence;
@@ -56,6 +57,7 @@ import grakn.core.server.kb.concept.AttributeTypeImpl;
 import grakn.core.server.kb.concept.ConceptUtils;
 import grakn.core.server.kb.concept.EntityImpl;
 import grakn.core.server.kb.concept.RelationImpl;
+import grakn.core.server.kb.concept.ValueConverter;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
@@ -430,9 +432,11 @@ public abstract class AttributeAtom extends Binary{
         //if the attribute already exists, only attach a new link to the owner, otherwise create a new attribute
         Attribute attribute = null;
         if(this.isValueEquality()){
-            Object value = Iterables.getOnlyElement(getMultiPredicate()).getPredicate().value();
-            Attribute existingAttribute = attributeType.attribute(value);
-            attribute = existingAttribute == null? attributeType.putAttributeInferred(value) : existingAttribute;
+            ValuePredicate vp = Iterables.getOnlyElement(getMultiPredicate());
+            Object value = vp.getPredicate().value();
+            Object persistedValue = ValueConverter.of(attributeType.dataType()).convert(value);
+            Attribute existingAttribute = attributeType.attribute(persistedValue);
+            attribute = existingAttribute == null? attributeType.putAttributeInferred(persistedValue) : existingAttribute;
         } else {
             Attribute existingAttribute = substitution.containsVar(resourceVariable)? substitution.get(resourceVariable).asAttribute() : null;
             //even if the attribute exists but is of different type (supertype for instance) we create a new one

--- a/test-integration/graql/query/NumberCastingIT.java
+++ b/test-integration/graql/query/NumberCastingIT.java
@@ -40,6 +40,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class NumberCastingIT {
 
@@ -71,6 +72,14 @@ public class NumberCastingIT {
         }
     }
 
+    private void verifyRead(SessionImpl session, Pattern pattern) {
+        MatchClause match = Graql.match(pattern.statements());
+        try (TransactionOLTP tx = session.transaction().write()) {
+            List<ConceptMap> answers = tx.execute(match);
+            assertFalse(answers.isEmpty());
+        }
+    }
+
     private void cleanup(SessionImpl session, Pattern pattern) {
         MatchClause match = Graql.match(pattern.statements());
         try (TransactionOLTP tx = session.transaction().write()) {
@@ -83,7 +92,7 @@ public class NumberCastingIT {
     public void whenAddressingDoubleAsInteger_ConversionHappens() {
         Pattern pattern = Graql.var("x").val(10).isa("attr-double");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 
@@ -91,7 +100,7 @@ public class NumberCastingIT {
     public void whenAddressingDoubleAsLong_ConversionHappens() {
         Pattern pattern = Graql.var("x").val(10L).isa("attr-double");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 
@@ -99,14 +108,14 @@ public class NumberCastingIT {
     public void whenAddressingDoubleAsFloat_ConversionHappens() {
         Pattern pattern = Graql.var("x").val(10f).isa("attr-double");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
     }
 
     @Test
     public void whenAddressingLongAsInt_ConversionHappens() {
         Pattern pattern = Graql.var("x").val(10).isa("attr-long");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 
@@ -116,7 +125,7 @@ public class NumberCastingIT {
 
         Pattern pattern = Graql.parsePattern("$x " + now + " isa attr-date;");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 
@@ -126,7 +135,7 @@ public class NumberCastingIT {
 
         Pattern pattern = Graql.parsePattern("$x " + now + " isa attr-date;");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 
@@ -135,7 +144,7 @@ public class NumberCastingIT {
         double value = 10.0;
         Pattern pattern = Graql.var("x").val(value).isa("attr-long");
         verifyWrite(session, pattern);
-        //TODO verifyRead(session, pattern);
+        verifyRead(session, pattern);
         cleanup(session, pattern);
     }
 

--- a/test-integration/graql/reasoner/atomic/AtomicConversionIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicConversionIT.java
@@ -45,8 +45,9 @@ import org.junit.Test;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
-public class ConversionIT {
+public class AtomicConversionIT {
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
@@ -165,7 +166,7 @@ public class ConversionIT {
             Atom attribute = ReasonerQueries.atomic(attributePattern, tx).getAtom();
             RelationAtom intermittentAtom = attribute.toRelationAtom();
             AttributeAtom equivalentAttribute = intermittentAtom.toAttributeAtom();
-            //assertTrue(attribute.isAlphaEquivalent(equivalentAttribute));
+            assertTrue(attribute.isAlphaEquivalent(equivalentAttribute));
             assertEquals(attribute, equivalentAttribute);
         }
     }

--- a/test-integration/graql/reasoner/atomic/BUILD
+++ b/test-integration/graql/reasoner/atomic/BUILD
@@ -39,10 +39,10 @@ java_test(
 java_test(
     name = "atomic-conversion-it",
     size = "medium",
-    srcs = ["ConversionIT.java"],
+    srcs = ["AtomicConversionIT.java"],
     classpath_resources = ["//test-integration/resources:logback-test"],
     resources = ["//test-integration/graql/reasoner/resources:generic-schema"],
-    test_class = "grakn.core.graql.reasoner.atomic.ConversionIT",
+    test_class = "grakn.core.graql.reasoner.atomic.AtomicConversionIT",
     deps = [
         "//concept",
         "//dependencies/maven/artifacts/com/google/guava",

--- a/test-integration/graql/reasoner/query/MaterialisationIT.java
+++ b/test-integration/graql/reasoner/query/MaterialisationIT.java
@@ -23,12 +23,16 @@ import com.google.common.collect.Sets;
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.thing.Entity;
+import grakn.core.concept.thing.Relation;
 import grakn.core.rule.GraknTestServer;
 import grakn.core.server.session.SessionImpl;
 import grakn.core.server.session.TransactionOLTP;
 import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
+import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -79,10 +83,7 @@ public class MaterialisationIT {
                     relation,
                     Graql.var("x").id(entity.id().getValue()),
                     Graql.var("y").id(anotherEntity.id().getValue())));
-            ReasonerAtomicQuery relationQuery = ReasonerQueries.atomic(pattern, tx);
-
-            Set<ConceptMap> materialised = relationQuery.materialise(new ConceptMap()).collect(toSet());
-            assertTrue(tx.execute(relationQuery.getQuery()).containsAll(materialised));
+            materialiseWithoutDuplicates(pattern, tx);
         }
     }
 
@@ -91,12 +92,9 @@ public class MaterialisationIT {
         try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
             Entity entity = tx.getMetaEntityType().instances().iterator().next();
 
-            Statement attribute = Graql.var("x").has("resource", "materialised").id(entity.id().getValue());
+            Statement attribute = Graql.var("x").has("resource-string", "materialised").id(entity.id().getValue());
             Conjunction<Statement> pattern = Graql.and(Collections.singleton(attribute));
-            ReasonerAtomicQuery attributeQuery = ReasonerQueries.atomic(pattern, tx);
-
-            Set<ConceptMap> materialised = attributeQuery.materialise(new ConceptMap()).collect(toSet());
-            assertTrue(tx.execute(attributeQuery.getQuery()).containsAll(materialised));
+            materialiseWithoutDuplicates(pattern, tx);
         }
     }
 
@@ -127,12 +125,7 @@ public class MaterialisationIT {
                     relation,
                     Graql.var("x").id(entity.id().getValue()),
                     Graql.var("y").id(anotherEntity.id().getValue())));
-            ReasonerAtomicQuery relationQuery = ReasonerQueries.atomic(pattern, tx);
-
-            List<ConceptMap> inserted = tx.execute(Graql.insert(pattern.statements()));
-            List<ConceptMap> postInsertAnswers = tx.execute(relationQuery.getQuery());
-            Set<ConceptMap> materialised = relationQuery.materialise(new ConceptMap()).collect(toSet());
-            assertCollectionsNonTriviallyEqual(postInsertAnswers, tx.execute(relationQuery.getQuery()));
+            materialiseWithoutDuplicates(pattern, tx);
         }
     }
 
@@ -141,14 +134,9 @@ public class MaterialisationIT {
         try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
             Entity entity = tx.getMetaEntityType().instances().iterator().next();
 
-            Statement attribute = Graql.var("x").has("resource", "materialised").id(entity.id().getValue());
+            Statement attribute = Graql.var("x").has("resource-string", "materialised").id(entity.id().getValue());
             Conjunction<Statement> pattern = Graql.and(Collections.singleton(attribute));
-            ReasonerAtomicQuery attributeQuery = ReasonerQueries.atomic(pattern, tx);
-
-            List<ConceptMap> inserted = tx.execute(Graql.insert(pattern.statements()));
-            List<ConceptMap> postInsertAnswers = tx.execute(attributeQuery.getQuery());
-            Set<ConceptMap> materialised = attributeQuery.materialise(new ConceptMap()).collect(toSet());
-            assertCollectionsNonTriviallyEqual(postInsertAnswers, tx.execute(attributeQuery.getQuery()));
+            materialiseWithoutDuplicates(pattern, tx);
         }
     }
 
@@ -158,77 +146,120 @@ public class MaterialisationIT {
             Iterator<Entity> entityIterator = tx.getMetaEntityType().instances().iterator();
             Entity entity = entityIterator.next();
 
-            Statement attribute = Graql.var("x").has("resource", "materialised").id(entity.id().getValue());
+            Statement attribute = Graql.var("x").has("resource-string", "materialised").id(entity.id().getValue());
             Conjunction<Statement> pattern = Graql.and(Collections.singleton(attribute));
             ReasonerAtomicQuery attributeQuery = ReasonerQueries.atomic(pattern, tx);
             ReasonerAtomicQuery implicitRelationQuery = ReasonerQueries.atomic(attributeQuery.getAtom().toRelationAtom());
 
-            Set<ConceptMap> materialised = implicitRelationQuery.materialise(new ConceptMap()).collect(toSet());
+            List<ConceptMap> materialised = materialiseWithoutDuplicates(implicitRelationQuery.getPattern(), tx);
             assertTrue(tx.execute(attributeQuery.getQuery()).containsAll(materialised));
         }
     }
 
     @Test
     public void whenMaterialisingEntity_MaterialisedInformationIsCorrectlyFlaggedAsInferred() {
-        TransactionOLTP tx = materialisationTestSession.transaction().write();
-        ReasonerAtomicQuery entityQuery = ReasonerQueries.atomic(conjunction("$x isa newEntity;"), tx);
-        assertTrue(entityQuery.materialise(new ConceptMap()).findFirst().orElse(null).get("x").asEntity().isInferred());
-        tx.close();
+        try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
+            ReasonerAtomicQuery entityQuery = ReasonerQueries.atomic(conjunction("$x isa newEntity;"), tx);
+            assertTrue(entityQuery.materialise(new ConceptMap()).findFirst().orElse(null).get("x").asEntity().isInferred());
+        }
     }
 
     @Test
-    public void whenMaterialisingResources_MaterialisedInformationIsCorrectlyFlaggedAsInferred() {
-        TransactionOLTP tx = materialisationTestSession.transaction().write();
-        Concept firstEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa someEntity; get;").asGet(), false)).get("x");
-        Concept secondEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa anotherEntity; get;").asGet(), false)).get("x");
-        Concept resource = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa resource; get;").asGet(), false)).get("x");
+    public void whenMaterialisingAttributes_MaterialisedInformationIsCorrectlyFlaggedAsInferred() {
+        try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
+            Concept firstEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa someEntity; get;").asGet(), false)).get("x");
+            Concept secondEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa anotherEntity; get;").asGet(), false)).get("x");
+            Concept resource = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa resource-string; get;").asGet(), false)).get("x");
 
-        ReasonerAtomicQuery resourceQuery = ReasonerQueries.atomic(conjunction("{ $x has resource $r;$r == 'inferred';$x id " + firstEntity.id().getValue() + "; };"), tx);
-        String reuseResourcePatternString =
-                "{" +
-                        " $x has resource $r;" +
-                        " $x id " + secondEntity.id().getValue() + ";" +
-                        " $r id " + resource.id().getValue() + ";" +
-                        " };";
+            Conjunction<Statement> resourcePattern = conjunction("{ $x has resource-string $r;$r == 'inferred';$x id " + firstEntity.id().getValue() + "; };");
+            Conjunction<Statement> reuseResourcePattern = conjunction(
+                    "{" +
+                            " $x has resource-string $r;" +
+                            " $x id " + secondEntity.id().getValue() + ";" +
+                            " $r id " + resource.id().getValue() + ";" +
+                            " };");
 
-        ReasonerAtomicQuery reuseResourceQuery = ReasonerQueries.atomic(conjunction(reuseResourcePatternString), tx);
+            List<ConceptMap> resourceAnswers = materialiseWithoutDuplicates(resourcePattern, tx);
+            assertTrue(Iterables.getOnlyElement(resourceAnswers).get("r").asAttribute().isInferred());
 
-        assertTrue(resourceQuery.materialise(new ConceptMap()).findFirst().orElse(null).get("r").asAttribute().isInferred());
-
-        List<ConceptMap> answers = reuseResourceQuery.materialise(new ConceptMap()).collect(Collectors.toList());
-        assertTrue(Iterables.getOnlyElement(
-                tx.execute(Graql.parse("match" +
-                        "$x has resource $r via $rel;" +
-                        "$x id " + secondEntity.id().getValue() + ";" +
-                        "$r id " + resource.id().getValue() + ";" +
-                        "get;").asGet(), false)).get("rel").asRelation().isInferred());
-        assertFalse(Iterables.getOnlyElement(
-                tx.execute(Graql.parse("match" +
-                        "$x has resource $r via $rel;" +
-                        "$x id " + firstEntity.id().getValue() + ";" +
-                        "$r id " + resource.id().getValue() + ";" +
-                        "get;").asGet(), false)).get("rel").asRelation().isInferred());
-        tx.close();
+            materialiseWithoutDuplicates(reuseResourcePattern, tx);
+            assertTrue(Iterables.getOnlyElement(
+                    tx.execute(Graql.parse("match" +
+                            "$x has resource-string $r via $rel;" +
+                            "$x id " + secondEntity.id().getValue() + ";" +
+                            "$r id " + resource.id().getValue() + ";" +
+                            "get;").asGet(), false)).get("rel").asRelation().isInferred());
+            assertFalse(Iterables.getOnlyElement(
+                    tx.execute(Graql.parse("match" +
+                            "$x has resource-string $r via $rel;" +
+                            "$x id " + firstEntity.id().getValue() + ";" +
+                            "$r id " + resource.id().getValue() + ";" +
+                            "get;").asGet(), false)).get("rel").asRelation().isInferred());
+        }
     }
+
+    @Test
+    public void whenMaterialisingAttributesWithCompatibleValues_noDuplicatesAreCreated() {
+        try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
+            Entity entity = tx.getMetaEntityType().instances().iterator().next();
+
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-string", "materialised").id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-boolean", true).id(entity.id().getValue()), tx);
+
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-double", 10L).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-double", 10).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-double", 10.0).id(entity.id().getValue()), tx);
+
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10.0).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10L).id(entity.id().getValue()), tx);
+
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10.0).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-long", 10L).id(entity.id().getValue()), tx);
+
+            materialiseWithoutDuplicates(Graql.var("x").has("resource-date", LocalDateTime.now()).id(entity.id().getValue()), tx);
+            materialiseWithoutDuplicates(Graql.parsePattern("$x id " + entity.id().getValue() + ", has resource-date " + LocalDate.now() + ";").statements().iterator().next(), tx);
+        }
+    }
+
 
     @Test
     public void whenMaterialisingRelations_MaterialisedInformationIsCorrectlyFlaggedAsInferred() {
-        TransactionOLTP tx = materialisationTestSession.transaction().write();
-        Concept firstEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa someEntity; get;").asGet(), false)).get("x");
-        Concept secondEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa anotherEntity; get;").asGet(), false)).get("x");
+        try(TransactionOLTP tx = materialisationTestSession.transaction().write()) {
+            Concept firstEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa someEntity; get;").asGet(), false)).get("x");
+            Concept secondEntity = Iterables.getOnlyElement(tx.execute(Graql.parse("match $x isa anotherEntity; get;").asGet(), false)).get("x");
 
-        ReasonerAtomicQuery relationQuery = ReasonerQueries.atomic(conjunction(
-                "{" +
-                        " $r (someRole: $x, anotherRole: $y);" +
-                        " $x id " + firstEntity.id().getValue() + ";" +
-                        " $y id " + secondEntity.id().getValue() + ";" +
-                        " };"
-                ),
-                tx
-        );
+            Conjunction<Statement> relationConj = conjunction(
+                    "{" +
+                            " $r (someRole: $x, anotherRole: $y);" +
+                            " $x id " + firstEntity.id().getValue() + ";" +
+                            " $y id " + secondEntity.id().getValue() + ";" +
+                            " };"
+            );
+            Relation materialisedRelation = Iterables.getOnlyElement(materialiseWithoutDuplicates(relationConj, tx)).get("r").asRelation();
+            assertTrue(materialisedRelation.isInferred());
+        }
+    }
 
-        assertTrue(relationQuery.materialise(new ConceptMap()).findFirst().orElse(null).get("r").asRelation().isInferred());
-        tx.close();
+    private List<ConceptMap> materialiseWithoutDuplicates(Pattern pattern, TransactionOLTP tx){
+        return materialiseWithoutDuplicates(Graql.and(pattern.statements()), tx);
+    }
+
+    private List<ConceptMap> materialiseWithoutDuplicates(Statement statement, TransactionOLTP tx){
+        return materialiseWithoutDuplicates(Graql.and(Collections.singleton(statement)), tx);
+    }
+
+    private List<ConceptMap> materialiseWithoutDuplicates(Conjunction<Statement> statement, TransactionOLTP tx){
+        ReasonerAtomicQuery query = ReasonerQueries.atomic(statement, tx);
+
+        List<ConceptMap> materialised = query.materialise(new ConceptMap()).collect(Collectors.toList());
+        List<ConceptMap> answers = tx.execute(query.getQuery());
+        assertTrue(answers.containsAll(materialised));
+        List<ConceptMap> reMaterialised = query.materialise(new ConceptMap()).collect(Collectors.toList());
+        assertCollectionsNonTriviallyEqual(materialised, reMaterialised);
+        assertCollectionsNonTriviallyEqual(answers, tx.execute(query.getQuery()));
+        return materialised;
     }
 
     private Conjunction<Statement> conjunction(String patternString) {

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -73,6 +73,23 @@ public class AttributeAttachmentIT {
 
     @Test
     //Expected result: When the head of a rule contains attribute assertions, the respective unique attributes should be generated or reused.
+    public void whenUsingNonPersistedDataType_noDuplicatesAreCreated() {
+        try(TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
+
+            String queryString = "match $x isa genericEntity, has reattachable-resource-string $y; get;";
+            List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
+            String queryString2 = "match $x isa reattachable-resource-string; get;";
+            List<ConceptMap> answers2 = tx.execute(Graql.parse(queryString2).asGet());
+
+            //two attributes for each entity
+            assertEquals(tx.getEntityType("genericEntity").instances().count() * 2, answers.size());
+            //one base resource, one sub
+            assertEquals(2, answers2.size());
+        }
+    }
+
+    @Test
+    //Expected result: When the head of a rule contains attribute assertions, the respective unique attributes should be generated or reused.
     public void reusingAttribute_reattachingAttributeToEntity() {
         try(TransactionOLTP tx = attributeAttachmentSession.transaction().write()) {
 

--- a/test-integration/graql/reasoner/resources/materialisationTest.gql
+++ b/test-integration/graql/reasoner/resources/materialisationTest.gql
@@ -5,27 +5,33 @@ anotherRole sub role;
 
 newEntity sub entity;
 
-someEntity sub entity,
+baseEntity sub entity,
     plays someRole,
     plays anotherRole,
-    has resource;
+    has resource-string,
+    has resource-long,
+    has resource-double,
+    has resource-boolean,
+    has resource-date;
 
-anotherEntity sub entity,
-    plays someRole,
-    plays anotherRole,
-    has resource;
+someEntity sub baseEntity;
+anotherEntity sub baseEntity;
 
 someRelation sub relation,
     relates someRole,
     relates anotherRole,
-    has resource;
+    has resource-string;
 
 #Resources
-resource sub attribute, datatype string;
+resource-string sub attribute, datatype string;
+resource-long sub attribute, datatype long;
+resource-double sub attribute, datatype double;
+resource-boolean sub attribute, datatype boolean;
+resource-date sub attribute, datatype date;
 
 insert
 
 #Data
 
-$x isa someEntity, has resource 'resource';
+$x isa someEntity, has resource-string 'resource';
 $y isa anotherEntity;


### PR DESCRIPTION
## What is the goal of this PR?
Previously when materialising attributes (inserting inferred attributes) we were using the value provided in the query. It was possible to have a mismatch between the provided value and the persisted value of the corresponding attribute. As a result, it was possible to miss an already existing attribute and proceed with the insertion resulting in an attribute duplicate. This PR fixes this issue by ensuring we are always following the PUT behaviour with a persisted attribute data type.

## What are the changes implemented in this PR?
When materialising attributes, before checking for attribute existence, we convert the value to the persisted data type
