### PR TITLE
Tag dependency for @graknlabs_grakn_console

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,10 +292,7 @@ jobs:
       - checkout
       - run: |
           bazel run @graknlabs_build_tools//ci:release-validate-deps -- \
-            graknlabs_common graknlabs_graql graknlabs_protocol
-            # TODO: add graknlabs_console once we've removed the
-            # cyclic dependency between core and client-java:
-            # https://github.com/graknlabs/grakn/issues/5272
+            graknlabs_common graknlabs_graql graknlabs_protocol graknlabs_console
 
   deploy-github:
     machine: true


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `grakn-core-all` depended on a snapshot version of `grakn-console` which could not be found in release repo. This situation can be prevented by enforcing dependency on tag

## What are the changes implemented in this PR?

- Enforce dependency on a tag when releasing