### PR TITLE
Adapt to latest @graknlabs_bazel_distribution

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -132,9 +132,11 @@ java_grpc_compile()
 # Load Distribution dependencies #
 ##################################
 
-# TODO: rename the macro we load here to deploy_github_dependencies
-load("@graknlabs_bazel_distribution//github:dependencies.bzl", "github_dependencies_for_deployment")
-github_dependencies_for_deployment()
+load("@graknlabs_bazel_distribution//github:dependencies.bzl", "tcnksm_ghr")
+tcnksm_ghr()
+
+load("@graknlabs_bazel_distribution//common:dependencies.bzl", "bazelbuild_rules_pkg")
+bazelbuild_rules_pkg()
 
 load("@graknlabs_build_tools//bazel:dependencies.bzl", "bazel_rules_docker")
 bazel_rules_docker()

--- a/config/rpm/grakn-core-server.spec
+++ b/config/rpm/grakn-core-server.spec
@@ -21,6 +21,7 @@ Grakn Core (server) - description
 %install
 mkdir -p %{buildroot}
 tar -xvf {_grakn-core-server-rpm-tar.tar.gz} -C %{buildroot}
+rm -fv {_grakn-core-server-rpm-tar.tar.gz}
 
 %files
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "a5dabc91ac4031aa80312bab4c4f7c4971aaba26", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "d909d8401650c404d6a56081297235e47783005e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Newest changes in `bazel-distribution` (graknlabs/bazel-distribution#181) are backwards-incompatible.

## What are the changes implemented in this PR?

- Bump `@graknlabs_build_tools`'s version
- Uses workspace macros from most recent `bazel-distribution` version
- Remove Grakn Core archive after unpacking in RPM spec file