### PR TITLE
Upgrade to latest @graknlabs_grakn_console

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -57,7 +57,7 @@ def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        commit = "88fa50935ad2e3a06e73a0bef172fb1e9f69e6d4"
+        commit = "0a91ec1abf91462a737ccd44c483817ff1aad0d6"
     )
 
 def graknlabs_benchmark():


### PR DESCRIPTION
## What is the goal of this PR?

Fix failing `test-deployment-linux-rpm` by upgrading `@graknlabs_grakn_console`

## What are the changes implemented in this PR?

Bump `@graknlabs_grakn_console` to latest `master`