### PR TITLE
Avoids running `sync-dependencies-snapshot` on user-facing repositories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,8 +275,8 @@ jobs:
           bazel run @graknlabs_build_tools//ci:sync-dependencies -- \
           --source grakn@$CIRCLE_SHA1 \
           --targets \
-          grakn-kgms:master workbase:master docs:master examples:master \
-          benchmark:master client-java:master console:master kglib:master
+          grakn-kgms:master workbase:master benchmark:master \
+          client-java:master console:master kglib:master
         # TODO: Remove benchmark and client-java once #5272 is solved
         # TODO: Remove console once #5270 is solved
 


### PR DESCRIPTION
## What is the goal of this PR?
`examples` and `docs` are user-facing repositories that should always depend on the latest stable release of `grakn`. For this reason, they have been removed from tagets of `sync-dependencies-snapshot`.