### PR TITLE
Use keyspace stats to fetch instance counts

### DIFF
--- a/server/src/graql/executor/ComputeExecutor.java
+++ b/server/src/graql/executor/ComputeExecutor.java
@@ -62,6 +62,7 @@ import grakn.core.graql.analytics.Utility;
 import grakn.core.graql.exception.GraqlSemanticException;
 import grakn.core.server.kb.Schema;
 import grakn.core.server.session.TransactionOLTP;
+import grakn.core.server.statistics.KeyspaceStatistics;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlCompute;
@@ -301,6 +302,12 @@ class ComputeExecutor {
             return Stream.of(new Numeric(0));
         }
 
+        Set<String> labels = query.in();
+        if (labels.contains(Schema.MetaSchema.THING.name())
+                && labels.stream().map(Label::of).noneMatch(Schema.MetaSchema::isMetaLabel)){
+            return retrieveCachedCount(query);
+        }
+
         Set<LabelId> scopeTypeLabelIDs = convertLabelsToIds(scopeTypeLabels(query));
         Set<LabelId> scopeTypeAndImpliedPlayersLabelIDs = convertLabelsToIds(scopeTypeLabelsImplicitPlayers(query));
         scopeTypeAndImpliedPlayersLabelIDs.addAll(scopeTypeLabelIDs);
@@ -322,6 +329,17 @@ class ComputeExecutor {
 
         LOG.debug("Count = {}", finalCount);
         return Stream.of(new Numeric(finalCount));
+    }
+
+    /**
+     * @param query compute count entry query
+     * @return aggregate instance counts fetched from keyspace statistics
+     */
+
+    private Stream<Numeric> retrieveCachedCount(GraqlCompute.Statistics.Count query){
+        KeyspaceStatistics keyspaceStats = tx.session().keyspaceStatistics();
+        long totalCount = scopeTypeLabels(query).stream().mapToLong(l -> keyspaceStats.count(tx, l)).sum();
+        return Stream.of(new Numeric(totalCount));
     }
 
     /**

--- a/server/src/graql/executor/ComputeExecutor.java
+++ b/server/src/graql/executor/ComputeExecutor.java
@@ -304,7 +304,7 @@ class ComputeExecutor {
 
         Set<String> labels = query.in();
         if (labels.contains(Schema.MetaSchema.THING.name())
-                && labels.stream().map(Label::of).noneMatch(Schema.MetaSchema::isMetaLabel)){
+                || labels.stream().map(Label::of).noneMatch(Schema.MetaSchema::isMetaLabel)){
             return retrieveCachedCount(query);
         }
 

--- a/server/src/graql/executor/ComputeExecutor.java
+++ b/server/src/graql/executor/ComputeExecutor.java
@@ -303,6 +303,7 @@ class ComputeExecutor {
         }
 
         Set<String> labels = query.in();
+        //TODO: simplify this when we update statistics to also contain ENTITY, RELATION and ATTRIBUTE
         if (labels.contains(Schema.MetaSchema.THING.name())
                 || labels.stream().map(Label::of).noneMatch(Schema.MetaSchema::isMetaLabel)){
             return retrieveCachedCount(query);

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -207,11 +207,15 @@ public class GraqlComputeIT {
     public void testGraqlCount() throws InvalidKBException {
         addSchemaAndEntities();
         try (TransactionOLTP tx = session.transaction().write()) {
-            assertEquals(6, tx.execute(Graql.parse("compute count;").asComputeStatistics())
-                    .get(0).number().intValue());
+            assertEquals(
+                    instanceCount.apply(Label.of("thing"), tx),
+                    tx.execute(Graql.parse("compute count;").asComputeStatistics()).get(0).number()
+            );
 
-            assertEquals(3, tx.execute(Graql.parse("compute count in [thingy, thingy];").asComputeStatistics())
-                    .get(0).number().intValue());
+            assertEquals(
+                    instanceCount.apply(Label.of("thingy"), tx),
+                    tx.execute(Graql.parse("compute count in [thingy, thingy];").asComputeStatistics()).get(0).number()
+            );
         }
     }
 

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -66,6 +66,7 @@ import static graql.lang.Graql.Token.Compute.Algorithm.DEGREE;
 import static graql.lang.query.GraqlCompute.Argument.contains;
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -83,6 +84,9 @@ public class GraqlComputeIT {
     private String entityId2;
     private String entityId3;
     private String entityId4;
+    private String attrId1;
+    private String attrId2;
+    private String attrId3;
     private String relationId12;
     private String relationId24;
 
@@ -267,18 +271,23 @@ public class GraqlComputeIT {
                     tx.execute(Graql.parse("compute centrality using degree;").asComputeCentrality());
 
             Map<String, Long> correctDegrees = new HashMap<>();
-            correctDegrees.put(entityId1, 1L);
-            correctDegrees.put(entityId2, 2L);
+            correctDegrees.put(entityId1, 2L);
+            correctDegrees.put(entityId2, 3L);
             correctDegrees.put(entityId3, 1L);
             correctDegrees.put(entityId4, 1L);
+            correctDegrees.put(attrId1, 1L);
+            correctDegrees.put(attrId2, 1L);
+            correctDegrees.put(attrId3, 1L);
             correctDegrees.put(relationId12, 2L);
             correctDegrees.put(relationId24, 2L);
 
-            assertTrue(!degrees.isEmpty());
+            assertFalse(degrees.isEmpty());
             degrees.forEach(conceptSetMeasure -> conceptSetMeasure.set().forEach(
                     id -> {
                         assertTrue(correctDegrees.containsKey(id.getValue()));
-                        assertEquals(correctDegrees.get(id.getValue()).intValue(), conceptSetMeasure.measurement().intValue());
+                        int expectedDegree = correctDegrees.get(id.getValue()).intValue();
+                        int computedDegree = conceptSetMeasure.measurement().intValue();
+                        assertEquals(expectedDegree + " != " + computedDegree, expectedDegree, computedDegree);
                     }
             ));
         }
@@ -447,6 +456,10 @@ public class GraqlComputeIT {
             Attribute<Long> attr1 = attributeType.create(1L);
             Attribute<Long> attr2 = attributeType.create(2L);
             Attribute<Long> attr3 = attributeType.create(3L);
+
+            attrId1 = attr1.id().getValue();
+            attrId2 = attr2.id().getValue();
+            attrId3 = attr3.id().getValue();
 
             Entity entity1 = entityType1.create().has(attr1);
             Entity entity2 = entityType1.create().has(attr2);


### PR DESCRIPTION
## What is the goal of this PR?
The goal of this PR is to optimise the `compute count` queries. 
Currently we are computing the counts each time the query is executed. This is potentially heavy and time-consuming for large graphs. However, we are already storing instance counts on type vertices in the graph. These come in the form of `KeyspaceStatistics`. We could readily use this information to provide instant compute count responses. 
In this PR we use the cached counts to provide instant response to compute count queries.

## What are the changes implemented in this PR?
Use `KeyspaceStatistics` counts in `runComputeCount` in `ComputeExecutor`.


