### PR TITLE
Accept relative paths in Grakn Console arguments

### DIFF
--- a/bin/grakn
+++ b/bin/grakn
@@ -43,7 +43,6 @@ exit_if_java_not_found() {
 # main routine
 # =============================================
 
-cd "$GRAKN_HOME"
 exit_if_java_not_found
 
 if [ -z "$1" ]; then

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -95,7 +95,7 @@ public class Storage {
             ByteArrayOutputStream outputstream = new ByteArrayOutputStream();
 
             // Read the original Cassandra config from services/cassandra/cassandra.yaml into a String
-            byte[] oldConfigBytes = Files.readAllBytes(Paths.get(STORAGE_CONFIG_PATH, STORAGE_CONFIG_NAME));
+            byte[] oldConfigBytes = Files.readAllBytes(graknHome.resolve(STORAGE_CONFIG_PATH).resolve(STORAGE_CONFIG_NAME));
             String oldConfig = new String(oldConfigBytes, StandardCharsets.UTF_8);
 
             // Convert the String of config values into a Map
@@ -127,7 +127,7 @@ public class Storage {
             // Write the new Cassandra config into the original file: services/cassandra/cassandra.yaml
             mapper.writeValue(outputstream, newConfigMap);
             String newConfigStr = outputstream.toString(StandardCharsets.UTF_8.name());
-            Files.write(Paths.get(STORAGE_CONFIG_PATH, STORAGE_CONFIG_NAME), newConfigStr.getBytes(StandardCharsets.UTF_8));
+            Files.write(graknHome.resolve(STORAGE_CONFIG_PATH).resolve(STORAGE_CONFIG_NAME), newConfigStr.getBytes(StandardCharsets.UTF_8));
 
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -158,6 +158,7 @@ public class Storage {
 
     public void clean() {
         Path dataDir = Paths.get(graknProperties.getProperty(ConfigKey.DATA_DIR));
+        dataDir = dataDir.isAbsolute() ? dataDir : graknHome.resolve(dataDir);
         System.out.print("Cleaning " + DISPLAY_NAME + "...");
         System.out.flush();
         try (Stream<Path> files = Files.walk(dataDir)) {

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -22,7 +22,7 @@
 
     <!--Configure a properties file (located on the classpath) from which values can be referenced-->
     <property resource="grakn.properties"/>
-    <property name="configuredLogDir" value="${log.dirs}" />
+    <property name="configuredLogDir" value="${grakn.dir}/${log.dirs}" />
 
 
     <!--Configure the standard out appender used to print the Grakn logo-->


### PR DESCRIPTION
## What is the goal of this PR?

Fix #5404
Previously, user would have needed to supply absolute paths as arguments (e.g. `-f /absolute/path/to/schema.gql`). This PR allows to supply paths relative to current directory (`../relative/path/schema.gql`)

## What are the changes implemented in this PR?

* Remove changing directory to `$GRAKN_HOME` in `grakn` bash script (all paths there are absolute already; not doing would make Grakn Console resolve relative arguments against `grakn.home`)
* Resolve Cassandra config against `grakn.home` instead of current directory
* If `data-dir` is relative, it is resolved against `grakn.home` (such that `grakn storage clean` works from any directory)
* `grakn.home` explicitly referenced in `logback.xml` such that `logs/grakn.log` is not created in directory from which user invokes `grakn`
