### PR TITLE
Agree to install packages (for non-interactive prompt)

### DIFF
--- a/test/deployment/apt/templates/apt_install_command.py
+++ b/test/deployment/apt/templates/apt_install_command.py
@@ -53,6 +53,7 @@ command = [
     'sudo',
     'aptitude',
     'install',
+    '-y',
     'grakn-core-all={}'.format(core_version),
     'grakn-core-server={}'.format(core_version),
     'grakn-console={}'.format(console_version),


### PR DESCRIPTION
## What is the goal of this PR?

Fix `test-deployment-linux-apt` CI job caused by not agreeing to install packages (in an interactive prompt)

## What are the changes implemented in this PR?

Add `-y` so `aptitude` proceeds with installing packages
