### PR TITLE
Revise query cache behaviours

### DIFF
--- a/graql/executor/property/value/ValueOperation.java
+++ b/graql/executor/property/value/ValueOperation.java
@@ -172,7 +172,7 @@ public abstract class ValueOperation<T, U> {
                 (this.predicate().test(that.valueSerialised()) || ((that.predicate()).test(this.valueSerialised())));
     }
 
-    public boolean subsumes(ValueOperation<?, ?> other) {
+    public boolean isSubsumedBy(ValueOperation<?, ?> other) {
         if (this.comparator().equals(Graql.Token.Comparator.LIKE)) {
             return isCompatibleWithRegex(other);
         } else if (other.comparator().equals(Graql.Token.Comparator.LIKE)) {

--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -110,10 +110,10 @@ public abstract class Atom extends AtomicBase {
      * i. e. the set of answers of A is a subset of the set of answers of B
      *
      * @param atomic to compare with
-     * @return true if this atom subsumes the provided atom
+     * @return true if this atom isSubsumedBy the provided atom
      */
     @Override
-    public boolean subsumes(Atomic atomic) {
+    public boolean isSubsumedBy(Atomic atomic) {
         if (!atomic.isAtom()) return false;
         Atom parent = (Atom) atomic;
         MultiUnifier multiUnifier = this.getMultiUnifier(parent, UnifierType.SUBSUMPTIVE);

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -62,7 +62,7 @@ public abstract class OntologicalAtom extends TypeAtom {
     }
 
     @Override
-    public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
+    public boolean isSubsumedBy(Atomic atom) { return this.isAlphaEquivalent(atom); }
 
     @Override
     public Stream<Rule> getPotentialRules(){ return Stream.empty();}

--- a/graql/reasoner/atom/binary/RelationAtom.java
+++ b/graql/reasoner/atom/binary/RelationAtom.java
@@ -942,9 +942,8 @@ public class RelationAtom extends IsaAtomBase {
         parentAtom.getRelationPlayers()
                 .forEach(prp -> {
                     Statement parentRolePattern = prp.getRole().orElse(null);
-                    if (parentRolePattern == null) {
-                        throw ReasonerException.rolePatternAbsent(parentAtom);
-                    }
+                    if (parentRolePattern == null) throw ReasonerException.rolePatternAbsent(parentAtom);
+
                     String parentRoleLabel = parentRolePattern.getType().isPresent() ? parentRolePattern.getType().get() : null;
                     Role parentRole = parentRoleLabel != null ? conceptManager.getRole(parentRoleLabel) : null;
                     Variable parentRolePlayer = prp.getPlayer().var();
@@ -955,9 +954,8 @@ public class RelationAtom extends IsaAtomBase {
                             //check for role compatibility
                             .filter(crp -> {
                                 Statement childRolePattern = crp.getRole().orElse(null);
-                                if (childRolePattern == null) {
-                                    throw ReasonerException.rolePatternAbsent(this);
-                                }
+                                if (childRolePattern == null) throw ReasonerException.rolePatternAbsent(this);
+
                                 String childRoleLabel = childRolePattern.getType().isPresent() ? childRolePattern.getType().get() : null;
                                 Role childRole = childRoleLabel != null ? conceptManager.getRole(childRoleLabel) : null;
 
@@ -1151,12 +1149,7 @@ public class RelationAtom extends IsaAtomBase {
             relation = substitution.get(getVarName()).asRelation();
         } else {
             Relation foundRelation = findRelation(substitution);
-            if (foundRelation == null) {
-                Relation insertedRelation = relationType.addRelationInferred();
-                relation = insertedRelation;
-            } else {
-                relation = foundRelation;
-            }
+            relation = foundRelation != null? foundRelation : relationType.addRelationInferred();
 
         }
 
@@ -1206,12 +1199,13 @@ public class RelationAtom extends IsaAtomBase {
      * @return new relation atom with user defined name if necessary or this
      */
     private RelationAtom rewriteWithRelationVariable(Atom parentAtom) {
-        if (this.getVarName().isReturned() || !parentAtom.getVarName().isReturned()) return this;
+        if (!parentAtom.getVarName().isReturned()) return this;
         return rewriteWithRelationVariable();
     }
 
     @Override
     public RelationAtom rewriteWithRelationVariable() {
+        if (this.getVarName().isReturned()) return this;
         StatementInstance newVar = new StatementThing(new Variable().asReturnedVar());
         Statement relVar = getPattern().getProperty(IsaProperty.class)
                 .map(prop -> newVar.isa(prop.type()))

--- a/graql/reasoner/atom/predicate/Predicate.java
+++ b/graql/reasoner/atom/predicate/Predicate.java
@@ -63,7 +63,7 @@ public abstract class Predicate<T> extends AtomicBase {
     }
 
     @Override
-    public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
+    public boolean isSubsumedBy(Atomic atom) { return this.isAlphaEquivalent(atom); }
 
     @Override
     public boolean equals(Object obj) {

--- a/graql/reasoner/atom/predicate/ValuePredicate.java
+++ b/graql/reasoner/atom/predicate/ValuePredicate.java
@@ -114,7 +114,7 @@ public class ValuePredicate extends Predicate<ValueProperty.Operation> {
     }
 
     @Override
-    public boolean subsumes(Atomic atomic){
+    public boolean isSubsumedBy(Atomic atomic){
         if (this.isAlphaEquivalent(atomic)) return true;
         if (atomic == null || this.getClass() != atomic.getClass()) return false;
         if (atomic == this) return true;

--- a/graql/reasoner/atom/predicate/ValuePredicate.java
+++ b/graql/reasoner/atom/predicate/ValuePredicate.java
@@ -120,7 +120,7 @@ public class ValuePredicate extends Predicate<ValueProperty.Operation> {
         if (atomic == this) return true;
         ValuePredicate that = (ValuePredicate) atomic;
         return ValueOperation.of(this.getPredicate())
-                .subsumes(ValueOperation.of(that.getPredicate()));
+                .isSubsumedBy(ValueOperation.of(that.getPredicate()));
     }
 
     @Override

--- a/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -144,7 +144,7 @@ public class VariableValuePredicate extends VariablePredicate {
         if (atomic == this) return true;
         VariableValuePredicate that = (VariableValuePredicate) atomic;
         return ValueOperation.of(this.operation())
-                .subsumes(ValueOperation.of(that.operation()));
+                .isSubsumedBy(ValueOperation.of(that.operation()));
     }
 
     @Override

--- a/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -138,7 +138,7 @@ public class VariableValuePredicate extends VariablePredicate {
     }
 
     @Override
-    public boolean subsumes(Atomic atomic){
+    public boolean isSubsumedBy(Atomic atomic){
         if (this.isAlphaEquivalent(atomic)) return true;
         if (atomic == null || this.getClass() != atomic.getClass()) return false;
         if (atomic == this) return true;

--- a/graql/reasoner/atom/property/DataTypeAtom.java
+++ b/graql/reasoner/atom/property/DataTypeAtom.java
@@ -81,5 +81,5 @@ public class DataTypeAtom extends AtomicBase {
     }
 
     @Override
-    public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
+    public boolean isSubsumedBy(Atomic atom) { return this.isAlphaEquivalent(atom); }
 }

--- a/graql/reasoner/atom/property/IsAbstractAtom.java
+++ b/graql/reasoner/atom/property/IsAbstractAtom.java
@@ -65,6 +65,6 @@ public class IsAbstractAtom extends AtomicBase {
     }
 
     @Override
-    public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
+    public boolean isSubsumedBy(Atomic atom) { return this.isAlphaEquivalent(atom); }
 
 }

--- a/graql/reasoner/atom/property/RegexAtom.java
+++ b/graql/reasoner/atom/property/RegexAtom.java
@@ -78,5 +78,5 @@ public class RegexAtom extends AtomicBase {
     public int structuralEquivalenceHashCode() { return alphaEquivalenceHashCode();}
 
     @Override
-    public boolean subsumes(Atomic atom) { return this.isAlphaEquivalent(atom); }
+    public boolean isSubsumedBy(Atomic atom) { return this.isAlphaEquivalent(atom); }
 }

--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -49,7 +49,7 @@ import static java.util.stream.Collectors.toSet;
  * and subsequently reusing their answer sets.
  *
  * Relies on the following concepts:
- * - Query Subsumption {@link ReasonerAtomicQuery#subsumes(ReasonerAtomicQuery)}
+ * - Query Subsumption {@link ReasonerAtomicQuery#isSubsumedBy(ReasonerAtomicQuery)} )}
  * Subsumption relation between a query C (child) and a provided query P (parent) holds if:
  *
  * C <= P,
@@ -89,7 +89,7 @@ public abstract class SemanticCache<
     public boolean isComplete(ReasonerAtomicQuery query){
         if (super.isComplete(query)) return true;
         return getParents(query).stream()
-                .filter(q -> query.subsumes(keyToQuery(q)))
+                .filter(q -> query.isSubsumedBy(keyToQuery(q)))
                 .anyMatch(q -> super.isComplete(keyToQuery(q)));
     }
 
@@ -191,7 +191,7 @@ public abstract class SemanticCache<
         Set<QE> computedParents = new HashSet<>();
         getFamily(child)
                 .map(this::keyToQuery)
-                .filter(child::subsumesStructurally)
+                .filter(child::isSubsumedStructurallyBy)
                 .map(this::queryToKey)
                 .peek(computedParents::add)
                 .forEach(parent -> parents.put(queryToKey(child), parent));
@@ -222,7 +222,7 @@ public abstract class SemanticCache<
                         boolean newAnswers = propagateAnswers(parentMatch, childMatch, propagateInferred);
                         newAnswersFound[0] = newAnswersFound[0] || newAnswers;
 
-                        boolean targetSubsumesParent = target.subsumes(keyToQuery(parent));
+                        boolean targetSubsumesParent = target.isSubsumedBy(keyToQuery(parent));
                         //since we compare queries structurally, freshly propagated answer might not necessarily answer
                         //the target query - hence this check
                         if(childGround && newAnswers && answersQuery(target)) ackCompleteness(target);

--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -298,10 +298,7 @@ public abstract class SemanticCache<
         boolean answersToGroundQuery = queryGround && answersQuery(query);
 
         //if db complete or we found answers to ground query via propagation we don't need to hit the database
-        if (queryDBComplete || answersToGroundQuery){
-            LOG.trace("Complete cache fetch: {}", query);
-            return cachePair;
-        }
+        if (queryDBComplete || answersToGroundQuery) return cachePair;
 
         //otherwise lookup and add inferred answers on top
         return new Pair<>(

--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -183,13 +183,7 @@ public abstract class SemanticCache<
     private void updateFamily(ReasonerAtomicQuery query){
         SchemaConcept schemaConcept = query.getAtom().getSchemaConcept();
         if (schemaConcept != null){
-            Set<QE> familyEntry = families.get(schemaConcept);
-            QE familyQuery = queryToKey(query);
-            if (familyEntry != null){
-                familyEntry.add(familyQuery);
-            } else {
-                families.put(schemaConcept, familyQuery);
-            }
+            families.put(schemaConcept, queryToKey(query));
         }
     }
 

--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -199,6 +199,7 @@ public abstract class SemanticCache<
     }
 
     /**
+     * TODO we might want to consider horizontal propagation (between compatible children) in addtion to the vertical parent->child one
      * NB: uses getEntry
      * NB: target and childMatch.query() are in general not the same hence explicit arguments
      * @param target query we want propagate the answers to

--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -285,7 +285,6 @@ public abstract class SemanticCache<
             );
 
             if (!fetchFromParent){
-                LOG.trace("Query Cache miss: {} with fetch from DB", query);
                 return getDBAnswerStreamWithUnifier(query);
             }
 
@@ -304,7 +303,6 @@ public abstract class SemanticCache<
             return cachePair;
         }
 
-        //LOG.trace("Incomplete cache fetch: {}", query);
         //otherwise lookup and add inferred answers on top
         return new Pair<>(
                 //NB: concat retains the order between elements from different streams so cache entries will come first

--- a/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -128,18 +128,16 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     public boolean hasUniqueAnswer(){ return getAtom().hasUniqueAnswer();}
 
     /**
-     * TODO
-     * @param parent
-     * @return
+     * @param parent query to compare with
+     * @return true if this query subsumes the provided query
      */
     public boolean subsumes(ReasonerAtomicQuery parent){
         return subsumes(parent, UnifierType.SUBSUMPTIVE);
     }
 
     /**
-     * TODO
-     * @param parent
-     * @return
+     * @param parent query to compare with
+     * @return true if this query structurally subsumes the provided query
      */
     public boolean subsumesStructurally(ReasonerAtomicQuery parent){
         return subsumes(parent, UnifierType.STRUCTURAL_SUBSUMPTIVE);
@@ -158,6 +156,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
      * i. e. the set of answers of C is a subset of the set of answers of P
      *
      * @param parent query to compare with
+     * @param unifierType unifier type specifying subsumption type
      * @return true if this query subsumes the provided query
      */
     private boolean subsumes(ReasonerAtomicQuery parent, UnifierType unifierType){

--- a/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -129,18 +129,18 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
 
     /**
      * @param parent query to compare with
-     * @return true if this query subsumes the provided query
+     * @return true if this query is subsumed by the provided query
      */
-    public boolean subsumes(ReasonerAtomicQuery parent){
-        return subsumes(parent, UnifierType.SUBSUMPTIVE);
+    public boolean isSubsumedBy(ReasonerAtomicQuery parent){
+        return isSubsumedBy(parent, UnifierType.SUBSUMPTIVE);
     }
 
     /**
      * @param parent query to compare with
-     * @return true if this query structurally subsumes the provided query
+     * @return true if this query is structurally subsumed by the provided query
      */
-    public boolean subsumesStructurally(ReasonerAtomicQuery parent){
-        return subsumes(parent, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+    public boolean isSubsumedStructurallyBy(ReasonerAtomicQuery parent){
+        return isSubsumedBy(parent, UnifierType.STRUCTURAL_SUBSUMPTIVE);
     }
 
     /**
@@ -157,9 +157,9 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
      *
      * @param parent query to compare with
      * @param unifierType unifier type specifying subsumption type
-     * @return true if this query subsumes the provided query
+     * @return true if this query is subsumed by the provided query
      */
-    private boolean subsumes(ReasonerAtomicQuery parent, UnifierType unifierType){
+    private boolean isSubsumedBy(ReasonerAtomicQuery parent, UnifierType unifierType){
         MultiUnifier multiUnifier = this.getMultiUnifier(parent, unifierType);
         if (multiUnifier.isEmpty()) return false;
         MultiUnifier inverse = multiUnifier.inverse();

--- a/graql/reasoner/query/ReasonerAtomicQuery.java
+++ b/graql/reasoner/query/ReasonerAtomicQuery.java
@@ -128,6 +128,24 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
     public boolean hasUniqueAnswer(){ return getAtom().hasUniqueAnswer();}
 
     /**
+     * TODO
+     * @param parent
+     * @return
+     */
+    public boolean subsumes(ReasonerAtomicQuery parent){
+        return subsumes(parent, UnifierType.SUBSUMPTIVE);
+    }
+
+    /**
+     * TODO
+     * @param parent
+     * @return
+     */
+    public boolean subsumesStructurally(ReasonerAtomicQuery parent){
+        return subsumes(parent, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+    }
+
+    /**
      * Determines whether the subsumption relation between this (C) and provided query (P) holds,
      * i. e. determines if:
      *
@@ -142,8 +160,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
      * @param parent query to compare with
      * @return true if this query subsumes the provided query
      */
-    public boolean subsumes(ReasonerAtomicQuery parent){
-        MultiUnifier multiUnifier = this.getMultiUnifier(parent, UnifierType.SUBSUMPTIVE);
+    private boolean subsumes(ReasonerAtomicQuery parent, UnifierType unifierType){
+        MultiUnifier multiUnifier = this.getMultiUnifier(parent, unifierType);
         if (multiUnifier.isEmpty()) return false;
         MultiUnifier inverse = multiUnifier.inverse();
 
@@ -151,8 +169,8 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
         boolean propagatedAnswersComplete = !inverse.isEmpty() &&
                 inverse.stream().allMatch(u -> u.values().containsAll(this.getVarNames()));
         return propagatedAnswersComplete
-                        && !parent.getAtoms(VariablePredicate.class).findFirst().isPresent()
-                        && !this.getAtoms(VariablePredicate.class).findFirst().isPresent();
+                && !parent.getAtoms(VariablePredicate.class).findFirst().isPresent()
+                && !this.getAtoms(VariablePredicate.class).findFirst().isPresent();
     }
 
     /**
@@ -197,7 +215,7 @@ public class ReasonerAtomicQuery extends ReasonerQueryImpl {
      * @return pair of: a parent->child unifier and a parent->child semantic difference between
      */
     public Set<Pair<Unifier, SemanticDifference>> getMultiUnifierWithSemanticDiff(ReasonerAtomicQuery child){
-        MultiUnifier unifier = child.getMultiUnifier(this, UnifierType.SUBSUMPTIVE);
+        MultiUnifier unifier = child.getMultiUnifier(this, UnifierType.STRUCTURAL_SUBSUMPTIVE);
         return unifier.stream()
                 .map(childParentUnifier -> {
                     Unifier inverse = childParentUnifier.inverse();

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -245,7 +245,7 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      *
      * C <= P,
      *
-     * i.e. C specialises P (C isSubsumedBy P) and A(C) is a subset of A(P).
+     * i.e. C specialises P (C isSubsumedBy P, P subsumes C) and A(C) is a subset of A(P).
      *
      * As a result, to relate it with the RULE unifier. We can say that if there exists a RULE unifier between child and
      * parent, i. e. C >= P holds, then there exists a SUBSUMPTIVE unifier between parent and child.

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -324,8 +324,10 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
     },
 
     /**
+     * Unifier type used to determine whether two queries are in a subsumption relation up to structural equivalence.
+     * Consequently two queries that are structurally equivalent are structurally subsumptive.
      *
-     */
+     * */
     STRUCTURAL_SUBSUMPTIVE {
         @Override public ReasonerQueryEquivalence equivalence() { return SUBSUMPTIVE.equivalence(); }
 

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -245,7 +245,7 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      *
      * C <= P,
      *
-     * i.e. C specialises P (C isSubsumedBy P, P subsumes C) and A(C) is a subset of A(P).
+     * i.e. C specialises P (C isSubsumedBy P, P isSubsumedBy C) and A(C) is a subset of A(P).
      *
      * As a result, to relate it with the RULE unifier. We can say that if there exists a RULE unifier between child and
      * parent, i. e. C >= P holds, then there exists a SUBSUMPTIVE unifier between parent and child.

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -245,7 +245,7 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      *
      * C <= P,
      *
-     * i.e. C specialises P (C subsumes P) and A(C) is a subset of A(P).
+     * i.e. C specialises P (C isSubsumedBy P) and A(C) is a subset of A(P).
      *
      * As a result, to relate it with the RULE unifier. We can say that if there exists a RULE unifier between child and
      * parent, i. e. C >= P holds, then there exists a SUBSUMPTIVE unifier between parent and child.
@@ -293,19 +293,19 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
         @Override
         public boolean idCompatibility(Atomic parent, Atomic child) {
             return parent == null
-                    || child != null && child.subsumes(parent);
+                    || child != null && child.isSubsumedBy(parent);
         }
 
         @Override
         public boolean valueCompatibility(Atomic parent, Atomic child) {
             return parent == null
-                    || child != null && child.subsumes(parent);
+                    || child != null && child.isSubsumedBy(parent);
         }
 
         @Override
         public boolean predicateCompatibility(Set<Atomic> parent, Set<Atomic> child, BiFunction<Atomic, Atomic, Boolean> comparison) {
             //check both ways to eliminate contradictions
-            boolean parentToChild = parent.stream().allMatch(pp -> child.stream().anyMatch(cp -> cp.subsumes(pp)));
+            boolean parentToChild = parent.stream().allMatch(pp -> child.stream().anyMatch(cp -> cp.isSubsumedBy(pp)));
             boolean childToParent = child.stream().allMatch(cp -> parent.stream().anyMatch(pp -> cp.isCompatibleWith(pp)));
             return super.predicateCompatibility(parent, child, comparison)
                     && (parent.isEmpty()

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -321,5 +321,55 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
             return childRes.values().stream()
                     .allMatch(r -> !parentRes.containsKey(r.getSchemaConcept()) || r.isUnifiableWith(parentRes.get(r.getSchemaConcept())));
         }
+    },
+
+    /**
+     *
+     */
+    STRUCTURAL_SUBSUMPTIVE {
+        @Override public ReasonerQueryEquivalence equivalence() { return SUBSUMPTIVE.equivalence(); }
+
+        @Override public boolean inferTypes() { return SUBSUMPTIVE.inferTypes(); }
+
+        @Override public boolean inferValues() { return SUBSUMPTIVE.inferValues(); }
+
+        @Override public boolean allowsNonInjectiveMappings() { return SUBSUMPTIVE.allowsNonInjectiveMappings(); }
+
+        @Override public boolean typeDirectednessCompatibility(Atomic parent, Atomic child) { return SUBSUMPTIVE.typeDirectednessCompatibility(parent, child); }
+
+        @Override public boolean roleCompatibility(Role parent, Role child) { return SUBSUMPTIVE.roleCompatibility(parent, child); }
+
+        @Override public boolean typePlayability(ReasonerQuery query, Variable var, Type type) { return SUBSUMPTIVE.typePlayability(query, var, type); }
+
+        @Override
+        public boolean typeCompatibility(Set<? extends SchemaConcept> parentTypes, Set<? extends SchemaConcept> childTypes) {
+            return SUBSUMPTIVE.typeCompatibility(parentTypes, childTypes);
+        }
+
+        @Override
+        public boolean valueCompatibility(Atomic parent, Atomic child) {
+            return SUBSUMPTIVE.valueCompatibility(parent, child);
+        }
+
+        @Override
+        public boolean predicateCompatibility(Set<Atomic> parent, Set<Atomic> child, BiFunction<Atomic, Atomic, Boolean> comparison) {
+            return SUBSUMPTIVE.predicateCompatibility(parent, child, comparison);
+        }
+
+        @Override
+        public boolean attributeCompatibility(ReasonerQuery parent, ReasonerQuery child, Variable parentVar, Variable childVar) {
+            return SUBSUMPTIVE.attributeCompatibility(parent, child, parentVar, childVar);
+        }
+
+        @Override
+        public boolean idCompatibility(Atomic parent, Atomic child) {
+            return parent == null || child != null;
+        }
+
+        @Override
+        public boolean idCompatibility(Set<Atomic> parent, Set<Atomic> child){
+            return parent.isEmpty()
+                    || isEquivalentCollection(parent, child, this::idCompatibility);
+        }
     }
 }

--- a/kb/graql/reasoner/atom/Atomic.java
+++ b/kb/graql/reasoner/atom/Atomic.java
@@ -121,10 +121,10 @@ public interface Atomic {
      * i. e. the set of answers of A is a subset of the set of answers of B
      *
      * @param atom to compare with
-     * @return true if this atom subsumes the provided atom
+     * @return true if this atom isSubsumedBy the provided atom
      */
     @CheckReturnValue
-    boolean subsumes(Atomic atom);
+    boolean isSubsumedBy(Atomic atom);
 
     /**
      * @return alpha-equivalence hash code

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -229,7 +229,7 @@ public class QueryCacheIT {
             //NB: WE ACK COMPLETENESS
             cache.ackDBCompleteness(parentQuery);
 
-            //fetch a query that subsumes parent
+            //fetch a query that isSubsumedBy parent
             ReasonerAtomicQuery groundChildQuery = testTx.reasonerQueryFactory().atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y) isa binary;" +
@@ -244,7 +244,7 @@ public class QueryCacheIT {
             childAnswers.forEach(ans -> assertTrue(ans.explanation().isRuleExplanation()));
             assertTrue(cache.isDBComplete(groundChildQuery));
 
-            //fetch a different query, the query is subsumes the parent structurally
+            //fetch a different query, the query is isSubsumedBy the parent structurally
             //although parent is present, the answer is not in the cache so it needs to be fetched from the db
             ReasonerAtomicQuery indirectGroundChildQuery = testTx.reasonerQueryFactory().atomic(conjunction(
                     "{" +
@@ -285,7 +285,7 @@ public class QueryCacheIT {
                     .forEach(ans -> cache.record(parentQuery, ans));
             cache.ackDBCompleteness(parentQuery);
 
-            //fetch a query that subsumes parent
+            //fetch a query that isSubsumedBy parent
             ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +
@@ -400,7 +400,7 @@ public class QueryCacheIT {
                     .map(ans -> ans.explain(new LookupExplanation(), parentQuery.getPattern()))
                     .forEach(ans -> cache.record(parentQuery, ans));
 
-            //fetch a query that subsumes parent
+            //fetch a query that isSubsumedBy parent
             ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction(
                     "{" +
                             "(baseRole1: $x, baseRole2: $y, baseRole3: $z) isa ternary;" +

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -333,7 +333,7 @@ public class QueryCacheIT {
                     "{" +
                             "(subRole1: $x, subRole2: $y) isa binary;" +
                             "$y id " + sConcept.id().getValue() + ";" +
-                            "};");
+                            "};"));
 
             tx.stream(genericQuery.getQuery(), false)
                     .filter(ans -> ans.get("y").equals(sConcept))

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -921,13 +921,13 @@ public class QueryCacheIT {
                                         "};"
                         ));
 
-                        boolean subsumes = xEntity.equals(entity) || yEntity.equals(entity);
+                        boolean isSubsumedBy = xEntity.equals(entity) || yEntity.equals(entity);
                         boolean strictlySubsumes = xEntity.equals(entity);
 
                         //cache will only contain entries and families if there are answers
                         assertEquals(
                                 "invalid completion outcome between parent:\n " + parentQuery + "\n and child:\n" + childQuery,
-                                subsumes && !parentAnswers.isEmpty(), cache.isComplete(childQuery)
+                                isSubsumedBy && !parentAnswers.isEmpty(), cache.isComplete(childQuery)
                         );
                         if (strictlySubsumes) {
                             List<ConceptMap> childAnswers = tx.execute(childQuery.getQuery());

--- a/test-integration/graql/reasoner/query/SubsumptionIT.java
+++ b/test-integration/graql/reasoner/query/SubsumptionIT.java
@@ -114,10 +114,10 @@ public class SubsumptionIT {
             ReasonerAtomicQuery child2 = reasonerQueryFactory.atomic(conjunction("{(baseRole1: $x, baseRole2: $y); $y id " + id + ";};"));
             ReasonerAtomicQuery parent = reasonerQueryFactory.atomic(conjunction("(baseRole1: $x, baseRole2: $x);"));
 
-            assertFalse(child.subsumes(parent));
-            assertFalse(child2.subsumes(parent));
-            assertFalse(child.subsumes(parent));
-            assertFalse(child2.subsumes(parent));
+            assertFalse(child.isSubsumedBy(parent));
+            assertFalse(child2.isSubsumedBy(parent));
+            assertFalse(child.isSubsumedBy(parent));
+            assertFalse(child2.isSubsumedBy(parent));
         }
     }
 
@@ -591,17 +591,17 @@ public class SubsumptionIT {
         }
     }
 
-    private void subsumption(String childString, String parentString, boolean subsumes, TestTransactionProvider.TestTransaction tx) {
+    private void subsumption(String childString, String parentString, boolean isSubsumedBy, TestTransactionProvider.TestTransaction tx) {
         ReasonerQueryFactory reasonerQueryFactory = tx.reasonerQueryFactory();
         ReasonerAtomicQuery child = reasonerQueryFactory.atomic(conjunction(childString));
         ReasonerAtomicQuery parent = reasonerQueryFactory.atomic(conjunction(parentString));
         UnifierType unifierType = UnifierType.SUBSUMPTIVE;
 
-        assertEquals("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n", subsumes, child.subsumes(parent));
+        assertEquals("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n", isSubsumedBy, child.isSubsumedBy(parent));
         MultiUnifier multiUnifier = child.getMultiUnifier(parent, unifierType);
-        if (subsumes) {
+        if (isSubsumedBy) {
             boolean queriesEquivalent = child.isEquivalent(parent);
-            assertEquals("Unexpected inverse subsumption outcome: between the child - parent pair:\n" + parent + " :\n" + child + "\n", queriesEquivalent, parent.subsumes(child));
+            assertEquals("Unexpected inverse subsumption outcome: between the child - parent pair:\n" + parent + " :\n" + child + "\n", queriesEquivalent, parent.isSubsumedBy(child));
             MultiUnifier multiUnifierInverse = parent.getMultiUnifier(child, unifierType);
             if (queriesEquivalent) assertEquals(multiUnifierInverse, multiUnifier.inverse());
         }

--- a/test-integration/graql/reasoner/reasoning/RecursionIT.java
+++ b/test-integration/graql/reasoner/reasoning/RecursionIT.java
@@ -80,13 +80,17 @@ public class RecursionIT {
                 String explicitQuery = "match $Y isa person, has name $name;" +
                         "{$name == 'aaa';} or {$name == 'aab';} or {$name == 'aaaa';};get $Y, $name;";
 
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitQuery).asGet(), false), tx.execute(Graql.parse(query).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitQuery).asGet(), false),
+                        tx.execute(Graql.parse(query).asGet()));
 
                 String noRoleQuery = "match ($X, $Y) isa Ancestor;$X has name 'aa'; get $Y;";
                 String explicitQuery2 = "match $Y isa person, has name $name;" +
                         "{$name == 'a';} or {$name == 'aaa';} or {$name == 'aab';} or {$name == 'aaaa';};get $Y;";
 
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitQuery2).asGet(), false), tx.execute(Graql.parse(noRoleQuery).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitQuery2).asGet(), false),
+                        tx.execute(Graql.parse(noRoleQuery).asGet()));
 
                 String closure = "match (ancestor: $X, descendant: $Y) isa Ancestor; get;";
                 String explicitClosure = "match $Y isa person, has name $nameY; $X isa person, has name $nameX;" +
@@ -96,7 +100,9 @@ public class RecursionIT {
                         "{$nameX == 'aa';$nameY == 'aab';} or {$nameX == 'aa';$nameY == 'aaaa';} or " +
                         "{$nameX == 'aaa';$nameY == 'aaaa';} or {$nameX == 'c';$nameY == 'ca';}; get $X, $Y;";
 
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitClosure).asGet(), false), tx.execute(Graql.parse(closure).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitClosure).asGet(), false),
+                        tx.execute(Graql.parse(closure).asGet()));
 
                 String noRoleClosure = "match ($X, $Y) isa Ancestor; get;";
                 String explicitNoRoleClosure = "match $Y isa person, has name $nameY; $X isa person, has name $nameX;" +
@@ -117,7 +123,9 @@ public class RecursionIT {
                         +
                         "{$nameX == 'c';$nameY == 'ca';} or " +
                         "{$nameY == 'c';$nameX == 'ca';}; get $X, $Y;";
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitNoRoleClosure).asGet(), false), tx.execute(Graql.parse(noRoleClosure).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitNoRoleClosure).asGet(), false),
+                        tx.execute(Graql.parse(noRoleClosure).asGet()));
             }
         }
     }
@@ -132,18 +140,26 @@ public class RecursionIT {
             try (Transaction tx = session.writeTransaction()) {
                 String ancestorVariant = "match (ancestor: $X, ancestor-friend: $Y) isa Ancestor-friend;$X has name 'a'; $Y has name $name; get $Y;";
                 String explicitAncestorQuery = "match $Y has name $name;{$name == 'd';} or {$name == 'g';}; get $Y;";
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitAncestorQuery).asGet(), false), tx.execute(Graql.parse(ancestorVariant).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitAncestorQuery).asGet(), false),
+                        tx.execute(Graql.parse(ancestorVariant).asGet()));
 
                 String noRoleAncestorQuery = "match ($X, $Y) isa Ancestor-friend;$X has name 'a'; get $Y;";
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitAncestorQuery).asGet(), false), tx.execute(Graql.parse(noRoleAncestorQuery).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitAncestorQuery).asGet(), false),
+                        tx.execute(Graql.parse(noRoleAncestorQuery).asGet()));
 
                 String ancestorFriendVariant = "match (ancestor: $X, ancestor-friend: $Y) isa Ancestor-friend;$Y has name 'd'; get $X;";
                 String explicitAncestorFriendQuery = "match $X has name $name;" +
                         "{$name == 'a';} or {$name == 'b';} or {$name == 'c';}; get $X;";
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitAncestorFriendQuery).asGet(), false), tx.execute(Graql.parse(ancestorFriendVariant).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitAncestorFriendQuery).asGet(), false),
+                        tx.execute(Graql.parse(ancestorFriendVariant).asGet()));
 
                 String noRoleAncestorFriendQuery = "match ($X, $Y) isa Ancestor-friend;$Y has name 'd'; get $X;";
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitAncestorFriendQuery).asGet(), false), tx.execute(Graql.parse(noRoleAncestorFriendQuery).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitAncestorFriendQuery).asGet(), false),
+                        tx.execute(Graql.parse(noRoleAncestorFriendQuery).asGet()));
             }
         }
     }
@@ -159,7 +175,9 @@ public class RecursionIT {
                 String queryString = "match ($x, $y) isa SameGen; $x has name 'a'; get $y;";
                 String explicitQuery = "match $y has name $name;{$name == 'f';} or {$name == 'a';};get $y;";
 
-                GraqlTestUtil.assertCollectionsNonTriviallyEqual(tx.execute(Graql.parse(explicitQuery).asGet(), false), tx.execute(Graql.parse(queryString).asGet()));
+                GraqlTestUtil.assertCollectionsNonTriviallyEqual(
+                        tx.execute(Graql.parse(explicitQuery).asGet(), false),
+                        tx.execute(Graql.parse(queryString).asGet()));
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

To revise the query cache behaviours so that we can increase the cache efficiency. In certain scenarios query results weren't reused when they could have. The specific scenario we address here is when there is a subsumption relation between a cache query and input query up to the choice of ids - which we refer to as structural subsumption.

Previously, we stored query cache entries with specific IDs attached in the lookup key. This led to a second layer of stored IDs that are all valid substitutions into the query. Effectively, the specific IDs attached at the lookup key are placeholders that we now ignore (using structural subsumption), and so can find all the IDs matching a query rather than a specific one.

## What are the changes implement in this PR?
* introduced `STRUCTURAL_SUBSUMTIVE` unifier for determination of structural subsumption relation
* query cache entries are now compared wrt structural subsumption
* revised the `GET` and `PROPAGATE` behaviours to incorporate the new comparison

