### PR TITLE
get rid of automatic tx inside JanusGraph

### DIFF
--- a/graph/core/JanusGraph.java
+++ b/graph/core/JanusGraph.java
@@ -19,74 +19,8 @@
 package grakn.core.graph.core;
 
 import grakn.core.graph.core.schema.JanusGraphManagement;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 
-/**
- * JanusGraph graph database implementation of the Blueprint's interface.
- * Use {@link JanusGraphFactory} to open and configure JanusGraph instances.
- */
-@Graph.OptIn(Graph.OptIn.SUITE_STRUCTURE_STANDARD)
-@Graph.OptIn(Graph.OptIn.SUITE_PROCESS_STANDARD)
-@Graph.OptIn(Graph.OptIn.SUITE_PROCESS_COMPUTER)
-//------------------------
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.structure.VertexPropertyTest$VertexPropertyAddition",
-        method = "shouldHandleSetVertexProperties",
-        reason = "JanusGraph can only handle SET cardinality for properties when defined in the schema.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest",
-        method = "shouldOnlyAllowReadingVertexPropertiesInMapReduce",
-        reason = "JanusGraph simply throws the wrong exception -- should not be a ReadOnly transaction exception but a specific one for MapReduce. This is too cumbersome to refactor in JanusGraph.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest",
-        method = "shouldProcessResultGraphNewWithPersistVertexProperties",
-        reason = "The result graph should return an empty iterator when vertex.edges() or vertex.vertices() is called.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphMLTest",
-        method = "shouldReadGraphMLWithNoEdgeLabels",
-        reason = "JanusGraph does not support default edge label (edge) used when GraphML is missing edge labels.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.structure.io.IoTest$GraphMLTest",
-        method = "shouldReadGraphMLWithoutEdgeIds",
-        reason = "JanusGraph does not support default edge label (edge) used when GraphML is missing edge ids.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.computer.GraphComputerTest",
-        method = "shouldSupportGraphFilter",
-        reason = "JanusGraph test graph computer (FulgoraGraphComputer) " +
-                "currently does not support graph filters but does not throw proper exception because doing so breaks numerous " +
-                "tests in gremlin-test ProcessComputerSuite.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.computer.search.path.ShortestPathVertexProgramTest",
-        method = "*",
-        reason = "ShortestPathVertexProgram currently has two bugs that prevent us from using it correctly. See " +
-                "https://issues.apache.org/jira/browse/TINKERPOP-2187 for more information.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ShortestPathTest$Traversals",
-        method = "*",
-        reason = "ShortestPathVertexProgram currently has two bugs that prevent us from using it correctly. See " +
-                "https://issues.apache.org/jira/browse/TINKERPOP-2187 for more information.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ConnectedComponentTest",
-        method = "g_V_hasLabelXsoftwareX_connectedComponent_project_byXnameX_byXcomponentX",
-        reason = "The test assumes that a certain vertex has always the lowest id which is not the case for " +
-                "JanusGraph. See https://issues.apache.org/jira/browse/TINKERPOP-2189 for more information.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ConnectedComponentTest",
-        method = "g_V_connectedComponent_withXEDGES_bothEXknowsXX_withXPROPERTY_NAME_clusterX_project_byXnameX_byXclusterX",
-        reason = "The test assumes that a certain vertex has always the lowest id which is not the case for " +
-                "JanusGraph. See https://issues.apache.org/jira/browse/TINKERPOP-2189 for more information.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.branch.RepeatTest",
-        method = "g_VX3X_repeatXbothX_createdXX_untilXloops_is_40XXemit_repeatXin_knowsXX_emit_loopsXisX1Xdedup_values",
-        reason = "The test assumes that a certain vertex has always the lowest id which is not the case for " +
-                "JanusGraph. See https://issues.apache.org/jira/browse/TINKERPOP-2189 for more information.")
-@Graph.OptOut(
-        test = "org.apache.tinkerpop.gremlin.process.traversal.step.map.ConnectedComponentTest",
-        method = "g_V_dedup_connectedComponent_hasXcomponentX",
-        reason = "The test involves serializing and deserializing of vertices, especially of CacheVertex. This class" +
-                "is however not serializable and it is non-trivial to enable serialization as the class is tied to a" +
-                "transaction. See #1519 for more information.")
-public interface JanusGraph extends Graph {
+public interface JanusGraph {
 
     /* ---------------------------------------------------------------
      * Transactions and general admin
@@ -149,6 +83,5 @@ public interface JanusGraph extends Graph {
      *
      * @throws JanusGraphException if closing the graph database caused errors in the storage backend
      */
-    @Override
     void close() throws JanusGraphException;
 }

--- a/graph/core/JanusGraph.java
+++ b/graph/core/JanusGraph.java
@@ -20,7 +20,7 @@ package grakn.core.graph.core;
 
 import grakn.core.graph.core.schema.JanusGraphManagement;
 
-public interface JanusGraph {
+public interface JanusGraph extends AutoCloseable{
 
     /* ---------------------------------------------------------------
      * Transactions and general admin

--- a/graph/graphdb/database/StandardJanusGraph.java
+++ b/graph/graphdb/database/StandardJanusGraph.java
@@ -125,7 +125,6 @@ public class StandardJanusGraph implements JanusGraph {
                 );
 
         //Register with cache
-        TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraph.class, graphStrategies);
         TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraphTx.class, graphStrategies);
     }
 

--- a/graph/graphdb/database/StandardJanusGraph.java
+++ b/graph/graphdb/database/StandardJanusGraph.java
@@ -85,16 +85,9 @@ import grakn.core.graph.graphdb.types.MixedIndexType;
 import grakn.core.graph.graphdb.types.system.BaseKey;
 import grakn.core.graph.graphdb.types.system.BaseRelationType;
 import grakn.core.graph.graphdb.types.vertices.JanusGraphSchemaVertex;
-import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
-import org.apache.tinkerpop.gremlin.structure.Vertex;
-import org.apache.tinkerpop.gremlin.structure.io.Io;
-import org.apache.tinkerpop.gremlin.structure.util.AbstractThreadLocalTransaction;
-import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,7 +97,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -112,7 +104,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -127,8 +118,11 @@ public class StandardJanusGraph implements JanusGraph {
 
     static {
         TraversalStrategies graphStrategies = TraversalStrategies.GlobalCache.getStrategies(Graph.class).clone()
-                .addStrategies(AdjacentVertexFilterOptimizerStrategy.instance(),
-                        JanusGraphLocalQueryOptimizerStrategy.instance(), JanusGraphStepStrategy.instance());
+                .addStrategies(
+                        AdjacentVertexFilterOptimizerStrategy.instance(),
+                        JanusGraphLocalQueryOptimizerStrategy.instance(),
+                        JanusGraphStepStrategy.instance()
+                );
 
         //Register with cache
         TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraph.class, graphStrategies);
@@ -158,8 +152,6 @@ public class StandardJanusGraph implements JanusGraph {
     private final AtomicLong txCounter; // used to generate unique transaction IDs
 
     private final Set<StandardJanusGraphTx> openTransactions;
-
-    private final AutomaticLocalTinkerTransaction tinkerTransaction = new AutomaticLocalTinkerTransaction();
 
     public StandardJanusGraph(GraphDatabaseConfiguration configuration, Backend backend) {
 
@@ -196,155 +188,13 @@ public class StandardJanusGraph implements JanusGraph {
         managementLog.registerReader(ReadMarker.fromNow(), this.managementLogger);
     }
 
-    // Get JanusTransaction which is wrapped inside the TinkerTransaction
-    // it opens the JanusTransaction if not initialised yet
-    private StandardJanusGraphTx getLocalJanusTransaction() {
-        if (!tinkerTransaction.isOpen()) {
-            tinkerTransaction.readWrite(); // creates a new JanusGraphTransaction internally (inside AutomaticLocalTinkerTransaction)
-        }
-        StandardJanusGraphTx tx = tinkerTransaction.getJanusTransaction();
-        Preconditions.checkNotNull(tx, "Invalid read-write behavior configured: Should either open transaction or throw exception.");
-        return tx;
-    }
-
-    //This returns the JanusTransaction contained inside tinkerTransaction -> it opens/creates a new one if the previous one is closed!
-    public JanusGraphTransaction getCurrentThreadTx() {
-        return getLocalJanusTransaction();
-    }
-
-    @Override
-    public Transaction tx() {
-        return tinkerTransaction;
-    }
-
     @Override
     public String toString() {
-        return StringFactory.graphString(this, backend.getStoreManager().getName());
+        return "StandardJanusGraph[" + backend.getStoreManager().getName() + "]";
     }
 
-    @Override
     public org.apache.commons.configuration.Configuration configuration() {
         return getConfiguration().getConfigurationAtOpen();
-    }
-
-    @Override
-    public <I extends Io> I io(Io.Builder<I> builder) {
-        return null;
-    }
-
-    @Override
-    public Variables variables() {
-        return null;
-    }
-
-    @Override
-    public <C extends GraphComputer> C compute(Class<C> graphComputerClass) throws IllegalArgumentException {
-        return null; //TODO, yeah...
-    }
-
-    // ########## TRANSACTIONAL FORWARDING ###########################
-
-    @Override
-    public JanusGraphVertex addVertex(Object... keyValues) {
-        return getLocalJanusTransaction().addVertex(keyValues);
-    }
-
-    @Override
-    public Iterator<Vertex> vertices(Object... vertexIds) {
-        return getLocalJanusTransaction().vertices(vertexIds);
-    }
-
-    @Override
-    public Iterator<Edge> edges(Object... edgeIds) {
-        return getLocalJanusTransaction().edges(edgeIds);
-    }
-
-    @Override
-    public GraphComputer compute() throws IllegalArgumentException {
-        return null; // TODO possibly think about this in the future.
-    }
-
-    @Override
-    public JanusGraphVertex addVertex(String vertexLabel) {
-        return getLocalJanusTransaction().addVertex(vertexLabel);
-    }
-
-    // Tinkerpop wrapper around StandardJanusGraph transaction, automatic transaction used by the graph
-    // when user cannot be bother to use manual/explicit transactions,
-    // i.e. when user wants to do graph.addVertex(); graph.tx().commit();
-    // rather than tx = graph.newTransaction(); tx.addVertex(); tx.commit();
-    // This wrapper internally uses the thread-local Janusgraph transaction.
-
-    //This transaction is AUTOmatic in so that it does not need to be explicitly open -> it will invoke readWrite which triggers tx.open() if not open yet
-    // It is also automatic because it is possible to invoke tx.close() directly without first explicitly invoking commit or rollback,
-    // when invoking close directly, the tx will internally trigger tx.rollback.
-    // Also this is public just so that we can use it in tests
-    public class AutomaticLocalTinkerTransaction extends AbstractThreadLocalTransaction {
-
-        private ThreadLocal<StandardJanusGraphTx> localJanusTransaction = ThreadLocal.withInitial(() -> null);
-
-        AutomaticLocalTinkerTransaction() {
-            super(StandardJanusGraph.this);
-        }
-
-        public StandardJanusGraphTx getJanusTransaction() {
-            return localJanusTransaction.get();
-        }
-
-        @Override
-        public void doOpen() {
-            StandardJanusGraphTx tx = localJanusTransaction.get();
-            if (tx != null && tx.isOpen()) throw Transaction.Exceptions.transactionAlreadyOpen();
-            tx = newThreadBoundTransaction();
-            localJanusTransaction.set(tx);
-        }
-
-        @Override
-        public void doCommit() {
-            localJanusTransaction.get().commit();
-        }
-
-        @Override
-        public void doRollback() {
-            localJanusTransaction.get().rollback();
-        }
-
-        @Override
-        public JanusGraphTransaction createThreadedTx() {
-            return newTransaction();
-        }
-
-        @Override
-        public boolean isOpen() {
-            if (StandardJanusGraph.this.isClosed()) {
-                // Graph has been closed
-                return false;
-            }
-            StandardJanusGraphTx tx = localJanusTransaction.get();
-            return tx != null && tx.isOpen();
-        }
-
-        @Override
-        protected void doClose() {
-            super.doClose();
-            transactionListeners.remove();
-            localJanusTransaction.remove();
-        }
-
-        @Override
-        public Transaction onReadWrite(Consumer<Transaction> transactionConsumer) {
-            if (StandardJanusGraph.this.isClosed()) { //cannot start a transaction if the enclosing graph is closed
-                throw new IllegalStateException("Graph has been closed");
-            }
-            Preconditions.checkArgument(transactionConsumer instanceof READ_WRITE_BEHAVIOR, "Only READ_WRITE_BEHAVIOR instances are accepted argument, got: %s", transactionConsumer);
-            return super.onReadWrite(transactionConsumer);
-        }
-
-        @Override
-        public Transaction onClose(Consumer<Transaction> transactionConsumer) {
-            Preconditions.checkArgument(transactionConsumer instanceof CLOSE_BEHAVIOR, "Only CLOSE_BEHAVIOR instances are accepted argument, got: %s", transactionConsumer);
-            return super.onClose(transactionConsumer);
-        }
     }
 
     @Override
@@ -384,7 +234,6 @@ public class StandardJanusGraph implements JanusGraph {
                     txCloseExceptions.put(otx, e);
                 }
             }
-            tinkerTransaction.close();
             idAssigner.close();
             backend.close();
         } finally {
@@ -403,8 +252,7 @@ public class StandardJanusGraph implements JanusGraph {
 
     // ################### Simple Getters #########################
 
-    @Override
-    public Features features() {
+    public Graph.Features features() {
         return JanusGraphFeatures.getFeatures(this, backend.getStoreFeatures());
     }
 

--- a/graph/graphdb/internal/Token.java
+++ b/graph/graphdb/internal/Token.java
@@ -27,7 +27,6 @@ public class Token {
     public static final char SEPARATOR_CHAR = 0x1e;
 
     public static final String systemETprefix = Graph.Hidden.hide("T$");
-    public static final String NON_EXISTANT_TYPE = systemETprefix + "doesNotExist";
 
     public static String getSeparatedName(String... components) {
         for (String component : components) verifyName(component);

--- a/graph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
+++ b/graph/graphdb/tinkerpop/optimize/JanusGraphTraversalUtil.java
@@ -97,17 +97,11 @@ public class JanusGraphTraversalUtil {
         Graph graph = optGraph.get();
         if (graph instanceof JanusGraphTransaction) {
             tx = (JanusGraphTransaction) graph;
-        } else if (graph instanceof StandardJanusGraph) {
-            tx = ((StandardJanusGraph) graph).getCurrentThreadTx();
         } else {
             throw new IllegalArgumentException("Traversal is not bound to a JanusGraph Graph, but: " + graph);
         }
 
-        if (tx == null) {
-            throw new IllegalArgumentException("Not a valid start step for a JanusGraph traversal: " + traversal);
-        }
-        if (tx.isOpen()) return tx;
-        else return ((StandardJanusGraphTx) tx).getNextTx();
+        return tx;
     }
 
     /**

--- a/graph/graphdb/transaction/StandardJanusGraphTx.java
+++ b/graph/graphdb/transaction/StandardJanusGraphTx.java
@@ -121,13 +121,11 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.structure.Direction;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.structure.Property;
 import org.apache.tinkerpop.gremlin.structure.T;
 import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.io.Io;
-import org.apache.tinkerpop.gremlin.structure.util.AbstractThreadedTransaction;
 import org.apache.tinkerpop.gremlin.structure.util.ElementHelper;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
 import org.slf4j.Logger;
@@ -321,19 +319,17 @@ public class StandardJanusGraphTx implements JanusGraphTransaction, TypeInspecto
 
     @Override
     public <I extends Io> I io(Io.Builder<I> builder) {
-        return getGraph().io(builder);
+        return null; // Not used
     }
 
     @Override
     public <C extends GraphComputer> C compute(Class<C> graphComputerClass) throws IllegalArgumentException {
-        StandardJanusGraph graph = getGraph();
-        if (isOpen()) commit();
-        return graph.compute(graphComputerClass);
+        return null; // This is only implemented in HadoopGraph
     }
 
     @Override
     public GraphComputer compute() throws IllegalArgumentException {
-        return null; // TODO think about this at some point in the future.
+        return null; // This is only implemented in HadoopGraph
     }
 
     /**
@@ -457,15 +453,6 @@ public class StandardJanusGraphTx implements JanusGraphTransaction, TypeInspecto
     /*
      * ------------------------------------ External Access ------------------------------------
      */
-
-    public StandardJanusGraphTx getNextTx() {
-        Preconditions.checkArgument(isClosed());
-        if (!config.isThreadBound()) {
-            throw new IllegalStateException("Cannot access element because its enclosing transaction is closed and unbound");
-        } else {
-            return (StandardJanusGraphTx) graph.getCurrentThreadTx();
-        }
-    }
 
     public TransactionConfiguration getConfiguration() {
         return config;

--- a/graph/graphdb/vertices/AbstractVertex.java
+++ b/graph/graphdb/vertices/AbstractVertex.java
@@ -55,17 +55,21 @@ public abstract class AbstractVertex extends AbstractElement implements Internal
 
     @Override
     public final InternalVertex it() {
-        if (tx.isOpen()) {
-            return this;
-        }
-        InternalVertex next = (InternalVertex) tx.getNextTx().getVertex(longId());
-        if (next == null) throw InvalidElementException.removedException(this);
-        else return next;
+        return this;
+        //The logic in Janus used to be the following:
+//        if (tx.isOpen()) {
+//            return this;
+//        }
+//        InternalVertex next = (InternalVertex) tx.getNextTx().getVertex(longId());
+//        if (next == null) throw InvalidElementException.removedException(this);
+//        else return next;
+
+        // But we have deleted the tx.getNextTx() method to make everything look less magical.
     }
 
     @Override
     public final StandardJanusGraphTx tx() {
-        return tx.isOpen() ? tx : tx.getNextTx();
+        return tx; //See comment above, original code: tx.isOpen() ? tx : tx.getNextTx();
     }
 
     public final boolean isTxOpen() {

--- a/graql/analytics/CommonOLAP.java
+++ b/graql/analytics/CommonOLAP.java
@@ -57,7 +57,7 @@ public abstract class CommonOLAP {
      *
      * @param configuration the apache config object that will be propagated
      */
-    public void storeState(final Configuration configuration) {
+    public void storeState(Configuration configuration) {
         // clear properties from vertex program
         Set<String> oldKeys = new HashSet<>();
         configuration.subset(PREFIX_SELECTED_TYPE_KEY).getKeys()
@@ -80,7 +80,7 @@ public abstract class CommonOLAP {
      * @param graph         the tinker graph
      * @param configuration the apache config object containing the values
      */
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(Graph graph, Configuration configuration) {
         // load selected types
         configuration.subset(PREFIX_SELECTED_TYPE_KEY).getKeys().forEachRemaining(key ->
                 selectedTypes.add((LabelId) configuration.getProperty(PREFIX_SELECTED_TYPE_KEY + "." + key)));

--- a/graql/analytics/DegreeVertexProgram.java
+++ b/graql/analytics/DegreeVertexProgram.java
@@ -63,7 +63,7 @@ public class DegreeVertexProgram extends GraknVertexProgram<Long> {
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(Graph graph, Configuration configuration) {
         super.loadState(graph, configuration);
         configuration.subset(OF_LABELS).getKeys().forEachRemaining(key ->
                 ofLabelIds.add((LabelId) configuration.getProperty(OF_LABELS + "." + key)));
@@ -75,13 +75,13 @@ public class DegreeVertexProgram extends GraknVertexProgram<Long> {
     }
 
     @Override
-    public Set<MessageScope> getMessageScopes(final Memory memory) {
+    public Set<MessageScope> getMessageScopes(Memory memory) {
         return memory.isInitialIteration() ?
                 Sets.newHashSet(messageScopeResourceIn, messageScopeOut) : Collections.emptySet();
     }
 
     @Override
-    public void safeExecute(final Vertex vertex, Messenger<Long> messenger, final Memory memory) {
+    public void safeExecute(Vertex vertex, Messenger<Long> messenger, Memory memory) {
         switch (memory.getIteration()) {
             case 0:
                 degreeMessagePassing(messenger);
@@ -95,7 +95,7 @@ public class DegreeVertexProgram extends GraknVertexProgram<Long> {
     }
 
     @Override
-    public boolean terminate(final Memory memory) {
+    public boolean terminate(Memory memory) {
         LOGGER.debug("Finished Degree Iteration " + memory.getIteration());
         return memory.getIteration() == 1;
     }

--- a/graql/analytics/GraknVertexProgram.java
+++ b/graql/analytics/GraknVertexProgram.java
@@ -57,12 +57,12 @@ public abstract class GraknVertexProgram<T> extends CommonOLAP implements Vertex
             () -> __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel()));
 
     @Override
-    public Set<MessageScope> getMessageScopes(final Memory memory) {
+    public Set<MessageScope> getMessageScopes(Memory memory) {
         return messageScopeSetInAndOut;
     }
 
     @Override
-    public void storeState(final Configuration configuration) {
+    public void storeState(Configuration configuration) {
         super.storeState(configuration);
 
         // store class name for reflection on spark executor
@@ -70,7 +70,7 @@ public abstract class GraknVertexProgram<T> extends CommonOLAP implements Vertex
     }
 
     @Override
-    public void setup(final Memory memory) {
+    public void setup(Memory memory) {
     }
 
     @Override
@@ -106,7 +106,7 @@ public abstract class GraknVertexProgram<T> extends CommonOLAP implements Vertex
     public GraknVertexProgram<T> clone() {
         try {
             return (GraknVertexProgram) super.clone();
-        } catch (final CloneNotSupportedException e) {
+        } catch (CloneNotSupportedException e) {
             throw GraknServerException.unreachableStatement(e);
         }
     }

--- a/graql/analytics/MedianVertexProgram.java
+++ b/graql/analytics/MedianVertexProgram.java
@@ -131,7 +131,7 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(Graph graph, Configuration configuration) {
         super.loadState(graph, configuration);
         configuration.subset(RESOURCE_TYPE).getKeys().forEachRemaining(key ->
                 statisticsResourceLabelIds.add((LabelId) configuration.getProperty(RESOURCE_TYPE + "." + key)));

--- a/graql/analytics/StatisticsMapReduce.java
+++ b/graql/analytics/StatisticsMapReduce.java
@@ -37,9 +37,7 @@ public abstract class StatisticsMapReduce<T> extends GraknMapReduce<T> {
 
     String degreePropertyKey;
 
-    StatisticsMapReduce() {
-
-    }
+    StatisticsMapReduce() {}
 
     StatisticsMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
         super(selectedLabelIds, resourceDataType);
@@ -48,7 +46,7 @@ public abstract class StatisticsMapReduce<T> extends GraknMapReduce<T> {
     }
 
     @Override
-    public void loadState(final Graph graph, final Configuration configuration) {
+    public void loadState(Graph graph, Configuration configuration) {
         super.loadState(graph, configuration);
         degreePropertyKey = (String) persistentProperties.get(DegreeVertexProgram.DEGREE);
     }

--- a/server/session/JanusGraphFactory.java
+++ b/server/session/JanusGraphFactory.java
@@ -63,7 +63,7 @@ final public class JanusGraphFactory {
         this.config = config;
     }
 
-    public synchronized StandardJanusGraph openGraph(String keyspace) {
+    public StandardJanusGraph openGraph(String keyspace) {
         StandardJanusGraph janusGraph = configureGraph(keyspace, config);
         buildJanusIndexes(janusGraph);
         if (!strategiesApplied.getAndSet(true)) {

--- a/server/session/JanusGraphFactory.java
+++ b/server/session/JanusGraphFactory.java
@@ -67,11 +67,10 @@ final public class JanusGraphFactory {
         StandardJanusGraph janusGraph = configureGraph(keyspace, config);
         buildJanusIndexes(janusGraph);
         if (!strategiesApplied.getAndSet(true)) {
-            TraversalStrategies strategies = TraversalStrategies.GlobalCache.getStrategies(StandardJanusGraph.class);
+            TraversalStrategies strategies = TraversalStrategies.GlobalCache.getStrategies(StandardJanusGraphTx.class);
             strategies = strategies.clone().addStrategies(new JanusPreviousPropertyStepStrategy());
             //TODO: find out why Tinkerpop added these strategies. They result in many NoOpBarrier steps which slowed down our queries so we had to remove them.
             strategies.removeStrategies(PathRetractionStrategy.class, LazyBarrierStrategy.class);
-            TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraph.class, strategies);
             TraversalStrategies.GlobalCache.registerStrategies(StandardJanusGraphTx.class, strategies);
         }
 

--- a/server/session/SessionImpl.java
+++ b/server/session/SessionImpl.java
@@ -99,7 +99,6 @@ public class SessionImpl implements Session {
         this.keyspace = keyspace;
         this.config = config;
         this.hadoopGraph = hadoopGraph;
-        // Open Janus Graph
         this.graph = graph;
 
         this.keyspaceSchemaCache = keyspaceSchemaCache;

--- a/server/session/TransactionOLTP.java
+++ b/server/session/TransactionOLTP.java
@@ -1095,8 +1095,6 @@ public class TransactionOLTP implements Transaction {
 
     /**
      * Set a new type shard checkpoint for a given label
-     *
-     * @param label
      */
     private void setShardCheckpoint(Label label, long checkpoint) {
         Concept schemaConcept = getSchemaConcept(label);

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -1079,7 +1079,7 @@ public class GraknClientIT {
         graknClient.keyspaces().delete(keyspace.name());
 
         exception.expect(IllegalStateException.class);
-        exception.expectMessage("Graph has been shut down");
+        exception.expectMessage("Operation cannot be executed because the enclosing transaction is closed");
 
         // try to operate on an open tx
         tx.getEntityType("entity");

--- a/test-integration/server/kb/RuleValidationIT.java
+++ b/test-integration/server/kb/RuleValidationIT.java
@@ -21,23 +21,22 @@ package grakn.core.server.kb;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.core.common.exception.ErrorMessage;
-import grakn.core.kb.concept.api.Concept;
-import grakn.core.kb.concept.api.Label;
+import grakn.core.core.Schema;
+import grakn.core.graql.reasoner.rule.InferenceRule;
+import grakn.core.graql.reasoner.rule.RuleUtils;
 import grakn.core.kb.concept.api.AttributeType;
+import grakn.core.kb.concept.api.Concept;
 import grakn.core.kb.concept.api.EntityType;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Role;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.concept.api.Type;
-import grakn.core.graql.reasoner.rule.InferenceRule;
-import grakn.core.graql.reasoner.rule.RuleUtils;
-import grakn.core.core.Schema;
-import grakn.core.rule.GraknTestServer;
-import grakn.core.kb.server.exception.InvalidKBException;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
+import grakn.core.kb.server.exception.InvalidKBException;
+import grakn.core.rule.GraknTestServer;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
-import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -46,6 +45,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertTrue;
 public class RuleValidationIT {
     @org.junit.Rule
     public final ExpectedException expectedException = ExpectedException.none();
-    
+
 
     @ClassRule
     public static final GraknTestServer server = new GraknTestServer();
@@ -71,18 +71,18 @@ public class RuleValidationIT {
     private Session session;
 
     @Before
-    public void setUp(){
+    public void setUp() {
         session = server.sessionWithNewKeyspace();
     }
 
     @After
-    public void tearDown(){
+    public void tearDown() {
         session.close();
     }
-    
+
     @Test
     public void whenCreatingRulesWithNullValues_Throw() throws NullPointerException {
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             expectedException.expect(NullPointerException.class);
             tx.putRule("A Thing", null, null);
         }
@@ -90,7 +90,7 @@ public class RuleValidationIT {
 
     @Test
     public void whenCreatingRulesWithNonExistentEntityType_Throw() throws InvalidKBException {
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             tx.putEntityType("My-Type");
 
             Pattern when = Graql.parsePattern("$x isa Your-Type;");
@@ -106,8 +106,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenCreatingDistinctRulesWithSimilarStringHashes_EnsureRulesDoNotClash(){
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenCreatingDistinctRulesWithSimilarStringHashes_EnsureRulesDoNotClash() {
+        try (Transaction tx = session.writeTransaction()) {
             String productRefused = "productRefused";
             Pattern when1 = Graql.parsePattern("{$step has step-id 9; $e (process-case: $case) isa process-record; $case has consent false;};");
             Pattern then1 = Graql.parsePattern("{(record: $e, step: $step) isa record-step;};");
@@ -204,7 +204,7 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingARuleThatCopiesValuesBetweenCompatibleAttributes_DoNotThrow(){
+    public void whenAddingARuleThatCopiesValuesBetweenCompatibleAttributes_DoNotThrow() {
         validateLegalHead(
                 Graql.parsePattern("$x has someAttribute $r;"),
                 Graql.parsePattern("$x has anotherAttribute $r;")
@@ -212,8 +212,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingARuleThatCopiesValuesBetweenIncompatibleAttributes_Throw()  throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingARuleThatCopiesValuesBetweenIncompatibleAttributes_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             initTx(tx);
             Rule rule = tx.putRule(
                     UUID.randomUUID().toString(),
@@ -476,14 +476,14 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingASimpleRuleWithNegationCycle_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingASimpleRuleWithNegationCycle_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             Pattern when = Graql.parsePattern(
-                "{" +
-                        "$x isa entity;" +
-                        "not {$y isa someEntity;};" +
-                        "($x, $y) isa someRelation;" +
-                        "};");
+                    "{" +
+                            "$x isa entity;" +
+                            "not {$y isa someEntity;};" +
+                            "($x, $y) isa someRelation;" +
+                            "};");
             Pattern then = Graql.parsePattern("$x isa someEntity;");
 
             initTx(tx);
@@ -498,8 +498,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingNonStratifiableRules_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingNonStratifiableRules_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             EntityType p = tx.putEntityType("p");
             EntityType q = tx.putEntityType("q");
             EntityType r = tx.putEntityType("r");
@@ -528,8 +528,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAdditionOfRuleWithMetaTypeMakesRulesNonstratifiable_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAdditionOfRuleWithMetaTypeMakesRulesNonstratifiable_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             tx.putEntityType("p");
             tx.putEntityType("q");
             tx.putEntityType("r");
@@ -545,7 +545,7 @@ public class RuleValidationIT {
             tx.commit();
         }
 
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             EntityType p = tx.putEntityType("p");
             EntityType q = tx.putEntityType("q");
             EntityType r = tx.putEntityType("r");
@@ -556,10 +556,10 @@ public class RuleValidationIT {
 
             expectedException.expect(InvalidKBException.class);
             expectedException.expectMessage(allOf(
-                containsString("The rule graph is not stratifiable"),
-                containsString(p.toString()),
-                containsString(q.toString()),
-                containsString(r.toString()))
+                    containsString("The rule graph is not stratifiable"),
+                    containsString(p.toString()),
+                    containsString(q.toString()),
+                    containsString(r.toString()))
             );
 
             tx.commit();
@@ -567,8 +567,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAdditionOfRuleMakesRulesNonstratifiable_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAdditionOfRuleMakesRulesNonstratifiable_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             tx.putEntityType("p");
             tx.putEntityType("q");
             tx.putEntityType("r");
@@ -584,7 +584,7 @@ public class RuleValidationIT {
             tx.commit();
         }
 
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             EntityType p = tx.putEntityType("p");
             EntityType q = tx.putEntityType("q");
             EntityType r = tx.putEntityType("r");
@@ -607,8 +607,8 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingAddingStratifiableRules_correctStratificationIsProduced(){
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingAddingStratifiableRules_correctStratificationIsProduced() {
+        try (Transaction tx = session.writeTransaction()) {
             EntityType p = tx.putEntityType("p");
             EntityType q = tx.putEntityType("q");
             EntityType r = tx.putEntityType("r");
@@ -634,7 +634,7 @@ public class RuleValidationIT {
 
             tx.commit();
         }
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             List<Rule> rules = RuleUtils.stratifyRules(tx.ruleCache().getRules().map(rule -> new InferenceRule(rule, tx)).collect(Collectors.toSet()))
                     .map(InferenceRule::getRule).collect(Collectors.toList());
             Rule Rp1 = tx.getRule("Rp1");
@@ -669,14 +669,14 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingARuleWithNestedNegationBlock_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingARuleWithNestedNegationBlock_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             Pattern when = Graql.parsePattern(
                     "{" +
                             "$x isa entity;" +
                             "not {" +
-                                "$y isa someRelation;" +
-                                "not {$y isa attribute;};" +
+                            "$y isa someRelation;" +
+                            "not {$y isa attribute;};" +
                             "};" +
                             "($x, $y) isa someRelation;" +
                             "};");
@@ -691,15 +691,15 @@ public class RuleValidationIT {
     }
 
     @Test
-    public void whenAddingARuleWithDisjunctiveNegationBlock_Throw() throws InvalidKBException{
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingARuleWithDisjunctiveNegationBlock_Throw() throws InvalidKBException {
+        try (Transaction tx = session.writeTransaction()) {
             Pattern when = Graql.parsePattern(
                     "{" +
                             "$x isa entity;" +
                             "($x, $y) isa someRelation;" +
                             "not {" +
-                                "{$y isa someRelation;} or " +
-                                "{$y isa attribute;};" +
+                            "{$y isa someRelation;} or " +
+                            "{$y isa attribute;};" +
                             "};" +
                             "};");
             Pattern then = Graql.parsePattern("$x isa someEntity;");
@@ -716,9 +716,9 @@ public class RuleValidationIT {
 
     @Test
     public void whenCreatingRules_EnsureHypothesisAndConclusionTypesAreFilledOnCommit() throws InvalidKBException {
-        try(Transaction tx = session.writeTransaction()) {
-            EntityType t1 = tx.putEntityType("someType");
-            EntityType t2 = tx.putEntityType("anotherType");
+        try (Transaction tx = session.writeTransaction()) {
+            tx.putEntityType("someType");
+            tx.putEntityType("anotherType");
 
             Pattern when = Graql.parsePattern("$x isa someType;");
             Pattern then = Graql.parsePattern("$x isa anotherType;");
@@ -728,20 +728,25 @@ public class RuleValidationIT {
             assertThat(rule.thenTypes().collect(Collectors.toSet()), empty());
 
             tx.commit();
-
-            assertThat(rule.whenTypes().collect(Collectors.toSet()), containsInAnyOrder(t1));
-            assertThat(rule.thenTypes().collect(Collectors.toSet()), containsInAnyOrder(t2));
         }
+        Transaction tx = session.readTransaction();
+        EntityType t1 = tx.getEntityType("someType");
+        EntityType t2 = tx.getEntityType("anotherType");
+        Rule rule = tx.getRule("My-Happy-Rule");
+
+        assertThat(rule.whenTypes().collect(Collectors.toSet()), containsInAnyOrder(t1));
+        assertThat(rule.thenTypes().collect(Collectors.toSet()), containsInAnyOrder(t2));
+        tx.close();
     }
 
     @Test
     public void whenCreatingRules_EnsureWhenTypesAndSignAreLinkedCorrectlyOnCommit() throws InvalidKBException {
-        try(Transaction tx = session.writeTransaction()) {
-            Type p = tx.putEntityType("p");
-            Type q = tx.putEntityType("q");
-            Type r = tx.putEntityType("r");
-            Type s = tx.putEntityType("s");
-            Type t = tx.putEntityType("t");
+        try (Transaction tx = session.writeTransaction()) {
+            tx.putEntityType("p");
+            tx.putEntityType("q");
+            tx.putEntityType("r");
+            tx.putEntityType("s");
+            tx.putEntityType("t");
 
             Rule rule = tx.putRule("Rule",
                     Graql.parsePattern("{" +
@@ -758,24 +763,32 @@ public class RuleValidationIT {
             assertThat(rule.thenTypes().collect(Collectors.toSet()), empty());
 
             tx.commit();
-
-            assertEquals(rule.whenTypes().collect(Collectors.toSet()), Sets.newHashSet(p, q, r, s));
-            assertEquals(rule.whenPositiveTypes().collect(Collectors.toSet()), Sets.newHashSet(p, q));
-            assertEquals(rule.whenNegativeTypes().collect(Collectors.toSet()), Sets.newHashSet(r, s));
-            assertThat(rule.thenTypes().collect(Collectors.toSet()), containsInAnyOrder(t));
         }
+        Transaction tx = session.readTransaction();
+        Type p = tx.getEntityType("p");
+        Type q = tx.getEntityType("q");
+        Type r = tx.getEntityType("r");
+        Type s = tx.getEntityType("s");
+        Type t = tx.getEntityType("t");
+        Rule rule = tx.getRule("Rule");
+
+        assertEquals(rule.whenTypes().collect(Collectors.toSet()), Sets.newHashSet(p, q, r, s));
+        assertEquals(rule.whenPositiveTypes().collect(Collectors.toSet()), Sets.newHashSet(p, q));
+        assertEquals(rule.whenNegativeTypes().collect(Collectors.toSet()), Sets.newHashSet(r, s));
+        assertThat(rule.thenTypes().collect(Collectors.toSet()), containsInAnyOrder(t));
+        tx.close();
     }
 
     @Test
     public void whenCreatingRules_EnsureTypesAreCorrectlyConnectedToRulesOnCommit() throws InvalidKBException {
-        try(Transaction tx = session.writeTransaction()) {
+        try (Transaction tx = session.writeTransaction()) {
             Type p = tx.putEntityType("p");
             Type q = tx.putEntityType("q");
             Type r = tx.putEntityType("r");
             Type s = tx.putEntityType("s");
             Type t = tx.putEntityType("t");
 
-            Rule rule = tx.putRule("Rule1",
+            tx.putRule("Rule1",
                     Graql.parsePattern("{" +
                             "$x isa p;" +
                             "$x isa q;" +
@@ -783,7 +796,7 @@ public class RuleValidationIT {
                             "};"),
                     Graql.parsePattern("$x isa s;"));
 
-            Rule rule2 = tx.putRule("Rule2",
+            tx.putRule("Rule2",
                     Graql.parsePattern("{" +
                             "$x isa q;" +
                             "$x isa r;" +
@@ -797,22 +810,31 @@ public class RuleValidationIT {
             });
 
             tx.commit();
-
-            assertEquals(p.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule));
-            assertEquals(q.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule, rule2));
-            assertEquals(r.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule, rule2));
-            assertEquals(s.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule2));
-            assertThat(t.whenRules().collect(Collectors.toSet()), empty());
-
-            Sets.newHashSet(p, q, r).forEach(type -> assertTrue(!type.thenRules().findFirst().isPresent()));
-            assertEquals(s.thenRules().collect(Collectors.toSet()), Sets.newHashSet(rule));
-            assertEquals(t.thenRules().collect(Collectors.toSet()), Sets.newHashSet(rule2));
         }
+        Transaction tx = session.readTransaction();
+        Type p = tx.getEntityType("p");
+        Type q = tx.getEntityType("q");
+        Type r = tx.getEntityType("r");
+        Type s = tx.getEntityType("s");
+        Type t = tx.getEntityType("t");
+        Rule rule = tx.getRule("Rule1");
+        Rule rule2 = tx.getRule("Rule2");
+
+        assertEquals(p.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule));
+        assertEquals(q.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule, rule2));
+        assertEquals(r.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule, rule2));
+        assertEquals(s.whenRules().collect(Collectors.toSet()), Sets.newHashSet(rule2));
+        assertThat(t.whenRules().collect(Collectors.toSet()), empty());
+
+        Sets.newHashSet(p, q, r).forEach(type -> assertTrue(!type.thenRules().findFirst().isPresent()));
+        assertEquals(s.thenRules().collect(Collectors.toSet()), Sets.newHashSet(rule));
+        assertEquals(t.thenRules().collect(Collectors.toSet()), Sets.newHashSet(rule2));
+        tx.close();
     }
 
     @Test
-    public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_ReturnTheSameRule(){
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingDuplicateRulesOfTheSameTypeWithTheSamePattern_ReturnTheSameRule() {
+        try (Transaction tx = session.writeTransaction()) {
             tx.putEntityType("someType");
             Pattern when = Graql.parsePattern("$x isa someType;");
             Pattern then = Graql.parsePattern("$x isa someType;");
@@ -826,8 +848,8 @@ public class RuleValidationIT {
 
     @Ignore("This is ignored because we currently have no way to determine if patterns with different variables name are equivalent")
     @Test
-    public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_ReturnTheSameRule(){
-        try(Transaction tx = session.writeTransaction()) {
+    public void whenAddingDuplicateRulesOfTheSameTypeWithDifferentPatternVariables_ReturnTheSameRule() {
+        try (Transaction tx = session.writeTransaction()) {
             tx.putEntityType("someType");
             Pattern when = Graql.parsePattern("$x isa someType;");
             Pattern then = Graql.parsePattern("$y isa someType;");
@@ -845,8 +867,8 @@ public class RuleValidationIT {
         return result;
     }
 
-    private void validateOntologicallyIllegalRule(Pattern when, Pattern then, ErrorMessage message, String... outputParams){
-        try(Transaction tx = session.writeTransaction()) {
+    private void validateOntologicallyIllegalRule(Pattern when, Pattern then, ErrorMessage message, String... outputParams) {
+        try (Transaction tx = session.writeTransaction()) {
             initTx(tx);
             Rule rule = tx.putRule(UUID.randomUUID().toString(), when, then);
 
@@ -859,8 +881,8 @@ public class RuleValidationIT {
         }
     }
 
-    private void validateIllegalRule(Pattern when, Pattern then, ErrorMessage message){
-        try(Transaction tx = session.writeTransaction()) {
+    private void validateIllegalRule(Pattern when, Pattern then, ErrorMessage message) {
+        try (Transaction tx = session.writeTransaction()) {
             initTx(tx);
             Rule rule = tx.putRule(UUID.randomUUID().toString(), when, then);
 
@@ -870,8 +892,8 @@ public class RuleValidationIT {
         }
     }
 
-    private void validateIllegalHead(Pattern when, Pattern then, ErrorMessage message){
-        try(Transaction tx = session.writeTransaction()) {
+    private void validateIllegalHead(Pattern when, Pattern then, ErrorMessage message) {
+        try (Transaction tx = session.writeTransaction()) {
             initTx(tx);
             Rule rule = tx.putRule(UUID.randomUUID().toString(), when, then);
 
@@ -881,15 +903,15 @@ public class RuleValidationIT {
         }
     }
 
-    private void validateLegalHead(Pattern when, Pattern then){
-        try(Transaction tx = session.writeTransaction()) {
+    private void validateLegalHead(Pattern when, Pattern then) {
+        try (Transaction tx = session.writeTransaction()) {
             initTx(tx);
             tx.putRule(UUID.randomUUID().toString(), when, then);
             tx.commit();
         }
     }
 
-    private void initTx(Transaction tx){
+    private void initTx(Transaction tx) {
         AttributeType<Integer> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.INTEGER);
         AttributeType<Integer> anotherAttribute = tx.putAttributeType("anotherAttribute", AttributeType.DataType.INTEGER);
         AttributeType<String> stringAttribute = tx.putAttributeType("stringAttribute", AttributeType.DataType.STRING);

--- a/test-integration/server/session/TransactionOLTPIT.java
+++ b/test-integration/server/session/TransactionOLTPIT.java
@@ -25,6 +25,7 @@ import grakn.core.common.exception.ErrorMessage;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.impl.TypeImpl;
 import grakn.core.core.Schema;
+import grakn.core.graph.core.JanusGraphTransaction;
 import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.Concept;
@@ -361,8 +362,10 @@ public class TransactionOLTPIT {
         }
         Set<Vertex> typeShards;
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            typeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
+            JanusGraphTransaction tx = janusGraph.newTransaction();
+            typeShards = tx.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
             assertEquals(1, typeShards.size());
+            tx.close();
         }
         ConceptId p1;
         try (Session session = sessionFactory.session(keyspace)) {
@@ -373,10 +376,12 @@ public class TransactionOLTPIT {
         }
         Vertex typeShardForP1;
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            typeShardForP1 = janusGraph.traversal().V(p1.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toList().get(0);
+            JanusGraphTransaction tx = janusGraph.newTransaction();
+            typeShardForP1 = tx.traversal().V(p1.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toList().get(0);
             assertEquals(typeShards.iterator().next(), typeShardForP1);
-            typeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
+            typeShards = tx.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
             assertEquals(2, typeShards.size());
+            tx.close();
         }
         ConceptId p2;
         try (Session session = sessionFactory.session(keyspace)) {
@@ -386,10 +391,12 @@ public class TransactionOLTPIT {
             }
         }
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            Vertex typeShardForP2 = janusGraph.traversal().V(p2.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toSet().iterator().next();
+            JanusGraphTransaction tx = janusGraph.newTransaction();
+            Vertex typeShardForP2 = tx.traversal().V(p2.getValue().substring(1)).out(Schema.EdgeLabel.ISA.getLabel()).toSet().iterator().next();
             assertEquals(Sets.difference(typeShards, Sets.newHashSet(typeShardForP1)).iterator().next(), typeShardForP2);
-            typeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
+            typeShards = tx.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
             assertEquals(3, typeShards.size());
+            tx.close();
         }
     }
 
@@ -430,10 +437,12 @@ public class TransactionOLTPIT {
             }
         }
         try (JanusGraph janusGraph = janusGraphFactory.openGraph(keyspace.name())) {
-            Set<Vertex> personTypeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
+            JanusGraphTransaction tx = janusGraph.newTransaction();
+            Set<Vertex> personTypeShards = tx.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "person").in().hasLabel("SHARD").toSet();
             assertEquals(3, personTypeShards.size());
-            Set<Vertex> companyTypeShards = janusGraph.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "company").in().hasLabel("SHARD").toSet();
+            Set<Vertex> companyTypeShards = tx.traversal().V().has(Schema.VertexProperty.SCHEMA_LABEL.name(), "company").in().hasLabel("SHARD").toSet();
             assertEquals(2, companyTypeShards.size());
+            tx.close();
         }
     }
 


### PR DESCRIPTION
What is the goal of this PR?

- Removed automatic transaction behaviour from JanusGraph, from Janus docs:
```
graph = JanusGraphFactory.open("berkeleyje:/tmp/janusgraph")
juno = graph.addVertex() //Automatically opens a new transaction
juno.property("name", "juno")
graph.tx().commit() //Commits transaction
```
we don't have that anymore. This behaviour provides very little advantages and creates a lot of magic and messy code (thanks to this we were getting OOM).

Now the transaction needs to be open and committed/closed manually, exactly as it happens in Grakn.
