### PR TITLE
Refactor how version is provided to deployment rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,12 +216,11 @@ jobs:
       - install-bazel-linux-rbe
       - checkout
       - run: sudo apt-get update && sudo apt-get install rpm
-      - run: echo 0.0.0_$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: |
           export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //server:deploy-rpm -- snapshot
-          bazel run //:deploy-rpm -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //server:deploy-rpm -- snapshot
+          bazel run --define version=$(git rev-parse HEAD) //:deploy-rpm -- snapshot
 
   test-deployment-linux-apt:
     machine: true
@@ -335,8 +334,8 @@ jobs:
       - run: |
           export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
           export DEPLOY_RPM_PASSWORD=$REPO_GRAKN_PASSWORD
-          bazel run //server:deploy-rpm -- release
-          bazel run //:deploy-rpm -- release
+          bazel run --define version=$(cat VERSION) //server:deploy-rpm -- release
+          bazel run --define version=$(cat VERSION) //:deploy-rpm -- release
 
   deploy-brew:
     machine: true
@@ -346,7 +345,7 @@ jobs:
       - checkout
       - run: |
           export DEPLOY_BREW_TOKEN=$REPO_GITHUB_TOKEN
-          bazel run //:deploy-brew -- release
+          bazel run --define version=$(cat VERSION) //:deploy-brew -- release
 
   deploy-docker:
     machine: true

--- a/BUILD
+++ b/BUILD
@@ -108,7 +108,6 @@ assemble_zip(
 assemble_rpm(
     name = "assemble-linux-rpm",
     package_name = "grakn-core-all",
-    version_file = "//:VERSION",
     spec_file = "//config/rpm:grakn-core-all.spec",
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json",
 )
@@ -137,13 +136,11 @@ assemble_versioned(
         "//server:assemble-mac-zip",
         "//server:assemble-windows-zip",
     ],
-    version_file = "//:VERSION",
 )
 
 assemble_versioned(
     name = "assemble-versioned-mac",
     targets = [":assemble-mac-zip"],
-    version_file = "//:VERSION"
 )
 
 checksum(
@@ -158,7 +155,6 @@ deploy_github(
     title_append_version = True,
     release_description = "//:RELEASE_TEMPLATE.md",
     archive = ":assemble-versioned-all",
-    version_file = "//:VERSION"
 )
 
 deploy_brew(
@@ -166,7 +162,6 @@ deploy_brew(
     checksum = "//:checksum-mac",
     deployment_properties = "@graknlabs_build_tools//:deployment.properties",
     formula = "//config/brew:grakn-core.rb",
-    version_file = "//:VERSION"
 )
 
 deploy_rpm(

--- a/server/BUILD
+++ b/server/BUILD
@@ -117,7 +117,6 @@ java_deps(
     name = "server-deps",
     target = ":server-binary",
     java_deps_root = "server/services/lib/",
-    version_file = "//:VERSION",
     visibility = ["//:__pkg__"]
 )
 
@@ -234,7 +233,6 @@ assemble_rpm(
     name = "assemble-linux-rpm",
     package_name = "grakn-core-server",
     installation_dir = "/opt/grakn/core/",
-    version_file = "//:VERSION",
     spec_file = "//config/rpm:grakn-core-server.spec",
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json",
     archives = [":server-deps"],


### PR DESCRIPTION
## What is the goal of this PR?

Fix graknlabs/bazel-distribution#150

## What are the changes implemented in this PR?

`version_file` argument is no longer used to provide version. As instead, `--define version=<>` argument is passed to Bazel everywhere a version is required
