### PR TITLE
Introduce reasoning context

### DIFF
--- a/graql/reasoner/ReasoningContext.java
+++ b/graql/reasoner/ReasoningContext.java
@@ -1,0 +1,56 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.reasoner;
+
+import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
+import grakn.core.kb.concept.manager.ConceptManager;
+import grakn.core.kb.graql.reasoner.cache.QueryCache;
+import grakn.core.kb.graql.reasoner.cache.RuleCache;
+import grakn.core.kb.keyspace.KeyspaceStatistics;
+
+/**
+ * Container class for reasoning-related entities - factories and caches.
+ */
+public class ReasoningContext {
+
+    private final ReasonerQueryFactory queryFactory;
+    private final ConceptManager conceptManager;
+    private final RuleCache ruleCache;
+    private final QueryCache queryCache;
+    private final KeyspaceStatistics keyspaceStatistics;
+
+    public ReasoningContext(ReasonerQueryFactory queryFactory,
+                     ConceptManager conceptManager,
+                     QueryCache queryCache,
+                     RuleCache ruleCache,
+                     KeyspaceStatistics keyspaceStatistics){
+        this.queryFactory = queryFactory;
+        this.conceptManager = conceptManager;
+        this.queryCache = queryCache;
+        this.ruleCache = ruleCache;
+        this.keyspaceStatistics = keyspaceStatistics;
+    }
+
+    public ReasonerQueryFactory queryFactory(){return queryFactory;}
+    public ConceptManager conceptManager(){return conceptManager;}
+    public QueryCache queryCache(){return queryCache;}
+    public RuleCache ruleCache(){return ruleCache;}
+    public KeyspaceStatistics keyspaceStatistics(){return keyspaceStatistics;}
+}

--- a/graql/reasoner/atom/AtomicUtil.java
+++ b/graql/reasoner/atom/AtomicUtil.java
@@ -39,11 +39,11 @@ public class AtomicUtil {
      * @return (partial) set of predicates corresponding to this answer
      */
     @CheckReturnValue
-    public static Set<Atomic> answerToPredicates(ConceptManager conceptManager, ConceptMap answer, ReasonerQuery parent) {
+    public static Set<Atomic> answerToPredicates(ConceptMap answer, ReasonerQuery parent, ConceptManager conceptManager) {
         Set<Variable> varNames = parent.getVarNames();
         return answer.map().entrySet().stream()
                 .filter(e -> varNames.contains(e.getKey()))
-                .map(e -> IdPredicate.create(conceptManager, e.getKey(), e.getValue().id(), parent))
+                .map(e -> IdPredicate.create(e.getKey(), e.getValue().id(), parent, conceptManager))
                 .collect(Collectors.toSet());
     }
 

--- a/graql/reasoner/atom/binary/HasAtom.java
+++ b/graql/reasoner/atom/binary/HasAtom.java
@@ -19,11 +19,10 @@
 
 package grakn.core.graql.reasoner.atom.binary;
 
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.Graql;
 import graql.lang.property.HasAttributeTypeProperty;
@@ -38,34 +37,33 @@ import javax.annotation.Nullable;
  */
 public class HasAtom extends OntologicalAtom {
 
-    HasAtom(ConceptManager conceptManager,
-            RuleCache ruleCache,
-            Variable varName,
-            Statement pattern,
-            ReasonerQuery parentQuery,
-            @Nullable ConceptId typeId,
-            Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, parentQuery, typeId, predicateVariable);
+    private HasAtom(Variable varName,
+                    Statement pattern,
+                    ReasonerQuery parentQuery,
+                    @Nullable ConceptId typeId,
+                    Variable predicateVariable,
+                    ReasoningContext ctx) {
+        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
     }
 
-    public static HasAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent) {
+    public static HasAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        Label label = conceptManager.getConcept(predicateId).asType().label();
-        return new HasAtom(conceptManager, ruleCache, varName, new Statement(varName).has(Graql.type(label.getValue())), parent, predicateId, predicateVar);
+        Label label = ctx.conceptManager().getConcept(predicateId).asType().label();
+        return new HasAtom(varName, new Statement(varName).has(Graql.type(label.getValue())), parent, predicateId, predicateVar, ctx);
     }
 
-    private static HasAtom create(ConceptManager conceptManager, RuleCache ruleCache, TypeAtom a, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent);
+    private static HasAtom create(TypeAtom a, ReasonerQuery parent) {
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
     }
 
     @Override
     OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return HasAtom.create(conceptManager, ruleCache, var, predicateVar, predicateId, parent);
+        return HasAtom.create(var, predicateVar, predicateId, parent, context());
     }
 
     @Override
-    public Atomic copy(ReasonerQuery parent){ return create(conceptManager, ruleCache, this, parent); }
+    public Atomic copy(ReasonerQuery parent){ return create(this, parent); }
 
     @Override
     public Class<? extends VarProperty> getVarPropertyClass() { return HasAttributeTypeProperty.class;}

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.inference.IsaTypeReasoner;
 import grakn.core.graql.reasoner.atom.inference.TypeReasoner;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
@@ -34,10 +35,8 @@ import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.EntityType;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.api.Type;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.pattern.Pattern;
@@ -62,38 +61,38 @@ public class IsaAtom extends IsaAtomBase {
     private int hashCode;
     private boolean hashCodeMemoised;
 
-    IsaAtom(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-            Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
-        this.typeReasoner = new IsaTypeReasoner(conceptManager);
+    private IsaAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+                    Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        this.typeReasoner = new IsaTypeReasoner(ctx.conceptManager());
     }
 
-    public static IsaAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable predicateVar, Statement pattern, @Nullable ConceptId predicateId, ReasonerQuery parent) {
-        return new IsaAtom(conceptManager, ruleCache, var.asReturnedVar(), pattern, parent, predicateId, predicateVar);
+    public static IsaAtom create(Variable var, Variable predicateVar, Statement pattern, @Nullable ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
+        return new IsaAtom(var.asReturnedVar(), pattern, parent, predicateId, predicateVar, ctx);
     }
 
-    public static IsaAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable predicateVar, @Nullable ConceptId predicateId, boolean isDirect, ReasonerQuery parent) {
+    public static IsaAtom create(Variable var, Variable predicateVar, @Nullable ConceptId predicateId, boolean isDirect, ReasonerQuery parent, ReasoningContext ctx) {
         Statement pattern = isDirect ?
                 new Statement(var).isaX(new Statement(predicateVar)) :
                 new Statement(var).isa(new Statement(predicateVar));
 
-        return new IsaAtom(conceptManager, ruleCache, var, pattern, parent, predicateId, predicateVar);
+        return new IsaAtom(var, pattern, parent, predicateId, predicateVar, ctx);
     }
 
-    public static IsaAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable predicateVar, SchemaConcept type, boolean isDirect, ReasonerQuery parent) {
+    public static IsaAtom create( Variable var, Variable predicateVar, SchemaConcept type, boolean isDirect, ReasonerQuery parent, ReasoningContext ctx) {
         Statement pattern = isDirect ?
                 new Statement(var).isaX(new Statement(predicateVar)) :
                 new Statement(var).isa(new Statement(predicateVar));
-        return new IsaAtom(conceptManager, ruleCache, var, pattern, parent, type.id(), predicateVar);
+        return new IsaAtom(var, pattern, parent, type.id(), predicateVar, ctx);
     }
 
-    private static IsaAtom create(ConceptManager conceptManager, RuleCache ruleCache,IsaAtom a, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, a.getVarName(), a.getPredicateVariable(), a.getPattern(), a.getTypeId(), parent);
+    private static IsaAtom create(IsaAtom a, ReasonerQuery parent) {
+        return create(a.getVarName(), a.getPredicateVariable(), a.getPattern(), a.getTypeId(), parent, a.context());
     }
 
     @Override
     public Atomic copy(ReasonerQuery parent){
-        return create(conceptManager, ruleCache, this, parent);
+        return create(this, parent);
     }
 
     @Override
@@ -155,7 +154,7 @@ public class IsaAtom extends IsaAtomBase {
     @Override
     public IsaAtom addType(SchemaConcept type) {
         if (getTypeId() != null) return this;
-        return create(conceptManager, ruleCache, getVarName(), getPredicateVariable(), type.id(), this.isDirect(), this.getParentQuery());
+        return create(getVarName(), getPredicateVariable(), type.id(), this.isDirect(), this.getParentQuery(), this.context());
     }
 
     @Override
@@ -192,7 +191,7 @@ public class IsaAtom extends IsaAtomBase {
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(conceptManager, ruleCache, getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), this.isDirect(), getParentQuery());
+        return create(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), this.isDirect(), getParentQuery(), context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/IsaAtomBase.java
+++ b/graql/reasoner/atom/binary/IsaAtomBase.java
@@ -19,14 +19,12 @@
 
 package grakn.core.graql.reasoner.atom.binary;
 
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.manager.ConceptManager;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -37,9 +35,9 @@ import java.util.stream.Collectors;
  */
 public abstract class IsaAtomBase extends TypeAtom{
 
-    IsaAtomBase(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-                Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
+    IsaAtomBase(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+                Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
     }
 
     @Override
@@ -47,6 +45,6 @@ public abstract class IsaAtomBase extends TypeAtom{
         Collection<Variable> vars = u.get(getVarName());
         return vars.isEmpty()?
                 Collections.singleton(this) :
-                vars.stream().map(v -> IsaAtom.create(conceptManager, ruleCache, v, getPredicateVariable(), getTypeId(), this.isDirect(), this.getParentQuery())).collect(Collectors.toSet());
+                vars.stream().map(v -> IsaAtom.create(v, getPredicateVariable(), getTypeId(), this.isDirect(), this.getParentQuery(), context())).collect(Collectors.toSet());
     }
 }

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -22,17 +22,15 @@ package grakn.core.graql.reasoner.atom.binary;
 import com.google.common.collect.Sets;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.rule.InferenceRule;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Rule;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -44,9 +42,9 @@ import java.util.stream.Stream;
  */
 public abstract class OntologicalAtom extends TypeAtom {
 
-    OntologicalAtom(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-                    Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
+    OntologicalAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+                    Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
     }
 
     abstract OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent);

--- a/graql/reasoner/atom/binary/PlaysAtom.java
+++ b/graql/reasoner/atom/binary/PlaysAtom.java
@@ -19,10 +19,9 @@
 
 package grakn.core.graql.reasoner.atom.binary;
 
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.PlaysProperty;
 import graql.lang.property.VarProperty;
@@ -34,29 +33,29 @@ import graql.lang.statement.Variable;
  */
 public class PlaysAtom extends OntologicalAtom {
 
-    PlaysAtom(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-              Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
+    private PlaysAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+                      Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
     }
 
-    public static PlaysAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent) {
+    public static PlaysAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new PlaysAtom(conceptManager, ruleCache, varName.asReturnedVar(), new Statement(varName).plays(new Statement(predicateVar)), parent, predicateId, predicateVar);
+        return new PlaysAtom(varName.asReturnedVar(), new Statement(varName).plays(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
     }
 
-    private static PlaysAtom create(ConceptManager conceptManager, RuleCache ruleCache,PlaysAtom a, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent);
+    private static PlaysAtom create(PlaysAtom a, ReasonerQuery parent) {
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
     }
 
     @Override
     OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, var, predicateVar, predicateId, parent);
+        return create(var, predicateVar, predicateId, parent, context());
     }
 
     @Override
     public Atomic copy(ReasonerQuery parent){
-        return create(conceptManager, ruleCache, this, parent);
+        return create(this, parent);
     }
 
     @Override

--- a/graql/reasoner/atom/binary/RelatesAtom.java
+++ b/graql/reasoner/atom/binary/RelatesAtom.java
@@ -19,10 +19,9 @@
 
 package grakn.core.graql.reasoner.atom.binary;
 
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.RelatesProperty;
 import graql.lang.property.VarProperty;
@@ -35,29 +34,29 @@ import graql.lang.statement.Variable;
  */
 public class RelatesAtom extends OntologicalAtom {
 
-    RelatesAtom(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-                Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
+    private RelatesAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+                        Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
     }
 
-    public static RelatesAtom create(ConceptManager conceptManager, RuleCache ruleCache,Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent) {
+    public static RelatesAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new RelatesAtom(conceptManager, ruleCache, varName, new Statement(varName).relates(new Statement(predicateVar)), parent, predicateId, predicateVar);
+        return new RelatesAtom(varName, new Statement(varName).relates(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
     }
 
-    private static RelatesAtom create(ConceptManager conceptManager, RuleCache ruleCache,RelatesAtom a, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent);
+    private static RelatesAtom create(RelatesAtom a, ReasonerQuery parent) {
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
     }
 
     @Override
     OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return RelatesAtom.create(conceptManager, ruleCache, var, predicateVar, predicateId, parent);
+        return RelatesAtom.create(var, predicateVar, predicateId, parent, context());
     }
 
     @Override
     public Atomic copy(ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, this, parent);
+        return create(this, parent);
     }
 
     @Override

--- a/graql/reasoner/atom/binary/RelationAtom.java
+++ b/graql/reasoner/atom/binary/RelationAtom.java
@@ -34,6 +34,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.core.Schema;
 import grakn.core.graql.reasoner.CacheCasting;
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.inference.RelationTypeReasoner;
 import grakn.core.graql.reasoner.atom.inference.TypeReasoner;
 import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
@@ -44,7 +45,6 @@ import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.cache.VariableDefinition;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueryEquivalence;
-import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
@@ -64,12 +64,9 @@ import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.ReasonerCheckedException;
 import grakn.core.kb.graql.reasoner.ReasonerException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.QueryCache;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
-import grakn.core.kb.keyspace.KeyspaceStatistics;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.IsaProperty;
@@ -103,9 +100,6 @@ import static graql.lang.Graql.var;
  */
 public class RelationAtom extends IsaAtomBase {
 
-    private final ReasonerQueryFactory reasonerQueryFactory;
-    private final QueryCache queryCache;
-    private final KeyspaceStatistics keyspaceStatistics;
     private final ImmutableList<RelationProperty.RolePlayer> relationPlayers;
     private final ImmutableSet<Label> roleLabels;
     private final TypeReasoner<RelationAtom> typeReasoner;
@@ -121,28 +115,21 @@ public class RelationAtom extends IsaAtomBase {
     private Multimap<Role, Variable> roleVarMap = null;
 
     private RelationAtom(
-            ReasonerQueryFactory reasonerQueryFactory,
-            ConceptManager conceptManager,
-            RuleCache ruleCache,
-            QueryCache queryCache,
-            KeyspaceStatistics keyspaceStatistics,
             Variable varName,
             Statement pattern,
             ReasonerQuery parentQuery,
             @Nullable ConceptId typeId,
             Variable predicateVariable,
             ImmutableList<RelationProperty.RolePlayer> relationPlayers,
-            ImmutableSet<Label> roleLabels) {
-        super(conceptManager, ruleCache, varName, pattern, parentQuery, typeId, predicateVariable);
-        this.reasonerQueryFactory = reasonerQueryFactory;
-        this.queryCache = queryCache;
-        this.keyspaceStatistics = keyspaceStatistics;
+            ImmutableSet<Label> roleLabels,
+            ReasoningContext ctx) {
+        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
         this.relationPlayers = relationPlayers;
         this.roleLabels = roleLabels;
-        this.typeReasoner = new RelationTypeReasoner(reasonerQueryFactory, queryCache, ruleCache, conceptManager, keyspaceStatistics);
+        this.typeReasoner = new RelationTypeReasoner(ctx);
     }
 
-    public static RelationAtom create(ReasonerQueryFactory reasonerQueryFactory, ConceptManager conceptManager, RuleCache ruleCache, QueryCache queryCache, KeyspaceStatistics keyspaceStatistics, Statement pattern, Variable predicateVar, @Nullable ConceptId predicateId, ReasonerQuery parent) {
+    public static RelationAtom create(Statement pattern, Variable predicateVar, @Nullable ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
         List<RelationProperty.RolePlayer> rps = new ArrayList<>();
         pattern.getProperty(RelationProperty.class)
                 .ifPresent(prop -> prop.relationPlayers().stream().sorted(Comparator.comparing(Object::hashCode)).forEach(rps::add));
@@ -155,11 +142,11 @@ public class RelationAtom extends IsaAtomBase {
                         .flatMap(Streams::optionalToStream)
                         .map(Label::of).iterator()
         ).build();
-        return new RelationAtom(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, pattern.var(), pattern, parent, predicateId, predicateVar, relationPlayers, roleLabels);
+        return new RelationAtom(pattern.var(), pattern, parent, predicateId, predicateVar, relationPlayers, roleLabels, ctx);
     }
 
-    public static RelationAtom create(ReasonerQueryFactory reasonerQueryFactory, ConceptManager conceptManager, RuleCache ruleCache, QueryCache queryCache, KeyspaceStatistics keyspaceStatistics, Statement pattern, Variable predicateVar, @Nullable ConceptId predicateId, @Nullable ImmutableList<Type> possibleTypes, ReasonerQuery parent) {
-        RelationAtom atom = create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, pattern, predicateVar, predicateId, parent);
+    public static RelationAtom create(Statement pattern, Variable predicateVar, @Nullable ConceptId predicateId, @Nullable ImmutableList<Type> possibleTypes, ReasonerQuery parent, ReasoningContext ctx) {
+        RelationAtom atom = create(pattern, predicateVar, predicateId, parent, ctx);
         atom.possibleTypes = possibleTypes;
         return atom;
     }
@@ -168,7 +155,7 @@ public class RelationAtom extends IsaAtomBase {
      * Copy constructor
      */
     private static RelationAtom create(RelationAtom a, ReasonerQuery parent) {
-        RelationAtom atom = new RelationAtom(a.reasonerQueryFactory, a.conceptManager, a.ruleCache, a.queryCache, a.keyspaceStatistics, a.getVarName(), a.getPattern(), parent, a.getTypeId(), a.getPredicateVariable(), a.getRelationPlayers(), a.getRoleLabels());
+        RelationAtom atom = new RelationAtom(a.getVarName(), a.getPattern(), parent, a.getTypeId(), a.getPredicateVariable(), a.getRelationPlayers(), a.getRoleLabels(), a.context());
         atom.possibleTypes = a.possibleTypes;
         return atom;
     }
@@ -210,6 +197,7 @@ public class RelationAtom extends IsaAtomBase {
     }
 
     private void checkPattern() {
+        ConceptManager conceptManager = context().conceptManager();
         getPattern().getProperties(RelationProperty.class)
                 .flatMap(p -> p.relationPlayers().stream())
                 .map(RelationProperty.RolePlayer::getRole).flatMap(Streams::optionalToStream)
@@ -245,6 +233,7 @@ public class RelationAtom extends IsaAtomBase {
             throw ReasonerException.illegalAtomConversion(this, AttributeAtom.class);
         }
         Label explicitLabel = Schema.ImplicitType.explicitLabel(type.label());
+        ConceptManager conceptManager = context().conceptManager();
         Role ownerRole = conceptManager.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(explicitLabel).getValue());
         Role valueRole = conceptManager.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(explicitLabel).getValue());
         Multimap<Role, Variable> roleVarMap = getRoleVarMap();
@@ -256,38 +245,34 @@ public class RelationAtom extends IsaAtomBase {
                 var(ownerVariable).has(explicitLabel.getValue(), var(attributeVariable), var(relationVariable)) :
                 var(ownerVariable).has(explicitLabel.getValue(), var(attributeVariable));
         AttributeAtom attributeAtom = AttributeAtom.create(
-                reasonerQueryFactory,
-                conceptManager,
-                ruleCache,
-                queryCache,
-                keyspaceStatistics,
                 attributeStatement,
                 attributeVariable,
                 relationVariable,
                 getPredicateVariable(),
                 conceptManager.getSchemaConcept(explicitLabel).id(),
                 new HashSet<>(),
-                getParentQuery()
+                getParentQuery(),
+                context()
         );
 
         Set<Statement> patterns = new HashSet<>(attributeAtom.getCombinedPattern().statements());
         this.getPredicates().map(Predicate::getPattern).forEach(patterns::add);
-        return reasonerQueryFactory.atomic(Graql.and(patterns)).getAtom().toAttributeAtom();
+        return context().queryFactory().atomic(Graql.and(patterns)).getAtom().toAttributeAtom();
     }
 
 
     @Override
     public IsaAtom toIsaAtom() {
-        IsaAtom isaAtom = IsaAtom.create(conceptManager, ruleCache, getVarName(), getPredicateVariable(), getTypeId(), false, getParentQuery());
+        IsaAtom isaAtom = IsaAtom.create(getVarName(), getPredicateVariable(), getTypeId(), false, getParentQuery(), context());
         Set<Statement> patterns = new HashSet<>(isaAtom.getCombinedPattern().statements());
         this.getPredicates().map(Predicate::getPattern).forEach(patterns::add);
-        return reasonerQueryFactory.atomic(Graql.and(patterns)).getAtom().toIsaAtom();
+        return context().queryFactory().atomic(Graql.and(patterns)).getAtom().toIsaAtom();
     }
 
     @Override
     public Set<Atom> rewriteToAtoms() {
         return this.getRelationPlayers().stream()
-                .map(rp -> create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, relationPattern(getVarName().asReturnedVar(), Sets.newHashSet(rp)), getPredicateVariable(), getTypeId(), null, this.getParentQuery()))
+                .map(rp -> create(relationPattern(getVarName().asReturnedVar(), Sets.newHashSet(rp)), getPredicateVariable(), getTypeId(), null, getParentQuery(), context()))
                 .collect(Collectors.toSet());
     }
 
@@ -372,6 +357,7 @@ public class RelationAtom extends IsaAtomBase {
 
     private ConceptMap getRoleSubstitution() {
         Map<Variable, Concept> roleSub = new HashMap<>();
+        ConceptManager conceptManager = context().conceptManager();
         getRolePredicates().forEach(p -> roleSub.put(p.getVarName(), conceptManager.getConcept(p.getPredicate())));
         return new ConceptMap(roleSub);
     }
@@ -493,6 +479,7 @@ public class RelationAtom extends IsaAtomBase {
 
     private Set<String> validateRelationPlayers(Rule rule) {
         Set<String> errors = new HashSet<>();
+        ConceptManager conceptManager = context().conceptManager();
         getRelationPlayers().forEach(rp -> {
             Statement role = rp.getRole().orElse(null);
             if (role == null) {
@@ -577,6 +564,7 @@ public class RelationAtom extends IsaAtomBase {
     }
 
     public Stream<IdPredicate> getRolePredicates() {
+        ConceptManager conceptManager = context().conceptManager();
         return getRelationPlayers().stream()
                 .map(RelationProperty.RolePlayer::getRole)
                 .flatMap(Streams::optionalToStream)
@@ -584,7 +572,7 @@ public class RelationAtom extends IsaAtomBase {
                 .filter(vp -> vp.getType().isPresent())
                 .map(vp -> {
                     String label = vp.getType().orElse(null);
-                    return IdPredicate.create(conceptManager, vp.var(), conceptManager.getRole(label).id(), getParentQuery());
+                    return IdPredicate.create(vp.var(), conceptManager.getRole(label).id(), getParentQuery(), conceptManager);
                 });
     }
 
@@ -640,6 +628,7 @@ public class RelationAtom extends IsaAtomBase {
     }
 
     public Stream<Role> getExplicitRoles() {
+        ConceptManager conceptManager = context().conceptManager();
         return getRelationPlayers().stream()
                 .map(RelationProperty.RolePlayer::getRole)
                 .flatMap(Streams::optionalToStream)
@@ -660,8 +649,7 @@ public class RelationAtom extends IsaAtomBase {
     public RelationAtom addType(SchemaConcept type) {
         if (getTypeId() != null) return this;
         //NB: do not cache possible types
-        return create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics,
-                this.getPattern(), this.getPredicateVariable(), type.id(), this.getParentQuery());
+        return create(this.getPattern(), this.getPredicateVariable(), type.id(), this.getParentQuery(), this.context());
     }
 
     @Override
@@ -697,7 +685,8 @@ public class RelationAtom extends IsaAtomBase {
     }
 
     @Override
-    public Stream<Predicate> getInnerPredicates() {
+    public Stream<Predicate> getInnerPredicates(){
+        ConceptManager conceptManager = context().conceptManager();
         return Stream.concat(
                 super.getInnerPredicates(),
                 getRelationPlayers().stream()
@@ -706,7 +695,7 @@ public class RelationAtom extends IsaAtomBase {
                         .filter(vp -> vp.var().isReturned())
                         .map(vp -> new Pair<>(vp.var(), vp.getType().orElse(null)))
                         .filter(p -> Objects.nonNull(p.second()))
-                        .map(p -> IdPredicate.create(conceptManager, p.first(), Label.of(p.second()), getParentQuery()))
+                        .map(p -> IdPredicate.create(p.first(), Label.of(p.second()), getParentQuery(), conceptManager))
         );
     }
 
@@ -722,6 +711,7 @@ public class RelationAtom extends IsaAtomBase {
 
     private Multimap<Role, Variable> computeRoleVarMap() {
         ImmutableMultimap.Builder<Role, Variable> builder = ImmutableMultimap.builder();
+        ConceptManager conceptManager = context().conceptManager();
 
         getRelationPlayers().forEach(c -> {
             Variable varName = c.getPlayer().var();
@@ -758,6 +748,7 @@ public class RelationAtom extends IsaAtomBase {
         //TODO:: of the (atom+parent) conjunction similarly to what we do at commit-time validation
 
         //establish compatible castings for each parent casting
+        ConceptManager conceptManager = context().conceptManager();
         List<Set<Pair<RelationProperty.RolePlayer, RelationProperty.RolePlayer>>> compatibleMappingsPerParentRP = new ArrayList<>();
         if (parentAtom.getRelationPlayers().size() > this.getRelationPlayers().size()) return new HashSet<>();
 
@@ -920,6 +911,7 @@ public class RelationAtom extends IsaAtomBase {
         SemanticDifference baseDiff = super.semanticDifference(child, unifier);
         if (!child.isRelation()) return baseDiff;
         RelationAtom childAtom = (RelationAtom) child;
+        ConceptManager conceptManager = context().conceptManager();
         Set<VariableDefinition> diff = new HashSet<>();
 
         Set<Variable> parentRoleVars = this.getRoleExpansionVariables();
@@ -954,8 +946,8 @@ public class RelationAtom extends IsaAtomBase {
     }
 
     private Relation findRelation(ConceptMap sub) {
-        ReasonerAtomicQuery query = reasonerQueryFactory.atomic(this).withSubstitution(sub);
-        MultilevelSemanticCache queryCache = CacheCasting.queryCacheCast(this.queryCache);
+        ReasonerAtomicQuery query = context().queryFactory().atomic(this).withSubstitution(sub);
+        MultilevelSemanticCache queryCache = CacheCasting.queryCacheCast(context().queryCache());
         ConceptMap answer = queryCache.getAnswerStream(query).findFirst().orElse(null);
 
         if (answer == null) queryCache.ackDBCompleteness(query);
@@ -1021,7 +1013,7 @@ public class RelationAtom extends IsaAtomBase {
                 relVar = relVar.rel(rp.getPlayer());
             }
         }
-        return create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, relVar, this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
+        return create(relVar, this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery(), this.context());
     }
 
     /**
@@ -1049,12 +1041,12 @@ public class RelationAtom extends IsaAtomBase {
                 relVar = relVar.rel(c.getPlayer());
             }
         }
-        return create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, relVar, this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
+        return create(relVar, this.getPredicateVariable(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery(), this.context());
     }
 
     @Override
     public RelationAtom rewriteWithTypeVariable() {
-        return create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics, this.getPattern(), this.getPredicateVariable().asReturnedVar(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery());
+        return create(this.getPattern(), this.getPredicateVariable().asReturnedVar(), this.getTypeId(), this.getPossibleTypes(), this.getParentQuery(), this.context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/SubAtom.java
+++ b/graql/reasoner/atom/binary/SubAtom.java
@@ -19,11 +19,10 @@
 
 package grakn.core.graql.reasoner.atom.binary;
 
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.SubProperty;
 import graql.lang.property.VarProperty;
@@ -43,32 +42,30 @@ import java.util.stream.Collectors;
  */
 public class SubAtom extends OntologicalAtom {
 
-    SubAtom(ConceptManager conceptManager,
-            RuleCache ruleCache,
-            Variable varName,
-            Statement pattern,
-            ReasonerQuery parentQuery,
-            @Nullable ConceptId typeId,
-            Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, parentQuery, typeId, predicateVariable);
+    private SubAtom(Variable varName,
+                    Statement pattern,
+                    ReasonerQuery parentQuery,
+                    @Nullable ConceptId typeId,
+                    Variable predicateVariable,
+                    ReasoningContext ctx) {
+        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
     }
 
-
-    public static SubAtom create(ConceptManager conceptManager, RuleCache ruleCache, Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent) {
+    public static SubAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new SubAtom(conceptManager, ruleCache, varName, new Statement(varName).sub(new Statement(predicateVar)), parent, predicateId, predicateVar);
+        return new SubAtom(varName, new Statement(varName).sub(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
     }
     /**
      * copy constructor
      */
     private static SubAtom create(SubAtom a, ReasonerQuery parent) {
-        return create(a.conceptManager, a.ruleCache, a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent);
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
     }
 
     @Override
     OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return create(conceptManager, ruleCache, var, predicateVar, predicateId, parent);
+        return create(var, predicateVar, predicateId, parent, context());
     }
 
 

--- a/graql/reasoner/atom/binary/TypeAtom.java
+++ b/graql/reasoner/atom/binary/TypeAtom.java
@@ -19,9 +19,8 @@
 package grakn.core.graql.reasoner.atom.binary;
 
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.manager.ConceptManager;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.statement.Statement;
@@ -48,9 +47,9 @@ import java.util.Set;
  */
 public abstract class TypeAtom extends Binary {
 
-    TypeAtom(ConceptManager conceptManager, RuleCache ruleCache, Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
-             Variable predicateVariable) {
-        super(conceptManager, ruleCache, varName, pattern, reasonerQuery, typeId, predicateVariable);
+    TypeAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+             Variable predicateVariable, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
     }
 
 

--- a/graql/reasoner/atom/inference/RelationTypeReasoner.java
+++ b/graql/reasoner/atom/inference/RelationTypeReasoner.java
@@ -29,8 +29,8 @@ import grakn.common.util.Pair;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.util.ConceptUtils;
 import grakn.core.core.Schema;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.binary.RelationAtom;
-import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.utils.ReasonerUtils;
 import grakn.core.graql.reasoner.utils.conversion.RoleConverter;
 import grakn.core.graql.reasoner.utils.conversion.TypeConverter;
@@ -41,8 +41,6 @@ import grakn.core.kb.concept.api.Role;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.concept.manager.ConceptManager;
-import grakn.core.kb.graql.reasoner.cache.QueryCache;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.keyspace.KeyspaceStatistics;
 import graql.lang.property.RelationProperty;
 import graql.lang.statement.Statement;
@@ -61,20 +59,10 @@ import static graql.lang.Graql.var;
 
 public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
 
-    private final ReasonerQueryFactory reasonerQueryFactory;
-    private final QueryCache queryCache;
-    private final KeyspaceStatistics keyspaceStatistics;
-    private final ConceptManager conceptManager;
-    private final RuleCache ruleCache;
+    private final ReasoningContext ctx;
 
-    public RelationTypeReasoner(ReasonerQueryFactory queryFactory,
-                         QueryCache queryCache, RuleCache ruleCache,
-                         ConceptManager conceptManger, KeyspaceStatistics stats){
-        this.reasonerQueryFactory = queryFactory;
-        this.queryCache = queryCache;
-        this.ruleCache = ruleCache;
-        this.conceptManager = conceptManger;
-        this.keyspaceStatistics = stats;
+    public RelationTypeReasoner(ReasoningContext ctx){
+        this.ctx = ctx;
     }
 
     @Override
@@ -95,46 +83,49 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
     public ImmutableList<Type> inferPossibleTypes(RelationAtom atom, ConceptMap sub) {
         if (atom.getSchemaConcept() != null) return ImmutableList.of(atom.getSchemaConcept().asType());
 
+
+        KeyspaceStatistics keyspaceStatistics = ctx.keyspaceStatistics();
+        ConceptManager conceptManager = ctx.conceptManager();
         Multimap<RelationType, Role> compatibleConfigurations = inferPossibleRelationConfigurations(atom, sub);
         Set<Variable> untypedRoleplayers = Sets.difference(atom.getRolePlayers(), atom.getParentQuery().getVarTypeMap().keySet());
         Set<RelationAtom> untypedNeighbours = atom.getNeighbours(RelationAtom.class)
                 .filter(at -> !Sets.intersection(at.getVarNames(), untypedRoleplayers).isEmpty())
                 .collect(Collectors.toSet());
 
-            ImmutableList.Builder<Type> builder = ImmutableList.builder();
-            //prioritise relations with higher chance of yielding answers
-            compatibleConfigurations.asMap().entrySet().stream()
-                    //prioritise relations with more allowed roles
-                    .sorted(Comparator.comparing(e -> -e.getValue().size()))
-                    //prioritise relations with number of roles equal to arity
-                    .sorted(Comparator.comparing(e -> e.getKey().roles().count() != atom.getRelationPlayers().size()))
-                    //prioritise relations having more instances
-                    .sorted(Comparator.comparing(e -> -keyspaceStatistics.count(conceptManager, e.getKey().label())))
-                    //prioritise relations with highest number of possible types played by untyped role players
-                    .map(e -> {
-                        if (untypedNeighbours.isEmpty()) return new Pair<>(e.getKey(), 0L);
+        ImmutableList.Builder<Type> builder = ImmutableList.builder();
+        //prioritise relations with higher chance of yielding answers
+        compatibleConfigurations.asMap().entrySet().stream()
+                //prioritise relations with more allowed roles
+                .sorted(Comparator.comparing(e -> -e.getValue().size()))
+                //prioritise relations with number of roles equal to arity
+                .sorted(Comparator.comparing(e -> e.getKey().roles().count() != atom.getRelationPlayers().size()))
+                //prioritise relations having more instances
+                .sorted(Comparator.comparing(e -> -keyspaceStatistics.count(conceptManager, e.getKey().label())))
+                //prioritise relations with highest number of possible types played by untyped role players
+                .map(e -> {
+                    if (untypedNeighbours.isEmpty()) return new Pair<>(e.getKey(), 0L);
 
-                        Iterator<RelationAtom> neighbourIterator = untypedNeighbours.iterator();
-                        Set<Type> typesFromNeighbour = inferPossibleEntityTypePlayers(neighbourIterator.next(), sub);
-                        while (neighbourIterator.hasNext()) {
-                            typesFromNeighbour = Sets.intersection(typesFromNeighbour, inferPossibleEntityTypePlayers(neighbourIterator.next(), sub));
-                        }
+                    Iterator<RelationAtom> neighbourIterator = untypedNeighbours.iterator();
+                    Set<Type> typesFromNeighbour = inferPossibleEntityTypePlayers(neighbourIterator.next(), sub);
+                    while (neighbourIterator.hasNext()) {
+                        typesFromNeighbour = Sets.intersection(typesFromNeighbour, inferPossibleEntityTypePlayers(neighbourIterator.next(), sub));
+                    }
 
-                        Set<Role> rs = e.getKey().roles().collect(Collectors.toSet());
-                        rs.removeAll(e.getValue());
-                        return new Pair<>(
-                                e.getKey(),
-                                rs.stream().flatMap(Role::players).filter(typesFromNeighbour::contains).count()
-                        );
-                    })
-                    .sorted(Comparator.comparing(p -> -p.second()))
-                    //prioritise non-implicit relations
-                    .sorted(Comparator.comparing(e -> e.first().isImplicit()))
-                    .map(Pair::first)
-                    //retain super types only
-                    .filter(t -> Sets.intersection(ConceptUtils.nonMetaSups(t), compatibleConfigurations.keySet()).isEmpty())
-                    .forEach(builder::add);
-            //TODO need to add THING and meta relation type as well to make it complete
+                    Set<Role> rs = e.getKey().roles().collect(Collectors.toSet());
+                    rs.removeAll(e.getValue());
+                    return new Pair<>(
+                            e.getKey(),
+                            rs.stream().flatMap(Role::players).filter(typesFromNeighbour::contains).count()
+                    );
+                })
+                .sorted(Comparator.comparing(p -> -p.second()))
+                //prioritise non-implicit relations
+                .sorted(Comparator.comparing(e -> e.first().isImplicit()))
+                .map(Pair::first)
+                //retain super types only
+                .filter(t -> Sets.intersection(ConceptUtils.nonMetaSups(t), compatibleConfigurations.keySet()).isEmpty())
+                .forEach(builder::add);
+        //TODO need to add THING and meta relation type as well to make it complete
         return builder.build();
     }
 
@@ -162,6 +153,7 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
         SetMultimap<Variable, Type> varTypeMap = atom.getParentQuery().getVarTypeMap(sub);
         Set<Type> types = atom.getRolePlayers().stream().filter(varTypeMap::containsKey).flatMap(v -> varTypeMap.get(v).stream()).collect(Collectors.toSet());
 
+        ConceptManager conceptManager = ctx.conceptManager();
         if (roles.isEmpty() && types.isEmpty()) {
             RelationType metaRelationType = conceptManager.getMetaRelationType();
             Multimap<RelationType, Role> compatibleTypes = HashMultimap.create();
@@ -215,7 +207,7 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
         boolean roleRecomputationViable = allRolesMeta && (!sub.isEmpty() || !Sets.intersection(varTypeMap.keySet(), atom.getRolePlayers()).isEmpty());
         if (explicitRoles.size() == atom.getRelationPlayers().size() && !roleRecomputationViable) return atom;
 
-        Role metaRole = conceptManager.getMetaRole();
+        Role metaRole = ctx.conceptManager().getMetaRole();
         List<RelationProperty.RolePlayer> allocatedRelationPlayers = new ArrayList<>();
         SchemaConcept schemaConcept = atom.getSchemaConcept();
         RelationType relType = null;
@@ -288,7 +280,6 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
                         relationPattern.isaX(new Statement(atom.getPredicateVariable())) :
                         relationPattern.isa(new Statement(atom.getPredicateVariable()))
                 );
-        return RelationAtom.create(reasonerQueryFactory, conceptManager, ruleCache, queryCache, keyspaceStatistics,
-                newPattern, atom.getPredicateVariable(), atom.getTypeId(), atom.getPossibleTypes(), atom.getParentQuery());
+        return RelationAtom.create(newPattern, atom.getPredicateVariable(), atom.getTypeId(), atom.getPossibleTypes(), atom.getParentQuery(), atom.context());
     }
 }

--- a/graql/reasoner/atom/predicate/IdPredicate.java
+++ b/graql/reasoner/atom/predicate/IdPredicate.java
@@ -41,28 +41,28 @@ public class IdPredicate extends Predicate<ConceptId> {
 
     private ConceptManager conceptManager;
 
-    private IdPredicate(ConceptManager conceptManager, Variable varName, Statement pattern, ReasonerQuery parentQuery, ConceptId predicate) {
+    private IdPredicate(Variable varName, Statement pattern, ReasonerQuery parentQuery, ConceptId predicate, ConceptManager conceptManager) {
         super(varName, pattern, predicate, parentQuery);
         this.conceptManager = conceptManager;
     }
 
-    public static IdPredicate create(ConceptManager conceptManager, Statement pattern, ReasonerQuery parent) {
-        return new IdPredicate(conceptManager, pattern.var(), pattern, parent, extractPredicate(pattern));
+    public static IdPredicate create(Statement pattern, ReasonerQuery parent, ConceptManager conceptManager) {
+        return new IdPredicate(pattern.var(), pattern, parent, extractPredicate(pattern), conceptManager);
     }
 
-    public static IdPredicate create(ConceptManager conceptManager, Variable varName, Label label, ReasonerQuery parent) {
-        return create(conceptManager, createIdVar(varName.asReturnedVar(), label, conceptManager), parent);
+    public static IdPredicate create(Variable varName, Label label, ReasonerQuery parent, ConceptManager conceptManager) {
+        return create(createIdVar(varName.asReturnedVar(), label, conceptManager), parent, conceptManager);
     }
 
-    public static IdPredicate create(ConceptManager conceptManager, Variable varName, ConceptId id, ReasonerQuery parent) {
-        return create(conceptManager, createIdVar(varName.asReturnedVar(), id), parent);
+    public static IdPredicate create(Variable varName, ConceptId id, ReasonerQuery parent, ConceptManager conceptManager) {
+        return create(createIdVar(varName.asReturnedVar(), id), parent, conceptManager);
     }
 
     /**
      * Copy constructor
      */
     private static IdPredicate create(IdPredicate a, ReasonerQuery parent) {
-        return create(a.conceptManager, a.getPattern(), parent);
+        return create(a.getPattern(), parent, a.conceptManager);
     }
 
     private static ConceptId extractPredicate(Statement var) {

--- a/graql/reasoner/plan/GraqlTraversalPlanner.java
+++ b/graql/reasoner/plan/GraqlTraversalPlanner.java
@@ -130,7 +130,7 @@ public class GraqlTraversalPlanner {
                 first.getVarNames().stream()
                         .peek(vars::add)
                         .filter(v -> !subVariables.contains(v))
-                        .map(v -> IdPredicate.create(conceptManager, v, ConceptId.of(PLACEHOLDER_ID), query))
+                        .map(v -> IdPredicate.create(v, ConceptId.of(PLACEHOLDER_ID), query, conceptManager))
                         .forEach(subs::add);
             }
         }

--- a/graql/reasoner/query/CompositeQuery.java
+++ b/graql/reasoner/query/CompositeQuery.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Sets;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.state.AnswerPropagatorState;
 import grakn.core.graql.reasoner.state.CompositeState;
 import grakn.core.graql.reasoner.state.ResolutionState;
@@ -36,7 +37,6 @@ import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.executor.ExecutorFactory;
 import grakn.core.kb.graql.reasoner.ReasonerException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.QueryCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
@@ -73,11 +73,10 @@ public class CompositeQuery extends ResolvableQuery {
 
     final private ReasonerQueryImpl conjunctiveQuery;
     final private Set<ResolvableQuery> complementQueries;
-    final private ReasonerQueryFactory queryFactory;
 
-    CompositeQuery(Conjunction<Pattern> pattern, ReasonerQueryFactory queryFactory, ExecutorFactory executorFactory, QueryCache queryCache) throws ReasonerException {
-        super(executorFactory, queryCache);
-        this.queryFactory = queryFactory;
+    CompositeQuery(Conjunction<Pattern> pattern, ExecutorFactory executorFactory, ReasoningContext ctx) throws ReasonerException {
+        super(executorFactory, ctx);
+        ReasonerQueryFactory queryFactory = context().queryFactory();
         Conjunction<Statement> positiveConj = Graql.and(
                 pattern.getPatterns().stream()
                         .filter(p -> !p.isNegation())
@@ -86,9 +85,9 @@ public class CompositeQuery extends ResolvableQuery {
         );
         //conjunction of negation patterns
         Set<Conjunction<Pattern>> complementPattern = complementPattern(pattern);
-        this.conjunctiveQuery = this.queryFactory.create(positiveConj);
+        this.conjunctiveQuery = queryFactory.create(positiveConj);
         this.complementQueries = complementPattern.stream()
-                .map(comp -> this.queryFactory.resolvable(comp))
+                .map(queryFactory::resolvable)
                 .collect(Collectors.toSet());
 
         if (!isNegationSafe()){
@@ -96,11 +95,10 @@ public class CompositeQuery extends ResolvableQuery {
         }
     }
 
-    CompositeQuery(ReasonerQueryImpl conj, Set<ResolvableQuery> comp, ReasonerQueryFactory queryFactory, ExecutorFactory executorFactory, QueryCache queryCache) {
-        super(executorFactory, queryCache);
+    CompositeQuery(ReasonerQueryImpl conj, Set<ResolvableQuery> comp, ExecutorFactory executorFactory, ReasoningContext ctx) {
+        super(executorFactory, ctx);
         this.conjunctiveQuery = conj;
         this.complementQueries = comp;
-        this.queryFactory = queryFactory;
     }
 
     @Override
@@ -212,15 +210,14 @@ public class CompositeQuery extends ResolvableQuery {
         return new CompositeQuery(
                 getConjunctiveQuery().withSubstitution(sub),
                 getComplementQueries().stream().map(q -> q.withSubstitution(sub)).collect(Collectors.toSet()),
-                queryFactory,
                 executorFactory,
-                queryCache
+                context()
         );
     }
 
     @Override
     public CompositeQuery inferTypes() {
-        return new CompositeQuery(getConjunctiveQuery().inferTypes(), getComplementQueries(), queryFactory, executorFactory, queryCache);
+        return new CompositeQuery(getConjunctiveQuery().inferTypes(), getComplementQueries(), executorFactory, context());
     }
 
     @Override
@@ -228,9 +225,8 @@ public class CompositeQuery extends ResolvableQuery {
         return new CompositeQuery(
                 getConjunctiveQuery().constantValuePredicateQuery(),
                 getComplementQueries(),
-                queryFactory,
                 executorFactory,
-                queryCache);
+                context());
     }
 
     public ReasonerQueryImpl getConjunctiveQuery() {
@@ -246,9 +242,8 @@ public class CompositeQuery extends ResolvableQuery {
         return new CompositeQuery(
                 getConjunctiveQuery().copy(),
                 getComplementQueries().stream().map(ResolvableQuery::copy).collect(Collectors.toSet()),
-                queryFactory,
                 executorFactory,
-                queryCache
+                context()
         );
     }
 
@@ -290,9 +285,8 @@ public class CompositeQuery extends ResolvableQuery {
                                 this.getPattern().getPatterns(),
                                 q.getPattern().getPatterns()
                         )),
-                queryFactory,
                 executorFactory,
-                queryCache
+                context()
         );
     }
 
@@ -375,9 +369,8 @@ public class CompositeQuery extends ResolvableQuery {
                 getComplementQueries().isEmpty()?
                         getComplementQueries() :
                         getComplementQueries().stream().map(ResolvableQuery::rewrite).collect(Collectors.toSet()),
-                queryFactory,
                 executorFactory,
-                queryCache
+                context()
         );
     }
 

--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -29,12 +29,12 @@ import com.google.common.collect.Sets;
 import grakn.common.util.Pair;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.util.ConceptUtils;
-import grakn.core.core.Schema;
 import grakn.core.graql.reasoner.CacheCasting;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.AtomicBase;
 import grakn.core.graql.reasoner.atom.AtomicUtil;
 import grakn.core.graql.reasoner.atom.PropertyAtomicFactory;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.binary.IsaAtom;
 import grakn.core.graql.reasoner.atom.binary.IsaAtomBase;
 import grakn.core.graql.reasoner.atom.binary.RelationAtom;
@@ -59,7 +59,6 @@ import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.Concept;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
-import grakn.core.kb.concept.api.Role;
 import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.executor.ExecutorFactory;
@@ -67,8 +66,6 @@ import grakn.core.kb.graql.planning.gremlin.TraversalPlanFactory;
 import grakn.core.kb.graql.reasoner.ReasonerCheckedException;
 import grakn.core.kb.graql.reasoner.ReasonerException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
-import grakn.core.kb.graql.reasoner.cache.QueryCache;
-import grakn.core.kb.graql.reasoner.cache.RuleCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
@@ -77,8 +74,6 @@ import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -90,6 +85,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -98,10 +94,7 @@ import java.util.stream.Stream;
  */
 public class ReasonerQueryImpl extends ResolvableQuery {
 
-    final ConceptManager conceptManager;
-    final RuleCache ruleCache;
-    final TraversalPlanFactory traversalPlanFactory;
-    final ReasonerQueryFactory reasonerQueryFactory;
+    protected final TraversalPlanFactory traversalPlanFactory;
 
     private ImmutableSet<Atomic> atomSet;
     private ConceptMap substitution = null;
@@ -114,16 +107,14 @@ public class ReasonerQueryImpl extends ResolvableQuery {
      * BUILDER constructor should only be used in the ReasonerQueryFactory because it utilises
      * the setAtomSet method to work around an ordering constraint
      */
-    ReasonerQueryImpl(Conjunction<Statement> pattern, PropertyAtomicFactory propertyAtomicFactory,
-                      ConceptManager conceptManager, RuleCache ruleCache, QueryCache queryCache,
-                      ExecutorFactory executorFactory, ReasonerQueryFactory reasonerQueryFactory,
-                      TraversalPlanFactory traversalPlanFactory) {
-        super(executorFactory, queryCache);
-        this.conceptManager = conceptManager;
-        this.ruleCache = ruleCache;
+    ReasonerQueryImpl(Conjunction<Statement> pattern,
+                      PropertyAtomicFactory propertyAtomicFactory,
+                      ExecutorFactory executorFactory,
+                      TraversalPlanFactory traversalPlanFactory,
+                      ReasoningContext ctx) {
+        super(executorFactory, ctx);
         this.traversalPlanFactory = traversalPlanFactory;
         this.atomSet = null;
-        this.reasonerQueryFactory = reasonerQueryFactory;
 
         this.atomSet = ImmutableSet.<Atomic>builder()
                 .addAll(propertyAtomicFactory.createAtoms(pattern, this).iterator())
@@ -133,14 +124,11 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     /**
      * create a reasoner query from provided set of atomics
      **/
-    ReasonerQueryImpl(Set<Atomic> atomsToCopy, ConceptManager conceptManager, RuleCache ruleCache, QueryCache queryCache, ExecutorFactory executorFactory, ReasonerQueryFactory reasonerQueryFactory, TraversalPlanFactory traversalPlanFactory) {
-        super(executorFactory, queryCache);
-        this.conceptManager = conceptManager;
-        this.ruleCache = ruleCache;
+    ReasonerQueryImpl(Set<Atomic> atomsToCopy,  ExecutorFactory executorFactory, TraversalPlanFactory traversalPlanFactory, ReasoningContext ctx) {
+        super(executorFactory, ctx);
         this.atomSet = ImmutableSet.<Atomic>builder()
                 .addAll(atomsToCopy.stream().map(at -> at.copy(this)).iterator())
                 .build();
-        this.reasonerQueryFactory = reasonerQueryFactory;
         this.traversalPlanFactory = traversalPlanFactory;
     }
 
@@ -148,24 +136,18 @@ public class ReasonerQueryImpl extends ResolvableQuery {
      * create a reasoner query from provided list of atoms
      * NB: atom constraints (types and predicates, if any) will be included in the query
      **/
-    ReasonerQueryImpl(List<Atom> atomsToPropagate, ConceptManager conceptManager, RuleCache ruleCache, QueryCache queryCache, ExecutorFactory executorFactory, ReasonerQueryFactory reasonerQueryFactory, TraversalPlanFactory traversalPlanFactory) {
-        super(executorFactory, queryCache);
-        this.conceptManager = conceptManager;
-        this.ruleCache = ruleCache;
+    ReasonerQueryImpl(List<Atom> atomsToPropagate, ExecutorFactory executorFactory, TraversalPlanFactory traversalPlanFactory, ReasoningContext ctx) {
+        super(executorFactory, ctx);
         this.atomSet =  ImmutableSet.<Atomic>builder()
                 .addAll(atomsToPropagate.stream()
                         .flatMap(at -> Stream.concat(Stream.of(at), at.getNonSelectableConstraints()))
                         .map(at -> at.copy(this)).iterator())
                 .build();
-        this.reasonerQueryFactory = reasonerQueryFactory;
         this.traversalPlanFactory = traversalPlanFactory;
     }
 
     ReasonerQueryImpl(ReasonerQueryImpl q) {
-        super(q.executorFactory, q.queryCache);
-        this.conceptManager = q.conceptManager;
-        this.ruleCache = q.ruleCache;
-        this.reasonerQueryFactory = q.reasonerQueryFactory;
+        super(q.executorFactory, q.context());
         this.traversalPlanFactory = q.traversalPlanFactory;
         this.atomSet =  ImmutableSet.<Atomic>builder()
                 .addAll(q.getAtoms().stream().map(at -> at.copy(this)).iterator())
@@ -176,46 +158,38 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     public ReasonerQuery conjunction(ReasonerQuery q) {
         return new ReasonerQueryImpl(
                 Sets.union(getAtoms(), q.getAtoms()),
-                conceptManager,
-                ruleCache,
-                queryCache,
                 executorFactory,
-                reasonerQueryFactory,
-                traversalPlanFactory
+                traversalPlanFactory,
+                context()
         );
     }
 
     @Override
     public CompositeQuery asComposite() {
-        return new CompositeQuery(getPattern(), reasonerQueryFactory, executorFactory, queryCache);
+        return new CompositeQuery(getPattern(), executorFactory, context());
     }
 
     @Override
     public ReasonerQueryImpl withSubstitution(ConceptMap sub){
         return new ReasonerQueryImpl(Sets.union(this.getAtoms(),
-                AtomicUtil.answerToPredicates(conceptManager, sub,this)),
-                conceptManager,
-                ruleCache,
-                queryCache,
+                AtomicUtil.answerToPredicates(sub,this, context().conceptManager())),
                 executorFactory,
-                reasonerQueryFactory,
-                traversalPlanFactory);
+                traversalPlanFactory,
+                context());
     }
 
     @Override
     public ReasonerQueryImpl inferTypes() {
-        return new ReasonerQueryImpl(getAtoms().stream().map(Atomic::inferTypes).collect(Collectors.toSet()),
-                conceptManager,
-                ruleCache,
-                queryCache,
+        return new ReasonerQueryImpl(
+                getAtoms().stream().map(Atomic::inferTypes).collect(Collectors.toSet()),
                 executorFactory,
-                reasonerQueryFactory,
-                traversalPlanFactory);
+                traversalPlanFactory,
+                context());
     }
 
     @Override
     public ReasonerQueryImpl constantValuePredicateQuery(){
-        return reasonerQueryFactory.create(
+        return context().queryFactory().create(
                 getAtoms().stream()
                         .filter(at -> !(at instanceof VariablePredicate))
                         .collect(Collectors.toSet()));
@@ -235,11 +209,11 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     public ReasonerQueryImpl transformIds(Map<Variable, ConceptId> transform){
         Set<Atomic> atoms = this.getAtoms(IdPredicate.class).map(p -> {
             ConceptId conceptId = transform.get(p.getVarName());
-            if (conceptId != null) return IdPredicate.create(conceptManager, p.getVarName(), conceptId, p.getParentQuery());
+            if (conceptId != null) return IdPredicate.create(p.getVarName(), conceptId, p.getParentQuery(), context().conceptManager());
             return p;
         }).collect(Collectors.toSet());
         getAtoms().stream().filter(at -> !(at instanceof IdPredicate)).forEach(atoms::add);
-        return new ReasonerQueryImpl(atoms, conceptManager, ruleCache, queryCache, executorFactory, reasonerQueryFactory, traversalPlanFactory);
+        return new ReasonerQueryImpl(atoms, executorFactory, traversalPlanFactory, context());
     }
 
     @Override
@@ -366,16 +340,16 @@ public class ReasonerQueryImpl extends ResolvableQuery {
 
     private Stream<IsaAtom> inferEntityTypes(ConceptMap sub) {
         Set<Variable> typedVars = getAtoms(IsaAtomBase.class).map(AtomicBase::getVarName).collect(Collectors.toSet());
+        ConceptManager conceptManager = context().conceptManager();
         return Stream.concat(
                 getAtoms(IdPredicate.class),
-                AtomicUtil.answerToPredicates(conceptManager, sub, this).stream()
+                AtomicUtil.answerToPredicates(sub, this, conceptManager).stream()
                 .map(IdPredicate.class::cast))
                 .filter(p -> !typedVars.contains(p.getVarName()))
                 .map(p -> new Pair<>(p, conceptManager.<Concept>getConcept(p.getPredicate())))
                 .filter(p -> Objects.nonNull(p.second()))
                 .filter(p -> p.second().isEntity())
-                .map(p -> IsaAtom.create(conceptManager, ruleCache, p.first().getVarName(), new Variable(),
-                        p.second().asEntity().type(), false,this));
+                .map(p -> IsaAtom.create(p.first().getVarName(), new Variable(), p.second().asEntity().type(), false, this, context()));
     }
 
     private Multimap<Variable, Type> getVarTypeMap(Stream<IsaAtomBase> isas){
@@ -452,7 +426,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
      */
     public ResolutionPlan resolutionPlan(){
         if (resolutionPlan == null){
-            resolutionPlan = new ResolutionPlan(conceptManager, traversalPlanFactory, this);
+            resolutionPlan = new ResolutionPlan(context().conceptManager(), traversalPlanFactory, this);
         }
         return resolutionPlan;
     }
@@ -492,6 +466,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
      */
     public ConceptMap getSubstitution(){
         if (substitution == null) {
+            ConceptManager conceptManager = context().conceptManager();
             Set<Variable> varNames = getVarNames();
             Set<IdPredicate> predicates = getAtoms(IsaAtomBase.class)
                     .map(IsaAtomBase::getTypePredicate)
@@ -513,6 +488,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
 
     public ConceptMap getRoleSubstitution(){
         Map<Variable, Concept> roleSub = new HashMap<>();
+        ConceptManager conceptManager = context().conceptManager();
         getAtoms(RelationAtom.class)
                 .flatMap(RelationAtom::getRolePredicates)
                 .forEach(p -> {
@@ -546,12 +522,9 @@ public class ReasonerQueryImpl extends ResolvableQuery {
                 this.selectAtoms()
                         .flatMap(at -> at.rewriteToAtoms().stream())
                         .collect(Collectors.toList()),
-                conceptManager,
-                ruleCache,
-                queryCache,
                 executorFactory,
-                reasonerQueryFactory,
-                traversalPlanFactory
+                traversalPlanFactory,
+                context()
         );
     }
 
@@ -561,9 +534,11 @@ public class ReasonerQueryImpl extends ResolvableQuery {
      * @return true if this query has complete entries in the cache
      */
     public boolean isCacheComplete(){
-        MultilevelSemanticCache queryCacheImpl = CacheCasting.queryCacheCast(queryCache);
+        MultilevelSemanticCache queryCache = CacheCasting.queryCacheCast(context().queryCache());
+        ReasonerQueryFactory reasonerQueryFactory = context().queryFactory();
+        ConceptManager conceptManager = context().conceptManager();
         if (selectAtoms().count() == 0) return false;
-        if (isAtomic()) return queryCacheImpl.isComplete(reasonerQueryFactory.atomic(selectAtoms().iterator().next()));
+        if (isAtomic()) return queryCache.isComplete(reasonerQueryFactory.atomic(selectAtoms().iterator().next()));
         List<ReasonerAtomicQuery> queries = resolutionPlan().plan().stream().map(reasonerQueryFactory::atomic).collect(Collectors.toList());
         Set<IdPredicate> subs = new HashSet<>();
         Map<ReasonerAtomicQuery, ReasonerAtomicQuery> queryMap = new HashMap<>();
@@ -581,14 +556,14 @@ public class ReasonerQueryImpl extends ResolvableQuery {
             queryMap.put(query, reasonerQueryFactory.atomic(conjunction));
             query.getVarNames().stream()
                     .filter(v -> subs.stream().noneMatch(s -> s.getVarName().equals(v)))
-                    .map(v -> IdPredicate.create(conceptManager, v, ConceptId.of(PLACEHOLDER_ID), query))
+                    .map(v -> IdPredicate.create(v, ConceptId.of(PLACEHOLDER_ID), query, conceptManager))
                     .forEach(subs::add);
         }
         return queryMap.entrySet().stream()
                 .filter(e -> e.getKey().isRuleResolvable())
                 .allMatch(e ->
                         Objects.nonNull(e.getKey().getAtom().getSchemaConcept())
-                                && queryCacheImpl.isComplete(e.getValue())
+                                && queryCache.isComplete(e.getValue())
                 );
     }
 
@@ -596,7 +571,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     public boolean requiresReiteration() {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
-        return RuleUtils.subGraphIsCyclical(dependentRules, queryCache)
+        return RuleUtils.subGraphIsCyclical(dependentRules, context().queryCache())
                 || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules)
                 || selectAtoms().filter(Atom::isDisconnected).filter(Atom::isRuleResolvable).count() > 1;
     }
@@ -628,7 +603,8 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     }
 
     private List<ConceptMap> splitToPartialAnswers(ConceptMap mergedAnswer){
-         return this.selectAtoms()
+        ReasonerQueryFactory reasonerQueryFactory = context().queryFactory();
+        return this.selectAtoms()
             .map(at -> at.inferTypes(mergedAnswer.project(at.getVarNames())))
             .map(reasonerQueryFactory::atomic)
                 .map(aq -> mergedAnswer.project(aq.getVarNames()).explain(new LookupExplanation(), aq.withSubstitution(mergedAnswer).getPattern()))
@@ -642,7 +618,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
 
         if(!this.isRuleResolvable()) {
             Set<Type> queryTypes = new HashSet<>(this.getVarTypeMap().values());
-            boolean fruitless = ruleCache.absentTypes(queryTypes);
+            boolean fruitless = context().ruleCache().absentTypes(queryTypes);
             if (fruitless) dbIterator = Collections.emptyIterator();
             else {
                 dbIterator = executorFactory.transactional( true).traverse(getPattern())
@@ -654,7 +630,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
         } else {
             dbIterator = Collections.emptyIterator();
 
-            ResolutionQueryPlan queryPlan = new ResolutionQueryPlan(reasonerQueryFactory, this);
+            ResolutionQueryPlan queryPlan = new ResolutionQueryPlan(context().queryFactory(), this);
             subGoalIterator = Iterators.singletonIterator(new JoinState(queryPlan.queries(), new ConceptMap(), parent.getUnifier(), parent, subGoals));
         }
         return Iterators.concat(dbIterator, subGoalIterator);

--- a/graql/reasoner/query/ResolvableQuery.java
+++ b/graql/reasoner/query/ResolvableQuery.java
@@ -22,10 +22,10 @@ package grakn.core.graql.reasoner.query;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.ResolutionIterator;
 import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.state.AnswerPropagatorState;
 import grakn.core.graql.reasoner.state.ResolutionState;
 import grakn.core.kb.graql.executor.ExecutorFactory;
-import grakn.core.kb.graql.reasoner.cache.QueryCache;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.Graql;
@@ -44,12 +44,12 @@ import java.util.stream.Stream;
  */
 public abstract class ResolvableQuery implements ReasonerQuery {
 
-    final ExecutorFactory executorFactory;
-    final QueryCache queryCache;
+    private final ReasoningContext ctx;
+    protected final ExecutorFactory executorFactory;
 
-    ResolvableQuery(ExecutorFactory executorFactory, QueryCache queryCache) {
+    ResolvableQuery(ExecutorFactory executorFactory, ReasoningContext ctx) {
         this.executorFactory = executorFactory;
-        this.queryCache = queryCache;
+        this.ctx = ctx;
     }
 
     @CheckReturnValue
@@ -57,6 +57,9 @@ public abstract class ResolvableQuery implements ReasonerQuery {
 
     @CheckReturnValue
     public abstract Stream<Atom> selectAtoms();
+
+    @CheckReturnValue
+    public ReasoningContext context(){ return ctx;}
 
     /**
      * @return this query in the composite form
@@ -139,7 +142,7 @@ public abstract class ResolvableQuery implements ReasonerQuery {
             //NB: the flag actually doesn't affect the traverse method which doesn't use reasoning
             return executorFactory.transactional(true).traverse(getPattern());
         } else {
-            return new ResolutionIterator(this, subGoals, queryCache).hasStream();
+            return new ResolutionIterator(this, subGoals, ctx.queryCache()).hasStream();
         }
     }
 

--- a/graql/reasoner/state/AtomicState.java
+++ b/graql/reasoner/state/AtomicState.java
@@ -54,12 +54,12 @@ public class AtomicState extends AnswerPropagatorState<ReasonerAtomicQuery> {
     private ReasonerQueryFactory reasonerQueryFactory;
     private QueryCache queryCache;
 
-    public AtomicState(ReasonerQueryFactory reasonerQueryFactory,
-                       ReasonerAtomicQuery query,
+    public AtomicState(ReasonerAtomicQuery query,
                        ConceptMap sub,
                        Unifier u,
                        AnswerPropagatorState parent,
                        Set<ReasonerAtomicQuery> subGoals,
+                       ReasonerQueryFactory reasonerQueryFactory,
                        QueryCache queryCache) {
         super(query.withSubstitution(sub), sub, u, parent, subGoals);
         this.reasonerQueryFactory = reasonerQueryFactory;

--- a/graql/reasoner/utils/ReasonerUtils.java
+++ b/graql/reasoner/utils/ReasonerUtils.java
@@ -84,8 +84,8 @@ public class ReasonerUtils {
         return  vars.stream()
                 .filter(v -> v.var().equals(typeVariable))
                 .flatMap(v -> v.hasProperty(TypeProperty.class)?
-                        v.getProperties(TypeProperty.class).map(np -> IdPredicate.create(conceptManager, typeVariable, Label.of(np.name()), parent)) :
-                        v.getProperties(IdProperty.class).map(np -> IdPredicate.create(conceptManager, typeVariable, ConceptId.of(np.id()), parent)))
+                        v.getProperties(TypeProperty.class).map(np -> IdPredicate.create(typeVariable, Label.of(np.name()), parent, conceptManager)) :
+                        v.getProperties(IdProperty.class).map(np -> IdPredicate.create(typeVariable, ConceptId.of(np.id()), parent, conceptManager)))
                 .findFirst().orElse(null);
     }
 
@@ -99,14 +99,14 @@ public class ReasonerUtils {
      * @return mapped IdPredicate
      */
     @Nullable
-    public static IdPredicate getIdPredicate(ConceptManager conceptManager, Variable typeVariable, Statement typeVar, Set<Statement> vars, ReasonerQuery parent){
+    public static IdPredicate getIdPredicate(Variable typeVariable, Statement typeVar, Set<Statement> vars, ReasonerQuery parent, ConceptManager conceptManager){
         IdPredicate predicate = null;
         //look for id predicate among vars
         if(typeVar.var().isReturned()) {
             predicate = getUserDefinedIdPredicate(conceptManager, typeVariable, vars, parent);
         } else {
             TypeProperty nameProp = typeVar.getProperty(TypeProperty.class).orElse(null);
-            if (nameProp != null) predicate = IdPredicate.create(conceptManager, typeVariable, Label.of(nameProp.name()), parent);
+            if (nameProp != null) predicate = IdPredicate.create(typeVariable, Label.of(nameProp.name()), parent, conceptManager);
         }
         return predicate;
     }

--- a/server/session/TransactionProviderImpl.java
+++ b/server/session/TransactionProviderImpl.java
@@ -98,7 +98,7 @@ public class TransactionProviderImpl implements TransactionProvider {
         MultilevelSemanticCache queryCache = new MultilevelSemanticCache(executorFactory, traversalPlanFactory);
 
         PropertyAtomicFactory propertyAtomicFactory = new PropertyAtomicFactory(conceptManager, ruleCache, queryCache, keyspaceStatistics);
-        ReasonerQueryFactory reasonerQueryFactory = new ReasonerQueryFactory(conceptManager, queryCache, ruleCache, executorFactory, propertyAtomicFactory, traversalPlanFactory);
+        ReasonerQueryFactory reasonerQueryFactory = new ReasonerQueryFactory(conceptManager, queryCache, ruleCache, keyspaceStatistics, executorFactory, propertyAtomicFactory, traversalPlanFactory);
         executorFactory.setReasonerQueryFactory(reasonerQueryFactory);
         propertyAtomicFactory.setReasonerQueryFactory(reasonerQueryFactory);
         ruleCache.setReasonerQueryFactory(reasonerQueryFactory);

--- a/test-integration/rule/TestTransactionProvider.java
+++ b/test-integration/rule/TestTransactionProvider.java
@@ -101,7 +101,7 @@ public class TestTransactionProvider implements TransactionProvider {
         MultilevelSemanticCache queryCache = new MultilevelSemanticCache(executorFactory, traversalPlanFactory);
 
         PropertyAtomicFactory propertyAtomicFactory = new PropertyAtomicFactory(conceptManager, ruleCache, queryCache, keyspaceStatistics);
-        ReasonerQueryFactory reasonerQueryFactory = new ReasonerQueryFactory(conceptManager, queryCache, ruleCache, executorFactory, propertyAtomicFactory, traversalPlanFactory);
+        ReasonerQueryFactory reasonerQueryFactory = new ReasonerQueryFactory(conceptManager, queryCache, ruleCache, keyspaceStatistics, executorFactory, propertyAtomicFactory, traversalPlanFactory);
         executorFactory.setReasonerQueryFactory(reasonerQueryFactory);
         propertyAtomicFactory.setReasonerQueryFactory(reasonerQueryFactory);
         ruleCache.setReasonerQueryFactory(reasonerQueryFactory);


### PR DESCRIPTION
## What is the goal of this PR?
To make atom construction and related classes cleaner. Before we were passing a number of context arguments to bottom classes which were propagated among the hierarchy. Now we abstract the context arguments into a single class which can then be stored in the base `Atom` class.

## What are the changes implemented in this PR?
We introduce a container `ReasoningContext` class which stores a `ReasonerQueryFactory`, `ConceptManager`, `RuleCache`, `QueryCache`, `KeyspaceStatistics`.

