### PR TITLE
Make Grakn Core 1.5.9 releasable by depending on released dependencies

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -29,7 +29,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        commit = "1087e5cf567d4bf3ace5ffa6e0e644a201b29741", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "0.2.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_graql():
@@ -43,7 +43,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "6fde744a5fd1315125247567eaaf566a04118ce0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():


### PR DESCRIPTION
## What is the goal of this PR?
Make Grakn Core 1.5.9 releasable by depending on released protocol `1.0.2` and common `0.2.0`. graql is already correctly set to `1.0.3`.