### PR TITLE
Validate resolution profiler answers

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -203,6 +203,7 @@ public enum ErrorMessage {
     INVALID_VARIABLE_PREDICATE_STATE("Invalid state in variable predicate [%s] with answer [%s]: either a concept is missing or not an attribute."),
     NO_ATOMS_SELECTED("No atoms were selected from the query [%s]."),
     INVALID_CACHE_ENTRY("Query cache entry for query [%s] contains an invalid entry: [%s]."),
+    INVALID_RESOLUTION_PROFILER_ANSWER("Resolution node for query [%s] contains an invalid answer: [%s]."),
     NON_EXISTENT_UNIFIER("Could not proceed with the unification as the unifier doesn't exist."),
     ILLEGAL_ATOM_CONVERSION("Attempted illegal atom conversion of atom [%s] to type [%s]."),
     CONCEPT_NOT_THING("Attempted concept conversion from concept [%s] that is not a thing."),

--- a/graql/reasoner/ResolutionIterator.java
+++ b/graql/reasoner/ResolutionIterator.java
@@ -78,8 +78,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
 
             ResolutionState newState = state.generateChildState();
             if (newState != null) {
-                if (LOG.isDebugEnabled())
-                    logTree.addState(newState);
+                if (LOG.isDebugEnabled()) logTree.addState(newState);
 
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);

--- a/graql/reasoner/ResolutionIterator.java
+++ b/graql/reasoner/ResolutionIterator.java
@@ -78,7 +78,7 @@ public class ResolutionIterator extends ReasonerQueryIterator {
 
             ResolutionState newState = state.generateChildState();
             if (newState != null) {
-                if (LOG.isDebugEnabled()) logTree.addState(newState);
+                if (LOG.isDebugEnabled()) logTree.addState(newState, state);
 
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);

--- a/graql/reasoner/ResolutionIterator.java
+++ b/graql/reasoner/ResolutionIterator.java
@@ -78,12 +78,13 @@ public class ResolutionIterator extends ReasonerQueryIterator {
 
             ResolutionState newState = state.generateChildState();
             if (newState != null) {
-                if (LOG.isTraceEnabled()) logTree.addState(newState);
+                if (LOG.isDebugEnabled())
+                    logTree.addState(newState);
 
                 if (!state.isAnswerState()) states.push(state);
                 states.push(newState);
             } else {
-                if (LOG.isTraceEnabled()) {
+                if (LOG.isDebugEnabled()) {
                     Node node = logTree.getNode(state);
                     if (node != null) node.ackCompletion();
                 }
@@ -149,6 +150,6 @@ public class ResolutionIterator extends ReasonerQueryIterator {
         subGoals.forEach(queryCache::ackCompleteness);
         queryCache.propagateAnswers();
 
-        if (LOG.isTraceEnabled()) logTree.outputToFile();
+        if (LOG.isDebugEnabled()) logTree.outputToFile();
     }
 }

--- a/graql/reasoner/state/AnswerPropagatorState.java
+++ b/graql/reasoner/state/AnswerPropagatorState.java
@@ -20,6 +20,7 @@ package grakn.core.graql.reasoner.state;
 
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
+import grakn.core.graql.reasoner.query.ReasonerQueryEquivalence;
 import grakn.core.graql.reasoner.query.ResolvableQuery;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import java.util.Iterator;
@@ -67,7 +68,7 @@ public abstract class AnswerPropagatorState<Q extends ResolvableQuery> extends R
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AnswerPropagatorState<?> that = (AnswerPropagatorState<?>) o;
-        return Objects.equals(query, that.query) &&
+        return ReasonerQueryEquivalence.Equality.equivalent(query, that.query) &&
                 Objects.equals(getSubstitution(), that.getSubstitution()) &&
                 Objects.equals(unifier, that.unifier);
     }

--- a/graql/reasoner/state/AnswerState.java
+++ b/graql/reasoner/state/AnswerState.java
@@ -22,6 +22,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.rule.InferenceRule;
 import grakn.core.kb.graql.reasoner.unifier.Unifier;
 import java.util.Objects;
+import javax.annotation.CheckReturnValue;
 
 /**
  *
@@ -75,7 +76,9 @@ public class AnswerState extends ResolutionState {
         return getParentState().propagateAnswer(this);
     }
 
-    InferenceRule getRule(){ return rule;}
+    @CheckReturnValue
+    public InferenceRule getRule(){ return rule;}
 
-    Unifier getUnifier(){ return unifier;}
+    @CheckReturnValue
+    public Unifier getUnifier(){ return unifier;}
 }

--- a/graql/reasoner/tree/NodeImpl.java
+++ b/graql/reasoner/tree/NodeImpl.java
@@ -19,13 +19,20 @@
 
 package grakn.core.graql.reasoner.tree;
 
+import com.google.common.collect.Sets;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.graql.reasoner.query.ResolvableQuery;
+import grakn.core.graql.reasoner.state.AnswerPropagatorState;
 import grakn.core.graql.reasoner.state.ResolutionState;
+import grakn.core.kb.graql.reasoner.ReasonerException;
+import grakn.core.kb.graql.reasoner.atom.Atomic;
+import graql.lang.statement.Variable;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -84,7 +91,24 @@ public class NodeImpl implements Node{
 
     @Override
     public void addAnswer(ConceptMap answer){
+        if (answer.isEmpty()) return;
+        validateAnswer(answer);
         answers.add(answer);
+    }
+
+    private void validateAnswer(ConceptMap answer){
+        if (state instanceof AnswerPropagatorState){
+            ResolvableQuery query = ((AnswerPropagatorState) state).getQuery();
+            Set<Variable> atomVars = query.getAtoms().stream()
+                    .filter(at -> at.isRelation() || at.isAttribute())
+                    .map(Atomic::getVarName)
+                    .collect(Collectors.toSet());
+            Set<Variable> vars = query.getVarNames();
+            Set<Variable> answerVars = answer.vars();
+           if(Sets.difference(vars, answerVars).stream().anyMatch(v -> !atomVars.contains(v))){
+                throw ReasonerException.invalidResolutionProfilerAnswer(query, answer);
+            }
+        }
     }
 
     @Override

--- a/graql/reasoner/tree/NodeImpl.java
+++ b/graql/reasoner/tree/NodeImpl.java
@@ -96,6 +96,10 @@ public class NodeImpl implements Node{
         answers.add(answer);
     }
 
+    /**
+     * Validates answer to be attached in flight -> as the tree is constructed. This is how we test it for now.
+     * @param answer
+     */
     private void validateAnswer(ConceptMap answer){
         if (state instanceof AnswerPropagatorState){
             ResolvableQuery query = ((AnswerPropagatorState) state).getQuery();

--- a/graql/reasoner/tree/ResolutionTree.java
+++ b/graql/reasoner/tree/ResolutionTree.java
@@ -23,7 +23,15 @@ import grakn.core.common.config.Config;
 import grakn.core.common.config.ConfigKey;
 import grakn.core.common.config.SystemProperty;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.graql.reasoner.query.ResolvableQuery;
+import grakn.core.graql.reasoner.rule.InferenceRule;
+import grakn.core.graql.reasoner.state.AnswerPropagatorState;
+import grakn.core.graql.reasoner.state.AnswerState;
+import grakn.core.graql.reasoner.state.AtomicState;
 import grakn.core.graql.reasoner.state.ResolutionState;
+import grakn.core.graql.reasoner.utils.AnswerUtil;
+import grakn.core.kb.graql.reasoner.unifier.Unifier;
+import graql.lang.statement.Variable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -66,17 +74,32 @@ public class ResolutionTree {
     }
 
     public void addState(ResolutionState state) {
-        ResolutionState parent = state.getParentState();
+        AnswerPropagatorState parent = state.getParentState();
         if (parent == null) return;
 
         if (state.isAnswerState()) {
-            Node parentNode = getNode(parent);
-            if (parentNode != null){
-                ConceptMap sub = state.getSubstitution();
-                parentNode.addAnswer(sub);
-            }
+            addAnswerState((AnswerState) state, parent);
         } else {
             addChildToNode(parent, state);
+        }
+    }
+
+    private void addAnswerState(AnswerState state, AnswerPropagatorState parent){
+        Node parentNode = getNode(parent);
+        if (parentNode != null){
+            ConceptMap sub = state.getSubstitution();
+            ResolvableQuery query = parent.getQuery();
+            Set<Variable> vars = query.getVarNames();
+            InferenceRule rule = state.getRule();
+            if((parent instanceof AtomicState) &&  rule != null){
+                Unifier unifier = state.getUnifier();
+                sub = AnswerUtil.joinAnswers(
+                        sub,
+                        rule.getHead().getRoleSubstitution()
+                );
+                sub = unifier.apply(sub);
+            }
+            parentNode.addAnswer(sub.project(vars));
         }
     }
 

--- a/kb/graql/reasoner/ReasonerException.java
+++ b/kb/graql/reasoner/ReasonerException.java
@@ -82,6 +82,10 @@ public class ReasonerException extends GraknException {
         return new ReasonerException(ErrorMessage.INVALID_CACHE_ENTRY.getMessage(query.toString(), answer.toString()));
     }
 
+    public static ReasonerException invalidResolutionProfilerAnswer(ReasonerQuery query, ConceptMap answer) {
+        return new ReasonerException(ErrorMessage.INVALID_RESOLUTION_PROFILER_ANSWER.getMessage(query.toString(), answer.toString()));
+    }
+
     public static ReasonerException nonRoleIdAssignedToRoleVariable(Statement var) {
         return new ReasonerException(ErrorMessage.ROLE_ID_IS_NOT_ROLE.getMessage(var.toString()));
     }

--- a/test-integration/graql/reasoner/BUILD
+++ b/test-integration/graql/reasoner/BUILD
@@ -38,7 +38,7 @@ java_test(
     name = "geo-inference-it",
     size = "medium",
     srcs = ["GeoInferenceIT.java"],
-    classpath_resources = ["//test-integration/resources:logback-test"],
+    classpath_resources = ["//test-integration/graql/reasoner/resources:reasoner-logback-test"],
     test_class = "grakn.core.graql.reasoner.GeoInferenceIT",
     deps = [
         "//concept/answer",

--- a/test-integration/graql/reasoner/resources/BUILD
+++ b/test-integration/graql/reasoner/resources/BUILD
@@ -104,3 +104,8 @@ filegroup(
     name = "resolution-plan",
     srcs = ["resolutionPlanTest.gql"],
 )
+
+filegroup(
+    name = "reasoner-logback-test",
+    srcs = ["logback.xml"],
+)

--- a/test-integration/graql/reasoner/resources/logback.xml
+++ b/test-integration/graql/reasoner/resources/logback.xml
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (C) 2020 Grakn Labs
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as
+  ~ published by the Free Software Foundation, either version 3 of the
+  ~ License, or (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="grakn.core.graql.reasoner" level="DEBUG" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="grakn.core" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="server.Server" level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+</configuration>


### PR DESCRIPTION
## What is the goal of this PR?
Resolve issues with incomplete/out of sync answers in the resolution profiler.

## What are the changes implemented in this PR?
- We ensure all the information from the `AnswerState` and its parent is propagated into the answer saved in the resolution Profiler. 
- Changed the logging level required to produce resolution profile to DEBUG.
- We test answer validity in the resolution profile as part of the `GeoInferenceIT` test. To do that we added an extra reasoner logback file.
- Fixed issue of comparing Resolution Nodes. We now explicitly test for Equality of the corresponding queries.


