### PR TITLE
Dont start Cassandra Thrift server 

### DIFF
--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -266,7 +266,7 @@ public class Storage {
                 "java", "-cp", classpath,
                 "-Dlogback.configurationFile=" + logback,
                 NodeTool.class.getCanonicalName(),
-                "statusthrift"
+                "statusbinary"
         );
     }
 

--- a/server/services/cassandra/cassandra.yaml
+++ b/server/services/cassandra/cassandra.yaml
@@ -425,7 +425,7 @@ native_transport_port: 9042
 # native_transport_max_concurrent_connections_per_ip: -1
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address or interface to bind the Thrift RPC service and native transport
 # server to.

--- a/test-integration/resources/cassandra-embedded.yaml
+++ b/test-integration/resources/cassandra-embedded.yaml
@@ -337,7 +337,7 @@ start_native_transport: true
 # native_transport_max_frame_size_in_mb: 256
 
 # Whether to start the thrift rpc server.
-start_rpc: true
+start_rpc: false
 
 # The address to bind the Thrift RPC service and native transport
 # server -- clients factory here.


### PR DESCRIPTION
## What is the goal of this PR?

As we have moved to only use CQL, we don't need to start the Cassandra Thrift server anymore.

## What are the changes implemented in this PR?

- set to `false` the `start_rpc` setting in `cassandra.yaml`
- use `nodetool statusbinary` instead of `nodetool statusthrift`
