### PR TITLE
Fix excessive rebuilding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # what is defined in this section will be applied at all times
-build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no
-test --show_result=0 --show_progress=no
-run --show_result=0 --show_progress=no
+build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no --incompatible_strict_action_env
+test --show_result=0 --show_progress=no --incompatible_strict_action_env
+run --show_result=0 --show_progress=no --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev


### PR DESCRIPTION
## What is the goal of this PR?

Previously, when switching between IDE and terminal builds, build cache would be fully invalidated. due to changed $PATH which defeats the sole purpose of caching. As per suggestion in [this](https://github.com/bazelbuild/intellij/issues/1169) thread, we're enabling strict environment for actions (which sets PATH alongside with other variables to minimally viable preconfigured values). 

## What are the changes implemented in this PR?

Specify `--incompatible_strict_action_env` for `build`/`test`/`run`