### PR TITLE
Replace unneed Gremlin noop step with a cheaper alternative

### DIFF
--- a/graql/gremlin/fragment/Fragments.java
+++ b/graql/gremlin/fragment/Fragments.java
@@ -199,7 +199,7 @@ public class Fragments {
      * This avoids issues with unchecked varargs.
      */
     static <S, E> GraphTraversal<S, E> union(Iterable<GraphTraversal<? super S, ? extends E>> traversals) {
-        return union(__.identity(), traversals);
+        return union(__.start(), traversals);
     }
 
     /**

--- a/graql/gremlin/fragment/IdFragment.java
+++ b/graql/gremlin/fragment/IdFragment.java
@@ -71,7 +71,7 @@ class IdFragment extends FragmentImpl {
         if (canOperateOnEdges()) {
             return traversal.or(
                     edgeTraversal(),
-                    vertexTraversal(__.identity())
+                    vertexTraversal(__.start())
             );
         } else {
             return vertexTraversal(traversal);
@@ -118,7 +118,7 @@ class IdFragment extends FragmentImpl {
         // if the ID may be for an edge,
         // we must extend the traversal that normally just operates on vertices
         // to operate on both edges and vertices
-        traversal.union(__.identity(), __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()));
+        traversal.union(__.start(), __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()));
     }
 
     @Override

--- a/graql/gremlin/fragment/InIsaFragment.java
+++ b/graql/gremlin/fragment/InIsaFragment.java
@@ -83,13 +83,13 @@ public class InIsaFragment extends EdgeFragment {
                     __.<Vertex>hasLabel(RELATION_TYPE.name()).has(IS_IMPLICIT.name(), true);
 
             GraphTraversal<Vertex, Element> toVertexAndEdgeInstances = Fragments.union(ImmutableSet.of(
-                    toVertexInstances(__.identity()),
+                    toVertexInstances(__.start()),
                     toEdgeInstances()
             ));
 
             return choose(vertexTraversal, isImplicitRelationType,
                     toVertexAndEdgeInstances,
-                    toVertexInstances(__.identity())
+                    toVertexInstances(__.start())
             );
         } else {
             return toVertexInstances(vertexTraversal);

--- a/graql/gremlin/fragment/OutIsaFragment.java
+++ b/graql/gremlin/fragment/OutIsaFragment.java
@@ -62,13 +62,13 @@ public class OutIsaFragment extends EdgeFragment {
 
         // from the traversal, branch to take either of these paths
         return Fragments.union(traversal, ImmutableSet.of(
-                Fragments.isVertex(__.identity()).out(ISA.getLabel()).out(SHARD.getLabel()),
+                Fragments.isVertex(__.start()).out(ISA.getLabel()).out(SHARD.getLabel()),
                 edgeTraversal() // what is this doing?
         ));
     }
 
     private GraphTraversal<Element, Vertex> edgeTraversal() {
-        return Fragments.traverseSchemaConceptFromEdge(Fragments.isEdge(__.identity()), RELATION_TYPE_LABEL_ID);
+        return Fragments.traverseSchemaConceptFromEdge(Fragments.isEdge(__.start()), RELATION_TYPE_LABEL_ID);
     }
 
     @Override

--- a/graql/gremlin/fragment/OutRolePlayerFragment.java
+++ b/graql/gremlin/fragment/OutRolePlayerFragment.java
@@ -107,7 +107,7 @@ public class OutRolePlayerFragment extends AbstractRolePlayerFragment {
     }
 
     private GraphTraversal<Element, Vertex> reifiedRelationTraversal(Transaction tx, Collection<Variable> vars) {
-        GraphTraversal<Element, Vertex> traversal = Fragments.isVertex(__.identity());
+        GraphTraversal<Element, Vertex> traversal = Fragments.isVertex(__.start());
 
         GraphTraversal<Element, Edge> edgeTraversal = traversal.outE(ROLE_PLAYER.getLabel()).as(edge().symbol());
 
@@ -123,7 +123,7 @@ public class OutRolePlayerFragment extends AbstractRolePlayerFragment {
     private GraphTraversal<Element, Vertex> edgeRelationTraversal(
             Transaction tx, Direction direction, Schema.EdgeProperty roleProperty, Collection<Variable> vars) {
 
-        GraphTraversal<Element, Edge> edgeTraversal = Fragments.isEdge(__.identity());
+        GraphTraversal<Element, Edge> edgeTraversal = Fragments.isEdge(__.start());
 
         // Filter by any provided type labels
         applyLabelsToTraversal(edgeTraversal, roleProperty, roleLabels(), tx);


### PR DESCRIPTION
## What is the goal of this PR?
A minor but free performance enhancement for `read` queries, in which we often have `__.identity()` steps in the traversal. These are redundant (documented no-op in janus) and were generated by our need to create anonymous traversals that could be joined to existing ones. Instead, we can use `__.start()` to obtain a new traversal. Since the `identity()` method actually iterates over all elements in the traversal (it appears, because it takes non-zero time) we want to avoid it.

## What are the changes implemented in this PR?
* Replace `__.identity()` noop with `__.start()`, an even cheaper anonymous traversal