### PR TITLE
Fix rule overpruning when rules with negated patterns do not have instances

### DIFF
--- a/concept/manager/ConceptListenerImpl.java
+++ b/concept/manager/ConceptListenerImpl.java
@@ -113,7 +113,7 @@ public class ConceptListenerImpl implements ConceptListener {
      */
     private void thingCreated(Thing thing, boolean isInferred) {
         Type thingType = thing.type();
-        ruleCache.ackTypeInstance(thingType);
+        ruleCache.ackTypeInstanceInsertion(thingType);
         statistics.increment(thingType);
 
         if (isInferred) {

--- a/graql/reasoner/cache/RuleCacheImpl.java
+++ b/graql/reasoner/cache/RuleCacheImpl.java
@@ -93,8 +93,6 @@ public class RuleCacheImpl implements RuleCache {
                 .filter(Objects::nonNull)
                 .filter(Concept::isType)
                 .map(Concept::asType)
-                //NB: we only update visited entries
-                //.filter(type -> Objects.nonNull())
                 .forEach(type -> {
                     Set<Rule> match = ruleMap.get(type);
                     if (match == null) {

--- a/graql/reasoner/cache/RuleCacheImpl.java
+++ b/graql/reasoner/cache/RuleCacheImpl.java
@@ -20,17 +20,18 @@
 package grakn.core.graql.reasoner.cache;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.HashMultimap;
 import grakn.core.core.Schema;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.rule.InferenceRule;
+import grakn.core.kb.concept.api.Concept;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.cache.RuleCache;
-
 import grakn.core.kb.keyspace.KeyspaceStatistics;
+import graql.lang.pattern.Pattern;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -44,12 +45,12 @@ import java.util.stream.Stream;
  */
 public class RuleCacheImpl implements RuleCache {
 
-    private final HashMultimap<Type, Rule> ruleMap = HashMultimap.create();
+    //NB: we specifically use map to differentiate between type with no rules (empty set) and unchecked type (null)
+    private final Map<Type, Set<Rule>> ruleMap = new HashMap<>();
     private final Map<Rule, InferenceRule> ruleConversionMap = new HashMap<>();
     private final ConceptManager conceptManager;
     private final KeyspaceStatistics keyspaceStatistics;
 
-    //TODO: these should be eventually stored together with statistics
     private Set<Type> absentTypes = new HashSet<>();
     private Set<Type> checkedTypes = new HashSet<>();
     private Set<Rule> unmatchableRules = new HashSet<>();
@@ -78,18 +79,35 @@ public class RuleCacheImpl implements RuleCache {
     }
 
     /**
-     * @param type rule head's type
      * @param rule to be appended
      */
     @Override
-    public void updateRules(Type type, Rule rule) {
-        Set<Rule> match = ruleMap.get(type);
-        if (match.isEmpty()) {
-            getTypes(type, false)
-                    .flatMap(SchemaConcept::thenRules)
-                    .forEach(r -> ruleMap.put(type, r));
-        }
-        ruleMap.put(type, rule);
+    public void ackRuleInsertion(Rule rule) {
+        Pattern thenPattern = rule.then();
+        if (thenPattern == null) return;
+        //NB: thenTypes() will be empty as type edges added on commit
+        //NB: this will cache also non-committed rules
+        thenPattern.statements().stream()
+                .flatMap(v -> v.getTypes().stream())
+                .map(type -> conceptManager.<SchemaConcept>getSchemaConcept(Label.of(type)))
+                .filter(Objects::nonNull)
+                .filter(Concept::isType)
+                .map(Concept::asType)
+                //NB: we only update visited entries
+                //.filter(type -> Objects.nonNull())
+                .forEach(type -> {
+                    Set<Rule> match = ruleMap.get(type);
+                    if (match == null) {
+                        Set<Rule> rules = new HashSet<>();
+                        rules.add(rule);
+                        getTypes(type, false)
+                                .flatMap(SchemaConcept::thenRules)
+                                .forEach(rules::add);
+                        ruleMap.put(type, rules);
+                    } else {
+                        match.add(rule);
+                    }
+                });
     }
 
     /**
@@ -132,7 +150,7 @@ public class RuleCacheImpl implements RuleCache {
      * @param type to be acked
      */
     @Override
-    public void ackTypeInstance(Type type){
+    public void ackTypeInstanceInsertion(Type type){
         checkedTypes.add(type);
         absentTypes.remove(type);
     }
@@ -147,14 +165,16 @@ public class RuleCacheImpl implements RuleCache {
         if (type == null) return getRules();
 
         Set<Rule> match = ruleMap.get(type);
-        if (!match.isEmpty()) return match.stream();
+        if (match != null) return match.stream();
 
+        Set<Rule> rules = new HashSet<>();
         getTypes(type, direct)
                 .flatMap(SchemaConcept::thenRules)
                 .filter(this::isRuleMatchable)
-                .forEach(rule -> ruleMap.put(type, rule));
+                .forEach(rules::add);
+        ruleMap.put(type, rules);
 
-        return match.stream();
+        return rules.stream();
     }
 
     private boolean instancePresent(Type type){
@@ -174,7 +194,9 @@ public class RuleCacheImpl implements RuleCache {
                 || type.subs().flatMap(SchemaConcept::thenRules).anyMatch(this::isRuleMatchable);
         if (!instancePresent){
             absentTypes.add(type);
-            type.whenRules().forEach(r -> unmatchableRules.add(r));
+            type.whenRules()
+                    .filter(rule -> rule.whenPositiveTypes().anyMatch(pt -> pt.equals(type)))
+                    .forEach(r -> unmatchableRules.add(r));
         }
         return instancePresent;
     }

--- a/kb/graql/reasoner/cache/RuleCache.java
+++ b/kb/graql/reasoner/cache/RuleCache.java
@@ -37,12 +37,6 @@ public interface RuleCache {
     Stream<Rule> getRules();
 
     /**
-     * @param type rule head's type
-     * @param rule to be appended
-     */
-    void updateRules(Type type, Rule rule);
-
-    /**
      * @param type for which rules containing it in the head are sought
      * @return rules containing specified type in the head
      */
@@ -56,10 +50,15 @@ public interface RuleCache {
     boolean absentTypes(Set<Type> types);
 
     /**
+     * @param rule whose insertion we want to acknowledge
+     */
+    void ackRuleInsertion(Rule rule);
+
+    /**
      * acknowledge addition of an instance of a specific type
      * @param type to be acked
      */
-    void ackTypeInstance(Type type);
+    void ackTypeInstanceInsertion(Type type);
 
     /**
      * @param type   for which rules containing it in the head are sought

--- a/server/session/TransactionImpl.java
+++ b/server/session/TransactionImpl.java
@@ -849,17 +849,7 @@ public class TransactionImpl implements Transaction {
             ConceptUtils.validateBaseType(SchemaConceptImpl.from(rule), Schema.BaseType.RULE);
         }
 
-        //NB: thenTypes() will be empty as type edges added on commit
-        //NB: this will cache also non-committed rules
-        if (rule.then() != null) {
-            rule.then().statements().stream()
-                    .flatMap(v -> v.getTypes().stream())
-                    .map(type -> this.<SchemaConcept>getSchemaConcept(Label.of(type)))
-                    .filter(Objects::nonNull)
-                    .filter(Concept::isType)
-                    .map(Concept::asType)
-                    .forEach(type -> ruleCache.updateRules(type, rule));
-        }
+        ruleCache.ackRuleInsertion(rule);
         return rule;
     }
 
@@ -1155,7 +1145,7 @@ public class TransactionImpl implements Transaction {
 
     private void removeInferredConcepts() {
         Set<Thing> inferredThingsToDiscard = transactionCache.getInferredInstancesToDiscard().collect(Collectors.toSet());
-        inferredThingsToDiscard.forEach(inferred -> transactionCache.remove(inferred));
+        inferredThingsToDiscard.forEach(transactionCache::remove);
         inferredThingsToDiscard.forEach(Concept::delete);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
When processing rules in `RuleCache`, a rule is discarded if any of its body types do not have an instance in the graph. This is because in such a scenario the rule cannot yield any answers. The instances with no instances are tracked in the `RuleCache`. The current approach takes into account that a premise might be negated - we only consider positive premises. However! The approach doesn't take into account the scenario in which 2 rules with the same type are present where one is positive and one is negative. In such scenario, if the type doesn't have instances and the rule with the positive type gets processed first, when processing the rule with negative type we would discard it.

## What are the changes implemented in this PR?
- when considering types with no instances, we make sure that any possibly discarded rule doesn't negate the premise with that type
- went from Multimap to Map so that we can differentiate whether a type has not been visited (get returns null) or has been visited but no rules are applicable (get returns an empty set)
- moved the whole logic of rule acking to `RuleCache`

