### PR TITLE
Make resolution query profiler output directional

### DIFF
--- a/graql/reasoner/tree/TreeWriter.java
+++ b/graql/reasoner/tree/TreeWriter.java
@@ -52,13 +52,13 @@ public class TreeWriter {
     private void writeEdge(Node from, Node to, Map<Node, Integer> ids, BufferedWriter writer) throws IOException {
         Integer nodeId = ids.get(from);
         Integer childId = ids.get(to);
-        writer.write(nodeId + " -- " + childId + ";");
+        writer.write(nodeId + " -> " + childId + ";");
         writer.newLine();
     }
 
     void write(Node root, Map<Node, Integer> ids) throws IOException {
         try(BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(filePath.toFile())))){
-            writer.write("graph {");
+            writer.write("digraph {");
             writer.newLine();
 
             Stack<Node> nodes = new Stack<>();


### PR DESCRIPTION

## What is the goal of this PR?
We make the resolution query profile explicitly directional (edges have a strict direction). It helps removing ambiguity when reading.

## What are the changes implemented in this PR?
Updated the `TreeWriter` to output edges with directionality.
