### PR TITLE
Remove tx.stream cycles from reasoner

### DIFF
--- a/server/src/graql/executor/QueryExecutor.java
+++ b/server/src/graql/executor/QueryExecutor.java
@@ -36,6 +36,7 @@ import grakn.core.graql.executor.property.PropertyExecutor;
 import grakn.core.graql.gremlin.GraqlTraversal;
 import grakn.core.graql.gremlin.TraversalPlanner;
 import grakn.core.graql.reasoner.DisjunctionIterator;
+import grakn.core.graql.reasoner.ResolutionIterator;
 import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
 import grakn.core.server.exception.GraknServerException;
@@ -106,22 +107,13 @@ public class QueryExecutor {
             validateClause(matchClause);
 
             if (!infer) {
-                // time to convert plan into a answer stream
-                int traversalToStreamSpanId = ServerTracing.startScopedChildSpanWithParentContext("QueryExecutor.match traversal to stream", createStreamSpanId);
-
                 answerStream = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream()
                         .map(p -> ReasonerQueries.create(p, transaction))
                         .map(ReasonerQueryImpl::getPattern)
                         .flatMap(p -> traversal(p, TraversalPlanner.createTraversal(p, transaction)));
 
-                ServerTracing.closeScopedChildSpan(traversalToStreamSpanId);
             } else {
-
-                int disjunctionSpanId = ServerTracing.startScopedChildSpanWithParentContext("QueryExecutor.match disjunction iterator", createStreamSpanId);
-
                 answerStream = new DisjunctionIterator(matchClause, transaction).hasStream();
-
-                ServerTracing.closeScopedChildSpan(disjunctionSpanId);
             }
         } catch (GraqlCheckedException e) {
             LOG.debug(e.getMessage());

--- a/server/src/graql/reasoner/DisjunctionIterator.java
+++ b/server/src/graql/reasoner/DisjunctionIterator.java
@@ -20,6 +20,8 @@ package grakn.core.graql.reasoner;
 
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.graql.executor.QueryExecutor;
+import grakn.core.graql.gremlin.TraversalPlanner;
 import grakn.core.graql.reasoner.query.ReasonerQueries;
 import grakn.core.graql.reasoner.query.ResolvableQuery;
 import grakn.core.server.session.TransactionOLTP;
@@ -69,7 +71,7 @@ public class DisjunctionIterator extends ReasonerQueryIterator {
         LOG.trace("Resolving conjunctive query ({}): {}", doNotResolve, query);
 
         return doNotResolve ?
-                tx.stream(query.getQuery(), false).iterator() :
+                tx.executor().traversal(query.getPattern(), TraversalPlanner.createTraversal(query.getPattern(), tx)).iterator() :
                 new ResolutionIterator(query, new HashSet<>());
     }
 

--- a/server/src/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/server/src/graql/reasoner/query/ReasonerQueryImpl.java
@@ -32,6 +32,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.type.Type;
 import grakn.core.graql.exception.GraqlCheckedException;
 import grakn.core.graql.exception.GraqlQueryException;
+import grakn.core.graql.gremlin.TraversalPlanner;
 import grakn.core.graql.reasoner.ResolutionIterator;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.Atomic;
@@ -563,7 +564,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
     public Stream<ConceptMap> resolve(Set<ReasonerAtomicQuery> subGoals){
         return isRuleResolvable()?
                 new ResolutionIterator(this, subGoals).hasStream() :
-                tx.stream(getQuery());
+                tx.executor().traversal(getPattern(), TraversalPlanner.createTraversal(getPattern(), tx));
     }
 
     @Override
@@ -610,7 +611,7 @@ public class ReasonerQueryImpl implements ResolvableQuery {
             boolean fruitless = tx.ruleCache().absentTypes(queryTypes);
             if (fruitless) dbIterator = Collections.emptyIterator();
             else {
-                dbIterator = tx.stream(getQuery(), false)
+                dbIterator = tx.executor().traversal(getPattern(), TraversalPlanner.createTraversal(getPattern(), tx))
                         .map(ans -> ans.explain(new JoinExplanation(this.getPattern(), this.splitToPartialAnswers(ans))))
                         .map(ans -> new AnswerState(ans, parent.getUnifier(), parent))
                         .iterator();


### PR DESCRIPTION
## What is the goal of this PR?
Remove round (recursive) trips within transaction stream method.

## What are the changes implemented in this PR?
Replace `tx.stream` calls with `tx.executor().traversal()` which is terminal.

