### PR TITLE
Fix CI by not specifying exact version of grakn-bin

### DIFF
--- a/test/deployment/apt/templates/apt_install_command.py
+++ b/test/deployment/apt/templates/apt_install_command.py
@@ -48,7 +48,6 @@ def get_dep_version(ws):
 
 core_version = '0.0.0-' + get_commit()
 console_version = get_dep_version("graknlabs_console")
-bin_version = get_dep_version("graknlabs_common")
 
 command = [
     'sudo',
@@ -57,7 +56,6 @@ command = [
     'grakn-core-all={}'.format(core_version),
     'grakn-core-server={}'.format(core_version),
     'grakn-console={}'.format(console_version),
-    'grakn-bin={}'.format(bin_version),
 ]
 
 print('Executing command: {}'.format(' '.join(command)))


### PR DESCRIPTION
## What is the goal of this PR?

Fix `test-deployment-linux-apt` CI job caused by inconsistent version requirement for `grakn-bin`

## What are the changes implemented in this PR?

Remove explicit version requirement of `grakn-bin` in `apt_install_command`
