### PR TITLE
Fix RPM deployment test

### DIFF
--- a/test/deployment/rpm/test.py
+++ b/test/deployment/rpm/test.py
@@ -104,7 +104,7 @@ try:
     lprint('Copying grakn distribution from CircleCI job into "' + instance + '"')
 
     sp.check_call(['cat', 'VERSION'])
-    sp.check_call(['git', 'archive', '--format', 'zip', '--output', 'grakn.zip', 'HEAD'])
+    sp.check_call(['zip', '-r', 'grakn.zip', '--exclude=*.git*', '.'])
     gcloud_scp(instance, local='grakn.zip', remote='~')
     gcloud_ssh(instance, 'mkdir /tmp/grakn && unzip grakn.zip -d /tmp/grakn')
 


### PR DESCRIPTION
## What is the goal of this PR?

RPM deployment test was broken because modified `VERSION` was not included into archive transferred to GCP which lead to testing a release version (e.g. `1.6.0`) instead of snapshot version (e.g. `0.0.0_snapshot`)

## What are the changes implemented in this PR?

Revert to using `zip` instead of `git archive` for packing repo archive