### PR TITLE
Use release-validate-deps to ensure that Grakn depends on released versions of common, console, graql, and protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,8 +284,8 @@ jobs:
       - run: |
           set +e
           bazel run @graknlabs_build_tools//ci:release-validate-deps \
-            graknlabs_common graknlabs_graql \
-            graknlabs_protocol graknlabs_console
+            graknlabs_graql \
+            graknlabs_protocol
           is_releasable=$?
           set -e
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,15 @@ jobs:
       - run: |
           export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
           export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run @graknlabs_build_tools//ci:release-approval
+          set -e
+          bazel run @graknlabs_build_tools//ci:release-validate-deps \
+            graknlabs_common graknlabs_graql \
+            graknlabs_protocol graknlabs_console
+          is_releasable=$?
+          set +e
+          if [ is_releasable -e 0 ]; then
+            bazel run @graknlabs_build_tools//ci:release-approval
+          fi
 
   deploy-github:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,12 +282,12 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          set -e
+          set +e
           bazel run @graknlabs_build_tools//ci:release-validate-deps \
             graknlabs_common graknlabs_graql \
             graknlabs_protocol graknlabs_console
           is_releasable=$?
-          set +e
+          set -e
 
           if [ is_releasable -e 0 ]; then
             export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,15 +282,16 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
-          export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
           set -e
           bazel run @graknlabs_build_tools//ci:release-validate-deps \
             graknlabs_common graknlabs_graql \
             graknlabs_protocol graknlabs_console
           is_releasable=$?
           set +e
+
           if [ is_releasable -e 0 ]; then
+            export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
+            export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
             bazel run @graknlabs_build_tools//ci:release-approval
           fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -409,212 +409,208 @@ jobs:
       - run: git push --delete origin grakn-release-branch
 
 workflows:
-  # TODO: revert
-  test:
+  grakn-core:
     jobs:
-      - release-approval
-#  grakn-core:
-#    jobs:
-#      - build:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - build-analysis:
-#          filters:
-#            branches:
-#              only: master
-#      - test-common:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-server:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-integration:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-integration-reasoner:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-integration-analytics:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-end-to-end:
-#          filters:
-#            branches:
-#              ignore: grakn-release-branch
-#      - test-assembly-mac-zip:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - build
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-integration
-#            - test-integration-reasoner
-#            - test-integration-analytics
-#            - test-end-to-end
-#      - test-assembly-windows-zip:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - build
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-integration
-#            - test-integration-reasoner
-#            - test-integration-analytics
-#            - test-end-to-end
-#      - test-assembly-linux-targz:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - build
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-integration
-#            - test-integration-reasoner
-#            - test-integration-analytics
-#            - test-end-to-end
-#      - test-assembly-docker:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - build
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-integration
-#            - test-integration-reasoner
-#            - test-integration-analytics
-#            - test-end-to-end
-#      - deploy-maven-snapshot:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-#      - deploy-apt-snapshot:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-#      - deploy-rpm-snapshot:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-#      - test-deployment-linux-apt:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - deploy-apt-snapshot
-#      - test-deployment-linux-rpm:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - deploy-rpm-snapshot
-#      - sync-dependencies-snapshot:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - deploy-maven-snapshot
-#            - test-deployment-linux-apt
-#            - test-deployment-linux-rpm
-#      - release-approval:
-#          filters:
-#            branches:
-#              only: master
-#          requires:
-#            - sync-dependencies-snapshot
+      - build:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - build-analysis:
+          filters:
+            branches:
+              only: master
+      - test-common:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-server:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-reasoner:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-analytics:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-end-to-end:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-assembly-mac-zip:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-analysis
+            - test-common
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-analysis
+            - test-common
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-linux-targz:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-analysis
+            - test-common
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - test-assembly-docker:
+          filters:
+            branches:
+              only: master
+          requires:
+            - build
+            - build-analysis
+            - test-common
+            - test-server
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-end-to-end
+      - deploy-maven-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-docker
+      - deploy-apt-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-docker
+      - deploy-rpm-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-docker
+      - test-deployment-linux-apt:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-apt-snapshot
+      - test-deployment-linux-rpm:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-rpm-snapshot
+      - sync-dependencies-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - deploy-maven-snapshot
+            - test-deployment-linux-apt
+            - test-deployment-linux-rpm
+      - release-approval:
+          filters:
+            branches:
+              only: master
+          requires:
+            - sync-dependencies-snapshot
 
-#  grakn-core-release:
-#    jobs:
-#      - deploy-github:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#      - deploy-approval:
-#          type: approval
-#          requires:
-#            - deploy-github
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#      - deploy-apt:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-approval
-#      - deploy-rpm:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-approval
-#      - deploy-brew:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-approval
-#      - deploy-docker:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-approval
-#      - deploy-maven:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-approval
-#      - sync-dependencies-release:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - deploy-apt
-#            - deploy-rpm
-#            - deploy-brew
-#            - deploy-docker
-#            - deploy-maven
-#      - release-notification:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - sync-dependencies-release
-#      - release-cleanup:
-#          filters:
-#            branches:
-#              only: grakn-release-branch
-#          requires:
-#            - release-notification
+  grakn-core-release:
+    jobs:
+      - deploy-github:
+          filters:
+            branches:
+              only: grakn-release-branch
+      - deploy-approval:
+          type: approval
+          requires:
+            - deploy-github
+          filters:
+            branches:
+              only: grakn-release-branch
+      - deploy-apt:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-rpm:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-brew:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-docker:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - deploy-maven:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-approval
+      - sync-dependencies-release:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - deploy-apt
+            - deploy-rpm
+            - deploy-brew
+            - deploy-docker
+            - deploy-maven
+      - release-notification:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - sync-dependencies-release
+      - release-cleanup:
+          filters:
+            branches:
+              only: grakn-release-branch
+          requires:
+            - release-notification

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,8 +292,8 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          bazel run @graknlabs_build_tools//ci:release-validate-deps graknlabs_common \
-            graknlabs_console graknlabs_graql graknlabs_protocol
+          bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
+            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
 
   deploy-github:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ workflows:
       - release-approval:
           filters:
             branches:
-              only: add-release-valdate-deps
+              only: add-release-validate-deps
 #  grakn-core:
 #    jobs:
 #      - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
           is_releasable=$?
           set -e
 
-          if [ is_releasable -e 0 ]; then
+          if [[ is_releasable -eq 0 ]]; then
             export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
             export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
             bazel run @graknlabs_build_tools//ci:release-approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -411,10 +411,7 @@ workflows:
   # TODO: revert
   test:
     jobs:
-      - release-approval:
-          filters:
-            branches:
-              only: add-release-validate-deps
+      - release-approval
 #  grakn-core:
 #    jobs:
 #      - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,208 +408,215 @@ jobs:
       - run: git push --delete origin grakn-release-branch
 
 workflows:
-  grakn-core:
+  # TODO: revert
+  test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - build-analysis:
-          filters:
-            branches:
-              only: master
-      - test-common:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-server:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-reasoner:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-analytics:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-end-to-end:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-assembly-mac-zip:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - build-analysis
-            - test-common
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - build-analysis
-            - test-common
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-linux-targz:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - build-analysis
-            - test-common
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - test-assembly-docker:
-          filters:
-            branches:
-              only: master
-          requires:
-            - build
-            - build-analysis
-            - test-common
-            - test-server
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-end-to-end
-      - deploy-maven-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
-      - deploy-apt-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
-      - deploy-rpm-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
-      - test-deployment-linux-apt:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-apt-snapshot
-      - test-deployment-linux-rpm:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-rpm-snapshot
-      - sync-dependencies-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - deploy-maven-snapshot
-            - test-deployment-linux-apt
-            - test-deployment-linux-rpm
       - release-approval:
           filters:
             branches:
-              only: master
-          requires:
-            - sync-dependencies-snapshot
+              only: add-release-valdate-deps
+#  grakn-core:
+#    jobs:
+#      - build:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - build-analysis:
+#          filters:
+#            branches:
+#              only: master
+#      - test-common:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-server:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-integration:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-integration-reasoner:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-integration-analytics:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-end-to-end:
+#          filters:
+#            branches:
+#              ignore: grakn-release-branch
+#      - test-assembly-mac-zip:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - build
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-integration
+#            - test-integration-reasoner
+#            - test-integration-analytics
+#            - test-end-to-end
+#      - test-assembly-windows-zip:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - build
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-integration
+#            - test-integration-reasoner
+#            - test-integration-analytics
+#            - test-end-to-end
+#      - test-assembly-linux-targz:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - build
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-integration
+#            - test-integration-reasoner
+#            - test-integration-analytics
+#            - test-end-to-end
+#      - test-assembly-docker:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - build
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-integration
+#            - test-integration-reasoner
+#            - test-integration-analytics
+#            - test-end-to-end
+#      - deploy-maven-snapshot:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+#      - deploy-apt-snapshot:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+#      - deploy-rpm-snapshot:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+#      - test-deployment-linux-apt:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - deploy-apt-snapshot
+#      - test-deployment-linux-rpm:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - deploy-rpm-snapshot
+#      - sync-dependencies-snapshot:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - deploy-maven-snapshot
+#            - test-deployment-linux-apt
+#            - test-deployment-linux-rpm
+#      - release-approval:
+#          filters:
+#            branches:
+#              only: master
+#          requires:
+#            - sync-dependencies-snapshot
 
-  grakn-core-release:
-    jobs:
-      - deploy-github:
-          filters:
-            branches:
-              only: grakn-release-branch
-      - deploy-approval:
-          type: approval
-          requires:
-            - deploy-github
-          filters:
-            branches:
-              only: grakn-release-branch
-      - deploy-apt:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-rpm:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-brew:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-docker:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - deploy-maven:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
-      - sync-dependencies-release:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-apt
-            - deploy-rpm
-            - deploy-brew
-            - deploy-docker
-            - deploy-maven
-      - release-notification:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - sync-dependencies-release
-      - release-cleanup:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - release-notification
+#  grakn-core-release:
+#    jobs:
+#      - deploy-github:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#      - deploy-approval:
+#          type: approval
+#          requires:
+#            - deploy-github
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#      - deploy-apt:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-approval
+#      - deploy-rpm:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-approval
+#      - deploy-brew:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-approval
+#      - deploy-docker:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-approval
+#      - deploy-maven:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-approval
+#      - sync-dependencies-release:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - deploy-apt
+#            - deploy-rpm
+#            - deploy-brew
+#            - deploy-docker
+#            - deploy-maven
+#      - release-notification:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - sync-dependencies-release
+#      - release-cleanup:
+#          filters:
+#            branches:
+#              only: grakn-release-branch
+#          requires:
+#            - release-notification

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ jobs:
       - run: |
           set +e
           bazel run @graknlabs_build_tools//ci:release-validate-deps \
+            graknlabs_common \
+            graknlabs_console \
             graknlabs_graql \
             graknlabs_protocol
           is_releasable=$?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -282,20 +282,18 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: |
-          set +e
-          bazel run @graknlabs_build_tools//ci:release-validate-deps \
-            graknlabs_common \
-            graknlabs_console \
-            graknlabs_graql \
-            graknlabs_protocol
-          is_releasable=$?
-          set -e
+          export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
+          export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
+          bazel run @graknlabs_build_tools//ci:release-approval
 
-          if [[ is_releasable -eq 0 ]]; then
-            export RELEASE_APPROVAL_USERNAME=$REPO_GITHUB_USERNAME
-            export RELEASE_APPROVAL_TOKEN=$REPO_GITHUB_TOKEN
-            bazel run @graknlabs_build_tools//ci:release-approval
-          fi
+  release-validate:
+    machine: true
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run: |
+          bazel run @graknlabs_build_tools//ci:release-validate-deps graknlabs_common \
+            graknlabs_console graknlabs_graql graknlabs_protocol
 
   deploy-github:
     machine: true
@@ -553,10 +551,16 @@ workflows:
 
   grakn-core-release:
     jobs:
+      - release-validate:
+          filters:
+            branches:
+              only: grakn-release-branch
       - deploy-github:
           filters:
             branches:
               only: grakn-release-branch
+          requires:
+            - release-validate
       - deploy-approval:
           type: approval
           requires:

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,14 +36,14 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         tag = "1.0.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+         commit = "5fc0b92f1f779878bc3977f34b0149cbe769ffe8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
      )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "1.0.1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "e83603accc8c26eb08f2db39a3d244c00eadab10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
@@ -57,7 +57,7 @@ def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        commit = "88fa50935ad2e3a06e73a0bef172fb1e9f69e6d4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
+        commit = "88fa50935ad2e3a06e73a0bef172fb1e9f69e6d4"
     )
 
 def graknlabs_benchmark():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -57,7 +57,7 @@ def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        commit = "88fa50935ad2e3a06e73a0bef172fb1e9f69e6d4"
+        commit = "88fa50935ad2e3a06e73a0bef172fb1e9f69e6d4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
     )
 
 def graknlabs_benchmark():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d909d8401650c404d6a56081297235e47783005e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "64517dae0380eb68d40a20286b02f41a24df427a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,14 +36,14 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         commit = "5fc0b92f1f779878bc3977f34b0149cbe769ffe8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+         tag = "1.0.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
      )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "e83603accc8c26eb08f2db39a3d244c00eadab10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():


### PR DESCRIPTION
## What is the goal of this PR?

We have added a validation step using `//ci:release-validate-deps` in order to ensure that Grakn is releasable only if it depends on released versions of Graql, protocol, common, and console.