### PR TITLE
Added necessary deps for building and running simulation from grakn repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,8 @@ load(
     "graknlabs_protocol",
     "graknlabs_client_java",
     "graknlabs_console",
-    "graknlabs_benchmark"
+    "graknlabs_benchmark",
+    "graknlabs_simulation",
 )
 graknlabs_build_tools()
 graknlabs_common()
@@ -40,6 +41,7 @@ graknlabs_protocol()
 graknlabs_client_java()
 graknlabs_console()
 graknlabs_benchmark()
+graknlabs_simulation()
 
 load("@graknlabs_build_tools//distribution:dependencies.bzl", "graknlabs_bazel_distribution")
 graknlabs_bazel_distribution()
@@ -158,6 +160,19 @@ container_pull(
   repository = "library/openjdk",
   tag = "8"
 )
+
+
+################################
+# Load Simulation dependencies #
+################################
+
+load("@graknlabs_simulation//dependencies/maven:dependencies.bzl",
+graknlabs_simulation_dependencies = "maven_dependencies")
+graknlabs_simulation_dependencies()
+
+load("@graknlabs_simulation//dependencies/graknlabs:dependencies.bzl", "graknlabs_grabl_tracing")
+graknlabs_grabl_tracing()
+
 
 #####################################
 # Load Bazel common workspace rules #

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -68,12 +68,8 @@ def graknlabs_benchmark():
     )
 
 def graknlabs_simulation():
-#    git_repository(
-#        name = "graknlabs_simulation",
-#        remote = "https://github.com/graknlabs/simulation",
-#        commit = "8f30aa7646177b4afce45584104191a7e4d99219",
-#    )
-    native.local_repository(
+    git_repository(
         name = "graknlabs_simulation",
-        path = "../simulation",
+        remote = "https://github.com/graknlabs/simulation",
+        commit = "c9a40339ca314b7ae46a1f20e268fd6b3a40e026", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_simulation
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -66,3 +66,14 @@ def graknlabs_benchmark():
         remote = "https://github.com/graknlabs/benchmark.git",
         commit = "78869c68a2b6073917f7d6ee085ffd0b0d6a29b0" # keep in sync with protocol changes
     )
+
+def graknlabs_simulation():
+#    git_repository(
+#        name = "graknlabs_simulation",
+#        remote = "https://github.com/graknlabs/simulation",
+#        commit = "8f30aa7646177b4afce45584104191a7e4d99219",
+#    )
+    native.local_repository(
+        name = "graknlabs_simulation",
+        path = "../simulation",
+    )

--- a/server/BUILD
+++ b/server/BUILD
@@ -133,6 +133,26 @@ java_binary(
     visibility = ["//:__pkg__"],
 )
 
+java_binary(
+    name = "server-core-binary",
+    main_class = "grakn.core.server.Grakn",
+    runtime_deps = [
+        "//server:server"
+    ],
+    tags = ["maven_coordinates=io.grakn.core:grakn-server-bin:{pom_version}"],
+    visibility = ["//:__pkg__"],
+)
+
+java_binary(
+    name = "server-storage-binary",
+    main_class = "grakn.core.server.GraknStorage",
+    runtime_deps = [
+        "//server:server"
+    ],
+    tags = ["maven_coordinates=io.grakn.core:grakn-server-bin:{pom_version}"],
+    visibility = ["//:__pkg__"],
+)
+
 java_deps(
     name = "server-deps",
     target = ":server-binary",


### PR DESCRIPTION
## What is the goal of this PR?

To add the dependencies required to build and run the simulation from this repo so that the grabl performance analysis is locked to a version of the simulation defined by this commit (and that can also be updated by grabl).

## What are the changes implemented in this PR?

Added the `@graknlabs_simulation` workspace and necessary rules to load the tracing client dependencies.