### PR TITLE
Defer db completeness check in query cache when fetching

### DIFF
--- a/graql/reasoner/cache/SemanticCache.java
+++ b/graql/reasoner/cache/SemanticCache.java
@@ -27,19 +27,17 @@ import grakn.core.graql.reasoner.rule.RuleUtils;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.api.Type;
-import grakn.core.kb.graql.executor.ExecutorFactory;
 import grakn.core.kb.graql.executor.TraversalExecutor;
 import grakn.core.kb.graql.planning.gremlin.TraversalPlanFactory;
 import grakn.core.kb.graql.reasoner.cache.CacheEntry;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import graql.lang.statement.Variable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -271,7 +269,6 @@ public abstract class SemanticCache<
     public Pair<Stream<ConceptMap>, MultiUnifier> getAnswerStreamWithUnifier(ReasonerAtomicQuery query) {
         CacheEntry<ReasonerAtomicQuery, SE> match = getEntry(query);
         boolean queryGround = query.isGround();
-        boolean queryDBComplete = isDBComplete(query);
 
         Pair<Stream<ConceptMap>, MultiUnifier> cachePair;
         if (match != null) {
@@ -297,6 +294,8 @@ public abstract class SemanticCache<
         //since ids in the parent entries are only placeholders, even if new answers are propagated they may not answer the query
         //NB: this does a GET at the moment
         boolean answersToGroundQuery = queryGround && answersQuery(query);
+        //we check the completion after possible answer propagation above
+        boolean queryDBComplete = isDBComplete(query);
 
         //if db complete or we found answers to ground query via propagation we don't need to hit the database
         if (queryDBComplete || answersToGroundQuery) return cachePair;

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -44,17 +44,17 @@ import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.query.GraqlGet;
 import graql.lang.statement.Statement;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
+import graql.lang.statement.Variable;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 import static grakn.core.util.GraqlTestUtil.assertCollectionsNonTriviallyEqual;
 import static grakn.core.util.GraqlTestUtil.loadFromFileAndCommit;
@@ -193,13 +193,20 @@ public class QueryCacheIT {
             tx.execute(parentQuery.getQuery()).stream()
                     .map(ans -> ans.explain(new LookupExplanation(), parentQuery.getPattern()))
                     .forEach(ans -> cache.record(parentQuery, ans));
+
+            //add a mocked answer to be able to check we actually retrieve from cache
+            Concept concept = tx.getEntityType("baseRoleEntity").instances().iterator().next();
+            ConceptMap mockedAnswer = new ConceptMap(ImmutableMap.of(new Variable("x"), concept, new Variable("y"), concept))
+                    .explain(new LookupExplanation(), parentQuery.getPattern());
+            cache.record(parentQuery, mockedAnswer);
             cache.ackDBCompleteness(parentQuery);
 
             //retrieve child
-            ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction("(subRole1: $x, subRole2: $y) isa binary;"));
-            Set<ConceptMap> cacheAnswers = cache.getAnswers(childQuery);
-            assertEquals(tx.stream(childQuery.getQuery()).collect(toSet()), cacheAnswers);
-            assertEquals(cacheAnswers, cache.getEntry(childQuery).cachedElement().getAll());
+            ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction("{(role: $x, role: $y) isa binary;$x isa entity;};"));
+            Set<ConceptMap> cachedAnswers = cache.getAnswers(childQuery);
+            assertTrue(cachedAnswers.contains(mockedAnswer));
+            assertTrue(cachedAnswers.containsAll(tx.execute(childQuery.getQuery())));
+            assertEquals(cachedAnswers, cache.getEntry(childQuery).cachedElement().getAll());
         }
     }
 

--- a/test-integration/graql/reasoner/cache/QueryCacheIT.java
+++ b/test-integration/graql/reasoner/cache/QueryCacheIT.java
@@ -202,7 +202,7 @@ public class QueryCacheIT {
             cache.ackDBCompleteness(parentQuery);
 
             //retrieve child
-            ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction("{(role: $x, role: $y) isa binary;$x isa entity;};"));
+            ReasonerAtomicQuery childQuery = testTx.reasonerQueryFactory().atomic(conjunction("{(role: $x, role: $y) isa binary;$x isa baseEntity;};"));
             Set<ConceptMap> cachedAnswers = cache.getAnswers(childQuery);
             assertTrue(cachedAnswers.contains(mockedAnswer));
             assertTrue(cachedAnswers.containsAll(tx.execute(childQuery.getQuery())));


### PR DESCRIPTION
## What is the goal of this PR?
When fetching answers from the query cache, we are currently checking for query completeness at the very beginning of the call. What is possible however is that we propagate answers from a complete parent and hence acknowledge a child complete. As a result, currently we would still resort to doing a DB lookup where all answers are actually available in the cache. Here, we correct this behaviour by deferring the completeness check to after potential answer propagation.

## What are the changes implemented in this PR?
Check for db-completeness only after we analysed the query match in `getAnswerStreamWithUnifier` in `SemanticCache`.

