### PR TITLE
Fix attributes by value always erroring

### DIFF
--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -280,6 +280,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
                         break;
                     case GETATTRIBUTES_ITER_REQ:
                         getAttributes(request.getGetAttributesIterReq(), request.getOptions());
+                        break;
                     default:
                     case REQ_NOT_SET:
                         throw ResponseBuilder.exception(Status.INVALID_ARGUMENT);


### PR DESCRIPTION
## What is the goal of this PR?

Due to a missing break, getting attribute by value unintentionally returns an error message.

## What are the changes implemented in this PR?

* Added the missing break.