### PR TITLE
Reasoner Key Atom Handling

### DIFF
--- a/test-integration/graql/reasoner/atomic/AtomicConversionIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicConversionIT.java
@@ -194,4 +194,17 @@ public class AtomicConversionIT {
             assertEquals(relation, equivalentRelation);
         }
     }
+
+    // TODO is this the right name?
+    @Test
+    public void whenConvertingAttributeAtomToRelation_equivalenceIsPreserved() {
+        try(Transaction tx = session.readTransaction()){
+            ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
+            Atom attributeAtom = reasonerQueryFactory.atomic(attributePattern).getAtom();
+
+
+            Atom equivalentRelation = attributeAtom.toRelationAtom();
+            assertEquals(attributeAtom, equivalentRelation);
+        }
+    }
 }

--- a/test-integration/graql/reasoner/resources/genericSchema.gql
+++ b/test-integration/graql/reasoner/resources/genericSchema.gql
@@ -40,6 +40,9 @@ baseEntity sub entity,
     plays baseRole3,
     abstract;
 
+keyedEntity sub baseEntity,
+    key key-resource;
+
 baseRoleEntity sub baseEntity;
 anotherBaseRoleEntity sub baseEntity;
 
@@ -101,6 +104,7 @@ resource-double sub attribute, datatype double;
 resource-date sub attribute, datatype date;
 resource-boolean sub attribute, datatype boolean;
 
+key-resource sub attribute, datatype string;
 
 binarySymmetricity sub rule,
 when {
@@ -124,8 +128,6 @@ insert
 #Instances
 
 $a isa anotherBaseRoleEntity;
-
-$b isa baseRoleEntity, has resource 'b';
 
 $f isa subRoleEntity, has resource 'f';
 $m isa subSubRoleEntity, has resource 'm';
@@ -153,6 +155,8 @@ $s isa subSubRoleEntity, has resource 's';
 
 (subSubRole1: $m, subSubRole2: $d, subSubRole3: $s) isa ternary;
 (subSubRole1: $m, subSubRole2: $m, subSubRole3: $s) isa ternary;
+
+$b isa keyedEntity, has key-resource 'b';
 
 $dummy 0 isa resource-long;
 $dummy2 1 isa resource-long;


### PR DESCRIPTION
## What is the goal of this PR?
As noted in #5503 , reasoner currently cannot convert an attribute instance ownership (using `has`) to a relation atom, if that `has` ownership is actually a `key`-ship. This is because reasoner currently assumes all ownerships are using the implicit ownership relation `@has-xxx` rather than the `@key-xxx`. This PR implements this different implicit relation.

## What are the changes implemented in this PR?
* Add test highlighting equivalence of an AttributeAtom with a key ownership -> RelationAtom being equivalent to a RelationAtom explicit to `AtomicConversionIT`