### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,17 +145,17 @@ jobs:
       - checkout
       - run-bazel-rbe:
           command: bazel build //:assemble-mac-zip
-      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-mac.zip --get
-      - run: unzip bazel-genfiles/grakn-core-all-mac.zip -d bazel-genfiles/
-      - run: nohup bazel-genfiles/grakn-core-all-mac/grakn server start
+      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-bin/grakn-core-all-mac.zip --get
+      - run: unzip bazel-bin/grakn-core-all-mac.zip -d bazel-bin/
+      - run: nohup bazel-bin/grakn-core-all-mac/grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
-      - run: bazel-genfiles/grakn-core-all-mac/grakn server stop
-      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-mac.zip --save-success
+      - run: bazel-bin/grakn-core-all-mac/grakn server stop
+      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-bin/grakn-core-all-mac.zip --save-success
       - store_artifacts:
-          path: bazel-genfiles/grakn-core-all-mac/logs/grakn.log
+          path: bazel-bin/grakn-core-all-mac/logs/grakn.log
           destination: logs/grakn.log
       - store_artifacts:
-          path: bazel-genfiles/grakn-core-all-mac/logs/cassandra.log
+          path: bazel-bin/grakn-core-all-mac/logs/cassandra.log
           destination: logs/cassandra.log
 
   test-assembly-windows-zip:
@@ -176,17 +176,17 @@ jobs:
       - checkout
       - run-bazel-rbe:
           command: bazel build //:assemble-linux-targz
-      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-linux.tar.gz --get
-      - run: tar -xf bazel-genfiles/grakn-core-all-linux.tar.gz -C bazel-genfiles
-      - run: nohup bazel-genfiles/grakn-core-all-linux/grakn server start
+      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-bin/grakn-core-all-linux.tar.gz --get
+      - run: tar -xf bazel-bin/grakn-core-all-linux.tar.gz -C bazel-bin
+      - run: nohup bazel-bin/grakn-core-all-linux/grakn server start
       - run: bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no
-      - run: bazel-genfiles/grakn-core-all-linux/grakn server stop
-      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-genfiles/grakn-core-all-linux.tar.gz --save-success
+      - run: bazel-bin/grakn-core-all-linux/grakn server stop
+      - run: TEST_CACHE_TOKEN=$REPO_GITHUB_TOKEN bazel run @graknlabs_build_tools//ci:test-cache -- --file $(pwd)/bazel-bin/grakn-core-all-linux.tar.gz --save-success
       - store_artifacts:
-          path: bazel-genfiles/grakn-core-all-linux/logs/grakn.log
+          path: bazel-bin/grakn-core-all-linux/logs/grakn.log
           destination: logs/grakn.log
       - store_artifacts:
-          path: bazel-genfiles/grakn-core-all-linux/logs/cassandra.log
+          path: bazel-bin/grakn-core-all-linux/logs/cassandra.log
           destination: logs/cassandra.log
 
   test-assembly-docker:

--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="bazel" version="0.29.1"/>
+    <package id="bazel" version="3.0.0"/>
     <package id="python" version="3.7.4"/>
     <package id="jdk8" version="8.0.221"/>
 </packages>

--- a/.circleci/windows/test-assembly.bat
+++ b/.circleci/windows/test-assembly.bat
@@ -25,8 +25,8 @@ REM build grakn-core-all-windows archive
 bazel build //:assemble-windows-zip || GOTO :error
 
 REM unpack and start Grakn server
-unzip bazel-genfiles\grakn-core-all-windows.zip -d bazel-genfiles\dist\ || GOTO :error
-PUSHD bazel-genfiles\dist\grakn-core-all-windows\
+unzip bazel-bin\grakn-core-all-windows.zip -d bazel-bin\dist\ || GOTO :error
+PUSHD bazel-bin\dist\grakn-core-all-windows\
 CALL grakn.bat server start || GOTO :error
 POPD
 
@@ -34,7 +34,7 @@ REM run application test
 bazel test //test/common:grakn-application-test --test_output=streamed --spawn_strategy=standalone --cache_test_results=no || GOTO :error
 
 REM stop Grakn server
-PUSHD bazel-genfiles\dist\grakn-core-all-windows\
+PUSHD bazel-bin\dist\grakn-core-all-windows\
 CALL grakn.bat server stop
 POPD
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously, CI failed because of changes caused by Bazel upgrade. Additionally, Bazel on Windows also needs to be bumped to the latest version

## What are the changes implemented in this PR?

- Bump `bazel` version for Windows CI jobs
- Replace `bazel-genfiles` with `bazel-bin` everywhere (`bazel-genfiles` symlink is no longer created by Bazel)