### PR TITLE
Re-expose attribtue cache builder

### DIFF
--- a/server/src/server/session/SessionFactory.java
+++ b/server/src/server/session/SessionFactory.java
@@ -115,7 +115,7 @@ public class SessionFactory {
     }
 
     // Keep visibility to protected as this is used by KGMS
-    private Cache<String, ConceptId> buildAttributeCache() {
+    protected Cache<String, ConceptId> buildAttributeCache() {
         return CacheBuilder.newBuilder()
                 .expireAfterAccess(TIMEOUT_MINUTES_ATTRIBUTES_CACHE, TimeUnit.MINUTES)
                 .maximumSize(ATTRIBUTES_CACHE_MAX_SIZE)


### PR DESCRIPTION
## What is the goal of this PR?
Re-expose a method that was accidentally changed from protected to private, back to protected in order to fix KGMS.

## What are the changes implemented in this PR?
* Change `private` to `protected`