### PR TITLE
Cleanup Maven deployment targets and jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,8 +206,8 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //concept:deploy-maven -- snapshot $CIRCLE_SHA1
-          bazel run //common:deploy-maven -- snapshot $CIRCLE_SHA1
+          bazel run --define version=$CIRCLE_SHA1 //concept:deploy-maven -- snapshot
+          bazel run --define version=$CIRCLE_SHA1 //common:deploy-maven -- snapshot
 
   deploy-apt-snapshot:
     machine: true
@@ -381,8 +381,8 @@ jobs:
       - run: |
           export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //concept:deploy-maven -- release $(cat VERSION)
-          bazel run //common:deploy-maven -- release $(cat VERSION)
+          bazel run --define version=$(cat VERSION) //concept:deploy-maven -- release
+          bazel run --define version=$(cat VERSION) //common:deploy-maven -- release
 
   sync-dependencies-release:
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,18 +197,6 @@ jobs:
           path: ./cassandra.log
           destination: logs/cassandra.log
 
-  deploy-maven-snapshot:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run --define version=$CIRCLE_SHA1 //concept:deploy-maven -- snapshot
-          bazel run --define version=$CIRCLE_SHA1 //common:deploy-maven -- snapshot
-
   deploy-apt-snapshot:
     machine: true
     working_directory: ~/grakn
@@ -371,19 +359,6 @@ jobs:
           docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
           bazel run //:deploy-docker
 
-  deploy-maven:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: cat VERSION
-      - run: |
-          export DEPLOY_MAVEN_USERNAME=$REPO_GRAKN_USERNAME
-          export DEPLOY_MAVEN_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run --define version=$(cat VERSION) //concept:deploy-maven -- release
-          bazel run --define version=$(cat VERSION) //common:deploy-maven -- release
-
   sync-dependencies-release:
     machine: true
     steps:
@@ -516,15 +491,6 @@ workflows:
             - test-integration-reasoner
             - test-integration-analytics
             - test-end-to-end
-      - deploy-maven-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
       - deploy-apt-snapshot:
           filters:
             branches:
@@ -560,7 +526,6 @@ workflows:
             branches:
               only: master
           requires:
-            - deploy-maven-snapshot
             - test-deployment-linux-apt
             - test-deployment-linux-rpm
       - release-approval:
@@ -613,12 +578,6 @@ workflows:
               only: grakn-release-branch
           requires:
             - deploy-approval
-      - deploy-maven:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - deploy-approval
       - sync-dependencies-release:
           filters:
             branches:
@@ -628,7 +587,6 @@ workflows:
             - deploy-rpm
             - deploy-brew
             - deploy-docker
-            - deploy-maven
       - release-notification:
           filters:
             branches:

--- a/common/BUILD
+++ b/common/BUILD
@@ -36,7 +36,6 @@ assemble_maven(
     name = "assemble-maven",
     target = ":common",
     package = "common",
-    version_file = "//:VERSION",
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
 )
 

--- a/common/BUILD
+++ b/common/BUILD
@@ -19,7 +19,6 @@
 package(default_visibility = ["@graknlabs_grakn_core//__subpackages__"])
 
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
 
 java_library(
     name = "common",
@@ -30,18 +29,6 @@ java_library(
     ],
     visibility = ["//visibility:public"],
     tags = ["maven_coordinates=io.grakn.core:grakn-common:{pom_version}"],
-)
-
-assemble_maven(
-    name = "assemble-maven",
-    target = ":common",
-    package = "common",
-    workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
-)
-
-deploy_maven(
-    name = "deploy-maven",
-    target = ":assemble-maven",
 )
 
 checkstyle_test(

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -42,7 +42,6 @@ assemble_maven(
     name = "assemble-maven",
     target = ":concept",
     package = "concept",
-    version_file = "//:VERSION",
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
 )
 

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -18,7 +18,6 @@
 #
 package(default_visibility = ["//visibility:public"])
 
-load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(
@@ -35,19 +34,6 @@ java_library(
         "//dependencies/maven/artifacts/com/google/code/findbugs:jsr305",
     ],
     tags = ["maven_coordinates=io.grakn.core:grakn-concept:{pom_version}"],
-)
-
-
-assemble_maven(
-    name = "assemble-maven",
-    target = ":concept",
-    package = "concept",
-    workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
-)
-
-deploy_maven(
-    name = "deploy-maven",
-    target = ":assemble-maven"
 )
 
 checkstyle_test(

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -18,7 +18,6 @@
 
 package(default_visibility = ["//visibility:__pkg__"])
 
-load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 java_library(

--- a/daemon/BUILD
+++ b/daemon/BUILD
@@ -45,19 +45,6 @@ java_library(
     tags = ["maven_coordinates=io.grakn.core:grakn-daemon:{pom_version}"],
 )
 
-assemble_maven(
-    name = "assemble-maven",
-    target = ":daemon",
-    package = "daemon",
-    version_file = "//:VERSION",
-    workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
-)
-
-deploy_maven(
-    name = "deploy-maven",
-    target = ":assemble-maven"
-)
-
 checkstyle_test(
     name = "checkstyle",
     targets = [

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "4a129d6f10c4d2bfb32fc86bbb8f847ce70b3f64", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "9f071825eeaca57b392755c3d8d7fe38bd29959c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():

--- a/server/BUILD
+++ b/server/BUILD
@@ -192,19 +192,6 @@ assemble_zip(
     visibility = ["//visibility:public"]
 )
 
-assemble_maven(
-    name = "assemble-maven",
-    target = ":server",
-    package = "server",
-    version_file = "//:VERSION",
-    workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json"
-)
-
-deploy_maven(
-    name = "deploy-maven",
-    target = ":assemble-maven"
-)
-
 assemble_apt(
     name = "assemble-linux-apt",
     package_name = "grakn-core-server",

--- a/server/BUILD
+++ b/server/BUILD
@@ -18,7 +18,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("@graknlabs_build_tools//distribution/maven:rules.bzl", "assemble_maven", "deploy_maven")
 load("@graknlabs_bazel_distribution//apt:rules.bzl", "assemble_apt", "deploy_apt")
 load("@graknlabs_bazel_distribution//common:rules.bzl", "assemble_targz", "java_deps", "assemble_zip")
 load("@graknlabs_bazel_distribution//rpm:rules.bzl", "assemble_rpm", "deploy_rpm")


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#191 changed the way how version should be provided for Maven deployment. This PR adapts Grakn Core to latest changes.

## What are the changes implemented in this PR?

* Pass `version` as a `--define` argument to `bazel` instead of `deploy_maven`
* Remove deployment of `daemon` and `server` into Maven repo
* Upgrade `build-tools`
