### PR TITLE
Add structural ops test

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -78,5 +78,5 @@ def graknlabs_theory():
     git_repository(
         name = "graknlabs_verification",
         remote = "git@github.com:graknlabs/verification.git",
-        commit = "1f3e6a81230ce1329b16877accc944f5f1c1b857",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "38422edb87643b95fecbf560ef92f84ab47c693e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )

--- a/test-integration/graql/reasoner/query/TransactionContext.java
+++ b/test-integration/graql/reasoner/query/TransactionContext.java
@@ -20,17 +20,29 @@
 package grakn.core.graql.reasoner.query;
 
 import grakn.core.core.Schema;
+import grakn.core.kb.concept.api.Concept;
+import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
+import grakn.core.kb.concept.api.Thing;
 import grakn.core.kb.server.Transaction;
 import grakn.verification.tools.operator.TypeContext;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class TransactionContext implements TypeContext {
     private final Transaction tx;
+    private final List<ConceptId> ids;
+    private final Random rand = new Random();
 
     TransactionContext(Transaction tx){
         this.tx = tx;
+        this.ids = tx.getMetaConcept().instances()
+                .map(Thing::asThing)
+                .map(Concept::id)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -59,5 +71,10 @@ class TransactionContext implements TypeContext {
         SchemaConcept type = tx.getSchemaConcept(Label.of(label));
         if (type == null) return Stream.empty();
         return type.subs().map(t -> t.label().getValue());
+    }
+
+    @Override
+    public String instanceId() {
+        return ids.get(rand.nextInt(ids.size())).getValue();
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
To use the newly introduced `IdFuzzyingOperator` to test structural and structural-subsumptive unification and equivalence.
## What are the changes implemented in this PR?
Added an extra test in `GenerativeOperationalIT` that takes the generated binary patterns, fuzzes their ids and checks that the operation preserves structural and structural-subsumptive equivalence as well as the corresponding unification outcomes.


