### PR TITLE
Remove shard readlock

### DIFF
--- a/concept/impl/ConceptManagerImpl.java
+++ b/concept/impl/ConceptManagerImpl.java
@@ -84,16 +84,13 @@ public class ConceptManagerImpl implements ConceptManager {
     private final TransactionCache transactionCache;
     private final ConceptObserver conceptObserver;
     private final AttributeManager attributeManager;
-    private final ReadWriteLock graphLock;
 
-    public ConceptManagerImpl(ElementFactory elementFactory, TransactionCache transactionCache, ConceptObserver conceptObserver, AttributeManager attributeManager, ReadWriteLock graphLock) {
+    public ConceptManagerImpl(ElementFactory elementFactory, TransactionCache transactionCache, ConceptObserver conceptObserver, AttributeManager attributeManager) {
         this.elementFactory = elementFactory;
         this.transactionCache = transactionCache;
         this.conceptObserver = conceptObserver;
         this.attributeManager = attributeManager;
-        this.graphLock = graphLock;
     }
-
 
     /*
 

--- a/concept/impl/ConceptManagerImpl.java
+++ b/concept/impl/ConceptManagerImpl.java
@@ -501,20 +501,18 @@ public class ConceptManagerImpl implements ConceptManager {
     /**
      * This is used when assigning a type to a concept - we check the current shard.
      * The read vertex property contains the current shard vertex id.
-     * We use a readLock as janusGraph commit does not seem to be atomic - the property might get updated before the corresponding vertex is actually created.
-     * As a result, without a lock we could get a ghost vertex READ - a vertex that's partially created.
-     * Further investigation needed
      */
     Shard getShardWithLock(String typeId) {
-        graphLock.readLock().lock();
-        Vertex shardVertex;
-        try {
-            Object currentShardId = elementFactory.getVertexWithId(typeId).property(Schema.VertexProperty.CURRENT_SHARD.name()).value();
-            shardVertex = elementFactory.getVertexWithId(currentShardId.toString());
-        } finally {
-            graphLock.readLock().unlock();
-        }
-        return elementFactory.getShard(shardVertex);
+        Object currentShardId = elementFactory.getVertexWithId(typeId).property(Schema.VertexProperty.CURRENT_SHARD.name()).value();
+
+        //Try to fetch the current shard vertex, because janus commits are not atomic, property might exists but the corresponding
+        //vertex might not yet be created. Consequently the fetch might return null.
+        Vertex shardVertex = elementFactory.getVertexWithId(currentShardId.toString());
+        if (shardVertex != null) return elementFactory.getShard(shardVertex);
+
+        //If current shard fetch fails. We pick any of the existing shards.
+        Vertex typeVertex = elementFactory.getVertexWithId(typeId);
+        return elementFactory.buildVertexElement(typeVertex).shards().findFirst().orElse(null);
     }
 
     public Rule getRule(String label) {

--- a/kb/server/ShardManager.java
+++ b/kb/server/ShardManager.java
@@ -42,7 +42,9 @@ public interface ShardManager {
     void ackShardRequest(Label type, String txId);
     void ackCommit(Set<Label> labels, String txId);
     boolean requiresLock(String txId);
-    Cache<Label, Long> shardCache();
+
+    Long getEphemeralShardCount(Label type);
+    void updateEphemeralShardCount(Label type, Long count);
 
     @VisibleForTesting
     boolean lockCandidatesPresent();

--- a/server/session/SessionImpl.java
+++ b/server/session/SessionImpl.java
@@ -156,7 +156,7 @@ public class SessionImpl implements Session {
         ConceptObserver conceptObserver = new ConceptObserver(cacheProvider, statisticsDelta, attributeManager(), janusGraphTransaction.toString());
 
         // Grakn elements
-        ConceptManagerImpl conceptManager = new ConceptManagerImpl(elementFactory, cacheProvider.getTransactionCache(), conceptObserver, attributeManager(), graphLock);
+        ConceptManagerImpl conceptManager = new ConceptManagerImpl(elementFactory, cacheProvider.getTransactionCache(), conceptObserver, attributeManager());
 
         TransactionOLTP tx = new TransactionOLTP(this, janusGraphTransaction, conceptManager, cacheProvider, statisticsDelta);
 

--- a/server/session/ShardManagerImpl.java
+++ b/server/session/ShardManagerImpl.java
@@ -23,7 +23,6 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.server.ShardManager;
-import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -32,12 +31,12 @@ public class ShardManagerImpl implements ShardManager {
     private final static int TIMEOUT_MINUTES_ATTRIBUTES_CACHE = 2;
     private final static int ATTRIBUTES_CACHE_MAX_SIZE = 10000;
 
-    private final Cache<Label, Long> shardCache;
+    private final Cache<Label, Long> shardsEphemeral;
     private final ConcurrentHashMap<Label, Set<String>> shardRequests;
     private final Set<String> lockCandidates;
 
     public ShardManagerImpl(){
-        this.shardCache = CacheBuilder.newBuilder()
+        this.shardsEphemeral = CacheBuilder.newBuilder()
                 .expireAfterAccess(TIMEOUT_MINUTES_ATTRIBUTES_CACHE, TimeUnit.MINUTES)
                 .maximumSize(ATTRIBUTES_CACHE_MAX_SIZE)
                 .build();
@@ -45,10 +44,9 @@ public class ShardManagerImpl implements ShardManager {
         this.lockCandidates = ConcurrentHashMap.newKeySet();
     }
 
-    @Override
-    public Cache<Label, Long> shardCache() {
-        return shardCache;
-    }
+
+    public Long getEphemeralShardCount(Label type){ return shardsEphemeral.getIfPresent(type);}
+    public void updateEphemeralShardCount(Label type, Long count){ shardsEphemeral.put(type, count);}
 
     @Override
     public void ackShardRequest(Label type, String txId) {

--- a/server/session/TransactionOLTP.java
+++ b/server/session/TransactionOLTP.java
@@ -283,10 +283,10 @@ public class TransactionOLTP implements Transaction {
         String txId = this.janusTransaction.toString();
         cache().getNewShards()
                 .forEach((label, count) -> {
-                    Long softCheckPoint = session.shardManager().shardCache().getIfPresent(label);
+                    Long softCheckPoint = session.shardManager().getEphemeralShardCount(label);
                     long instanceCount = session.keyspaceStatistics().count(this, label) + uncomittedStatisticsDelta.delta(label);
                     if (softCheckPoint == null || instanceCount - softCheckPoint >= typeShardThreshold) {
-                        session.shardManager().shardCache().put(label, instanceCount);
+                        session.shardManager().updateEphemeralShardCount(label, instanceCount);
                         LOG.trace(txId + " creates a shard for type: " + label + ", instance count: " + instanceCount + " ,");
                         shard(getType(label).id());
                         setShardCheckpoint(label, instanceCount);

--- a/test-integration/server/kb/structure/EdgeIT.java
+++ b/test-integration/server/kb/structure/EdgeIT.java
@@ -91,7 +91,7 @@ public class EdgeIT {
 
         // Grakn elements
         ConceptObserver conceptObserver = new ConceptObserver(cacheProvider, statisticsDelta, attributeManager, janusGraphTransaction.toString());
-        ConceptManagerImpl conceptManager = new ConceptManagerImpl(elementFactory, cacheProvider.getTransactionCache(), conceptObserver, attributeManager, new ReentrantReadWriteLock());
+        ConceptManagerImpl conceptManager = new ConceptManagerImpl(elementFactory, cacheProvider.getTransactionCache(), conceptObserver, attributeManager);
 
         tx = new TransactionOLTP(session, janusGraphTransaction, conceptManager, cacheProvider, statisticsDelta);
         tx.open(Transaction.Type.WRITE);


### PR DESCRIPTION
## What is the goal of this PR?
To remove the shard readlock which was not working properly.

## What are the changes implemented in this PR?
- removed the shard readlock in `ConceptManagerImpl`
- instead of using readlock, we try to fetch the shard vertex from the type property, if the fetch fails, we retrieve one of the existing shards
