### PR TITLE
Abstract type reasoning in atoms

### DIFF
--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -331,7 +331,7 @@ public abstract class Atom extends AtomicBase {
      * @param <T>  the type of neighbour Atomic to return
      * @return neighbours of this atoms, i.e. atoms connected to this atom via shared variable
      */
-    protected <T extends Atomic> Stream<T> getNeighbours(Class<T> type) {
+    public <T extends Atomic> Stream<T> getNeighbours(Class<T> type) {
         return getParentQuery().getAtoms(type)
                 .filter(atom -> atom != this)
                 .filter(atom -> !Sets.intersection(this.getVarNames(), atom.getVarNames()).isEmpty());

--- a/graql/reasoner/atom/inference/IsaTypeReasoner.java
+++ b/graql/reasoner/atom/inference/IsaTypeReasoner.java
@@ -1,0 +1,91 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.reasoner.atom.inference;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.util.ConceptUtils;
+import grakn.core.graql.reasoner.atom.binary.Binary;
+import grakn.core.graql.reasoner.atom.binary.IsaAtom;
+import grakn.core.graql.reasoner.atom.binary.RelationAtom;
+import grakn.core.kb.concept.api.Concept;
+import grakn.core.kb.concept.api.Type;
+import grakn.core.kb.concept.manager.ConceptManager;
+import graql.lang.statement.Variable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class IsaTypeReasoner implements TypeReasoner<IsaAtom> {
+
+    private final ConceptManager conceptManager;
+
+    public IsaTypeReasoner(ConceptManager conceptManager){
+        this.conceptManager = conceptManager;
+    }
+
+    @Override
+    public IsaAtom inferType(IsaAtom atom, ConceptMap sub) {
+        if (atom.getTypePredicate() != null) return atom;
+        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
+        return atom;
+    }
+
+    @Override
+    public IsaAtom inferTypes(IsaAtom atom, ConceptMap sub) {
+        return inferType(atom, sub);
+    }
+
+    @Override
+    public ImmutableList<Type> inferPossibleTypes(IsaAtom atom, ConceptMap sub){
+        if (atom.getSchemaConcept() != null) return ImmutableList.of(atom.getSchemaConcept().asType());
+        if (sub.containsVar(atom.getPredicateVariable())) return ImmutableList.of(sub.get(atom.getPredicateVariable()).asType());
+
+        Variable varName = atom.getVarName();
+        //determine compatible types from played roles
+        Set<Type> typesFromRoles = atom.getParentQuery().getAtoms(RelationAtom.class)
+                .filter(r -> r.getVarNames().contains(varName))
+                .flatMap(r -> r.getRoleVarMap().entries().stream()
+                        .filter(e -> e.getValue().equals(varName))
+                        .map(Map.Entry::getKey))
+                .map(role -> role.players().collect(Collectors.toSet()))
+                .reduce(Sets::intersection)
+                .orElse(Sets.newHashSet());
+
+        Set<Type> typesFromTypes = atom.getParentQuery().getAtoms(IsaAtom.class)
+                .filter(at -> at.getVarNames().contains(varName))
+                .filter(at -> at != atom)
+                .map(Binary::getSchemaConcept)
+                .filter(Objects::nonNull)
+                .filter(Concept::isType)
+                .map(Concept::asType)
+                .collect(Collectors.toSet());
+
+        Set<Type> types = typesFromTypes.isEmpty()?
+                typesFromRoles :
+                typesFromRoles.isEmpty()? typesFromTypes: Sets.intersection(typesFromRoles, typesFromTypes);
+
+        return !types.isEmpty()?
+                ImmutableList.copyOf(ConceptUtils.top(types)) :
+                conceptManager.getMetaConcept().subs().collect(ImmutableList.toImmutableList());
+    }
+}

--- a/graql/reasoner/atom/inference/IsaTypeReasoner.java
+++ b/graql/reasoner/atom/inference/IsaTypeReasoner.java
@@ -44,15 +44,10 @@ public class IsaTypeReasoner implements TypeReasoner<IsaAtom> {
     }
 
     @Override
-    public IsaAtom inferType(IsaAtom atom, ConceptMap sub) {
+    public IsaAtom inferTypes(IsaAtom atom, ConceptMap sub) {
         if (atom.getTypePredicate() != null) return atom;
         if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
         return atom;
-    }
-
-    @Override
-    public IsaAtom inferTypes(IsaAtom atom, ConceptMap sub) {
-        return inferType(atom, sub);
     }
 
     @Override

--- a/graql/reasoner/atom/inference/RelationTypeReasoner.java
+++ b/graql/reasoner/atom/inference/RelationTypeReasoner.java
@@ -1,0 +1,295 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.reasoner.atom.inference;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import grakn.common.util.Pair;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.util.ConceptUtils;
+import grakn.core.core.Schema;
+import grakn.core.graql.reasoner.atom.binary.RelationAtom;
+import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
+import grakn.core.graql.reasoner.utils.ReasonerUtils;
+import grakn.core.graql.reasoner.utils.conversion.RoleConverter;
+import grakn.core.graql.reasoner.utils.conversion.TypeConverter;
+import grakn.core.kb.concept.api.Concept;
+import grakn.core.kb.concept.api.Label;
+import grakn.core.kb.concept.api.RelationType;
+import grakn.core.kb.concept.api.Role;
+import grakn.core.kb.concept.api.SchemaConcept;
+import grakn.core.kb.concept.api.Type;
+import grakn.core.kb.concept.manager.ConceptManager;
+import grakn.core.kb.graql.reasoner.cache.QueryCache;
+import grakn.core.kb.graql.reasoner.cache.RuleCache;
+import grakn.core.kb.keyspace.KeyspaceStatistics;
+import graql.lang.property.RelationProperty;
+import graql.lang.statement.Statement;
+import graql.lang.statement.Variable;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static grakn.core.concept.util.ConceptUtils.top;
+import static graql.lang.Graql.var;
+
+public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
+
+    private final ReasonerQueryFactory reasonerQueryFactory;
+    private final QueryCache queryCache;
+    private final KeyspaceStatistics keyspaceStatistics;
+    private final ConceptManager conceptManager;
+    private final RuleCache ruleCache;
+
+    public RelationTypeReasoner(ReasonerQueryFactory queryFactory,
+                         QueryCache queryCache, RuleCache ruleCache,
+                         ConceptManager conceptManger, KeyspaceStatistics stats){
+        this.reasonerQueryFactory = queryFactory;
+        this.queryCache = queryCache;
+        this.ruleCache = ruleCache;
+        this.conceptManager = conceptManger;
+        this.keyspaceStatistics = stats;
+    }
+
+    @Override
+    public RelationAtom inferTypes(RelationAtom atom, ConceptMap sub) {
+        RelationAtom typedRelation = inferType(atom, sub);
+        return inferRoles(typedRelation, sub);
+    }
+
+    /**
+     * attempt to infer the relation type of this relation
+     *
+     * @param sub extra instance information to aid entity type inference
+     * @return either this if relation type can't be inferred or a fresh relation with inferred relation type
+     */
+    @Override
+    public RelationAtom inferType(RelationAtom atom, ConceptMap sub) {
+        if (atom.getTypePredicate() != null) return atom;
+        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
+        List<Type> relationTypes = inferPossibleTypes(atom, sub);
+        if (relationTypes.size() == 1) return atom.addType(Iterables.getOnlyElement(relationTypes));
+        return atom;
+    }
+
+    /**
+     * infer RelationTypes that this RelationAtom can potentially have
+     * NB: EntityTypes and link Roles are treated separately as they behave differently:
+     * NB: Not using Memoized as memoized methods can't have parameters
+     * EntityTypes only play the explicitly defined Roles (not the relevant part of the hierarchy of the specified Role) and the Role inherited from parent
+     *
+     * @return list of RelationTypes this atom can have ordered by the number of compatible Roles
+     */
+    @Override
+    public ImmutableList<Type> inferPossibleTypes(RelationAtom atom, ConceptMap sub) {
+        if (atom.getSchemaConcept() != null) return ImmutableList.of(atom.getSchemaConcept().asType());
+
+        Multimap<RelationType, Role> compatibleConfigurations = inferPossibleRelationConfigurations(atom, sub);
+        Set<Variable> untypedRoleplayers = Sets.difference(atom.getRolePlayers(), atom.getParentQuery().getVarTypeMap().keySet());
+        Set<RelationAtom> untypedNeighbours = atom.getNeighbours(RelationAtom.class)
+                .filter(at -> !Sets.intersection(at.getVarNames(), untypedRoleplayers).isEmpty())
+                .collect(Collectors.toSet());
+
+            ImmutableList.Builder<Type> builder = ImmutableList.builder();
+            //prioritise relations with higher chance of yielding answers
+            compatibleConfigurations.asMap().entrySet().stream()
+                    //prioritise relations with more allowed roles
+                    .sorted(Comparator.comparing(e -> -e.getValue().size()))
+                    //prioritise relations with number of roles equal to arity
+                    .sorted(Comparator.comparing(e -> e.getKey().roles().count() != atom.getRelationPlayers().size()))
+                    //prioritise relations having more instances
+                    .sorted(Comparator.comparing(e -> -keyspaceStatistics.count(conceptManager, e.getKey().label())))
+                    //prioritise relations with highest number of possible types played by untyped role players
+                    .map(e -> {
+                        if (untypedNeighbours.isEmpty()) return new Pair<>(e.getKey(), 0L);
+
+                        Iterator<RelationAtom> neighbourIterator = untypedNeighbours.iterator();
+                        Set<Type> typesFromNeighbour = inferPossibleEntityTypePlayers(neighbourIterator.next(), sub);
+                        while (neighbourIterator.hasNext()) {
+                            typesFromNeighbour = Sets.intersection(typesFromNeighbour, inferPossibleEntityTypePlayers(neighbourIterator.next(), sub));
+                        }
+
+                        Set<Role> rs = e.getKey().roles().collect(Collectors.toSet());
+                        rs.removeAll(e.getValue());
+                        return new Pair<>(
+                                e.getKey(),
+                                rs.stream().flatMap(Role::players).filter(typesFromNeighbour::contains).count()
+                        );
+                    })
+                    .sorted(Comparator.comparing(p -> -p.second()))
+                    //prioritise non-implicit relations
+                    .sorted(Comparator.comparing(e -> e.first().isImplicit()))
+                    .map(Pair::first)
+                    //retain super types only
+                    .filter(t -> Sets.intersection(ConceptUtils.nonMetaSups(t), compatibleConfigurations.keySet()).isEmpty())
+                    .forEach(builder::add);
+            //TODO need to add THING and meta relation type as well to make it complete
+        return builder.build();
+    }
+
+    /**
+     * infer RelationTypes that this RelationAtom can potentially have
+     * NB: EntityTypes and link Roles are treated separately as they behave differently:
+     * EntityTypes only play the explicitly defined Roles (not the relevant part of the hierarchy of the specified Role) and the Role inherited from parent
+     *
+     * @return list of RelationTypes this atom can have ordered by the number of compatible Roles
+     */
+    private Set<Type> inferPossibleEntityTypePlayers(RelationAtom atom, ConceptMap sub) {
+        return inferPossibleRelationConfigurations(atom, sub).asMap().entrySet().stream()
+                .flatMap(e -> {
+                    Set<Role> rs = e.getKey().roles().collect(Collectors.toSet());
+                    rs.removeAll(e.getValue());
+                    return rs.stream().flatMap(Role::players);
+                }).collect(Collectors.toSet());
+    }
+
+    /**
+     * @return a map of relations and corresponding roles that could be played by this atom
+     */
+    private Multimap<RelationType, Role> inferPossibleRelationConfigurations(RelationAtom atom, ConceptMap sub) {
+        Set<Role> roles = atom.getExplicitRoles().filter(r -> !Schema.MetaSchema.isMetaLabel(r.label())).collect(Collectors.toSet());
+        SetMultimap<Variable, Type> varTypeMap = atom.getParentQuery().getVarTypeMap(sub);
+        Set<Type> types = atom.getRolePlayers().stream().filter(varTypeMap::containsKey).flatMap(v -> varTypeMap.get(v).stream()).collect(Collectors.toSet());
+
+        if (roles.isEmpty() && types.isEmpty()) {
+            RelationType metaRelationType = conceptManager.getMetaRelationType();
+            Multimap<RelationType, Role> compatibleTypes = HashMultimap.create();
+            metaRelationType.subs()
+                    .filter(rt -> !rt.equals(metaRelationType))
+                    .forEach(rt -> compatibleTypes.putAll(rt, rt.roles().collect(Collectors.toSet())));
+            return compatibleTypes;
+        }
+
+        //intersect relation types from roles and types
+        Multimap<RelationType, Role> compatibleTypes;
+        Multimap<RelationType, Role> compatibleTypesFromRoles = ReasonerUtils.compatibleRelationTypesWithRoles(roles, new RoleConverter());
+        Multimap<RelationType, Role> compatibleTypesFromTypes = ReasonerUtils.compatibleRelationTypesWithRoles(types, new TypeConverter());
+
+        if (roles.isEmpty()) {
+            compatibleTypes = compatibleTypesFromTypes;
+        }
+        //no types from roles -> roles correspond to mutually exclusive relations
+        else if (compatibleTypesFromRoles.isEmpty() || types.isEmpty()) {
+            compatibleTypes = compatibleTypesFromRoles;
+        } else {
+            compatibleTypes = ReasonerUtils.multimapIntersection(compatibleTypesFromTypes, compatibleTypesFromRoles);
+        }
+        return compatibleTypes;
+    }
+
+    /**
+     * attempt to infer role types of this relation and return a fresh relation with inferred role types
+     *
+     * @return either this if nothing/no roles can be inferred or fresh relation with inferred role types
+     */
+    private RelationAtom inferRoles(RelationAtom atom, ConceptMap sub) {
+        //return if all roles known and non-meta
+        List<Role> explicitRoles = atom.getExplicitRoles().collect(Collectors.toList());
+        SetMultimap<Variable, Type> varTypeMap = atom.getParentQuery().getVarTypeMap(sub);
+        boolean allRolesMeta = explicitRoles.stream().allMatch(role -> Schema.MetaSchema.isMetaLabel(role.label()));
+        boolean roleRecomputationViable = allRolesMeta && (!sub.isEmpty() || !Sets.intersection(varTypeMap.keySet(), atom.getRolePlayers()).isEmpty());
+        if (explicitRoles.size() == atom.getRelationPlayers().size() && !roleRecomputationViable) return atom;
+
+        Role metaRole = conceptManager.getMetaRole();
+        List<RelationProperty.RolePlayer> allocatedRelationPlayers = new ArrayList<>();
+        SchemaConcept schemaConcept = atom.getSchemaConcept();
+        RelationType relType = null;
+        if (schemaConcept != null && schemaConcept.isRelationType()) relType = schemaConcept.asRelationType();
+
+        //explicit role types from castings
+        List<RelationProperty.RolePlayer> inferredRelationPlayers = new ArrayList<>();
+        atom.getRelationPlayers().forEach(rp -> {
+            Variable varName = rp.getPlayer().var();
+            Statement rolePattern = rp.getRole().orElse(null);
+            if (rolePattern != null) {
+                String roleLabel = rolePattern.getType().orElse(null);
+                //allocate if variable role or if label non meta
+                if (roleLabel == null || !Schema.MetaSchema.isMetaLabel(Label.of(roleLabel))) {
+                    inferredRelationPlayers.add(new RelationProperty.RolePlayer(rolePattern, new Statement(varName)));
+                    allocatedRelationPlayers.add(rp);
+                }
+            }
+        });
+
+        //remaining roles
+        //role types can repeat so no matter what has been allocated still the full spectrum of possibilities is present
+        //TODO make restrictions based on cardinality constraints
+        Set<Role> possibleRoles = relType != null ?
+                relType.roles().collect(Collectors.toSet()) :
+                inferPossibleTypes(atom, sub).stream()
+                        .filter(Concept::isRelationType)
+                        .map(Concept::asRelationType)
+                        .flatMap(RelationType::roles).collect(Collectors.toSet());
+
+        //possible role types for each casting based on its type
+        Map<RelationProperty.RolePlayer, Set<Role>> mappings = new HashMap<>();
+        atom.getRelationPlayers().stream()
+                .filter(rp -> !allocatedRelationPlayers.contains(rp))
+                .forEach(rp -> {
+                    Variable varName = rp.getPlayer().var();
+                    Set<Type> types = varTypeMap.get(varName);
+                    mappings.put(rp, top(ReasonerUtils.compatibleRoles(types, possibleRoles)));
+                });
+
+
+        //allocate all unambiguous mappings
+        mappings.entrySet().stream()
+                .filter(entry -> entry.getValue().size() == 1)
+                .forEach(entry -> {
+                    RelationProperty.RolePlayer rp = entry.getKey();
+                    Variable varName = rp.getPlayer().var();
+                    Role role = Iterables.getOnlyElement(entry.getValue());
+                    Statement rolePattern = var().type(role.label().getValue());
+                    inferredRelationPlayers.add(new RelationProperty.RolePlayer(rolePattern, new Statement(varName)));
+                    allocatedRelationPlayers.add(rp);
+                });
+
+        //fill in unallocated roles with metarole
+        atom.getRelationPlayers().stream()
+                .filter(rp -> !allocatedRelationPlayers.contains(rp))
+                .forEach(rp -> {
+                    Variable varName = rp.getPlayer().var();
+                    Statement rolePattern = rp.getRole().orElse(null);
+
+                    rolePattern = rolePattern != null ?
+                            rolePattern.type(metaRole.label().getValue()) :
+                            var().type(metaRole.label().getValue());
+                    inferredRelationPlayers.add(new RelationProperty.RolePlayer(rolePattern, new Statement(varName)));
+                });
+
+        Statement relationPattern = RelationAtom.relationPattern(atom.getVarName(), inferredRelationPlayers);
+        Statement newPattern =
+                (atom.isDirect() ?
+                        relationPattern.isaX(new Statement(atom.getPredicateVariable())) :
+                        relationPattern.isa(new Statement(atom.getPredicateVariable()))
+                );
+        return RelationAtom.create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics,
+                newPattern, atom.getPredicateVariable(), atom.getTypeId(), atom.getPossibleTypes(), atom.getParentQuery());
+    }
+}

--- a/graql/reasoner/atom/inference/RelationTypeReasoner.java
+++ b/graql/reasoner/atom/inference/RelationTypeReasoner.java
@@ -84,21 +84,6 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
     }
 
     /**
-     * attempt to infer the relation type of this relation
-     *
-     * @param sub extra instance information to aid entity type inference
-     * @return either this if relation type can't be inferred or a fresh relation with inferred relation type
-     */
-    @Override
-    public RelationAtom inferType(RelationAtom atom, ConceptMap sub) {
-        if (atom.getTypePredicate() != null) return atom;
-        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
-        List<Type> relationTypes = inferPossibleTypes(atom, sub);
-        if (relationTypes.size() == 1) return atom.addType(Iterables.getOnlyElement(relationTypes));
-        return atom;
-    }
-
-    /**
      * infer RelationTypes that this RelationAtom can potentially have
      * NB: EntityTypes and link Roles are treated separately as they behave differently:
      * NB: Not using Memoized as memoized methods can't have parameters
@@ -201,6 +186,20 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
             compatibleTypes = ReasonerUtils.multimapIntersection(compatibleTypesFromTypes, compatibleTypesFromRoles);
         }
         return compatibleTypes;
+    }
+
+    /**
+     * attempt to infer the relation type of this relation
+     *
+     * @param sub extra instance information to aid entity type inference
+     * @return either this if relation type can't be inferred or a fresh relation with inferred relation type
+     */
+    private RelationAtom inferType(RelationAtom atom, ConceptMap sub) {
+        if (atom.getTypePredicate() != null) return atom;
+        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
+        List<Type> relationTypes = inferPossibleTypes(atom, sub);
+        if (relationTypes.size() == 1) return atom.addType(Iterables.getOnlyElement(relationTypes));
+        return atom;
     }
 
     /**

--- a/graql/reasoner/atom/inference/TypeReasoner.java
+++ b/graql/reasoner/atom/inference/TypeReasoner.java
@@ -27,17 +27,18 @@ import grakn.core.kb.concept.api.Type;
 public interface TypeReasoner<T extends Atom>  {
 
     /**
-     * Attempts to infer all the types of the provided atom (including roles).
-     * @param atom target atom
-     * @param sub additional substitution information
-     * @return a new corresponding atom with possible types inferred
+     * Attempts to infer all unambiguous types of the provided atom (including roles) and returns a new atom with
+     * that information.
+     * @param atom the source atom from which to create a new atom with newly inferred types
+     * @param sub a concept map containing Ids for concepts that may be used during the inference process
+     * @return a new atom with unambiguous types inferred
      */
     T inferTypes(T atom, ConceptMap sub);
 
     /**
-     *
-     * @param atom target atom
-     * @param sub additional substitution information
+     * Attempts to infer all possible types associated with the atom. At least one must be the correct type of the atom.
+     * @param atom the source atom from which to find possible types
+     * @param sub a concept map containing Ids for concepts that may be used during the inference process
      * @return list of semantically possible types that the provided atom can have
      */
     ImmutableList<Type> inferPossibleTypes(T atom, ConceptMap sub);

--- a/graql/reasoner/atom/inference/TypeReasoner.java
+++ b/graql/reasoner/atom/inference/TypeReasoner.java
@@ -26,9 +26,19 @@ import grakn.core.kb.concept.api.Type;
 
 public interface TypeReasoner<T extends Atom>  {
 
-    T inferType(T atom, ConceptMap sub);
-
+    /**
+     * Attempts to infer all the types of the provided atom (including roles).
+     * @param atom target atom
+     * @param sub additional substitution information
+     * @return a new corresponding atom with possible types inferred
+     */
     T inferTypes(T atom, ConceptMap sub);
 
+    /**
+     *
+     * @param atom target atom
+     * @param sub additional substitution information
+     * @return list of semantically possible types that the provided atom can have
+     */
     ImmutableList<Type> inferPossibleTypes(T atom, ConceptMap sub);
 }

--- a/graql/reasoner/atom/inference/TypeReasoner.java
+++ b/graql/reasoner/atom/inference/TypeReasoner.java
@@ -1,0 +1,34 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.reasoner.atom.inference;
+
+import com.google.common.collect.ImmutableList;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.kb.concept.api.Type;
+
+public interface TypeReasoner<T extends Atom>  {
+
+    T inferType(T atom, ConceptMap sub);
+
+    T inferTypes(T atom, ConceptMap sub);
+
+    ImmutableList<Type> inferPossibleTypes(T atom, ConceptMap sub);
+}


### PR DESCRIPTION
## What is the goal of this PR?
To delegate the type inference tasks in `Atom`s to a new `TypeReasoner` entity so that the `Atom` implementations hold less responsibility and are less crowded - easier to maintain and understand.

## What are the changes implemented in this PR?
We introduce a `TypeReasoner` interface with implementations for `IsaAtom` and `RelationAtom` which allows to abstract and delegate the type inference procedures present in the corresponding `Atom`s.
