### PR TITLE
Fix an issue in CI caused by the custom flag in the scp command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,224 +490,228 @@ jobs:
           --body "This is an automated email to inform you that Grakn $(cat VERSION) has been released. Please update the Grakn version accordingly."
 
 workflows:
-  grakn-core:
+  # TODO(lolski): revert workflow
+  test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-common:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-console:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-server:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-reasoner:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-analytics:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-end-to-end:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-assembly-mac-zip:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-console
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-console
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-linux-targz:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-console
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-linux-apt:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-console
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-docker:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-console
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - deploy-maven-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-linux-apt
-            - test-assembly-docker
-      - deploy-apt-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-linux-apt
-            - test-assembly-docker
-      - deploy-rpm-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-linux-apt
-            - test-assembly-docker
-      - test-deployment-linux-apt:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-apt-snapshot
-      - test-deployment-linux-rpm:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-rpm-snapshot
-      - sync-dependencies-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-maven-snapshot
-            - test-deployment-linux-apt
-            - test-deployment-linux-rpm
-      - release-approval:
-          filters:
-            branches:
-              only: master
-          requires:
-            - sync-dependencies-snapshot
+      - test-assembly-windows-zip
+  # grakn-core:
+  #   jobs:
+  #     - build:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-common:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-console:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-server:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-reasoner:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-analytics:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-end-to-end:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-assembly-mac-zip:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - build
+  #           - test-common
+  #           - test-console
+  #           - test-server
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-end-to-end
+  #     - test-assembly-windows-zip:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - build
+  #           - test-common
+  #           - test-console
+  #           - test-server
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-end-to-end
+  #     - test-assembly-linux-targz:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - build
+  #           - test-common
+  #           - test-console
+  #           - test-server
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-end-to-end
+  #     - test-assembly-linux-apt:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - build
+  #           - test-common
+  #           - test-console
+  #           - test-server
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-end-to-end
+  #     - test-assembly-docker:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - build
+  #           - test-common
+  #           - test-console
+  #           - test-server
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-end-to-end
+  #     - deploy-maven-snapshot:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - test-assembly-mac-zip
+  #           - test-assembly-windows-zip
+  #           - test-assembly-linux-targz
+  #           - test-assembly-linux-apt
+  #           - test-assembly-docker
+  #     - deploy-apt-snapshot:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - test-assembly-mac-zip
+  #           - test-assembly-windows-zip
+  #           - test-assembly-linux-targz
+  #           - test-assembly-linux-apt
+  #           - test-assembly-docker
+  #     - deploy-rpm-snapshot:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - test-assembly-mac-zip
+  #           - test-assembly-windows-zip
+  #           - test-assembly-linux-targz
+  #           - test-assembly-linux-apt
+  #           - test-assembly-docker
+  #     - test-deployment-linux-apt:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - deploy-apt-snapshot
+  #     - test-deployment-linux-rpm:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - deploy-rpm-snapshot
+  #     - sync-dependencies-snapshot:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - deploy-maven-snapshot
+  #           - test-deployment-linux-apt
+  #           - test-deployment-linux-rpm
+  #     - release-approval:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - sync-dependencies-snapshot
 
-  grakn-core-release:
-    jobs:
-      - deploy-github:
-          filters:
-            branches:
-              only: grakn-release-branch
-      - deploy-approval:
-          type: approval
-          requires:
-            - deploy-github
-          filters:
-            branches:
-              only: grakn-release-branch
-      - deploy-apt:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-rpm:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-brew:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-docker:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-maven:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - sync-dependencies-release:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-apt
-            - deploy-rpm
-            - deploy-brew
-            - deploy-docker
-            - deploy-maven
-      - email-db-engines:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - sync-dependencies-release
-      - release-cleanup:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - sync-dependencies-release
+  # grakn-core-release:
+  #   jobs:
+  #     - deploy-github:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #     - deploy-approval:
+  #         type: approval
+  #         requires:
+  #           - deploy-github
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #     - deploy-apt:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-approval
+  #     - deploy-rpm:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-approval
+  #     - deploy-brew:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-approval
+  #     - deploy-docker:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-approval
+  #     - deploy-maven:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-approval
+  #     - sync-dependencies-release:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - deploy-apt
+  #           - deploy-rpm
+  #           - deploy-brew
+  #           - deploy-docker
+  #           - deploy-maven
+  #     - email-db-engines:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - sync-dependencies-release
+  #     - release-cleanup:
+  #         filters:
+  #           branches:
+  #             only: grakn-release-branch
+  #         requires:
+  #           - sync-dependencies-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -490,228 +490,224 @@ jobs:
           --body "This is an automated email to inform you that Grakn $(cat VERSION) has been released. Please update the Grakn version accordingly."
 
 workflows:
-  # TODO(lolski): revert workflow
-  test:
+  grakn-core:
     jobs:
-      - test-assembly-windows-zip
-  # grakn-core:
-  #   jobs:
-  #     - build:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-common:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-console:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-server:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-reasoner:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-analytics:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-end-to-end:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-assembly-mac-zip:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - build
-  #           - test-common
-  #           - test-console
-  #           - test-server
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-end-to-end
-  #     - test-assembly-windows-zip:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - build
-  #           - test-common
-  #           - test-console
-  #           - test-server
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-end-to-end
-  #     - test-assembly-linux-targz:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - build
-  #           - test-common
-  #           - test-console
-  #           - test-server
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-end-to-end
-  #     - test-assembly-linux-apt:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - build
-  #           - test-common
-  #           - test-console
-  #           - test-server
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-end-to-end
-  #     - test-assembly-docker:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - build
-  #           - test-common
-  #           - test-console
-  #           - test-server
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-end-to-end
-  #     - deploy-maven-snapshot:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - test-assembly-mac-zip
-  #           - test-assembly-windows-zip
-  #           - test-assembly-linux-targz
-  #           - test-assembly-linux-apt
-  #           - test-assembly-docker
-  #     - deploy-apt-snapshot:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - test-assembly-mac-zip
-  #           - test-assembly-windows-zip
-  #           - test-assembly-linux-targz
-  #           - test-assembly-linux-apt
-  #           - test-assembly-docker
-  #     - deploy-rpm-snapshot:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - test-assembly-mac-zip
-  #           - test-assembly-windows-zip
-  #           - test-assembly-linux-targz
-  #           - test-assembly-linux-apt
-  #           - test-assembly-docker
-  #     - test-deployment-linux-apt:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - deploy-apt-snapshot
-  #     - test-deployment-linux-rpm:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - deploy-rpm-snapshot
-  #     - sync-dependencies-snapshot:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - deploy-maven-snapshot
-  #           - test-deployment-linux-apt
-  #           - test-deployment-linux-rpm
-  #     - release-approval:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - sync-dependencies-snapshot
+      - build:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-common:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-console:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-server:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-reasoner:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-analytics:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-end-to-end:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-assembly-mac-zip:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-targz:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-apt:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-docker:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - test-common
+            - test-console
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - deploy-maven-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-docker
+      - deploy-apt-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-docker
+      - deploy-rpm-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-linux-apt
+            - test-assembly-docker
+      - test-deployment-linux-apt:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-apt-snapshot
+      - test-deployment-linux-rpm:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-rpm-snapshot
+      - sync-dependencies-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-maven-snapshot
+            - test-deployment-linux-apt
+            - test-deployment-linux-rpm
+      - release-approval:
+          filters:
+            branches:
+              only: master
+          requires:
+            - sync-dependencies-snapshot
 
-  # grakn-core-release:
-  #   jobs:
-  #     - deploy-github:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #     - deploy-approval:
-  #         type: approval
-  #         requires:
-  #           - deploy-github
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #     - deploy-apt:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-approval
-  #     - deploy-rpm:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-approval
-  #     - deploy-brew:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-approval
-  #     - deploy-docker:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-approval
-  #     - deploy-maven:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-approval
-  #     - sync-dependencies-release:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - deploy-apt
-  #           - deploy-rpm
-  #           - deploy-brew
-  #           - deploy-docker
-  #           - deploy-maven
-  #     - email-db-engines:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - sync-dependencies-release
-  #     - release-cleanup:
-  #         filters:
-  #           branches:
-  #             only: grakn-release-branch
-  #         requires:
-  #           - sync-dependencies-release
+  grakn-core-release:
+    jobs:
+      - deploy-github:
+          filters:
+            branches:
+              only: grakn-release-branch
+      - deploy-approval:
+          type: approval
+          requires:
+            - deploy-github
+          filters:
+            branches:
+              only: grakn-release-branch
+      - deploy-apt:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-rpm:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-brew:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-docker:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-maven:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - sync-dependencies-release:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-apt
+            - deploy-rpm
+            - deploy-brew
+            - deploy-docker
+            - deploy-maven
+      - email-db-engines:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - sync-dependencies-release
+      - release-cleanup:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - sync-dependencies-release

--- a/test/assembly/windows/windows-zip.py
+++ b/test/assembly/windows/windows-zip.py
@@ -41,17 +41,14 @@ def ssh(command, ssh_host, ssh_user, ssh_pass, attempts=5):
 
 def scp(remote, local, ssh_host, ssh_user, ssh_pass):
     system = platform.system()
-    sp.check_call(filter(None, [
+    sp.check_call([
         'sshpass',
         '-p',
         ssh_pass,
         'scp',
-        # '-T' (suppresses strict filename check) parameter
-        # is not available on scp on macOS
-        '-T' if system == 'Linux' else None,
         '{}@{}:"{}"'.format(ssh_user, ssh_host, remote),
         local,
-    ]))
+    ])
 
 
 def wait_for_ssh(ssh_host, ssh_user, ssh_pass, timeout_mins=10):


### PR DESCRIPTION
## What is the goal of this PR?

We've removed the `-T` option when calling `scp`. It is apparently a custom flag which is no longer supported.