### PR TITLE
Experimental KeyspaceStatistics using Cassandra's counter column

### DIFF
--- a/server/src/server/ServerFactory.java
+++ b/server/src/server/ServerFactory.java
@@ -55,16 +55,15 @@ public class ServerFactory {
         LockManager lockManager = new LockManager();
 
         // CQL cluster used by KeyspaceManager to fetch all existing keyspaces
-        Cluster cluster = Cluster.builder()
+        Cluster.Builder clusterBuilder = Cluster.builder()
                 .addContactPoint(config.getProperty(ConfigKey.STORAGE_HOSTNAME))
-                .withPort(config.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT))
-                .build();
+                .withPort(config.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT));
 
-        KeyspaceManager keyspaceManager = new KeyspaceManager(cluster);
+        KeyspaceManager keyspaceManager = new KeyspaceManager(clusterBuilder.build());
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(config);
 
         // session factory
-        SessionFactory sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, config);
+        SessionFactory sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, config, clusterBuilder);
 
         // Enable server tracing
         if (benchmark) {

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -209,12 +209,11 @@ public class GraknTestServer extends ExternalResource {
         LockManager lockManager = new LockManager();
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(serverConfig);
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(serverConfig);
-        Cluster cluster = Cluster.builder()
+        Cluster.Builder clusterBuilder = Cluster.builder()
                 .addContactPoint(serverConfig.getProperty(ConfigKey.STORAGE_HOSTNAME))
-                .withPort(serverConfig.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT))
-                .build();
-        keyspaceManager = new KeyspaceManager(cluster);
-        sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, serverConfig);
+                .withPort(serverConfig.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT));
+        keyspaceManager = new KeyspaceManager(clusterBuilder.build());
+        sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, serverConfig, clusterBuilder);
 
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);
 

--- a/test-integration/server/session/BUILD
+++ b/test-integration/server/session/BUILD
@@ -40,6 +40,7 @@ java_test(
         "//api",
         "//common",
         "//concept",
+        "//dependencies/maven/artifacts/com/datastax/cassandra:cassandra-driver-core",
         "//dependencies/maven/artifacts/com/google/guava:guava",
         "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",

--- a/test-integration/server/session/TransactionOLTPIT.java
+++ b/test-integration/server/session/TransactionOLTPIT.java
@@ -18,6 +18,7 @@
 
 package grakn.core.server.session;
 
+import com.datastax.driver.core.Cluster;
 import com.google.common.collect.Sets;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
@@ -344,7 +345,10 @@ public class TransactionOLTPIT {
         Config config = Config.read(tmpConfig);
         config.setConfigProperty(ConfigKey.TYPE_SHARD_THRESHOLD, 1L);
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(config);
-        SessionFactory sessionFactory = new SessionFactory(new LockManager(), janusGraphFactory, new HadoopGraphFactory(config), config);
+        Cluster.Builder clusterBuilder = Cluster.builder()
+                .addContactPoint(config.getProperty(ConfigKey.STORAGE_HOSTNAME))
+                .withPort(config.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT));
+        SessionFactory sessionFactory = new SessionFactory(new LockManager(), janusGraphFactory, new HadoopGraphFactory(config), config, clusterBuilder);
         KeyspaceImpl keyspace = server.randomKeyspaceName();
         try (SessionImpl session = sessionFactory.session(keyspace)) {
             keyspace = session.keyspace();
@@ -395,7 +399,10 @@ public class TransactionOLTPIT {
         Config config = Config.read(tmpConfig);
         config.setConfigProperty(ConfigKey.TYPE_SHARD_THRESHOLD, 1L);
         JanusGraphFactory janusGraphFactory = new JanusGraphFactory(config);
-        SessionFactory sessionFactory = new SessionFactory(new LockManager(), janusGraphFactory, new HadoopGraphFactory(config), config);
+        Cluster.Builder clusterBuilder = Cluster.builder()
+                .addContactPoint(config.getProperty(ConfigKey.STORAGE_HOSTNAME))
+                .withPort(config.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT));
+        SessionFactory sessionFactory = new SessionFactory(new LockManager(), janusGraphFactory, new HadoopGraphFactory(config), config, clusterBuilder);
         KeyspaceImpl keyspace = server.randomKeyspaceName();
         try (SessionImpl session = sessionFactory.session(keyspace)) {
             keyspace = session.keyspace();


### PR DESCRIPTION
## THIS IS AN EXPERIMENT! DO NOT MERGE!

## What is the goal of this PR?

This is the experimental `KeyspaceStatistics` implementation which uses Cassandra counters. The purpose of this experiment is to test if we can use it as a cache for `match; aggregate;` and/or `compute;` to speed up the query.

- The function `commit` and `count` behaves identically to the current keyspace statistics
- However, the atomicity behavior (or the lack thereof) may behave differently, given that we're not using the transaction object, but instead, a separate `Cluster`. We know that Janusgraph's `commit` to Cassandra isn't really atomic either, but this one is, even "less atomic", so to say.
- Counter table is `int` only. We can't have `float` or `double`, meaning we can't store other statistics such as the mean, median, min, and max of an attribute (which maybe useful for certain types of query: `match; get; aggregate mean;`)
- Need to do more research on counter precision - there seem to be failure conditions which can cause it to be incorrect: https://stackoverflow.com/questions/53794343/race-conditions-with-cassandra-counters
- Does not implement the in-memory cache count, therefore it is 10-20 times slower. It can't be easily implemented in a cluster scenario.
- Changes the data structure in an incompatible way such that you can no longer use data from 1.5.8.