### PR TITLE
Adapt to latest changes in assemble_(tar|zip)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
           bazel run @graknlabs_build_tools//ci:release-notes -- grakn $(cat VERSION) ./RELEASE_TEMPLATE.md
       - run: |
           export DEPLOY_GITHUB_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-github -- $CIRCLE_SHA1
+          bazel run --define version=$(cat VERSION) //:deploy-github -- $CIRCLE_SHA1
 
   deploy-apt:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

Recent changes in `bazel-distribution` made it necessary to adapt how deployed archives are versioned.

## What are the changes implemented in this PR?

Correctly pass version to `deploy_github`