### PR TITLE
Also log the type of a Thing that needs a key

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -88,7 +88,7 @@ public enum ErrorMessage {
     VALIDATION_ROLE_TYPE_MISSING_RELATION_TYPE("Role [%s] does not have a relates connection to any Relation Type. \n"),
     VALIDATION_RELATION_TYPE("Relation Type [%s] does not have one or more roles \n"),
 
-    VALIDATION_NOT_EXACTLY_ONE_KEY("Thing [%s] does not have exactly one key of type [%s]. It either has no keys assigned to it, or it has more than one. \n"),
+    VALIDATION_NOT_EXACTLY_ONE_KEY("Thing [%s] of type [%s] does not have exactly one key of type [%s]. It either has no keys assigned to it, or it has more than one. \n"),
     VALIDATION_MORE_THAN_ONE_USE_OF_KEY("There is more than one thing of type [%s] that owns the key [%s] of type [%s]. \n"),
 
     VALIDATION_RELATION_TYPES_ROLES_SCHEMA("The Role [%s] which is connected to Relation Type [%s] " +

--- a/server/ValidateGlobalRules.java
+++ b/server/ValidateGlobalRules.java
@@ -252,7 +252,7 @@ public class ValidateGlobalRules {
 
                     // Assert there is a relation for this type
                     if (!Streams.containsOnly(thing.relations(role), 1)) {
-                        return Optional.of(VALIDATION_NOT_EXACTLY_ONE_KEY.getMessage(thing.id(), attributeLabel));
+                        return Optional.of(VALIDATION_NOT_EXACTLY_ONE_KEY.getMessage(thing.id(), thing.type().label().getValue(), attributeLabel));
                     }
 
                     Optional<String> uniquenessViolation = validateKeyUniqueness(conceptManager, thing, role, type, attributeLabel);

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -5,7 +5,6 @@ java_library(
     srcs = glob(["QueryTestUtil.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "//common",
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/junit",
         "//graql/reasoner",
@@ -28,7 +27,6 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//graql/reasoner",
-        "//kb/graql/reasoner",
         "//kb/server",
         "//test-integration/graql/reasoner/query:query-test-util",
         "//test-integration/rule:grakn-test-server",


### PR DESCRIPTION
## What is the goal of this PR?

We have improved the error message that is displayed when you're not inserting the key of a concept that needs it. Not knowing the type of the concept you are trying to insert as you try to fix the query is quite painful.

The error message before this PR:
```
Thing [V4320] does not have exactly one key of type [symbol]. It either has no keys assigned to it, or it has more than one. 
```

The error message **after** this PR:
```
Thing [V4320] of type [commit] does not have exactly one key of type [symbol]. It either has no keys assigned to it, or it has more than one. 
```