### PR TITLE
Grpc threads optimisation

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -71,7 +71,9 @@ java_library(
         "//dependencies/maven/artifacts/commons-configuration:commons-configuration", # PREVIOUSLY UNDECLARED
         "//dependencies/maven/artifacts/commons-lang:commons-lang",
         "//dependencies/maven/artifacts/io/grpc:grpc-core",
+        "//dependencies/maven/artifacts/io/grpc:grpc-netty",
         "//dependencies/maven/artifacts/io/grpc:grpc-stub",
+        "//dependencies/maven/artifacts/io/netty:netty-all",
         "//dependencies/maven/artifacts/io/zipkin/brave:brave",
         "//dependencies/maven/artifacts/org/apache/cassandra:cassandra-all", # PREVIOUSLY UNDECLARED
         "//dependencies/maven/artifacts/org/apache/thrift:libthrift",
@@ -93,7 +95,6 @@ java_library(
     runtime_deps = [
         "//dependencies/maven/artifacts/ch/qos/logback:logback-classic",
         "//dependencies/maven/artifacts/ch/qos/logback:logback-core",
-        "//dependencies/maven/artifacts/io/grpc:grpc-netty",
         "//dependencies/maven/artifacts/javax/servlet:javax-servlet-api", # PREVIOUSLY UNDECLARED
     ],
     resources = ["LICENSE"] + glob(["resources/*"]),

--- a/server/ServerFactory.java
+++ b/server/ServerFactory.java
@@ -20,6 +20,7 @@
 package grakn.core.server;
 
 import com.datastax.driver.core.Cluster;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
@@ -38,6 +39,7 @@ import io.grpc.netty.NettyServerBuilder;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
@@ -45,6 +47,9 @@ import java.util.concurrent.TimeUnit;
  * This is a factory class which contains methods for instantiating a Server in different ways.
  */
 public class ServerFactory {
+
+    private static final int GRPC_EXECUTOR_THREADS = Runtime.getRuntime().availableProcessors() * 2; // default Netty way of assigning threads, probably expose in config in future
+    private static final int ELG_THREADS = 4; // this could also be 1, but to avoid risks set it to 4, probably expose in config in future
 
     /**
      * Create a Server configured for Grakn Core.
@@ -97,6 +102,31 @@ public class ServerFactory {
         return server;
     }
 
+    /**
+     * Build a GrpcServer using the Netty default builder.
+     * The Netty builder accepts 3 thread executors (threadpools):
+     *  - Boss Event Loop Group  (a.k.a. bossEventLoopGroup() )
+     *  - Worker Event Loop Group ( a.k.a. workerEventLoopGroup() )
+     *  - Application Executor (a.k.a. executor() )
+     *
+     * The Boss group can be the same as the worker group.
+     * It's purpose is to accept calls from the network, and create Netty channels (not gRPC Channels) to handle the socket.
+     *
+     * Once the Netty channel has been created it gets passes to the Worker Event Loop Group.
+     * This is the threadpool dedicating to doing socket read() and write() calls.
+     *
+     * The last thread group is the application executor, also called the "app thread".
+     * This is where the gRPC stubs do their main work.
+     * It is for handling the callbacks that bubble up from the network thread.
+     *
+     * Note from grpc-java developers:
+     * Most people should use either reuse the same boss event loop group as the worker group.
+     * Barring this, the boss eventloop group should be a single thread, since it does very little work.
+     * For the app thread, users should provide a fixed size thread pool, as the default unbounded cached threadpool
+     * is not the most efficient, and can be dangerous in some circumstances.
+     *
+     * More info here: https://groups.google.com/d/msg/grpc-io/LrnAbWFozb0/VYCVarkWBQAJ
+     */
     private static io.grpc.Server createServerRPC(Config config, SessionFactory sessionFactory, KeyspaceManager keyspaceManager, JanusGraphFactory janusGraphFactory) {
         int grpcPort = config.getProperty(ConfigKey.GRPC_PORT);
         OpenRequest requestOpener = new ServerOpenRequest(sessionFactory);
@@ -108,11 +138,12 @@ public class ServerFactory {
 
         Runtime.getRuntime().addShutdownHook(new Thread(sessionService::shutdown, "session-service-shutdown"));
 
-        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(4);
-        int numThreads = Runtime.getRuntime().availableProcessors() * 2;// Netty default
+        NioEventLoopGroup eventLoopGroup = new NioEventLoopGroup(ELG_THREADS, new ThreadFactoryBuilder().setNameFormat("grpc-ELG-handler-%d").build());
+
+        ExecutorService grpcExecutorService = Executors.newFixedThreadPool(GRPC_EXECUTOR_THREADS, new ThreadFactoryBuilder().setNameFormat("grpc-request-handler-%d").build());
 
         return NettyServerBuilder.forPort(grpcPort)
-                .executor(Executors.newFixedThreadPool(numThreads))
+                .executor(grpcExecutorService)
                 .workerEventLoopGroup(eventLoopGroup)
                 .bossEventLoopGroup(eventLoopGroup)
                 .maxConnectionIdle(1, TimeUnit.HOURS)

--- a/server/ServerFactory.java
+++ b/server/ServerFactory.java
@@ -34,9 +34,7 @@ import grakn.core.server.session.HadoopGraphFactory;
 import grakn.core.server.session.JanusGraphFactory;
 import grakn.core.server.session.SessionFactory;
 import grakn.core.server.util.LockManager;
-import io.grpc.ServerBuilder;
 import io.grpc.netty.NettyServerBuilder;
-import io.netty.channel.ServerChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 

--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -248,7 +248,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
                     case REQ_NOT_SET:
                         throw ResponseBuilder.exception(Status.INVALID_ARGUMENT);
                 }
-            } catch (RuntimeException e) {
+            } catch (Throwable e) {
                 close(e);
             }
         }

--- a/server/session/SessionFactory.java
+++ b/server/session/SessionFactory.java
@@ -26,7 +26,6 @@ import grakn.core.kb.server.Session;
 import grakn.core.kb.server.cache.KeyspaceSchemaCache;
 import grakn.core.kb.server.keyspace.Keyspace;
 import grakn.core.kb.server.statistics.KeyspaceStatistics;
-import grakn.core.server.keyspace.KeyspaceImpl;
 import grakn.core.server.util.LockManager;
 import org.apache.tinkerpop.gremlin.hadoop.structure.HadoopGraph;
 import org.janusgraph.graphdb.database.StandardJanusGraph;


### PR DESCRIPTION
## What is the goal of this PR?

- Don't let grpc threads grow unbounded: before it could happen that with a lot of concurrent grpc transactions the server would start creating a very big number of threads (1 per connection-request) instead of reusing already existing threads, specifically when handling Event Loop Group.
We know provide a Threadpool to GrpcServer so that threads will be reused following best practices described by Grpc devs.


- Kill all grpc transaction threads when a client either closes a remote session or terminates connection abruptly: before when a client terminates a grpc connection or a specific grpc session we would just close the current Grpc session, we now track all the transaction threads accotiated to it and terminate those as well.

## What are the changes implemented in this PR?

- move from default grpc `ServerBuilder` to the actual implementation of it, which is `NettyServerBuilder`, this is so that we can inject customised thread executors and have more control on other options, such as `maxConnectionIdle`
- added a quick description about main executors used by grpc server
- change `transactionListernerSet` to a map (`transactionListeners`) so that we can associate a set of transactions listeners to a `SessionId`
