### PR TITLE
Made release clean-up to use GitHub credential rather than SSH keys

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,7 +406,7 @@ jobs:
     machine: true
     steps:
       - checkout
-      - run: git push --delete origin grakn-release-branch
+      - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/grakn $CIRCLE_BRANCH
 
 workflows:
   grakn-core:


### PR DESCRIPTION
## What is the goal of this PR?

Use GitHub credential for release-cleanup. This removes the need for adding an additional SSH key to CircleCI.