### PR TITLE
Fix the equality comparison of AttributeAtoms with differing attribute variables

### DIFF
--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -251,7 +251,7 @@ public class AttributeAtom extends Atom{
     @Override
     public final int hashCode() {
         int hashCode = this.alphaEquivalenceHashCode();
-        hashCode = hashCode * 37 + this.getVarName().hashCode();
+        hashCode = hashCode * 37 + this.getVarName().hashCode() + this.getAttributeVariable().hashCode();
         return hashCode;
     }
 

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -216,7 +216,8 @@ public class AttributeAtom extends Atom{
         AttributeAtom a2 = (AttributeAtom) obj;
         return Objects.equals(this.getTypeLabel(), a2.getTypeLabel())
                 && this.getVarName().equals(a2.getVarName())
-                && this.multiPredicateEqual(a2);
+                && this.multiPredicateEqual(a2)
+                && this.getAttributeVariable().equals(a2.getAttributeVariable());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -216,8 +216,9 @@ public class AttributeAtom extends Atom{
         AttributeAtom a2 = (AttributeAtom) obj;
         return Objects.equals(this.getTypeLabel(), a2.getTypeLabel())
                 && this.getVarName().equals(a2.getVarName())
-                && this.multiPredicateEqual(a2)
-                && this.getAttributeVariable().equals(a2.getAttributeVariable());
+                && this.getAttributeVariable().equals(a2.getAttributeVariable())
+                && this.multiPredicateEqual(a2);
+
     }
 
     @Override

--- a/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -123,6 +123,16 @@ public class AtomicEquivalenceIT {
     }
 
     @Test
+    public void testEqualityOfAttributeAtoms() {
+        ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
+
+        String patternString = "{ $x has resource $v1; };";
+        String patternString2 = "{ $x has resource $v2; };";
+
+        atomicEquality(patternString, patternString2, false, reasonerQueryFactory);
+    }
+
+    @Test
     public void testEquality_DifferentRelationVariants() {
         ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
 

--- a/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -123,7 +123,7 @@ public class AtomicEquivalenceIT {
     }
 
     @Test
-    public void testEqualityOfAttributeAtoms() {
+    public void testEquality_AttributeAtomsWithDifferingAttributeVariables() {
         ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
 
         String patternString = "{ $x has resource $v1; };";

--- a/test-integration/graql/reasoner/reasoning/BUILD
+++ b/test-integration/graql/reasoner/reasoning/BUILD
@@ -124,7 +124,7 @@ java_test(
 
 java_test(
     name = "variable-roles-it",
-    size = "medium",
+    size = "large",
     srcs = ["VariableRolesIT.java"],
     classpath_resources = ["//test-integration/resources:logback-test"],
     resources = ["//test-integration/graql/reasoner/stubs:reasoning-stubs"],


### PR DESCRIPTION
## What is the goal of this PR?

We add a fix for the comparison of AttributeAtoms with different variables, but the same owner variable, and the same attribute type.

## What are the changes implemented in this PR?

- Equality comparison of `AttributeAtoms` now considers the attributes` variables.
- Adds a test to check this works as expected