### PR TITLE
Integrate checking for unused Java dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,16 @@ jobs:
       - run-bazel-rbe:
           command: bazel test $(bazel query 'kind(checkstyle_test, //...)')
 
+  build-unused-deps:
+    machine: true
+    working_directory: ~/grakn
+    steps:
+      - install-bazel-linux-rbe
+      - checkout
+      - run:
+          command: bazel run @graknlabs_build_tools//unused_deps -- list
+          no_output_timeout: 30m
+
   build-analysis:
     machine: true
     working_directory: ~/grakn
@@ -412,6 +422,10 @@ workflows:
           filters:
             branches:
               only: master
+      - build-unused-deps:
+          filters:
+            branches:
+              ignore: grakn-release-branch
       - test-common:
           filters:
             branches:
@@ -444,6 +458,7 @@ workflows:
             - build
             - build-checkstyle
             - build-analysis
+            - build-unused-deps
             - test-common
             - test-server
             - test-integration

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,6 +44,9 @@ graknlabs_benchmark()
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
 
+load("@graknlabs_build_tools//unused_deps:dependencies.bzl", "unused_deps_dependencies")
+unused_deps_dependencies()
+
 ###########################
 # Load Bazel dependencies #
 ###########################

--- a/kb/concept/util/BUILD
+++ b/kb/concept/util/BUILD
@@ -24,7 +24,6 @@ java_library(
     name = "util",
     srcs = glob(["*.java"]),
     deps = [
-        "//common:common",
         "//kb/concept/api:api",
         "//concept/answer:answer",
 

--- a/test-integration/graql/reasoner/pattern/BUILD
+++ b/test-integration/graql/reasoner/pattern/BUILD
@@ -11,7 +11,6 @@ java_library(
     srcs = ["RelationPattern.java"],
     visibility = ["//test-integration:__subpackages__"],
     deps = [
-        "//common:common",
         "//dependencies/maven/artifacts/com/google/guava",
         "//kb/concept/api",
         "//test-integration/graql/reasoner/pattern:query-pattern",

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -193,7 +193,6 @@ java_test(
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_common//:common",
     ],
 )
 
@@ -207,7 +206,6 @@ java_test(
     ],
     test_class = "grakn.core.graql.reasoner.query.SemanticDifferenceIT",
     deps = [
-        "//common:common",
         "//concept/answer",
         "//dependencies/maven/artifacts/com/google/guava",
         "//graql:graql",

--- a/test-integration/graql/reasoner/reasoning/BUILD
+++ b/test-integration/graql/reasoner/reasoning/BUILD
@@ -24,7 +24,6 @@ java_test(
     resources = ["//test-integration/graql/reasoner/stubs:reasoning-stubs"],
     test_class = "grakn.core.graql.reasoner.reasoning.ValuePredicateIT",
     deps = [
-        "//common:common",
         "//concept/answer",
         "//dependencies/maven/artifacts/com/google/guava",
         "//graql:graql",

--- a/test-integration/server/BUILD
+++ b/test-integration/server/BUILD
@@ -25,7 +25,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.server.AttributeUniquenessIT",
     deps = [
-        "//common:common",
         "//concept/answer",
         "//core",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",

--- a/test-integration/server/session/BUILD
+++ b/test-integration/server/session/BUILD
@@ -77,7 +77,6 @@ java_test(
     data = ["//test-integration/resources:grakn-small-tx-cache"],
     test_class = "grakn.core.server.session.cache.TransactionCacheIT",
     deps = [
-        "//common:common",
         "//core",
         "//dependencies/maven/artifacts/org/apache/tinkerpop:gremlin-core",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",


### PR DESCRIPTION
## What is the goal of this PR?

Integrate checking for unused Java dependencies

## What are the changes implemented in this PR?

- Load `@graknlabs_build_tools//unused_deps`'s dependencies
- New CI job: `build-unused-deps`
- Remove unused Java deps
