### PR TITLE
Update console dep

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -56,7 +56,8 @@ def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        tag = "1.0.3",
+        # tag = "1.0.3",
+        commit = "27409b68d86b0b08ece1300b62dadd24baefe78b",
     )
 
 def graknlabs_benchmark():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -48,15 +48,14 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        commit = "3875b975dc781e6173119ddf28d59f579bcf7fe3",
+        remote = "https://github.com/flyingsilverfin/client-java",
+        commit = "364e640e462c2a7634e6849e5876093d35c320df",
     )
 
 def graknlabs_console():
     git_repository(
         name = "graknlabs_console",
         remote = "https://github.com/graknlabs/console",
-        # tag = "1.0.3",
         commit = "27409b68d86b0b08ece1300b62dadd24baefe78b",
     )
 


### PR DESCRIPTION
## What is the goal of this PR?
Due to a breaking change in client-java and console's printer (preventing client-java from merging its update), we have to merge console (with a dependency on my fork of client-java) and update the dependency on console here. We can then go and merge client-java and make console point at a graknlabs client java dependency again.

## What are the changes implemented in this PR?
* Bump console dependency