### PR TITLE
Disable release-validate-deps for console for until we fix the cyclic dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,7 +293,10 @@ jobs:
       - checkout
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
-            graknlabs_common graknlabs_console graknlabs_graql graknlabs_protocol
+            graknlabs_common graknlabs_graql graknlabs_protocol
+            # TODO: add graknlabs_console once we've removed the
+            # cyclic dependency between core and client-java:
+            # https://github.com/graknlabs/grakn/issues/5272
 
   deploy-github:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

We temporarily disable release-validate-deps for console in order to allow for releasing grakn without having to release console first. Otherwise, it would be impossible to release grakn, console, and client-java due to the cyclic dependency that exist between them. The issue for removing the cyclic dependency is tracked here: https://github.com/graknlabs/grakn/issues/5272.