### PR TITLE
Fix relabeling and fail fast for invalid concept ID

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -44,7 +44,7 @@ public enum ErrorMessage {
     SUPER_LOOP_DETECTED("By setting the super of concept [%s] to [%s]. You will be creating a loop. This is prohibited"),
     INVALID_UNIQUE_PROPERTY_MUTATION("Property [%s] of Concept [%s] cannot be changed to [%s] as it is already taken by Concept [%s]"),
     UNIQUE_PROPERTY_TAKEN("Property [%s] with value [%s] is already taken by concept [%s]"),
-    INVALID_DATATYPE("The value [%s] of type [%s] must be of datatype [%s]"),
+    INVALID_DATATYPE("The value [%s] of type [%s] must be of datatype [%s] for attribute type [%s]"),
     INVALID_OBJECT_TYPE("The concept [%s] is not of type [%s]"),
     REGEX_INSTANCE_FAILURE("The regex [%s] of Attribute Type [%s] cannot be applied because value [%s] " +
             "does not conform to the regular expression"),

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -152,6 +152,7 @@ public enum ErrorMessage {
 
     MUST_BE_ATTRIBUTE_TYPE("type '%s' must be an attribute-type"),
     ID_NOT_FOUND("id '%s' not found"),
+    INVALID_CONCEPT_ID_FORMAT("Concept Id '%s' is invalid"),
     LABEL_NOT_FOUND("label '%s' not found"),
     NOT_A_ROLE_TYPE("'%s' is not a role type. perhaps you meant 'isa %s'?"),
     NOT_A_RELATION_TYPE("'%s' is not a relation type. perhaps you forgot to separate your statements with a ';'?"),
@@ -207,7 +208,6 @@ public enum ErrorMessage {
     K_SMALLER_THAN_TWO("k can't be smaller than 2."),
     INSTANCE_DOES_NOT_EXIST("Instance does not exist in the subgraph."),
     MAX_ITERATION_REACHED("Max iteration of [%s] reached.");
-
     private final String message;
 
     ErrorMessage(String message) {

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -434,6 +434,8 @@ public class ConceptManagerImpl implements ConceptManager {
 
     @Override
     public <T extends Concept> T getConcept(ConceptId conceptId) {
+        Schema.validateConceptId(conceptId);
+
         if (transactionCache.isConceptCached(conceptId)) {
             return transactionCache.getCachedConcept(conceptId);
         }

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -434,7 +434,10 @@ public class ConceptManagerImpl implements ConceptManager {
 
     @Override
     public <T extends Concept> T getConcept(ConceptId conceptId) {
-        Schema.validateConceptId(conceptId);
+        if (!Schema.validateConceptId(conceptId)) {
+            // fail fast if the concept Id format is invalid
+            return null;
+        }
 
         if (transactionCache.isConceptCached(conceptId)) {
             return transactionCache.getCachedConcept(conceptId);

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -268,7 +268,7 @@ public class ConceptManagerImpl implements ConceptManager {
         try {
             convertedValue = AttributeValueConverter.of(type.dataType()).convert(value);
         } catch (ClassCastException e){
-            throw GraknConceptException.invalidAttributeValue(value, dataType);
+            throw GraknConceptException.invalidAttributeValue(type, value, dataType);
         }
 
         // set persisted value

--- a/concept/manager/ConceptNotificationChannelImpl.java
+++ b/concept/manager/ConceptNotificationChannelImpl.java
@@ -69,7 +69,7 @@ public class ConceptNotificationChannelImpl implements ConceptNotificationChanne
 
     @Override
     public void labelAdded(SchemaConcept schemaConcept) {
-        conceptListener.labelRemoved(schemaConcept);
+        conceptListener.labelAdded(schemaConcept);
     }
 
     @Override

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -73,7 +73,9 @@ public final class Schema {
 
     public static void validateConceptId(ConceptId conceptId) throws GraknConceptException {
         try {
-            Long.parseLong(elementId(conceptId));
+            if (!isEdgeId(conceptId)) {
+                Long.parseLong(elementId(conceptId));
+            }
         } catch (NumberFormatException e) {
             throw GraknConceptException.illegalConceptId(conceptId);
         }

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -23,6 +23,7 @@ import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Entity;
 import grakn.core.kb.concept.api.EntityType;
+import grakn.core.kb.concept.api.GraknConceptException;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.LabelId;
 import grakn.core.kb.concept.api.Relation;
@@ -68,6 +69,14 @@ public final class Schema {
 
     public static String elementId(ConceptId conceptId){
         return conceptId.getValue().substring(1);
+    }
+
+    public static void validateConceptId(ConceptId conceptId) throws GraknConceptException {
+        try {
+            Long.parseLong(elementId(conceptId));
+        } catch (NumberFormatException e) {
+            throw GraknConceptException.illegalConceptId(conceptId);
+        }
     }
 
     public static boolean isEdgeId(ConceptId conceptId){

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -58,30 +58,31 @@ public final class Schema {
         throw new UnsupportedOperationException();
     }
 
-    public static ConceptId conceptIdFromVertexId(Object vertexId){
+    public static ConceptId conceptIdFromVertexId(Object vertexId) {
         return ConceptId.of(PREFIX_VERTEX + vertexId);
     }
 
-    public static ConceptId conceptId(Element element){
-        String prefix = element instanceof Edge? PREFIX_EDGE : PREFIX_VERTEX;
+    public static ConceptId conceptId(Element element) {
+        String prefix = element instanceof Edge ? PREFIX_EDGE : PREFIX_VERTEX;
         return ConceptId.of(prefix + element.id().toString());
     }
 
-    public static String elementId(ConceptId conceptId){
+    public static String elementId(ConceptId conceptId) {
         return conceptId.getValue().substring(1);
     }
 
-    public static void validateConceptId(ConceptId conceptId) throws GraknConceptException {
+    public static boolean validateConceptId(ConceptId conceptId) throws GraknConceptException {
         try {
             if (!isEdgeId(conceptId)) {
                 Long.parseLong(elementId(conceptId));
             }
         } catch (NumberFormatException e) {
-            throw GraknConceptException.illegalConceptId(conceptId);
+            return false;
         }
+        return true;
     }
 
-    public static boolean isEdgeId(ConceptId conceptId){
+    public static boolean isEdgeId(ConceptId conceptId) {
         return conceptId.getValue().startsWith(Schema.PREFIX_EDGE);
     }
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,7 +36,7 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         tag = "1.0.4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+         commit = "cd58f610a07ac5396615458cb991e335186a5894", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
      )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -36,7 +36,7 @@ def graknlabs_graql():
      git_repository(
          name = "graknlabs_graql",
          remote = "https://github.com/graknlabs/graql",
-         commit = "cd58f610a07ac5396615458cb991e335186a5894", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+         commit = "11d374b157efc00145851e0b8125d65a716b4bd8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
      )
 
 def graknlabs_protocol():

--- a/dependencies/maven/dependencies.yaml
+++ b/dependencies/maven/dependencies.yaml
@@ -24,7 +24,7 @@ options:
       type: default
       url: https://repo.maven.apache.org/maven2/
     - id: mavengraknai
-      url: http://maven.grakn.ai/nexus/content/repositories/snapshots/
+      url: https://maven.grakn.ai/nexus/content/repositories/snapshots/
     - id: repograknai
       type: default
       url: https://repo.grakn.ai/repository/maven-snapshot/

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -46,6 +46,11 @@ public class GraknConceptException extends GraknException {
         return GraknConceptException.create(ErrorMessage.NOT_A_TYPE.getMessage(concept.id(), concept.getClass()));
     }
 
+    public static GraknConceptException illegalConceptId(ConceptId conceptId) {
+        return GraknConceptException.create(ErrorMessage.INVALID_CONCEPT_ID_FORMAT.getMessage(conceptId))
+        ;
+    }
+
     @Override
     public String getName() {
         return this.getClass().getName();

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -117,8 +117,8 @@ public class GraknConceptException extends GraknException {
     /**
      * Thrown when creating an Attribute whose value Object does not match attribute data type
      */
-    public static GraknConceptException invalidAttributeValue(Object object, AttributeType.DataType dataType) {
-        return create(ErrorMessage.INVALID_DATATYPE.getMessage(object, object.getClass().getSimpleName(), dataType.name()));
+    public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object, AttributeType.DataType dataType) {
+        return create(ErrorMessage.INVALID_DATATYPE.getMessage(object, object.getClass().getSimpleName(), dataType.name(), attributeType.label()));
     }
 
     /**

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -46,11 +46,6 @@ public class GraknConceptException extends GraknException {
         return GraknConceptException.create(ErrorMessage.NOT_A_TYPE.getMessage(concept.id(), concept.getClass()));
     }
 
-    public static GraknConceptException illegalConceptId(ConceptId conceptId) {
-        return GraknConceptException.create(ErrorMessage.INVALID_CONCEPT_ID_FORMAT.getMessage(conceptId))
-        ;
-    }
-
     @Override
     public String getName() {
         return this.getClass().getName();

--- a/test-integration/concept/AttributeIT.java
+++ b/test-integration/concept/AttributeIT.java
@@ -177,7 +177,7 @@ public class AttributeIT {
         String invalidThing = "Invalid Thing";
         AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.DataType.LONG);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(invalidThing, AttributeType.DataType.LONG).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(longAttributeType, invalidThing, AttributeType.DataType.LONG).getMessage());
         longAttributeType.create(invalidThing);
     }
 
@@ -186,10 +186,10 @@ public class AttributeIT {
     @Test
     public void whenCreatingResourceWithAnInvalidDataTypeOnADate_Throw() {
         String invalidThing = "Invalid Thing";
-        AttributeType longAttributeType = tx.putAttributeType("date", AttributeType.DataType.DATE);
+        AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.DataType.DATE);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(invalidThing, AttributeType.DataType.DATE).getMessage());
-        longAttributeType.create(invalidThing);
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.DataType.DATE).getMessage());
+        dateAttributeType.create(invalidThing);
     }
 
     // this is deliberately an incorrect type for the test

--- a/test-integration/concept/SchemaConceptIT.java
+++ b/test-integration/concept/SchemaConceptIT.java
@@ -49,6 +49,7 @@ import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -86,12 +87,16 @@ public class SchemaConceptIT {
         //Change The Label
         entityType.label(newLabel);
 
-        //Check the label is changes
-        assertEquals(newLabel, entityType.label());
-        assertEquals(entityType, tx.getType(newLabel));
-
         //Check old label is dead
         assertNull(tx.getType(originalLabel));
+
+        // check new label is not dead
+        assertNotNull(tx.getSchemaConcept(newLabel));
+        assertEquals(entityType, tx.getType(newLabel));
+
+        //Check the label is changes
+        assertEquals(newLabel, entityType.label());
+
     }
 
     @Test

--- a/test-integration/server/session/TransactionIT.java
+++ b/test-integration/server/session/TransactionIT.java
@@ -122,11 +122,8 @@ public class TransactionIT {
     }
 
     @Test
-    public void whenGettingConceptWithInvalidId_Throw() {
-        expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("Concept Id");
-        expectedException.expectMessage("is invalid");
-        tx.getConcept(ConceptId.of("not_valid_id"));
+    public void whenGettingConceptWithInvalidId_Null() {
+        assertNull(tx.getConcept(ConceptId.of("not_valid_id")));
     }
 
     @Test

--- a/test-integration/server/session/TransactionIT.java
+++ b/test-integration/server/session/TransactionIT.java
@@ -32,6 +32,7 @@ import grakn.core.kb.concept.api.Concept;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Entity;
 import grakn.core.kb.concept.api.EntityType;
+import grakn.core.kb.concept.api.GraknConceptException;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.RelationType;
 import grakn.core.kb.concept.api.Role;
@@ -118,6 +119,14 @@ public class TransactionIT {
     public void whenGettingConceptById_ReturnTheConcept() {
         EntityType entityType = tx.putEntityType("test-name");
         assertEquals(entityType, tx.getConcept(entityType.id()));
+    }
+
+    @Test
+    public void whenGettingConceptWithInvalidId_Throw() {
+        expectedException.expect(GraknConceptException.class);
+        expectedException.expectMessage("Concept Id");
+        expectedException.expectMessage("is invalid");
+        tx.getConcept(ConceptId.of("not_valid_id"));
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?
Fix bugs that were flagged from client-python, including tests that were failing during the process of re-labeling a concept type, and a horribly long stack trace when simply providing an invalidly formatted concept ID, which now returns a null concept.

## What are the changes implemented in this PR?
* New error message, validation, and test for invalid concept Id format, which should return null fast
* Fix bug introduced by refactors that when re-labeling a concept the new label is not available via `tx.getType` or `tx.getSchemaConcept`
* Invalid data type supplied to instantiating a attribute with a different data type returns a more meaningful error.