### PR TITLE
Add basic reasoner operational test for attributes

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -78,5 +78,5 @@ def graknlabs_theory():
     git_repository(
         name = "graknlabs_verification",
         remote = "git@github.com:graknlabs/verification.git",
-        commit = "bfba07563cc493951a37890d99339737b6641dfc",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "f71bc2043303d44947cba42b39594fe8be7b32fd",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -5,7 +5,6 @@ java_library(
     srcs = glob(["QueryTestUtil.java"]),
     visibility = ["//visibility:public"],
     deps = [
-        "//common",
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/junit",
         "//graql/reasoner",

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -28,7 +28,6 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//graql/reasoner",
-        "//kb/graql/reasoner",
         "//kb/server",
         "//test-integration/graql/reasoner/query:query-test-util",
         "//test-integration/rule:grakn-test-server",

--- a/test-integration/graql/reasoner/query/GenerativeOperationalIT.java
+++ b/test-integration/graql/reasoner/query/GenerativeOperationalIT.java
@@ -167,7 +167,6 @@ public class GenerativeOperationalIT {
         }
     }
 
-
     @Test
     public void whenGeneralisingAttributes_SubsumptionRelationHoldsBetweenPairs(){
         int depth = 10;
@@ -194,7 +193,6 @@ public class GenerativeOperationalIT {
                 secondTree.keySet().forEach(p -> {
                     ReasonerAtomicQuery unrelated = reasonerQueryFactory.atomic(conjunction(p));
                     if (!unrelated.getAtom().toAttributeAtom().isValueEquality()) {
-                        System.out.println(parent + " !<= " + unrelated);
                         QueryTestUtil.unification(parent, unrelated, false, UnifierType.RULE);
                         QueryTestUtil.unification(parent, unrelated, false, UnifierType.SUBSUMPTIVE);
                         QueryTestUtil.unification(parent, unrelated, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);

--- a/test-integration/graql/reasoner/query/GenerativeOperationalIT.java
+++ b/test-integration/graql/reasoner/query/GenerativeOperationalIT.java
@@ -21,7 +21,6 @@ package grakn.core.graql.reasoner.query;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import grakn.common.util.Pair;
 import grakn.core.common.config.Config;
 import grakn.core.graql.reasoner.unifier.UnifierType;
@@ -37,7 +36,6 @@ import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -171,7 +169,7 @@ public class GenerativeOperationalIT {
 
 
     @Test
-    public void test(){
+    public void whenGeneralisingAttributes_SubsumptionRelationHoldsBetweenPairs(){
         int depth = 10;
         try (Transaction tx = genericSchemaSession.readTransaction()) {
             ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction) tx).reasonerQueryFactory();
@@ -193,39 +191,28 @@ public class GenerativeOperationalIT {
                 QueryTestUtil.unification(parent, child,true, UnifierType.SUBSUMPTIVE);
                 QueryTestUtil.unification(parent, child,true, UnifierType.STRUCTURAL_SUBSUMPTIVE);
 
-                //if (!parent.getAtom().toAttributeAtom().isValueEquality()) {
-                    secondTree.keySet().forEach(p -> {
-                        ReasonerAtomicQuery unrelated = reasonerQueryFactory.atomic(conjunction(p));
-                        if (!unrelated.getAtom().toAttributeAtom().isValueEquality()) {
-                            System.out.println(parent + " !<= " + unrelated);
-                            QueryTestUtil.unification(parent, unrelated, false, UnifierType.RULE);
-                            QueryTestUtil.unification(parent, unrelated, false, UnifierType.SUBSUMPTIVE);
-                            QueryTestUtil.unification(parent, unrelated, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
-                            QueryTestUtil.unification(unrelated, parent, false, UnifierType.RULE);
-                            QueryTestUtil.unification(unrelated, parent, false, UnifierType.SUBSUMPTIVE);
-                            QueryTestUtil.unification(unrelated, parent, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
-                        }
-                    });
-                //}
+                secondTree.keySet().forEach(p -> {
+                    ReasonerAtomicQuery unrelated = reasonerQueryFactory.atomic(conjunction(p));
+                    if (!unrelated.getAtom().toAttributeAtom().isValueEquality()) {
+                        System.out.println(parent + " !<= " + unrelated);
+                        QueryTestUtil.unification(parent, unrelated, false, UnifierType.RULE);
+                        QueryTestUtil.unification(parent, unrelated, false, UnifierType.SUBSUMPTIVE);
+                        QueryTestUtil.unification(parent, unrelated, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+                        QueryTestUtil.unification(unrelated, parent, false, UnifierType.RULE);
+                        QueryTestUtil.unification(unrelated, parent, false, UnifierType.SUBSUMPTIVE);
+                        QueryTestUtil.unification(unrelated, parent, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+
+                        QueryTestUtil.unification(child, unrelated, false, UnifierType.RULE);
+                        QueryTestUtil.unification(child, unrelated, false, UnifierType.SUBSUMPTIVE);
+                        QueryTestUtil.unification(child, unrelated, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+                        QueryTestUtil.unification(unrelated, child, false, UnifierType.RULE);
+                        QueryTestUtil.unification(unrelated, child, false, UnifierType.SUBSUMPTIVE);
+                        QueryTestUtil.unification(unrelated, child, false, UnifierType.STRUCTURAL_SUBSUMPTIVE);
+                    }
+                });
+
             });
 
-            /*
-            while(pairIterator.hasNext()){
-                Pair<Pattern, Pattern> pair = pairIterator.next();
-
-                ReasonerQueryImpl pQuery = reasonerQueryFactory.create(conjunction(pair.first()));
-                ReasonerQueryImpl cQuery = reasonerQueryFactory.create(conjunction(pair.second()));
-
-                if (pQuery.isAtomic() && cQuery.isAtomic()) {
-                    ReasonerAtomicQuery parent = (ReasonerAtomicQuery) pQuery;
-                    ReasonerAtomicQuery child = (ReasonerAtomicQuery) cQuery;
-
-                    QueryTestUtil.unification(parent, child,true, UnifierType.RULE);
-                    QueryTestUtil.unification(parent, child,true, UnifierType.SUBSUMPTIVE);
-                    QueryTestUtil.unification(parent, child,true, UnifierType.STRUCTURAL_SUBSUMPTIVE);
-                }
-            }
-             */
         }
     }
 

--- a/test-integration/graql/reasoner/query/SubsumptionIT.java
+++ b/test-integration/graql/reasoner/query/SubsumptionIT.java
@@ -23,6 +23,7 @@ import grakn.core.common.config.Config;
 import grakn.core.graql.reasoner.graph.GenericSchemaGraph;
 import grakn.core.graql.reasoner.pattern.QueryPattern;
 import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
@@ -32,6 +33,8 @@ import grakn.core.rule.TestTransactionProvider;
 import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.statement.Statement;
+import java.util.Arrays;
+import java.util.Collections;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -43,6 +46,7 @@ import java.util.Set;
 import static java.util.stream.Collectors.toSet;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class SubsumptionIT {
@@ -576,6 +580,91 @@ public class SubsumptionIT {
                     (TestTransactionProvider.TestTransaction) tx
             );
         }
+    }
+
+    @Test
+    public void testSubsumption_DifferentNonVariablePredicateVariantsWithNumbers(){
+        Statement value = Graql.var("value");
+        final long bound = 1667L;
+        try(Transaction tx = genericSchemaSession.readTransaction() ) {
+            Statement eq = value.eq(bound);
+            Statement gte = value.gte(bound);
+            Statement gt = value.gt(bound);
+            Statement lte = value.lte(bound);
+            Statement lt = value.lt(bound);
+            Statement neq = value.neq(bound);
+
+            subsumption(eq, Arrays.asList(gte, lte), Arrays.asList(neq, gt, lt), tx);
+            subsumption(gte, Collections.emptyList(), Arrays.asList(eq, gt, lte, lt, neq), tx);
+            subsumption(gt, Collections.singletonList(gte), Arrays.asList(eq, lte, lt, neq), tx);
+            subsumption(lte, Collections.emptyList(), Arrays.asList(eq, gte, gt, lt, neq), tx);
+            subsumption(lt, Collections.singletonList(lte), Arrays.asList(eq, gte, gt, neq), tx);
+            subsumption(neq, Collections.emptyList(), Arrays.asList(eq, gte, gt, lte, lt), tx);
+        }
+    }
+/*
+    @Test
+    public void testSubsumption_DifferentNonVariablePredicateVariantsWithStrings(){
+        Statement value = Graql.var("value");
+        final String bound = "value";
+        try(TransactionOLTP tx = genericSchemaSession.transaction().read() ) {
+            Statement eq = value.eq(bound);
+            Statement gte = value.gte(bound);
+            Statement gt = value.gt(bound);
+            Statement lte = value.lte(bound);
+            Statement lt = value.lt(bound);
+            Statement neq = value.neq(bound);
+            Statement contains = value.contains(bound);
+
+            subsumption(eq, Arrays.asList(gte, lte, contains), Arrays.asList(gt, lt, neq), tx);
+
+            subsumption(gte, Collections.emptyList(), Arrays.asList(eq, gt, lte, lt, neq), tx);
+            subsumption(gt, Collections.singletonList(gte), Arrays.asList(eq, lte, lt, neq), tx);
+            subsumption(lte, Collections.emptyList(), Arrays.asList(eq, gte, gt, lt, neq), tx);
+            subsumption(lt, Collections.singletonList(lte), Arrays.asList(eq, gte, gt, neq), tx);
+            subsumption(neq, Collections.emptyList(), Arrays.asList(eq, gte, gt, lte, lt), tx);
+        }
+    }
+
+    @Test
+    public void testSubsumption_DifferentVariablePredicateVariants(){
+        Statement value = Graql.var("value");
+        Statement anotherValue = Graql.var("anotherValue");
+        try(Transaction tx = genericSchemaSession.transaction().read() ) {
+            Statement eq = value.eq(anotherValue);
+            Statement gte = value.gte(anotherValue);
+            Statement gt = value.gt(anotherValue);
+            Statement lte = value.lte(anotherValue);
+            Statement lt = value.lt(anotherValue);
+            Statement neq = value.neq(anotherValue);
+
+            subsumption(eq, Collections.emptyList(), Arrays.asList(gte, gt, lte, lt, neq), tx);
+            subsumption(gte, Collections.emptyList(), Arrays.asList(eq, gt, lte, lt, neq), tx);
+            subsumption(gt, Collections.emptyList(), Arrays.asList(eq, gte, lte, lt, neq), tx);
+            subsumption(lte, Collections.emptyList(), Arrays.asList(eq, gte, gt, lt, neq), tx);
+            subsumption(lt, Collections.emptyList(), Arrays.asList(eq, gte, gt, lte, neq), tx);
+            subsumption(neq, Collections.emptyList(), Arrays.asList(eq, gte, gt, lte, lt), tx);
+        }
+    }
+*/
+    private void subsumption(Statement childStatement, List<Statement> subsumes, List<Statement> doesntSubsume, Transaction tx){
+        TestTransactionProvider.TestTransaction testTx = (TestTransactionProvider.TestTransaction) tx;
+        ReasonerQueryFactory reasonerQueryFactory = testTx.reasonerQueryFactory();
+        Conjunction<Statement> conj = (Conjunction<Statement>) Graql.and(childStatement);
+        Atomic child = reasonerQueryFactory.create(conj).getAtoms().stream().findFirst().orElse(null);
+        Atomic childCopy = child.copy(child.getParentQuery());
+        assertTrue("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + childCopy + "\n", child.isSubsumedBy(childCopy));
+
+        subsumes.forEach(parentStatement -> {
+            Conjunction<Statement> conj2 = (Conjunction<Statement>) Graql.and(parentStatement);
+            Atomic parent = reasonerQueryFactory.create(conj2).getAtoms().stream().findFirst().orElse(null);
+            assertTrue("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n", child.isSubsumedBy(parent));
+        });
+        doesntSubsume.forEach(parentStatement -> {
+            Conjunction<Statement> conj2 = (Conjunction<Statement>) Graql.and(parentStatement);
+            Atomic parent = reasonerQueryFactory.create(conj2).getAtoms().stream().findFirst().orElse(null);
+            assertFalse("Unexpected subsumption outcome: between the child - parent pair:\n" + child + " :\n" + parent + "\n", child.isSubsumedBy(parent));
+        });
     }
 
     private void subsumption(List<String> children, List<String> parents, int[][] resultMatrix, TestTransactionProvider.TestTransaction tx) {


### PR DESCRIPTION
## What is the goal of this PR?
To use the newly defined `GeneraliseAttributeOperator` to test unification facilities in the context of attribute atoms. We want to extend the `GenerativeOperationalIT` to cover basic cases with attributes.

## What are the changes implemented in this PR?
Expanded the `GenerativeOperationalIT` to coer basic cases with attributes - subsumption between value ranges.

