### PR TITLE
Cache attributes within transaction

### DIFF
--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -25,6 +25,7 @@ import grakn.core.server.exception.TransactionException;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.kb.structure.VertexElement;
 
+import grakn.core.server.session.cache.TransactionCache;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.function.BiFunction;
@@ -169,6 +170,11 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Nullable
     public Attribute<D> attribute(D value) {
         String index = Schema.generateAttributeIndex(label(), value.toString());
+
+        TransactionCache txCache = vertex().tx().cache();
+        Attribute concept = txCache.getAttributeCache().get(index);
+        if (concept != null) return (Attribute<D>)concept;
+
         return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);
     }
 
@@ -178,6 +184,11 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      */
     private Attribute<D> attributeWithLock(D value) {
         String index = Schema.generateAttributeIndex(label(), value.toString());
+
+        TransactionCache txCache = vertex().tx().cache();
+        Attribute concept = txCache.getAttributeCache().get(index);
+        if (concept != null) return (Attribute<D>)concept;
+        
         vertex().tx().session().graphLock().readLock().lock();
         try {
             return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);

--- a/server/src/server/kb/concept/AttributeTypeImpl.java
+++ b/server/src/server/kb/concept/AttributeTypeImpl.java
@@ -173,7 +173,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
 
         TransactionCache txCache = vertex().tx().cache();
         Attribute concept = txCache.getAttributeCache().get(index);
-        if (concept != null) return (Attribute<D>)concept;
+        if (concept != null) return concept;
 
         return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);
     }
@@ -187,8 +187,8 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
 
         TransactionCache txCache = vertex().tx().cache();
         Attribute concept = txCache.getAttributeCache().get(index);
-        if (concept != null) return (Attribute<D>)concept;
-        
+        if (concept != null) return concept;
+
         vertex().tx().session().graphLock().readLock().lock();
         try {
             return vertex().tx().getConcept(Schema.VertexProperty.INDEX, index);

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -146,7 +146,7 @@ public class TransactionCache {
             AttributeImpl attr = AttributeImpl.from(concept.asAttribute());
             String attrIndex = attr.getIndex();
             newAttributes.remove(new Pair<>(attr.type().label(), attrIndex));
-            attributeCache.remove(attrIndex, attr);
+            attributeCache.remove(attrIndex);
             removedAttributes.add(Schema.generateAttributeIndex(attr.type().label(), attr.value().toString()));
         }
 

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -144,7 +144,9 @@ public class TransactionCache {
 
         if (concept.isAttribute()) {
             AttributeImpl attr = AttributeImpl.from(concept.asAttribute());
-            newAttributes.remove(new Pair<>(attr.type().label(), attr.getIndex()));
+            String attrIndex = attr.getIndex();
+            newAttributes.remove(new Pair<>(attr.type().label(), attrIndex));
+            attributeCache.remove(attrIndex, attr);
             removedAttributes.add(Schema.generateAttributeIndex(attr.type().label(), attr.value().toString()));
         }
 

--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -55,6 +55,7 @@ public class TransactionCache {
 
     //Caches any concept which has been touched before
     private final Map<ConceptId, Concept> conceptCache = new HashMap<>();
+    private final Map<String, Attribute> attributeCache = new HashMap<>();
     private final Map<Label, SchemaConcept> schemaConceptCache = new HashMap<>();
     private final Map<Label, LabelId> labelCache = new HashMap<>();
 
@@ -179,6 +180,11 @@ public class TransactionCache {
             SchemaConcept schemaConcept = concept.asSchemaConcept();
             schemaConceptCache.put(schemaConcept.label(), schemaConcept);
             labelCache.put(schemaConcept.label(), schemaConcept.labelId());
+        }
+        if (concept.isAttribute()){
+            Attribute<Object> attribute = concept.asAttribute();
+            String index = Schema.generateAttributeIndex(attribute.type().label(), attribute.value().toString());
+            attributeCache.put(index, attribute);
         }
     }
 
@@ -340,6 +346,10 @@ public class TransactionCache {
     @VisibleForTesting
     Map<ConceptId, Concept> getConceptCache() {
         return conceptCache;
+    }
+
+    public Map<String, Attribute> getAttributeCache() {
+        return attributeCache;
     }
 
     @VisibleForTesting

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -61,6 +61,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
@@ -373,7 +374,7 @@ public class TransactionCacheIT {
     }
 
     @Test
-    public void whenInsertingAttribute_attributeIsCached(){
+    public void whenInsertingAndDeletingAttribute_attributeCachedIsUpdated(){
         AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
         String value = "banana";
         Attribute attribute = AttributeTypeImpl.from(attributeType).create(value);
@@ -383,6 +384,9 @@ public class TransactionCacheIT {
         assertNotNull(cachedAttribute);
         assertEquals(attribute, cachedAttribute);
         assertEquals(attribute, attributeType.attribute(value));
+
+        attribute.delete();
+        assertNull(tx.cache().getAttributeCache().get(index));
     }
 
     @Test

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -60,6 +60,7 @@ import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 
@@ -369,6 +370,19 @@ public class TransactionCacheIT {
         assertTrue(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(attribute)));
         attribute.delete();
         assertFalse(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(attribute)));
+    }
+
+    @Test
+    public void whenInsertingAttribute_attributeIsCached(){
+        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
+        String value = "banana";
+        Attribute attribute = AttributeTypeImpl.from(attributeType).create(value);
+        String index = Schema.generateAttributeIndex(attributeType.label(), value);
+
+        Attribute cachedAttribute = tx.cache().getAttributeCache().get(index);
+        assertNotNull(cachedAttribute);
+        assertEquals(attribute, cachedAttribute);
+        assertEquals(attribute, attributeType.attribute(value));
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?
In situations when we insert multiple attributes within a transaction, especially when the attribute value is a super node (for example `male/female` gender), it is beneficial to cache the inserted attribute instead of doing a db lookup which requires an index check. Otherwise we need to fetch the same attribute multiple times. This PR introduces an extra transaction-based attribute cache to allow to cache attributes. 

## What are the changes implemented in this PR?
Introduce attribute cache in `TransactionCache` to store attributes created in that transaction.
