### PR TITLE
Update resolution state terminology

### DIFF
--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -52,7 +52,7 @@ import grakn.core.graql.reasoner.rule.RuleUtils;
 import grakn.core.graql.reasoner.state.AnswerPropagatorState;
 import grakn.core.graql.reasoner.state.AnswerState;
 import grakn.core.graql.reasoner.state.ConjunctiveState;
-import grakn.core.graql.reasoner.state.CumulativeState;
+import grakn.core.graql.reasoner.state.JoinState;
 import grakn.core.graql.reasoner.state.ResolutionState;
 import grakn.core.graql.reasoner.state.VariableComparisonState;
 import grakn.core.graql.reasoner.unifier.UnifierType;
@@ -673,7 +673,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
             dbIterator = Collections.emptyIterator();
 
             ResolutionQueryPlan queryPlan = new ResolutionQueryPlan(reasonerQueryFactory, this);
-            subGoalIterator = Iterators.singletonIterator(new CumulativeState(queryPlan.queries(), new ConceptMap(), parent.getUnifier(), parent, subGoals));
+            subGoalIterator = Iterators.singletonIterator(new JoinState(queryPlan.queries(), new ConceptMap(), parent.getUnifier(), parent, subGoals));
         }
         return Iterators.concat(dbIterator, subGoalIterator);
     }

--- a/graql/reasoner/state/JoinState.java
+++ b/graql/reasoner/state/JoinState.java
@@ -38,15 +38,15 @@ import java.util.stream.Collectors;
 /**
  * Query state corresponding to a an intermediate state obtained from decomposing a conjunctive query (ReasonerQueryImpl) in the resolution tree.
  */
-public class CumulativeState extends AnswerPropagatorState<ReasonerQueryImpl> {
+public class JoinState extends AnswerPropagatorState<ReasonerQueryImpl> {
 
     private final LinkedList<ReasonerQueryImpl> subQueries;
 
-    public CumulativeState(List<ReasonerQueryImpl> qs,
-                           ConceptMap sub,
-                           Unifier u,
-                           AnswerPropagatorState parent,
-                           Set<ReasonerAtomicQuery> subGoals) {
+    public JoinState(List<ReasonerQueryImpl> qs,
+                     ConceptMap sub,
+                     Unifier u,
+                     AnswerPropagatorState parent,
+                     Set<ReasonerAtomicQuery> subGoals) {
         super(Iterables.getFirst(qs, null), sub, u, parent, subGoals);
         this.subQueries = new LinkedList<>(qs);
         subQueries.removeFirst();
@@ -80,7 +80,7 @@ public class CumulativeState extends AnswerPropagatorState<ReasonerQueryImpl> {
 
         if (answer.isEmpty()) return null;
         if (subQueries.isEmpty()) return new AnswerState(answer, getUnifier(), getParentState());
-        return new CumulativeState(subQueries, answer, getUnifier(), getParentState(), getVisitedSubGoals());
+        return new JoinState(subQueries, answer, getUnifier(), getParentState(), getVisitedSubGoals());
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

Change some of the resolution state terminology so it makes more sense and is less confusing, additionally it aligns with explanation terminology.

## What are the changes implemented in this PR?

- rename `CumulativeState` to `JoinState`
