### PR TITLE
Role Subtype Unification Test

### DIFF
--- a/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
@@ -169,6 +169,8 @@ public class RelationSemanticProcessor implements SemanticProcessor<RelationAtom
 
                                 // if we have IDs for both variables' types for the role players
                                 // we use that for checking role compatibility rather than the type labels
+                                // in other words, we allow ID compatibility to take precedence over role type compatibility
+                                // TODO, in the future, the behaviors should be explicit and aligned
                                 boolean checkedByIdCompatibility = false;
                                 if (crp.getRole().isPresent() && prp.getRole().isPresent()) {
                                     Variable childRPVar = crp.getRole().get().var();

--- a/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.Sets;
-import com.sun.javafx.beans.IDProperty;
 import grakn.common.util.Pair;
 import grakn.core.common.util.Streams;
 import grakn.core.core.Schema;

--- a/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/RelationSemanticProcessor.java
@@ -186,7 +186,19 @@ public class RelationSemanticProcessor implements SemanticProcessor<RelationAtom
                             .filter(crp -> {
                                 Set<Atomic> parentIds = parentAtom.getPredicates(prp.getPlayer().var(), IdPredicate.class).collect(Collectors.toSet());
                                 Set<Atomic> childIds = childAtom.getPredicates(crp.getPlayer().var(), IdPredicate.class).collect(Collectors.toSet());
-                                return unifierType.idCompatibility(parentIds, childIds);
+
+
+                                Set<Atomic> parentRoleIds = new HashSet<>();
+                                if (prp.getRole().isPresent()) {
+                                    parentAtom.getAllPredicates(prp.getRole().get().var(), IdPredicate.class).forEach(parentRoleIds::add);
+                                }
+
+                                Set<Atomic> childRoleIds = new HashSet<>();
+                                if (crp.getRole().isPresent()) {
+                                    childAtom.getAllPredicates(crp.getRole().get().var(), IdPredicate.class).forEach(childRoleIds::add);
+                                }
+
+                                return unifierType.idCompatibility(parentIds, childIds) && unifierType.idCompatibility(parentRoleIds, childRoleIds);
                             })
                             //check for value predicate compatibility
                             .filter(crp -> {

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -149,9 +149,9 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
      * Rule unifier, found between queries and rule heads, allows rule heads to be more general than matched queries.
      * Used in rule matching. The general condition of the child query C (rule head) and parent query P that needs to be satisfied is:
      *
-     * C >= P,
+     * P >= C,
      *
-     * i. e. parent specialises the child.
+     * i. e. child specialises the parent.
      *
      * If two queries are alpha-equivalent they are rule-unifiable.
      * Rule unification relaxes restrictions of exact unification in that it merely

--- a/graql/reasoner/unifier/UnifierType.java
+++ b/graql/reasoner/unifier/UnifierType.java
@@ -293,8 +293,7 @@ public enum UnifierType implements UnifierComparison, EquivalenceCoupling {
 
         @Override
         public boolean idCompatibility(Atomic parent, Atomic child) {
-            return parent == null
-                    || child != null && child.isSubsumedBy(parent);
+            return parent == null || child != null && child.isSubsumedBy(parent);
         }
 
         @Override

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -555,15 +555,12 @@ public class AtomicQueryUnificationIT {
             unification(query, potentialEquivalent, true, UnifierType.RULE, testTx);
             unification(potentialEquivalent, query, true, UnifierType.RULE, testTx);
 
-            // we block subtype checking by tying the type of $role in the potentialEquivalent
+            // 'query' has answers that are not a subset of 'potentialEquivalent' because of the extra returned variable
             unification(query, potentialEquivalent, false, UnifierType.SUBSUMPTIVE, testTx);
             unification(potentialEquivalent, query, true, UnifierType.SUBSUMPTIVE, testTx);
         }
     }
 
-    /**
-     * An example of a test where we have different levels of relaxed-ness of the unifiers
-     */
     @Test
     public void testUnification_RelationRolesNotIdentical() {
         try (Transaction tx = genericSchemaSession.writeTransaction()) {
@@ -584,7 +581,7 @@ public class AtomicQueryUnificationIT {
             // structural_subsumptive is the most relaxed unifier - we don't care about IDs if they don't exist
             // and if they do, then they don't have to match
             unification(query, potentiallyParent, true, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
-            unification(potentiallyParent, query, false, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
+            unification(potentiallyParent, query, true, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
         }
     }
 

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -571,14 +571,20 @@ public class AtomicQueryUnificationIT {
             String query = "{ ($r1 : $a, $r2: $b); $r1 type baseRole1; };";
             String potentiallyParent = "{ ($r1: $x, $r2: $y); $r1 type role;};";
             unification(query, potentiallyParent, false, UnifierType.EXACT, testTx);
+
             unification(query, potentiallyParent, false, UnifierType.RULE, testTx);
+            unification(potentiallyParent, query, false, UnifierType.RULE, testTx);
             // structural requires IDs to be present in all the same places, but may not have to match
             // this is false because of role inference - we rewrite $r1 to be specific role
             unification(query, potentiallyParent, false, UnifierType.STRUCTURAL, testTx);
+            unification(potentiallyParent, query, false, UnifierType.STRUCTURAL, testTx);
+
             unification(query, potentiallyParent, false, UnifierType.SUBSUMPTIVE, testTx);
+            unification(potentiallyParent, query, false, UnifierType.SUBSUMPTIVE, testTx);
             // structural_subsumptive is the most relaxed unifier - we don't care about IDs if they don't exist
             // and if they do, then they don't have to match
             unification(query, potentiallyParent, true, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
+            unification(potentiallyParent, query, false, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
         }
     }
 

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -555,7 +555,8 @@ public class AtomicQueryUnificationIT {
             unification(query, potentialEquivalent, true, UnifierType.RULE, testTx);
             unification(potentialEquivalent, query, true, UnifierType.RULE, testTx);
 
-            unification(query, potentialEquivalent, true, UnifierType.SUBSUMPTIVE, testTx);
+            // we block subtype checking by tying the type of $role in the potentialEquivalent
+            unification(query, potentialEquivalent, false, UnifierType.SUBSUMPTIVE, testTx);
             unification(potentialEquivalent, query, true, UnifierType.SUBSUMPTIVE, testTx);
         }
     }

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -560,6 +560,25 @@ public class AtomicQueryUnificationIT {
         }
     }
 
+    /**
+     *
+     */
+    @Test
+    public void testUnification_RelationRolesNotIdentical() {
+        try (Transaction tx = genericSchemaSession.writeTransaction()) {
+            TestTransactionProvider.TestTransaction testTx = ((TestTransactionProvider.TestTransaction) tx);
+            String query = "{ ($r1 : $a, $r2: $b); $r1 type baseRole1; };";
+            String potentiallyParent = "{ ($r1: $x, $r2: $y); $r1 type role;};";
+            unification(query, potentiallyParent, false, UnifierType.EXACT, testTx);
+            unification(query, potentiallyParent, false, UnifierType.RULE, testTx);
+            // WHY is this false!
+            unification(query, potentiallyParent, false, UnifierType.STRUCTURAL, testTx);
+            unification(query, potentiallyParent, false, UnifierType.SUBSUMPTIVE, testTx);
+            // WHY does this not match structural and subsumptive
+            unification(query, potentiallyParent, false, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
+        }
+    }
+
     @Test
     public void testUnification_differentRelationVariants_EXACT() {
         try (Transaction tx = genericSchemaSession.readTransaction()) {

--- a/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test-integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -561,7 +561,7 @@ public class AtomicQueryUnificationIT {
     }
 
     /**
-     *
+     * An example of a test where we have different levels of relaxed-ness of the unifiers
      */
     @Test
     public void testUnification_RelationRolesNotIdentical() {
@@ -571,11 +571,13 @@ public class AtomicQueryUnificationIT {
             String potentiallyParent = "{ ($r1: $x, $r2: $y); $r1 type role;};";
             unification(query, potentiallyParent, false, UnifierType.EXACT, testTx);
             unification(query, potentiallyParent, false, UnifierType.RULE, testTx);
-            // WHY is this false!
+            // structural requires IDs to be present in all the same places, but may not have to match
+            // this is false because of role inference - we rewrite $r1 to be specific role
             unification(query, potentiallyParent, false, UnifierType.STRUCTURAL, testTx);
             unification(query, potentiallyParent, false, UnifierType.SUBSUMPTIVE, testTx);
-            // WHY does this not match structural and subsumptive
-            unification(query, potentiallyParent, false, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
+            // structural_subsumptive is the most relaxed unifier - we don't care about IDs if they don't exist
+            // and if they do, then they don't have to match
+            unification(query, potentiallyParent, true, UnifierType.STRUCTURAL_SUBSUMPTIVE, testTx);
         }
     }
 

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -252,7 +252,7 @@ public class SemanticDifferenceIT {
             ReasonerAtomicQuery parent = reasonerQueryFactory.atomic(conjunction(parentPattern));
             ReasonerAtomicQuery child = reasonerQueryFactory.atomic(conjunction(childPattern));
 
-            // this is
+            // uses STRUCTURAL_SUBSUMPTIVE, so we have two different unifiers from role - role and role - role2 (the role vars are not distinct, so any combination possible)
             Set<Pair<Unifier, SemanticDifference>> semanticPairs = parent.getMultiUnifierWithSemanticDiff(child);
 
             for (Pair<Unifier, SemanticDifference> semanticPair : semanticPairs) {

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -231,26 +231,6 @@ public class SemanticDifferenceIT {
         }
     }
 
-    @Test
-    public void whenChildGeneralisesRoleButInheritanceBlocked_semanticDifferenceDoesNotExist(){
-        try(TestTransaction tx = ((TestTransaction) genericSchemaSession.writeTransaction())) {
-            ReasonerQueryFactory reasonerQueryFactory = tx.reasonerQueryFactory();
-            Role baseRole = tx.getRole("baseRole1");
-            Role metaRole = tx.getMetaRole();
-
-            Pattern parentPattern = and(
-                    var().rel(var("role"), var("z")).rel("baseRole2", var("w")).isa("binary"),
-                    var("role").type(baseRole.label().getValue()));
-            Pattern childPattern = and(
-                    var().rel(var("role"), var("x")).rel("baseRole2", var("y")).isa("binary"),
-                    var("role").type(metaRole.label().getValue()));
-            ReasonerAtomicQuery parent = reasonerQueryFactory.atomic(conjunction(parentPattern));
-            ReasonerAtomicQuery child = reasonerQueryFactory.atomic(conjunction(childPattern));
-
-            Unifier unifier = parent.getMultiUnifier(child, UnifierType.SUBSUMPTIVE).getUnifier();
-            assertFalse(parent.getAtom().computeSemanticDifference(child.getAtom(), unifier).isTrivial());
-        }
-    }
 
     @Test
     public void whenChildSpecialisesRole_rolePlayersPlayingMultipleRoles_differenceIsCalculatedCorrectly(){

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -252,18 +252,20 @@ public class SemanticDifferenceIT {
             ReasonerAtomicQuery parent = reasonerQueryFactory.atomic(conjunction(parentPattern));
             ReasonerAtomicQuery child = reasonerQueryFactory.atomic(conjunction(childPattern));
 
+            // this is
             Set<Pair<Unifier, SemanticDifference>> semanticPairs = parent.getMultiUnifierWithSemanticDiff(child);
-            Pair<Unifier, SemanticDifference> semanticPair = Iterables.getOnlyElement(semanticPairs);
 
-            SemanticDifference expected = new SemanticDifference(
-                    ImmutableSet.of(
-                            new VariableDefinition(new Variable("z"), null, null, Sets.newHashSet(subRole1, subRole2), new HashSet<>())
-                    )
-            );
-            assertEquals(expected, semanticPair.second());
-            Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
-            Set<ConceptMap> propagatedAnswers = projectAnswersToChild(tx, child, parent, semanticPair.first(), semanticPair.second());
-            assertCollectionsEqual(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            for (Pair<Unifier, SemanticDifference> semanticPair : semanticPairs) {
+                SemanticDifference expected = new SemanticDifference(
+                        ImmutableSet.of(
+                                new VariableDefinition(new Variable("z"), null, null, Sets.newHashSet(subRole1, subRole2), new HashSet<>())
+                        )
+                );
+                assertEquals(expected, semanticPair.second());
+                Set<ConceptMap> childAnswers = tx.stream(child.getQuery(), false).collect(Collectors.toSet());
+                Set<ConceptMap> propagatedAnswers = projectAnswersToChild(tx, child, parent, semanticPair.first(), semanticPair.second());
+                assertCollectionsEqual(propagatedAnswers + "\n!=\n" + childAnswers + "\n", childAnswers, propagatedAnswers);
+            }
         }
     }
 

--- a/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
+++ b/test-integration/graql/reasoner/query/SemanticDifferenceIT.java
@@ -60,6 +60,7 @@ import static graql.lang.Graql.val;
 import static graql.lang.Graql.var;
 import static java.util.stream.Collectors.toSet;
 import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("Duplicates")
@@ -231,7 +232,7 @@ public class SemanticDifferenceIT {
     }
 
     @Test
-    public void whenChildGeneralisesRole_semanticDifferenceIsTrivial(){
+    public void whenChildGeneralisesRoleButInheritanceBlocked_semanticDifferenceDoesNotExist(){
         try(TestTransaction tx = ((TestTransaction) genericSchemaSession.writeTransaction())) {
             ReasonerQueryFactory reasonerQueryFactory = tx.reasonerQueryFactory();
             Role baseRole = tx.getRole("baseRole1");
@@ -247,7 +248,7 @@ public class SemanticDifferenceIT {
             ReasonerAtomicQuery child = reasonerQueryFactory.atomic(conjunction(childPattern));
 
             Unifier unifier = parent.getMultiUnifier(child, UnifierType.SUBSUMPTIVE).getUnifier();
-            assertTrue(parent.getAtom().computeSemanticDifference(child.getAtom(), unifier).isTrivial());
+            assertFalse(parent.getAtom().computeSemanticDifference(child.getAtom(), unifier).isTrivial());
         }
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
An issue highlighted when debugging #5651 via #5654 , we have a corner case in Graql that has to do with role subtyping in relations. Specifically the unification in cases where we have variable roles with types indicated separately. This test highlights the followign case:
```
child = { ($r1 : $a, $r2: $b); $r1 type baseRole1; };

parent = { ($r1: $x, $r2: $y); $r1 type role;};
```

These queries are NOT in any kind of subsumption relation, because we bind `$r1` to a specific type and inheritance mechanisms are not triggered. It is also NOT a structural unification because $r1 is inferred to be a type and replaced, meaning the structure is not the same. In this interesting case, we DO have  a STRUCTURAL_SUBSUMPTIVE unifier, as replacing $r1 with the inferred role ID leads to satisfying the more relaxed structural_subsumptive condition that IDs are not required to match.

## What are the changes implemented in this PR?
* Write a test for specifically this case, with listing the expected outcomes of each type of unification. 
* Fix one failing case where we expect the RULE unifier to fail when it doesn't, because we did not check the role variable IDs when they were present
* Skip checking role type compatibility if there are also IDs present for the role variables