### PR TITLE
Increase server and client storage frame size

### DIFF
--- a/common/config/ConfigKey.java
+++ b/common/config/ConfigKey.java
@@ -62,6 +62,7 @@ public class ConfigKey<T> {
     public static final ConfigKey<Integer> STORAGE_CQL_NATIVE_PORT = key("cassandra.input.native.port", INT);
     public static final ConfigKey<String> STORAGE_KEYSPACE = key("storage.cassandra.keyspace", STRING);
     public static final ConfigKey<Integer> STORAGE_REPLICATION_FACTOR = key("storage.cassandra.replication-factor", INT);
+    public static final ConfigKey<Integer> STORAGE_FRAME_SIZE = key("storage.cassandra.frame-size-mb", INT);
 
     public static final ConfigKey<Long> SHARDING_THRESHOLD = key("knowledge-base.sharding-threshold", LONG);
     public static final ConfigKey<String> DATA_DIR = key("data-dir");

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -64,8 +64,8 @@ cassandra.input.native.port=9042
 # Timeout in milliseconds when connecting to storage backend
 storage.connection-timeout=20000
 
-# The maximum allowed size of a frame
-storage.internal.thrift_framed_transport_size_in_mb=256
+# Frame size for thrift (maximum message length).
+storage.internal.thrift_framed_transport_size_in_mb=60
 
 # Whether to enable the database-level cache, which is shared across all transactions.
 # Enabling this option speeds up traversals by holding hot elements in memory,

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -64,6 +64,9 @@ cassandra.input.native.port=9042
 # Timeout in milliseconds when connecting to storage backend
 storage.connection-timeout=20000
 
+# The maximum allowed size of a frame
+storage.internal.thrift_framed_transport_size_in_mb=256
+
 # Whether to enable the database-level cache, which is shared across all transactions.
 # Enabling this option speeds up traversals by holding hot elements in memory,
 # but also increases the likelihood of reading stale data. Disabling it forces each transaction

--- a/server/src/server/session/JanusGraphFactory.java
+++ b/server/src/server/session/JanusGraphFactory.java
@@ -57,6 +57,7 @@ final public class JanusGraphFactory {
     private static final AtomicBoolean strategiesApplied = new AtomicBoolean(false);
     private static final String STORAGE_KEYSPACE = ConfigKey.STORAGE_KEYSPACE.name();
     private static final String STORAGE_BACKEND = ConfigKey.STORAGE_BACKEND.name();
+    private static final String STORAGE_FRAME_SIZE = ConfigKey.STORAGE_FRAME_SIZE.name();
     private static final String THRIFT_BACKEND = "cassandrathrift";
 
     private Config config;
@@ -99,7 +100,8 @@ final public class JanusGraphFactory {
     private static StandardJanusGraph configureGraph(String keyspace, Config config) {
         org.janusgraph.core.JanusGraphFactory.Builder builder = org.janusgraph.core.JanusGraphFactory.build()
                 .set(STORAGE_BACKEND, THRIFT_BACKEND)
-                .set(STORAGE_KEYSPACE, keyspace);
+                .set(STORAGE_KEYSPACE, keyspace)
+                .set(STORAGE_FRAME_SIZE, 256);
 
         //Load Passed in properties
         config.properties().forEach((key, value) -> {

--- a/server/src/server/session/JanusGraphFactory.java
+++ b/server/src/server/session/JanusGraphFactory.java
@@ -101,7 +101,7 @@ final public class JanusGraphFactory {
         org.janusgraph.core.JanusGraphFactory.Builder builder = org.janusgraph.core.JanusGraphFactory.build()
                 .set(STORAGE_BACKEND, THRIFT_BACKEND)
                 .set(STORAGE_KEYSPACE, keyspace)
-                .set(STORAGE_FRAME_SIZE, 256);
+                .set(STORAGE_FRAME_SIZE, 60);
 
         //Load Passed in properties
         config.properties().forEach((key, value) -> {


### PR DESCRIPTION
## What is the goal of this PR?
Increase frame size so we do not hit exceptions when doing reads.
## What are the changes implemented in this PR?
Upped thrift frame size to 60 MB.