### PR TITLE
Remove copying logs from Windows GCP machine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,12 +156,6 @@ jobs:
       - run:
           command: test/assembly/windows/windows-zip.py
           no_output_timeout: 20m
-      - store_artifacts:
-          path: ./grakn.log
-          destination: logs/grakn.log
-      - store_artifacts:
-          path: ./cassandra.log
-          destination: logs/cassandra.log
 
   test-assembly-linux-targz:
     machine: true

--- a/test/assembly/windows/windows-zip.py
+++ b/test/assembly/windows/windows-zip.py
@@ -39,18 +39,6 @@ def ssh(command, ssh_host, ssh_user, ssh_pass, attempts=5):
     ])
 
 
-def scp(remote, local, ssh_host, ssh_user, ssh_pass):
-    system = platform.system()
-    sp.check_call([
-        'sshpass',
-        '-p',
-        ssh_pass,
-        'scp',
-        '{}@{}:"{}"'.format(ssh_user, ssh_host, remote),
-        local,
-    ])
-
-
 def wait_for_ssh(ssh_host, ssh_user, ssh_pass, timeout_mins=10):
     def time_elapsed_in_seconds():
         return time.time() - start_time
@@ -189,13 +177,6 @@ try:
     lprint('[Remote]: test finished successfully!')
 
 finally:
-    lprint('Copying logs from remote instance')
-    scp('/Users/circleci/repo/bazel-genfiles/a directory with whitespace/grakn-core-all-windows/logs/grakn.log',
-        'grakn.log',
-        instance_ip, 'circleci', instance_password)
-    scp('/Users/circleci/repo/bazel-genfiles/a directory with whitespace/grakn-core-all-windows/logs/cassandra.log',
-        'cassandra.log',
-        instance_ip, 'circleci', instance_password)
     lprint('Remove instance')
     sp.check_call([
         'gcloud', '--quiet', 'compute', 'instances',


### PR DESCRIPTION
## What is the goal of this PR?

Fix failing `test-assembly-windows-zip` CI job

## What are the changes implemented in this PR?

Remove copying logs from remote GCP machine and storing them as CircleCI artifacts
