### PR TITLE
Rule validate duplicate role players are distinct

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -141,6 +141,8 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_ROLE_CANNOT_BE_PLAYED("Rule [%s] asserts [%s] plays role [%s] that it can never play\n"),
 
+    VALIDATION_RULE_ILLEGAL_HEAD_RELATION_POSSIBLE_DUPLICATE_ROLE_PLAYER("Rule [%s] that may infer duplicate roles played by same concept is missing != check between variables in 'when' clause: [%s]\n"),
+
     VALIDATION_RULE_INVALID_RELATION_TYPE("Rule [%s] attempts to define a relation pattern with type [%s] which is not a relation type\n"),
 
     VALIDATION_RULE_INVALID_ATTRIBUTE_TYPE("Rule [%s] attempts to define an attribute pattern with type [%s] which is not an attribute type\n"),

--- a/graql/reasoner/atom/task/validate/RelationAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/RelationAtomValidator.java
@@ -73,7 +73,7 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
         return Sets.union(
                 basicValidator.validateAsRuleHead(atom, rule, ctx),
                 validateRelationPlayers(atom, rule, ctx),
-                validateDuplicateInferredRolesMustBeDifferentConcepts(atom, ctx);
+                validateDuplicateInferredRolesMustBeDifferentConcepts(atom, rule, ctx);
     }
 
     @Override

--- a/graql/reasoner/atom/task/validate/RelationAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/RelationAtomValidator.java
@@ -70,10 +70,11 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
     @Override
     public Set<String> validateAsRuleHead(RelationAtom atom, Rule rule, ReasoningContext ctx) {
         //can form a rule head if type is specified, type is not implicit and all relation players are insertable
-        return Sets.union(
+        Set<String> errors = Sets.union(
                 basicValidator.validateAsRuleHead(atom, rule, ctx),
-                validateRelationPlayers(atom, rule, ctx),
-                validateDuplicateInferredRolesMustBeDifferentConcepts(atom, rule, ctx);
+                validateRelationPlayers(atom, rule, ctx));
+        errors.addAll(validateDuplicateInferredRolesMustBeDifferentConcepts(atom, rule, ctx));
+        return errors;
     }
 
     @Override

--- a/graql/reasoner/atom/task/validate/RelationAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/RelationAtomValidator.java
@@ -73,8 +73,7 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
         Set<String> errors = Sets.union(
                 basicValidator.validateAsRuleHead(atom, rule, ctx),
                 validateRelationPlayers(atom, rule, ctx));
-        errors.addAll(validateDuplicateInferredRolesMustBeDifferentConcepts(atom, rule, ctx));
-        return errors;
+        return Sets.union(errors, validateDuplicateInferredRolesMustBeDifferentConcepts(atom, rule, ctx));
     }
 
     @Override
@@ -168,7 +167,7 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
      * Requiring a '!=' between variables that may result in an inferred relation with duplicate role player edges.
      * For example:
      */
-    private static Set<String> validateDuplicateInferredRolesMustBeDifferentConcepts(RelationAtom headAtom, Rule rule, ReasoningContext ctx) {
+    private Set<String> validateDuplicateInferredRolesMustBeDifferentConcepts(RelationAtom headAtom, Rule rule, ReasoningContext ctx) {
         Set<String> errors = new HashSet<>();
         Map<Role, Collection<Variable>> roleVarMap = headAtom.getRoleVarMap().asMap();
         Set<Role> duplicateRoles = roleVarMap.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).collect(Collectors.toSet());
@@ -191,7 +190,7 @@ public class RelationAtomValidator implements AtomValidator<RelationAtom> {
                 boolean requiredInequalityFound = neqAssertions.stream()
                         .anyMatch(neq -> neq.getVarNames().equals(pair));
                 if (!requiredInequalityFound) {
-                    errors.add("Rule that may infer duplicate roles played by same concept is missing != check between variables: " + pair.toString());
+                    errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_RELATION_POSSIBLE_DUPLICATE_ROLE_PLAYER.getMessage(rule.label(), pair));
                 }
             }
         }

--- a/server/ValidateGlobalRules.java
+++ b/server/ValidateGlobalRules.java
@@ -366,8 +366,6 @@ public class ValidateGlobalRules {
                     .filter(Atomic::isSelectable)
                     .collect(Collectors.toSet());
 
-            validateDuplicateInferredRolesMustBeDifferentConcepts(headQuery, bodyQuery);
-
             if (selectableHeadAtoms.size() > 1) {
                 errors.add(ErrorMessage.VALIDATION_RULE_HEAD_NON_ATOMIC.getMessage(rule.label()));
             }

--- a/server/ValidateGlobalRules.java
+++ b/server/ValidateGlobalRules.java
@@ -19,6 +19,7 @@
 package grakn.core.server;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.util.Streams;
 import grakn.core.concept.impl.RelationTypeImpl;
@@ -26,6 +27,7 @@ import grakn.core.concept.impl.RuleImpl;
 import grakn.core.concept.impl.SchemaConceptImpl;
 import grakn.core.concept.impl.TypeImpl;
 import grakn.core.core.Schema;
+import grakn.core.graql.reasoner.atom.binary.RelationAtom;
 import grakn.core.graql.reasoner.query.CompositeQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.rule.RuleUtils;
@@ -47,6 +49,7 @@ import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
 import graql.lang.statement.Statement;
+import graql.lang.statement.Variable;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -358,6 +361,16 @@ public class ValidateGlobalRules {
                     .filter(Atomic::isAtom)
                     .filter(Atomic::isSelectable)
                     .collect(Collectors.toSet());
+
+            headQuery.getAtoms(RelationAtom.class)
+                    .map(relationAtom -> {
+                        Map<Role, Collection<Variable>> roleVarMap = relationAtom.getRoleVarMap().asMap();
+                        Set<Role> duplicateRoles = roleVarMap.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).collect(Collectors.toSet());
+
+                        // check that each pair of variables from the duplicate roles has a !=
+                        // otherwise there is a risk of having duplicate edges
+
+                    })
 
             if (selectableHeadAtoms.size() > 1) {
                 errors.add(ErrorMessage.VALIDATION_RULE_HEAD_NON_ATOMIC.getMessage(rule.label()));

--- a/server/ValidateGlobalRules.java
+++ b/server/ValidateGlobalRules.java
@@ -20,6 +20,7 @@ package grakn.core.server;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.util.Streams;
 import grakn.core.concept.impl.RelationTypeImpl;
@@ -28,6 +29,7 @@ import grakn.core.concept.impl.SchemaConceptImpl;
 import grakn.core.concept.impl.TypeImpl;
 import grakn.core.core.Schema;
 import grakn.core.graql.reasoner.atom.binary.RelationAtom;
+import grakn.core.graql.reasoner.atom.predicate.NeqIdPredicate;
 import grakn.core.graql.reasoner.query.CompositeQuery;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.rule.RuleUtils;
@@ -48,6 +50,7 @@ import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
 import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
+import graql.lang.property.NeqProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 
@@ -59,6 +62,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static grakn.core.common.exception.ErrorMessage.VALIDATION_CASTING;
 import static grakn.core.common.exception.ErrorMessage.VALIDATION_MORE_THAN_ONE_USE_OF_KEY;
@@ -362,15 +366,7 @@ public class ValidateGlobalRules {
                     .filter(Atomic::isSelectable)
                     .collect(Collectors.toSet());
 
-            headQuery.getAtoms(RelationAtom.class)
-                    .map(relationAtom -> {
-                        Map<Role, Collection<Variable>> roleVarMap = relationAtom.getRoleVarMap().asMap();
-                        Set<Role> duplicateRoles = roleVarMap.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).collect(Collectors.toSet());
-
-                        // check that each pair of variables from the duplicate roles has a !=
-                        // otherwise there is a risk of having duplicate edges
-
-                    })
+            validateDuplicateInferredRolesMustBeDifferentConcepts(headQuery, bodyQuery);
 
             if (selectableHeadAtoms.size() > 1) {
                 errors.add(ErrorMessage.VALIDATION_RULE_HEAD_NON_ATOMIC.getMessage(rule.label()));
@@ -439,5 +435,45 @@ public class ValidateGlobalRules {
             return Optional.of(ErrorMessage.VALIDATION_RELATION_WITH_NO_ROLE_PLAYERS.getMessage(relation.id(), relation.type().label()));
         }
         return Optional.empty();
+    }
+
+    /**
+     * We have an over-strict defensive check we enforce for now, to ensure that a rule will not throw at runtime
+     * Requiring a '!=' between variables that may result in an inferred relation with duplicate role player edges.
+     * For example:
+     *
+     *
+     * @param headQuery
+     * @param bodyQuery
+     * @return
+     */
+    private static Set<String> validateDuplicateInferredRolesMustBeDifferentConcepts(ReasonerQuery headQuery, ReasonerQuery bodyQuery) {
+        Set<String> errors = new HashSet<>();
+        headQuery.getAtoms(RelationAtom.class)
+                .forEach(relationAtom -> {
+                    Map<Role, Collection<Variable>> roleVarMap = relationAtom.getRoleVarMap().asMap();
+                    Set<Role> duplicateRoles = roleVarMap.entrySet().stream().filter(entry -> entry.getValue().size() > 1).map(Map.Entry::getKey).collect(Collectors.toSet());
+
+                    // check that each pair of variables from the duplicate roles has a !=
+                    // otherwise there is a risk of having duplicate edges
+
+                    List<NeqIdPredicate> neqAssertions = bodyQuery.getAtoms(NeqIdPredicate.class).collect(Collectors.toList());
+
+                    for (Role duplicateRole : duplicateRoles) {
+                        Set<Variable> variables = new HashSet<>(roleVarMap.get(duplicateRole));
+                        Set<List<Variable>> variablePairsWithDuplicates = Sets.cartesianProduct(variables, variables);
+                        // we can remove all the duplicate pairs because (X,Y) and (Y,X) only need to be checked once
+                        // also remove pairs (X,X), these are over-generated
+                        Set<Set<Variable>> pairs = variablePairsWithDuplicates.stream().map(HashSet::new).filter(pair -> pair.size() > 1).collect(Collectors.toSet());
+                        for (Set<Variable> pair : pairs) {
+                            boolean requiredInequalityFound = neqAssertions.stream()
+                                    .anyMatch(neq -> neq.getVarNames().equals(pair));
+                            if (!requiredInequalityFound) {
+                                errors.add("Rule that may infer duplicate roles played by same concept is missing != check between variables: " + pair.toString());
+                            }
+                        }
+                    }
+                });
+        return errors;
     }
 }

--- a/test-integration/graql/reasoner/resources/genericSchema.gql
+++ b/test-integration/graql/reasoner/resources/genericSchema.gql
@@ -105,6 +105,7 @@ resource-boolean sub attribute, datatype boolean;
 binarySymmetricity sub rule,
 when {
     (baseRole1: $x, baseRole2: $y) isa binary;
+    $x != $y;
 },
 then {
     (symmetricRole: $x, symmetricRole: $y) isa binary-symmetric;
@@ -114,6 +115,7 @@ binaryTransitivity sub rule,
 when {
     (symmetricRole: $x, symmetricRole: $y) isa binary-symmetric;
     (symmetricRole: $y, symmetricRole: $z) isa binary-symmetric;
+    $y != $z;
 },
 then {
     (symmetricRole: $y, symmetricRole: $z) isa binary-trans;

--- a/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
@@ -129,6 +129,7 @@ alternative-ternary-rule sub rule,
     when {
     	(someRole: $x, subRole: $y) isa binary;
     	(someRole: $y, subRole: $z) isa binary;
+    	$z != $y;
     },
     then {
     	(someRole:$x, subRole:$y, subRole: $z) isa ternary;
@@ -148,6 +149,7 @@ typed-reifying-rule sub rule,
     when {
     	$x isa anotherTwoRoleEntity;
     	$y isa anotherTwoRoleEntity;
+    	$x != $y;
     },
     then {
     	(symmetricRole:$x, symmetricRole:$y) isa reifying-relation;


### PR DESCRIPTION
## What is the goal of this PR?
In order to fix #5658 and #5649 , one required step is to remove the ability to infer relations that can have duplicate role players of the same role in the same relation. We do this by checking whether the rule can _possibly_ infer (as given in the `then`) a duplicate role being played by the same variable, and reject the rule at validation time if the required `!=` are missing. This is over-strict in some cases (eg. if attribute values are given making the role players always distinct in the rule `when`).

## What are the changes implemented in this PR?
Closes #5649 
* add extra rule validation to ensure that duplicate role players that may be inferred can not be identical
* tests for the above
