### PR TITLE
Disable source code analysis by SonarCloud

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,17 @@ jobs:
           command: bazel run @graknlabs_build_tools//unused_deps -- list
           no_output_timeout: 30m
 
-  build-analysis:
-    machine: true
-    working_directory: ~/grakn
-    steps:
-      - install-bazel-linux-rbe
-      - checkout
-      - run: |
-          SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
-            bazel run @graknlabs_build_tools//sonarcloud:code-analysis -- \
-            --project-key graknlabs_grakn_core --commit-id=$CIRCLE_SHA1 --branch=$CIRCLE_BRANCH
+  # TODO: restore when graknlabs/grakn#5551 is fixed
+  # build-analysis:
+  #   machine: true
+  #   working_directory: ~/grakn
+  #   steps:
+  #     - install-bazel-linux-rbe
+  #     - checkout
+  #     - run: |
+  #         SONARCLOUD_CODE_ANALYSIS_CREDENTIAL=$SONARCLOUD_CREDENTIAL \
+  #           bazel run @graknlabs_build_tools//sonarcloud:code-analysis -- \
+  #           --project-key graknlabs_grakn_core --commit-id=$CIRCLE_SHA1 --branch=$CIRCLE_BRANCH
   
   test-common:
     machine: true
@@ -408,10 +409,10 @@ workflows:
           filters:
             branches:
               ignore: grakn-release-branch
-      - build-analysis:
-          filters:
-            branches:
-              only: master
+      # - build-analysis:
+      #     filters:
+      #       branches:
+      #         only: master
       - test-common:
           filters:
             branches:
@@ -443,7 +444,7 @@ workflows:
           requires:
             - build
             - build-checkstyle
-            - build-analysis
+            # - build-analysis
             - test-common
             - test-server
             - test-integration
@@ -457,7 +458,7 @@ workflows:
           requires:
             - build
             - build-checkstyle
-            - build-analysis
+            # - build-analysis
             - test-common
             - test-server
             - test-integration
@@ -471,7 +472,7 @@ workflows:
           requires:
             - build
             - build-checkstyle
-            - build-analysis
+            # - build-analysis
             - test-common
             - test-server
             - test-integration
@@ -485,7 +486,7 @@ workflows:
           requires:
             - build
             - build-checkstyle
-            - build-analysis
+            # - build-analysis
             - test-common
             - test-server
             - test-integration


### PR DESCRIPTION
## What is the goal of this PR?

`build-analysis` repetitively fails because of a bug in SonarCloud (relevant issue: #5551)

## What are the changes implemented in this PR?

Comment out `build-analysis` CI job