### PR TITLE
Bring back the previous LogInstanceCount behaviour

### DIFF
--- a/graql/planning/TraversalPlanFactoryImpl.java
+++ b/graql/planning/TraversalPlanFactoryImpl.java
@@ -328,6 +328,8 @@ public class TraversalPlanFactoryImpl implements TraversalPlanFactory {
     private double getLogInstanceCount(Fragment fragment) {
         // set the weight of the node as a starting point based on log(number of this node)
         double logInstanceCount;
+
+        //this is to make sure we don't end up with log(0)
         double shardLoadFactor = 0.25;
         if (fragment instanceof LabelFragment) {
             // only LabelFragment (corresponding to type vertices) can be sharded


### PR DESCRIPTION
## What is the goal of this PR?
Revert the `getLogInstanceCount` function to previous behaviour as the query planner needs updating to implement the function in a more granular fashion.
## What are the changes implemented in this PR?
- revert `getLogInstanceCount` to previous behaviour
