### PR TITLE
Fix and Implement Direct Sub

### DIFF
--- a/graql/executor/QueryExecutorImpl.java
+++ b/graql/executor/QueryExecutorImpl.java
@@ -119,11 +119,14 @@ public class QueryExecutorImpl implements QueryExecutor {
 
                 // TODO: lazy flatMap() is automatically fixed in Java 10 or OpenJDK 8u222, remove workaround if these conditions met
                 // custom workaround to deal with non-lazy Java 8 flatMap() functions is in LazyMergingStream
-                Stream<Conjunction<Statement>> conjunctions = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream();
-                Stream<Stream<ConceptMap>> answerStreams = conjunctions
-                        .map(p -> reasonerQueryFactory.create(p))
-                        .map(ReasonerQuery::getPattern)
+//                Stream<Conjunction<Statement>> conjunctions = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream();
+
+                Stream<Stream<ConceptMap>> answerStreams = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream()
                         .map(p -> traverse(p));
+//                Stream<Stream<ConceptMap>> answerStreams = conjunctions
+//                        .map(p -> reasonerQueryFactory.create(p))
+//                        .map(ReasonerQuery::getPattern)
+//                        .map(p -> traverse(p));
 
                 LazyMergingStream<ConceptMap> mergedStreams = new LazyMergingStream<>(answerStreams);
                 return mergedStreams.flatStream();
@@ -213,7 +216,7 @@ public class QueryExecutorImpl implements QueryExecutor {
     }
 
     @Override
-    public Stream<ConceptMap> traverse(Conjunction<Pattern> pattern) {
+    public Stream<ConceptMap> traverse(Conjunction<? extends Pattern> pattern) {
         return traverse(pattern, traversalPlanFactory.createTraversal(pattern));
     }
 
@@ -223,7 +226,7 @@ public class QueryExecutorImpl implements QueryExecutor {
      * @return resulting answer stream
      */
     @Override
-    public Stream<ConceptMap> traverse(Conjunction<Pattern> pattern, GraqlTraversal graqlTraversal) {
+    public Stream<ConceptMap> traverse(Conjunction<? extends Pattern> pattern, GraqlTraversal graqlTraversal) {
         Set<Variable> vars = Sets.filter(pattern.variables(), Variable::isReturned);
         GraphTraversal<Vertex, Map<String, Element>> traversal = graqlTraversal.getGraphTraversal(vars);
 

--- a/graql/executor/QueryExecutorImpl.java
+++ b/graql/executor/QueryExecutorImpl.java
@@ -119,14 +119,8 @@ public class QueryExecutorImpl implements QueryExecutor {
 
                 // TODO: lazy flatMap() is automatically fixed in Java 10 or OpenJDK 8u222, remove workaround if these conditions met
                 // custom workaround to deal with non-lazy Java 8 flatMap() functions is in LazyMergingStream
-//                Stream<Conjunction<Statement>> conjunctions = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream();
-
                 Stream<Stream<ConceptMap>> answerStreams = matchClause.getPatterns().getDisjunctiveNormalForm().getPatterns().stream()
                         .map(p -> traverse(p));
-//                Stream<Stream<ConceptMap>> answerStreams = conjunctions
-//                        .map(p -> reasonerQueryFactory.create(p))
-//                        .map(ReasonerQuery::getPattern)
-//                        .map(p -> traverse(p));
 
                 LazyMergingStream<ConceptMap> mergedStreams = new LazyMergingStream<>(answerStreams);
                 return mergedStreams.flatStream();

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -221,7 +221,13 @@ public class PropertyAtomicFactory {
 
     private Atomic sub(Variable var, SubProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {
         Label label = getLabel(property.type().var(), property.type(), otherStatements, ctx.conceptManager());
-        return OntologicalAtom.create(var, property.type().var(), label, parent, OntologicalAtom.OntologicalAtomType.SubAtom, ctx);
+        boolean isDirect = property.isExplicit();
+        if (isDirect) {
+            return OntologicalAtom.create(var, property.type().var(), label, parent, OntologicalAtom.OntologicalAtomType.SubDirectAtom, ctx);
+        } else {
+            return OntologicalAtom.create(var, property.type().var(), label, parent, OntologicalAtom.OntologicalAtomType.SubAtom, ctx);
+        }
+
     }
 
     private Atomic relates(Variable var, RelatesProperty property, ReasonerQuery parent, Set<Statement> otherStatements) {

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -57,6 +57,7 @@ public class OntologicalAtom extends TypeAtom {
         HasAtom(HasAttributeTypeProperty.class, (v, label) -> var(v.first()).has(type(label.getValue()))),
         PlaysAtom(PlaysProperty.class, (v, label) -> var(v.first()).plays(var(v.second()))),
         SubAtom(SubProperty.class, (v, label) -> var(v.first()).sub(var(v.second()))),
+        SubDirectAtom(SubProperty.class, (v, label) -> var(v.first()).subX(var(v.second()))),
         RelatesAtom(RelatesProperty.class, (v, label) -> var(v.first()).relates(var(v.second())));
 
         private final Class<? extends VarProperty> property;

--- a/kb/graql/executor/QueryExecutor.java
+++ b/kb/graql/executor/QueryExecutor.java
@@ -37,12 +37,12 @@ import java.util.stream.Stream;
 public interface QueryExecutor {
     Stream<ConceptMap> match(MatchClause matchClause);
 
-    Stream<ConceptMap> traverse(Conjunction<Pattern> pattern);
+    Stream<ConceptMap> traverse(Conjunction<? extends Pattern> pattern);
 
     /**
      * @return resulting answer stream
      */
-    Stream<ConceptMap> traverse(Conjunction<Pattern> pattern, GraqlTraversal graqlTraversal);
+    Stream<ConceptMap> traverse(Conjunction<? extends Pattern> pattern, GraqlTraversal graqlTraversal);
 
     Stream<ConceptMap> define(GraqlDefine query);
 

--- a/test-integration/graql/executor/BUILD
+++ b/test-integration/graql/executor/BUILD
@@ -18,11 +18,31 @@
 load("@graknlabs_build_tools//checkstyle:rules.bzl", "checkstyle_test")
 
 java_test(
-    name = "isa-explicit-it",
-    size = "large",
-    srcs = ["IsaExplicitIT.java"],
+    name = "direct-sub-it",
+    size = "small",
+    srcs = ["DirectSubIT.java"],
     classpath_resources = ["//test-integration/resources:logback-test"],
-    test_class = "grakn.core.graql.executor.IsaExplicitIT",
+    test_class = "grakn.core.graql.executor.DirectSubIT",
+    deps = [
+        "//common",
+        "//dependencies/maven/artifacts/com/google/guava",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
+        "//graql/planning",
+        "//kb/concept/api",
+        "//kb/graql/planning",
+        "//kb/server",
+        "//concept/answer",
+        "//test-integration/rule:grakn-test-server",
+        "@graknlabs_graql//java:graql",
+    ],
+)
+
+java_test(
+    name = "direct-isa-it",
+    size = "medium",
+    srcs = ["DirectIsaIT.java"],
+    classpath_resources = ["//test-integration/resources:logback-test"],
+    test_class = "grakn.core.graql.executor.DirectIsaIT",
     deps = [
         "//common",
         "//dependencies/maven/artifacts/com/google/guava",
@@ -38,5 +58,8 @@ java_test(
 
 checkstyle_test(
     name = "checkstyle",
-    targets = [":isa-explicit-it"],
+    targets = [
+        ":direct-isa-it",
+        ":direct-sub-it"
+    ],
 )

--- a/test-integration/graql/executor/BUILD
+++ b/test-integration/graql/executor/BUILD
@@ -24,7 +24,6 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.graql.executor.DirectSubIT",
     deps = [
-        "//kb/concept/api",
         "//kb/server",
         "//concept/answer",
         "//test-integration/rule:grakn-test-server",

--- a/test-integration/graql/executor/BUILD
+++ b/test-integration/graql/executor/BUILD
@@ -25,6 +25,7 @@ java_test(
     test_class = "grakn.core.graql.executor.DirectSubIT",
     deps = [
         "//kb/server",
+        "//kb/concept/api",
         "//concept/answer",
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",

--- a/test-integration/graql/executor/BUILD
+++ b/test-integration/graql/executor/BUILD
@@ -24,16 +24,13 @@ java_test(
     classpath_resources = ["//test-integration/resources:logback-test"],
     test_class = "grakn.core.graql.executor.DirectSubIT",
     deps = [
-        "//common",
-        "//dependencies/maven/artifacts/com/google/guava",
-        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
-        "//graql/planning",
         "//kb/concept/api",
-        "//kb/graql/planning",
         "//kb/server",
         "//concept/answer",
         "//test-integration/rule:grakn-test-server",
         "@graknlabs_graql//java:graql",
+        "//dependencies/maven/artifacts/com/google/guava",
+        "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
     ],
 )
 

--- a/test-integration/graql/executor/DirectIsaIT.java
+++ b/test-integration/graql/executor/DirectIsaIT.java
@@ -56,7 +56,7 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
 
 @SuppressWarnings({"CheckReturnValue", "Duplicates"})
-public class IsaExplicitIT {
+public class DirectIsaIT {
 
     @ClassRule
     public static final GraknTestStorage storage = new GraknTestStorage();

--- a/test-integration/graql/executor/DirectSubIT.java
+++ b/test-integration/graql/executor/DirectSubIT.java
@@ -19,8 +19,6 @@
 package grakn.core.graql.executor;
 
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.kb.concept.api.Label;
-import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
 import grakn.core.rule.GraknTestServer;

--- a/test-integration/graql/executor/DirectSubIT.java
+++ b/test-integration/graql/executor/DirectSubIT.java
@@ -65,7 +65,17 @@ public class DirectSubIT {
     }
 
     @Test
-    public void directSubReturnsOnlyItselfAndDirectChildTypes() {
+    public void directSubReturnsOnlyItselfAndDirectChildTypesWithoutReasoning() {
+        tx.execute(Graql.parse("define person sub entity; child sub person;").asDefine());
+        tx.commit();
+
+        tx = session.writeTransaction();
+        List<ConceptMap> directSubs = tx.execute(Graql.match(Graql.var("x").subX("entity")).get(), false);
+        assertEquals(2, directSubs.size());
+    }
+
+    @Test
+    public void directSubReturnsOnlyItselfAndDirectChildTypesWithReasoning() {
         tx.execute(Graql.parse("define person sub entity; child sub person;").asDefine());
         tx.commit();
 

--- a/test-integration/graql/executor/DirectSubIT.java
+++ b/test-integration/graql/executor/DirectSubIT.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.graql.executor;
+
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.kb.concept.api.Label;
+import grakn.core.kb.concept.api.SchemaConcept;
+import grakn.core.kb.server.Session;
+import grakn.core.kb.server.Transaction;
+import grakn.core.rule.GraknTestServer;
+import graql.lang.Graql;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DirectSubIT {
+
+    @ClassRule
+    public static final GraknTestServer graknServer = new GraknTestServer();
+    public static Session session;
+    private Transaction tx;
+
+    @BeforeClass
+    public static void newSession() {
+        session = graknServer.sessionWithNewKeyspace();
+    }
+
+    @Before
+    public void newTransaction() {
+        tx = session.writeTransaction();
+    }
+
+    @After
+    public void closeTransaction() {
+        tx.close();
+    }
+
+    @AfterClass
+    public static void closeSession() {
+        session.close();
+    }
+
+    @Test
+    public void directSubReturnsOnlyItselfAndDirectChildTypes() {
+        tx.execute(Graql.parse("define person sub entity; child sub person;").asDefine());
+        tx.commit();
+
+        tx = session.writeTransaction();
+        List<ConceptMap> directSubs = tx.execute(Graql.match(Graql.var("x").subX("entity")).get());
+        assertEquals(2, directSubs.size());
+    }
+
+
+    // TODO when subX is in the ConceptAPI, we can add this test
+    @Ignore
+    @Test
+    public void directSubInConceptAPIReturnsOnlyItselfAndDirectChildTypes() {
+    }
+}

--- a/test-integration/graql/executor/DirectSubIT.java
+++ b/test-integration/graql/executor/DirectSubIT.java
@@ -19,6 +19,7 @@
 package grakn.core.graql.executor;
 
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
 import grakn.core.rule.GraknTestServer;
@@ -34,6 +35,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class DirectSubIT {
 
@@ -70,6 +72,7 @@ public class DirectSubIT {
         tx = session.writeTransaction();
         List<ConceptMap> directSubs = tx.execute(Graql.match(Graql.var("x").subX("entity")).get(), false);
         assertEquals(2, directSubs.size());
+        assertFalse(directSubs.stream().anyMatch(conceptMap -> conceptMap.get("x").asType().label().equals(Label.of("child"))));
     }
 
     @Test
@@ -80,6 +83,7 @@ public class DirectSubIT {
         tx = session.writeTransaction();
         List<ConceptMap> directSubs = tx.execute(Graql.match(Graql.var("x").subX("entity")).get());
         assertEquals(2, directSubs.size());
+        assertFalse(directSubs.stream().anyMatch(conceptMap -> conceptMap.get("x").asType().label().equals(Label.of("child"))));
     }
 
 


### PR DESCRIPTION
## What is the goal of this PR?
#5628 flags that direct sub is broken, and #4473 indicates reasoning is not able to handle direct Sub at all. This PR implements direct Sub in reasoner, and removes the reasoning code from the non-reasoning code path to fix the direct sub when reasoning is disabled.

## What are the changes implemented in this PR?
* Add tests for direct sub with reasoning on and off
* Implement `OntologicalAtom` enum for direct sub
* Remove reasoning code from non-reasoning code path (`QueryExecutorImpl`)