### PR TITLE
Use port 587 instead of the default 25 for sending release-notification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,7 +398,7 @@ jobs:
           sudo apt-get -y install perl
       - run: |
           ./swaks --auth \
-          --server smtp.mailgun.org \
+          --server smtp.mailgun.org:587 \
           --au $SMTP_MAILGUN_EMAIL \
           --ap $SMTP_MAILGUN_PASSWORD \
           --from $SMTP_MAILGUN_EMAIL \


### PR DESCRIPTION
## What is the goal of this PR?

We have used a more appropriate port `587` for sending SMTP email. The default one (port `25`) is throttled by default ([reference article](https://support.circleci.com/hc/en-us/articles/360007444314-Sending-email-from-a-container)) and therefore should not use that.