### PR TITLE
Store labels instead of ids in atoms

### DIFF
--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -72,6 +72,9 @@ public abstract class Atom extends AtomicBase {
 
     private final Label typeLabel;
 
+    /**
+     * NB: NULL typeLabel signals that the we don't know the specific non-meta type of this atom.
+     */
     public Atom(ReasonerQuery reasonerQuery, Variable varName, Statement pattern, @Nullable Label typeLabel, ReasoningContext ctx) {
         super(reasonerQuery, varName, pattern);
         this.ctx = ctx;

--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -70,20 +70,20 @@ public abstract class Atom extends AtomicBase {
     private final AtomValidator<Atom> validator = new BasicAtomValidator();
     private Set<InferenceRule> applicableRules = null;
 
-    private final ConceptId typeId;
+    private final Label typeLabel;
 
-    public Atom(ReasonerQuery reasonerQuery, Variable varName, Statement pattern, ConceptId typeId, ReasoningContext ctx) {
+    public Atom(ReasonerQuery reasonerQuery, Variable varName, Statement pattern, @Nullable Label typeLabel, ReasoningContext ctx) {
         super(reasonerQuery, varName, pattern);
         this.ctx = ctx;
-        this.typeId = typeId;
+        this.typeLabel = typeLabel;
     }
 
     /**
      * @return type id of the corresponding type if any
      */
     @Nullable
-    public ConceptId getTypeId() {
-        return typeId;
+    public Label getTypeLabel() {
+        return typeLabel;
     }
 
     public ReasoningContext context(){ return ctx;}

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -163,8 +163,6 @@ public class PropertyAtomicFactory {
     private Atomic sub(Variable var, SubProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
         Label label = getLabel(property.type().var(), property.type(), otherStatements, ctx.conceptManager());
         return SubAtom.create(var, property.type().var(), label, parent, ctx);
-        //ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
-        //return SubAtom.create(var, property.type().var(), predicateId, parent, ctx);
     }
 
     private Atomic relation(Variable var, RelationProperty property, ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -74,7 +74,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static grakn.core.graql.reasoner.utils.ReasonerUtils.getIdPredicate;
+import static grakn.core.graql.reasoner.utils.ReasonerUtils.getLabelFromUserDefinedVar;
+import static grakn.core.graql.reasoner.utils.ReasonerUtils.getLabel;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.getUserDefinedIdPredicate;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.getValuePredicates;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.typeFromLabel;
@@ -163,9 +164,10 @@ public class PropertyAtomicFactory {
     }
 
     private Atomic sub(Variable var, SubProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
-        IdPredicate predicate = getIdPredicate(property.type().var(), property.type(), otherStatements, parent, ctx.conceptManager());
-        ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
-        return SubAtom.create(var, property.type().var(), predicateId, parent, ctx);
+        Label label = getLabel(property.type().var(), property.type(), otherStatements, ctx.conceptManager());
+        return SubAtom.create(var, property.type().var(), label, parent, ctx);
+        //ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
+        //return SubAtom.create(var, property.type().var(), predicateId, parent, ctx);
     }
 
     private Atomic relation(Variable var, RelationProperty property, ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
@@ -183,25 +185,19 @@ public class PropertyAtomicFactory {
             if (rolePattern != null) {
                 Variable roleVar = rolePattern.var();
                 //look for indirect role definitions
-                IdPredicate roleId = getUserDefinedIdPredicate(conceptManager, roleVar, otherStatements, parent);
-                if (roleId != null) {
-                    Concept concept = conceptManager.getConcept(roleId.getPredicate());
-                    if (concept != null) {
-                        if (concept.isRole()) {
-                            Label roleLabel = concept.asSchemaConcept().label();
-                            rolePattern = new Statement(roleVar).type(roleLabel.getValue());
-                        } else {
-                            throw GraqlQueryException.nonRoleIdAssignedToRoleVariable(statement);
-                        }
-                    }
+                Label roleLabel = getLabelFromUserDefinedVar(roleVar, otherStatements, conceptManager);
+                if (roleLabel != null) {
+                    rolePattern = new Statement(roleVar).type(roleLabel.getValue());
                 }
                 relVar = relVar.rel(rolePattern, rolePlayer);
-            } else relVar = relVar.rel(rolePlayer);
+            } else {
+                relVar = relVar.rel(rolePlayer);
+            }
         }
 
         //isa part
         IsaProperty isaProp = statement.getProperty(IsaProperty.class).orElse(null);
-        IdPredicate predicate = null;
+        Label typeLabel = null;
 
         //if no isa property present generate type variable
         Variable typeVariable = isaProp != null ? isaProp.type().var() : new Variable();
@@ -211,25 +207,21 @@ public class PropertyAtomicFactory {
             Statement isaVar = isaProp.type();
             String label = isaVar.getType().orElse(null);
             if (label != null) {
-                SchemaConcept type = typeFromLabel(Label.of(label), ctx.conceptManager());
-                predicate = IdPredicate.create(typeVariable, type.id(), parent);
+                typeLabel = typeFromLabel(Label.of(label), ctx.conceptManager()).label();
             } else {
                 typeVariable = isaVar.var();
-                predicate = getUserDefinedIdPredicate(conceptManager, typeVariable, otherStatements, parent);
+                typeLabel = getLabelFromUserDefinedVar(typeVariable, otherStatements, conceptManager);
             }
         }
-        ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
         relVar = isaProp != null && isaProp.isExplicit() ?
                 relVar.isaX(new Statement(typeVariable.asReturnedVar())) :
                 relVar.isa(new Statement(typeVariable.asReturnedVar()));
-        return RelationAtom.create(relVar, typeVariable, predicateId, parent, ctx);
+        return RelationAtom.create(relVar, typeVariable, typeLabel, parent, ctx);
     }
 
-
     private Atomic relates(Variable var, RelatesProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
-        IdPredicate predicate = getIdPredicate(property.role().var(), property.role(), otherStatements, parent, ctx.conceptManager());
-        ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
-        return RelatesAtom.create(var, property.role().var(), predicateId, parent, ctx);
+        Label label = getLabel(property.role().var(), property.role(), otherStatements, ctx.conceptManager());
+        return RelatesAtom.create(var, property.role().var(), label, parent, ctx);
     }
 
     private Atomic regex(Variable var, RegexProperty property, ReasonerQuery parent) {
@@ -237,9 +229,8 @@ public class PropertyAtomicFactory {
     }
 
     private Atomic plays(Variable var, PlaysProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
-        IdPredicate predicate = getIdPredicate(property.role().var(), property.role(), otherStatements, parent, ctx.conceptManager());
-        ConceptId predicateId = predicate == null ? null : predicate.getPredicate();
-        return PlaysAtom.create(var, property.role().var(), predicateId, parent, ctx);
+        Label label = getLabel(property.role().var(), property.role(), otherStatements, ctx.conceptManager());
+        return PlaysAtom.create(var, property.role().var(), label, parent, ctx);
     }
 
     private Atomic neq(Variable var, NeqProperty property, ReasonerQuery parent) {
@@ -256,8 +247,8 @@ public class PropertyAtomicFactory {
 
         Variable predicateVar = new Variable();
         SchemaConcept attributeType = ctx.conceptManager().getSchemaConcept(Label.of(label));
-        ConceptId predicateId = attributeType != null ? attributeType.id() : null;
-        return HasAtom.create(var, predicateVar, predicateId, parent, ctx);
+        Label typeLabel = attributeType != null ? attributeType.label() : null;
+        return HasAtom.create(var, predicateVar, typeLabel, parent, ctx);
     }
 
     private Atomic hasAttribute(Variable var, HasAttributeProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
@@ -273,14 +264,13 @@ public class PropertyAtomicFactory {
 
         IsaProperty isaProp = property.attribute().getProperties(IsaProperty.class).findFirst().orElse(null);
         Statement typeVar = isaProp != null ? isaProp.type() : null;
-        IdPredicate predicate = typeVar != null ? getIdPredicate(predicateVariable, typeVar, otherStatements, parent, ctx.conceptManager()) : null;
-        ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
+        Label typeLabel = typeVar != null ? getLabel(predicateVariable, typeVar, otherStatements, ctx.conceptManager()) : null;
 
         //add resource atom
         Statement resVar = relationVariable.isReturned() ?
                 new Statement(varName).has(property.type(), new Statement(attributeVariable), new Statement(relationVariable)) :
                 new Statement(varName).has(property.type(), new Statement(attributeVariable));
-        return AttributeAtom.create(resVar, attributeVariable, relationVariable, predicateVariable, predicateId, predicates, parent, ctx);
+        return AttributeAtom.create(resVar, attributeVariable, relationVariable, predicateVariable, typeLabel, predicates, parent, ctx);
     }
 
 
@@ -319,22 +309,18 @@ public class PropertyAtomicFactory {
         if (statement.hasProperty(RelationProperty.class)) return null;
 
         Variable typeVar = property.type().var();
-
-        IdPredicate predicate = getIdPredicate(typeVar, property.type(), otherStatements, parent, ctx.conceptManager());
-        ConceptId predicateId = predicate != null ? predicate.getPredicate() : null;
+        Label typeLabel = getLabel(typeVar, property.type(), otherStatements, ctx.conceptManager());
 
         //isa part
         Statement isaVar;
-
         if (property.isExplicit()) {
             isaVar = new Statement(var).isaX(new Statement(typeVar));
         } else {
             isaVar = new Statement(var).isa(new Statement(typeVar));
         }
 
-        return IsaAtom.create(var, typeVar, isaVar, predicateId, parent, ctx);
+        return IsaAtom.create(var, typeVar, isaVar, typeLabel, parent, ctx);
     }
-
 
     /**
      * @param pattern conjunction of patterns to be converted to atoms

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -37,12 +37,10 @@ import grakn.core.graql.reasoner.atom.property.RegexAtom;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.utils.ReasonerUtils;
 import grakn.core.kb.concept.api.AttributeType;
-import grakn.core.kb.concept.api.Concept;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.manager.ConceptManager;
-import grakn.core.kb.graql.exception.GraqlQueryException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.cache.QueryCache;
 import grakn.core.kb.graql.reasoner.cache.RuleCache;
@@ -74,9 +72,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static grakn.core.graql.reasoner.utils.ReasonerUtils.getLabelFromUserDefinedVar;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.getLabel;
-import static grakn.core.graql.reasoner.utils.ReasonerUtils.getUserDefinedIdPredicate;
+import static grakn.core.graql.reasoner.utils.ReasonerUtils.getLabelFromUserDefinedVar;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.getValuePredicates;
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.typeFromLabel;
 

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -37,7 +37,6 @@ import grakn.core.graql.reasoner.atom.task.validate.AttributeAtomValidator;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.AttributeType;
-import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.concept.api.SchemaConcept;
@@ -52,12 +51,11 @@ import graql.lang.property.ValueProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.isEquivalentCollection;
 
@@ -92,13 +90,13 @@ public class AttributeAtom extends Binary{
             Variable varName,
             Statement pattern,
             ReasonerQuery parentQuery,
-            @Nullable ConceptId typeId,
+            @Nullable Label label,
             Variable predicateVariable,
             Variable relationVariable,
             Variable attributeVariable,
             ImmutableSet<ValuePredicate> multiPredicate,
             ReasoningContext ctx) {
-        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, parentQuery, label, predicateVariable, ctx);
         this.relationVariable = relationVariable;
         this.attributeVariable = attributeVariable;
         this.multiPredicate = multiPredicate;
@@ -117,15 +115,15 @@ public class AttributeAtom extends Binary{
     }
 
     public static AttributeAtom create(Statement pattern, Variable attributeVariable,
-                                       Variable relationVariable, Variable predicateVariable, ConceptId predicateId,
+                                       Variable relationVariable, Variable predicateVariable, @Nullable Label label,
                                        Set<ValuePredicate> ps, ReasonerQuery parent, ReasoningContext ctx) {
-        return new AttributeAtom(pattern.var(), pattern, parent, predicateId, predicateVariable, relationVariable,
+        return new AttributeAtom(pattern.var(), pattern, parent, label, predicateVariable, relationVariable,
                 attributeVariable, ImmutableSet.copyOf(ps), ctx);
     }
 
     private static AttributeAtom create(AttributeAtom a, ReasonerQuery parent) {
         return create(a.getPattern(), a.getAttributeVariable(), a.getRelationVariable(), a.getPredicateVariable(),
-                a.getTypeId(), a.getMultiPredicate(), parent, a.context());
+                a.getTypeLabel(), a.getMultiPredicate(), parent, a.context());
     }
 
     private AttributeAtom convertValues(){
@@ -147,7 +145,7 @@ public class AttributeAtom extends Binary{
             return ValuePredicate.create(vp.getVarName(), operation, getParentQuery());
         }).collect(Collectors.toSet());
         return create(getPattern(), getAttributeVariable(), getRelationVariable(), getPredicateVariable(),
-                getTypeId(), newMultiPredicate, getParentQuery(), context());
+                getTypeLabel(), newMultiPredicate, getParentQuery(), context());
     }
 
 
@@ -159,7 +157,7 @@ public class AttributeAtom extends Binary{
         return create(getPattern(), getAttributeVariable(),
                 getRelationVariable(),
                 getPredicateVariable(),
-                getTypeId(),
+                getTypeLabel(),
                 newPredicates,
                 getParentQuery(),
                 context());
@@ -206,7 +204,7 @@ public class AttributeAtom extends Binary{
         if (obj == null || this.getClass() != obj.getClass()) return false;
         if (obj == this) return true;
         AttributeAtom a2 = (AttributeAtom) obj;
-        return Objects.equals(this.getTypeId(), a2.getTypeId())
+        return Objects.equals(this.getTypeLabel(), a2.getTypeLabel())
                 && this.getVarName().equals(a2.getVarName())
                 && this.multiPredicateEqual(a2);
     }
@@ -232,7 +230,7 @@ public class AttributeAtom extends Binary{
     @Override
     public int alphaEquivalenceHashCode() {
         int hashCode = 1;
-        hashCode = hashCode * 37 + (this.getTypeId() != null? this.getTypeId().hashCode() : 0);
+        hashCode = hashCode * 37 + (this.getTypeLabel() != null? this.getTypeLabel().hashCode() : 0);
         hashCode = hashCode * 37 + AtomicEquivalence.equivalenceHash(this.getMultiPredicate(), AtomicEquivalence.AlphaEquivalence);
         return hashCode;
     }
@@ -338,12 +336,12 @@ public class AttributeAtom extends Binary{
         Variable relationVariable = getRelationVariable().asReturnedVar();
         Statement newVar = new Statement(getVarName())
                 .has(getSchemaConcept().label().getValue(), new Statement(attributeVariable), new Statement(relationVariable));
-        return create(newVar, attributeVariable, relationVariable, getPredicateVariable(), getTypeId(), getMultiPredicate(), getParentQuery(), context());
+        return create(newVar, attributeVariable, relationVariable, getPredicateVariable(), getTypeLabel(), getMultiPredicate(), getParentQuery(), context());
     }
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getPattern(), getAttributeVariable(), getRelationVariable(), getPredicateVariable().asReturnedVar(), getTypeId(), getMultiPredicate(), getParentQuery(), context());
+        return create(getPattern(), getAttributeVariable(), getRelationVariable(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getMultiPredicate(), getParentQuery(), context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/Binary.java
+++ b/graql/reasoner/atom/binary/Binary.java
@@ -27,9 +27,8 @@ import grakn.core.graql.reasoner.atom.task.relate.BinarySemanticProcessor;
 import grakn.core.graql.reasoner.atom.task.relate.SemanticProcessor;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
-import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
-import grakn.core.kb.graql.reasoner.ReasonerCheckedException;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.Graql;
@@ -37,12 +36,11 @@ import graql.lang.pattern.Pattern;
 import graql.lang.property.IsaProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -63,9 +61,9 @@ public abstract class Binary extends Atom {
     private SchemaConcept type = null;
     private IdPredicate typePredicate = null;
 
-    Binary(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    Binary(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
            Variable predicateVariable, ReasoningContext ctx) {
-        super(reasonerQuery, varName, pattern, typeId, ctx);
+        super(reasonerQuery, varName, pattern, label, ctx);
         this.predicateVariable = predicateVariable;
         this.semanticProcessor = new BinarySemanticProcessor(ctx.conceptManager());
     }
@@ -76,8 +74,8 @@ public abstract class Binary extends Atom {
 
     @Nullable
     public IdPredicate getTypePredicate(){
-        if (typePredicate == null && getTypeId() != null) {
-            typePredicate = IdPredicate.create(new Statement(getPredicateVariable()).id(getTypeId().getValue()), getParentQuery());
+        if (typePredicate == null && getTypeLabel() != null) {
+            typePredicate = IdPredicate.create(new Statement(getPredicateVariable()).id(getTypeLabel().getValue()), getParentQuery());
         }
         return typePredicate;
     }
@@ -90,9 +88,10 @@ public abstract class Binary extends Atom {
     @Nullable
     @Override
     public SchemaConcept getSchemaConcept(){
-        if (type == null && getTypeId() != null) {
-            SchemaConcept concept = context().conceptManager().getConcept(getTypeId());
-            if (concept == null) throw ReasonerCheckedException.idNotFound(getTypeId());
+        if (type == null && getTypeLabel() != null) {
+            SchemaConcept concept = context().conceptManager().getSchemaConcept(getTypeLabel());
+            //TODO
+            //if (concept == null) throw ReasonerCheckedException.idNotFound(getTypeLabel());
             type = concept;
         }
         return type;
@@ -120,7 +119,7 @@ public abstract class Binary extends Atom {
     @Override
     public int alphaEquivalenceHashCode() {
         int hashCode = 1;
-        hashCode = hashCode * 37 + (this.getTypeId() != null? this.getTypeId().hashCode() : 0);
+        hashCode = hashCode * 37 + (this.getTypeLabel() != null? this.getTypeLabel().hashCode() : 0);
         return hashCode;
     }
 
@@ -136,7 +135,7 @@ public abstract class Binary extends Atom {
         return (this.isUserDefined() == that.isUserDefined())
                 && (this.getPredicateVariable().isReturned() == that.getPredicateVariable().isReturned())
                 && this.isDirect() == that.isDirect()
-                && Objects.equals(this.getTypeId(), that.getTypeId());
+                && Objects.equals(this.getTypeLabel(), that.getTypeLabel());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/Binary.java
+++ b/graql/reasoner/atom/binary/Binary.java
@@ -30,6 +30,7 @@ import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
+import grakn.core.kb.graql.reasoner.ReasonerCheckedException;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.Graql;
@@ -92,8 +93,7 @@ public abstract class Binary extends Atom {
     public SchemaConcept getSchemaConcept(){
         if (type == null && getTypeLabel() != null) {
             SchemaConcept concept = context().conceptManager().getSchemaConcept(getTypeLabel());
-            //TODO
-            //if (concept == null) throw ReasonerCheckedException.idNotFound(getTypeLabel());
+            if (concept == null) throw ReasonerCheckedException.labelNotFound(getTypeLabel());
             type = concept;
         }
         return type;

--- a/graql/reasoner/atom/binary/Binary.java
+++ b/graql/reasoner/atom/binary/Binary.java
@@ -27,6 +27,7 @@ import grakn.core.graql.reasoner.atom.task.relate.BinarySemanticProcessor;
 import grakn.core.graql.reasoner.atom.task.relate.SemanticProcessor;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.concept.api.ConceptId;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
@@ -75,7 +76,8 @@ public abstract class Binary extends Atom {
     @Nullable
     public IdPredicate getTypePredicate(){
         if (typePredicate == null && getTypeLabel() != null) {
-            typePredicate = IdPredicate.create(new Statement(getPredicateVariable()).id(getTypeLabel().getValue()), getParentQuery());
+            ConceptId typeId = context().conceptManager().getSchemaConcept(getTypeLabel()).id();
+            typePredicate = IdPredicate.create(new Statement(getPredicateVariable()).id(typeId.getValue()), getParentQuery());
         }
         return typePredicate;
     }

--- a/graql/reasoner/atom/binary/HasAtom.java
+++ b/graql/reasoner/atom/binary/HasAtom.java
@@ -39,26 +39,25 @@ public class HasAtom extends OntologicalAtom {
     private HasAtom(Variable varName,
                     Statement pattern,
                     ReasonerQuery parentQuery,
-                    @Nullable ConceptId typeId,
+                    @Nullable Label label,
                     Variable predicateVariable,
                     ReasoningContext ctx) {
-        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, parentQuery, label, predicateVariable, ctx);
     }
 
-    public static HasAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
+    public static HasAtom create(Variable var, Variable pVar, @Nullable Label label, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        Label label = ctx.conceptManager().getConcept(predicateId).asType().label();
-        return new HasAtom(varName, new Statement(varName).has(Graql.type(label.getValue())), parent, predicateId, predicateVar, ctx);
+        return new HasAtom(varName, new Statement(varName).has(Graql.type(label.getValue())), parent, label, predicateVar, ctx);
     }
 
     private static HasAtom create(TypeAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), parent, a.context());
     }
 
     @Override
-    OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return HasAtom.create(var, predicateVar, predicateId, parent, context());
+    OntologicalAtom createSelf(Variable var, Variable predicateVar, @Nullable Label label, ReasonerQuery parent) {
+        return HasAtom.create(var, predicateVar, label, parent, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/IsaAtomBase.java
+++ b/graql/reasoner/atom/binary/IsaAtomBase.java
@@ -20,6 +20,7 @@ package grakn.core.graql.reasoner.atom.binary;
 
 import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.statement.Statement;
@@ -29,15 +30,16 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /**
  * Base class for isa atoms.
  */
 public abstract class IsaAtomBase extends TypeAtom{
 
-    IsaAtomBase(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    IsaAtomBase(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
                 Variable predicateVariable, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
     @Override
@@ -45,6 +47,6 @@ public abstract class IsaAtomBase extends TypeAtom{
         Collection<Variable> vars = u.get(getVarName());
         return vars.isEmpty()?
                 Collections.singleton(this) :
-                vars.stream().map(v -> IsaAtom.create(v, getPredicateVariable(), getTypeId(), this.isDirect(), this.getParentQuery(), context())).collect(Collectors.toSet());
+                vars.stream().map(v -> IsaAtom.create(v, getPredicateVariable(), getTypeLabel(), this.isDirect(), this.getParentQuery(), context())).collect(Collectors.toSet());
     }
 }

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -24,6 +24,7 @@ import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.rule.InferenceRule;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
@@ -36,18 +37,19 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /**
  * Base class for defining ontological Atom - ones referring to ontological elements.
  */
 public abstract class OntologicalAtom extends TypeAtom {
 
-    OntologicalAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    OntologicalAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
                     Variable predicateVariable, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
-    abstract OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent);
+    abstract OntologicalAtom createSelf(Variable var, Variable predicateVar, @Nullable Label label, ReasonerQuery parent);
 
     @Override
     public String toString(){
@@ -78,18 +80,18 @@ public abstract class OntologicalAtom extends TypeAtom {
         Collection<Variable> vars = u.get(getVarName());
         return vars.isEmpty()?
                 Collections.singleton(this) :
-                vars.stream().map(v -> createSelf(v, getPredicateVariable(), getTypeId(), this.getParentQuery())).collect(Collectors.toSet());
+                vars.stream().map(v -> createSelf(v, getPredicateVariable(), getTypeLabel(), this.getParentQuery())).collect(Collectors.toSet());
     }
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), getParentQuery());
+        return createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getParentQuery());
     }
 
     @Override
     public Atom rewriteToUserDefined(Atom parentAtom) {
         return parentAtom.getPredicateVariable().isReturned()?
-                createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeId(), getParentQuery()) :
+                createSelf(getVarName(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getParentQuery()) :
                 this;
     }
 
@@ -101,7 +103,7 @@ public abstract class OntologicalAtom extends TypeAtom {
         if (o instanceof OntologicalAtom) {
             OntologicalAtom that = (OntologicalAtom) o;
             return (this.getVarName().equals(that.getVarName()))
-                    && ((this.getTypeId() == null) ? (that.getTypeId() == null) : this.getTypeId().equals(that.getTypeId()));
+                    && ((this.getTypeLabel() == null) ? (that.getTypeLabel() == null) : this.getTypeLabel().equals(that.getTypeLabel()));
         }
         return false;
     }
@@ -112,7 +114,7 @@ public abstract class OntologicalAtom extends TypeAtom {
         h *= 1000003;
         h ^= this.getVarName().hashCode();
         h *= 1000003;
-        h ^= (getTypeId() == null) ? 0 : this.getTypeId().hashCode();
+        h ^= (getTypeLabel() == null) ? 0 : this.getTypeLabel().hashCode();
         return h;
     }
 }

--- a/graql/reasoner/atom/binary/PlaysAtom.java
+++ b/graql/reasoner/atom/binary/PlaysAtom.java
@@ -19,37 +19,38 @@
 package grakn.core.graql.reasoner.atom.binary;
 
 import grakn.core.graql.reasoner.ReasoningContext;
-import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.PlaysProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import javax.annotation.Nullable;
 
 /**
  * TypeAtom corresponding to graql a PlaysProperty property.
  */
 public class PlaysAtom extends OntologicalAtom {
 
-    private PlaysAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    private PlaysAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
                       Variable predicateVariable, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
-    public static PlaysAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
+    public static PlaysAtom create(Variable var, Variable pVar, @Nullable Label label, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new PlaysAtom(varName.asReturnedVar(), new Statement(varName).plays(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
+        return new PlaysAtom(varName.asReturnedVar(), new Statement(varName).plays(new Statement(predicateVar)), parent, label, predicateVar, ctx);
     }
 
     private static PlaysAtom create(PlaysAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), parent, a.context());
     }
 
     @Override
-    OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return create(var, predicateVar, predicateId, parent, context());
+    OntologicalAtom createSelf(Variable var, Variable predicateVar, @Nullable Label label, ReasonerQuery parent) {
+        return create(var, predicateVar, label, parent, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/RelatesAtom.java
+++ b/graql/reasoner/atom/binary/RelatesAtom.java
@@ -19,13 +19,14 @@
 package grakn.core.graql.reasoner.atom.binary;
 
 import grakn.core.graql.reasoner.ReasoningContext;
-import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.RelatesProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+import javax.annotation.Nullable;
 
 
 /**
@@ -33,24 +34,24 @@ import graql.lang.statement.Variable;
  */
 public class RelatesAtom extends OntologicalAtom {
 
-    private RelatesAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    private RelatesAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
                         Variable predicateVariable, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
-    public static RelatesAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
+    public static RelatesAtom create(Variable var, Variable pVar, @Nullable Label label, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new RelatesAtom(varName, new Statement(varName).relates(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
+        return new RelatesAtom(varName, new Statement(varName).relates(new Statement(predicateVar)), parent, label, predicateVar, ctx);
     }
 
     private static RelatesAtom create(RelatesAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), parent, a.context());
     }
 
     @Override
-    OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return RelatesAtom.create(var, predicateVar, predicateId, parent, context());
+    OntologicalAtom createSelf(Variable var, Variable predicateVar, @Nullable Label label, ReasonerQuery parent) {
+        return RelatesAtom.create(var, predicateVar, label, parent, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/SubAtom.java
+++ b/graql/reasoner/atom/binary/SubAtom.java
@@ -21,6 +21,7 @@ package grakn.core.graql.reasoner.atom.binary;
 import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.property.SubProperty;
@@ -44,27 +45,27 @@ public class SubAtom extends OntologicalAtom {
     private SubAtom(Variable varName,
                     Statement pattern,
                     ReasonerQuery parentQuery,
-                    @Nullable ConceptId typeId,
+                    @Nullable Label label,
                     Variable predicateVariable,
                     ReasoningContext ctx) {
-        super(varName, pattern, parentQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, parentQuery, label, predicateVariable, ctx);
     }
 
-    public static SubAtom create(Variable var, Variable pVar, ConceptId predicateId, ReasonerQuery parent, ReasoningContext ctx) {
+    public static SubAtom create(Variable var, Variable pVar, @Nullable Label label, ReasonerQuery parent, ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
         Variable predicateVar = pVar.asReturnedVar();
-        return new SubAtom(varName, new Statement(varName).sub(new Statement(predicateVar)), parent, predicateId, predicateVar, ctx);
+        return new SubAtom(varName, new Statement(varName).sub(new Statement(predicateVar)), parent, label, predicateVar, ctx);
     }
     /**
      * copy constructor
      */
     private static SubAtom create(SubAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeId(), parent, a.context());
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), parent, a.context());
     }
 
     @Override
-    OntologicalAtom createSelf(Variable var, Variable predicateVar, ConceptId predicateId, ReasonerQuery parent) {
-        return create(var, predicateVar, predicateId, parent, context());
+    OntologicalAtom createSelf(Variable var, Variable predicateVar, @Nullable Label label, ReasonerQuery parent) {
+        return create(var, predicateVar, label, parent, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/TypeAtom.java
+++ b/graql/reasoner/atom/binary/TypeAtom.java
@@ -20,12 +20,14 @@ package grakn.core.graql.reasoner.atom.binary;
 import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  *
@@ -46,9 +48,9 @@ import java.util.Set;
  */
 public abstract class TypeAtom extends Binary {
 
-    TypeAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, ConceptId typeId,
+    TypeAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
              Variable predicateVariable, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, typeId, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
     @Override

--- a/graql/reasoner/atom/task/convert/AttributeAtomConverter.java
+++ b/graql/reasoner/atom/task/convert/AttributeAtomConverter.java
@@ -49,7 +49,7 @@ public class AttributeAtomConverter implements AtomConverter<AttributeAtom> {
                         .rel(Schema.ImplicitType.HAS_VALUE.getLabel(type.label()).getValue(), new Statement(atom.getAttributeVariable()))
                         .isa(typeLabel.getValue()),
                 atom.getPredicateVariable(),
-                ctx.conceptManager().getSchemaConcept(typeLabel).id(),
+                typeLabel,
                 atom.getParentQuery(),
                 ctx
         );
@@ -70,7 +70,7 @@ public class AttributeAtomConverter implements AtomConverter<AttributeAtom> {
      */
     @Override
     public IsaAtom toIsaAtom(AttributeAtom atom, ReasoningContext ctx) {
-        IsaAtom isaAtom = IsaAtom.create(atom.getAttributeVariable(), atom.getPredicateVariable(), atom.getTypeId(), false, atom.getParentQuery(), ctx);
+        IsaAtom isaAtom = IsaAtom.create(atom.getAttributeVariable(), atom.getPredicateVariable(), atom.getTypeLabel(), false, atom.getParentQuery(), ctx);
         Set<Statement> patterns = new HashSet<>(isaAtom.getCombinedPattern().statements());
         atom.getPredicates().map(Predicate::getPattern).forEach(patterns::add);
         atom.getMultiPredicate().stream().map(Predicate::getPattern).forEach(patterns::add);

--- a/graql/reasoner/atom/task/convert/RelationAtomConverter.java
+++ b/graql/reasoner/atom/task/convert/RelationAtomConverter.java
@@ -70,7 +70,7 @@ public class RelationAtomConverter implements AtomConverter<RelationAtom> {
                 attributeVariable,
                 relationVariable,
                 atom.getPredicateVariable(),
-                conceptManager.getSchemaConcept(explicitLabel).id(),
+                explicitLabel,
                 new HashSet<>(),
                 atom.getParentQuery(),
                 ctx
@@ -84,7 +84,7 @@ public class RelationAtomConverter implements AtomConverter<RelationAtom> {
 
     @Override
     public IsaAtom toIsaAtom(RelationAtom atom, ReasoningContext ctx) {
-        IsaAtom isaAtom = IsaAtom.create(atom.getVarName(), atom.getPredicateVariable(), atom.getTypeId(), false, atom.getParentQuery(), ctx);
+        IsaAtom isaAtom = IsaAtom.create(atom.getVarName(), atom.getPredicateVariable(), atom.getTypeLabel(), false, atom.getParentQuery(), ctx);
         Set<Statement> patterns = new HashSet<>(isaAtom.getCombinedPattern().statements());
         atom.getPredicates().map(Predicate::getPattern).forEach(patterns::add);
         return ctx.queryFactory().atomic(Graql.and(patterns)).getAtom().toIsaAtom();

--- a/graql/reasoner/atom/task/infer/RelationTypeReasoner.java
+++ b/graql/reasoner/atom/task/infer/RelationTypeReasoner.java
@@ -295,6 +295,6 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
                         relationPattern.isa(new Statement(atom.getPredicateVariable()))
                 );
 
-        return RelationAtom.create(newPattern, atom.getPredicateVariable(), atom.getTypeId(), atom.getPossibleTypes(), atom.getParentQuery(), atom.context());
+        return RelationAtom.create(newPattern, atom.getPredicateVariable(), atom.getTypeLabel(), atom.getPossibleTypes(), atom.getParentQuery(), atom.context());
     }
 }

--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -353,7 +353,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
                 .map(p -> new Pair<>(p, conceptManager.<Concept>getConcept(p.getPredicate())))
                 .filter(p -> Objects.nonNull(p.second()))
                 .filter(p -> p.second().isEntity())
-                .map(p -> IsaAtom.create(p.first().getVarName(), new Variable(), p.second().asEntity().type(), false, this, context()));
+                .map(p -> IsaAtom.create(p.first().getVarName(), new Variable(), p.second().asEntity().type().label(), false, this, context()));
     }
 
     private Multimap<Variable, Type> getVarTypeMap(Stream<IsaAtomBase> isas){

--- a/graql/reasoner/utils/ReasonerUtils.java
+++ b/graql/reasoner/utils/ReasonerUtils.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Sets;
 import grakn.core.core.Schema;
 import grakn.core.graql.reasoner.atom.PropertyAtomicFactory;
 import grakn.core.graql.reasoner.atom.binary.TypeAtom;
-import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.graql.reasoner.utils.conversion.RoleConverter;
@@ -47,8 +46,6 @@ import graql.lang.property.TypeProperty;
 import graql.lang.property.ValueProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -59,6 +56,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 import static java.util.stream.Collectors.toSet;
 

--- a/graql/reasoner/utils/ReasonerUtils.java
+++ b/graql/reasoner/utils/ReasonerUtils.java
@@ -79,47 +79,40 @@ public class ReasonerUtils {
     }
 
     /**
-     * looks for an appropriate var property with a specified name among the vars and maps it to an IdPredicate,
-     * covers the case when specified variable name is user defined
+     * Looks for an appropriate var property with a specified name among the vars and maps it to a Label if possible.
+     * Covers the case when specified variable name is user defined.
      * @param typeVariable variable name of interest
      * @param vars VarAdmins to look for properties
-     * @param parent reasoner query the mapped predicate should belong to
      * @return mapped IdPredicate
      */
-    public static IdPredicate getUserDefinedIdPredicate(ConceptManager conceptManager, Variable typeVariable, Set<Statement> vars, ReasonerQuery parent){
+    public static Label getLabelFromUserDefinedVar(Variable typeVariable, Set<Statement> vars, ConceptManager conceptManager){
         return  vars.stream()
                 .filter(v -> v.var().equals(typeVariable))
                 .flatMap(v -> v.hasProperty(TypeProperty.class)?
-                        v.getProperties(TypeProperty.class).map(np -> IdPredicate.create(typeVariable, typeFromLabel(Label.of(np.name()), conceptManager).id(), parent)) :
-                        v.getProperties(IdProperty.class).map(np -> IdPredicate.create(typeVariable, ConceptId.of(np.id()), parent)))
+                        v.getProperties(TypeProperty.class).map(np -> Label.of(np.name())) :
+                        v.getProperties(IdProperty.class).map(np -> conceptManager.getConcept(ConceptId.of(np.id())).asType().label()))
                 .findFirst().orElse(null);
     }
 
     /**
-     * looks for an appropriate var property with a specified name among the vars and maps it to an IdPredicate,
-     * covers both the cases when variable is and isn't user defined
+     * Looks for an appropriate var property with a specified name among the vars and maps it to a Label if possible.
+     * Covers both the cases when variable is and isn't user defined.
      * @param typeVariable variable name of interest
      * @param typeVar Statement to look for in case the variable name is not user defined
      * @param vars VarAdmins to look for properties
-     * @param parent reasoner query the mapped predicate should belong to
      * @return mapped IdPredicate
      */
     @Nullable
-    public static IdPredicate getIdPredicate(Variable typeVariable, Statement typeVar, Set<Statement> vars, ReasonerQuery parent, ConceptManager conceptManager){
-        IdPredicate predicate = null;
+    public static Label getLabel(Variable typeVariable, Statement typeVar, Set<Statement> vars, ConceptManager conceptManager){
+        Label label = null;
         //look for id predicate among vars
         if(typeVar.var().isReturned()) {
-            predicate = getUserDefinedIdPredicate(conceptManager, typeVariable, vars, parent);
+            label = getLabelFromUserDefinedVar(typeVariable, vars, conceptManager);
         } else {
             TypeProperty nameProp = typeVar.getProperty(TypeProperty.class).orElse(null);
-
-            if (nameProp != null){
-                Label typeLabel = Label.of(nameProp.name());
-                SchemaConcept type = typeFromLabel(typeLabel, conceptManager);
-                if (type != null) predicate = IdPredicate.create(typeVariable, type.id(), parent);
-            }
+            if (nameProp != null) label = Label.of(nameProp.name());
         }
-        return predicate;
+        return label;
     }
 
     /**

--- a/kb/graql/reasoner/ReasonerCheckedException.java
+++ b/kb/graql/reasoner/ReasonerCheckedException.java
@@ -20,6 +20,7 @@ package grakn.core.kb.graql.reasoner;
 
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Label;
 import graql.lang.exception.GraqlException;
 
 public class ReasonerCheckedException extends GraqlException {
@@ -30,5 +31,9 @@ public class ReasonerCheckedException extends GraqlException {
 
     public static ReasonerCheckedException idNotFound(ConceptId id) {
         return new ReasonerCheckedException(ErrorMessage.ID_NOT_FOUND.getMessage(id));
+    }
+
+    public static ReasonerCheckedException labelNotFound(Label label) {
+        return new ReasonerCheckedException(ErrorMessage.LABEL_NOT_FOUND.getMessage(label));
     }
 }

--- a/test-integration/graql/reasoner/query/BUILD
+++ b/test-integration/graql/reasoner/query/BUILD
@@ -219,7 +219,6 @@ java_test(
         "//graql/planning",
         "//graql/reasoner",
         "//kb/concept/api",
-        "//kb/concept/manager",
         "//kb/graql/planning",
         "//kb/graql/reasoner",
         "//kb/keyspace",


### PR DESCRIPTION
## What is the goal of this PR?
To store `SchemaConcept` labels instead of their ids in atoms. 
Reasons: 
1) ids carry little information and require further manipulation (lookups) to extract their meaning
2) we often want to use the label which then requires doing a lookup via `ConceptManager`. 

As we trim down the number of dependencies on `ConceptManager`, this change also should allow to remove `ReasoningContext` out of atoms and instead inject it to functions that require it.

## What are the changes implemented in this PR?
Instead of storing type `ConceptId`s in atoms, we store their `Label`s.



