### PR TITLE
Statistics for MetaTypes and Modify `compute count;` behavior

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -75,6 +75,7 @@ public enum ErrorMessage {
     INVALID_KEYSPACE_NAME("Keyspace name is invalid: [%s]. Keyspace name cannot start with a number, " +
             "and can only contain maximum 48 characters of lower case, alphanumeric and underscore characters."),
     FILE_WRITE_EXCEPTION("Failed to write to file: %s"),
+    UNKNOWN_META_TYPE("Type [%s] has unknown meta type class [%s]"),
 
     //--------------------------------------------- Validation Errors
     VALIDATION("A structural validation error has occurred. Please correct the [`%s`] errors found. \n"),

--- a/graql/executor/ComputeExecutor.java
+++ b/graql/executor/ComputeExecutor.java
@@ -24,26 +24,15 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
-import grakn.core.kb.concept.api.Concept;
-import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.api.Label;
-import grakn.core.kb.concept.api.LabelId;
 import grakn.core.concept.answer.ConceptList;
 import grakn.core.concept.answer.ConceptSet;
 import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Numeric;
-import grakn.core.kb.concept.api.Thing;
-import grakn.core.kb.concept.api.AttributeType;
-import grakn.core.kb.concept.api.RelationType;
-import grakn.core.kb.concept.api.Role;
-import grakn.core.kb.concept.api.SchemaConcept;
-import grakn.core.kb.concept.api.Type;
+import grakn.core.core.Schema;
 import grakn.core.graql.analytics.ClusterMemberMapReduce;
 import grakn.core.graql.analytics.ConnectedComponentVertexProgram;
 import grakn.core.graql.analytics.ConnectedComponentsVertexProgram;
 import grakn.core.graql.analytics.CorenessVertexProgram;
-import grakn.core.graql.analytics.CountMapReduceWithAttribute;
-import grakn.core.graql.analytics.CountVertexProgram;
 import grakn.core.graql.analytics.DegreeDistributionMapReduce;
 import grakn.core.graql.analytics.DegreeStatisticsVertexProgram;
 import grakn.core.graql.analytics.DegreeVertexProgram;
@@ -60,36 +49,43 @@ import grakn.core.graql.analytics.StatisticsMapReduce;
 import grakn.core.graql.analytics.StdMapReduce;
 import grakn.core.graql.analytics.SumMapReduce;
 import grakn.core.graql.analytics.Utility;
-import grakn.core.kb.server.exception.GraqlSemanticException;
-import grakn.core.core.Schema;
+import grakn.core.kb.concept.api.AttributeType;
+import grakn.core.kb.concept.api.Concept;
+import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
+import grakn.core.kb.concept.api.LabelId;
+import grakn.core.kb.concept.api.RelationType;
+import grakn.core.kb.concept.api.Role;
+import grakn.core.kb.concept.api.SchemaConcept;
+import grakn.core.kb.concept.api.Thing;
+import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.server.Transaction;
+import grakn.core.kb.server.exception.GraqlSemanticException;
 import grakn.core.kb.server.statistics.KeyspaceStatistics;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.builder.Computable;
-
-import java.io.Serializable;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.stream.Stream;
-import javax.annotation.Nullable;
-
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
 import org.apache.tinkerpop.gremlin.process.computer.VertexProgram;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.stream.Stream;
 
 import static graql.lang.Graql.Token.Compute.Algorithm.CONNECTED_COMPONENT;
 import static graql.lang.Graql.Token.Compute.Algorithm.DEGREE;
@@ -538,8 +534,9 @@ class ComputeExecutor {
         }
 
         GraknMapReduce<?> mapReduce;
-        if (restrictSize)
+        if (restrictSize) {
             mapReduce = new ClusterMemberMapReduce(ConnectedComponentsVertexProgram.CLUSTER_LABEL, query.where().size().get());
+        }
         else mapReduce = new ClusterMemberMapReduce(ConnectedComponentsVertexProgram.CLUSTER_LABEL);
 
         Memory memory = compute(vertexProgram, mapReduce, scopeTypeLabelIDs).memory();

--- a/graql/executor/ComputeExecutor.java
+++ b/graql/executor/ComputeExecutor.java
@@ -68,6 +68,7 @@ import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlCompute;
 import graql.lang.query.builder.Computable;
+
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -82,6 +83,7 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+
 import org.apache.tinkerpop.gremlin.process.computer.ComputerResult;
 import org.apache.tinkerpop.gremlin.process.computer.MapReduce;
 import org.apache.tinkerpop.gremlin.process.computer.Memory;
@@ -186,7 +188,7 @@ class ComputeExecutor {
      */
     private Stream<Numeric> runComputeStd(GraqlCompute.Statistics.Value query) {
         Map<String, Double> stdTuple = runComputeStatistics(query);
-        if (stdTuple == null)  return Stream.empty();
+        if (stdTuple == null) return Stream.empty();
 
         double squareSum = stdTuple.get(StdMapReduce.SQUARE_SUM);
         double sum = stdTuple.get(StdMapReduce.SUM);
@@ -283,7 +285,7 @@ class ComputeExecutor {
             return new MaxMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(MEAN)) {
             return new MeanMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
-        }else if (method.equals(STD)) {
+        } else if (method.equals(STD)) {
             return new StdMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(SUM)) {
             return new SumMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
@@ -332,7 +334,7 @@ class ComputeExecutor {
      * @return aggregate instance counts fetched from keyspace statistics
      */
 
-    private Stream<Numeric> retrieveCachedCount(GraqlCompute.Statistics.Count query){
+    private Stream<Numeric> retrieveCachedCount(GraqlCompute.Statistics.Count query) {
         KeyspaceStatistics keyspaceStats = tx.session().keyspaceStatistics();
 
         // retrieve all types that must be counted
@@ -393,8 +395,7 @@ class ComputeExecutor {
             if (scopeIncludesAttributes(query)) {
                 paths = getComputePathResultListIncludingImplicitRelations(paths);
             }
-        }
-        else {
+        } else {
             paths = Collections.emptyList();
         }
 
@@ -446,8 +447,8 @@ class ComputeExecutor {
         Set<LabelId> targetTypeLabelIDs = convertLabelsToIds(targetTypeLabels);
 
         ComputerResult computerResult = compute(new DegreeVertexProgram(targetTypeLabelIDs),
-                                                new DegreeDistributionMapReduce(targetTypeLabelIDs, DegreeVertexProgram.DEGREE),
-                                                scopeTypeLabelIDs);
+                new DegreeDistributionMapReduce(targetTypeLabelIDs, DegreeVertexProgram.DEGREE),
+                scopeTypeLabelIDs);
 
         Map<Long, Set<ConceptId>> centralityMap = computerResult.memory().get(DegreeDistributionMapReduce.class.getName());
 
@@ -495,8 +496,8 @@ class ComputeExecutor {
 
         try {
             result = compute(new CorenessVertexProgram(k),
-                             new DegreeDistributionMapReduce(targetTypeLabelIDs, CorenessVertexProgram.CORENESS),
-                             scopeTypeLabelIDs);
+                    new DegreeDistributionMapReduce(targetTypeLabelIDs, CorenessVertexProgram.CORENESS),
+                    scopeTypeLabelIDs);
         } catch (NoResultException e) {
             return Stream.empty();
         }
@@ -537,7 +538,8 @@ class ComputeExecutor {
         }
 
         GraknMapReduce<?> mapReduce;
-        if (restrictSize) mapReduce = new ClusterMemberMapReduce(ConnectedComponentsVertexProgram.CLUSTER_LABEL, query.where().size().get());
+        if (restrictSize)
+            mapReduce = new ClusterMemberMapReduce(ConnectedComponentsVertexProgram.CLUSTER_LABEL, query.where().size().get());
         else mapReduce = new ClusterMemberMapReduce(ConnectedComponentsVertexProgram.CLUSTER_LABEL);
 
         Memory memory = compute(vertexProgram, mapReduce, scopeTypeLabelIDs).memory();
@@ -585,7 +587,7 @@ class ComputeExecutor {
      * Helper method to get list of all shortest paths
      *
      * @param resultGraph edge map
-     * @param fromID starting vertex
+     * @param fromID      starting vertex
      * @return
      */
     private List<List<ConceptId>> getComputePathResultList(Multimap<ConceptId, ConceptId> resultGraph, ConceptId fromID) {
@@ -762,19 +764,10 @@ class ComputeExecutor {
      * @return stream of Concept Types
      */
     private Stream<Type> scopeTypes(GraqlCompute query) {
-        // Get all types if query.inTypes() is empty, else get all scoped types of each meta type.
-        // Only include attributes and implicit "has-xxx" relations when user specifically asked for them.
+        // Get all types if query.inTypes() is empty, else get all scoped types
         if (query.in().isEmpty()) {
             ImmutableSet.Builder<Type> typeBuilder = ImmutableSet.builder();
-
-            if (scopeIncludesAttributes(query)) {
-                tx.getMetaConcept().subs().forEach(typeBuilder::add);
-            } else {
-                tx.getMetaEntityType().subs().forEach(typeBuilder::add);
-                tx.getMetaRelationType().subs()
-                        .filter(relationType -> !relationType.isImplicit()).forEach(typeBuilder::add);
-            }
-
+            tx.getMetaConcept().subs().forEach(typeBuilder::add);
             return typeBuilder.build().stream();
         } else {
             Stream<Type> subTypes = query.in().stream().map(t -> {
@@ -783,10 +776,6 @@ class ComputeExecutor {
                 if (type == null) throw GraqlSemanticException.labelNotFound(label);
                 return type;
             }).flatMap(Type::subs);
-
-            if (!scopeIncludesAttributes(query)) {
-                subTypes = subTypes.filter(relationType -> !relationType.isImplicit());
-            }
 
             return subTypes;
         }
@@ -818,7 +807,7 @@ class ComputeExecutor {
                 .flatMap(pattern -> tx.executor().traverse(pattern))
                 .findFirst().isPresent();
     }
-    
+
     /**
      * Helper method to check if concept instances exist in the query scope
      *

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -130,6 +130,13 @@ public class GraknConceptException extends GraknException {
         return create(UNKNOWN_CONCEPT.getMessage(type));
     }
 
+    /**
+     * Thrown when trying to identify the meta type of a type but cannot
+     */
+    public static GraknConceptException unknownTypeMetaType(Type type) {
+        return create(ErrorMessage.UNKNOWN_META_TYPE.getMessage(type.label().toString(), type.getClass().toString()));
+    }
+
 
     /**
      * Thrown when changing the Label of an SchemaConcept which is owned by another SchemaConcept

--- a/kb/server/statistics/KeyspaceStatistics.java
+++ b/kb/server/statistics/KeyspaceStatistics.java
@@ -60,8 +60,6 @@ public class KeyspaceStatistics {
     public void commit(Transaction tx, UncomittedStatisticsDelta statisticsDelta) {
         HashMap<Label, Long> deltaMap = statisticsDelta.instanceDeltas();
 
-        statisticsDelta.updateThingCount();
-
         // merge each delta into the cache, then flush the cache to Janus
         Set<Label> labelsToPersist = new HashSet<>();
         deltaMap.entrySet().stream()

--- a/kb/server/statistics/KeyspaceStatistics.java
+++ b/kb/server/statistics/KeyspaceStatistics.java
@@ -39,8 +39,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * On cache miss, we read from JanusGraph schema vertices, which only have the INSTANCE_COUNT property if the
  * count is non-zero or has been non-zero in the past. No such property means instance count is 0.
  *
- * We also store the total count of all concepts the same was as any other schema concept, but on the `Thing` meta
- * concept. Note that this is different from the other instance counts as it DOES include counts of all subtypes. The
+ * We also store the total count of all concepts the same was as any other schema concept, but on the meta
+ * concept types. Note that this is different from the other instance counts as it DOES include counts of all subtypes. The
  * other counts on user-defined schema concepts are for for that concrete type only
  */
 public class KeyspaceStatistics {

--- a/kb/server/statistics/UncomittedStatisticsDelta.java
+++ b/kb/server/statistics/UncomittedStatisticsDelta.java
@@ -72,11 +72,11 @@ public class UncomittedStatisticsDelta {
         Long currentCount = instanceDeltas.getOrDefault(label, 0L);
         instanceDeltas.put(label, currentCount - 1);
         thingCount--;
-        if (type.getClass().equals(EntityType.class)) {
+        if (type instanceof EntityType) {
             entityCount--;
-        } else if (type.getClass().equals(RelationType.class)) {
+        } else if (type instanceof RelationType) {
             relationCount--;
-        } else if (type.getClass().equals(AttributeType.class)) {
+        } else if (type instanceof AttributeType) {
             attributeCount--;
         } else {
             // some exception

--- a/kb/server/statistics/UncomittedStatisticsDelta.java
+++ b/kb/server/statistics/UncomittedStatisticsDelta.java
@@ -56,11 +56,11 @@ public class UncomittedStatisticsDelta {
         Long currentCount = instanceDeltas.getOrDefault(label, 0L);
         instanceDeltas.put(label, currentCount + 1);
         thingCount++;
-        if (type.getClass().equals(EntityType.class)) {
+        if (type instanceof EntityType) {
             entityCount++;
-        } else if (type.getClass().equals(RelationType.class)) {
+        } else if (type instanceof RelationType) {
             relationCount++;
-        } else if (type.getClass().equals(AttributeType.class)) {
+        } else if (type instanceof AttributeType) {
             attributeCount++;
         } else {
             // some exception
@@ -96,10 +96,18 @@ public class UncomittedStatisticsDelta {
 
     public HashMap<Label, Long> instanceDeltas() {
         // copy the meta type counts into the map on retrieval
-        instanceDeltas.put(Schema.MetaSchema.THING.getLabel(), thingCount);
-        instanceDeltas.put(Schema.MetaSchema.ENTITY.getLabel(), entityCount);
-        instanceDeltas.put(Schema.MetaSchema.RELATION.getLabel(), relationCount);
-        instanceDeltas.put(Schema.MetaSchema.ATTRIBUTE.getLabel(), attributeCount);
+        if (thingCount != 0) {
+            instanceDeltas.put(Schema.MetaSchema.THING.getLabel(), thingCount);
+        }
+        if (entityCount != 0) {
+            instanceDeltas.put(Schema.MetaSchema.ENTITY.getLabel(), entityCount);
+        }
+        if (relationCount != 0) {
+            instanceDeltas.put(Schema.MetaSchema.RELATION.getLabel(), relationCount);
+        }
+        if (attributeCount != 0) {
+            instanceDeltas.put(Schema.MetaSchema.ATTRIBUTE.getLabel(), attributeCount);
+        }
         return instanceDeltas;
     }
 }

--- a/kb/server/statistics/UncomittedStatisticsDelta.java
+++ b/kb/server/statistics/UncomittedStatisticsDelta.java
@@ -21,10 +21,12 @@ package grakn.core.kb.server.statistics;
 
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.EntityType;
+import grakn.core.kb.concept.api.GraknConceptException;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.core.Schema;
 import grakn.core.kb.concept.api.RelationType;
 import grakn.core.kb.concept.api.Type;
+import grakn.core.kb.server.exception.TransactionException;
 
 import java.util.HashMap;
 
@@ -63,7 +65,7 @@ public class UncomittedStatisticsDelta {
         } else if (type instanceof AttributeType) {
             attributeCount++;
         } else {
-            // some exception
+            throw GraknConceptException.unknownTypeMetaType(type);
         }
     }
 
@@ -79,7 +81,7 @@ public class UncomittedStatisticsDelta {
         } else if (type instanceof AttributeType) {
             attributeCount--;
         } else {
-            // some exception
+            throw GraknConceptException.unknownTypeMetaType(type);
         }
     }
 

--- a/kb/server/statistics/UncomittedStatisticsDelta.java
+++ b/kb/server/statistics/UncomittedStatisticsDelta.java
@@ -19,8 +19,12 @@
 
 package grakn.core.kb.server.statistics;
 
+import grakn.core.kb.concept.api.AttributeType;
+import grakn.core.kb.concept.api.EntityType;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.core.Schema;
+import grakn.core.kb.concept.api.RelationType;
+import grakn.core.kb.concept.api.Type;
 
 import java.util.HashMap;
 
@@ -33,6 +37,12 @@ import java.util.HashMap;
 public class UncomittedStatisticsDelta {
 
     private HashMap<Label, Long> instanceDeltas;
+    // keep these outside of the hashmap to avoid a large number of hash() method calls
+    private long thingCount = 0;
+    private long entityCount = 0;
+    private long relationCount = 0;
+    private long attributeCount = 0;
+
     public UncomittedStatisticsDelta() {
         instanceDeltas = new HashMap<>();
     }
@@ -41,32 +51,55 @@ public class UncomittedStatisticsDelta {
         return instanceDeltas.getOrDefault(label, 0L);
     }
 
-    public void increment(Label label) {
+    public void increment(Type type) {
+        Label label = type.label();
         Long currentCount = instanceDeltas.getOrDefault(label, 0L);
         instanceDeltas.put(label, currentCount + 1);
+        thingCount++;
+        if (type.getClass().equals(EntityType.class)) {
+            entityCount++;
+        } else if (type.getClass().equals(RelationType.class)) {
+            relationCount++;
+        } else if (type.getClass().equals(AttributeType.class)) {
+            attributeCount++;
+        } else {
+            // some exception
+        }
     }
 
-    public void decrement(Label label) {
+    public void decrement(Type type) {
+        Label label = type.label();
         Long currentCount = instanceDeltas.getOrDefault(label, 0L);
         instanceDeltas.put(label, currentCount - 1);
-    }
-
-    public HashMap<Label, Long> instanceDeltas() {
-        return instanceDeltas;
+        thingCount--;
+        if (type.getClass().equals(EntityType.class)) {
+            entityCount--;
+        } else if (type.getClass().equals(RelationType.class)) {
+            relationCount--;
+        } else if (type.getClass().equals(AttributeType.class)) {
+            attributeCount--;
+        } else {
+            // some exception
+        }
     }
 
     /**
-     * Updates the concept count for Thing. It overwrites the entry to be equal to the sum of contributions in the
-     * delta map.
+     * Special case decrement for attribute deduplication
+     * @param label
      */
-    void updateThingCount(){
-        // precompute the delta for all Thing's and update the delta map
-        long thingDelta = instanceDeltas.values().stream()
-                .reduce(Long::sum)
-                .orElse(0L);
-        if (thingDelta != 0) {
-            Label thingLabel = Schema.MetaSchema.THING.getLabel();
-            instanceDeltas.put(thingLabel, thingDelta);
-        }
+    public void decrementAttribute(Label label) {
+        Long currentCount = instanceDeltas.getOrDefault(label, 0L);
+        instanceDeltas.put(label, currentCount - 1);
+        thingCount--;
+        attributeCount--;
+    }
+
+    public HashMap<Label, Long> instanceDeltas() {
+        // copy the meta type counts into the map on retrieval
+        instanceDeltas.put(Schema.MetaSchema.THING.getLabel(), thingCount);
+        instanceDeltas.put(Schema.MetaSchema.ENTITY.getLabel(), entityCount);
+        instanceDeltas.put(Schema.MetaSchema.RELATION.getLabel(), relationCount);
+        instanceDeltas.put(Schema.MetaSchema.ATTRIBUTE.getLabel(), attributeCount);
+        return instanceDeltas;
     }
 }

--- a/server/session/TransactionOLTP.java
+++ b/server/session/TransactionOLTP.java
@@ -212,7 +212,7 @@ public class TransactionOLTP implements Transaction {
                 ConceptId targetId = session.attributesCache().getIfPresent(labelIndexPair.second());
                 if (targetId != null) {
                     merge(getTinkerTraversal(), conceptId, targetId);
-                    statisticsDelta().decrement(labelIndexPair.first());
+                    statisticsDelta().decrementAttribute(labelIndexPair.first());
                 } else {
                     session.attributesCache().put(labelIndexPair.second(), conceptId);
                 }

--- a/test-integration/graql/analytics/CountIT.java
+++ b/test-integration/graql/analytics/CountIT.java
@@ -67,7 +67,6 @@ public class CountIT {
         // assert the tx is empty
         try (Transaction tx = session.readTransaction()) {
             assertEquals(0, tx.execute(Graql.compute().count()).get(0).number().intValue());
-            assertEquals(0, tx.execute(Graql.compute().count().attributes(true)).get(0).number().intValue());
         }
 
         // add 2 instances
@@ -90,7 +89,7 @@ public class CountIT {
 
         try (Transaction tx = session.readTransaction()) {
             // assert computer returns the correct count of instances
-            assertEquals(2, tx.execute(Graql.compute().count().in(nameThing).attributes(true)).get(0).number().intValue());
+            assertEquals(2, tx.execute(Graql.compute().count().in(nameThing)).get(0).number().intValue());
             assertEquals(3, tx.execute(Graql.compute().count()).get(0).number().intValue());
         }
     }
@@ -145,10 +144,7 @@ public class CountIT {
         Numeric count;
         try (Transaction tx = session.readTransaction()) {
             count = tx.execute(Graql.compute().count()).get(0);
-            assertEquals(1, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().attributes(true)).get(0);
-            assertEquals(3L, count.number().intValue());
+            assertEquals(3, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("name")).get(0);
             assertEquals(1, count.number().intValue());
@@ -163,9 +159,6 @@ public class CountIT {
             assertEquals(2, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("relation")).get(0);
-            assertEquals(0, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().in("relation").attributes(true)).get(0);
             assertEquals(1, count.number().intValue());
         }
 
@@ -193,15 +186,9 @@ public class CountIT {
 
         try (Transaction tx = session.readTransaction()) {
             count = tx.execute(Graql.compute().count()).get(0);
-            assertEquals(2, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().attributes(true)).get(0);
             assertEquals(5, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("name")).get(0);
-            assertEquals(1, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().attributes(true).in("name")).get(0);
             assertEquals(1, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("@has-name")).get(0);
@@ -214,9 +201,6 @@ public class CountIT {
             assertEquals(3, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("relation")).get(0);
-            assertEquals(0, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().in("relation").attributes(true)).get(0);
             assertEquals(2, count.number().intValue());
         }
     }
@@ -252,9 +236,6 @@ public class CountIT {
         Numeric count;
         try (Transaction tx = session.readTransaction()) {
             count = tx.execute(Graql.compute().count()).get(0);
-            assertEquals(1, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().attributes(true)).get(0);
             assertEquals(3, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("name")).get(0);
@@ -267,9 +248,6 @@ public class CountIT {
             assertEquals(2, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("relation")).get(0);
-            assertEquals(0, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().in("relation").attributes(true)).get(0);
             assertEquals(1, count.number().intValue());
         }
 
@@ -282,7 +260,7 @@ public class CountIT {
         }
 
         try (Transaction tx = session.readTransaction()) {
-            count = tx.execute(Graql.compute().count().attributes(true)).get(0);
+            count = tx.execute(Graql.compute().count()).get(0);
             assertEquals(5, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("name")).get(0);
@@ -295,9 +273,6 @@ public class CountIT {
             assertEquals(3, count.number().intValue());
 
             count = tx.execute(Graql.compute().count().in("relation")).get(0);
-            assertEquals(0, count.number().intValue());
-
-            count = tx.execute(Graql.compute().count().in("relation").attributes(true)).get(0);
             assertEquals(2, count.number().intValue());
         }
     }

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -167,9 +167,7 @@ public class GraqlComputeIT {
             Label topImplicitType = Schema.ImplicitType.HAS.getLabel(metaAttributeLabel);
             GraqlGet thingQuery = Graql.match(
                     Graql.and(
-                            Graql.var("x").isa(tx.getMetaConcept().label().getValue()),
-                            Graql.not(Graql.var("x").isa(metaAttributeLabel.getValue())),
-                            Graql.not(Graql.var("x").isa(topImplicitType.getValue()))
+                            Graql.var("x").isa(tx.getMetaConcept().label().getValue())
                     )
             ).get();
             assertEquals(

--- a/test-integration/server/statistics/KeyspaceStatisticsIT.java
+++ b/test-integration/server/statistics/KeyspaceStatisticsIT.java
@@ -342,7 +342,6 @@ public class KeyspaceStatisticsIT {
         assertEquals(2L, personCount - personCountStart);
         assertEquals(3L, ageCount - ageCountStart);
         assertEquals(personCount, entityCount);
-        assertEquals(0L, relationCount);
         assertEquals(ageCount, attributeCount);
         assertEquals(personCount + ageCount, thingCount);
     }

--- a/test-integration/server/statistics/KeyspaceStatisticsIT.java
+++ b/test-integration/server/statistics/KeyspaceStatisticsIT.java
@@ -119,12 +119,18 @@ public class KeyspaceStatisticsIT {
         long friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
         long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        long entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        long relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        long attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         assertEquals(2, personCount);
         assertEquals(1, ageCount);
         assertEquals(1, friendshipCount);
         assertEquals(3, implicitAgeCount);
+        assertEquals(2, entityCount);
+        assertEquals(4, relationCount);
+        assertEquals(1, attributeCount);
         assertEquals(personCount + ageCount + friendshipCount + implicitAgeCount, thingCount);
 
         tx = localSession.writeTransaction();
@@ -137,12 +143,18 @@ public class KeyspaceStatisticsIT {
         friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
         thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         assertEquals(2, personCount);
         assertEquals(1, ageCount);
         assertEquals(0, friendshipCount);
         assertEquals(3, implicitAgeCount);
+        assertEquals(2, entityCount);
+        assertEquals(3, relationCount);
+        assertEquals(1, attributeCount);
         assertEquals(personCount + ageCount + friendshipCount + implicitAgeCount, thingCount);
 
         tx = localSession.writeTransaction();
@@ -154,12 +166,18 @@ public class KeyspaceStatisticsIT {
         friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
         thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         assertEquals(0, personCount);
         assertEquals(0, ageCount);
         assertEquals(0, friendshipCount);
         assertEquals(0, implicitAgeCount);
+        assertEquals(0, entityCount);
+        assertEquals(0, relationCount);
+        assertEquals(0, attributeCount);
         assertEquals(0, thingCount);
     }
 
@@ -188,11 +206,17 @@ public class KeyspaceStatisticsIT {
         long ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         long friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
+        long entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        long relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        long attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         assertEquals(0, personCount);
         assertEquals(0, ageCount);
         assertEquals(0, friendshipCount);
+        assertEquals(0, entityCount);
+        assertEquals(0, relationCount);
+        assertEquals(0, attributeCount);
         assertEquals(0, implicitAgeCount);
     }
 
@@ -223,6 +247,9 @@ public class KeyspaceStatisticsIT {
         long friendshipCount = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCount = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
         long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        long entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        long relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        long attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         localSession.close();
@@ -237,6 +264,9 @@ public class KeyspaceStatisticsIT {
         long friendshipCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("friendship"));
         long implicitAgeCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("@has-age"));
         long thingCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        long entityCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        long relationCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        long attributeCountReopened = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
         tx.close();
 
         assertEquals(personCount, personCountReopened);
@@ -244,6 +274,9 @@ public class KeyspaceStatisticsIT {
         assertEquals(friendshipCount, friendshipCountReopened);
         assertEquals(implicitAgeCount, implicitAgeCountReopened);
         assertEquals(thingCount, thingCountReopened);
+        assertEquals(entityCount, entityCountReopened);
+        assertEquals(relationCount, relationCountReopened);
+        assertEquals(attributeCount, attributeCountReopened);
     }
 
     @Test
@@ -300,10 +333,17 @@ public class KeyspaceStatisticsIT {
         long personCount = localSession.keyspaceStatistics().count(tx, Label.of("person"));
         long ageCount = localSession.keyspaceStatistics().count(tx, Label.of("age"));
         long thingCount = localSession.keyspaceStatistics().count(tx, Label.of("thing"));
+        long entityCount = localSession.keyspaceStatistics().count(tx, Label.of("entity"));
+        long relationCount = localSession.keyspaceStatistics().count(tx, Label.of("relation"));
+        long attributeCount = localSession.keyspaceStatistics().count(tx, Label.of("attribute"));
+
         tx.close();
 
         assertEquals(2L, personCount - personCountStart);
         assertEquals(3L, ageCount - ageCountStart);
+        assertEquals(personCount, entityCount);
+        assertEquals(0L, relationCount);
+        assertEquals(ageCount, attributeCount);
         assertEquals(personCount + ageCount, thingCount);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
As noted in #5421, we aren't currently caching statistics for Entity, Relation and Attribute like we do for `Thing`. This means that since we answer `compute count in thing;` or any concrete label using statistics, we can now also answer `compute count in entity/relation/attribute;` the same way instead of having to execute the `compute count` via OLAP fully.

## What are the changes implemented in this PR?
* Increment and decrement statistics for Entity, Relation and Attribute, storing these on the Meta Type vertex similarly to the statistics for `Thing`
* Update tests to reflect the new counts in statistics