### PR TITLE
Add release repository to test-deployment-apt and test-deployment-rpm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: sudo add-apt-repository 'deb [ arch=all ] https://repo.grakn.ai/repository/apt-snapshot/ trusty main'
+      - run: sudo add-apt-repository 'deb [ arch=all ] https://repo.grakn.ai/repository/apt/ trusty main'
       - run: sudo apt-key adv --keyserver keyserver.ubuntu.com --recv 8F3DA4B5E9AEF44C
       - run: sudo apt update
       - run: echo 0.0.0-$CIRCLE_SHA1 > VERSION && cat VERSION

--- a/test/deployment/rpm/test.py
+++ b/test/deployment/rpm/test.py
@@ -111,6 +111,7 @@ try:
 
     lprint('Installing RPM packages. Grakn will be available system-wide')
     gcloud_ssh(instance, 'sudo yum-config-manager --add-repo https://repo.grakn.ai/repository/meta/rpm-snapshot.repo')
+    gcloud_ssh(instance, 'sudo yum-config-manager --add-repo https://repo.grakn.ai/repository/meta/rpm.repo')
     gcloud_ssh(instance, 'sudo yum -y update')
     gcloud_ssh(instance, 'sudo yum -y install grakn-core-all-$(cat VERSION)')
 


### PR DESCRIPTION
## What is the goal of this PR?

`test-deployment-apt` and `test-deployment-rpm` needs to access the release repository. For example, when grakn depends on the `common` version `0.2.0`, it is a released dependency and will exist in the release repository.