### PR TITLE
Adds the checkout step in release-notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,6 +392,8 @@ jobs:
     machine: true
     working_directory: ~/grakn
     steps:
+      - install-bazel-linux-rbe
+      - checkout
       - run: |
           curl http://www.jetmore.org/john/code/swaks/files/swaks-20130209.0/swaks -o swaks
           chmod +x swaks


### PR DESCRIPTION
## What is the goal of this PR?

`release-notification` needs to do the checkout step in order to access the VERSION file.
