### PR TITLE
remove input native port

### DIFF
--- a/common/config/ConfigKey.java
+++ b/common/config/ConfigKey.java
@@ -57,7 +57,6 @@ public class ConfigKey<T> {
     public static final ConfigKey<String> STORAGE_BACKEND = key("storage.backend", STRING);
     public static final ConfigKey<Integer> STORAGE_PORT = key("storage.port", INT);
     public static final ConfigKey<Integer> HADOOP_STORAGE_PORT = key("janusgraphmr.ioformat.conf.storage.port", INT);
-    public static final ConfigKey<Integer> STORAGE_CQL_NATIVE_PORT = key("cassandra.input.native.port", INT);
     public static final ConfigKey<String> STORAGE_KEYSPACE = key("storage.cql.keyspace", STRING);
 
     public static final ConfigKey<Long> TYPE_SHARD_THRESHOLD = key("knowledge-base.type-shard-threshold", LONG);

--- a/graph-hadoop/BUILD
+++ b/graph-hadoop/BUILD
@@ -29,6 +29,7 @@ java_library(
         # Internal dependencies
         "//graph",
         "//graph-cql",
+        "//common",
         # External dependencies from @graknlabs
 
         # External dependencies from Maven

--- a/graph-hadoop/config/JanusGraphHadoopConfiguration.java
+++ b/graph-hadoop/config/JanusGraphHadoopConfiguration.java
@@ -27,24 +27,6 @@ public class JanusGraphHadoopConfiguration {
     public static final ConfigNamespace MAPRED_NS =
             new ConfigNamespace(null, "janusgraphmr", "JanusGraph MapReduce configuration root");
 
-    // ScanJob configuration
-
-    public static final ConfigNamespace SCAN_NS =
-            new ConfigNamespace(MAPRED_NS, "scanjob", "ScanJob configuration");
-
-    public static final ConfigOption<String> SCAN_JOB_CONFIG_ROOT =
-            new ConfigOption<>(SCAN_NS, "conf-root",
-                    "A string in the form \"PACKAGE.CLASS#STATICFIELD\" representing the config namespace root to use for the ScanJob",
-                    ConfigOption.Type.LOCAL, String.class);
-
-    public static final ConfigNamespace SCAN_JOB_CONFIG_KEYS =
-            new ConfigNamespace(SCAN_NS, "conf", "ScanJob configuration");
-
-    public static final ConfigOption<String> SCAN_JOB_CLASS =
-            new ConfigOption<>(SCAN_NS, "class",
-                    "A string in the form \"PACKAGE.CLASS\" representing the ScanJob to use.  Must have a no-arg constructor.",
-                    ConfigOption.Type.LOCAL, String.class);
-
     // JanusGraph Hadoop I/O format configuration
 
     public static final ConfigNamespace IOFORMAT_NS =

--- a/graph-hadoop/formats/cql/GraknInputFormat.java
+++ b/graph-hadoop/formats/cql/GraknInputFormat.java
@@ -68,6 +68,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static grakn.core.common.config.ConfigKey.STORAGE_PORT;
 import static java.util.stream.Collectors.toMap;
 
 /**
@@ -94,7 +95,6 @@ import static java.util.stream.Collectors.toMap;
 
 public class GraknInputFormat extends org.apache.hadoop.mapreduce.InputFormat<Long, Row> implements org.apache.hadoop.mapred.InputFormat<Long, Row> {
     public static final String MAPRED_TASK_ID = "mapred.task.id";
-    private static final String INPUT_NATIVE_PORT = "cassandra.input.native.port";
     private static final Logger LOG = LoggerFactory.getLogger(CqlInputFormat.class);
 
     private String keyspace;
@@ -288,7 +288,7 @@ public class GraknInputFormat extends org.apache.hadoop.mapreduce.InputFormat<Lo
     }
 
     private static int getInputNativePort(Configuration conf) {
-        return Integer.parseInt(conf.get(INPUT_NATIVE_PORT, "9042"));
+        return Integer.parseInt(conf.get(STORAGE_PORT.name(), "9042"));
     }
 
 

--- a/graph-hadoop/formats/util/input/JanusGraphHadoopSetupImpl.java
+++ b/graph-hadoop/formats/util/input/JanusGraphHadoopSetupImpl.java
@@ -51,11 +51,11 @@ public class JanusGraphHadoopSetupImpl implements JanusGraphHadoopSetup {
     private final StandardJanusGraph graph;
     private final StandardJanusGraphTx tx;
 
-    public JanusGraphHadoopSetupImpl(final Configuration config) {
+    public JanusGraphHadoopSetupImpl(Configuration config) {
         scanConf = ModifiableHadoopConfiguration.of(JanusGraphHadoopConfiguration.MAPRED_NS, config);
         BasicConfiguration bc = scanConf.getJanusGraphConf();
-        graph = (StandardJanusGraph) JanusGraphFactory.open(bc);
-        tx = (StandardJanusGraphTx)graph.buildTransaction().readOnly().vertexCacheSize(200).start();
+        graph = JanusGraphFactory.open(bc);
+        tx = graph.buildTransaction().readOnly().vertexCacheSize(200).start();
     }
 
     @Override

--- a/server/ServerFactory.java
+++ b/server/ServerFactory.java
@@ -66,11 +66,11 @@ public class ServerFactory {
         // locks
         LockManager lockManager = new LockManager();
 
-        Integer cqlPort = config.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT);
+        Integer storagePort = config.getProperty(ConfigKey.STORAGE_PORT);
         String storageHostname = config.getProperty(ConfigKey.STORAGE_HOSTNAME);
         // CQL cluster used by KeyspaceManager to fetch all existing keyspaces
         CqlSession cqlSession = CqlSession.builder()
-                .addContactPoint(new InetSocketAddress(storageHostname, cqlPort))
+                .addContactPoint(new InetSocketAddress(storageHostname, storagePort))
                 .withLocalDatacenter("datacenter1")
                 .build();
 
@@ -108,26 +108,26 @@ public class ServerFactory {
     /**
      * Build a GrpcServer using the Netty default builder.
      * The Netty builder accepts 3 thread executors (threadpools):
-     *  - Boss Event Loop Group  (a.k.a. bossEventLoopGroup() )
-     *  - Worker Event Loop Group ( a.k.a. workerEventLoopGroup() )
-     *  - Application Executor (a.k.a. executor() )
-     *
+     * - Boss Event Loop Group  (a.k.a. bossEventLoopGroup() )
+     * - Worker Event Loop Group ( a.k.a. workerEventLoopGroup() )
+     * - Application Executor (a.k.a. executor() )
+     * <p>
      * The Boss group can be the same as the worker group.
      * It's purpose is to accept calls from the network, and create Netty channels (not gRPC Channels) to handle the socket.
-     *
+     * <p>
      * Once the Netty channel has been created it gets passes to the Worker Event Loop Group.
      * This is the threadpool dedicating to doing socket read() and write() calls.
-     *
+     * <p>
      * The last thread group is the application executor, also called the "app thread".
      * This is where the gRPC stubs do their main work.
      * It is for handling the callbacks that bubble up from the network thread.
-     *
+     * <p>
      * Note from grpc-java developers:
      * Most people should use either reuse the same boss event loop group as the worker group.
      * Barring this, the boss eventloop group should be a single thread, since it does very little work.
      * For the app thread, users should provide a fixed size thread pool, as the default unbounded cached threadpool
      * is not the most efficient, and can be dangerous in some circumstances.
-     *
+     * <p>
      * More info here: https://groups.google.com/d/msg/grpc-io/LrnAbWFozb0/VYCVarkWBQAJ
      */
     private static io.grpc.Server createServerRPC(Config config, SessionFactory sessionFactory, KeyspaceManager keyspaceManager, JanusGraphFactory janusGraphFactory) {

--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -58,9 +58,6 @@ log.level=INFO
 storage.hostname=127.0.0.1
 storage.port=9042
 
-#Port used by KeyspaceManager
-cassandra.input.native.port=9042
-
 # Timeout in milliseconds when connecting to storage backend
 storage.connection-timeout=20000
 

--- a/server/rpc/KeyspaceRequestsHandler.java
+++ b/server/rpc/KeyspaceRequestsHandler.java
@@ -20,6 +20,11 @@ package grakn.core.server.rpc;
 
 import grakn.protocol.keyspace.KeyspaceProto;
 
+
+/**
+ * This interface has 2 different implementations in Grakn Core and Grakn KGMS
+ * It is used to handle retrieve and delete keyspace requests.
+ */
 public interface KeyspaceRequestsHandler {
 
     Iterable<String> retrieve(KeyspaceProto.Keyspace.Retrieve.Req request);

--- a/server/session/HadoopGraphFactory.java
+++ b/server/session/HadoopGraphFactory.java
@@ -47,6 +47,13 @@ public class HadoopGraphFactory {
     private static final String STORAGE_HOSTNAME = ConfigKey.STORAGE_HOSTNAME.name();
     // Keep visibility to protected as this is used by KGMS
     protected static final String STORAGE_KEYSPACE = ConfigKey.STORAGE_KEYSPACE.name();
+
+    //NOTE: In JanusGraphHadoopConfiguration class there is the definition of this prefix (MAPRED_NS)
+    // which is used to prefix all the properties that will be passed to OLAP operations
+    // The prefix is there so that one can connect to different backends for OLTP and OLAP operations
+    // using different authentication methods and so on. This might be too generic for Grakn usecase,
+    // in the future might be worth to just remove this prefix and let all the configs be the same.
+
     // Keep visibility to protected as this is used by KGMS
     protected static final String JANUSGRAPHMR_IOFORMAT_CONF = "janusgraphmr.ioformat.conf.";
 

--- a/server/session/JanusGraphFactory.java
+++ b/server/session/JanusGraphFactory.java
@@ -55,18 +55,12 @@ import static java.util.Arrays.stream;
 final public class JanusGraphFactory {
     private final static Logger LOG = LoggerFactory.getLogger(JanusGraphFactory.class);
     private static final AtomicBoolean strategiesApplied = new AtomicBoolean(false);
-    private static final String STORAGE_KEYSPACE = ConfigKey.STORAGE_KEYSPACE.name();
-    private static final String STORAGE_BACKEND = ConfigKey.STORAGE_BACKEND.name();
     private static final String CQL_BACKEND = "cql";
 
     private Config config;
 
     public JanusGraphFactory(Config config) {
         this.config = config;
-    }
-
-    public Config config() {
-        return config;
     }
 
     public synchronized StandardJanusGraph openGraph(String keyspace) {
@@ -95,11 +89,10 @@ final public class JanusGraphFactory {
         }
     }
 
-
     private static StandardJanusGraph configureGraph(String keyspace, Config config) {
         grakn.core.graph.core.JanusGraphFactory.Builder builder = grakn.core.graph.core.JanusGraphFactory.build()
-                .set(STORAGE_BACKEND, CQL_BACKEND)
-                .set(STORAGE_KEYSPACE, keyspace);
+                .set(ConfigKey.STORAGE_BACKEND.name(), CQL_BACKEND)
+                .set(ConfigKey.STORAGE_KEYSPACE.name(), keyspace);
 
         //Load Passed in properties
         config.properties().forEach((key, value) -> {

--- a/test-integration/rule/GraknTestServer.java
+++ b/test-integration/rule/GraknTestServer.java
@@ -80,8 +80,6 @@ public class GraknTestServer extends ExternalResource {
     protected File updatedCassandraConfigPath;
     protected int storagePort;
     protected int nativeTransportPort;
-    protected int thriftPort;
-
 
     public GraknTestServer() {
         this(DEFAULT_SERVER_CONFIG_PATH, DEFAULT_CASSANDRA_CONFIG_PATH);
@@ -166,7 +164,6 @@ public class GraknTestServer extends ExternalResource {
     protected void generateCassandraRandomPorts() throws IOException {
         storagePort = findUnusedLocalPort();
         nativeTransportPort = findUnusedLocalPort();
-        thriftPort = findUnusedLocalPort();
     }
 
     protected File buildCassandraConfigWithRandomPorts() throws IOException {
@@ -175,7 +172,6 @@ public class GraknTestServer extends ExternalResource {
 
         configString = configString + "\nstorage_port: " + storagePort;
         configString = configString + "\nnative_transport_port: " + nativeTransportPort;
-        configString = configString + "\nrpc_port: " + thriftPort;
         InputStream configStream = new ByteArrayInputStream(configString.getBytes(StandardCharsets.UTF_8));
 
         String directory = "target/embeddedCassandra";
@@ -206,7 +202,6 @@ public class GraknTestServer extends ExternalResource {
 
         //Override ports used by HadoopGraph
         config.setConfigProperty(ConfigKey.HADOOP_STORAGE_PORT, nativeTransportPort);
-        config.setConfigProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT, nativeTransportPort);
 
         return config;
     }
@@ -217,13 +212,14 @@ public class GraknTestServer extends ExternalResource {
         janusGraphFactory = new JanusGraphFactory(serverConfig);
         HadoopGraphFactory hadoopGraphFactory = new HadoopGraphFactory(serverConfig);
 
-        Integer cqlPort = serverConfig.getProperty(ConfigKey.STORAGE_CQL_NATIVE_PORT);
+        Integer storagePort = serverConfig.getProperty(ConfigKey.STORAGE_PORT);
         String storageHostname = serverConfig.getProperty(ConfigKey.STORAGE_HOSTNAME);
         // CQL cluster used by KeyspaceManager to fetch all existing keyspaces
         CqlSession cqlSession = CqlSession.builder()
-                .addContactPoint(new InetSocketAddress(storageHostname, cqlPort))
+                .addContactPoint(new InetSocketAddress(storageHostname, storagePort))
                 .withLocalDatacenter("datacenter1")
                 .build();
+
         keyspaceManager = new KeyspaceManager(cqlSession);
         sessionFactory = new SessionFactory(lockManager, janusGraphFactory, hadoopGraphFactory, serverConfig);
 


### PR DESCRIPTION
## What is the goal of this PR?

As we have migrated to CQL, remove redundant `cassandra.input.native.port` setting and only rely on `storage.port`