### PR TITLE
Increase commit performance by optimising type sharding

### DIFF
--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -236,7 +236,9 @@ public class TransactionOLTP implements Transaction {
     }
 
     private void createNewTypeShardsWhenThresholdReached() {
-        session.getKeyspaceCache().getCachedLabels().forEach((label, labelId) -> {
+        Set<Label> types = uncomittedStatisticsDelta.instanceDeltas().keySet();
+        LOG.trace("Initiating type sharding check. The following types have new instances: " + types + ". Check if we may need to shard some of them...");
+        types.forEach(label -> {
             long instancesCount = session.keyspaceStatistics().count(this, label);
             long lastShardCheckpointForThisInstance = getShardCheckpoint(label);
             if (instancesCount - lastShardCheckpointForThisInstance >= typeShardThreshold) {
@@ -245,6 +247,7 @@ public class TransactionOLTP implements Transaction {
                 setShardCheckpoint(label, instancesCount);
             }
         });
+        LOG.trace("Type sharding complete.");
     }
 
     private static void merge(GraphTraversalSource tinkerTraversal, ConceptId duplicateId, ConceptId targetId) {

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -236,10 +236,9 @@ public class TransactionOLTP implements Transaction {
     }
 
     private void createNewTypeShardsWhenThresholdReached() {
-        Set<Label> types = uncomittedStatisticsDelta.instanceDeltas().keySet();
-        LOG.trace("Initiating type sharding check. The following types have new instances: " + types + ". Check if we may need to shard some of them...");
-        types.forEach(label -> {
-            long instancesCount = session.keyspaceStatistics().count(this, label);
+        LOG.trace("Initiating type sharding check. The following types have new instances: " + uncomittedStatisticsDelta.instanceDeltas().keySet() + ". Check if we may need to shard some of them...");
+        uncomittedStatisticsDelta.instanceDeltas().forEach((label, uncommittedCount) -> {
+            long instancesCount = session.keyspaceStatistics().count(this, label) + uncomittedStatisticsDelta.instanceDeltas().get(label) + uncommittedCount;
             long lastShardCheckpointForThisInstance = getShardCheckpoint(label);
             if (instancesCount - lastShardCheckpointForThisInstance >= typeShardThreshold) {
                 LOG.trace(label + " has a count of " + instancesCount + ". last sharding happens at " + lastShardCheckpointForThisInstance + ". Will create a new shard.");

--- a/server/src/server/session/TransactionOLTP.java
+++ b/server/src/server/session/TransactionOLTP.java
@@ -236,7 +236,6 @@ public class TransactionOLTP implements Transaction {
     }
 
     private void createNewTypeShardsWhenThresholdReached() {
-        LOG.trace("Initiating type sharding check. The following types have new instances: " + uncomittedStatisticsDelta.instanceDeltas().keySet() + ". Check if we may need to shard some of them...");
         uncomittedStatisticsDelta.instanceDeltas().forEach((label, uncommittedCount) -> {
             long instancesCount = session.keyspaceStatistics().count(this, label) + uncomittedStatisticsDelta.instanceDeltas().get(label) + uncommittedCount;
             long lastShardCheckpointForThisInstance = getShardCheckpoint(label);
@@ -246,7 +245,6 @@ public class TransactionOLTP implements Transaction {
                 setShardCheckpoint(label, instancesCount);
             }
         });
-        LOG.trace("Type sharding complete.");
     }
 
     private static void merge(GraphTraversalSource tinkerTraversal, ConceptId duplicateId, ConceptId targetId) {

--- a/server/src/server/session/cache/KeyspaceCache.java
+++ b/server/src/server/session/cache/KeyspaceCache.java
@@ -92,7 +92,7 @@ public class KeyspaceCache {
      *
      * @return an immutable copy of the cached labels.
      */
-    public Map<Label, LabelId> getCachedLabels() {
+    private Map<Label, LabelId> getCachedLabels() {
         return ImmutableMap.copyOf(cachedLabels);
     }
 

--- a/server/src/server/statistics/UncomittedStatisticsDelta.java
+++ b/server/src/server/statistics/UncomittedStatisticsDelta.java
@@ -50,7 +50,7 @@ public class UncomittedStatisticsDelta {
         instanceDeltas.put(label, currentCount - 1);
     }
 
-    HashMap<Label, Long> instanceDeltas() {
+    public HashMap<Label, Long> instanceDeltas() {
         return instanceDeltas;
     }
 

--- a/test-integration/server/session/TransactionOLTPIT.java
+++ b/test-integration/server/session/TransactionOLTPIT.java
@@ -364,7 +364,7 @@ public class TransactionOLTPIT {
         }
         Vertex typeShardForP1;
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            assertEquals(1, janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet().size());
+            assertEquals(2, janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet().size());
             typeShardForP1 = janusGraph.traversal().V(p1.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toList().get(0);
             assertEquals(janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet().iterator().next(), typeShardForP1);
         }
@@ -376,7 +376,7 @@ public class TransactionOLTPIT {
             }
         }
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            assertEquals(2, janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet().size());
+            assertEquals(3, janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet().size());
             Vertex typeShardForP2 = janusGraph.traversal().V(p2.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toSet().iterator().next();
             assertEquals(Sets.difference(janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet(), Sets.newHashSet(typeShardForP1)).iterator().next(), typeShardForP2);
         }
@@ -422,7 +422,7 @@ public class TransactionOLTPIT {
             Set<Vertex> personTypeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
             assertEquals(3, personTypeShards.size());
             Set<Vertex> companyTypeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "company").in().hasLabel("SHARD").toSet();
-            assertEquals(1, companyTypeShards.size());
+            assertEquals(2, companyTypeShards.size());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

The recently introduced type-sharding (https://github.com/graknlabs/grakn/pull/5412) caused the commit time to increase.

This PR cuts down the commit time by optimising the checks that are performed before performing type sharding. Whereas previously we check every type for whether it needs to be sharded, with this PR only types which contain new instances are checked.

Additionally, the PR contains a minor fix where we simplify the type shard behaviour: type shard is always created right after the threshold has been reached. This change has been reflected in the test.