### PR TITLE
Include rule in explanation

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -49,7 +49,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/jmsfltchr/client-java",
-        commit = "d507ddb876b600355751b447beb71479371d2f5d",
+        commit = "cdbc13fe0d0d61f22298b9921e6620dd2127533b",
     )
 
 def graknlabs_console():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -41,15 +41,15 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "32c55fc10a7a17552b9983cffe6ab74eb69d7efa",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/jmsfltchr/protocol",
+        commit = "87c5b205ab7b8747e05e9310cc8e64bdc34c41bc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "c37f67a6a95e93d9647403b08aa3421cc047e1a7",
+        remote = "https://github.com/jmsfltchr/client-java",
+        commit = "d507ddb876b600355751b447beb71479371d2f5d",
     )
 
 def graknlabs_console():
@@ -70,7 +70,7 @@ def graknlabs_simulation():
     git_repository(
         name = "graknlabs_simulation",
         remote = "https://github.com/graknlabs/simulation",
-        commit = "c5edff018df75d96300c70bcc667f38570b389b0",
+        commit = "33ead5a0258be5bd76318d62ebdbacbb1edf6bed",
     )
 
 def graknlabs_verification():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -41,15 +41,15 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/jmsfltchr/protocol",
-        commit = "87c5b205ab7b8747e05e9310cc8e64bdc34c41bc", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "42f980f5b86f0dd79115da76f2d1867578ac061a", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/jmsfltchr/client-java",
-        commit = "cdbc13fe0d0d61f22298b9921e6620dd2127533b",
+        remote = "https://github.com/graknlabs/client-java",
+        commit = "e50f1076f5eecc6cddbc74d4e91458579f6931ce",
     )
 
 def graknlabs_console():
@@ -70,7 +70,7 @@ def graknlabs_simulation():
     git_repository(
         name = "graknlabs_simulation",
         remote = "https://github.com/graknlabs/simulation",
-        commit = "33ead5a0258be5bd76318d62ebdbacbb1edf6bed",
+        commit = "33ead5a0258be5bd76318d62ebdbacbb1edf6bed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_verification():

--- a/graql/reasoner/explanation/RuleExplanation.java
+++ b/graql/reasoner/explanation/RuleExplanation.java
@@ -20,7 +20,7 @@ package grakn.core.graql.reasoner.explanation;
 
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.Explanation;
-import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Rule;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,14 +31,14 @@ import java.util.List;
  */
 public class RuleExplanation extends Explanation {
 
-    private final ConceptId ruleId;
+    private final Rule rule;
 
-    public RuleExplanation(ConceptId ruleId){
-        this.ruleId = ruleId;
+    public RuleExplanation(Rule rule){
+        this.rule = rule;
     }
-    private RuleExplanation(List<ConceptMap> answers, ConceptId ruleId){
+    private RuleExplanation(List<ConceptMap> answers, Rule rule){
         super(answers);
-        this.ruleId = ruleId;
+        this.rule = rule;
     }
 
     @Override
@@ -50,11 +50,13 @@ public class RuleExplanation extends Explanation {
                         Collections.singletonList(ans) :
                         explanation.getAnswers()
         );
-        return new RuleExplanation(answerList, getRuleId());
+        return new RuleExplanation(answerList, rule);
     }
 
     @Override
     public boolean isRuleExplanation(){ return true;}
 
-    public ConceptId getRuleId(){ return ruleId;}
+    public Rule getRule() {
+        return rule;
+    }
 }

--- a/graql/reasoner/state/AtomicState.java
+++ b/graql/reasoner/state/AtomicState.java
@@ -137,7 +137,7 @@ public class AtomicState extends AnswerPropagatorState<ReasonerAtomicQuery> {
 
         return AnswerUtil.joinAnswers(answer, query.getSubstitution())
                 .project(query.getVarNames())
-                .explain(new RuleExplanation(rule.getRule().id()), query.getPattern());
+                .explain(new RuleExplanation(rule.getRule()), query.getPattern());
     }
 
     private ConceptMap materialisedAnswer(ConceptMap baseAnswer, InferenceRule rule, Unifier unifier) {
@@ -161,7 +161,7 @@ public class AtomicState extends AnswerPropagatorState<ReasonerAtomicQuery> {
         ConceptMap materialisedSub = ruleHead.materialise(baseAnswer).findFirst().orElse(null);
         ConceptMap answer = baseAnswer;
         if (materialisedSub != null) {
-            RuleExplanation ruleExplanation = new RuleExplanation(rule.getRule().id());
+            RuleExplanation ruleExplanation = new RuleExplanation(rule.getRule());
             ConceptMap ruleAnswer = materialisedSub.explain(ruleExplanation, query.getPattern());
             queryCache.record(ruleHead, ruleAnswer);
             Atom ruleAtom = ruleHead.getAtom();
@@ -177,6 +177,6 @@ public class AtomicState extends AnswerPropagatorState<ReasonerAtomicQuery> {
 
         return AnswerUtil.joinAnswers(answer, query.getSubstitution())
                 .project(query.getVarNames())
-                .explain(new RuleExplanation(rule.getRule().id()), query.getPattern());
+                .explain(new RuleExplanation(rule.getRule()), query.getPattern());
     }
 }

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -26,8 +26,10 @@ import grakn.core.concept.answer.ConceptSetMeasure;
 import grakn.core.concept.answer.Explanation;
 import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.answer.Void;
+import grakn.core.graql.reasoner.explanation.RuleExplanation;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.ConceptId;
+import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.concept.structure.PropertyNotUniqueException;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.server.exception.GraknServerException;
@@ -141,6 +143,13 @@ public class ResponseBuilder {
             AnswerProto.Explanation.Res.Builder explanationBuilder = AnswerProto.Explanation.Res.newBuilder()
                     .addAllExplanation(explanation.getAnswers().stream().map(Answer::conceptMap)
                             .collect(Collectors.toList()));
+
+            if (explanation.isRuleExplanation()) {
+                Rule rule = ((RuleExplanation) explanation).getRule();
+                ConceptProto.Concept ruleProto = Concept.concept(rule);
+                explanationBuilder.setRule(ruleProto);
+            }
+
             res.setExplanationRes(explanationBuilder.build());
             return res.build();
         }

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -326,9 +326,12 @@ public class ResponseBuilder {
                 conceptMapProto.putMap(var.name(), conceptProto);
             });
 
+            if (answer.getPattern() != null) {
+                conceptMapProto.setPattern(answer.getPattern().toString());
+            }
+
             if (answer.explanation() != null && !answer.explanation().isEmpty()) {
                 conceptMapProto.setHasExplanation(true);
-                conceptMapProto.setPattern(answer.getPattern().toString());
             } else {
                 conceptMapProto.setHasExplanation(false);
             }

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -221,7 +221,7 @@ public class QueryCacheIT {
 
             //record parent, mark the answers to be explained by a rule so that we can distinguish them
             tx.execute(parentQuery.getQuery(), false).stream()
-                    .map(ans -> ans.explain(new RuleExplanation(tx.getMetaRule().id()), parentQuery.getPattern()))
+                    .map(ans -> ans.explain(new RuleExplanation(tx.getMetaRule()), parentQuery.getPattern()))
                     .forEach(ans -> cache.record(parentQuery, ans));
 
             //NB: WE ACK COMPLETENESS
@@ -344,7 +344,7 @@ public class QueryCacheIT {
                             Graql.var("x").var(), mConcept,
                             Graql.var("y").var(), fConcept
                     ),
-                    new RuleExplanation(tx.getMetaRule().id()),
+                    new RuleExplanation(tx.getMetaRule()),
                     parentQuery.getPattern()
             );
             cache.record(parentQuery, inferredAnswer);
@@ -472,7 +472,7 @@ public class QueryCacheIT {
             ConceptMap inferredAnswer = new ConceptMap(ImmutableMap.of(
                     Graql.var("x").var(), tx.getEntityType("entity").instances().iterator().next(),
                     Graql.var("y").var(), tx.getEntityType("entity").instances().iterator().next()),
-                    new RuleExplanation(tx.getMetaRule().id()),
+                    new RuleExplanation(tx.getMetaRule()),
                     query.getPattern()
             );
             cache.record(query, inferredAnswer);
@@ -511,7 +511,7 @@ public class QueryCacheIT {
                     .forEach(ans -> cache.record(query, ans));
 
             //mock a rule explained answer that is equal to a dbAnswer
-            ConceptMap inferredAnswer = dbAnswer.explain(new RuleExplanation(tx.getMetaRule().id()), query.getPattern());
+            ConceptMap inferredAnswer = dbAnswer.explain(new RuleExplanation(tx.getMetaRule()), query.getPattern());
             cache.record(query, inferredAnswer);
 
             //retrieve
@@ -597,7 +597,7 @@ public class QueryCacheIT {
             ConceptMap inferredAnswer = new ConceptMap(ImmutableMap.of(
                     Graql.var("x").var(), mConcept,
                     Graql.var("y").var(), tx.getEntityType("entity").instances().iterator().next()),
-                    new RuleExplanation(tx.getMetaRule().id()),
+                    new RuleExplanation(tx.getMetaRule()),
                     childQuery.getPattern()
             );
 

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -263,6 +263,8 @@ public class GraknClientIT {
                 assertNotNull(ans.queryPattern());
                 if (ans.hasExplanation()) {
                     assertEquals("transitive-location", ans.explanation().getRule().label().toString());
+                    assertEquals("{ (contained: $x, container: $y) isa contains; (contained: $y, container: $z) isa contains; };", ans.explanation().getRule().when().toString());
+                    assertEquals("{ (contained: $x, container: $z) isa contains; };", ans.explanation().getRule().then().toString());
                     return true;
                 }
                 return false;

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -260,6 +260,7 @@ public class GraknClientIT {
 
             Set<ConceptMap> deductions = deductions(answer);
             assertTrue(deductions.stream().anyMatch(ans -> {
+                assertNotNull(ans.queryPattern());
                 if (ans.hasExplanation()) {
                     assertEquals("transitive-location", ans.explanation().getRule().label().toString());
                     return true;


### PR DESCRIPTION
## What is the goal of this PR?

When returning an explanation, we now return the rule from which the explanation is derived.

Requires:
[https://github.com/graknlabs/protocol/pull/24](https://github.com/graknlabs/protocol/pull/24)
[https://github.com/graknlabs/client-java/pull/81](https://github.com/graknlabs/client-java/pull/81)

## What are the changes implemented in this PR?

- Contruct Explanations by passing a rule rather than a rule id
  - Update other tests 
- Nest a rule in an explanation in an explanation grpc response
  - Include a test for this
- Update deps
