### PR TITLE
Cleanup GenerativeOperationalIT

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -22,61 +22,61 @@ def graknlabs_build_tools():
     git_repository(
         name = "graknlabs_build_tools",
         remote = "https://github.com/graknlabs/build-tools",
-        commit = "b731eae85c90128878de58848a1cd8fe516ce58e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
+        commit = "b731eae85c90128878de58848a1cd8fe516ce58e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_build_tools
     )
 
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        tag = "0.2.2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "0.2.2",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_graql():
-     git_repository(
-         name = "graknlabs_graql",
-         remote = "https://github.com/graknlabs/graql",
-         tag = "1.0.6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
-     )
+    git_repository(
+        name = "graknlabs_graql",
+        remote = "https://github.com/graknlabs/graql",
+        tag = "1.0.6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+    )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "1.0.4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        tag = "1.0.4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
-     git_repository(
-         name = "graknlabs_client_java",
-         remote = "https://github.com/graknlabs/client-java",
-         tag = "1.6.2",
-     )
+    git_repository(
+        name = "graknlabs_client_java",
+        remote = "https://github.com/graknlabs/client-java",
+        tag = "1.6.2",
+    )
 
 def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        tag = "1.0.3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
+        tag = "1.0.3",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_console
     )
 
 def graknlabs_benchmark():
     git_repository(
         name = "graknlabs_benchmark",
         remote = "https://github.com/graknlabs/benchmark.git",
-        commit = "78869c68a2b6073917f7d6ee085ffd0b0d6a29b0" # keep in sync with protocol changes
+        commit = "78869c68a2b6073917f7d6ee085ffd0b0d6a29b0",  # keep in sync with protocol changes
     )
 
 def graknlabs_simulation():
     git_repository(
         name = "graknlabs_simulation",
         remote = "https://github.com/graknlabs/simulation",
-        commit = "c9a40339ca314b7ae46a1f20e268fd6b3a40e026", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_simulation
+        commit = "c9a40339ca314b7ae46a1f20e268fd6b3a40e026",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_simulation
     )
 
 def graknlabs_theory():
     git_repository(
         name = "graknlabs_theory",
         remote = "git@github.com:graknlabs/theory.git",
-        commit = "a50bbda8264ba4597951ac1468c90ccc4e55d09c",  # keep in sync with protocol changes
+        commit = "7cb3a92011cf8f790bace3face161108f4bbc701",  # keep in sync with protocol changes
     )

--- a/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
@@ -395,7 +395,6 @@ public class AtomicQueryEquivalenceIT {
         atomicEquivalence(a.getAtom(), b.getAtom(), expectation, equiv.atomicEquivalence());
     }
 
-
     private void queryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, ReasonerQueryEquivalence equiv){
         singleQueryEquivalence(a, a, true, equiv);
         singleQueryEquivalence(b, b, true, equiv);

--- a/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryEquivalenceIT.java
@@ -22,16 +22,16 @@ package grakn.core.graql.reasoner.query;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import grakn.core.common.config.Config;
-import grakn.core.graql.reasoner.atom.AtomicEquivalence;
-import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
 import grakn.core.rule.GraknTestStorage;
 import grakn.core.rule.SessionUtil;
 import grakn.core.rule.TestTransactionProvider;
 import graql.lang.Graql;
-import graql.lang.pattern.Conjunction;
-import graql.lang.statement.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -39,16 +39,10 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
+import static grakn.core.graql.reasoner.query.QueryTestUtil.atomicEquivalence;
+import static grakn.core.graql.reasoner.query.QueryTestUtil.conjunction;
+import static grakn.core.graql.reasoner.query.QueryTestUtil.queryEquivalence;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
-import static java.util.stream.Collectors.toSet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("CheckReturnValue")
 public class AtomicQueryEquivalenceIT {
@@ -393,45 +387,6 @@ public class AtomicQueryEquivalenceIT {
         ReasonerAtomicQuery b = reasonerQueryFactory.atomic(conjunction(patternB));
         queryEquivalence(a, b, expectation, equiv);
         atomicEquivalence(a.getAtom(), b.getAtom(), expectation, equiv.atomicEquivalence());
-    }
-
-    private void queryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, ReasonerQueryEquivalence equiv){
-        singleQueryEquivalence(a, a, true, equiv);
-        singleQueryEquivalence(b, b, true, equiv);
-        singleQueryEquivalence(a, b, queryExpectation, equiv);
-        singleQueryEquivalence(b, a, queryExpectation, equiv);
-    }
-
-    private void atomicEquivalence(Atomic a, Atomic b, boolean expectation, AtomicEquivalence equiv){
-        singleAtomicEquivalence(a, a, true, equiv);
-        singleAtomicEquivalence(b, b, true, equiv);
-        singleAtomicEquivalence(a, b, expectation, equiv);
-        singleAtomicEquivalence(b, a, expectation, equiv);
-    }
-
-    private void singleQueryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, ReasonerQueryEquivalence equiv){
-        assertEquals(equiv.name() + " - Query:\n" + a + "\n=?\n" + b, queryExpectation, equiv.equivalent(a, b));
-
-        //check hash additionally if need to be equal
-        if (queryExpectation) {
-            assertTrue(equiv.name() + ":\n" + a + "\nhash=?\n" + b, equiv.hash(a) == equiv.hash(b));
-        }
-    }
-
-    private void singleAtomicEquivalence(Atomic a, Atomic b, boolean expectation, AtomicEquivalence equivalence){
-        assertEquals(equivalence.name() + " - Atom:\n" + a + "\n=?\n" + b, expectation,  equivalence.equivalent(a, b));
-
-        //check hash additionally if need to be equal
-        if (expectation) {
-            assertTrue(equivalence.name() + ":\n" + a + "\nhash=?\n" + b, equivalence.hash(a) == equivalence.hash(b));
-        }
-    }
-
-    private Conjunction<Statement> conjunction(String patternString){
-        Set<Statement> vars = Graql.parsePattern(patternString)
-                .getDisjunctiveNormalForm().getPatterns()
-                .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
-        return Graql.and(vars);
     }
 
 }

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -1,9 +1,25 @@
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
+java_library(
+    name = "query-test-util",
+    srcs = glob(["QueryTestUtil.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//common",
+        "//dependencies/maven/artifacts/com/google/guava",
+        "//dependencies/maven/artifacts/junit",
+        "//graql/reasoner",
+        "//kb/graql/reasoner",
+        "@graknlabs_graql//java:graql",
+    ],
+)
+
 java_test(
     name = "query-equivalence-it",
     size = "medium",
-    srcs = ["AtomicQueryEquivalenceIT.java"],
+    srcs = [
+        "AtomicQueryEquivalenceIT.java",
+    ],
     classpath_resources = ["//test-integration/resources:logback-test"],
     resources = ["//test-integration/graql/reasoner/resources:generic-schema"],
     test_class = "grakn.core.graql.reasoner.query.AtomicQueryEquivalenceIT",
@@ -14,6 +30,7 @@ java_test(
         "//graql/reasoner",
         "//kb/graql/reasoner",
         "//kb/server",
+        "//test-integration/graql/reasoner/query:query-test-util",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
@@ -142,6 +159,7 @@ java_test(
         "//kb/server",
         "//test-integration/graql/reasoner:pattern",
         "//test-integration/graql/reasoner/graph:generic-schema-graph",
+        "//test-integration/graql/reasoner/query:query-test-util",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
         "@graknlabs_graql//java:graql",
@@ -260,6 +278,7 @@ java_test(
         "//graql/reasoner",
         "//kb/concept/api",
         "//kb/server",
+        "//test-integration/graql/reasoner/query:query-test-util",
         "//test-integration/rule:grakn-test-server",
         "//test-integration/util:graql-test-util",
         "@graknlabs_common//:common",

--- a/test-integration/graql/reasoner/query/QueryTestUtil.java
+++ b/test-integration/graql/reasoner/query/QueryTestUtil.java
@@ -1,3 +1,22 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
 package grakn.core.graql.reasoner.query;
 
 import grakn.core.graql.reasoner.atom.AtomicEquivalence;

--- a/test-integration/graql/reasoner/query/QueryTestUtil.java
+++ b/test-integration/graql/reasoner/query/QueryTestUtil.java
@@ -1,0 +1,71 @@
+package grakn.core.graql.reasoner.query;
+
+import grakn.core.graql.reasoner.atom.AtomicEquivalence;
+import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.graql.reasoner.atom.Atomic;
+import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
+import graql.lang.Graql;
+import graql.lang.pattern.Conjunction;
+import graql.lang.statement.Statement;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class QueryTestUtil {
+
+    public static MultiUnifier unification(ReasonerAtomicQuery child, ReasonerAtomicQuery parent, boolean unifierExists, UnifierType unifierType) {
+        if (unifierType.equivalence() != null) {
+            queryEquivalence(child, parent, unifierExists, unifierType.equivalence());
+        }
+        MultiUnifier multiUnifier = child.getMultiUnifier(parent, unifierType);
+
+        assertEquals("Unexpected unifier: " + multiUnifier + " between the child - parent pair:\n" + child + " :\n" + parent, unifierExists, !multiUnifier.isEmpty());
+        if (unifierExists && unifierType.equivalence() != null) {
+            MultiUnifier multiUnifierInverse = parent.getMultiUnifier(child, unifierType);
+            assertEquals("Unexpected unifier inverse: " + multiUnifier + " of type " + unifierType.name() + " between the child - parent pair:\n" + parent + " :\n" + child, unifierExists, !multiUnifierInverse.isEmpty());
+            assertEquals(multiUnifierInverse, multiUnifier.inverse());
+        }
+        return multiUnifier;
+    }
+
+    public static void queryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, ReasonerQueryEquivalence equiv){
+        singleQueryEquivalence(a, a, true, equiv);
+        singleQueryEquivalence(b, b, true, equiv);
+        singleQueryEquivalence(a, b, queryExpectation, equiv);
+        singleQueryEquivalence(b, a, queryExpectation, equiv);
+    }
+
+    public static void atomicEquivalence(Atomic a, Atomic b, boolean expectation, AtomicEquivalence equiv){
+        singleAtomicEquivalence(a, a, true, equiv);
+        singleAtomicEquivalence(b, b, true, equiv);
+        singleAtomicEquivalence(a, b, expectation, equiv);
+        singleAtomicEquivalence(b, a, expectation, equiv);
+    }
+
+    private static void singleQueryEquivalence(ReasonerAtomicQuery a, ReasonerAtomicQuery b, boolean queryExpectation, ReasonerQueryEquivalence equiv){
+        assertEquals(equiv.name() + " - Query:\n" + a + "\n=?\n" + b, queryExpectation, equiv.equivalent(a, b));
+
+        //check hash additionally if need to be equal
+        if (queryExpectation) {
+            assertTrue(equiv.name() + ":\n" + a + "\nhash=?\n" + b, equiv.hash(a) == equiv.hash(b));
+        }
+    }
+
+    private static void singleAtomicEquivalence(Atomic a, Atomic b, boolean expectation, AtomicEquivalence equivalence){
+        assertEquals(equivalence.name() + " - Atom:\n" + a + "\n=?\n" + b, expectation,  equivalence.equivalent(a, b));
+
+        //check hash additionally if need to be equal
+        if (expectation) {
+            assertTrue(equivalence.name() + ":\n" + a + "\nhash=?\n" + b, equivalence.hash(a) == equivalence.hash(b));
+        }
+    }
+
+    public static Conjunction<Statement> conjunction(String patternString) {
+        Set<Statement> vars = Graql.parsePattern(patternString)
+                .getDisjunctiveNormalForm().getPatterns()
+                .stream().flatMap(p -> p.getPatterns().stream()).collect(toSet());
+        return Graql.and(vars);
+    }
+}


### PR DESCRIPTION
## What is the goal of this PR?
We abstract the unification testing facilities in `QueryTestUtil` so that the `GenerativeOperationIT`, `AtomicQueryEquivalenceIT` and `AtomicQueryUnificationIT` can reuse them.

## What are the changes implemented in this PR?
- added `QueryTestUtil` containing unification testing facilities
- redefined the test cases in `GenerativeOperationIT` to have better coverage and additionally include equivalence checks

