### PR TITLE
Fix output filenames in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ You can visit the [Setup Guide](https://dev.grakn.ai/docs/running-grakn/install-
 ```
 $ bazel build //:assemble-linux-targz
 ```
-Outputs to: `bazel-genfiles/grakn-core-all-linux.tar.gz`
+Outputs to: `bazel-bin/grakn-core-all-linux.tar.gz`
 ```
 $ bazel build //:assemble-mac-zip
 ```
-Outputs to: `bazel-genfiles/grakn-core-all-mac.zip`
+Outputs to: `bazel-bin/grakn-core-all-mac.zip`
 ```
 $ bazel build //:assemble-windows-zip
 ```
-Outputs to: `bazel-genfiles/grakn-core-all-windows.zip`
+Outputs to: `bazel-bin/grakn-core-all-windows.zip`
 
 ## Contributions
 


### PR DESCRIPTION
## What is the goal of this PR?

Keep `README.md` up-to-date

## What are the changes implemented in this PR?

Replace `bazel-genfiles` with `bazel-bin` since this is the current directory to output files into