### PR TITLE
Improve validation and disallow more rule types

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -201,7 +201,6 @@ public enum ErrorMessage {
     INVALID_VARIABLE_PREDICATE_STATE("Invalid state in variable predicate [%s] with answer [%s]: either a concept is missing or not an attribute."),
     NO_ATOMS_SELECTED("No atoms were selected from the query [%s]."),
     INVALID_CACHE_ENTRY("Query cache entry for query [%s] contains an invalid entry: [%s]."),
-    UNIFICATION_ATOM_INCOMPATIBILITY("Attempted unification from child atom [%s] to parent atom [%s] was incompatible."),
     NON_EXISTENT_UNIFIER("Could not proceed with the unification as the unifier doesn't exist."),
     ILLEGAL_ATOM_CONVERSION("Attempted illegal atom conversion of atom [%s] to type [%s]."),
     CONCEPT_NOT_THING("Attempted concept conversion from concept [%s] that is not a thing."),

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -133,6 +133,8 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES("Attribute [%s] is not allowed to form a rule head of rule [%s] as it copies an attribute value from an incompatible attribute type [%s]\n"),
 
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE("Rule [%s] attempts to rewrite the type"),
+
     VALIDATION_RULE_INVALID_RELATION_TYPE("Rule [%s] attempts to define a relation pattern with type [%s] which is not a relation type\n"),
 
     VALIDATION_RULE_INVALID_ATTRIBUTE_TYPE("Rule [%s] attempts to define an attribute pattern with type [%s] which is not an attribute type\n"),
@@ -142,6 +144,7 @@ public enum ErrorMessage {
     VALIDATION_RULE_ROLE_CANNOT_BE_PLAYED("Rule [%s] attempts to define a rule containing a relation pattern with role [%s] which cannot be played in relation [%s]\n"),
 
     VALIDATION_RULE_TYPE_CANNOT_PLAY_ROLE("Rule [%s] attempts to define a rule containing a relation pattern with type [%s] that cannot play role [%s] in relation [%s]\n"),
+
 
     //--------------------------------------------- Factory Errors
     INVALID_PATH_TO_CONFIG("Unable to open config file [%s]"),

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -133,7 +133,11 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES("Attribute [%s] is not allowed to form a rule head of rule [%s] as it copies an attribute value from an incompatible attribute type [%s]\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE("Rule [%s] attempts to rewrite the type"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION("Rule [%s] attempts to rewrite type to a relation type"),
+
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new datatype [%s]"),
+
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]"),
 
     VALIDATION_RULE_INVALID_RELATION_TYPE("Rule [%s] attempts to define a relation pattern with type [%s] which is not a relation type\n"),
 
@@ -197,8 +201,8 @@ public enum ErrorMessage {
     INVALID_VARIABLE_PREDICATE_STATE("Invalid state in variable predicate [%s] with answer [%s]: either a concept is missing or not an attribute."),
     NO_ATOMS_SELECTED("No atoms were selected from the query [%s]."),
     INVALID_CACHE_ENTRY("Query cache entry for query [%s] contains an invalid entry: [%s]."),
-    UNIFICATION_ATOM_INCOMPATIBILITY("Attempted unification on incompatible atoms."),
-    NON_EXISTENT_UNIFIER("Could not proceed with thr unification as the unifier doesn't exist."),
+    UNIFICATION_ATOM_INCOMPATIBILITY("Attempted unification from child atom [%s] to parent atom [%s] was incompatible."),
+    NON_EXISTENT_UNIFIER("Could not proceed with the unification as the unifier doesn't exist."),
     ILLEGAL_ATOM_CONVERSION("Attempted illegal atom conversion of atom [%s] to type [%s]."),
     CONCEPT_NOT_THING("Attempted concept conversion from concept [%s] that is not a thing."),
     AMBIGUOUS_TYPE("Sought variable [%s] has ambiguous types [%s]"),

--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -432,10 +432,9 @@ public abstract class Atom extends AtomicBase {
      * @param unifierType type of unifier to be computed
      * @return multiunifier
      */
-    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
-        Unifier unifier = this.getUnifier(parentAtom, unifierType);
-        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
-    }
+    public abstract MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType);
+//        Unifier unifier = this.getUnifier(parentAtom, unifierType);
+//        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
 
     /**
      * Calculates the semantic difference between the this (parent) and child atom,

--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -433,8 +433,6 @@ public abstract class Atom extends AtomicBase {
      * @return multiunifier
      */
     public abstract MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType);
-//        Unifier unifier = this.getUnifier(parentAtom, unifierType);
-//        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
 
     /**
      * Calculates the semantic difference between the this (parent) and child atom,

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -43,6 +43,7 @@ import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
+import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
@@ -306,6 +307,11 @@ public class AttributeAtom extends Binary{
     @Override
     public Unifier getUnifier(Atom parentAtom, UnifierType unifierType) {
         return semanticProcessor.getUnifier(this, parentAtom, unifierType, context());
+    }
+
+    @Override
+    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
+        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/Binary.java
+++ b/graql/reasoner/atom/binary/Binary.java
@@ -32,6 +32,7 @@ import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.graql.reasoner.ReasonerCheckedException;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
+import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
@@ -171,5 +172,10 @@ public abstract class Binary extends Atom {
     @Override
     public Unifier getUnifier(Atom parentAtom, UnifierType unifierType) {
         return semanticProcessor.getUnifier(this, parentAtom, unifierType, context());
+    }
+
+    @Override
+    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
+        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 }

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -191,6 +191,5 @@ public class IsaAtom extends IsaAtomBase {
     public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
         Unifier unifier = this.getUnifier(parentAtom, unifierType);
         return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
-//        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 }

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -59,7 +59,6 @@ import javax.annotation.Nullable;
 public class IsaAtom extends IsaAtomBase {
 
     private final TypeReasoner<IsaAtom> typeReasoner = new IsaTypeReasoner();
-    private final SemanticProcessor<Binary> semanticProcessor = new BinarySemanticProcessor();
 
     private int hashCode;
     private boolean hashCodeMemoised;
@@ -190,6 +189,8 @@ public class IsaAtom extends IsaAtomBase {
 
     @Override
     public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
-        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
+        Unifier unifier = this.getUnifier(parentAtom, unifierType);
+        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
+//        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 }

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -26,6 +26,7 @@ import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.atom.task.infer.IsaTypeReasoner;
 import grakn.core.graql.reasoner.atom.task.infer.TypeReasoner;
 import grakn.core.graql.reasoner.atom.task.materialise.IsaMaterialiser;
+import grakn.core.graql.reasoner.atom.task.validate.IsaAtomValidator;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.Label;
@@ -141,10 +142,7 @@ public class IsaAtom extends IsaAtomBase {
     @Override
     public void checkValid(){
         super.checkValid();
-        SchemaConcept type = getSchemaConcept();
-        if (type != null && !type.isType()) {
-            throw GraqlSemanticException.cannotGetInstancesOfNonType(type.label());
-        }
+        (new IsaAtomValidator()).checkValid(this, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -26,7 +26,11 @@ import grakn.core.graql.reasoner.atom.predicate.Predicate;
 import grakn.core.graql.reasoner.atom.task.infer.IsaTypeReasoner;
 import grakn.core.graql.reasoner.atom.task.infer.TypeReasoner;
 import grakn.core.graql.reasoner.atom.task.materialise.IsaMaterialiser;
+import grakn.core.graql.reasoner.atom.task.relate.AttributeSemanticProcessor;
+import grakn.core.graql.reasoner.atom.task.relate.BinarySemanticProcessor;
+import grakn.core.graql.reasoner.atom.task.relate.SemanticProcessor;
 import grakn.core.graql.reasoner.atom.task.validate.IsaAtomValidator;
+import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.Label;
@@ -35,6 +39,7 @@ import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
+import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import graql.lang.pattern.Pattern;
 import graql.lang.property.IsaProperty;
@@ -54,6 +59,7 @@ import javax.annotation.Nullable;
 public class IsaAtom extends IsaAtomBase {
 
     private final TypeReasoner<IsaAtom> typeReasoner = new IsaTypeReasoner();
+    private final SemanticProcessor<Binary> semanticProcessor = new BinarySemanticProcessor();
 
     private int hashCode;
     private boolean hashCodeMemoised;
@@ -180,5 +186,10 @@ public class IsaAtom extends IsaAtomBase {
         //in general this <= parent, so no specialisation viable
         if (this.getClass() != parentAtom.getClass()) return UnifierImpl.nonExistent();
         return super.getUnifier(parentAtom, unifierType);
+    }
+
+    @Override
+    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
+        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 }

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -48,8 +48,6 @@ import javax.annotation.Nullable;
  */
 public abstract class OntologicalAtom extends TypeAtom {
 
-    BinarySemanticProcessor semanticProcessor = new BinarySemanticProcessor();
-
     OntologicalAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
                     Variable predicateVariable, ReasoningContext ctx) {
         super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
@@ -94,11 +92,6 @@ public abstract class OntologicalAtom extends TypeAtom {
         return vars.isEmpty() ?
                 Collections.singleton(this) :
                 vars.stream().map(v -> createSelf(v, getPredicateVariable(), getTypeLabel(), this.getParentQuery())).collect(Collectors.toSet());
-    }
-
-    @Override
-    public MultiUnifier getMultiUnifier(Atom parentAtom, UnifierType unifierType) {
-        return semanticProcessor.getMultiUnifier(this, parentAtom, unifierType, context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/RelationAtom.java
+++ b/graql/reasoner/atom/binary/RelationAtom.java
@@ -44,7 +44,9 @@ import grakn.core.graql.reasoner.atom.task.validate.AtomValidator;
 import grakn.core.graql.reasoner.atom.task.validate.RelationAtomValidator;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.Label;
+import grakn.core.kb.concept.api.Relation;
 import grakn.core.kb.concept.api.Role;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.concept.api.SchemaConcept;
@@ -492,10 +494,15 @@ public class RelationAtom extends IsaAtomBase {
 
     @Override
     public boolean isRuleApplicableViaAtom(Atom ruleAtom) {
-        if (!(ruleAtom instanceof RelationAtom)) return isRuleApplicableViaAtom(ruleAtom.toRelationAtom());
-        RelationAtom atomWithType = typeReasoner.inferTypes(this.addType(ruleAtom.getSchemaConcept()), new ConceptMap(), context());
-        return ruleAtom.isUnifiableWith(atomWithType);
+        if (ruleAtom instanceof RelationAtom || ruleAtom instanceof AttributeAtom)  {
+            RelationAtom atomWithType = typeReasoner.inferTypes(this.addType(ruleAtom.toRelationAtom().getSchemaConcept()), new ConceptMap(), context());
+            return ruleAtom.isUnifiableWith(atomWithType);
+        } else {
+
+        }
+        return false;
     }
+
 
     @Override
     public RelationAtom addType(SchemaConcept type) {

--- a/graql/reasoner/atom/binary/RelationAtom.java
+++ b/graql/reasoner/atom/binary/RelationAtom.java
@@ -497,8 +497,6 @@ public class RelationAtom extends IsaAtomBase {
         if (ruleAtom instanceof RelationAtom || ruleAtom instanceof AttributeAtom)  {
             RelationAtom atomWithType = typeReasoner.inferTypes(this.addType(ruleAtom.toRelationAtom().getSchemaConcept()), new ConceptMap(), context());
             return ruleAtom.isUnifiableWith(atomWithType);
-        } else {
-
         }
         return false;
     }

--- a/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
@@ -27,6 +27,7 @@ import grakn.core.graql.reasoner.atom.binary.RelationAtom;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.cache.VariableDefinition;
+import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
@@ -79,7 +80,18 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
 
     @Override
     public MultiUnifier getMultiUnifier(AttributeAtom childAtom, Atom parentAtom, UnifierType unifierType, ReasoningContext ctx) {
-        return binarySemanticProcessor.getMultiUnifier(childAtom, parentAtom, unifierType, ctx);
+        if (!(parentAtom instanceof AttributeAtom)) {
+            // in general this >= parent, hence for rule unifiers we can potentially specialise child to match parent
+            if (unifierType.equals(UnifierType.RULE)) {
+                if (parentAtom instanceof IsaAtom) return childAtom.toIsaAtom().getMultiUnifier(parentAtom, unifierType);
+                else if (parentAtom instanceof RelationAtom){
+                    return childAtom.toRelationAtom().getMultiUnifier(parentAtom, unifierType);
+                }
+            }
+            return MultiUnifierImpl.nonExistent();
+        }
+        Unifier unifier = getUnifier(childAtom, parentAtom, unifierType, ctx);
+        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
     }
 
     @Override

--- a/graql/reasoner/atom/task/relate/BinarySemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/BinarySemanticProcessor.java
@@ -24,6 +24,7 @@ import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.binary.Binary;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
+import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
 import grakn.core.kb.concept.api.SchemaConcept;
@@ -80,7 +81,8 @@ public class BinarySemanticProcessor implements SemanticProcessor<Binary> {
 
     @Override
     public MultiUnifier getMultiUnifier(Binary childAtom, Atom parentAtom, UnifierType unifierType, ReasoningContext ctx) {
-        return basicSemanticProcessor.getMultiUnifier(childAtom, parentAtom, unifierType, ctx);
+        Unifier unifier = getUnifier(childAtom, parentAtom, unifierType, ctx);
+        return unifier != null ? new MultiUnifierImpl(unifier) : MultiUnifierImpl.nonExistent();
     }
 
     @Override

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -1,0 +1,106 @@
+/*
+ * GRAKN.AI - THE KNOWLEDGE GRAPH
+ * Copyright (C) 2019 Grakn Labs Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.reasoner.atom.task.validate;
+
+import grakn.core.common.exception.ErrorMessage;
+import grakn.core.graql.reasoner.ReasoningContext;
+import grakn.core.graql.reasoner.atom.Atom;
+import grakn.core.graql.reasoner.atom.binary.AttributeAtom;
+import grakn.core.graql.reasoner.atom.binary.IsaAtom;
+import grakn.core.kb.concept.api.Attribute;
+import grakn.core.kb.concept.api.AttributeType;
+import grakn.core.kb.concept.api.Label;
+import grakn.core.kb.concept.api.Rule;
+import grakn.core.kb.concept.api.SchemaConcept;
+import graql.lang.statement.Variable;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+public class IsaAtomValidator implements AtomValidator<IsaAtom> {
+
+    private final BasicAtomValidator basicValidator;
+
+    public IsaAtomValidator(){
+        this.basicValidator = new BasicAtomValidator();
+    }
+
+    @Override
+    public void checkValid(IsaAtom atom, ReasoningContext ctx) {
+        basicValidator.checkValid(atom, ctx);
+    }
+
+    @Override
+    public Set<String> validateAsRuleHead(IsaAtom atom, Rule rule, ReasoningContext ctx) {
+        /*
+        An IsaAtom is ok as the head of a rule when:
+
+        1. The atom is NOT a relation type (must specify roles, making it a RelationAtom
+        2. If it is an attribute type, the datatype must match
+        3. Types between rule head and body must be of same meta type
+        */
+
+        Set<String> errors = new HashSet<>();
+
+        SchemaConcept type = atom.getSchemaConcept();
+        if (type.isRelationType()) {
+            errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE.getMessage(rule.label()));
+        } else if (type.isAttributeType()) {
+            AttributeType.DataType<Object> datatypeInHead = type.asAttributeType().dataType();
+
+            Variable headVariable = atom.getVarName();
+            // parent query is the combined rule head and body
+
+            boolean datatypeMatchesBody = atom.getParentQuery().getAtoms(Atom.class)
+                    .filter(ruleAtom -> ruleAtom instanceof AttributeAtom || ruleAtom instanceof IsaAtom)
+                    .map(ruleAtom -> ruleAtom.getSchemaConcept())
+                    .filter(Objects::nonNull)
+                    .filter(SchemaConcept::isAttributeType)
+                    .anyMatch(schemaConcept -> schemaConcept.asAttributeType().dataType().equals(datatypeInHead));
+
+            if (!datatypeMatchesBody) {
+
+                // TODO append error to errors
+
+            }
+        } else {
+            boolean typeMatchesBody = atom.getParentQuery().getAtoms(IsaAtom.class)
+                    .map(isaAtom -> isaAtom.getSchemaConcept())
+                    .filter(Objects::nonNull)
+                    .anyMatch(schemaConcept -> type.isAttributeType() && schemaConcept.isAttributeType() ||
+                                        type.isEntityType() && schemaConcept.isEntityType() ||
+                                        type.isAttributeType() && schemaConcept.isAttributeType());
+
+            if (!typeMatchesBody) {
+
+                // TODO append error to errors
+
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public Set<String> validateAsRuleBody(IsaAtom atom, Label ruleLabel, ReasoningContext ctx) {
+        return new HashSet<>();
+    }
+}

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -62,11 +62,10 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
 
         SchemaConcept type = atom.getSchemaConcept();
         if (type.isRelationType()) {
-            errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE.getMessage(rule.label()));
+            errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION.getMessage(rule.label()));
         } else if (type.isAttributeType()) {
             AttributeType.DataType<Object> datatypeInHead = type.asAttributeType().dataType();
 
-            Variable headVariable = atom.getVarName();
             // parent query is the combined rule head and body
 
             boolean datatypeMatchesBody = atom.getParentQuery().getAtoms(Atom.class)
@@ -77,9 +76,7 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
                     .anyMatch(schemaConcept -> schemaConcept.asAttributeType().dataType().equals(datatypeInHead));
 
             if (!datatypeMatchesBody) {
-
-                // TODO append error to errors
-
+                errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE.getMessage(rule, datatypeInHead));
             }
         } else {
             boolean typeMatchesBody = atom.getParentQuery().getAtoms(IsaAtom.class)
@@ -90,9 +87,8 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
                                         type.isAttributeType() && schemaConcept.isAttributeType());
 
             if (!typeMatchesBody) {
-
-                // TODO append error to errors
-
+                Variable headVariable = atom.getVarName();
+                errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE.getMessage(rule, headVariable));
             }
         }
 

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -1,6 +1,6 @@
 /*
  * GRAKN.AI - THE KNOWLEDGE GRAPH
- * Copyright (C) 2019 Grakn Labs Ltd
+ * Copyright (C) 2020 Grakn Labs
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -24,7 +24,6 @@ import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.binary.AttributeAtom;
 import grakn.core.graql.reasoner.atom.binary.IsaAtom;
-import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Rule;

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -1,5 +1,4 @@
 /*
- * GRAKN.AI - THE KNOWLEDGE GRAPH
  * Copyright (C) 2020 Grakn Labs
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,7 +13,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
 package grakn.core.graql.reasoner.atom.task.validate;

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -246,6 +246,8 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      *
      * Subsumption relation is NOT symmetric in general. The only case when it is symmetric is when parent and child
      * queries are alpha-equivalent.
+     *
+     * Used in the query cache
      */
     SUBSUMPTIVE {
 
@@ -326,7 +328,8 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      * Unifier type used to determine whether two queries are in a subsumption relation up to structural equivalence.
      * Consequently two queries that are structurally equivalent are structurally subsumptive.
      *
-     * */
+     * Used by query cache
+     */
     STRUCTURAL_SUBSUMPTIVE {
         @Override public ReasonerQueryEquivalence equivalence() { return SUBSUMPTIVE.equivalence(); }
 

--- a/kb/graql/reasoner/ReasonerException.java
+++ b/kb/graql/reasoner/ReasonerException.java
@@ -94,7 +94,4 @@ public class ReasonerException extends GraknException {
         return new ReasonerException(ErrorMessage.UNSAFE_NEGATION_BLOCK.getMessage(query));
     }
 
-    public static ReasonerException incompatibleAtomUnification(Atomic atomic, Atomic parent) {
-        return new ReasonerException(ErrorMessage.UNIFICATION_ATOM_INCOMPATIBILITY.getMessage(atomic.toString(), parent.toString()));
-    }
 }

--- a/kb/graql/reasoner/ReasonerException.java
+++ b/kb/graql/reasoner/ReasonerException.java
@@ -93,4 +93,8 @@ public class ReasonerException extends GraknException {
     public static ReasonerException unsafeNegationBlock(ReasonerQuery query) {
         return new ReasonerException(ErrorMessage.UNSAFE_NEGATION_BLOCK.getMessage(query));
     }
+
+    public static ReasonerException incompatibleAtomUnification(Atomic atomic, Atomic parent) {
+        return new ReasonerException(ErrorMessage.UNIFICATION_ATOM_INCOMPATIBILITY.getMessage(atomic.toString(), parent.toString()));
+    }
 }


### PR DESCRIPTION
## What is the goal of this PR?
In the errors flagged in #5596 lead to the issues being fixed in this PR. We are more strict with rule validation, not allowing a rule to change the type of a concept if the meta type is not the same between the `when` and the `then` and not allowing setting a type via `isa` to be a relation, unless specifying role players.

## What are the changes implemented in this PR?
* Implement better validation for rules, which reject newly rules with `isa` as the conclusion
