### PR TITLE
Disable janus consistency checks

### DIFF
--- a/server/src/server/session/SessionImpl.java
+++ b/server/src/server/session/SessionImpl.java
@@ -143,7 +143,7 @@ public class SessionImpl implements Session {
         ConceptObserver conceptObserver = new ConceptObserver(cacheProvider, statisticsDelta);
 
         // janus elements
-        JanusGraphTransaction janusGraphTransaction = graph.newThreadBoundTransaction();
+        JanusGraphTransaction janusGraphTransaction = graph.buildTransaction().threadBound().consistencyChecks(false).start();
         ElementFactory elementFactory = new ElementFactory(janusGraphTransaction);
 
         // Grakn elements


### PR DESCRIPTION
## What is the goal of this PR?
Janus does optional consistency checking to avoid duplicate edges and duplicate properties on vertices.

The checking behaviour in case of encountering already existing equivalents is to throw.
Those checks are redundant for us as Grakn already ensures uniqueness in these cases.
## What are the changes implemented in this PR?
When building transactions, disable consistency checking at Janus level.
