### PR TITLE
Revert Client-Java dependency origin and Expand Reasoner tests

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -50,7 +50,7 @@ def graknlabs_client_java():
      git_repository(
          name = "graknlabs_client_java",
          remote = "https://github.com/graknlabs/client-java",
-         commit = "48321b87ebecfea3e9708887bbf841969d5b6888",
+         commit = "c3dd0174af66b9bcc8d8d48aab73d6c6810c6490",
      )
 
 def graknlabs_console():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -49,8 +49,8 @@ def graknlabs_protocol():
 def graknlabs_client_java():
      git_repository(
          name = "graknlabs_client_java",
-         remote = "https://github.com/flyingsilverfin/client-java",
-         commit = "b848620c24f1905b85e8f307cfc0a9b5dcd5cd74",
+         remote = "https://github.com/graknlabs/client-java",
+         commit = "48321b87ebecfea3e9708887bbf841969d5b6888",
      )
 
 def graknlabs_console():

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -258,10 +258,9 @@ public class BenchmarkBigIT {
      */
     @Test
     public void testRandomSetLinearTransitivity() {
-        final int N = 200;
+        final int N = 1000;
         final int limit = 100;
-        System.out.println(new Object() {
-        }.getClass().getEnclosingMethod().getName());
+        System.out.println(new Object() {}.getClass().getEnclosingMethod().getName());
         loadTransitivityData(N);
 
         try (GraknClient.Session session = new GraknClient(server.grpcUri()).session(keyspace)) {
@@ -343,9 +342,8 @@ public class BenchmarkBigIT {
      */
     @Test
     public void testJoinRuleChain() {
-        final int N = 20; // TODO: Increase this number again to > 100, once we fix issue #4545
-        System.out.println(new Object() {
-        }.getClass().getEnclosingMethod().getName());
+        final int N = 200;
+        System.out.println(new Object() {}.getClass().getEnclosingMethod().getName());
         loadRuleChainData(N);
 
         try (GraknClient.Session session = new GraknClient(server.grpcUri()).session(keyspace)) {


### PR DESCRIPTION
## What is the goal of this PR?
Restore proper state of core by changing dependency from temporary `flyingsilverfin` to `graknlabs` client-java sources.

Also, now that Explanations are no longer returned in one deeply nested gRPC message, we undo the changes from #4583 and point 4 in #4546

## What are the changes implemented in this PR?
* Switch dependency
* Expand reasoner tests mentioned in the above PRs that were reduced to accommodate gRPC explanation message size limits