### PR TITLE
Install APT packages via Bazel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,9 +271,7 @@ jobs:
       - run: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
       - run: sudo apt update
       - run: echo $(cat VERSION)-$CIRCLE_SHA1 > VERSION && cat VERSION
-      - run: |
-          sudo apt install grakn-core-all=$(cat VERSION) grakn-bin=$(cat VERSION) \
-                           grakn-core-server=$(cat VERSION) grakn-console=$(cat VERSION)
+      - run: bazel run //test-deployment:apt-install
       - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
       - run: nohup grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,29 +179,6 @@ jobs:
           path: bazel-genfiles/grakn-core-all-linux/logs/cassandra.log
           destination: logs/cassandra.log
 
-  test-assembly-linux-apt:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - apt-wait
-      - install-bazel-linux-rbe
-      - checkout
-      - run-bazel-rbe:
-          command: bazel build @graknlabs_common//bin:assemble-linux-apt
-      - run-bazel-rbe:
-          command: bazel build //server:assemble-linux-apt
-      - run: sudo dpkg -i bazel-bin/server/grakn-core-server__all.deb
-      - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
-      - run: nohup grakn server start
-      - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
-      - run: grakn server stop
-      - store_artifacts:
-          path: /opt/grakn/core/logs/grakn.log
-          destination: logs/grakn.log
-      - store_artifacts:
-          path: /opt/grakn/core/logs/cassandra.log
-          destination: logs/cassandra.log
-
   test-assembly-docker:
     machine: true
     working_directory: ~/grakn
@@ -517,18 +494,6 @@ workflows:
             - test-integration-reasoner
             - test-integration-analytics
             - test-end-to-end
-      - test-assembly-linux-apt:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - test-common
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
       - test-assembly-docker:
           filters:
             branches:
@@ -549,7 +514,6 @@ workflows:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
             - test-assembly-linux-targz
-            - test-assembly-linux-apt
             - test-assembly-docker
       - deploy-apt-snapshot:
           filters:
@@ -559,7 +523,6 @@ workflows:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
             - test-assembly-linux-targz
-            - test-assembly-linux-apt
             - test-assembly-docker
       - deploy-rpm-snapshot:
           filters:
@@ -569,7 +532,6 @@ workflows:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
             - test-assembly-linux-targz
-            - test-assembly-linux-apt
             - test-assembly-docker
       - test-deployment-linux-apt:
           filters:

--- a/test-deployment/BUILD
+++ b/test-deployment/BUILD
@@ -1,0 +1,24 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("//test-deployment/rules:rules.bzl", "apt_install_command")
+
+apt_install_command(
+    name = "apt-install",
+    workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
+)

--- a/test-deployment/rules/BUILD
+++ b/test-deployment/rules/BUILD
@@ -1,0 +1,17 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/test-deployment/rules/rules.bzl
+++ b/test-deployment/rules/rules.bzl
@@ -1,0 +1,53 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+def _apt_install_command_impl(ctx):
+    fn = "{}_apt_install.py".format(ctx.attr.name)
+    install_script = ctx.actions.declare_file(fn)
+
+    ctx.actions.expand_template(
+        template = ctx.file._apt_install_command_py,
+        output = install_script,
+        substitutions = {},
+        is_executable = True
+    )
+
+    return DefaultInfo(
+        executable = install_script,
+        runfiles = ctx.runfiles(
+             files=[ctx.file.workspace_refs],
+             symlinks = {
+                 "workspace_refs.json": ctx.file.workspace_refs
+             }))
+
+apt_install_command = rule(
+    attrs = {
+        "workspace_refs": attr.label(
+            allow_single_file = [".json"]
+        ),
+        "version_file": attr.label(
+            allow_single_file = True
+        ),
+        "_apt_install_command_py": attr.label(
+            allow_single_file = True,
+            default = "//test-deployment/rules/templates:apt_install_command.py"
+        )
+    },
+    implementation = _apt_install_command_impl,
+    executable = True
+)

--- a/test-deployment/rules/templates/BUILD
+++ b/test-deployment/rules/templates/BUILD
@@ -1,0 +1,19 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+exports_files(["apt_install_command.py"])

--- a/test-deployment/rules/templates/apt_install_command.py
+++ b/test-deployment/rules/templates/apt_install_command.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2019 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+import json
+import subprocess as sp
+
+refs = {
+    'commits': {},
+    'tags': {},
+}
+
+with open("workspace_refs.json") as f:
+    refs = json.load(f)
+
+
+def get_commit():
+    return sp.check_output([
+        'git', 'rev-parse', 'HEAD'
+    ], cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY')).decode().strip()
+
+
+def get_dep_version(ws):
+    if ws in refs['commits']:
+        return '0.0.0-' + refs['commits'][ws]
+    elif ws in refs['tags']:
+        return refs['tags'][ws]
+    else:
+        raise Exception('no reference of workspace @{}'.format(ws))
+
+
+core_version = '0.0.0-' + get_commit()
+console_version = get_dep_version("graknlabs_console")
+bin_version = get_dep_version("graknlabs_common")
+
+command = [
+    'sudo',
+    'apt',
+    'install',
+    'grakn-core-server={}'.format(core_version),
+    'grakn-core-console={}'.format(console_version),
+    'grakn-core-bin={}'.format(bin_version),
+]
+
+print('Executing command: {}'.format(' '.join(command)))
+sp.check_call(command)

--- a/test-deployment/rules/templates/apt_install_command.py
+++ b/test-deployment/rules/templates/apt_install_command.py
@@ -54,6 +54,7 @@ command = [
     'sudo',
     'apt',
     'install',
+    'grakn-core-all={}'.format(core_version),
     'grakn-core-server={}'.format(core_version),
     'grakn-core-console={}'.format(console_version),
     'grakn-core-bin={}'.format(bin_version),


### PR DESCRIPTION
## What is the goal of this PR?

Previously, all dependencies had the same version (equal to that of `grakn-core-server`). After splitting `grakn-core-bin` and `grakn-core-console` out to separate repositories (`@graknlabs_common` and `@graknlabs_console`) they got their own release cycles.

## What are the changes implemented in this PR?

Introduce a runnable target `//test-deployment:apt-install` which installs `grakn-core-server` with dependencies (console, bin). Their versions are taken from workspace references file.

Additionally, `test-assembly-linux-apt` is removed since all of its functions are covered by deployment test