### PR TITLE
Add stricter rule validation for unplayable roles

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -133,13 +133,13 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES("Attribute [%s] is not allowed to form a rule head of rule [%s] as it copies an attribute value from an incompatible attribute type [%s]\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION("Rule [%s] attempts to rewrite type to a relation type"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION("Rule [%s] attempts to rewrite type to a relation type\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new datatype [%s]"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new datatype [%s]\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED("Rule [%s] asserts [%s] plays a role that it can never play"),
+    VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED("Rule [%s] asserts [%s] plays role [%s] that it can never play\n"),
 
     VALIDATION_RULE_INVALID_RELATION_TYPE("Rule [%s] attempts to define a relation pattern with type [%s] which is not a relation type\n"),
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -139,6 +139,8 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]"),
 
+    VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED("Rule [%s] asserts [%s] plays a role that it can never play"),
+
     VALIDATION_RULE_INVALID_RELATION_TYPE("Rule [%s] attempts to define a relation pattern with type [%s] which is not a relation type\n"),
 
     VALIDATION_RULE_INVALID_ATTRIBUTE_TYPE("Rule [%s] attempts to define an attribute pattern with type [%s] which is not an attribute type\n"),

--- a/graql/reasoner/atom/task/validate/RelationAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/RelationAtomValidator.java
@@ -147,7 +147,7 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
                     ImmutableList<Type> possibleTypesOfRolePlayer = isaAtom.getPossibleTypes();
                     boolean anyCanPlayRequiredRole = possibleTypesOfRolePlayer.stream().anyMatch(type -> type.playing().anyMatch(rolePlayed -> rolePlayed.equals(roleType)));
                     if (!anyCanPlayRequiredRole) {
-                        errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED.getMessage(rule.label(), rp.getPlayer().var()));
+                        errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED.getMessage(rule.label(), rp.getPlayer().var(), roleLabel));
                     }
                 }
             }

--- a/test-end-to-end/client-java/ClientJavaE2E.java
+++ b/test-end-to-end/client-java/ClientJavaE2E.java
@@ -140,7 +140,7 @@ public class ClientJavaE2E {
                     type("parentship").sub("relation").relates("parent").relates("child"),
 
                     type("name").sub("attribute").datatype(Graql.Token.DataType.STRING),
-                    type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring")
+                    type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring").plays("parent").plays("child")
             );
 
             GraqlDefine ruleQuery = Graql.define(type("infer-parentship-from-mating-and-child-bearing").sub("rule")

--- a/test-integration/server/RuleValidationIT.java
+++ b/test-integration/server/RuleValidationIT.java
@@ -886,6 +886,8 @@ public class RuleValidationIT {
                     Graql.var().isa("other-rel").rel("unplayed", "x")
             );
 
+            expectedException.expect(InvalidKBException.class);
+            expectedException.expectMessage("Rule [invalid-role-assignment] asserts [$x] plays a role that it can never play");
             tx.commit();
         }
     }

--- a/test-integration/server/RuleValidationIT.java
+++ b/test-integration/server/RuleValidationIT.java
@@ -887,7 +887,7 @@ public class RuleValidationIT {
             );
 
             expectedException.expect(InvalidKBException.class);
-            expectedException.expectMessage("Rule [invalid-role-assignment] asserts [$x] plays a role that it can never play");
+            expectedException.expectMessage("Rule [invalid-role-assignment] asserts [$x] plays role [unplayed] that it can never play");
             tx.commit();
         }
     }

--- a/test-integration/server/RuleValidationIT.java
+++ b/test-integration/server/RuleValidationIT.java
@@ -869,6 +869,27 @@ public class RuleValidationIT {
         }
     }
 
+    @Test
+    public void whenCreatingRuleWithImpossibleRole_rejectRule() {
+        try (Transaction tx = session.writeTransaction()) {
+            tx.execute(Graql.parse("define " +
+                    "valid-rel sub relation, relates left, relates right;" +
+                    "other-rel sub relation, relates unplayed;" +
+                    "player sub entity, plays left, plays right;"
+            ).asDefine());
+            tx.execute(Graql.insert(Sets.newHashSet(
+                    Graql.var("x").isa("player"),
+                    Graql.var("r").rel("left", "x").rel("right", "x").isa("valid-rel"))
+            ));
+            tx.putRule("invalid-role-assignment",
+                    Graql.var("r").isa("valid-rel").rel("left", "x").rel("right", "y"),
+                    Graql.var().isa("other-rel").rel("unplayed", "x")
+            );
+
+            tx.commit();
+        }
+    }
+
     public static <T> T[] concat(T[] first, T[] second) {
         T[] result = Arrays.copyOf(first, first.length + second.length);
         System.arraycopy(second, 0, result, first.length, second.length);


### PR DESCRIPTION
## What is the goal of this PR?
Validate rules more strictly, banning all occurences of rules that infer a role that can never be played for any possible type that the role player variable may be.

## What are the changes implemented in this PR?
* Add stricter rule validation for each role that is mentioned in the `then` of a rule (the head)
* Add a test that validates this throws when this is violated
* Fix client-java-E2E, which had an error in its schema flagged by this stronger validation
