### PR TITLE
Upgrade @io_bazel_rules_docker to latest version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -148,6 +148,9 @@ load("@io_bazel_rules_docker//repositories:repositories.bzl",
 bazel_rules_docker_repositories = "repositories")
 bazel_rules_docker_repositories()
 
+load("@io_bazel_rules_docker//repositories:deps.bzl", bazel_rules_docker_container_deps = "deps")
+bazel_rules_docker_container_deps()
+
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 container_pull(
   name = "openjdk_image",

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,7 +22,7 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "d8e266644cc5c1d44dc17515069b1a6b70c98c44", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "f758cf07c374c0a00ad822998cfe5b5fd8fac142", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Allow releasing Grakn Docker image

## What are the changes implemented in this PR?

- Upgrade to `@graknlabs_build_tools` with latest rules for Docker
- Load new `@io_bazel_rules_docker`'s dependencies
