### PR TITLE
Only allow explicit idpredicate construction

### DIFF
--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -152,9 +152,10 @@ public class PropertyAtomicFactory {
 
     private Atomic type(Variable var, TypeProperty property, ReasonerQuery parent) {
         ConceptManager conceptManager = ctx.conceptManager();
-        SchemaConcept schemaConcept = conceptManager.getSchemaConcept(Label.of(property.name()));
-        if (schemaConcept == null) throw GraqlSemanticException.labelNotFound(Label.of(property.name()));
-        return IdPredicate.create(var.asReturnedVar(), Label.of(property.name()), parent, conceptManager);
+        Label typeLabel = Label.of(property.name());
+        SchemaConcept type = conceptManager.getSchemaConcept(typeLabel);
+        if (type == null) throw GraqlSemanticException.labelNotFound(typeLabel);
+        return IdPredicate.create(var.asReturnedVar(), type.id(), parent);
     }
 
     private Atomic when() {
@@ -215,7 +216,10 @@ public class PropertyAtomicFactory {
             Statement isaVar = isaProp.type();
             String label = isaVar.getType().orElse(null);
             if (label != null) {
-                predicate = IdPredicate.create(typeVariable, Label.of(label), parent, conceptManager);
+                SchemaConcept type = conceptManager.getSchemaConcept(Label.of(label));
+                if (type != null) {
+                    predicate = IdPredicate.create(typeVariable, type.id(), parent);
+                }
             } else {
                 typeVariable = isaVar.var();
                 predicate = getUserDefinedIdPredicate(conceptManager, typeVariable, otherStatements, parent);

--- a/graql/reasoner/atom/binary/RelationAtom.java
+++ b/graql/reasoner/atom/binary/RelationAtom.java
@@ -118,6 +118,7 @@ public class RelationAtom extends IsaAtomBase {
         super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
         this.relationPlayers = relationPlayers;
         this.roleLabels = roleLabels;
+
         this.typeReasoner = new RelationTypeReasoner(ctx);
         this.semanticProcessor = new RelationSemanticProcessor(ctx.conceptManager());
         this.validator = new RelationAtomValidator(ctx.conceptManager());
@@ -601,7 +602,9 @@ public class RelationAtom extends IsaAtomBase {
                         .filter(vp -> vp.var().isReturned())
                         .map(vp -> new Pair<>(vp.var(), vp.getType().orElse(null)))
                         .filter(p -> Objects.nonNull(p.second()))
-                        .map(p -> IdPredicate.create(p.first(), Label.of(p.second()), getParentQuery(), conceptManager))
+                        .map(p -> new Pair<Variable, SchemaConcept>(p.first(), conceptManager.getSchemaConcept(Label.of(p.second()))))
+                        .filter(p -> Objects.nonNull(p.second()))
+                        .map(p -> IdPredicate.create(p.first(), p.second().id(), getParentQuery()))
         );
     }
 

--- a/graql/reasoner/atom/predicate/IdPredicate.java
+++ b/graql/reasoner/atom/predicate/IdPredicate.java
@@ -21,10 +21,7 @@ package grakn.core.graql.reasoner.atom.predicate;
 
 import grakn.core.kb.concept.api.Concept;
 import grakn.core.kb.concept.api.ConceptId;
-import grakn.core.kb.concept.api.Label;
-import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.manager.ConceptManager;
-import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.Graql;
@@ -46,10 +43,6 @@ public class IdPredicate extends Predicate<ConceptId> {
         return new IdPredicate(pattern.var(), pattern, parent, extractPredicate(pattern));
     }
 
-    public static IdPredicate create(Variable varName, Label label, ReasonerQuery parent, ConceptManager conceptManager) {
-        return create(createIdVar(varName.asReturnedVar(), label, conceptManager), parent);
-    }
-
     public static IdPredicate create(Variable varName, ConceptId id, ReasonerQuery parent) {
         return create(createIdVar(varName.asReturnedVar(), id), parent);
     }
@@ -67,12 +60,6 @@ public class IdPredicate extends Predicate<ConceptId> {
 
     private static Statement createIdVar(Variable varName, ConceptId typeId) {
         return new Statement(varName).id(typeId.getValue());
-    }
-
-    private static Statement createIdVar(Variable varName, Label label, ConceptManager conceptManager) {
-        SchemaConcept schemaConcept = conceptManager.getSchemaConcept(label);
-        if (schemaConcept == null) throw GraqlSemanticException.labelNotFound(label);
-        return new Statement(varName).id(schemaConcept.id().getValue());
     }
 
     @Override

--- a/graql/reasoner/utils/ReasonerUtils.java
+++ b/graql/reasoner/utils/ReasonerUtils.java
@@ -84,7 +84,7 @@ public class ReasonerUtils {
         return  vars.stream()
                 .filter(v -> v.var().equals(typeVariable))
                 .flatMap(v -> v.hasProperty(TypeProperty.class)?
-                        v.getProperties(TypeProperty.class).map(np -> IdPredicate.create(typeVariable, Label.of(np.name()), parent, conceptManager)) :
+                        v.getProperties(TypeProperty.class).map(np -> IdPredicate.create(typeVariable, conceptManager.getSchemaConcept(Label.of(np.name())).id(), parent)) :
                         v.getProperties(IdProperty.class).map(np -> IdPredicate.create(typeVariable, ConceptId.of(np.id()), parent)))
                 .findFirst().orElse(null);
     }
@@ -106,7 +106,12 @@ public class ReasonerUtils {
             predicate = getUserDefinedIdPredicate(conceptManager, typeVariable, vars, parent);
         } else {
             TypeProperty nameProp = typeVar.getProperty(TypeProperty.class).orElse(null);
-            if (nameProp != null) predicate = IdPredicate.create(typeVariable, Label.of(nameProp.name()), parent, conceptManager);
+
+            if (nameProp != null){
+                Label typeLabel = Label.of(nameProp.name());
+                SchemaConcept type = conceptManager.getSchemaConcept(typeLabel);
+                if (type != null) predicate = IdPredicate.create(typeVariable, type.id(), parent);
+            }
         }
         return predicate;
     }


### PR DESCRIPTION
## What is the goal of this PR?
We only allow creating `IdPredicate` by passing `ConceptId`s directly, instead of allowing to pass labels which require `ConceptManager` involvement.

## What are the changes implemented in this PR?
Removed the `IdPredicate` constructors accepting `Label`s.
