### PR TITLE
Refactor definition and application of semantic difference

### DIFF
--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -461,36 +461,34 @@ public abstract class Atom extends AtomicBase {
     }
 
     /**
-     * Calculates the semantic difference between the parent and this (child) atom,
+     * Calculates the semantic difference between the this (parent) and child atom,
      * that needs to be applied on A(P) to find the subset belonging to A(C).
      *
-     * @param parentAtom parent atom
-     * @param unifier    child->parent unifier
-     * @return semantic difference between child and parent
+     * @param childAtom child atom
+     * @param unifier    parent->child unifier
+     * @return semantic difference between this and child defined in terms of this variables
      */
-    public SemanticDifference semanticDifference(Atom parentAtom, Unifier unifier) {
+    public SemanticDifference semanticDifference(Atom childAtom, Unifier unifier) {
         Set<VariableDefinition> diff = new HashSet<>();
         Unifier unifierInverse = unifier.inverse();
 
         unifier.mappings().forEach(m -> {
-            Variable childVar = m.getKey();
-            Variable parentVar = m.getValue();
+            Variable parentVar = m.getKey();
+            Variable childVar = m.getValue();
 
-            Type childType = this.getParentQuery().getUnambiguousType(childVar, false);
-            Type parentType = parentAtom.getParentQuery().getUnambiguousType(parentVar, false);
-            Type type = childType != null ?
+            Type parentType = this.getParentQuery().getUnambiguousType(childVar, false);
+            Type childType = childAtom.getParentQuery().getUnambiguousType(parentVar, false);
+            Type requiredType = childType != null ?
                     parentType != null ?
                             (!parentType.equals(childType) ? childType : null) :
                             childType
                     : null;
 
+            Set<ValuePredicate> predicatesToSatisfy = childAtom.getPredicates(childVar, ValuePredicate.class)
+                    .flatMap(vp -> vp.unify(unifierInverse).stream()).collect(toSet());
+            this.getPredicates(parentVar, ValuePredicate.class).forEach(predicatesToSatisfy::remove);
 
-            Set<ValuePredicate> predicates = this.getPredicates(childVar, ValuePredicate.class).collect(toSet());
-            parentAtom.getPredicates(parentVar, ValuePredicate.class)
-                    .flatMap(vp -> vp.unify(unifierInverse).stream())
-                    .forEach(predicates::remove);
-
-            diff.add(new VariableDefinition(childVar, type, null, new HashSet<>(), predicates));
+            diff.add(new VariableDefinition(parentVar, requiredType, null, new HashSet<>(), predicatesToSatisfy));
         });
         return new SemanticDifference(diff);
     }

--- a/server/src/graql/reasoner/atom/Atom.java
+++ b/server/src/graql/reasoner/atom/Atom.java
@@ -476,8 +476,8 @@ public abstract class Atom extends AtomicBase {
             Variable parentVar = m.getKey();
             Variable childVar = m.getValue();
 
-            Type parentType = this.getParentQuery().getUnambiguousType(childVar, false);
-            Type childType = childAtom.getParentQuery().getUnambiguousType(parentVar, false);
+            Type parentType = this.getParentQuery().getUnambiguousType(parentVar, false);
+            Type childType = childAtom.getParentQuery().getUnambiguousType(childVar, false);
             Type requiredType = childType != null ?
                     parentType != null ?
                             (!parentType.equals(childType) ? childType : null) :

--- a/server/src/graql/reasoner/atom/binary/RelationAtom.java
+++ b/server/src/graql/reasoner/atom/binary/RelationAtom.java
@@ -1007,24 +1007,25 @@ public abstract class RelationAtom extends IsaAtomBase {
         getRoleVarMap().asMap().forEach((key, value) -> value.forEach(var -> map.put(var, key)));
         return map;
     }
+
     @Override
-    public SemanticDifference semanticDifference(Atom p, Unifier unifier) {
-        SemanticDifference baseDiff = super.semanticDifference(p, unifier);
-        if (!p.isRelation()) return baseDiff;
-        RelationAtom parentAtom = (RelationAtom) p;
+    public SemanticDifference semanticDifference(Atom child, Unifier unifier) {
+        SemanticDifference baseDiff = super.semanticDifference(child, unifier);
+        if (!child.isRelation()) return baseDiff;
+        RelationAtom childAtom = (RelationAtom) child;
         Set<VariableDefinition> diff = new HashSet<>();
 
-        Set<Variable> parentRoleVars= parentAtom.getRoleExpansionVariables();
-        HashMultimap<Variable, Role> childVarRoleMap = this.getVarRoleMap();
-        HashMultimap<Variable, Role> parentVarRoleMap = parentAtom.getVarRoleMap();
+        Set<Variable> parentRoleVars = this.getRoleExpansionVariables();
+        HashMultimap<Variable, Role> childVarRoleMap = childAtom.getVarRoleMap();
+        HashMultimap<Variable, Role> parentVarRoleMap = this.getVarRoleMap();
         unifier.mappings().forEach( m -> {
-            Variable childVar = m.getKey();
-            Variable parentVar = m.getValue();
+            Variable childVar = m.getValue();
+            Variable parentVar = m.getKey();
             Set<Role> childRoles = childVarRoleMap.get(childVar);
             Set<Role> parentRoles = parentVarRoleMap.get(parentVar);
-            Role role = null;
+            Role requiredRole = null;
             if(parentRoleVars.contains(parentVar)){
-                Set<Label> roleLabels = this.getRelationPlayers().stream()
+                Set<Label> roleLabels = childAtom.getRelationPlayers().stream()
                         .map(RelationProperty.RolePlayer::getRole)
                         .flatMap(Streams::optionalToStream)
                         .filter(roleStatement -> roleStatement.var().equals(childVar))
@@ -1033,10 +1034,10 @@ public abstract class RelationAtom extends IsaAtomBase {
                         .map(Label::of)
                         .collect(toSet());
                 if (!roleLabels.isEmpty()){
-                    role = tx().getRole(Iterables.getOnlyElement(roleLabels).getValue());
+                    requiredRole = tx().getRole(Iterables.getOnlyElement(roleLabels).getValue());
                 }
             }
-            diff.add(new VariableDefinition(childVar,null, role, bottom(Sets.difference(childRoles, parentRoles)), new HashSet<>()));
+            diff.add(new VariableDefinition(parentVar,null, requiredRole, bottom(Sets.difference(childRoles, parentRoles)), new HashSet<>()));
         });
         return baseDiff.merge(new SemanticDifference(diff));
     }

--- a/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
+++ b/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
@@ -28,14 +28,11 @@ import grakn.core.graql.reasoner.unifier.Unifier;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.graql.reasoner.utils.Pair;
 import graql.lang.statement.Variable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -91,25 +88,20 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
         IndexedAnswerSet parentAnswers = parentEntry.cachedElement();
         IndexedAnswerSet childAnswers = childEntry.cachedElement();
 
-        Set<Pair<Unifier, SemanticDifference>> parentToChildUnifierDelta =
-                child.getMultiUnifierWithSemanticDiff(parent).stream()
-                .map(unifierDelta -> new Pair<>(unifierDelta.getKey().inverse(), unifierDelta.getValue()))
-                .collect(toSet());
-
         /*
          * propagate answers to child:
          * * calculate constraint difference
          * * apply constraints from the difference
          */
+        Set<Pair<Unifier, SemanticDifference>> parentToChildUnifierDelta = child.getMultiUnifierWithSemanticDiff(parent);
         Set<Variable> childVars = child.getVarNames();
-        ConceptMap partialSub = child.getRoleSubstitution();
+        ConceptMap childPartialSub = child.getRoleSubstitution();
         Set<ConceptMap> newAnswers = new HashSet<>();
-
+        
         parentAnswers.getAll().stream()
-                .filter(ans -> propagateInferred || ans.explanation().isLookupExplanation())
-                .flatMap(ans -> parentToChildUnifierDelta.stream()
-                                .map(unifierDelta -> unifierDelta.getValue()
-                                        .applyToAnswer(ans, partialSub, childVars, unifierDelta.getKey()))
+                .filter(parentAns -> propagateInferred || parentAns.explanation().isLookupExplanation())
+                .flatMap(parentAns -> parentToChildUnifierDelta.stream()
+                        .map(unifierDelta -> unifierDelta.getValue().propagateAnswer(parentAns, childPartialSub, childVars, unifierDelta.getKey()))
                 )
                 .filter(ans -> !ans.isEmpty())
                 .peek(ans -> validateAnswer(ans, child, childVars))

--- a/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
+++ b/server/src/graql/reasoner/cache/MultilevelSemanticCache.java
@@ -93,7 +93,7 @@ public class MultilevelSemanticCache extends SemanticCache<Equivalence.Wrapper<R
          * * calculate constraint difference
          * * apply constraints from the difference
          */
-        Set<Pair<Unifier, SemanticDifference>> parentToChildUnifierDelta = child.getMultiUnifierWithSemanticDiff(parent);
+        Set<Pair<Unifier, SemanticDifference>> parentToChildUnifierDelta = parent.getMultiUnifierWithSemanticDiff(child);
         Set<Variable> childVars = child.getVarNames();
         ConceptMap childPartialSub = child.getRoleSubstitution();
         Set<ConceptMap> newAnswers = new HashSet<>();

--- a/server/src/graql/reasoner/cache/SemanticDifference.java
+++ b/server/src/graql/reasoner/cache/SemanticDifference.java
@@ -107,11 +107,13 @@ public class SemanticDifference {
             Variable var = vd.var();
             Concept concept = answer.get(var);
             if (concept == null) return false;
-            Type type = vd.type();
-            Role role = vd.role();
+            Type requiredType = vd.type();
+            Role requiredRole = vd.role();
+            Type conceptType = requiredType != null? concept.asThing().type() : null;
+            Role conceptRole = requiredRole != null? concept.asRole() : null;
             Set<ValuePredicate> vps = vd.valuePredicates();
-            return (type == null || type.subs().anyMatch(t -> t.equals(concept.asThing().type()))) &&
-                    (role == null || role.subs().anyMatch(r -> r.equals(concept.asRole()))) &&
+            return (requiredType == null || requiredType.subs().anyMatch(t -> t.equals(conceptType))) &&
+                    (requiredRole == null || requiredRole.subs().anyMatch(r -> r.equals(conceptRole))) &&
                     (vps.isEmpty() || vps.stream().allMatch(
                             vp -> ValueOperation.of(vp.getPredicate()).test(concept.asAttribute().value())
                     ));
@@ -129,19 +131,19 @@ public class SemanticDifference {
     }
 
     /**
-     * @param answer to project
-     * @param partialSub partial child substitution that needs to be incorporated
-     * @param vars       child vars
-     * @param unifier    parent-child unifier
-     * @return projected answer (empty if semantic difference not satisfied)
+     * @param answer to parent query - answer we want to propagate
+     * @param childSub partial child substitution that needs to be incorporated
+     * @param childVars       child vars
+     * @param unifier    parent->child unifier
+     * @return propagated answer to child query or empty answer if semantic difference not satisfied
      */
     @CheckReturnValue
-    public ConceptMap applyToAnswer(ConceptMap answer, ConceptMap partialSub, Set<Variable> vars, Unifier unifier) {
+    public ConceptMap propagateAnswer(ConceptMap answer, ConceptMap childSub, Set<Variable> childVars, Unifier unifier) {
+        if (!this.satisfiedBy(answer)) return new ConceptMap();
         ConceptMap unified = unifier.apply(answer);
         if (unified.isEmpty()) return unified;
-        Set<Variable> varsToRetain = Sets.difference(unified.vars(), partialSub.vars());
-        return !this.satisfiedBy(unified) ? new ConceptMap() :
-                ConceptUtils.mergeAnswers(unified.project(varsToRetain), partialSub).project(vars);
+        Set<Variable> varsToRetain = Sets.difference(unified.vars(), childSub.vars());
+        return ConceptUtils.mergeAnswers(unified.project(varsToRetain), childSub).project(childVars);
     }
 
     boolean isEmpty() { return definition.stream().allMatch(VariableDefinition::isTrivial);}

--- a/server/src/graql/reasoner/cache/SemanticDifference.java
+++ b/server/src/graql/reasoner/cache/SemanticDifference.java
@@ -73,6 +73,8 @@ public class SemanticDifference {
         return definition.hashCode();
     }
 
+    public boolean isTrivial(){ return definition.isEmpty();}
+
     private Set<Relation> rolesToRels(Variable var, Set<Role> roles, ConceptMap answer) {
         if (!answer.containsVar(var)) return new HashSet<>();
         Set<Role> roleAndTheirSubs = roles.stream().flatMap(Role::subs).collect(Collectors.toSet());

--- a/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -164,14 +164,18 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
 
     /**
      * Calculates:
-     * - subsumptive unifier between this (child) and parent query
-     * - semantic difference between this (child and parent query
-     * @param parent parent query
-     * @return pair of subsumptive unifier and semantic difference between this and parent query
+     * - unifier between this (parent, source) and child (target) query
+     * - semantic difference between this (parent, source) and child (target) query
+     * @param child query
+     * @return pair of: a parent->child unifier and a parent->child semantic difference between
      */
-    public Set<Pair<Unifier, SemanticDifference>> getMultiUnifierWithSemanticDiff(ReasonerAtomicQuery parent){
-        return this.getMultiUnifier(parent, UnifierType.SUBSUMPTIVE).stream()
-                .map(u -> new Pair<>(u, this.getAtom().semanticDifference(parent.getAtom(), u)))
+    public Set<Pair<Unifier, SemanticDifference>> getMultiUnifierWithSemanticDiff(ReasonerAtomicQuery child){
+        MultiUnifier unifier = child.getMultiUnifier(this, UnifierType.SUBSUMPTIVE);
+        return unifier.stream()
+                .map(childParentUnifier -> {
+                    Unifier inverse = childParentUnifier.inverse();
+                    return new Pair<>(inverse, this.getAtom().semanticDifference(child.getAtom(), inverse));
+                })
                 .collect(Collectors.toSet());
     }
 

--- a/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/server/src/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -166,6 +166,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
      * Calculates:
      * - unifier between this (parent, source) and child (target) query
      * - semantic difference between this (parent, source) and child (target) query
+     * - child is more specific than parent ( child <= parent)
      * @param child query
      * @return pair of: a parent->child unifier and a parent->child semantic difference between
      */

--- a/server/src/graql/reasoner/unifier/UnifierType.java
+++ b/server/src/graql/reasoner/unifier/UnifierType.java
@@ -238,8 +238,9 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
     /**
      * Unifier type used to determine whether two queries are in a subsumption relation.
      * Subsumption can be regarded as a stricter version of the semantic overlap requirement seen in RULE UnifierType.
-     * Defining queries C and P and their respective answer sets A(C) and A(P) we say that a subsumptive unifier between child
-     * and parent exists if:
+     * Defining queries C and P and their respective answer sets A(C) and A(P) we say that:
+     *
+     * A subsumptive unifier between child and parent exists if:
      *
      * C <= P,
      *

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -221,6 +221,26 @@ public class SemanticDifferenceIT {
     }
 
     @Test
+    public void whenChildGeneralisesRole_semanticDifferenceIsTrivial(){
+        try(TransactionOLTP tx = genericSchemaSession.transaction().write()) {
+            Role baseRole = tx.getRole("baseRole1");
+            Role metaRole = tx.getMetaRole();
+
+            Pattern parentPattern = and(
+                    var().rel(var("role"), var("z")).rel("baseRole2", var("w")).isa("binary"),
+                    var("role").type(baseRole.label().getValue()));
+            Pattern childPattern = and(
+                    var().rel(var("role"), var("x")).rel("baseRole2", var("y")).isa("binary"),
+                    var("role").type(metaRole.label().getValue()));
+            ReasonerAtomicQuery parent = ReasonerQueries.atomic(conjunction(parentPattern), tx);
+            ReasonerAtomicQuery child = ReasonerQueries.atomic(conjunction(childPattern), tx);
+
+            Unifier unifier = parent.getMultiUnifier(child, UnifierType.SUBSUMPTIVE).getUnifier();
+            assertTrue(parent.getAtom().semanticDifference(child.getAtom(), unifier).isTrivial());
+        }
+    }
+
+    @Test
     public void whenChildSpecialisesRole_rolePlayersPlayingMultipleRoles_differenceIsCalculatedCorrectly(){
         try(TransactionOLTP tx = genericSchemaSession.transaction().write()) {
             Role baseRole1 = tx.getRole("baseRole1");


### PR DESCRIPTION
## What is the goal of this PR?
Refactor the definition and application of semantic difference so that it is less confusing to understand and that it follows the processing flow more naturally.
## What are the changes implemented in this PR?
When determining how to propagate answers from parent (more general) to child (more specific) query, we define the semantic difference:
- in terms of the parent query variables
- in terms of the parent->child unifier.

When applying the difference we filter the answers to the parent query based on the content of the semantic difference.

Also, made sure the semantic difference is trivial if the child is actually more general.
