### PR TITLE
Exit with correct exit code on invalid args

### DIFF
--- a/bin/grakn
+++ b/bin/grakn
@@ -43,7 +43,7 @@ exit_if_java_not_found() {
 # main routine
 # =============================================
 
-pushd "$GRAKN_HOME" > /dev/null
+cd "$GRAKN_HOME"
 exit_if_java_not_found
 
 if [ -z "$1" ]; then

--- a/bin/grakn
+++ b/bin/grakn
@@ -59,6 +59,7 @@ elif [ "$1" = "console" ]; then
     else
         echo "Grakn Core Console is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Console or Grakn Core (all)."
+        exit 1
     fi
 elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     if [[ -f "${SERVER_JAR_FILENAME}" ]]; then
@@ -68,6 +69,7 @@ elif [[ "$1" = "server" ]] || [[ "$1" = "version" ]]; then
     else
         echo "Grakn Core Server is not included in this Grakn distribution."
         echo "You may want to install Grakn Core Server or Grakn Core (all)."
+        exit 1
     fi
 else
     echo "Invalid argument: $1. Possible commands are: "

--- a/bin/grakn
+++ b/bin/grakn
@@ -43,8 +43,6 @@ exit_if_java_not_found() {
 # main routine
 # =============================================
 
-exit_code=0
-
 pushd "$GRAKN_HOME" > /dev/null
 exit_if_java_not_found
 
@@ -52,6 +50,7 @@ if [ -z "$1" ]; then
     echo "Missing argument. Possible commands are:"
     echo "  Server:          grakn server [--help]"
     echo "  Console:         grakn console [--help]"
+    exit 1
 elif [ "$1" = "console" ]; then
     if [ -f "${CONSOLE_JAR_FILENAME}" ]; then
         SERVICE_LIB_CP="console/services/lib/*"
@@ -74,10 +73,8 @@ else
     echo "Invalid argument: $1. Possible commands are: "
     echo "  Server:          grakn server [--help]"
     echo "  Console:         grakn console [--help]"
+    exit 1
 fi
 
-exit_code=$?
+exit $?
 
-popd > /dev/null
-
-exit $exit_code


### PR DESCRIPTION
## What is the goal of this PR?'

Fix #5389 

## What are the changes implemented in this PR?

- Exit with `1` when an argument is missing or incorrect
- Remove unneeded `popd`