### PR TITLE
Flatten AttributeAtom

### DIFF
--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -161,7 +161,7 @@ public abstract class Atom extends AtomicBase {
      * @return true if this atom is bounded - via substitution/specific resource or schema
      */
     public boolean isBounded() {
-        return isResource() && ((AttributeAtom) this).isValueEquality()
+        return isAttribute() && ((AttributeAtom) this).isValueEquality()
                 || this instanceof OntologicalAtom
                 || isGround();
     }

--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -209,7 +209,9 @@ public abstract class Atom extends AtomicBase {
     /**
      * @return true if this atom requires direct schema lookups
      */
-    public abstract boolean requiresSchema();
+    public boolean requiresSchema() {
+        return getTypeLabel() == null || this instanceof OntologicalAtom;
+    }
 
     private boolean isRuleApplicable(InferenceRule child) {
         return (getIdPredicate(getVarName()) == null

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -305,16 +305,7 @@ public class PropertyAtomicFactory {
 
         Variable typeVar = property.type().var();
         Label typeLabel = getLabel(typeVar, property.type(), otherStatements, ctx.conceptManager());
-
-        //isa part
-        Statement isaVar;
-        if (property.isExplicit()) {
-            isaVar = new Statement(var).isaX(new Statement(typeVar));
-        } else {
-            isaVar = new Statement(var).isa(new Statement(typeVar));
-        }
-
-        return IsaAtom.create(var, typeVar, isaVar, typeLabel, parent, ctx);
+        return IsaAtom.create(var, typeVar, typeLabel, property.isExplicit(), parent, ctx);
     }
 
     /**

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -154,20 +154,6 @@ public class AttributeAtom extends Atom{
                 getTypeLabel(), newMultiPredicate, getParentQuery(), context());
     }
 
-    /**
-     * TODO remove this, short term workaround
-     * copy constructor that overrides the predicates
-     */
-    public AttributeAtom copy(Set<ValuePredicate> newPredicates) {
-        return create(getPattern(), getAttributeVariable(),
-                getRelationVariable(),
-                getPredicateVariable(),
-                getTypeLabel(),
-                newPredicates,
-                getParentQuery(),
-                context());
-    }
-
     public IsaAtom ownerIsa(){ return ownerIsa;}
     public IsaAtom attributeIsa(){ return attributeIsa;}
 

--- a/graql/reasoner/atom/binary/Binary.java
+++ b/graql/reasoner/atom/binary/Binary.java
@@ -87,12 +87,6 @@ public abstract class Binary extends Atom {
         return typePredicate;
     }
 
-
-    @Override
-    public boolean requiresSchema() {
-        return getTypeLabel() == null || this instanceof OntologicalAtom;
-    }
-
     @Nullable
     @Override
     public SchemaConcept getSchemaConcept(){

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -59,7 +59,7 @@ public class IsaAtom extends IsaAtomBase {
 
     private IsaAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label, Variable predicateVariable,
                     ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
+        super(varName.asReturnedVar(), pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
     public static IsaAtom create(Variable var, Variable predicateVar, @Nullable Label label, boolean isDirect, ReasonerQuery parent,

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -62,21 +62,16 @@ public class IsaAtom extends IsaAtomBase {
         super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
     }
 
-    public static IsaAtom create(Variable var, Variable predicateVar, Statement pattern, @Nullable Label label, ReasonerQuery parent,
-                                 ReasoningContext ctx) {
-        return new IsaAtom(var.asReturnedVar(), pattern, parent, label, predicateVar, ctx);
-    }
-
     public static IsaAtom create(Variable var, Variable predicateVar, @Nullable Label label, boolean isDirect, ReasonerQuery parent,
                                  ReasoningContext ctx) {
-        Statement pattern = isDirect ?
+        Statement pattern = isDirect?
                 new Statement(var).isaX(new Statement(predicateVar)) :
                 new Statement(var).isa(new Statement(predicateVar));
         return new IsaAtom(var, pattern, parent, label, predicateVar, ctx);
     }
 
     private static IsaAtom create(IsaAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getPattern(), a.getTypeLabel(), parent, a.context());
+        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), a.isDirect(), parent, a.context());
     }
 
     @Override

--- a/graql/reasoner/atom/task/convert/AttributeAtomConverter.java
+++ b/graql/reasoner/atom/task/convert/AttributeAtomConverter.java
@@ -70,7 +70,7 @@ public class AttributeAtomConverter implements AtomConverter<AttributeAtom> {
      */
     @Override
     public IsaAtom toIsaAtom(AttributeAtom atom, ReasoningContext ctx) {
-        IsaAtom isaAtom = IsaAtom.create(atom.getAttributeVariable(), atom.getPredicateVariable(), atom.getTypeLabel(), false, atom.getParentQuery(), ctx);
+        IsaAtom isaAtom = atom.attributeIsa();
         Set<Statement> patterns = new HashSet<>(isaAtom.getCombinedPattern().statements());
         atom.getPredicates().map(Predicate::getPattern).forEach(patterns::add);
         atom.getMultiPredicate().stream().map(Predicate::getPattern).forEach(patterns::add);

--- a/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
@@ -55,16 +55,13 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
         }
 
         AttributeAtom parent = (AttributeAtom) parentAtom;
-
-        Unifier unifier = binarySemanticProcessor.getUnifier(childAtom, parentAtom, unifierType, ctx);
+        Unifier unifier = binarySemanticProcessor.getUnifier(childAtom.attributeIsa(), parent.attributeIsa(), unifierType, ctx);
         if (unifier == null) return UnifierImpl.nonExistent();
 
-        //unify attribute vars
-        Variable childAttributeVarName = childAtom.getAttributeVariable();
-        Variable parentAttributeVarName = parent.getAttributeVariable();
-        if (parentAttributeVarName.isReturned()){
-            unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(childAttributeVarName, parentAttributeVarName)));
-        }
+        //unify owner isa
+        Unifier ownerUnifier = binarySemanticProcessor.getUnifier(childAtom.ownerIsa(), parent.ownerIsa(), unifierType, ctx);
+        if (ownerUnifier == null) return UnifierImpl.nonExistent();
+        unifier = unifier.merge(ownerUnifier);
 
         //unify relation vars
         Variable childRelationVarName = childAtom.getRelationVariable();
@@ -79,12 +76,12 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
 
     @Override
     public MultiUnifier getMultiUnifier(AttributeAtom childAtom, Atom parentAtom, UnifierType unifierType, ReasoningContext ctx) {
-        return binarySemanticProcessor.getMultiUnifier(childAtom, parentAtom, unifierType, ctx);
+        return binarySemanticProcessor.getMultiUnifier(childAtom.toIsaAtom(), parentAtom.toIsaAtom(), unifierType, ctx);
     }
 
     @Override
     public SemanticDifference computeSemanticDifference(AttributeAtom parent, Atom child, Unifier unifier, ReasoningContext ctx) {
-        SemanticDifference baseDiff = binarySemanticProcessor.computeSemanticDifference(parent, child, unifier, ctx);
+        SemanticDifference baseDiff = binarySemanticProcessor.computeSemanticDifference(parent.toIsaAtom(), child, unifier, ctx);
         if (!child.isResource()) return baseDiff;
         AttributeAtom childAtom = (AttributeAtom) child;
         Set<VariableDefinition> diff = new HashSet<>();

--- a/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
@@ -82,7 +82,7 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
     @Override
     public SemanticDifference computeSemanticDifference(AttributeAtom parent, Atom child, Unifier unifier, ReasoningContext ctx) {
         SemanticDifference baseDiff = binarySemanticProcessor.computeSemanticDifference(parent.toIsaAtom(), child, unifier, ctx);
-        if (!child.isResource()) return baseDiff;
+        if (!child.isAttribute()) return baseDiff;
         AttributeAtom childAtom = (AttributeAtom) child;
         Set<VariableDefinition> diff = new HashSet<>();
 

--- a/graql/reasoner/atom/task/validate/AttributeAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/AttributeAtomValidator.java
@@ -23,7 +23,6 @@ import grakn.core.graql.reasoner.CacheCasting;
 import grakn.core.graql.reasoner.ReasoningContext;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.atom.binary.AttributeAtom;
-import grakn.core.graql.reasoner.atom.binary.Binary;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.query.ResolvableQuery;
 import grakn.core.kb.concept.api.AttributeType;
@@ -77,7 +76,7 @@ public class AttributeAtomValidator implements AtomValidator<AttributeAtom> {
             ErrorMessage incompatibleValuesMsg = ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES;
             body.getAtoms(AttributeAtom.class)
                     .filter(at -> at.getAttributeVariable().equals(attributeVar))
-                    .map(Binary::getSchemaConcept)
+                    .map(AttributeAtom::getSchemaConcept)
                     .filter(t -> !t.asAttributeType().dataType().equals(dataType))
                     .forEach(t -> errors.add(incompatibleValuesMsg.getMessage(type.label(), rule.label(), t.label())));
         }

--- a/graql/reasoner/rule/InferenceRule.java
+++ b/graql/reasoner/rule/InferenceRule.java
@@ -246,7 +246,14 @@ public class InferenceRule {
 
                 // TODO revert this to old implementation of instantiating without copy constructor
                 // or do it properly with a factory
-                headAtom = resourceHead.copy(innerVps);
+                headAtom = AttributeAtom.create(resourceHead.getPattern(), resourceHead.getAttributeVariable(),
+                        resourceHead.getRelationVariable(),
+                        resourceHead.getPredicateVariable(),
+                        resourceHead.getTypeLabel(),
+                        innerVps,
+                        resourceHead.getParentQuery(),
+                        resourceHead.context());
+                //headAtom = resourceHead.copy(innerVps);
             }
         }
 

--- a/graql/reasoner/rule/InferenceRule.java
+++ b/graql/reasoner/rule/InferenceRule.java
@@ -217,7 +217,7 @@ public class InferenceRule {
      * @return rule with propagated constraints from parent
      */
     private InferenceRule propagateConstraints(Atom parentAtom, Unifier unifier){
-        if (!parentAtom.isRelation() && !parentAtom.isResource()) return this;
+        if (!parentAtom.isRelation() && !parentAtom.isAttribute()) return this;
         Atom headAtom = head.getAtom();
 
         //we are only rewriting the conjunction atoms (not complement atoms) as
@@ -235,7 +235,7 @@ public class InferenceRule {
         bodyConjunctionAtoms.addAll(vpsToPropagate);
 
         //if head is a resource merge vps into head
-        if (headAtom.isResource()) {
+        if (headAtom.isAttribute()) {
             AttributeAtom resourceHead = (AttributeAtom) headAtom;
 
             if (resourceHead.getMultiPredicate().isEmpty()) {
@@ -314,7 +314,7 @@ public class InferenceRule {
     }
 
     private InferenceRule rewriteHeadToRelation(Atom parentAtom){
-        if (parentAtom.isRelation() && getHead().getAtom().isResource()){
+        if (parentAtom.isRelation() && getHead().getAtom().isAttribute()){
             return new InferenceRule(
                     reasonerQueryFactory.atomic(getHead().getAtom().toRelationAtom()),
                     getBody(),

--- a/graql/reasoner/rule/RuleUtils.java
+++ b/graql/reasoner/rule/RuleUtils.java
@@ -163,7 +163,7 @@ public class RuleUtils {
                     .flatMap(type -> queryCacheImpl.getFamily(type).stream())
                     .map(Equivalence.Wrapper::get)
                     .filter(q -> queryCacheImpl.getParents(q).isEmpty())
-                    .filter(q -> q.getAtom().isRelation() || q.getAtom().isResource())
+                    .filter(q -> q.getAtom().isRelation() || q.getAtom().isAttribute())
                     .collect(toSet());
             //if we don't have full information (query answers in cache), we assume reiteration is needed
             if (!queries.stream().allMatch(q -> queryCacheImpl.isDBComplete(q))) return true;

--- a/kb/graql/reasoner/atom/Atomic.java
+++ b/kb/graql/reasoner/atom/Atomic.java
@@ -92,7 +92,7 @@ public interface Atomic {
      * @return true if the atomic corresponds to a resource atom
      */
     @CheckReturnValue
-    default boolean isResource(){ return false;}
+    default boolean isAttribute(){ return false;}
 
     /**
      * @return if atom contains properties considering only explicit type hierarchies

--- a/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
@@ -354,7 +354,7 @@ public class RuleApplicabilityIT {
             Atom attribute3 = reasonerQueryFactory.create(conjunction(relationString3)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
             Set<InferenceRule> attributeRules = testTx.ruleCache().getRules()
                     .map(r -> new InferenceRule(r, reasonerQueryFactory))
-                    .filter(r -> r.getHead().getAtom().isResource())
+                    .filter(r -> r.getHead().getAtom().isAttribute())
                     .collect(Collectors.toSet());
 
             assertEquals(
@@ -388,7 +388,7 @@ public class RuleApplicabilityIT {
             assertEquals(2, type.getApplicableRules().count());
             assertEquals(1, type2.getApplicableRules().count());
             assertEquals(3, type3.getApplicableRules().count());
-            assertEquals(rules.stream().filter(r -> r.getHead().getAtom().isResource()).count(), type4.getApplicableRules().count());
+            assertEquals(rules.stream().filter(r -> r.getHead().getAtom().isAttribute()).count(), type4.getApplicableRules().count());
             assertEquals(rules.stream().filter(r -> r.getHead().getAtom().isRelation()).count(), type5.getApplicableRules().count());
         }
     }

--- a/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
+++ b/test-integration/graql/reasoner/atomic/RuleApplicabilityIT.java
@@ -343,17 +343,27 @@ public class RuleApplicabilityIT {
     @Test
     public void typedAttributes(){
         try(Transaction tx = ruleApplicabilitySession.writeTransaction()) {
-            ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
+            TestTransactionProvider.TestTransaction testTx = (TestTransactionProvider.TestTransaction)tx;
+            ReasonerQueryFactory reasonerQueryFactory = testTx.reasonerQueryFactory();
 
             String relationString = "{ $x isa reifiable-relation; $x has description $d; };";
             String relationString2 = "{ $x isa typed-relation; $x has description $d; };";
             String relationString3 = "{ $x isa relation; $x has description $d; };";
-            Atom resource = reasonerQueryFactory.create(conjunction(relationString)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
-            Atom resource2 = reasonerQueryFactory.create(conjunction(relationString2)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
-            Atom resource3 = reasonerQueryFactory.create(conjunction(relationString3)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
-            assertEquals(2, resource.getApplicableRules().count());
-            assertEquals(2, resource2.getApplicableRules().count());
-            assertEquals(3, resource3.getApplicableRules().count());
+            Atom attribute = reasonerQueryFactory.create(conjunction(relationString)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
+            Atom attribute2 = reasonerQueryFactory.create(conjunction(relationString2)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
+            Atom attribute3 = reasonerQueryFactory.create(conjunction(relationString3)).getAtoms(AttributeAtom.class).findFirst().orElse(null);
+            Set<InferenceRule> attributeRules = testTx.ruleCache().getRules()
+                    .map(r -> new InferenceRule(r, reasonerQueryFactory))
+                    .filter(r -> r.getHead().getAtom().isResource())
+                    .collect(Collectors.toSet());
+
+            assertEquals(
+                    attributeRules.stream().filter(r -> !r.getRule().label().equals(Label.of("typed-relation-description-rule"))).collect(toSet()),
+                    attribute.getApplicableRules().collect(toSet()));
+            assertEquals(
+                    attributeRules.stream().filter(r -> !r.getRule().label().equals(Label.of("reifiable-relation-description-rule"))).collect(toSet()),
+                    attribute2.getApplicableRules().collect(toSet()));
+            assertEquals(attributeRules, attribute3.getApplicableRules().collect(toSet()));
         }
     }
 

--- a/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
@@ -183,7 +183,7 @@ attributed-relation-long-rule sub rule,
     	(someRole:$x, subRole:$y, anotherRole: $z) isa attributed-relation;
     };
 
-resource-rule sub rule,
+reifiable-relation-description-rule sub rule,
     when {
         $rel (someRole: $x, subRole: $y) isa reifiable-relation;
     },
@@ -191,7 +191,7 @@ resource-rule sub rule,
         $rel has description 'reified';
     };
 
-resource-rule2 sub rule,
+typed-relation-description-rule sub rule,
     when {
         $r1 (someRole:$x, subRole:$y, anotherRole: $z) isa typed-relation;
     },
@@ -199,7 +199,7 @@ resource-rule2 sub rule,
         $r1 has description 'reified';
     };
 
-resource-rule3 sub rule,
+description-rule sub rule,
     when {
         $r has description 'typed';
         $r has description 'reified';


### PR DESCRIPTION
## What is the goal of this PR?
Instead of extending `Binary`, we make the `AttributeAtom` contain relevant `IsaAtom`s so that the `Atom` hierarchy is simpler and we enable further simplifications.
## What are the changes implemented in this PR?
`AttributeAtom` now simply extends `Atom`. We store the binary information in relevant `IsaAtom`s which we use directly for attribute unification and equivalence.

