### PR TITLE
Fix nondeterministic query resolution by extending requiresReiteration

### DIFF
--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -580,7 +580,7 @@ public class ReasonerQueryImpl extends ResolvableQuery {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
         return RuleUtils.subGraphIsCyclical(dependentRules, context().queryCache())
-                // if any role players are added, we could create a data cycle that explicit in the rules
+                // if any role players are added, we could create a data cycle that is not explicit in the rules
                 || dependentRules.stream().anyMatch(InferenceRule::appendsRolePlayers)
                 || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules)
                 || selectAtoms().filter(Atom::isDisconnected).filter(Atom::isRuleResolvable).count() > 1;

--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -580,6 +580,8 @@ public class ReasonerQueryImpl extends ResolvableQuery {
         if (isCacheComplete()) return false;
         Set<InferenceRule> dependentRules = RuleUtils.getDependentRules(this);
         return RuleUtils.subGraphIsCyclical(dependentRules, context().queryCache())
+                // if any role players are added, we could create a data cycle that explicit in the rules
+                || dependentRules.stream().anyMatch(InferenceRule::appendsRolePlayers)
                 || RuleUtils.subGraphHasRulesWithHeadSatisfyingBody(dependentRules)
                 || selectAtoms().filter(Atom::isDisconnected).filter(Atom::isRuleResolvable).count() > 1;
     }


### PR DESCRIPTION
## What is the goal of this PR?
Issue #5502 highlights a flaky test in reasoning that throws when a particular order of query resolution is picked. This is fixed by extending the reiteration criterion, which re-performs the resolution to find answers that might have been missed the first time around. 

## What are the changes implemented in this PR?
* Add `appendsRolePlayers()` for any rule to the criterion for reiteration in the resolution process. This is because extending a relation with a role player extends an existing relation can cause data cycles that we cannot detect statically (without extensively analyising the rules)