### PR TITLE
Refactor how version is provided for APT deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,12 +203,11 @@ jobs:
     steps:
       - install-bazel-linux-rbe
       - checkout
-      - run: echo 0.0.0-$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: |
           export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //server:deploy-apt -- snapshot
-          bazel run //:deploy-apt -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //server:deploy-apt -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-apt -- snapshot
 
   deploy-rpm-snapshot:
     machine: true
@@ -322,8 +321,8 @@ jobs:
       - run: |
           export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //server:deploy-apt -- release
-          bazel run //:deploy-apt -- release
+          bazel run --define version=$(cat VERSION) //server:deploy-apt -- release
+          bazel run --define version=$(cat VERSION) //:deploy-apt -- release
 
   deploy-rpm:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -119,7 +119,6 @@ assemble_apt(
     package_name = "grakn-core-all",
     maintainer = "Grakn Labs <community@grakn.ai>",
     description = "Grakn Core (all)",
-    version_file = "//:VERSION",
     depends = [
         "openjdk-8-jre",
         "grakn-core-server (=%{version})",

--- a/server/BUILD
+++ b/server/BUILD
@@ -196,7 +196,6 @@ assemble_apt(
     package_name = "grakn-core-server",
     maintainer = "Grakn Labs <community@grakn.ai>",
     description = "Grakn Core (server)",
-    version_file = "//:VERSION",
     depends = [
       "openjdk-8-jre",
       "grakn-bin (>=%{@graknlabs_common})"


### PR DESCRIPTION
## What is the goal of this PR?

graknlabs/bazel-distribution#192 changed the way how version should be provided for APT deployment. This PR adapts Grakn Core to latest changes.

## What are the changes implemented in this PR?

* Pass `version` as a `--define` argument to `bazel` instead of modifying `VERSION` file for snapshot deployment
