### PR TITLE
Skip searching concepts to persist if no inferred concepts exist

### DIFF
--- a/server/src/server/session/cache/TransactionCache.java
+++ b/server/src/server/session/cache/TransactionCache.java
@@ -261,7 +261,7 @@ public class TransactionCache {
         inferredConceptsToPersist.add(t);
     }
 
-    Stream<Thing> getInferredInstances() {
+    public Stream<Thing> getInferredInstances() {
         return inferredConcepts.stream();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We incur a substantial performance hit by searching the dependency tree of every concept that is written/queried in a `match...insert`. This can entirely be avoided if there are 0 inferred concepts live in this Transaction. The PR implements this slightly conservative check that should be a large help with data loading jobs using `match...insert` without any inference.

## What are the changes implemented in this PR?
* Check for the existence of any inferred concepts before actually searching the dependency tree of every concept that matched or inserted.
