### PR TITLE
Use keyspace stats for determining instance existence in RuleCache

### DIFF
--- a/graql/reasoner/cache/RuleCacheImpl.java
+++ b/graql/reasoner/cache/RuleCacheImpl.java
@@ -158,8 +158,12 @@ public class RuleCacheImpl implements RuleCache {
     }
 
     private boolean instancePresent(Type type){
-        return type.subs()
+        boolean instanceCountPresent = type.subs()
                 .anyMatch(t -> keyspaceStatistics.count(conceptManager, t.label()) != 0);
+        if (instanceCountPresent) return true;
+
+        //NB: this is a defensive check, it stat count shows 0 (no instances) we additionally check the DB
+        return type.instances().findFirst().isPresent();
     }
 
     private boolean typeHasInstances(Type type){

--- a/graql/reasoner/cache/RuleCacheImpl.java
+++ b/graql/reasoner/cache/RuleCacheImpl.java
@@ -163,6 +163,7 @@ public class RuleCacheImpl implements RuleCache {
         if (instanceCountPresent) return true;
 
         //NB: this is a defensive check, it stat count shows 0 (no instances) we additionally check the DB
+        //also, if we have ephemeral instances (inserted but not committed), we will catch them by doing the DB check
         return type.instances().findFirst().isPresent();
     }
 

--- a/graql/reasoner/cache/RuleCacheImpl.java
+++ b/graql/reasoner/cache/RuleCacheImpl.java
@@ -30,6 +30,7 @@ import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.cache.RuleCache;
 
+import grakn.core.kb.keyspace.KeyspaceStatistics;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -45,7 +46,8 @@ public class RuleCacheImpl implements RuleCache {
 
     private final HashMultimap<Type, Rule> ruleMap = HashMultimap.create();
     private final Map<Rule, InferenceRule> ruleConversionMap = new HashMap<>();
-    private ConceptManager conceptManager;
+    private final ConceptManager conceptManager;
+    private final KeyspaceStatistics keyspaceStatistics;
 
     //TODO: these should be eventually stored together with statistics
     private Set<Type> absentTypes = new HashSet<>();
@@ -54,8 +56,9 @@ public class RuleCacheImpl implements RuleCache {
     private Set<Rule> checkedRules = new HashSet<>();
     private ReasonerQueryFactory reasonerQueryFactory;
 
-    public RuleCacheImpl(ConceptManager conceptManager) {
+    public RuleCacheImpl(ConceptManager conceptManager, KeyspaceStatistics keyspaceStatistics) {
         this.conceptManager = conceptManager;
+        this.keyspaceStatistics = keyspaceStatistics;
     }
 
     /*
@@ -154,10 +157,15 @@ public class RuleCacheImpl implements RuleCache {
         return match.stream();
     }
 
+    private boolean instancePresent(Type type){
+        return type.subs()
+                .anyMatch(t -> keyspaceStatistics.count(conceptManager, t.label()) != 0);
+    }
+
     private boolean typeHasInstances(Type type){
         if (checkedTypes.contains(type)) return !absentTypes.contains(type);
         checkedTypes.add(type);
-        boolean instancePresent = type.instances().findFirst().isPresent()
+        boolean instancePresent =instancePresent(type)
                 || type.subs().flatMap(SchemaConcept::thenRules).anyMatch(this::isRuleMatchable);
         if (!instancePresent){
             absentTypes.add(type);

--- a/server/session/TransactionProviderImpl.java
+++ b/server/session/TransactionProviderImpl.java
@@ -91,7 +91,7 @@ public class TransactionProviderImpl implements TransactionProvider {
         ConceptManager conceptManager = new ConceptManagerImpl(elementFactory, transactionCache, conceptNotificationChannel, attributeManager);
         TraversalPlanFactory traversalPlanFactory = new TraversalPlanFactoryImpl(janusTraversalSourceProvider, conceptManager, typeShardThreshold, keyspaceStatistics);
         ExecutorFactoryImpl executorFactory = new ExecutorFactoryImpl(conceptManager, hadoopGraph, keyspaceStatistics, traversalPlanFactory);
-        RuleCacheImpl ruleCache = new RuleCacheImpl(conceptManager);
+        RuleCacheImpl ruleCache = new RuleCacheImpl(conceptManager, keyspaceStatistics);
         MultilevelSemanticCache queryCache = new MultilevelSemanticCache(executorFactory, traversalPlanFactory);
 
         PropertyAtomicFactory propertyAtomicFactory = new PropertyAtomicFactory(conceptManager, ruleCache, queryCache, keyspaceStatistics);

--- a/test-integration/rule/TestTransactionProvider.java
+++ b/test-integration/rule/TestTransactionProvider.java
@@ -94,7 +94,7 @@ public class TestTransactionProvider implements TransactionProvider {
         ConceptManagerImpl conceptManager = new ConceptManagerImpl(elementFactory, transactionCache, conceptNotificationChannel, attributeManager);
         TraversalPlanFactory traversalPlanFactory = new TraversalPlanFactoryImpl(janusTraversalSourceProvider, conceptManager, typeShardThreshold, keyspaceStatistics);
         ExecutorFactoryImpl executorFactory = new ExecutorFactoryImpl(conceptManager, hadoopGraph, keyspaceStatistics, traversalPlanFactory);
-        RuleCacheImpl ruleCache = new RuleCacheImpl(conceptManager);
+        RuleCacheImpl ruleCache = new RuleCacheImpl(conceptManager, keyspaceStatistics);
         MultilevelSemanticCache queryCache = new MultilevelSemanticCache(executorFactory, traversalPlanFactory);
 
         PropertyAtomicFactory propertyAtomicFactory = new PropertyAtomicFactory(conceptManager, ruleCache, queryCache, keyspaceStatistics);


### PR DESCRIPTION
## What is the goal of this PR?

To prioritise using keyspace statistics for determining whether a type has instances (instead of using concept api) - fetching from keyspace statistics is much cheaper than checking the DB.

## What are the changes implemented in this PR?
* use keyspace statistics to find out whether any type instances exist
