### PR TITLE
Fix key enforcement when dealing with concurrent txs

### DIFF
--- a/concept/impl/ConceptObserver.java
+++ b/concept/impl/ConceptObserver.java
@@ -113,9 +113,14 @@ public class ConceptObserver {
 
         transactionCache.cacheConcept(thing);
 
-        //This Thing gets tracked for validation only if it has keys which need to be checked.
+        //This Thing gets tracked for validation only if it has keys which need to be checked
         if (thingType.keys().findAny().isPresent()) {
             transactionCache.trackForValidation(thing);
+        }
+
+        //acknowledge key relation modification if the thing is one
+        if (thingType.isImplicit() && Schema.ImplicitType.isKey(thingType.label())){
+            transactionCache.modifiedKeyRelation();
         }
     }
 

--- a/concept/impl/ConceptObserver.java
+++ b/concept/impl/ConceptObserver.java
@@ -120,7 +120,7 @@ public class ConceptObserver {
 
         //acknowledge key relation modification if the thing is one
         if (thingType.isImplicit() && Schema.ImplicitType.isKey(thingType.label())){
-            transactionCache.modifiedKeyRelation();
+            transactionCache.ackModifiedKeyRelation();
         }
     }
 

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -342,6 +342,11 @@ public final class Schema {
             //return the Label without the `@has-`or '@key-' prefix
             return Label.of(implicitType.getValue().substring(5, endIndex));
         }
+
+        @CheckReturnValue
+        public static boolean isKey(Label implicitType) {
+            return implicitType.getValue().startsWith("@key");
+        }
     }
 
     /**

--- a/kb/server/cache/TransactionCache.java
+++ b/kb/server/cache/TransactionCache.java
@@ -78,6 +78,7 @@ public class TransactionCache {
     // Track the removed attributes so that we can evict old attribute indexes from attributesCache in session
     // after commit
     private Set<String> removedAttributes = new HashSet<>();
+    private boolean modifiedKeyRelations = false;
 
     public TransactionCache(KeyspaceSchemaCache keyspaceSchemaCache) {
         this.keyspaceSchemaCache = keyspaceSchemaCache;
@@ -292,6 +293,10 @@ public class TransactionCache {
         newAttributes.put(new Pair<>(label, index), conceptId);
     }
 
+    public void modifiedKeyRelation(){
+        modifiedKeyRelations = true;
+    }
+
     public Map<Pair<Label, String>, ConceptId> getNewAttributes() {
         return newAttributes;
     }
@@ -308,6 +313,8 @@ public class TransactionCache {
     public Set<RelationType> getModifiedRelationTypes() {
         return modifiedRelationTypes;
     }
+
+    public boolean modifiedKeyRelations(){ return modifiedKeyRelations;}
 
     public Set<Rule> getModifiedRules() {
         return modifiedRules;

--- a/kb/server/cache/TransactionCache.java
+++ b/kb/server/cache/TransactionCache.java
@@ -293,7 +293,7 @@ public class TransactionCache {
         newAttributes.put(new Pair<>(label, index), conceptId);
     }
 
-    public void modifiedKeyRelation(){
+    public void ackModifiedKeyRelation(){
         modifiedKeyRelations = true;
     }
 

--- a/server/session/TransactionOLTP.java
+++ b/server/session/TransactionOLTP.java
@@ -173,7 +173,7 @@ public class TransactionOLTP implements Transaction {
     private void commitInternal() throws InvalidKBException {
         if (!cache().getNewAttributes().isEmpty()) {
             mergeAttributesAndCommit();
-        } else if (!cache().getRemovedAttributes().isEmpty()) {
+        } else if (!cache().getRemovedAttributes().isEmpty() || cache().modifiedKeyRelations()) {
             // In this case we need to lock, so that other concurrent Transactions
             // that are trying to create new attributes will read an updated version of attributesCache
             // Not locking here might lead to concurrent transactions reading the attributesCache that still
@@ -190,7 +190,6 @@ public class TransactionOLTP implements Transaction {
             createNewTypeShardsWhenThresholdReached();
             persistInternal();
         }
-
     }
 
     private void persistInternal() throws InvalidKBException {

--- a/server/session/TransactionOLTP.java
+++ b/server/session/TransactionOLTP.java
@@ -21,7 +21,6 @@ package grakn.core.server.session;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
-import grakn.benchmark.lib.instrumentation.ServerTracing;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.concept.answer.Answer;
@@ -62,7 +61,6 @@ import grakn.core.kb.graql.executor.property.PropertyExecutorFactory;
 import grakn.core.kb.graql.planning.TraversalPlanFactory;
 import grakn.core.graql.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.kb.graql.reasoner.cache.QueryCache;
-import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
 import grakn.core.server.cache.CacheProviderImpl;
@@ -172,8 +170,7 @@ public class TransactionOLTP implements Transaction {
      * - use a lock to serialise commits that are removing attributes, so concurrent txs don't use outdated attribute IDs from attributesCache
      * - don't lock when added or removed attributes are not involved
      */
-    private void commitInternal() {
-        LOG.trace("Graph is valid. Committing graph...");
+    private void commitInternal() throws InvalidKBException {
         if (!cache().getNewAttributes().isEmpty()) {
             mergeAttributesAndCommit();
         } else if (!cache().getRemovedAttributes().isEmpty()) {
@@ -184,17 +181,23 @@ public class TransactionOLTP implements Transaction {
             session.graphLock().writeLock().lock();
             try {
                 createNewTypeShardsWhenThresholdReached();
-                session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
-                janusTransaction.commit();
+                persistInternal();
                 cache().getRemovedAttributes().forEach(index -> session.attributesCache().invalidate(index));
             } finally {
                 session.graphLock().writeLock().unlock();
             }
         } else {
             createNewTypeShardsWhenThresholdReached();
-            session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
-            janusTransaction.commit();
+            persistInternal();
         }
+
+    }
+
+    private void persistInternal() throws InvalidKBException {
+        validateGraph();
+        session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
+        LOG.trace("Graph is valid. Committing graph...");
+        janusTransaction.commit();
         LOG.trace("Graph committed.");
     }
 
@@ -219,8 +222,7 @@ public class TransactionOLTP implements Transaction {
                     session.attributesCache().put(labelIndexPair.second(), conceptId);
                 }
             }));
-            session.keyspaceStatistics().commit(this, uncomittedStatisticsDelta);
-            janusTransaction.commit();
+            persistInternal();
         } finally {
             session.graphLock().writeLock().unlock();
         }
@@ -1040,23 +1042,13 @@ public class TransactionOLTP implements Transaction {
             return;
         }
         try {
-            /* This method has permanent tracing because commits can take varying lengths of time depending on operations */
-            int validateSpanId = ServerTracing.startScopedChildSpan("commit validate");
-
             checkMutationAllowed();
             removeInferredConcepts();
-            validateGraph();
-
-            ServerTracing.closeScopedChildSpan(validateSpanId);
-
-            int commitSpanId = ServerTracing.startScopedChildSpan("commit");
 
             // lock on the keyspace cache shared between concurrent tx's to the same keyspace
             // force serialized updates, keeping Janus and our KeyspaceCache in sync
             commitInternal();
             transactionCache.flushSchemaLabelIdsToCache();
-
-            ServerTracing.closeScopedChildSpan(commitSpanId);
         } finally {
             String closeMessage = ErrorMessage.TX_CLOSED_ON_ACTION.getMessage("committed", keyspace());
             closeTransaction(closeMessage);

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -125,7 +125,7 @@ public class AttributeUniquenessIT {
     }
 
     @Test
-    public void whenAttemptingToConcurrentlyInsertExistingKey_txsFail(){
+    public void whenAttemptingToConcurrentlyAttachExistingKey_onlyOneIsAccepted(){
         Transaction tx = session.writeTransaction();
         tx.execute(Graql.parse("define \n" +
                 "name sub attribute, \n" +
@@ -135,11 +135,11 @@ public class AttributeUniquenessIT {
         tx.commit();
 
         tx = session.writeTransaction();
-        GraqlInsert keyQuery = Graql.parse("insert $x isa person, has name \"Marco\";").asInsert();
+        GraqlInsert keyQuery = Graql.parse("insert $x \"Marco\" isa name;").asInsert();
         tx.execute(keyQuery);
         tx.commit();
 
-        //Try to insert 2 persons with same name, both txs should throw exception
+        //Try to insert 2 persons with same name, both txs should fail
         expectedException.expect(InvalidKBException.class);
         List<Future> queryFutures = createQueryFutures(Collections.list(keyQuery, keyQuery));
         for (Future future : queryFutures) {
@@ -441,7 +441,7 @@ public class AttributeUniquenessIT {
         }
     }
 
-    private void insertConcurrently(GraqlInsert query, int repetitions) throws InvalidKBException{
+    private void insertConcurrently(GraqlInsert query, int repetitions){
         List<GraqlInsert> queries = new ArrayList<>();
         for (int i = 0; i < repetitions; i++) {
             queries.add(query);

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -138,7 +138,7 @@ public class AttributeUniquenessIT {
         tx.execute(Graql.parse("insert $x \"Marco\" isa name;").asInsert());
         tx.commit();
 
-        //Try to insert 2 persons with same name, both txs should fail
+        //Try to insert 2 persons with same name, one tx should fail
         GraqlInsert keyQuery = Graql.parse("insert $x isa person, has name \"Marco\";").asInsert();
         expectedException.expect(InvalidKBException.class);
         List<Future> queryFutures = createQueryFutures(Collections.list(keyQuery, keyQuery));

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -25,14 +25,10 @@ import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
+import grakn.core.kb.server.exception.InvalidKBException;
 import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import graql.lang.query.GraqlInsert;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -43,6 +39,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static graql.lang.Graql.type;
 import static graql.lang.Graql.var;
@@ -90,6 +91,69 @@ public class AttributeUniquenessIT {
             List<ConceptMap> conceptMaps = tx.execute(Graql.match(var(testAttributeLabel).isa(testAttributeLabel).val(testAttributeValue)).get());
             assertThat(conceptMaps, hasSize(1));
         }
+    }
+
+    @org.junit.Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void whenInsertingKeyConcurrently_onlyOneIsAccepted(){
+        Transaction tx = session.writeTransaction();
+        tx.execute(Graql.parse("define \n" +
+                "name sub attribute, \n" +
+                "    datatype string;\n" +
+                "person sub entity, \n" +
+                "    key name;").asDefine());
+        tx.commit();
+
+        //Try to insert 2 persons with same name in two transactions, one transaction should throw
+        GraqlInsert keyQuery = Graql.parse("insert $x isa person, has name \"Marco\";").asInsert();
+        expectedException.expect(InvalidKBException.class);
+        List<Future> queryFutures = createQueryFutures(Collections.list(keyQuery, keyQuery));
+        for (Future future : queryFutures) {
+            try{
+                future.get();
+            } catch (Exception e) {
+                e.printStackTrace();
+                if (e.getCause() instanceof InvalidKBException) throw (InvalidKBException) e.getCause();
+            }
+        }
+
+        tx = session.readTransaction();
+        List<ConceptMap> result = tx.execute(Graql.parse("match $x isa person, has name \"Marco\"; get;").asGet());
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void whenAttemptingToConcurrentlyInsertExistingKey_txsFail(){
+        Transaction tx = session.writeTransaction();
+        tx.execute(Graql.parse("define \n" +
+                "name sub attribute, \n" +
+                "    datatype string;\n" +
+                "person sub entity, \n" +
+                "    key name;").asDefine());
+        tx.commit();
+
+        tx = session.writeTransaction();
+        GraqlInsert keyQuery = Graql.parse("insert $x isa person, has name \"Marco\";").asInsert();
+        tx.execute(keyQuery);
+        tx.commit();
+
+        //Try to insert 2 persons with same name, both txs should throw exception
+        expectedException.expect(InvalidKBException.class);
+        List<Future> queryFutures = createQueryFutures(Collections.list(keyQuery, keyQuery));
+        for (Future future : queryFutures) {
+            try{
+                future.get();
+            } catch (Exception e) {
+                e.printStackTrace();
+                if (e.getCause() instanceof InvalidKBException) throw (InvalidKBException) e.getCause();
+            }
+        }
+
+        tx = session.readTransaction();
+        List<ConceptMap> result = tx.execute(Graql.parse("match $x isa person, has name \"Marco\"; get;").asGet());
+        assertEquals(1, result.size());
     }
 
     @Test
@@ -377,7 +441,7 @@ public class AttributeUniquenessIT {
         }
     }
 
-    private void insertConcurrently(GraqlInsert query, int repetitions) {
+    private void insertConcurrently(GraqlInsert query, int repetitions) throws InvalidKBException{
         List<GraqlInsert> queries = new ArrayList<>();
         for (int i = 0; i < repetitions; i++) {
             queries.add(query);
@@ -385,7 +449,7 @@ public class AttributeUniquenessIT {
         insertConcurrently(queries);
     }
 
-    private void insertConcurrently(Collection<GraqlInsert> queries) {
+    private List<Future> createQueryFutures(Collection<GraqlInsert> queries) {
         // use latch to make sure all threads will insert a new attribute instance
         CountDownLatch commitLatch = new CountDownLatch(queries.size());
         ExecutorService executorService = Executors.newFixedThreadPool(queries.size());
@@ -403,7 +467,12 @@ public class AttributeUniquenessIT {
                 tx.commit();
             }));
         });
-        for (Future future : futures) {
+        return futures;
+    }
+
+    private void insertConcurrently(Collection<GraqlInsert> queries) {
+        List<Future> queryFutures = createQueryFutures(queries);
+        for (Future future : queryFutures) {
             try {
                 future.get();
             } catch (InterruptedException e) {

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -135,11 +135,11 @@ public class AttributeUniquenessIT {
         tx.commit();
 
         tx = session.writeTransaction();
-        GraqlInsert keyQuery = Graql.parse("insert $x \"Marco\" isa name;").asInsert();
-        tx.execute(keyQuery);
+        tx.execute(Graql.parse("insert $x \"Marco\" isa name;").asInsert());
         tx.commit();
 
         //Try to insert 2 persons with same name, both txs should fail
+        GraqlInsert keyQuery = Graql.parse("insert $x isa person, has name \"Marco\";").asInsert();
         expectedException.expect(InvalidKBException.class);
         List<Future> queryFutures = createQueryFutures(Collections.list(keyQuery, keyQuery));
         for (Future future : queryFutures) {


### PR DESCRIPTION
## What is the goal of this PR?
When concurrent Grakn transactions are used, it is possible to insert two instances with the same type and key, which violates key uniqueness. We ensure uniqueness by doing graph validation after attribute merge and locking on commit if key relations are present within the transaction.

## What are the changes implemented in this PR?
Fixes #5481;
- move graph validation immediately before the internal graph commit
- lock graph when adding new key implicit relations
