### PR TITLE
Prepare for bazel upgrade

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,5 @@
 # what is defined in this section will be applied at all times
-build --workspace_status_command bin/workspace_status.sh --java_toolchain @graknlabs_build_tools//bazel:java-toolchain --show_result=0 --show_progress=no
+build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no
 test --show_result=0 --show_progress=no
 run --show_result=0 --show_progress=no
 


### PR DESCRIPTION
## What is the goal of this PR?

Bazel upgrade to `0.29.0` planned across all repos is going to break all CI because newest version doesn't work with our custom Java toolchain (due to bazelbuild/bazel#8659). However, we found a different way to approach the original problem (described in bazelbuild/bazel#8277) which is modifying the IntelliJ Bazel plugin. This solution does not require custom Java toolchain and therefore it'll be removed.

## What are the changes implemented in this PR?

Stop using custom `java_toolchain` [with modified `singlejar` binary] for all builds
