### PR TITLE
Replaced the term 'DataType' with 'ValueType'

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -43,7 +43,7 @@ public enum ErrorMessage {
     SUPER_LOOP_DETECTED("By setting the super of concept [%s] to [%s]. You will be creating a loop. This is prohibited"),
     INVALID_UNIQUE_PROPERTY_MUTATION("Property [%s] of Concept [%s] cannot be changed to [%s] as it is already taken by Concept [%s]"),
     UNIQUE_PROPERTY_TAKEN("Property [%s] with value [%s] is already taken by concept [%s]"),
-    INVALID_VALUETYPE("The value [%s] of type [%s] must be of valuetype [%s] for attribute type [%s]"),
+    INVALID_VALUETYPE("The value [%s] of type [%s] must be of value type [%s] for attribute type [%s]"),
     INVALID_OBJECT_TYPE("The concept [%s] is not of type [%s]"),
     REGEX_INSTANCE_FAILURE("The regex [%s] of Attribute Type [%s] cannot be applied because value [%s] " +
             "does not conform to the regular expression"),
@@ -136,7 +136,7 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION("Rule [%s] attempts to rewrite type to a relation type\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_VALUETYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new valuetype [%s]\n"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_VALUETYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new value type [%s]\n"),
 
     VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]\n"),
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -43,7 +43,7 @@ public enum ErrorMessage {
     SUPER_LOOP_DETECTED("By setting the super of concept [%s] to [%s]. You will be creating a loop. This is prohibited"),
     INVALID_UNIQUE_PROPERTY_MUTATION("Property [%s] of Concept [%s] cannot be changed to [%s] as it is already taken by Concept [%s]"),
     UNIQUE_PROPERTY_TAKEN("Property [%s] with value [%s] is already taken by concept [%s]"),
-    INVALID_DATATYPE("The value [%s] of type [%s] must be of datatype [%s] for attribute type [%s]"),
+    INVALID_VALUETYPE("The value [%s] of type [%s] must be of valuetype [%s] for attribute type [%s]"),
     INVALID_OBJECT_TYPE("The concept [%s] is not of type [%s]"),
     REGEX_INSTANCE_FAILURE("The regex [%s] of Attribute Type [%s] cannot be applied because value [%s] " +
             "does not conform to the regular expression"),
@@ -136,7 +136,7 @@ public enum ErrorMessage {
 
     VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION("Rule [%s] attempts to rewrite type to a relation type\n"),
 
-    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new datatype [%s]\n"),
+    VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_VALUETYPE_INCOMPATIBLE("Rule [%s] attempts to convert attribute to a new valuetype [%s]\n"),
 
     VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_META_TYPE("Rule [%s] changes meta type for variable [%s]\n"),
 

--- a/concept/impl/AttributeImpl.java
+++ b/concept/impl/AttributeImpl.java
@@ -36,7 +36,7 @@ import java.util.stream.Stream;
  * Represent a literal resource in the graph.
  * Acts as an Thing when relating to other instances except it has the added functionality of:
  * 1. It is unique to its AttributeType based on it's value.
- * 2. It has a AttributeType.DataType associated with it which constrains the allowed values.
+ * 2. It has a AttributeType.ValueType associated with it which constrains the allowed values.
  *
  * @param <D> The data type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
@@ -54,8 +54,8 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
      * @return The data type of this Attribute's AttributeType.
      */
     @Override
-    public AttributeType.DataType<D> dataType() {
-        return type().dataType();
+    public AttributeType.ValueType<D> valueType() {
+        return type().valueType();
     }
 
     /**
@@ -76,8 +76,8 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
      */
     @Override
     public D value() {
-        return AttributeSerialiser.of(dataType()).deserialise(
-                vertex().property(Schema.VertexProperty.ofDataType(dataType()))
+        return AttributeSerialiser.of(valueType()).deserialise(
+                vertex().property(Schema.VertexProperty.ofValueType(valueType()))
         );
     }
 

--- a/concept/impl/AttributeTypeImpl.java
+++ b/concept/impl/AttributeTypeImpl.java
@@ -133,7 +133,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      * @throws GraknConceptException when the value does not conform to the regex of its types
      */
     private void checkConformsToRegexes(String value) {
-        //Not checking the valuetype because the regex will always be null for non strings.
+        //Not checking the value type because the regex will always be null for non strings.
         this.sups().forEach(sup -> {
             String regex = sup.regex();
             if (regex != null && !Pattern.matches(regex, value)) {

--- a/concept/impl/AttributeTypeImpl.java
+++ b/concept/impl/AttributeTypeImpl.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
  * An ontological element which models and categorises the various Attribute in the graph.
  * This ontological element behaves similarly to Type when defining how it relates to other
  * types. It has two additional functions to be aware of:
- * 1. It has a AttributeType.DataType constraining the data types of the values it's instances may take.
+ * 1. It has a AttributeType.ValueType constraining the data types of the values it's instances may take.
  * 2. Any of it's instances are unique to the type.
  * For example if you have a AttributeType modelling month throughout the year there can only be one January.
  *
@@ -67,7 +67,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      */
     @Override
     public AttributeType<D> regex(String regex) {
-        if (dataType() == null || !dataType().equals(DataType.STRING)) {
+        if (valueType() == null || !valueType().equals(ValueType.STRING)) {
             throw GraknConceptException.cannotSetRegex(this);
         }
 
@@ -111,7 +111,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     private Attribute<D> putAttribute(D value, boolean isInferred) {
         Objects.requireNonNull(value);
 
-        if (dataType().equals(DataType.STRING)) checkConformsToRegexes((String) value);
+        if (valueType().equals(ValueType.STRING)) checkConformsToRegexes((String) value);
 
         Attribute<D> instance = getAttribute(value);
         if (instance == null) {
@@ -133,7 +133,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      * @throws GraknConceptException when the value does not conform to the regex of its types
      */
     private void checkConformsToRegexes(String value) {
-        //Not checking the datatype because the regex will always be null for non strings.
+        //Not checking the valuetype because the regex will always be null for non strings.
         this.sups().forEach(sup -> {
             String regex = sup.regex();
             if (regex != null && !Pattern.matches(regex, value)) {
@@ -166,14 +166,14 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @SuppressWarnings({"unchecked"})
     @Nullable
     @Override
-    public DataType<D> dataType() {
+    public ValueType<D> valueType() {
         String className = vertex().property(Schema.VertexProperty.DATA_TYPE);
         if (className == null) return null;
 
         try {
-            return (DataType<D>) DataType.of(Class.forName(className));
+            return (ValueType<D>) ValueType.of(Class.forName(className));
         } catch (ClassNotFoundException e) {
-            throw GraknConceptException.unsupportedDataType(className);
+            throw GraknConceptException.unsupportedValueType(className);
         }
     }
 

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -151,9 +151,9 @@ public class ConceptManagerImpl implements ConceptManager {
 
 
     @Override
-    public <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.DataType<V> dataType) {
+    public <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.ValueType<V> valueType) {
         VertexElement vertexElement = createSchemaVertex(label, ATTRIBUTE_TYPE, false);
-        vertexElement.propertyImmutable(Schema.VertexProperty.DATA_TYPE, dataType, null, AttributeType.DataType::name);
+        vertexElement.propertyImmutable(Schema.VertexProperty.DATA_TYPE, valueType, null, AttributeType.ValueType::name);
         AttributeType<V> attributeType = new AttributeTypeImpl<>(vertexElement, this, conceptNotificationChannel);
         attributeType.createShard();
         attributeType.sup(superType);
@@ -261,18 +261,18 @@ public class ConceptManagerImpl implements ConceptManager {
 
         VertexElement vertex = createInstanceVertex(ATTRIBUTE, isInferred);
 
-        AttributeType.DataType<V> dataType = type.dataType();
+        AttributeType.ValueType<V> dataType = type.valueType();
 
         V convertedValue;
         try {
-            convertedValue = AttributeValueConverter.of(type.dataType()).convert(value);
+            convertedValue = AttributeValueConverter.of(type.valueType()).convert(value);
         } catch (ClassCastException e){
             throw GraknConceptException.invalidAttributeValue(type, value, dataType);
         }
 
         // set persisted value
         Object valueToPersist = AttributeSerialiser.of(dataType).serialise(convertedValue);
-        Schema.VertexProperty property = Schema.VertexProperty.ofDataType(dataType);
+        Schema.VertexProperty property = Schema.VertexProperty.ofValueType(dataType);
         vertex.propertyImmutable(property, valueToPersist, null);
 
         // set unique index - combination of type and value to an indexed Janus property, used for lookups

--- a/core/AttributeSerialiser.java
+++ b/core/AttributeSerialiser.java
@@ -44,23 +44,23 @@ public abstract class AttributeSerialiser<DESERIALISED, SERIALISED> {
 
     public abstract DESERIALISED deserialise(SERIALISED value);
 
-    private static Map<AttributeType.DataType<?>, AttributeSerialiser<?, ?>> serialisers = map(
-            pair(AttributeType.DataType.BOOLEAN, BOOLEAN),
-            pair(AttributeType.DataType.DATE, DATE),
-            pair(AttributeType.DataType.DOUBLE, DOUBLE),
-            pair(AttributeType.DataType.FLOAT, FLOAT),
-            pair(AttributeType.DataType.INTEGER, INTEGER),
-            pair(AttributeType.DataType.LONG, LONG),
-            pair(AttributeType.DataType.STRING, STRING)
+    private static Map<AttributeType.ValueType<?>, AttributeSerialiser<?, ?>> serialisers = map(
+            pair(AttributeType.ValueType.BOOLEAN, BOOLEAN),
+            pair(AttributeType.ValueType.DATE, DATE),
+            pair(AttributeType.ValueType.DOUBLE, DOUBLE),
+            pair(AttributeType.ValueType.FLOAT, FLOAT),
+            pair(AttributeType.ValueType.INTEGER, INTEGER),
+            pair(AttributeType.ValueType.LONG, LONG),
+            pair(AttributeType.ValueType.STRING, STRING)
     );
 
 
     // TODO: This method should not be needed if all usage of this class is
     //       accessed via the constant properties defined above.
-    public static <DESERIALISED> AttributeSerialiser<DESERIALISED, ?> of(AttributeType.DataType<DESERIALISED> dataType) {
-        AttributeSerialiser<?, ?> attributeSerialiser = serialisers.get(dataType);
+    public static <DESERIALISED> AttributeSerialiser<DESERIALISED, ?> of(AttributeType.ValueType<DESERIALISED> valueType) {
+        AttributeSerialiser<?, ?> attributeSerialiser = serialisers.get(valueType);
         if (attributeSerialiser == null){
-            throw new UnsupportedOperationException("Unsupported DataType: " + dataType.toString());
+            throw new UnsupportedOperationException("Unsupported ValueType: " + valueType.toString());
         }
         return (AttributeSerialiser<DESERIALISED, ?>) attributeSerialiser;
 

--- a/core/AttributeValueConverter.java
+++ b/core/AttributeValueConverter.java
@@ -31,20 +31,20 @@ import java.util.Map;
  */
 public abstract class AttributeValueConverter<SOURCE, TARGET>{
 
-    private static Map<AttributeType.DataType<?>, AttributeValueConverter<?, ?>> converters = ImmutableMap.<AttributeType.DataType<?>, AttributeValueConverter<?, ?>>builder()
-            .put(AttributeType.DataType.BOOLEAN, new IdentityConverter<Boolean, Boolean>())
-            .put(AttributeType.DataType.DATE, new DateConverter())
-            .put(AttributeType.DataType.DOUBLE, new DoubleConverter())
-            .put(AttributeType.DataType.FLOAT, new FloatConverter())
-            .put(AttributeType.DataType.INTEGER, new IntegerConverter())
-            .put(AttributeType.DataType.LONG, new LongConverter())
-            .put(AttributeType.DataType.STRING, new IdentityConverter<String, String>())
+    private static Map<AttributeType.ValueType<?>, AttributeValueConverter<?, ?>> converters = ImmutableMap.<AttributeType.ValueType<?>, AttributeValueConverter<?, ?>>builder()
+            .put(AttributeType.ValueType.BOOLEAN, new IdentityConverter<Boolean, Boolean>())
+            .put(AttributeType.ValueType.DATE, new DateConverter())
+            .put(AttributeType.ValueType.DOUBLE, new DoubleConverter())
+            .put(AttributeType.ValueType.FLOAT, new FloatConverter())
+            .put(AttributeType.ValueType.INTEGER, new IntegerConverter())
+            .put(AttributeType.ValueType.LONG, new LongConverter())
+            .put(AttributeType.ValueType.STRING, new IdentityConverter<String, String>())
             .build();
 
-    public static <SOURCE, TARGET> AttributeValueConverter<SOURCE, TARGET> of(AttributeType.DataType<TARGET> dataType) {
-        AttributeValueConverter<?, ?> converter = converters.get(dataType);
+    public static <SOURCE, TARGET> AttributeValueConverter<SOURCE, TARGET> of(AttributeType.ValueType<TARGET> valueType) {
+        AttributeValueConverter<?, ?> converter = converters.get(valueType);
         if (converter == null){
-            throw new UnsupportedOperationException("Unsupported DataType: " + dataType.toString());
+            throw new UnsupportedOperationException("Unsupported ValueType: " + valueType.toString());
         }
         return (AttributeValueConverter<SOURCE, TARGET>) converter;
     }

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -221,30 +221,30 @@ public final class Schema {
         VALUE_INTEGER(Integer.class), VALUE_FLOAT(Float.class),
         VALUE_DATE(Long.class);
 
-        private final Class dataType;
+        private final Class valueType;
 
-        private static Map<AttributeType.DataType, VertexProperty> dataTypeVertexProperty = map(
-                pair(AttributeType.DataType.BOOLEAN, VertexProperty.VALUE_BOOLEAN),
-                pair(AttributeType.DataType.DATE, VertexProperty.VALUE_DATE),
-                pair(AttributeType.DataType.DOUBLE, VertexProperty.VALUE_DOUBLE),
-                pair(AttributeType.DataType.FLOAT, VertexProperty.VALUE_FLOAT),
-                pair(AttributeType.DataType.INTEGER, VertexProperty.VALUE_INTEGER),
-                pair(AttributeType.DataType.LONG, VertexProperty.VALUE_LONG),
-                pair(AttributeType.DataType.STRING, VertexProperty.VALUE_STRING)
+        private static Map<AttributeType.ValueType, VertexProperty> valueTypeVertexProperty = map(
+                pair(AttributeType.ValueType.BOOLEAN, VertexProperty.VALUE_BOOLEAN),
+                pair(AttributeType.ValueType.DATE, VertexProperty.VALUE_DATE),
+                pair(AttributeType.ValueType.DOUBLE, VertexProperty.VALUE_DOUBLE),
+                pair(AttributeType.ValueType.FLOAT, VertexProperty.VALUE_FLOAT),
+                pair(AttributeType.ValueType.INTEGER, VertexProperty.VALUE_INTEGER),
+                pair(AttributeType.ValueType.LONG, VertexProperty.VALUE_LONG),
+                pair(AttributeType.ValueType.STRING, VertexProperty.VALUE_STRING)
         );
 
-        VertexProperty(Class dataType) {
-            this.dataType = dataType;
+        VertexProperty(Class valueType) {
+            this.valueType = valueType;
         }
 
         @CheckReturnValue
         public Class getPropertyClass() {
-            return dataType;
+            return valueType;
         }
 
         // TODO: This method feels out of place
-        public static VertexProperty ofDataType(AttributeType.DataType dataType) {
-            return dataTypeVertexProperty.get(dataType);
+        public static VertexProperty ofValueType(AttributeType.ValueType valueType) {
+            return valueTypeVertexProperty.get(valueType);
         }
     }
 
@@ -259,15 +259,15 @@ public final class Schema {
         REQUIRED(Boolean.class),
         IS_INFERRED(Boolean.class);
 
-        private final Class dataType;
+        private final Class valueType;
 
-        EdgeProperty(Class dataType) {
-            this.dataType = dataType;
+        EdgeProperty(Class valueType) {
+            this.valueType = valueType;
         }
 
         @CheckReturnValue
         public Class getPropertyClass() {
-            return dataType;
+            return valueType;
         }
     }
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -34,8 +34,8 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/haikalpribadi/graql",
-        commit = "eb67f0b2eeb2452ca63d8088e5b6527cc151add8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        remote = "https://github.com/graknlabs/graql",
+        commit = "1c573108b3ab8505ab0168f146071fe032d62a61",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -48,8 +48,8 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
-        tag = "1.7.0",
+        remote = "https://github.com/haikalpribadi/client-java",
+        commit = "04e318d512bfbaff4385e0b738b486311948e5d2",
     )
 
 def graknlabs_console():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -35,7 +35,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/haikalpribadi/graql",
-        commit = "7c0adc15412437519d5e3008ccdedd2160d9f028",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "eb67f0b2eeb2452ca63d8088e5b6527cc151add8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "git@github.com:graknlabs/verification.git",
-        commit = "57bd3d144835b494512a35c442b49e789788900d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "d0790e06ff5569b2c5347f55a73d66d50072a515",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -35,7 +35,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "1c573108b3ab8505ab0168f146071fe032d62a61",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "71e25d448805f34090bdd408205cdef7aa8eb929",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -34,8 +34,8 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        tag = "1.0.6",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        remote = "https://github.com/haikalpribadi/graql",
+        commit = "7c0adc15412437519d5e3008ccdedd2160d9f028",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -69,8 +69,8 @@ def graknlabs_simulation():
 def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
-        remote = "git@github.com:graknlabs/verification.git",
-        commit = "d0790e06ff5569b2c5347f55a73d66d50072a515",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        remote = "git@github.com:haikalpribadi/verification.git",
+        commit = "1c5324a6741a86963d4757cbc33ab6d9a1da6b64",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/graql/analytics/GraknMapReduce.java
+++ b/graql/analytics/GraknMapReduce.java
@@ -51,9 +51,9 @@ public abstract class GraknMapReduce<T> extends CommonOLAP
         this.selectedTypes = selectedTypes;
     }
 
-    GraknMapReduce(Set<LabelId> selectedTypes, AttributeType.DataType resourceDataType) {
+    GraknMapReduce(Set<LabelId> selectedTypes, AttributeType.ValueType valueType) {
         this(selectedTypes);
-        persistentProperties.put(RESOURCE_DATA_TYPE_KEY, resourceDataType.name());
+        persistentProperties.put(RESOURCE_DATA_TYPE_KEY, valueType.name());
     }
 
     // Needed internally for OLAP tasks
@@ -136,6 +136,6 @@ public abstract class GraknMapReduce<T> extends CommonOLAP
     }
 
     final boolean usingLong() {
-        return persistentProperties.get(RESOURCE_DATA_TYPE_KEY).equals(AttributeType.DataType.LONG.name());
+        return persistentProperties.get(RESOURCE_DATA_TYPE_KEY).equals(AttributeType.ValueType.LONG.name());
     }
 }

--- a/graql/analytics/MaxMapReduce.java
+++ b/graql/analytics/MaxMapReduce.java
@@ -38,8 +38,8 @@ public class MaxMapReduce extends StatisticsMapReduce<Number> {
     public MaxMapReduce() {
     }
 
-    public MaxMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
-        super(selectedLabelIds, resourceDataType, degreePropertyKey);
+    public MaxMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreePropertyKey) {
+        super(selectedLabelIds, valueType, degreePropertyKey);
     }
 
     @Override

--- a/graql/analytics/MeanMapReduce.java
+++ b/graql/analytics/MeanMapReduce.java
@@ -43,8 +43,8 @@ public class MeanMapReduce extends StatisticsMapReduce<Map<String, Double>> {
     public MeanMapReduce() {
     }
 
-    public MeanMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreeKey) {
-        super(selectedLabelIds, resourceDataType, degreeKey);
+    public MeanMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreeKey) {
+        super(selectedLabelIds, valueType, degreeKey);
     }
 
     @Override

--- a/graql/analytics/MedianVertexProgram.java
+++ b/graql/analytics/MedianVertexProgram.java
@@ -51,8 +51,8 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
     private static final int MAX_ITERATION = 40;
     public static final String MEDIAN = "medianVertexProgram.median";
 
-    private static final String RESOURCE_DATA_TYPE = "medianVertexProgram.resourceDataType";
-    private static final String RESOURCE_TYPE = "medianVertexProgram.statisticsResourceType";
+    private static final String ATTRIBUTE_VALUE_TYPE = "medianVertexProgram.attributeValueType";
+    private static final String ATTRIBUTE_TYPE = "medianVertexProgram.attributeType";
     private static final String LABEL = "medianVertexProgram.label";
     private static final String COUNT = "medianVertexProgram.count";
     private static final String INDEX_START = "medianVertexProgram.indexStart";
@@ -90,12 +90,12 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
     }
 
     public MedianVertexProgram(Set<LabelId> statisticsResourceLabelIds,
-                               AttributeType.DataType resourceDataType) {
+                               AttributeType.ValueType valueType) {
         this.statisticsResourceLabelIds = statisticsResourceLabelIds;
 
-        String resourceDataTypeValue = resourceDataType.equals(AttributeType.DataType.LONG) ?
+        String valueTypeStr = valueType.equals(AttributeType.ValueType.LONG) ?
                 Schema.VertexProperty.VALUE_LONG.name() : Schema.VertexProperty.VALUE_DOUBLE.name();
-        persistentProperties.put(RESOURCE_DATA_TYPE, resourceDataTypeValue);
+        persistentProperties.put(ATTRIBUTE_VALUE_TYPE, valueTypeStr);
     }
 
     @Override
@@ -126,14 +126,14 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
     public void storeState(final Configuration configuration) {
         super.storeState(configuration);
         statisticsResourceLabelIds.forEach(
-                typeId -> configuration.addProperty(RESOURCE_TYPE + "." + typeId, typeId));
+                typeId -> configuration.addProperty(ATTRIBUTE_TYPE + "." + typeId, typeId));
     }
 
     @Override
     public void loadState(Graph graph, Configuration configuration) {
         super.loadState(graph, configuration);
-        configuration.subset(RESOURCE_TYPE).getKeys().forEachRemaining(key ->
-                statisticsResourceLabelIds.add((LabelId) configuration.getProperty(RESOURCE_TYPE + "." + key)));
+        configuration.subset(ATTRIBUTE_TYPE).getKeys().forEachRemaining(key ->
+                statisticsResourceLabelIds.add((LabelId) configuration.getProperty(ATTRIBUTE_TYPE + "." + key)));
     }
 
     @Override
@@ -144,7 +144,7 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
         memory.set(NEGATIVE_COUNT, 0L);
         memory.set(POSITIVE_COUNT, 0L);
         memory.set(FOUND, false);
-        if (persistentProperties.get(RESOURCE_DATA_TYPE).equals(Schema.VertexProperty.VALUE_LONG.name())) {
+        if (persistentProperties.get(ATTRIBUTE_VALUE_TYPE).equals(Schema.VertexProperty.VALUE_LONG.name())) {
             memory.set(MEDIAN, 0L);
             memory.set(PIVOT, 0L);
             memory.set(PIVOT_NEGATIVE, 0L);
@@ -175,7 +175,7 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
                     // select pivot randomly
                     if (degree > 0) {
                         memory.add(PIVOT,
-                                vertex.value((String) persistentProperties.get(RESOURCE_DATA_TYPE)));
+                                vertex.value((String) persistentProperties.get(ATTRIBUTE_VALUE_TYPE)));
                         memory.add(COUNT, degree);
                     }
                 }
@@ -183,7 +183,7 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
             case 3:
                 if (vertexHasSelectedTypeId(vertex, statisticsResourceLabelIds) &&
                         (long) vertex.value(DEGREE) > 0) {
-                    Number value = vertex.value((String) persistentProperties.get(RESOURCE_DATA_TYPE));
+                    Number value = vertex.value((String) persistentProperties.get(ATTRIBUTE_VALUE_TYPE));
                     if (value.doubleValue() < memory.<Number>get(PIVOT).doubleValue()) {
                         updateMemoryNegative(vertex, memory, value);
                     } else if (value.doubleValue() > memory.<Number>get(PIVOT).doubleValue()) {
@@ -199,7 +199,7 @@ public class MedianVertexProgram extends GraknVertexProgram<Long> {
                 if (vertexHasSelectedTypeId(vertex, statisticsResourceLabelIds) &&
                         (long) vertex.value(DEGREE) > 0 &&
                         (int) vertex.value(LABEL) == memory.<Integer>get(LABEL_SELECTED)) {
-                    Number value = vertex.value((String) persistentProperties.get(RESOURCE_DATA_TYPE));
+                    Number value = vertex.value((String) persistentProperties.get(ATTRIBUTE_VALUE_TYPE));
                     if (value.doubleValue() < memory.<Number>get(PIVOT).doubleValue()) {
                         updateMemoryNegative(vertex, memory, value);
                     } else if (value.doubleValue() > memory.<Number>get(PIVOT).doubleValue()) {

--- a/graql/analytics/MinMapReduce.java
+++ b/graql/analytics/MinMapReduce.java
@@ -38,8 +38,8 @@ public class MinMapReduce extends StatisticsMapReduce<Number> {
     public MinMapReduce() {
     }
 
-    public MinMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
-        super(selectedLabelIds, resourceDataType, degreePropertyKey);
+    public MinMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreePropertyKey) {
+        super(selectedLabelIds, valueType, degreePropertyKey);
     }
 
     @Override

--- a/graql/analytics/StatisticsMapReduce.java
+++ b/graql/analytics/StatisticsMapReduce.java
@@ -38,8 +38,8 @@ public abstract class StatisticsMapReduce<T> extends GraknMapReduce<T> {
 
     StatisticsMapReduce() {}
 
-    StatisticsMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
-        super(selectedLabelIds, resourceDataType);
+    StatisticsMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreePropertyKey) {
+        super(selectedLabelIds, valueType);
         this.degreePropertyKey = degreePropertyKey;
         this.persistentProperties.put(DegreeVertexProgram.DEGREE, degreePropertyKey);
     }

--- a/graql/analytics/StdMapReduce.java
+++ b/graql/analytics/StdMapReduce.java
@@ -44,8 +44,8 @@ public class StdMapReduce extends StatisticsMapReduce<Map<String, Double>> {
     public StdMapReduce() {
     }
 
-    public StdMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
-        super(selectedLabelIds, resourceDataType, degreePropertyKey);
+    public StdMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreePropertyKey) {
+        super(selectedLabelIds, valueType, degreePropertyKey);
     }
 
     @Override

--- a/graql/analytics/SumMapReduce.java
+++ b/graql/analytics/SumMapReduce.java
@@ -39,8 +39,8 @@ public class SumMapReduce extends StatisticsMapReduce<Number> {
     public SumMapReduce() {
     }
 
-    public SumMapReduce(Set<LabelId> selectedLabelIds, AttributeType.DataType resourceDataType, String degreePropertyKey) {
-        super(selectedLabelIds, resourceDataType, degreePropertyKey);
+    public SumMapReduce(Set<LabelId> selectedLabelIds, AttributeType.ValueType valueType, String degreePropertyKey) {
+        super(selectedLabelIds, valueType, degreePropertyKey);
     }
 
     @Override

--- a/graql/executor/ComputeExecutorImpl.java
+++ b/graql/executor/ComputeExecutorImpl.java
@@ -221,14 +221,14 @@ public class ComputeExecutorImpl implements ComputeExecutor {
      */
     @Nullable
     private <S> S runComputeStatistics(GraqlCompute.Statistics.Value query) {
-        AttributeType.DataType<?> targetDataType = validateAndGetTargetDataType(query);
+        AttributeType.ValueType<?> targetValueType = validateAndGetTargetValueType(query);
         if (!targetContainsInstance(query)) return null;
 
         Set<LabelId> extendedScopeTypes = convertLabelsToIds(extendedScopeTypeLabels(query));
         Set<LabelId> targetTypes = convertLabelsToIds(targetTypeLabels(query));
 
-        VertexProgram program = initStatisticsVertexProgram(query, targetTypes, targetDataType);
-        StatisticsMapReduce<?> mapReduce = initStatisticsMapReduce(query, targetTypes, targetDataType);
+        VertexProgram program = initStatisticsVertexProgram(query, targetTypes, targetValueType);
+        StatisticsMapReduce<?> mapReduce = initStatisticsMapReduce(query, targetTypes, targetValueType);
         ComputerResult computerResult = compute(program, mapReduce, extendedScopeTypes);
 
         if (query.method().equals(MEDIAN)) {
@@ -245,29 +245,29 @@ public class ComputeExecutorImpl implements ComputeExecutor {
     /**
      * Helper method to validate that the target types are of one data type, and get that data type
      *
-     * @return the DataType of the target types
+     * @return the ValueType of the target types
      */
     @Nullable
-    private AttributeType.DataType<?> validateAndGetTargetDataType(GraqlCompute.Statistics.Value query) {
-        AttributeType.DataType<?> dataType = null;
+    private AttributeType.ValueType<?> validateAndGetTargetValueType(GraqlCompute.Statistics.Value query) {
+        AttributeType.ValueType<?> valueType = null;
         for (Type type : targetTypes(query)) {
             // check if the selected type is a attribute type
             if (!type.isAttributeType()) throw GraqlSemanticException.mustBeAttributeType(type.label());
             AttributeType<?> attributeType = type.asAttributeType();
-            if (dataType == null) {
+            if (valueType == null) {
                 // check if the attribute type has data-type LONG or DOUBLE
-                dataType = attributeType.dataType();
-                if (!dataType.equals(AttributeType.DataType.LONG) && !dataType.equals(AttributeType.DataType.DOUBLE)) {
-                    throw GraqlSemanticException.attributeMustBeANumber(dataType, attributeType.label());
+                valueType = attributeType.valueType();
+                if (!valueType.equals(AttributeType.ValueType.LONG) && !valueType.equals(AttributeType.ValueType.DOUBLE)) {
+                    throw GraqlSemanticException.attributeMustBeANumber(valueType, attributeType.label());
                 }
             } else {
                 // check if all the attribute types have the same data-type
-                if (!dataType.equals(attributeType.dataType())) {
-                    throw GraqlSemanticException.attributesWithDifferentDataTypes(query.of());
+                if (!valueType.equals(attributeType.valueType())) {
+                    throw GraqlSemanticException.attributesWithDifferentValueTypes(query.of());
                 }
             }
         }
-        return dataType;
+        return valueType;
     }
 
     /**
@@ -275,11 +275,11 @@ public class ComputeExecutorImpl implements ComputeExecutor {
      *
      * @param query          representing the compute query
      * @param targetTypes    representing the attribute types in which the statistics computation is targeted for
-     * @param targetDataType representing the data type of the target attribute types
+     * @param targetValueType representing the data type of the target attribute types
      * @return an object which is a subclass of VertexProgram
      */
-    private VertexProgram initStatisticsVertexProgram(GraqlCompute query, Set<LabelId> targetTypes, AttributeType.DataType<?> targetDataType) {
-        if (query.method().equals(MEDIAN)) return new MedianVertexProgram(targetTypes, targetDataType);
+    private VertexProgram initStatisticsVertexProgram(GraqlCompute query, Set<LabelId> targetTypes, AttributeType.ValueType<?> targetValueType) {
+        if (query.method().equals(MEDIAN)) return new MedianVertexProgram(targetTypes, targetValueType);
         else return new DegreeStatisticsVertexProgram(targetTypes);
     }
 
@@ -287,23 +287,23 @@ public class ComputeExecutorImpl implements ComputeExecutor {
      * Helper method to initialise the MapReduce algorithm for compute statistics queries
      *
      * @param targetTypes    representing the attribute types in which the statistics computation is targeted for
-     * @param targetDataType representing the data type of the target attribute types
+     * @param targetValueType representing the data type of the target attribute types
      * @return an object which is a subclass of StatisticsMapReduce
      */
     private StatisticsMapReduce<?> initStatisticsMapReduce(GraqlCompute.Statistics.Value query,
                                                            Set<LabelId> targetTypes,
-                                                           AttributeType.DataType<?> targetDataType) {
+                                                           AttributeType.ValueType<?> targetValueType) {
         Graql.Token.Compute.Method method = query.method();
         if (method.equals(MIN)) {
-            return new MinMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
+            return new MinMapReduce(targetTypes, targetValueType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(MAX)) {
-            return new MaxMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
+            return new MaxMapReduce(targetTypes, targetValueType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(MEAN)) {
-            return new MeanMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
+            return new MeanMapReduce(targetTypes, targetValueType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(STD)) {
-            return new StdMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
+            return new StdMapReduce(targetTypes, targetValueType, DegreeVertexProgram.DEGREE);
         } else if (method.equals(SUM)) {
-            return new SumMapReduce(targetTypes, targetDataType, DegreeVertexProgram.DEGREE);
+            return new SumMapReduce(targetTypes, targetValueType, DegreeVertexProgram.DEGREE);
         }
 
         return null;

--- a/graql/executor/ConceptBuilderImpl.java
+++ b/graql/executor/ConceptBuilderImpl.java
@@ -148,8 +148,8 @@ public class ConceptBuilderImpl implements ConceptBuilder {
     }
 
     @Override
-    public ConceptBuilder dataType(AttributeType.DataType<?> dataType) {
-        return set(DATA_TYPE, dataType);
+    public ConceptBuilder valueType(AttributeType.ValueType<?> valueType) {
+        return set(DATA_TYPE, valueType);
     }
 
     @Override
@@ -275,7 +275,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
     private static final BuilderParam<Label> LABEL = BuilderParam.of(Graql.Token.Property.TYPE);
     private static final BuilderParam<ConceptId> ID = BuilderParam.of(Graql.Token.Property.ID);
     private static final BuilderParam<Object> VALUE = BuilderParam.of(Graql.Token.Property.VALUE);
-    private static final BuilderParam<AttributeType.DataType<?>> DATA_TYPE = BuilderParam.of(Graql.Token.Property.DATA_TYPE);
+    private static final BuilderParam<AttributeType.ValueType<?>> DATA_TYPE = BuilderParam.of(Graql.Token.Property.VALUETYPE);
     private static final BuilderParam<Pattern> WHEN = BuilderParam.of(Graql.Token.Property.WHEN);
     private static final BuilderParam<Pattern> THEN = BuilderParam.of(Graql.Token.Property.THEN);
     private static final BuilderParam<Unit> IS_ROLE = BuilderParam.of("role"); // TODO: replace this with a value registered in an enum
@@ -340,7 +340,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
         validateParam(concept, LABEL, SchemaConcept.class, SchemaConcept::label);
         validateParam(concept, ID, Concept.class, Concept::id);
         validateParam(concept, VALUE, Attribute.class, Attribute::value);
-        validateParam(concept, DATA_TYPE, AttributeType.class, AttributeType::dataType);
+        validateParam(concept, DATA_TYPE, AttributeType.class, AttributeType::valueType);
         validateParam(concept, WHEN, Rule.class, Rule::when);
         validateParam(concept, THEN, Rule.class, Rule::then);
     }
@@ -394,8 +394,8 @@ public class ConceptBuilderImpl implements ConceptBuilder {
             concept = putSchemaConcept(label, () -> conceptManager.createRole(label, superConcept.asRole()), Role.class);
         } else if (superConcept.isAttributeType()) {
             AttributeType attributeType = superConcept.asAttributeType();
-            AttributeType.DataType<?> dataType = useOrDefault(DATA_TYPE, attributeType.dataType());
-            concept = putSchemaConcept(label, () -> conceptManager.createAttributeType(label, superConcept.asAttributeType(), dataType), AttributeType.class);
+            AttributeType.ValueType<?> valueType = useOrDefault(DATA_TYPE, attributeType.valueType());
+            concept = putSchemaConcept(label, () -> conceptManager.createAttributeType(label, superConcept.asAttributeType(), valueType), AttributeType.class);
         } else if (superConcept.isRule()) {
             concept = putSchemaConcept(label, () -> conceptManager.createRule(label, use(WHEN), use(THEN), superConcept.asRule()), Rule.class);
         } else {

--- a/graql/executor/ConceptBuilderImpl.java
+++ b/graql/executor/ConceptBuilderImpl.java
@@ -275,7 +275,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
     private static final BuilderParam<Label> LABEL = BuilderParam.of(Graql.Token.Property.TYPE);
     private static final BuilderParam<ConceptId> ID = BuilderParam.of(Graql.Token.Property.ID);
     private static final BuilderParam<Object> VALUE = BuilderParam.of(Graql.Token.Property.VALUE);
-    private static final BuilderParam<AttributeType.ValueType<?>> DATA_TYPE = BuilderParam.of(Graql.Token.Property.VALUETYPE);
+    private static final BuilderParam<AttributeType.ValueType<?>> DATA_TYPE = BuilderParam.of(Graql.Token.Property.VALUE_TYPE);
     private static final BuilderParam<Pattern> WHEN = BuilderParam.of(Graql.Token.Property.WHEN);
     private static final BuilderParam<Pattern> THEN = BuilderParam.of(Graql.Token.Property.THEN);
     private static final BuilderParam<Unit> IS_ROLE = BuilderParam.of("role"); // TODO: replace this with a value registered in an enum

--- a/graql/executor/property/PropertyExecutorFactoryImpl.java
+++ b/graql/executor/property/PropertyExecutorFactoryImpl.java
@@ -22,7 +22,7 @@ import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.executor.property.PropertyExecutor;
 import grakn.core.kb.graql.executor.property.PropertyExecutorFactory;
 import graql.lang.property.AbstractProperty;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.property.HasAttributeProperty;
 import graql.lang.property.HasAttributeTypeProperty;
 import graql.lang.property.IdProperty;
@@ -65,8 +65,8 @@ public class PropertyExecutorFactoryImpl implements PropertyExecutorFactory {
     }
 
     public PropertyExecutor create(Variable var, VarProperty property) {
-        if (property instanceof DataTypeProperty) {
-            return new DataTypeExecutor(var, (DataTypeProperty) property);
+        if (property instanceof ValueTypeProperty) {
+            return new ValueTypeExecutor(var, (ValueTypeProperty) property);
 
         } else if (property instanceof HasAttributeProperty) {
             return new HasAttributeExecutor(var, (HasAttributeProperty) property);

--- a/graql/executor/property/ValueTypeExecutor.java
+++ b/graql/executor/property/ValueTypeExecutor.java
@@ -26,21 +26,21 @@ import grakn.core.kb.graql.executor.WriteExecutor;
 import grakn.core.kb.graql.executor.property.PropertyExecutor;
 import grakn.core.kb.graql.planning.gremlin.EquivalentFragmentSet;
 import graql.lang.Graql;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class DataTypeExecutor implements PropertyExecutor.Definable {
+public class ValueTypeExecutor implements PropertyExecutor.Definable {
 
     private final Variable var;
-    private final DataTypeProperty property;
-    private final AttributeType.DataType dataType;
-    private static final ImmutableMap<Graql.Token.DataType, AttributeType.DataType<?>> DATA_TYPES = dataTypes();
+    private final ValueTypeProperty property;
+    private final AttributeType.ValueType valueType;
+    private static final ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> DATA_TYPES = valueTypes();
 
-    DataTypeExecutor(Variable var, DataTypeProperty property) {
+    ValueTypeExecutor(Variable var, ValueTypeProperty property) {
         if (var == null) {
             throw new NullPointerException("Variable is null");
         }
@@ -51,42 +51,42 @@ public class DataTypeExecutor implements PropertyExecutor.Definable {
         }
         this.property = property;
 
-        if (!DATA_TYPES.containsKey(property.dataType())) {
+        if (!DATA_TYPES.containsKey(property.valueType())) {
             throw new IllegalArgumentException("Unrecognised Attribute data type");
         }
-        this.dataType = DATA_TYPES.get(property.dataType());
+        this.valueType = DATA_TYPES.get(property.valueType());
     }
 
-    private static ImmutableMap<Graql.Token.DataType, AttributeType.DataType<?>> dataTypes() {
-        ImmutableMap.Builder<Graql.Token.DataType, AttributeType.DataType<?>> dataTypes = new ImmutableMap.Builder<>();
-        dataTypes.put(Graql.Token.DataType.BOOLEAN, AttributeType.DataType.BOOLEAN);
-        dataTypes.put(Graql.Token.DataType.DATE, AttributeType.DataType.DATE);
-        dataTypes.put(Graql.Token.DataType.DOUBLE, AttributeType.DataType.DOUBLE);
-        dataTypes.put(Graql.Token.DataType.LONG, AttributeType.DataType.LONG);
-        dataTypes.put(Graql.Token.DataType.STRING, AttributeType.DataType.STRING);
+    private static ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes() {
+        ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes = new ImmutableMap.Builder<>();
+        valueTypes.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
+        valueTypes.put(Graql.Token.ValueType.DATE, AttributeType.ValueType.DATE);
+        valueTypes.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
+        valueTypes.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
+        valueTypes.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);
 
-        return dataTypes.build();
+        return valueTypes.build();
     }
 
     @Override
     public Set<EquivalentFragmentSet> matchFragments() {
         return Collections.unmodifiableSet(Collections.singleton(
-                EquivalentFragmentSets.dataType(property, var, dataType)
+                EquivalentFragmentSets.valueType(property, var, valueType)
         ));
     }
 
 
     @Override
     public Set<PropertyExecutor.Writer> defineExecutors() {
-        return ImmutableSet.of(new DefineDataType());
+        return ImmutableSet.of(new DefineValueType());
     }
 
     @Override
     public Set<PropertyExecutor.Writer> undefineExecutors() {
-        return ImmutableSet.of(new UndefineDataType());
+        return ImmutableSet.of(new UndefineValueType());
     }
 
-    private abstract class DataTypeWriter {
+    private abstract class ValueTypeWriter {
 
         public Variable var() {
             return var;
@@ -101,11 +101,11 @@ public class DataTypeExecutor implements PropertyExecutor.Definable {
         }
     }
 
-    private class DefineDataType extends DataTypeWriter implements PropertyExecutor.Writer {
+    private class DefineValueType extends ValueTypeWriter implements PropertyExecutor.Writer {
 
         @Override
         public void execute(WriteExecutor executor) {
-            executor.getBuilder(var).dataType(dataType);
+            executor.getBuilder(var).valueType(valueType);
         }
 
         @Override
@@ -114,7 +114,7 @@ public class DataTypeExecutor implements PropertyExecutor.Definable {
         }
     }
 
-    private class UndefineDataType extends DataTypeWriter implements PropertyExecutor.Writer {
+    private class UndefineValueType extends ValueTypeWriter implements PropertyExecutor.Writer {
 
         @Override
         public Set<Variable> producedVars() {
@@ -124,15 +124,15 @@ public class DataTypeExecutor implements PropertyExecutor.Definable {
         @Override
         public void execute(WriteExecutor executor) {
             // TODO: resolve the below issue correctly
-            // undefine for datatype must be supported, because it is supported in define.
+            // undefine for valueType must be supported, because it is supported in define.
             // However, making it do the right thing is difficult. Ideally we want the same as define:
             //
-            //    undefine name datatype string, sub attribute; <- Remove `name`
+            //    undefine name valueType string, sub attribute; <- Remove `name`
             //    undefine first-name sub name;                 <- Remove `first-name`
-            //    undefine name datatype string;                <- FAIL
+            //    undefine name valueType string;                <- FAIL
             //    undefine name sub attribute;                  <- FAIL
             //
-            // Doing this is tough because it means the `datatype` property needs to be aware of the context somehow.
+            // Doing this is tough because it means the `valueType` property needs to be aware of the context somehow.
             // As a compromise, we make all the cases succeed (where some do nothing)
         }
     }

--- a/graql/executor/property/ValueTypeExecutor.java
+++ b/graql/executor/property/ValueTypeExecutor.java
@@ -52,7 +52,7 @@ public class ValueTypeExecutor implements PropertyExecutor.Definable {
         this.property = property;
 
         if (!DATA_TYPES.containsKey(property.valueType())) {
-            throw new IllegalArgumentException("Unrecognised Attribute data type");
+            throw new IllegalArgumentException("Unrecognised Attribute value type");
         }
         this.valueType = DATA_TYPES.get(property.valueType());
     }

--- a/graql/planning/gremlin/fragment/FragmentImpl.java
+++ b/graql/planning/gremlin/fragment/FragmentImpl.java
@@ -88,7 +88,7 @@ public abstract class FragmentImpl implements Fragment {
     static final double COST_NODE_INDEX_VALUE = -Math.log(NUM_INSTANCES_PER_TYPE / NUM_RESOURCES_PER_VALUE);
 
     static final double COST_NODE_NEQ = -Math.log(2D);
-    static final double COST_NODE_DATA_TYPE = -Math.log(AttributeType.DataType.values().size() / 2D);
+    static final double COST_NODE_DATA_TYPE = -Math.log(AttributeType.ValueType.values().size() / 2D);
     static final double COST_NODE_UNSPECIFIC_PREDICATE = -Math.log(2D);
     static final double COST_NODE_REGEX = -Math.log(2D);
     static final double COST_NODE_NOT_INTERNAL = -Math.log(1.1D);

--- a/graql/planning/gremlin/fragment/Fragments.java
+++ b/graql/planning/gremlin/fragment/Fragments.java
@@ -93,8 +93,8 @@ public class Fragments {
         return new OutIsaFragment(varProperty, start, end);
     }
 
-    public static Fragment dataType(VarProperty varProperty, Variable start, AttributeType.DataType dataType) {
-        return new DataTypeFragment(varProperty, start, dataType);
+    public static Fragment valueType(VarProperty varProperty, Variable start, AttributeType.ValueType valueType) {
+        return new ValueTypeFragment(varProperty, start, valueType);
     }
 
     public static Fragment inPlays(VarProperty varProperty, Variable start, Variable end, boolean required) {

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -52,7 +52,7 @@ class ValueTypeFragment extends FragmentImpl {
 
     @Override
     public String name() {
-        return "[valuetype:" + valueType().name() + "]";
+        return "[value:" + valueType().name() + "]";
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -31,28 +31,28 @@ import java.util.Objects;
 
 import static grakn.core.core.Schema.VertexProperty.DATA_TYPE;
 
-class DataTypeFragment extends FragmentImpl {
+class ValueTypeFragment extends FragmentImpl {
 
-    private final AttributeType.DataType dataType;
+    private final AttributeType.ValueType valueType;
 
-    DataTypeFragment(@Nullable VarProperty varProperty, Variable start, AttributeType.DataType dataType) {
+    ValueTypeFragment(@Nullable VarProperty varProperty, Variable start, AttributeType.ValueType valueType) {
         super(varProperty, start);
-        this.dataType = dataType;
+        this.valueType = valueType;
     }
 
-    private AttributeType.DataType dataType() {
-        return dataType;
+    private AttributeType.ValueType valueType() {
+        return valueType;
     }
 
     @Override
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return traversal.has(DATA_TYPE.name(), dataType().name());
+        return traversal.has(DATA_TYPE.name(), valueType().name());
     }
 
     @Override
     public String name() {
-        return "[datatype:" + dataType().name() + "]";
+        return "[valuetype:" + valueType().name() + "]";
     }
 
     @Override
@@ -65,17 +65,17 @@ class DataTypeFragment extends FragmentImpl {
         if (o == this) {
             return true;
         }
-        if (o instanceof DataTypeFragment) {
-            DataTypeFragment that = (DataTypeFragment) o;
+        if (o instanceof ValueTypeFragment) {
+            ValueTypeFragment that = (ValueTypeFragment) o;
             return ((this.varProperty == null) ? (that.varProperty() == null) : this.varProperty.equals(that.varProperty()))
                     && (this.start.equals(that.start()))
-                    && (this.dataType.equals(that.dataType()));
+                    && (this.valueType.equals(that.valueType()));
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(varProperty, start, dataType);
+        return Objects.hash(varProperty, start, valueType);
     }
 }

--- a/graql/planning/gremlin/sets/AttributeIndexFragmentSet.java
+++ b/graql/planning/gremlin/sets/AttributeIndexFragmentSet.java
@@ -111,11 +111,11 @@ public class AttributeIndexFragmentSet extends EquivalentFragmentSetImpl {
 
         Object value = valueSet.operation().value();
 
-        AttributeType.DataType<?> dataType = conceptManager.getAttributeType(label.getValue()).dataType();
-        if (Number.class.isAssignableFrom(dataType.dataClass())) {
-            if (dataType.dataClass() == Long.class && value instanceof Double && ((Double) value % 1 == 0)) {
+        AttributeType.ValueType<?> valueType = conceptManager.getAttributeType(label.getValue()).valueType();
+        if (Number.class.isAssignableFrom(valueType.valueClass())) {
+            if (valueType.valueClass() == Long.class && value instanceof Double && ((Double) value % 1 == 0)) {
                 value = ((Double) value).longValue();
-            } else if (dataType.dataClass() == Double.class && value instanceof Long) {
+            } else if (valueType.valueClass() == Double.class && value instanceof Long) {
                 value = ((Long) value).doubleValue();
             }
         }

--- a/graql/planning/gremlin/sets/EquivalentFragmentSets.java
+++ b/graql/planning/gremlin/sets/EquivalentFragmentSets.java
@@ -150,8 +150,8 @@ public class EquivalentFragmentSets {
     /**
      * An EquivalentFragmentSet that indicates a variable representing a resource type with a data-type.
      */
-    public static EquivalentFragmentSet dataType(VarProperty varProperty, Variable resourceType, AttributeType.DataType<?> dataType) {
-        return new DataTypeFragmentSet(varProperty, resourceType, dataType);
+    public static EquivalentFragmentSet valueType(VarProperty varProperty, Variable resourceType, AttributeType.ValueType<?> valueType) {
+        return new ValueTypeFragmentSet(varProperty, resourceType, valueType);
     }
 
     /**

--- a/graql/planning/gremlin/sets/ValueTypeFragmentSet.java
+++ b/graql/planning/gremlin/sets/ValueTypeFragmentSet.java
@@ -29,27 +29,23 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * see EquivalentFragmentSets#dataType(VarProperty, Variable, AttributeType.DataType)
+ * see EquivalentFragmentSets#valueType(VarProperty, Variable, AttributeType.DataType)
  *
  */
-class DataTypeFragmentSet extends EquivalentFragmentSetImpl {
+class ValueTypeFragmentSet extends EquivalentFragmentSetImpl {
     private final Variable attributeType;
-    private final AttributeType.DataType dataType;
+    private final AttributeType.ValueType valueType;
 
-    DataTypeFragmentSet(
-            @Nullable VarProperty varProperty,
-            Variable attributeType,
-            AttributeType.DataType dataType) {
+    ValueTypeFragmentSet(@Nullable VarProperty varProperty, Variable attributeType, AttributeType.ValueType valueType) {
         super(varProperty);
-
         this.attributeType = attributeType;
-        this.dataType = dataType;
+        this.valueType = valueType;
     }
 
 
     @Override
     public final Set<Fragment> fragments() {
-        return ImmutableSet.of(Fragments.dataType(varProperty(), attributeType, dataType));
+        return ImmutableSet.of(Fragments.valueType(varProperty(), attributeType, valueType));
     }
 
     @Override
@@ -57,17 +53,17 @@ class DataTypeFragmentSet extends EquivalentFragmentSetImpl {
         if (o == this) {
             return true;
         }
-        if (o instanceof DataTypeFragmentSet) {
-            DataTypeFragmentSet that = (DataTypeFragmentSet) o;
+        if (o instanceof ValueTypeFragmentSet) {
+            ValueTypeFragmentSet that = (ValueTypeFragmentSet) o;
             return ((this.varProperty() == null) ? (that.varProperty() == null) : this.varProperty().equals(that.varProperty()))
                     && (this.attributeType.equals(that.attributeType))
-                    && (this.dataType.equals(that.dataType));
+                    && (this.valueType.equals(that.valueType));
         }
         return false;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(varProperty(), attributeType, dataType);
+        return Objects.hash(varProperty(), attributeType, valueType);
     }
 }

--- a/graql/planning/gremlin/value/ValueComparison.java
+++ b/graql/planning/gremlin/value/ValueComparison.java
@@ -193,8 +193,8 @@ public abstract class ValueComparison<T, U> extends ValueOperation<T, U> {
         private final java.lang.String gremlinVariable;
 
         private static final Map<Graql.Token.Comparator, Function<java.lang.String, P<java.lang.String>>> PREDICATES_VAR = varPredicates();
-        private static final java.lang.String[] VALUE_PROPERTIES = AttributeType.DataType.values().stream()
-                .map(Schema.VertexProperty::ofDataType).distinct()
+        private static final java.lang.String[] VALUE_PROPERTIES = AttributeType.ValueType.values().stream()
+                .map(Schema.VertexProperty::ofValueType).distinct()
                 .map(Enum::name).toArray(java.lang.String[]::new);
 
         Variable(Graql.Token.Comparator comparator, Statement value) {

--- a/graql/planning/gremlin/value/ValueOperation.java
+++ b/graql/planning/gremlin/value/ValueOperation.java
@@ -78,9 +78,9 @@ public abstract class ValueOperation<T, U> {
 
     public <S, E> GraphTraversal<S, E> apply(GraphTraversal<S, E> traversal) {
         List<GraphTraversal<?, E>> valueTraversals = new ArrayList<>();
-        AttributeType.DataType<?> dataType = AttributeType.DataType.of(value().getClass());
-        for (AttributeType.DataType<?> comparableDataType : dataType.comparableDataTypes()) {
-            Schema.VertexProperty property = Schema.VertexProperty.ofDataType(comparableDataType);
+        AttributeType.ValueType<?> valueType = AttributeType.ValueType.of(value().getClass());
+        for (AttributeType.ValueType<?> comparableValueType : valueType.comparableValueTypes()) {
+            Schema.VertexProperty property = Schema.VertexProperty.ofValueType(comparableValueType);
             valueTraversals.add(__.has(property.name(), predicate()));
         }
 
@@ -92,8 +92,8 @@ public abstract class ValueOperation<T, U> {
     public boolean test(Object otherValue) {
         if (this.value().getClass().isInstance(otherValue)) {
             // TODO: Remove this forced casting
-            AttributeType.DataType<T> dataType = (AttributeType.DataType<T>) AttributeType.DataType.of(value().getClass());
-            return predicate().test((U) AttributeSerialiser.of(dataType).serialise((T) otherValue));
+            AttributeType.ValueType<T> valueType = (AttributeType.ValueType<T>) AttributeType.ValueType.of(value().getClass());
+            return predicate().test((U) AttributeSerialiser.of(valueType).serialise((T) otherValue));
         } else {
             return false;
         }

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -28,7 +28,7 @@ import grakn.core.graql.reasoner.atom.predicate.IdPredicate;
 import grakn.core.graql.reasoner.atom.predicate.NeqIdPredicate;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.atom.predicate.VariableValuePredicate;
-import grakn.core.graql.reasoner.atom.property.DataTypeAtom;
+import grakn.core.graql.reasoner.atom.property.ValueTypeAtom;
 import grakn.core.graql.reasoner.atom.property.IsAbstractAtom;
 import grakn.core.graql.reasoner.atom.property.RegexAtom;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
@@ -46,7 +46,7 @@ import grakn.core.kb.keyspace.KeyspaceStatistics;
 import graql.lang.Graql;
 import graql.lang.pattern.Conjunction;
 import graql.lang.property.AbstractProperty;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.property.HasAttributeProperty;
 import graql.lang.property.HasAttributeTypeProperty;
 import graql.lang.property.IdProperty;
@@ -91,8 +91,8 @@ public class PropertyAtomicFactory {
     }
 
     private Atomic createAtom(Variable var, VarProperty property, ReasonerQuery parent, Statement statement, Set<Statement> otherStatements) {
-        if (property instanceof DataTypeProperty) {
-            return dataType(var, (DataTypeProperty) property, parent);
+        if (property instanceof ValueTypeProperty) {
+            return valueType(var, (ValueTypeProperty) property, parent);
 
         } else if (property instanceof HasAttributeProperty) {
             return hasAttribute(var, (HasAttributeProperty) property, parent, otherStatements);
@@ -273,15 +273,15 @@ public class PropertyAtomicFactory {
     }
 
 
-    private DataTypeAtom dataType(Variable var, DataTypeProperty property, ReasonerQuery parent) {
-        ImmutableMap.Builder<Graql.Token.DataType, AttributeType.DataType<?>> dataTypesBuilder = new ImmutableMap.Builder<>();
-        dataTypesBuilder.put(Graql.Token.DataType.BOOLEAN, AttributeType.DataType.BOOLEAN);
-        dataTypesBuilder.put(Graql.Token.DataType.DATE, AttributeType.DataType.DATE);
-        dataTypesBuilder.put(Graql.Token.DataType.DOUBLE, AttributeType.DataType.DOUBLE);
-        dataTypesBuilder.put(Graql.Token.DataType.LONG, AttributeType.DataType.LONG);
-        dataTypesBuilder.put(Graql.Token.DataType.STRING, AttributeType.DataType.STRING);
-        ImmutableMap<Graql.Token.DataType, AttributeType.DataType<?>> dataTypes = dataTypesBuilder.build();
-        return DataTypeAtom.create(var, property, parent, dataTypes.get(property.dataType()));
+    private ValueTypeAtom valueType(Variable var, ValueTypeProperty property, ReasonerQuery parent) {
+        ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypesBuilder = new ImmutableMap.Builder<>();
+        valueTypesBuilder.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
+        valueTypesBuilder.put(Graql.Token.ValueType.DATE, AttributeType.ValueType.DATE);
+        valueTypesBuilder.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
+        valueTypesBuilder.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
+        valueTypesBuilder.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);
+        ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes = valueTypesBuilder.build();
+        return ValueTypeAtom.create(var, property, parent, valueTypes.get(property.valueType()));
     }
 
     private Atomic isAbstract(Variable var, ReasonerQuery parent) {

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -54,11 +54,12 @@ import graql.lang.property.ValueProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
+
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
 
 import static grakn.core.graql.reasoner.utils.ReasonerUtils.isEquivalentCollection;
 
@@ -138,15 +139,15 @@ public class AttributeAtom extends Atom{
         AttributeType<Object> attributeType = type.isAttributeType()? type.asAttributeType() : null;
         if (attributeType == null || Schema.MetaSchema.isMetaLabel(attributeType.label())) return this;
 
-        AttributeType.DataType<Object> dataType = attributeType.dataType();
+        AttributeType.ValueType<Object> valueType = attributeType.valueType();
         Set<ValuePredicate> newMultiPredicate = this.getMultiPredicate().stream().map(vp -> {
             Object value = vp.getPredicate().value();
             if (value == null) return vp;
             Object convertedValue;
             try {
-                convertedValue = AttributeValueConverter.of(dataType).convert(value);
+                convertedValue = AttributeValueConverter.of(valueType).convert(value);
             } catch (ClassCastException e){
-                throw GraqlSemanticException.incompatibleAttributeValue(dataType, value);
+                throw GraqlSemanticException.incompatibleAttributeValue(valueType, value);
             }
             ValueProperty.Operation operation = ValueProperty.Operation.Comparison.of(vp.getPredicate().comparator(), convertedValue);
             return ValuePredicate.create(vp.getVarName(), operation, getParentQuery());

--- a/graql/reasoner/atom/property/ValueTypeAtom.java
+++ b/graql/reasoner/atom/property/ValueTypeAtom.java
@@ -40,7 +40,7 @@ public class ValueTypeAtom extends AtomicBase {
 
     public static ValueTypeAtom create(Variable var, ValueTypeProperty prop, ReasonerQuery parent, AttributeType.ValueType<?> dataType) {
         Variable varName = var.asReturnedVar();
-        return new ValueTypeAtom(varName, new Statement(varName).valueType(prop.valueType()), parent, dataType);
+        return new ValueTypeAtom(varName, new Statement(varName).value(prop.valueType()), parent, dataType);
     }
 
     private static ValueTypeAtom create(ValueTypeAtom a, ReasonerQuery parent) {

--- a/graql/reasoner/atom/property/ValueTypeAtom.java
+++ b/graql/reasoner/atom/property/ValueTypeAtom.java
@@ -22,33 +22,33 @@ import grakn.core.graql.reasoner.atom.AtomicBase;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.graql.reasoner.atom.Atomic;
 import grakn.core.kb.graql.reasoner.query.ReasonerQuery;
-import graql.lang.property.DataTypeProperty;
+import graql.lang.property.ValueTypeProperty;
 import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 
 /**
- * Atomic corresponding to DataTypeProperty.
+ * Atomic corresponding to ValueTypeProperty.
  */
-public class DataTypeAtom extends AtomicBase {
+public class ValueTypeAtom extends AtomicBase {
 
-    private final AttributeType.DataType<?> dataType;
+    private final AttributeType.ValueType<?> valueType;
 
-    private DataTypeAtom(Variable varName, Statement pattern, ReasonerQuery parentQuery, AttributeType.DataType<?> dataType) {
+    private ValueTypeAtom(Variable varName, Statement pattern, ReasonerQuery parentQuery, AttributeType.ValueType<?> valueType) {
         super(parentQuery, varName, pattern);
-        this.dataType = dataType;
+        this.valueType = valueType;
     }
 
-    public static DataTypeAtom create(Variable var, DataTypeProperty prop, ReasonerQuery parent, AttributeType.DataType<?> dataType) {
+    public static ValueTypeAtom create(Variable var, ValueTypeProperty prop, ReasonerQuery parent, AttributeType.ValueType<?> dataType) {
         Variable varName = var.asReturnedVar();
-        return new DataTypeAtom(varName, new Statement(varName).datatype(prop.dataType()), parent, dataType);
+        return new ValueTypeAtom(varName, new Statement(varName).valueType(prop.valueType()), parent, dataType);
     }
 
-    private static DataTypeAtom create(DataTypeAtom a, ReasonerQuery parent) {
-        return new DataTypeAtom(a.getVarName(), a.getPattern(), parent, a.getDataType());
+    private static ValueTypeAtom create(ValueTypeAtom a, ReasonerQuery parent) {
+        return new ValueTypeAtom(a.getVarName(), a.getPattern(), parent, a.getValueType());
     }
 
-    public AttributeType.DataType<?> getDataType() {
-        return dataType;
+    public AttributeType.ValueType<?> getValueType() {
+        return valueType;
     }
 
     @Override
@@ -58,13 +58,13 @@ public class DataTypeAtom extends AtomicBase {
     public boolean isAlphaEquivalent(Object obj) {
         if (obj == null || this.getClass() != obj.getClass()) return false;
         if (obj == this) return true;
-        DataTypeAtom a2 = (DataTypeAtom) obj;
-        return this.getDataType().equals(a2.getDataType());
+        ValueTypeAtom a2 = (ValueTypeAtom) obj;
+        return this.getValueType().equals(a2.getValueType());
     }
 
     @Override
     public int alphaEquivalenceHashCode() {
-        return getDataType().hashCode();
+        return getValueType().hashCode();
     }
 
     @Override

--- a/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
+++ b/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
@@ -55,7 +55,7 @@ public class AttributeMaterialiser implements AtomMaterialiser<AttributeAtom> {
         if (atom.isValueEquality()) {
             ValuePredicate vp = Iterables.getOnlyElement(atom.getMultiPredicate());
             Object value = vp.getPredicate().value();
-            Object persistedValue = AttributeValueConverter.of(attributeType.dataType()).convert(value);
+            Object persistedValue = AttributeValueConverter.of(attributeType.valueType()).convert(value);
             Attribute existingAttribute = attributeType.attribute(persistedValue);
             attribute = existingAttribute == null ? attributeType.putAttributeInferred(persistedValue) : existingAttribute;
         } else {

--- a/graql/reasoner/atom/task/validate/AttributeAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/AttributeAtomValidator.java
@@ -71,13 +71,13 @@ public class AttributeAtomValidator implements AtomValidator<AttributeAtom> {
                 errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_ATOM_WITH_UNBOUND_VARIABLE.getMessage(rule.then(), rule.label()));
             }
 
-            AttributeType.DataType<Object> dataType = type.asAttributeType().dataType();
+            AttributeType.ValueType<Object> valueType = type.asAttributeType().valueType();
             ResolvableQuery body = CacheCasting.ruleCacheCast(ctx.ruleCache()).getRule(rule).getBody();
             ErrorMessage incompatibleValuesMsg = ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_COPYING_INCOMPATIBLE_ATTRIBUTE_VALUES;
             body.getAtoms(AttributeAtom.class)
                     .filter(at -> at.getAttributeVariable().equals(attributeVar))
                     .map(AttributeAtom::getSchemaConcept)
-                    .filter(t -> !t.asAttributeType().dataType().equals(dataType))
+                    .filter(t -> !t.asAttributeType().valueType().equals(valueType))
                     .forEach(t -> errors.add(incompatibleValuesMsg.getMessage(type.label(), rule.label(), t.label())));
         }
 

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -51,7 +51,7 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
         An IsaAtom is ok as the head of a rule when:
 
         1. The atom is NOT a relation type (must specify roles, making it a RelationAtom
-        2. If it is an attribute type, the valuetype must match
+        2. If it is an attribute type, the value type must match
         3. Types between rule head and body must be of same meta type
         */
 

--- a/graql/reasoner/atom/task/validate/IsaAtomValidator.java
+++ b/graql/reasoner/atom/task/validate/IsaAtomValidator.java
@@ -51,7 +51,7 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
         An IsaAtom is ok as the head of a rule when:
 
         1. The atom is NOT a relation type (must specify roles, making it a RelationAtom
-        2. If it is an attribute type, the datatype must match
+        2. If it is an attribute type, the valuetype must match
         3. Types between rule head and body must be of same meta type
         */
 
@@ -61,19 +61,19 @@ public class IsaAtomValidator implements AtomValidator<IsaAtom> {
         if (type.isRelationType()) {
             errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_TO_RELATION.getMessage(rule.label()));
         } else if (type.isAttributeType()) {
-            AttributeType.DataType<Object> datatypeInHead = type.asAttributeType().dataType();
+            AttributeType.ValueType<Object> valueTypeInHead = type.asAttributeType().valueType();
 
             // parent query is the combined rule head and body
 
-            boolean datatypeMatchesBody = atom.getParentQuery().getAtoms(Atom.class)
+            boolean valueTypeMatchesBody = atom.getParentQuery().getAtoms(Atom.class)
                     .filter(ruleAtom -> ruleAtom instanceof AttributeAtom || ruleAtom instanceof IsaAtom)
                     .map(ruleAtom -> ruleAtom.getSchemaConcept())
                     .filter(Objects::nonNull)
                     .filter(SchemaConcept::isAttributeType)
-                    .anyMatch(schemaConcept -> schemaConcept.asAttributeType().dataType().equals(datatypeInHead));
+                    .anyMatch(schemaConcept -> schemaConcept.asAttributeType().valueType().equals(valueTypeInHead));
 
-            if (!datatypeMatchesBody) {
-                errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_DATATYPE_INCOMPATIBLE.getMessage(rule, datatypeInHead));
+            if (!valueTypeMatchesBody) {
+                errors.add(ErrorMessage.VALIDATION_RULE_ILLEGAL_HEAD_REWRITING_TYPE_VALUETYPE_INCOMPATIBLE.getMessage(rule, valueTypeInHead));
             }
         } else {
             boolean typeMatchesBody = atom.getParentQuery().getAtoms(IsaAtom.class)

--- a/kb/concept/api/Attribute.java
+++ b/kb/concept/api/Attribute.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
  * Represent a literal Attribute in the graph.
  * Acts as an Thing when relating to other instances except it has the added functionality of:
  * 1. It is unique to its AttributeType based on it's value.
- * 2. It has an AttributeType.DataType associated with it which constrains the allowed values.
+ * 2. It has an AttributeType.ValueType associated with it which constrains the allowed values.
  *
  * @param <D> The data type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
@@ -57,7 +57,7 @@ public interface Attribute<D> extends Thing {
      * @return The data type of this Attribute's type.
      */
     @CheckReturnValue
-    AttributeType.DataType<D> dataType();
+    AttributeType.ValueType<D> valueType();
 
     /**
      * Retrieves the set of all Instances that possess this Attribute.

--- a/kb/concept/api/AttributeType.java
+++ b/kb/concept/api/AttributeType.java
@@ -34,7 +34,7 @@ import static grakn.common.util.Collections.set;
  * An ontological element which models and categorises the various Attribute in the graph.
  * This ontological element behaves similarly to Type when defining how it relates to other
  * types. It has two additional functions to be aware of:
- * 1. It has a DataType constraining the data types of the values it's instances may take.
+ * 1. It has a ValueType constraining the data types of the values it's instances may take.
  * 2. Any of it's instances are unique to the type.
  * For example if you have an AttributeType modelling month throughout the year there can only be one January.
  *
@@ -193,7 +193,7 @@ public interface AttributeType<D> extends Type {
      */
     @Nullable
     @CheckReturnValue
-    DataType<D> dataType();
+    ValueType<D> valueType();
 
     /**
      * Retrieve the regular expression to which instances of this AttributeType must conform, or {@code null} if no
@@ -228,57 +228,57 @@ public interface AttributeType<D> extends Type {
      *
      * @param <D> The data type.
      */
-    abstract class DataType<D> {
-        public static final DataType<Boolean> BOOLEAN = new DataType<Boolean>(Boolean.class){
+    abstract class ValueType<D> {
+        public static final ValueType<Boolean> BOOLEAN = new ValueType<Boolean>(Boolean.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() { return Collections.singleton(DataType.BOOLEAN); }
+            public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.BOOLEAN); }
         };
-        public static final DataType<LocalDateTime> DATE = new DataType<LocalDateTime>(LocalDateTime.class){
+        public static final ValueType<LocalDateTime> DATE = new ValueType<LocalDateTime>(LocalDateTime.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() { return Collections.singleton(DataType.DATE); }
+            public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.DATE); }
         };
-        public static final DataType<Double> DOUBLE = new DataType<Double>(Double.class){
+        public static final ValueType<Double> DOUBLE = new ValueType<Double>(Double.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() {
-                return set(DataType.DOUBLE,
-                        //DataType.FLOAT,
-                        //DataType.INTEGER,
-                        DataType.LONG);
+            public Set<ValueType<?>> comparableValueTypes() {
+                return set(ValueType.DOUBLE,
+                           //ValueType.FLOAT,
+                           //ValueType.INTEGER,
+                           ValueType.LONG);
             }
         };
 
-        public static final DataType<Float> FLOAT = new DataType<Float>(Float.class){
+        public static final ValueType<Float> FLOAT = new ValueType<Float>(Float.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() { return new HashSet<>(); }
+            public Set<ValueType<?>> comparableValueTypes() { return new HashSet<>(); }
         };
-        public static final DataType<Integer> INTEGER = new DataType<Integer>(Integer.class){
+        public static final ValueType<Integer> INTEGER = new ValueType<Integer>(Integer.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() { return new HashSet<>(); }
+            public Set<ValueType<?>> comparableValueTypes() { return new HashSet<>(); }
         };
-        public static final DataType<Long> LONG = new DataType<Long>(Long.class){
+        public static final ValueType<Long> LONG = new ValueType<Long>(Long.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() {
-                return set(DataType.DOUBLE,
-                        //DataType.FLOAT,
-                        //DataType.INTEGER,
-                        DataType.LONG);
+            public Set<ValueType<?>> comparableValueTypes() {
+                return set(ValueType.DOUBLE,
+                           //ValueType.FLOAT,
+                           //ValueType.INTEGER,
+                           ValueType.LONG);
             }
         };
-        public static final DataType<String> STRING = new DataType<String>(String.class){
+        public static final ValueType<String> STRING = new ValueType<String>(String.class){
             @Override
-            public Set<DataType<?>> comparableDataTypes() { return Collections.singleton(DataType.STRING); }
+            public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.STRING); }
         };
 
-        private static final List<DataType<?>> values = list(BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, LONG, STRING);
+        private static final List<ValueType<?>> values = list(BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, LONG, STRING);
 
         private final Class<D> dataClass;
 
-        private DataType(Class<D> dataClass) {
+        private ValueType(Class<D> dataClass) {
             this.dataClass = dataClass;
         }
 
         @CheckReturnValue
-        public Class<D> dataClass() {
+        public Class<D> valueClass() {
             return dataClass;
         }
 
@@ -293,19 +293,19 @@ public interface AttributeType<D> extends Type {
         }
 
         @CheckReturnValue
-        public static List<DataType<?>> values() {
+        public static List<ValueType<?>> values() {
             return values;
         }
 
         @CheckReturnValue
-        public abstract Set<DataType<?>> comparableDataTypes();
+        public abstract Set<ValueType<?>> comparableValueTypes();
 
         @SuppressWarnings("unchecked")
         @CheckReturnValue
-        public static <D> DataType<D> of(Class<D> name) {
-            for (DataType<?> dc : DataType.values()) {
+        public static <D> ValueType<D> of(Class<D> name) {
+            for (ValueType<?> dc : ValueType.values()) {
                 if (dc.dataClass.equals(name)) {
-                    return (DataType<D>) dc;
+                    return (ValueType<D>) dc;
                 }
             }
             return null;
@@ -316,9 +316,9 @@ public interface AttributeType<D> extends Type {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
 
-            DataType<?> that = (DataType<?>) o;
+            ValueType<?> that = (ValueType<?>) o;
 
-            return (this.dataClass().equals(that.dataClass()));
+            return (this.valueClass().equals(that.valueClass()));
         }
 
         @Override

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -71,7 +71,7 @@ public class GraknConceptException extends GraknException {
 
     /**
      * Thrown when attempting to set a regex on a Attribute whose type AttributeType is not of the
-     * data type AttributeType.DataType#STRING
+     * data type AttributeType.ValueType#STRING
      */
     public static GraknConceptException cannotSetRegex(AttributeType attributeType) {
         return create(REGEX_NOT_STRING.getMessage(attributeType.label()));
@@ -93,9 +93,9 @@ public class GraknConceptException extends GraknException {
         return create(String.format("Thing {%s} was already created and cannot be set to inferred", thing));
     }
 
-    public static GraknConceptException unsupportedDataType(String name) {
-        String supported = AttributeType.DataType.values().stream().map(AttributeType.DataType::name).collect(Collectors.joining(","));
-        return create(ErrorMessage.INVALID_DATATYPE.getMessage(name, supported));
+    public static GraknConceptException unsupportedValueType(String name) {
+        String supported = AttributeType.ValueType.values().stream().map(AttributeType.ValueType::name).collect(Collectors.joining(","));
+        return create(ErrorMessage.INVALID_VALUETYPE.getMessage(name, supported));
     }
 
 
@@ -111,8 +111,8 @@ public class GraknConceptException extends GraknException {
     /**
      * Thrown when creating an Attribute whose value Object does not match attribute data type
      */
-    public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object, AttributeType.DataType dataType) {
-        return create(ErrorMessage.INVALID_DATATYPE.getMessage(object, object.getClass().getSimpleName(), dataType.name(), attributeType.label()));
+    public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object, AttributeType.ValueType valueType) {
+        return create(ErrorMessage.INVALID_VALUETYPE.getMessage(object, object.getClass().getSimpleName(), valueType.name(), attributeType.label()));
     }
 
     /**

--- a/kb/concept/manager/ConceptManager.java
+++ b/kb/concept/manager/ConceptManager.java
@@ -86,7 +86,7 @@ public interface ConceptManager {
 
     EntityType createEntityType(Label label, EntityType superType);
     RelationType createRelationType(Label label, RelationType superType);
-    <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.DataType<V> dataType);
+    <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.ValueType<V> valueType);
     Rule createRule(Label label, Pattern when, Pattern then, Rule superType);
     Role createRole(Label label, Role superType);
 

--- a/kb/graql/exception/GraqlSemanticException.java
+++ b/kb/graql/exception/GraqlSemanticException.java
@@ -217,15 +217,15 @@ public class GraqlSemanticException extends GraknException {
         return new GraqlSemanticException(ErrorMessage.K_SMALLER_THAN_TWO.getMessage());
     }
 
-    public static GraqlSemanticException incompatibleAttributeValue(AttributeType.DataType dataType, Object value) {
-        return new GraqlSemanticException("Value " + value + " is not compatible with attribute datatype: " + dataType.name());
+    public static GraqlSemanticException incompatibleAttributeValue(AttributeType.ValueType valueType, Object value) {
+        return new GraqlSemanticException("Value " + value + " is not compatible with attribute valuetype: " + valueType.name());
     }
 
-    public static GraqlSemanticException attributeMustBeANumber(AttributeType.DataType dataType, Label attributeType) {
-        return new GraqlSemanticException(attributeType + " must have data type of `long` or `double`, but was " + dataType.name());
+    public static GraqlSemanticException attributeMustBeANumber(AttributeType.ValueType valueType, Label attributeType) {
+        return new GraqlSemanticException(attributeType + " must have data type of `long` or `double`, but was " + valueType.name());
     }
 
-    public static GraqlSemanticException attributesWithDifferentDataTypes(Collection<String> attributeTypes) {
+    public static GraqlSemanticException attributesWithDifferentValueTypes(Collection<String> attributeTypes) {
         return new GraqlSemanticException("resource types " + attributeTypes + " have different data types");
     }
 

--- a/kb/graql/exception/GraqlSemanticException.java
+++ b/kb/graql/exception/GraqlSemanticException.java
@@ -218,7 +218,7 @@ public class GraqlSemanticException extends GraknException {
     }
 
     public static GraqlSemanticException incompatibleAttributeValue(AttributeType.ValueType valueType, Object value) {
-        return new GraqlSemanticException("Value " + value + " is not compatible with attribute valuetype: " + valueType.name());
+        return new GraqlSemanticException("Value " + value + " is not compatible with attribute value type: " + valueType.name());
     }
 
     public static GraqlSemanticException attributeMustBeANumber(AttributeType.ValueType valueType, Label attributeType) {

--- a/kb/graql/executor/ConceptBuilder.java
+++ b/kb/graql/executor/ConceptBuilder.java
@@ -44,7 +44,7 @@ public interface ConceptBuilder {
 
     ConceptBuilder value(Object value);
 
-    ConceptBuilder dataType(AttributeType.DataType<?> dataType);
+    ConceptBuilder valueType(AttributeType.ValueType<?> valueType);
 
     ConceptBuilder when(Pattern when);
 

--- a/kb/server/Transaction.java
+++ b/kb/server/Transaction.java
@@ -182,19 +182,18 @@ public interface Transaction extends AutoCloseable {
 
     /**
      * @param label    A unique label for the AttributeType
-     * @param dataType The data type of the AttributeType.
-     *                 Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param valueType The data type of the AttributeType.
+     *                 Supported types include: ValueType.STRING, ValueType.LONG, ValueType.DOUBLE, and ValueType.BOOLEAN
      * @param <V>
      * @return A new or existing AttributeType with the provided label and data type.
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
      * @throws GraknElementException if the {@param label} is already in use by an existing AttributeType which is
-     *                                    unique or has a different datatype.
+     *                                    unique or has a different ValueType.
      */
-    @SuppressWarnings("unchecked")
-    <V> AttributeType<V> putAttributeType(Label label, AttributeType.DataType<V> dataType);
+    <V> AttributeType<V> putAttributeType(Label label, AttributeType.ValueType<V> valueType);
 
-    <V> AttributeType<V> putAttributeType(String label, AttributeType.DataType<V> dataType);
+    <V> AttributeType<V> putAttributeType(String label, AttributeType.ValueType<V> valueType);
 
     /**
      * @param label A unique label for the Rule

--- a/kb/server/exception/TransactionException.java
+++ b/kb/server/exception/TransactionException.java
@@ -50,14 +50,14 @@ public class TransactionException extends GraknException {
     }
 
     /**
-     * Thrown when using an unsupported datatype with resources
+     * Thrown when using an unsupported ValueType with resources
      */
-    public static TransactionException unsupportedDataType(Object value) {
-        return unsupportedDataType(value.getClass());
+    public static TransactionException unsupportedValueType(Object value) {
+        return unsupportedValueType(value.getClass());
     }
 
-    public static TransactionException unsupportedDataType(Class<?> clazz) {
-        return unsupportedDataType(clazz.getName());
+    public static TransactionException unsupportedValueType(Class<?> clazz) {
+        return unsupportedValueType(clazz.getName());
     }
 
     /**

--- a/server/rpc/ConceptMethod.java
+++ b/server/rpc/ConceptMethod.java
@@ -30,7 +30,6 @@ import graql.lang.pattern.Pattern;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -126,7 +125,7 @@ public class ConceptMethod {
                 con.asAttributeType().attribute(req.getAttributeTypeAttributeReq().getValue());
                 return;
             case ATTRIBUTETYPE_DATATYPE_REQ:
-                con.asAttributeType().dataType();
+                con.asAttributeType().valueType();
                 return;
             case ATTRIBUTETYPE_GETREGEX_REQ:
                 con.asAttributeType().regex();
@@ -707,14 +706,14 @@ public class ConceptMethod {
                 responseSender.accept(transactionRes(response));
             }
 
-            private void dataType() {
-                grakn.core.kb.concept.api.AttributeType.DataType<?> dataType = concept.asAttributeType().dataType();
+            private void valueType() {
+                grakn.core.kb.concept.api.AttributeType.ValueType<?> valueType = concept.asAttributeType().valueType();
 
                 ConceptProto.AttributeType.DataType.Res.Builder methodResponse =
                         ConceptProto.AttributeType.DataType.Res.newBuilder();
 
-                if (dataType == null) methodResponse.setNull(ConceptProto.Null.getDefaultInstance()).build();
-                else methodResponse.setDataType(ResponseBuilder.Concept.DATA_TYPE(dataType)).build();
+                if (valueType == null) methodResponse.setNull(ConceptProto.Null.getDefaultInstance()).build();
+                else methodResponse.setDataType(ResponseBuilder.Concept.VALUE_TYPE(valueType)).build();
 
                 ConceptProto.Method.Res response = ConceptProto.Method.Res.newBuilder()
                         .setAttributeTypeDataTypeRes(methodResponse).build();

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -203,7 +203,7 @@ public class ResponseBuilder {
                     builder.setValueRes(ConceptProto.Attribute.Value.Res.newBuilder()
                             .setValue(attributeValue(concept.asAttribute().value())));
                     builder.setDataTypeRes(ConceptProto.AttributeType.DataType.Res.newBuilder()
-                            .setDataType(DATA_TYPE(concept.asAttribute().dataType())));
+                            .setDataType(VALUE_TYPE(concept.asAttribute().valueType())));
                 }
             }
 
@@ -234,45 +234,45 @@ public class ResponseBuilder {
             }
         }
 
-        static ConceptProto.AttributeType.DATA_TYPE DATA_TYPE(AttributeType.DataType<?> dataType) {
-            if (dataType.equals(AttributeType.DataType.STRING)) {
+        static ConceptProto.AttributeType.DATA_TYPE VALUE_TYPE(AttributeType.ValueType<?> valueType) {
+            if (valueType.equals(AttributeType.ValueType.STRING)) {
                 return ConceptProto.AttributeType.DATA_TYPE.STRING;
-            } else if (dataType.equals(AttributeType.DataType.BOOLEAN)) {
+            } else if (valueType.equals(AttributeType.ValueType.BOOLEAN)) {
                 return ConceptProto.AttributeType.DATA_TYPE.BOOLEAN;
-            } else if (dataType.equals(AttributeType.DataType.INTEGER)) {
+            } else if (valueType.equals(AttributeType.ValueType.INTEGER)) {
                 return ConceptProto.AttributeType.DATA_TYPE.INTEGER;
-            } else if (dataType.equals(AttributeType.DataType.LONG)) {
+            } else if (valueType.equals(AttributeType.ValueType.LONG)) {
                 return ConceptProto.AttributeType.DATA_TYPE.LONG;
-            } else if (dataType.equals(AttributeType.DataType.FLOAT)) {
+            } else if (valueType.equals(AttributeType.ValueType.FLOAT)) {
                 return ConceptProto.AttributeType.DATA_TYPE.FLOAT;
-            } else if (dataType.equals(AttributeType.DataType.DOUBLE)) {
+            } else if (valueType.equals(AttributeType.ValueType.DOUBLE)) {
                 return ConceptProto.AttributeType.DATA_TYPE.DOUBLE;
-            } else if (dataType.equals(AttributeType.DataType.DATE)) {
+            } else if (valueType.equals(AttributeType.ValueType.DATE)) {
                 return ConceptProto.AttributeType.DATA_TYPE.DATE;
             } else {
-                throw GraknServerException.unreachableStatement("Unrecognised " + dataType);
+                throw GraknServerException.unreachableStatement("Unrecognised " + valueType);
             }
         }
 
-        public static AttributeType.DataType<?> DATA_TYPE(ConceptProto.AttributeType.DATA_TYPE dataType) {
-            switch (dataType) {
+        public static AttributeType.ValueType<?> VALUE_TYPE(ConceptProto.AttributeType.DATA_TYPE valueType) {
+            switch (valueType) {
                 case STRING:
-                    return AttributeType.DataType.STRING;
+                    return AttributeType.ValueType.STRING;
                 case BOOLEAN:
-                    return AttributeType.DataType.BOOLEAN;
+                    return AttributeType.ValueType.BOOLEAN;
                 case INTEGER:
-                    return AttributeType.DataType.INTEGER;
+                    return AttributeType.ValueType.INTEGER;
                 case LONG:
-                    return AttributeType.DataType.LONG;
+                    return AttributeType.ValueType.LONG;
                 case FLOAT:
-                    return AttributeType.DataType.FLOAT;
+                    return AttributeType.ValueType.FLOAT;
                 case DOUBLE:
-                    return AttributeType.DataType.DOUBLE;
+                    return AttributeType.ValueType.DOUBLE;
                 case DATE:
-                    return AttributeType.DataType.DATE;
+                    return AttributeType.ValueType.DATE;
                 default:
                 case UNRECOGNIZED:
-                    throw new IllegalArgumentException("Unrecognised " + dataType);
+                    throw new IllegalArgumentException("Unrecognised " + valueType);
             }
         }
 

--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -390,9 +390,9 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
 
         private void putAttributeType(Transaction.PutAttributeType.Req request) {
             Label label = Label.of(request.getLabel());
-            AttributeType.DataType<?> dataType = ResponseBuilder.Concept.DATA_TYPE(request.getDataType());
+            AttributeType.ValueType<?> valueType = ResponseBuilder.Concept.VALUE_TYPE(request.getDataType());
 
-            AttributeType<?> attributeType = tx().putAttributeType(label, dataType);
+            AttributeType<?> attributeType = tx().putAttributeType(label, valueType);
             Transaction.Res response = ResponseBuilder.Transaction.putAttributeType(attributeType);
             onNextResponse(response);
         }

--- a/server/session/TransactionImpl.java
+++ b/server/session/TransactionImpl.java
@@ -789,30 +789,30 @@ public class TransactionImpl implements Transaction {
 
     /**
      * @param label    A unique label for the AttributeType
-     * @param dataType The data type of the AttributeType.
-     *                 Supported types include: DataType.STRING, DataType.LONG, DataType.DOUBLE, and DataType.BOOLEAN
+     * @param valueType The data type of the AttributeType.
+     *                 Supported types include: ValueType.STRING, ValueType.LONG, ValueType.DOUBLE, and ValueType.BOOLEAN
      * @param <V>
      * @return A new or existing AttributeType with the provided label and data type.
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
      * @throws GraknElementException       if the {@param label} is already in use by an existing AttributeType which is
-     *                                    unique or has a different datatype.
+     *                                    unique or has a different ValueType.
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <V> AttributeType<V> putAttributeType(Label label, AttributeType.DataType<V> dataType) {
+    public <V> AttributeType<V> putAttributeType(Label label, AttributeType.ValueType<V> valueType) {
         checkGraphIsOpen();
         AttributeType<V> attributeType = conceptManager.getSchemaConcept(label);
         if (attributeType == null) {
-            attributeType = conceptManager.createAttributeType(label, getMetaAttributeType(), dataType);
+            attributeType = conceptManager.createAttributeType(label, getMetaAttributeType(), valueType);
         } else {
             ConceptUtils.validateBaseType(SchemaConceptImpl.from(attributeType), Schema.BaseType.ATTRIBUTE_TYPE);
-            //These checks is needed here because caching will return a type by label without checking the datatype
+            //These checks is needed here because caching will return a type by label without checking the ValueType
 
             if (Schema.MetaSchema.isMetaLabel(label)) {
                 throw GraknConceptException.metaTypeImmutable(label);
-            } else if (!dataType.equals(attributeType.dataType())) {
-                throw GraknElementException.immutableProperty(attributeType.dataType(), dataType, Schema.VertexProperty.DATA_TYPE);
+            } else if (!valueType.equals(attributeType.valueType())) {
+                throw GraknElementException.immutableProperty(attributeType.valueType(), valueType, Schema.VertexProperty.DATA_TYPE);
             }
         }
 
@@ -820,8 +820,8 @@ public class TransactionImpl implements Transaction {
     }
 
     @Override
-    public <V> AttributeType<V> putAttributeType(String label, AttributeType.DataType<V> dataType) {
-        return putAttributeType(Label.of(label), dataType);
+    public <V> AttributeType<V> putAttributeType(String label, AttributeType.ValueType<V> valueType) {
+        return putAttributeType(Label.of(label), valueType);
     }
 
     /**
@@ -953,15 +953,15 @@ public class TransactionImpl implements Transaction {
         checkGraphIsOpen();
         if (value == null) return Collections.emptySet();
 
-        // TODO: Remove this forced casting once we replace DataType to be Parameterised Generic Enum
-        AttributeType.DataType<V> dataType =
-                (AttributeType.DataType<V>) AttributeType.DataType.of(value.getClass());
-        if (dataType == null) {
-            throw TransactionException.unsupportedDataType(value);
+        // TODO: Remove this forced casting once we replace ValueType to be Parameterised Generic Enum
+        AttributeType.ValueType<V> valueType =
+                (AttributeType.ValueType<V>) AttributeType.ValueType.of(value.getClass());
+        if (valueType == null) {
+            throw TransactionException.unsupportedValueType(value);
         }
 
         HashSet<Attribute<V>> attributes = new HashSet<>();
-        conceptManager.getConcepts(Schema.VertexProperty.ofDataType(dataType), AttributeSerialiser.of(dataType).serialise(value))
+        conceptManager.getConcepts(Schema.VertexProperty.ofValueType(valueType), AttributeSerialiser.of(valueType).serialise(value))
                 .forEach(concept -> {
                     if (concept != null && concept.isAttribute()) {
                         attributes.add(concept.asAttribute());

--- a/test-end-to-end/client-java/ClientJavaE2E.java
+++ b/test-end-to-end/client-java/ClientJavaE2E.java
@@ -139,7 +139,7 @@ public class ClientJavaE2E {
                     type("mating").sub("relation").relates("male-partner").relates("female-partner").plays("child-bearer"),
                     type("parentship").sub("relation").relates("parent").relates("child"),
 
-                    type("name").sub("attribute").datatype(Graql.Token.DataType.STRING),
+                    type("name").sub("attribute").valueType(Graql.Token.ValueType.STRING),
                     type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring").plays("parent").plays("child")
             );
 

--- a/test-end-to-end/client-java/ClientJavaE2E.java
+++ b/test-end-to-end/client-java/ClientJavaE2E.java
@@ -139,7 +139,7 @@ public class ClientJavaE2E {
                     type("mating").sub("relation").relates("male-partner").relates("female-partner").plays("child-bearer"),
                     type("parentship").sub("relation").relates("parent").relates("child"),
 
-                    type("name").sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type("name").sub("attribute").value(Graql.Token.ValueType.STRING),
                     type("lion").sub("entity").has("name").plays("male-partner").plays("female-partner").plays("offspring").plays("parent").plays("child")
             );
 

--- a/test-end-to-end/distribution/AttributeUniquenessE2E.java
+++ b/test-end-to-end/distribution/AttributeUniquenessE2E.java
@@ -97,7 +97,7 @@ public class AttributeUniquenessE2E {
     private void defineParentChildSchema(GraknClient.Session session) {
         try (GraknClient.Transaction tx = session.transaction().write()) {
             List<grakn.client.answer.ConceptMap> answer = tx.execute(Graql.define(
-                    type("name").sub("attribute").datatype(Graql.Token.DataType.STRING),
+                    type("name").sub("attribute").valueType(Graql.Token.ValueType.STRING),
                     type("parent").sub("role"),
                     type("child").sub("role"),
                     type("person").sub("entity").has("name").plays("parent").plays("child"),

--- a/test-end-to-end/distribution/AttributeUniquenessE2E.java
+++ b/test-end-to-end/distribution/AttributeUniquenessE2E.java
@@ -97,7 +97,7 @@ public class AttributeUniquenessE2E {
     private void defineParentChildSchema(GraknClient.Session session) {
         try (GraknClient.Transaction tx = session.transaction().write()) {
             List<grakn.client.answer.ConceptMap> answer = tx.execute(Graql.define(
-                    type("name").sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type("name").sub("attribute").value(Graql.Token.ValueType.STRING),
                     type("parent").sub("role"),
                     type("child").sub("role"),
                     type("person").sub("entity").has("name").plays("parent").plays("child"),

--- a/test-end-to-end/distribution/ConcurrencyE2E.java
+++ b/test-end-to-end/distribution/ConcurrencyE2E.java
@@ -98,9 +98,9 @@ public class ConcurrencyE2E {
         GraknClient.Transaction tx = session.transaction().write();
         tx.execute(Graql.parse("define " +
                 "person sub entity, has name, has surname, has age; " +
-                "name sub attribute, datatype string;" +
-                "surname sub attribute, datatype string;" +
-                "age sub attribute, datatype long;").asDefine());
+                "name sub attribute, valuetype string;" +
+                "surname sub attribute, valuetype string;" +
+                "age sub attribute, valuetype long;").asDefine());
 
         tx.commit();
         ExecutorService executorService = Executors.newFixedThreadPool(36);

--- a/test-end-to-end/distribution/ConcurrencyE2E.java
+++ b/test-end-to-end/distribution/ConcurrencyE2E.java
@@ -98,9 +98,9 @@ public class ConcurrencyE2E {
         GraknClient.Transaction tx = session.transaction().write();
         tx.execute(Graql.parse("define " +
                 "person sub entity, has name, has surname, has age; " +
-                "name sub attribute, valuetype string;" +
-                "surname sub attribute, valuetype string;" +
-                "age sub attribute, valuetype long;").asDefine());
+                "name sub attribute, value string;" +
+                "surname sub attribute, value string;" +
+                "age sub attribute, value long;").asDefine());
 
         tx.commit();
         ExecutorService executorService = Executors.newFixedThreadPool(36);

--- a/test-end-to-end/distribution/ConcurrencyE2E.java
+++ b/test-end-to-end/distribution/ConcurrencyE2E.java
@@ -19,7 +19,7 @@ package grakn.core.distribution;
 
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.Concept;
 import grakn.client.concept.type.EntityType;
@@ -220,10 +220,10 @@ public class ConcurrencyE2E {
         try(GraknClient.Transaction tx = session.transaction().write()){
             tx.stream(Graql.parse("match $x isa thing;get;").asGet()).forEach(ans -> ans.get("x").asRemote(tx).delete());
             EntityType.Remote someEntity = tx.putEntityType("someEntity").asRemote(tx);
-            someEntity.has(tx.putAttributeType("attribute0", DataType.INTEGER));
-            someEntity.has(tx.putAttributeType("attribute1", DataType.STRING));
+            someEntity.has(tx.putAttributeType("attribute0",  ValueType.INTEGER));
+            someEntity.has(tx.putAttributeType("attribute1",  ValueType.STRING));
             for(int attributeNo = 2; attributeNo < noOfAttributes ; attributeNo++){
-                someEntity.has(tx.putAttributeType("attribute" + attributeNo, DataType.STRING));
+                someEntity.has(tx.putAttributeType("attribute" + attributeNo,  ValueType.STRING));
             }
             tx.commit();
         }

--- a/test-end-to-end/test-fixtures/basic-genealogy.gql
+++ b/test-end-to-end/test-fixtures/basic-genealogy.gql
@@ -21,15 +21,15 @@ person sub entity,
 
 # Resources
 
-identifier sub attribute, valuetype string;
-firstname sub attribute, valuetype string;
-surname sub attribute, valuetype string;
-middlename sub attribute, valuetype string;
-picture sub attribute, valuetype string;
-age sub attribute, valuetype long;
-birth-date sub attribute, valuetype date;
-death-date sub attribute, valuetype date;
-gender sub attribute, valuetype string;
+identifier sub attribute, value string;
+firstname sub attribute, value string;
+surname sub attribute, value string;
+middlename sub attribute, value string;
+picture sub attribute, value string;
+age sub attribute, value long;
+birth-date sub attribute, value date;
+death-date sub attribute, value date;
+gender sub attribute, value string;
 
 # Roles and Relations
 

--- a/test-end-to-end/test-fixtures/basic-genealogy.gql
+++ b/test-end-to-end/test-fixtures/basic-genealogy.gql
@@ -21,15 +21,15 @@ person sub entity,
 
 # Resources
 
-identifier sub attribute, datatype string;
-firstname sub attribute, datatype string;
-surname sub attribute, datatype string;
-middlename sub attribute, datatype string;
-picture sub attribute, datatype string;
-age sub attribute, datatype long;
-birth-date sub attribute, datatype date;
-death-date sub attribute, datatype date;
-gender sub attribute, datatype string;
+identifier sub attribute, valuetype string;
+firstname sub attribute, valuetype string;
+surname sub attribute, valuetype string;
+middlename sub attribute, valuetype string;
+picture sub attribute, valuetype string;
+age sub attribute, valuetype long;
+birth-date sub attribute, valuetype date;
+death-date sub attribute, valuetype date;
+gender sub attribute, valuetype string;
 
 # Roles and Relations
 

--- a/test-integration/concept/AttributeIT.java
+++ b/test-integration/concept/AttributeIT.java
@@ -50,7 +50,6 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
@@ -89,8 +88,8 @@ public class AttributeIT {
 
     @Test
     public void whenSubTypeSharesAttributes_noDuplicatesAreProducedWhenRetrievingAttributes(){
-        AttributeType<String> resource = tx.putAttributeType("resource", AttributeType.DataType.STRING);
-        AttributeType<String> anotherResource = tx.putAttributeType("anotherResource", AttributeType.DataType.STRING);
+        AttributeType<String> resource = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
+        AttributeType<String> anotherResource = tx.putAttributeType("anotherResource", AttributeType.ValueType.STRING);
         EntityType someEntity = tx.putEntityType("someEntity")
                 .has(resource)
                 .has(anotherResource);
@@ -105,16 +104,16 @@ public class AttributeIT {
     }
 
     @Test
-    public void whenCreatingResource_EnsureTheResourcesDataTypeIsTheSameAsItsType() throws Exception {
-        AttributeType<String> attributeType = tx.putAttributeType("attributeType", AttributeType.DataType.STRING);
+    public void whenCreatingResource_EnsureTheResourcesValueTypeIsTheSameAsItsType() throws Exception {
+        AttributeType<String> attributeType = tx.putAttributeType("attributeType", AttributeType.ValueType.STRING);
         Attribute attribute = attributeType.create("resource");
-        assertEquals(AttributeType.DataType.STRING, attribute.dataType());
+        assertEquals(AttributeType.ValueType.STRING, attribute.valueType());
     }
 
     @Test
     public void whenAttachingResourcesToInstances_EnsureInstancesAreReturnedAsOwners() throws Exception {
         EntityType randomThing = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType("A Attribute Thing", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("A Attribute Thing", AttributeType.ValueType.STRING);
         RelationType hasResource = tx.putRelationType("Has Attribute");
         Role resourceRole = tx.putRole("Attribute Role");
         Role actorRole = tx.putRole("Actor");
@@ -142,11 +141,11 @@ public class AttributeIT {
     // this is due to the generic of getResourcesByValue
     @SuppressWarnings("unchecked")
     @Test
-    public void whenCreatingResources_EnsureDataTypesAreEnforced() {
-        AttributeType<String> strings = tx.putAttributeType("String Type", AttributeType.DataType.STRING);
-        AttributeType<Long> longs = tx.putAttributeType("Long Type", AttributeType.DataType.LONG);
-        AttributeType<Double> doubles = tx.putAttributeType("Double Type", AttributeType.DataType.DOUBLE);
-        AttributeType<Boolean> booleans = tx.putAttributeType("Boolean Type", AttributeType.DataType.BOOLEAN);
+    public void whenCreatingResources_EnsureValueTypesAreEnforced() {
+        AttributeType<String> strings = tx.putAttributeType("String Type", AttributeType.ValueType.STRING);
+        AttributeType<Long> longs = tx.putAttributeType("Long Type", AttributeType.ValueType.LONG);
+        AttributeType<Double> doubles = tx.putAttributeType("Double Type", AttributeType.ValueType.DOUBLE);
+        AttributeType<Boolean> booleans = tx.putAttributeType("Boolean Type", AttributeType.ValueType.BOOLEAN);
 
         Attribute<String> attribute1 = strings.create("1");
         Attribute<Long> attribute2 = longs.create(1L);
@@ -172,30 +171,30 @@ public class AttributeIT {
     // this is deliberately an incorrect type for the test
     @SuppressWarnings("unchecked")
     @Test
-    public void whenCreatingResourceWithAnInvalidDataType_Throw() {
+    public void whenCreatingResourceWithAnInvalidValueType_Throw() {
         String invalidThing = "Invalid Thing";
-        AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.DataType.LONG);
+        AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.ValueType.LONG);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(longAttributeType, invalidThing, AttributeType.DataType.LONG).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(longAttributeType, invalidThing, AttributeType.ValueType.LONG).getMessage());
         longAttributeType.create(invalidThing);
     }
 
     // this is deliberately an incorrect type for the test
     @SuppressWarnings("unchecked")
     @Test
-    public void whenCreatingResourceWithAnInvalidDataTypeOnADate_Throw() {
+    public void whenCreatingResourceWithAnInvalidValueTypeOnADate_Throw() {
         String invalidThing = "Invalid Thing";
-        AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.DataType.DATE);
+        AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.ValueType.DATE);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.DataType.DATE).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.ValueType.DATE).getMessage());
         dateAttributeType.create(invalidThing);
     }
 
     // this is deliberately an incorrect type for the test
     @SuppressWarnings("unchecked")
     @Test
-    public void whenCreatingResourceWithAnInvalidDataType_DoNotCreateTheResource() {
-        AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.DataType.LONG);
+    public void whenCreatingResourceWithAnInvalidValueType_DoNotCreateTheResource() {
+        AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.ValueType.LONG);
 
         try {
             longAttributeType.create("Invalid Thing");
@@ -212,7 +211,7 @@ public class AttributeIT {
     @Test
     public void whenSavingDateIntoResource_DateIsReturnedInSameFormat() {
         LocalDateTime date = LocalDateTime.now();
-        AttributeType<LocalDateTime> attributeType = tx.putAttributeType("My Birthday", AttributeType.DataType.DATE);
+        AttributeType<LocalDateTime> attributeType = tx.putAttributeType("My Birthday", AttributeType.ValueType.DATE);
         Attribute<LocalDateTime> myBirthday = attributeType.create(date);
 
         assertEquals(date, myBirthday.value());
@@ -222,8 +221,8 @@ public class AttributeIT {
 
     @Test
     public void whenCreatingAttributeInstancesWithHierarchies_HierarchyOfImplicitRelationsIsPreserved(){
-        AttributeType<String> baseAttribute = tx.putAttributeType("baseAttribute", AttributeType.DataType.STRING);
-        AttributeType<String> subAttribute = tx.putAttributeType("subAttribute", AttributeType.DataType.STRING).sup(baseAttribute);
+        AttributeType<String> baseAttribute = tx.putAttributeType("baseAttribute", AttributeType.ValueType.STRING);
+        AttributeType<String> subAttribute = tx.putAttributeType("subAttribute", AttributeType.ValueType.STRING).sup(baseAttribute);
 
         tx.putEntityType("someEntity")
                 .has(baseAttribute)
@@ -239,7 +238,7 @@ public class AttributeIT {
 
     @Test
     public void whenLinkingResourcesToThings_EnsureTheRelationIsAnEdge() {
-        AttributeType<String> attributeType = tx.putAttributeType("My attribute type", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("My attribute type", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("A String");
 
         EntityType entityType = tx.putEntityType("My entity type").has(attributeType);
@@ -257,7 +256,7 @@ public class AttributeIT {
     @Test
     public void whenAddingRolePlayerToRelationEdge_RelationAutomaticallyReifies() {
         //Create boring attribute which creates a relation edge
-        AttributeType<String> attributeType = tx.putAttributeType("My attribute type", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("My attribute type", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("A String");
         EntityType entityType = tx.putEntityType("My entity type").has(attributeType);
         Entity entity = entityType.create();
@@ -300,7 +299,7 @@ public class AttributeIT {
 
     @Test
     public void whenInsertingAThingWithTwoKeys_Throw() {
-        AttributeType<String> attributeType = tx.putAttributeType("Key Thingy", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("Key Thingy", AttributeType.ValueType.STRING);
         EntityType entityType = tx.putEntityType("Entity Type Thingy").key(attributeType);
         Entity entity = entityType.create();
 
@@ -317,7 +316,7 @@ public class AttributeIT {
 
     @Test
     public void whenGettingTheRelationsOfResources_EnsureIncomingResourceEdgesAreTakingIntoAccount() {
-        AttributeType<String> attributeType = tx.putAttributeType("Attribute Type Thingy", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("Attribute Type Thingy", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("Thingy");
 
         EntityType entityType = tx.putEntityType("Entity Type Thingy").key(attributeType);
@@ -337,7 +336,7 @@ public class AttributeIT {
 
     @Test
     public void whenCreatingAnInferredAttribute_EnsureMarkedAsInferred() {
-        AttributeTypeImpl at = AttributeTypeImpl.from(tx.putAttributeType("at", AttributeType.DataType.STRING));
+        AttributeTypeImpl at = AttributeTypeImpl.from(tx.putAttributeType("at", AttributeType.ValueType.STRING));
         Attribute attribute = at.create("blergh");
         Attribute attributeInferred = at.putAttributeInferred("bloorg");
         assertFalse(attribute.isInferred());
@@ -346,7 +345,7 @@ public class AttributeIT {
 
     @Test
     public void whenDeletingAnAttribute_associatedEdgeRelationsAreDeleted() {
-        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("polok");
 
         EntityType entityType = tx.putEntityType("someEntity").has(attributeType);

--- a/test-integration/concept/AttributeTypeIT.java
+++ b/test-integration/concept/AttributeTypeIT.java
@@ -59,7 +59,7 @@ public class AttributeTypeIT {
     public void setUp() {
         session = server.sessionWithNewKeyspace();
         tx = session.transaction(Transaction.Type.WRITE);
-        attributeType = tx.putAttributeType("Attribute Type", AttributeType.DataType.STRING);
+        attributeType = tx.putAttributeType("Attribute Type", AttributeType.ValueType.STRING);
     }
 
     @After
@@ -70,8 +70,8 @@ public class AttributeTypeIT {
 
 
     @Test
-    public void whenCreatingResourceTypeOfTypeString_DataTypeIsString() throws Exception {
-        assertEquals(AttributeType.DataType.STRING, attributeType.dataType());
+    public void whenCreatingResourceTypeOfTypeString_ValueTypeIsString() throws Exception {
+        assertEquals(AttributeType.ValueType.STRING, attributeType.valueType());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class AttributeTypeIT {
 
     @Test
     public void whenSettingRegexOnNonStringResourceType_Throw() {
-        AttributeType<Long> thing = tx.putAttributeType("Random ID", AttributeType.DataType.LONG);
+        AttributeType<Long> thing = tx.putAttributeType("Random ID", AttributeType.ValueType.LONG);
         expectedException.expect(GraknConceptException.class);
         expectedException.expectMessage(GraknConceptException.cannotSetRegex(thing).getMessage());
         thing.regex("blab");
@@ -115,8 +115,8 @@ public class AttributeTypeIT {
 
     @Test
     public void whenGettingTheResourceFromAResourceType_ReturnTheResource() {
-        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.DataType.STRING);
-        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.DataType.STRING);
+        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.ValueType.STRING);
+        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.ValueType.STRING);
 
         Attribute c1 = t1.create("1");
         Attribute c2 = t2.create("2");
@@ -130,8 +130,8 @@ public class AttributeTypeIT {
 
     @Test
     public void whenCreatingMultipleResourceTypesWithDifferentRegexes_EnsureAllRegexesAreChecked() {
-        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.DataType.STRING).regex("[b]");
-        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.DataType.STRING).regex("[abc]").sup(t1);
+        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.ValueType.STRING).regex("[b]");
+        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.ValueType.STRING).regex("[abc]").sup(t1);
 
         //Valid Attribute
         Attribute<String> attribute = t2.create("b");
@@ -144,8 +144,8 @@ public class AttributeTypeIT {
 
     @Test
     public void whenSettingTheSuperTypeOfAStringResourceType_EnsureAllRegexesAreAppliedToResources() {
-        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.DataType.STRING).regex("[b]");
-        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.DataType.STRING).regex("[abc]");
+        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.ValueType.STRING).regex("[b]");
+        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.ValueType.STRING).regex("[abc]");
 
         //Future Invalid
         t2.create("a");
@@ -157,8 +157,8 @@ public class AttributeTypeIT {
 
     @Test
     public void whenSettingRegexOfSuperType_EnsureAllRegexesAreApplied() {
-        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.DataType.STRING);
-        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.DataType.STRING).regex("[abc]").sup(t1);
+        AttributeType<String> t1 = tx.putAttributeType("t1", AttributeType.ValueType.STRING);
+        AttributeType<String> t2 = tx.putAttributeType("t2", AttributeType.ValueType.STRING).regex("[abc]").sup(t1);
         t2.create("a");
 
         expectedException.expect(GraknConceptException.class);
@@ -176,7 +176,7 @@ public class AttributeTypeIT {
         // now add the timezone to the graph
         try (Session session = server.sessionWithNewKeyspace()) {
             try (Transaction graph = session.transaction(Transaction.Type.WRITE)) {
-                AttributeType<LocalDateTime> aTime = graph.putAttributeType("aTime", AttributeType.DataType.DATE);
+                AttributeType<LocalDateTime> aTime = graph.putAttributeType("aTime", AttributeType.ValueType.DATE);
                 aTime.create(rightNow);
                 graph.commit();
             }
@@ -196,7 +196,7 @@ public class AttributeTypeIT {
 
     @Test
     public void whenNamingAttributeTypeValue_NoErrorsThrown() {
-        AttributeType<String> valueAttributeType = tx.putAttributeType("value", AttributeType.DataType.STRING);
+        AttributeType<String> valueAttributeType = tx.putAttributeType("value", AttributeType.ValueType.STRING);
 
         Attribute<String> attribute = valueAttributeType.create("testing");
         EntityType person = tx.putEntityType("person").has(valueAttributeType);
@@ -211,7 +211,7 @@ public class AttributeTypeIT {
 
     @Test
     public void whenNamingAttributeTypeOwner_NoErrorsThrown() {
-        AttributeType<String> ownerAttributeType = tx.putAttributeType("owner", AttributeType.DataType.STRING);
+        AttributeType<String> ownerAttributeType = tx.putAttributeType("owner", AttributeType.ValueType.STRING);
 
         Attribute<String> attribute = ownerAttributeType.create("testing");
         EntityType person = tx.putEntityType("person").has(ownerAttributeType);

--- a/test-integration/concept/EntityIT.java
+++ b/test-integration/concept/EntityIT.java
@@ -143,7 +143,7 @@ public class EntityIT {
     public void whenAddingResourceToAnEntity_EnsureTheicitStructureIsCreated(){
         Label resourceLabel = Label.of("A Attribute Thing");
         EntityType entityType = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType(resourceLabel, AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType(resourceLabel, AttributeType.ValueType.STRING);
         entityType.has(attributeType);
 
         Entity entity = entityType.create();
@@ -158,7 +158,7 @@ public class EntityIT {
     @Test
     public void whenAddingResourceToEntityWithoutAllowingItBetweenTypes_Throw(){
         EntityType entityType = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType("A Attribute Thing", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("A Attribute Thing", AttributeType.ValueType.STRING);
 
         Entity entity = entityType.create();
         Attribute attribute = attributeType.create("A attribute thing");
@@ -173,7 +173,7 @@ public class EntityIT {
     public void whenAddingMultipleResourcesToEntity_EnsureDifferentRelationsAreBuilt() throws InvalidKBException {
         String resourceTypeId = "A Attribute Thing";
         EntityType entityType = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType(resourceTypeId, AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType(resourceTypeId, AttributeType.ValueType.STRING);
         entityType.has(attributeType);
 
         Entity entity = entityType.create();
@@ -193,7 +193,7 @@ public class EntityIT {
     public void checkKeyCreatesCorrectResourceStructure(){
         Label resourceLabel = Label.of("A Attribute Thing");
         EntityType entityType = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType(resourceLabel, AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType(resourceLabel, AttributeType.ValueType.STRING);
         entityType.key(attributeType);
 
         Entity entity = entityType.create();
@@ -209,7 +209,7 @@ public class EntityIT {
     public void whenCreatingAnEntityAndNotLinkingARequiredKey_Throw() throws InvalidKBException {
         String resourceTypeId = "A Attribute Thing";
         EntityType entityType = tx.putEntityType("A Thing");
-        AttributeType<String> attributeType = tx.putAttributeType(resourceTypeId, AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType(resourceTypeId, AttributeType.ValueType.STRING);
         entityType.key(attributeType);
 
         entityType.create();
@@ -237,8 +237,8 @@ public class EntityIT {
 
     @Test
     public void whenGettingEntityKeys_EnsureKeysAreReturned(){
-        AttributeType<String> attributeType = tx.putAttributeType("An Attribute", AttributeType.DataType.STRING);
-        AttributeType<String> keyType = tx.putAttributeType("A Key", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("An Attribute", AttributeType.ValueType.STRING);
+        AttributeType<String> keyType = tx.putAttributeType("A Key", AttributeType.ValueType.STRING);
         EntityType entityType = tx.putEntityType("A Thing").has(attributeType).key(keyType);
 
         Attribute<String> a1 = attributeType.create("a1");
@@ -264,7 +264,7 @@ public class EntityIT {
 
     @Test
     public void whenRemovingAnAttributedFromAnEntity_EnsureTheAttributeIsNoLongerReturned(){
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
         Attribute<String> fim = name.create("Fim");
         Attribute<String> tim = name.create("Tim");
         Attribute<String> pim = name.create("Pim");
@@ -280,7 +280,7 @@ public class EntityIT {
 
     @Test
     public void whenCreatingInferredAttributeLink_EnsureMarkedAsInferred(){
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
         Attribute<String> attribute1 = name.create("An attribute 1");
         Attribute<String> attribute2 = name.create("An attribute 2");
         EntityType et = tx.putEntityType("et").has(name);

--- a/test-integration/concept/EntityTypeIT.java
+++ b/test-integration/concept/EntityTypeIT.java
@@ -283,8 +283,8 @@ public class EntityTypeIT {
         Label superLabel = Label.of("Super Attribute Type");
         Label label = Label.of("Attribute Type");
 
-        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.DataType.STRING);
-        AttributeType attributeType = tx.putAttributeType(label, AttributeType.DataType.STRING).sup(superAttributeType);
+        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.ValueType.STRING);
+        AttributeType attributeType = tx.putAttributeType(label, AttributeType.ValueType.STRING).sup(superAttributeType);
         AttributeType metaType = tx.getMetaAttributeType();
 
         entityType1.has(superAttributeType);
@@ -326,8 +326,8 @@ public class EntityTypeIT {
         Label superLabel = Label.of("Abstract Super Attribute Type");
         Label label = Label.of("Attribute Type");
 
-        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.DataType.STRING);
-        AttributeType attributeType = tx.putAttributeType(label, AttributeType.DataType.STRING).sup(superAttributeType);
+        AttributeType superAttributeType = tx.putAttributeType(superLabel, AttributeType.ValueType.STRING);
+        AttributeType attributeType = tx.putAttributeType(label, AttributeType.ValueType.STRING).sup(superAttributeType);
         AttributeType metaType = tx.getMetaAttributeType();
 
         entityType.has(attributeType);
@@ -413,9 +413,9 @@ public class EntityTypeIT {
     @Test
     public void checkThatResourceTypesCanBeRetrievedFromTypes(){
         EntityType e1 = tx.putEntityType("e1");
-        AttributeType r1 = tx.putAttributeType("r1", AttributeType.DataType.STRING);
-        AttributeType r2 = tx.putAttributeType("r2", AttributeType.DataType.LONG);
-        AttributeType r3 = tx.putAttributeType("r3", AttributeType.DataType.BOOLEAN);
+        AttributeType r1 = tx.putAttributeType("r1", AttributeType.ValueType.STRING);
+        AttributeType r2 = tx.putAttributeType("r2", AttributeType.ValueType.LONG);
+        AttributeType r3 = tx.putAttributeType("r3", AttributeType.ValueType.BOOLEAN);
 
         assertTrue("Entity is linked to resources when it shouldn't", e1.attributes().collect(toSet()).isEmpty());
         e1.has(r1);
@@ -426,8 +426,8 @@ public class EntityTypeIT {
 
     @Test
     public void addResourceTypeAsKeyToOneEntityTypeAndAsResourceToAnotherEntityType(){
-        AttributeType<String> attributeType1 = tx.putAttributeType("Shared Attribute 1", AttributeType.DataType.STRING);
-        AttributeType<String> attributeType2 = tx.putAttributeType("Shared Attribute 2", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType1 = tx.putAttributeType("Shared Attribute 1", AttributeType.ValueType.STRING);
+        AttributeType<String> attributeType2 = tx.putAttributeType("Shared Attribute 2", AttributeType.ValueType.STRING);
 
         EntityType entityType1 = tx.putEntityType("EntityType 1");
         EntityType entityType2 = tx.putEntityType("EntityType 2");
@@ -469,7 +469,7 @@ public class EntityTypeIT {
 
     @Test
     public void whenAddingResourceTypeAsKeyAfterResource_Throw(){
-        AttributeType<String> attributeType = tx.putAttributeType("Shared Attribute", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("Shared Attribute", AttributeType.ValueType.STRING);
         EntityType entityType = tx.putEntityType("EntityType");
 
         entityType.has(attributeType);
@@ -482,7 +482,7 @@ public class EntityTypeIT {
 
     @Test
     public void whenAddingResourceTypeAsResourceAfterResource_Throw(){
-        AttributeType<String> attributeType = tx.putAttributeType("Shared Attribute", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("Shared Attribute", AttributeType.ValueType.STRING);
         EntityType entityType = tx.putEntityType("EntityType");
 
         entityType.key(attributeType);
@@ -524,8 +524,8 @@ public class EntityTypeIT {
 
     @Test
     public void whenRemovingAttributesFromAType_EnsureTheTypeNoLongerHasThoseAttributes(){
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
-        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.DataType.INTEGER);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
+        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.ValueType.INTEGER);
         EntityType person = tx.putEntityType("person").has(name).has(age);
         assertThat(person.attributes().collect(toSet()), containsInAnyOrder(name, age));
         person.unhas(name);
@@ -534,9 +534,9 @@ public class EntityTypeIT {
 
     @Test
     public void whenRemovingKeysFromAType_EnsureKeysAreRemovedt(){
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
-        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.DataType.INTEGER);
-        AttributeType<Integer> id = tx.putAttributeType("id", AttributeType.DataType.INTEGER);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
+        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.ValueType.INTEGER);
+        AttributeType<Integer> id = tx.putAttributeType("id", AttributeType.ValueType.INTEGER);
         EntityType person = tx.putEntityType("person").has(name).has(age).key(id);
 
         assertThat(person.attributes().collect(toSet()), containsInAnyOrder(name, age, id));
@@ -550,9 +550,9 @@ public class EntityTypeIT {
 
     @Test
     public void whenRemovingKeyAsHas_Throw(){
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
-        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.DataType.INTEGER);
-        AttributeType<Integer> id = tx.putAttributeType("id", AttributeType.DataType.INTEGER);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
+        AttributeType<Integer> age = tx.putAttributeType("age", AttributeType.ValueType.INTEGER);
+        AttributeType<Integer> id = tx.putAttributeType("id", AttributeType.ValueType.INTEGER);
         EntityType person = tx.putEntityType("person").has(name).has(age).key(id);
 
         assertThat(person.attributes().collect(toSet()), containsInAnyOrder(name, age, id));

--- a/test-integration/concept/RelationIT.java
+++ b/test-integration/concept/RelationIT.java
@@ -225,7 +225,7 @@ public class RelationIT {
         Role entityRole = tx.putRole("Entity Role");
         Role degreeRole = tx.putRole("Degree Role");
         EntityType entityType = tx.putEntityType("Entity Type").plays(entityRole);
-        AttributeType<Long> degreeType = tx.putAttributeType("Attribute Type", AttributeType.DataType.LONG).plays(degreeRole);
+        AttributeType<Long> degreeType = tx.putAttributeType("Attribute Type", AttributeType.ValueType.LONG).plays(degreeRole);
 
         RelationType hasDegree = tx.putRelationType("Has Degree").relates(entityRole).relates(degreeRole);
 
@@ -274,7 +274,7 @@ public class RelationIT {
 
     @Test
     public void whenAttemptingToLinkTheInstanceOfAResourceRelationToTheResourceWhichCreatedIt_ThrowIfTheRelationTypeDoesNotHavePermissionToPlayTheNecessaryRole(){
-        AttributeType<String> attributeType = tx.putAttributeType("what a pain", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("what a pain", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("a real pain");
 
         EntityType entityType = tx.putEntityType("yay").has(attributeType);
@@ -291,7 +291,7 @@ public class RelationIT {
     public void whenAddingDuplicateRelationsWithDifferentKeys_EnsureTheyCanBeCommitted(){
         Role role1 = tx.putRole("dark");
         Role role2 = tx.putRole("souls");
-        AttributeType<Long> attributeType = tx.putAttributeType("Death Number", AttributeType.DataType.LONG);
+        AttributeType<Long> attributeType = tx.putAttributeType("Death Number", AttributeType.ValueType.LONG);
         RelationType relationType = tx.putRelationType("Dark Souls").relates(role1).relates(role2).key(attributeType);
         EntityType entityType = tx.putEntityType("Dead Guys").plays(role1).plays(role2);
 
@@ -343,7 +343,7 @@ public class RelationIT {
 
     @Test
     public void whenAttributeLinkedToRelationIsInferred_EnsureItIsMarkedAsInferred(){
-        AttributeType attributeType = tx.putAttributeType("Another thing of sorts", AttributeType.DataType.STRING);
+        AttributeType attributeType = tx.putAttributeType("Another thing of sorts", AttributeType.ValueType.STRING);
         RelationType relationType = tx.putRelationType("A thing of sorts").has(attributeType);
 
         Attribute attribute = attributeType.create("Things");
@@ -371,7 +371,7 @@ public class RelationIT {
 
         Role member = tx.putRole("member");
         Role member_of = tx.putRole("member_of");
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
         RelationType membership = tx.putRelationType("membership")
                 .relates(member)
                 .relates(member_of)
@@ -405,7 +405,7 @@ public class RelationIT {
                 "motherhood sub relation, relates mother, relates son;" +
                 "sisterhood sub relation, relates sister;" +
                 "aunthood sub relation, relates aunt, relates nephew, has number;" +
-                "number sub attribute, datatype long;" +
+                "number sub attribute, valuetype long;" +
                 "auntie-rule sub rule, " +
                 "when { " +
                 "$mother isa person; " +

--- a/test-integration/concept/RelationIT.java
+++ b/test-integration/concept/RelationIT.java
@@ -405,7 +405,7 @@ public class RelationIT {
                 "motherhood sub relation, relates mother, relates son;" +
                 "sisterhood sub relation, relates sister;" +
                 "aunthood sub relation, relates aunt, relates nephew, has number;" +
-                "number sub attribute, valuetype long;" +
+                "number sub attribute, value long;" +
                 "auntie-rule sub rule, " +
                 "when { " +
                 "$mother isa person; " +

--- a/test-integration/concept/RelationTypeIT.java
+++ b/test-integration/concept/RelationTypeIT.java
@@ -91,7 +91,7 @@ public class RelationTypeIT {
 
     @Test
     public void whenCallingInstancesOnImplicitRelationType_RelationEdgesAreReturned(){
-        AttributeType<String> attributeType = tx.putAttributeType("My Special Attribute Type", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("My Special Attribute Type", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("Ad thing");
 
         EntityType entityType = tx.putEntityType("My Special Entity Type").has(attributeType);
@@ -109,7 +109,7 @@ public class RelationTypeIT {
 
     @Test
     public void whenSettingAnImplicitRelationTypeWithInstancesAbstract_Throw(){
-        AttributeType<String> attributeType = tx.putAttributeType("My Special Attribute Type", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("My Special Attribute Type", AttributeType.ValueType.STRING);
         Attribute<String> attribute = attributeType.create("Ad thing");
 
         EntityType entityType = tx.putEntityType("My Special Entity Type").has(attributeType);

--- a/test-integration/concept/SchemaConceptIT.java
+++ b/test-integration/concept/SchemaConceptIT.java
@@ -102,7 +102,7 @@ public class SchemaConceptIT {
     public void whenSpecifyingTheResourceTypeOfAnEntityType_EnsureTheImplicitStructureIsCreated(){
         Label resourceLabel = Label.of("Attribute Type");
         EntityType entityType = tx.putEntityType("Entity1");
-        AttributeType attributeType = tx.putAttributeType("Attribute Type", AttributeType.DataType.STRING);
+        AttributeType attributeType = tx.putAttributeType("Attribute Type", AttributeType.ValueType.STRING);
 
         //Implicit Names
         Label hasResourceOwnerLabel = Schema.ImplicitType.HAS_OWNER.getLabel(resourceLabel);

--- a/test-integration/concept/SchemaMutationIT.java
+++ b/test-integration/concept/SchemaMutationIT.java
@@ -141,7 +141,7 @@ public class SchemaMutationIT {
     @Test
     public void whenAddingResourceToSubTypeOfEntityType_EnsureNoValidationErrorsOccur() {
         //Create initial Schema
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
         EntityType person = tx.putEntityType("person").has(name);
         EntityType animal = tx.putEntityType("animal").sup(person);
         Attribute bob = name.create("Bob");
@@ -176,7 +176,7 @@ public class SchemaMutationIT {
 
     @Test
     public void whenChangingTheSuperTypeOfAnEntityTypeWhichHasAResource_EnsureTheResourceIsStillAccessibleViaTheRelationTypeInstances_ByPreventingChange() {
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
 
         //Create a animal and allow animal to have a name
         EntityType animal = tx.putEntityType("animal").has(name);

--- a/test-integration/graql/analytics/ConnectedComponentIT.java
+++ b/test-integration/graql/analytics/ConnectedComponentIT.java
@@ -156,7 +156,7 @@ public class ConnectedComponentIT {
 
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             AttributeType<String> attributeType =
-                    tx.putAttributeType(aResourceTypeLabel, AttributeType.DataType.STRING);
+                    tx.putAttributeType(aResourceTypeLabel, AttributeType.ValueType.STRING);
             tx.getEntityType(thing).has(attributeType);
             tx.getEntityType(anotherThing).has(attributeType);
             Attribute aAttribute = attributeType.create("blah");
@@ -291,13 +291,13 @@ public class ConnectedComponentIT {
                     .assign(role2, entity4).id();
 
             List<AttributeType> attributeTypeList = new ArrayList<>();
-            attributeTypeList.add(tx.putAttributeType(resourceType1, AttributeType.DataType.DOUBLE));
-            attributeTypeList.add(tx.putAttributeType(resourceType2, AttributeType.DataType.LONG));
-            attributeTypeList.add(tx.putAttributeType(resourceType3, AttributeType.DataType.LONG));
-            attributeTypeList.add(tx.putAttributeType(resourceType4, AttributeType.DataType.STRING));
-            attributeTypeList.add(tx.putAttributeType(resourceType5, AttributeType.DataType.LONG));
-            attributeTypeList.add(tx.putAttributeType(resourceType6, AttributeType.DataType.DOUBLE));
-            attributeTypeList.add(tx.putAttributeType(resourceType7, AttributeType.DataType.DOUBLE));
+            attributeTypeList.add(tx.putAttributeType(resourceType1, AttributeType.ValueType.DOUBLE));
+            attributeTypeList.add(tx.putAttributeType(resourceType2, AttributeType.ValueType.LONG));
+            attributeTypeList.add(tx.putAttributeType(resourceType3, AttributeType.ValueType.LONG));
+            attributeTypeList.add(tx.putAttributeType(resourceType4, AttributeType.ValueType.STRING));
+            attributeTypeList.add(tx.putAttributeType(resourceType5, AttributeType.ValueType.LONG));
+            attributeTypeList.add(tx.putAttributeType(resourceType6, AttributeType.ValueType.DOUBLE));
+            attributeTypeList.add(tx.putAttributeType(resourceType7, AttributeType.ValueType.DOUBLE));
 
             attributeTypeList.forEach(attributeType -> {
                 entityType1.has(attributeType);

--- a/test-integration/graql/analytics/CorenessIT.java
+++ b/test-integration/graql/analytics/CorenessIT.java
@@ -155,7 +155,7 @@ public class CorenessIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             String aResourceTypeLabel = "aResourceTypeLabel";
             AttributeType<String> attributeType =
-                    tx.putAttributeType(aResourceTypeLabel, AttributeType.DataType.STRING);
+                    tx.putAttributeType(aResourceTypeLabel, AttributeType.ValueType.STRING);
             tx.getEntityType(thing).has(attributeType);
             tx.getEntityType(anotherThing).has(attributeType);
 

--- a/test-integration/graql/analytics/CountIT.java
+++ b/test-integration/graql/analytics/CountIT.java
@@ -133,7 +133,7 @@ public class CountIT {
     public void testHasResourceEdges() {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             EntityType person = tx.putEntityType("person");
-            AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+            AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
             person.has(name);
             Entity aPerson = person.create();
             aPerson.has(name.create("jason"));
@@ -166,7 +166,7 @@ public class CountIT {
             // manually construct the relation type and instance
             EntityType person = tx.getEntityType("person");
             Entity aPerson = person.create();
-            AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+            AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
             Attribute jason = name.create("jason");
 
             Role resourceOwner = tx.putRole(Schema.ImplicitType.HAS_OWNER.getLabel(Label.of("name")));
@@ -211,7 +211,7 @@ public class CountIT {
             // manually construct the relation type and instance
             EntityType person = tx.putEntityType("person");
             Entity aPerson = person.create();
-            AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+            AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
             Attribute jason = name.create("jason");
 
             person.has(name);
@@ -252,7 +252,7 @@ public class CountIT {
 
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             EntityType person = tx.getEntityType("person");
-            AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+            AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
             Entity aPerson = person.create();
             aPerson.has(name.attribute("jason"));
             tx.commit();

--- a/test-integration/graql/analytics/DegreeIT.java
+++ b/test-integration/graql/analytics/DegreeIT.java
@@ -197,9 +197,9 @@ public class DegreeIT {
 
         EntityType person = tx.putEntityType("person").plays(owner);
         EntityType animal = tx.putEntityType("animal").plays(pet);
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
         AttributeType<String> altName =
-                tx.putAttributeType("alternate-name", AttributeType.DataType.STRING);
+                tx.putAttributeType("alternate-name", AttributeType.ValueType.STRING);
 
         animal.has(name).has(altName);
 
@@ -288,7 +288,7 @@ public class DegreeIT {
         RelationType hasOwnershipResource = tx.putRelationType("has-ownership-resource")
                 .relates(ownership).relates(ownershipResource);
 
-        AttributeType<String> startDate = tx.putAttributeType("start-date", AttributeType.DataType.STRING);
+        AttributeType<String> startDate = tx.putAttributeType("start-date", AttributeType.ValueType.STRING);
         startDate.plays(ownershipResource);
         mansBestFriend.plays(ownership);
 

--- a/test-integration/graql/analytics/GraqlComputeIT.java
+++ b/test-integration/graql/analytics/GraqlComputeIT.java
@@ -114,7 +114,7 @@ public class GraqlComputeIT {
             Label resourceTypeId = Label.of("degree");
             EntityType thingy = tx.putEntityType("thingy");
 
-            AttributeType<Long> attribute = tx.putAttributeType(resourceTypeId, AttributeType.DataType.LONG);
+            AttributeType<Long> attribute = tx.putAttributeType(resourceTypeId, AttributeType.ValueType.LONG);
             thingy.has(attribute);
 
             Role degreeOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(resourceTypeId).getValue());
@@ -311,7 +311,7 @@ public class GraqlComputeIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             Label resourceTypeId = Label.of("my-resource");
 
-            AttributeType<Long> resource = tx.putAttributeType(resourceTypeId, AttributeType.DataType.LONG);
+            AttributeType<Long> resource = tx.putAttributeType(resourceTypeId, AttributeType.ValueType.LONG);
             EntityType thingy = tx.putEntityType("thingy");
             thingy.has(resource);
 
@@ -421,7 +421,7 @@ public class GraqlComputeIT {
     @Test
     public void testAnalyticsDoesNotCommitByMistake() throws InvalidKBException {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.putAttributeType("number", AttributeType.DataType.LONG);
+            tx.putAttributeType("number", AttributeType.ValueType.LONG);
             tx.commit();
         }
 
@@ -447,7 +447,7 @@ public class GraqlComputeIT {
 
     private void addSchemaAndEntities() throws InvalidKBException {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            AttributeType<Long> attributeType = tx.putAttributeType(someAttribute, AttributeType.DataType.LONG);
+            AttributeType<Long> attributeType = tx.putAttributeType(someAttribute, AttributeType.ValueType.LONG);
             EntityType entityType1 = tx.putEntityType(thingy).has(attributeType);
             EntityType entityType2 = tx.putEntityType(anotherThing);
             EntityType subEntityType = tx.putEntityType(subThingy).sup(entityType1);

--- a/test-integration/graql/analytics/KCoreIT.java
+++ b/test-integration/graql/analytics/KCoreIT.java
@@ -153,7 +153,7 @@ public class KCoreIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             String aResourceTypeLabel = "aResourceTypeLabel";
             AttributeType<String> attributeType =
-                    tx.putAttributeType(aResourceTypeLabel, AttributeType.DataType.STRING);
+                    tx.putAttributeType(aResourceTypeLabel, AttributeType.ValueType.STRING);
             tx.getEntityType(thing).has(attributeType);
             Attribute aAttribute = attributeType.create("blah");
             tx.getConcept(entityId1).asEntity().has(aAttribute);
@@ -181,7 +181,7 @@ public class KCoreIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             String aResourceTypeLabel = "aResourceTypeLabel";
             AttributeType<String> attributeType =
-                    tx.putAttributeType(aResourceTypeLabel, AttributeType.DataType.STRING);
+                    tx.putAttributeType(aResourceTypeLabel, AttributeType.ValueType.STRING);
             tx.getEntityType(thing).has(attributeType);
 
             Attribute Attribute1 = attributeType.create("blah");

--- a/test-integration/graql/analytics/PathIT.java
+++ b/test-integration/graql/analytics/PathIT.java
@@ -402,7 +402,7 @@ public class PathIT {
         ConceptId endId;
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             EntityType person = tx.putEntityType("person");
-            AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
+            AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
             person.has(name);
             Entity aPerson = person.create();
             startId = aPerson.id();
@@ -446,7 +446,7 @@ public class PathIT {
 
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             EntityType person = tx.putEntityType("person");
-            AttributeType<Long> power = tx.putAttributeType("power", AttributeType.DataType.LONG);
+            AttributeType<Long> power = tx.putAttributeType("power", AttributeType.ValueType.LONG);
 
             person.has(power);
 

--- a/test-integration/graql/analytics/StatisticsIT.java
+++ b/test-integration/graql/analytics/StatisticsIT.java
@@ -506,7 +506,7 @@ public class StatisticsIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
 
             // manually construct the relation type and instance
-            AttributeType<Long> power = tx.putAttributeType("power", AttributeType.DataType.LONG);
+            AttributeType<Long> power = tx.putAttributeType("power", AttributeType.ValueType.LONG);
             EntityType person = tx.putEntityType("person").has(power);
             Role resourceOwner = tx.getRole(Schema.ImplicitType.HAS_OWNER.getLabel(Label.of("power")).getValue());
             Role resourceValue = tx.getRole(Schema.ImplicitType.HAS_VALUE.getLabel(Label.of("power")).getValue());
@@ -585,13 +585,13 @@ public class StatisticsIT {
                     .assign(relation1, entity2)
                     .assign(relation2, entity4);
 
-            AttributeType<Double> attribute1 = tx.putAttributeType(resourceType1, AttributeType.DataType.DOUBLE);
-            AttributeType<Long> attribute2 = tx.putAttributeType(resourceType2, AttributeType.DataType.LONG);
-            AttributeType<Long> attribute3 = tx.putAttributeType(resourceType3, AttributeType.DataType.LONG);
-            AttributeType<String> attribute4 = tx.putAttributeType(resourceType4, AttributeType.DataType.STRING);
-            AttributeType<Long> attribute5 = tx.putAttributeType(resourceType5, AttributeType.DataType.LONG);
-            AttributeType<Double> attribute6 = tx.putAttributeType(resourceType6, AttributeType.DataType.DOUBLE);
-            AttributeType<Double> attribute7 = tx.putAttributeType(resourceType7, AttributeType.DataType.DOUBLE);
+            AttributeType<Double> attribute1 = tx.putAttributeType(resourceType1, AttributeType.ValueType.DOUBLE);
+            AttributeType<Long> attribute2 = tx.putAttributeType(resourceType2, AttributeType.ValueType.LONG);
+            AttributeType<Long> attribute3 = tx.putAttributeType(resourceType3, AttributeType.ValueType.LONG);
+            AttributeType<String> attribute4 = tx.putAttributeType(resourceType4, AttributeType.ValueType.STRING);
+            AttributeType<Long> attribute5 = tx.putAttributeType(resourceType5, AttributeType.ValueType.LONG);
+            AttributeType<Double> attribute6 = tx.putAttributeType(resourceType6, AttributeType.ValueType.DOUBLE);
+            AttributeType<Double> attribute7 = tx.putAttributeType(resourceType7, AttributeType.ValueType.DOUBLE);
 
             entityType1.has(attribute1);
             entityType1.has(attribute2);

--- a/test-integration/graql/graph/MovieGraph.java
+++ b/test-integration/graql/graph/MovieGraph.java
@@ -75,14 +75,14 @@ public class MovieGraph {
 
     private static void buildSchema(Transaction tx) {
 
-        tmdbVoteCount = tx.putAttributeType("tmdb-vote-count", AttributeType.DataType.LONG);
-        tmdbVoteAverage = tx.putAttributeType("tmdb-vote-average", AttributeType.DataType.DOUBLE);
-        releaseDate = tx.putAttributeType("release-date", AttributeType.DataType.DATE);
-        runtime = tx.putAttributeType("runtime", AttributeType.DataType.LONG);
-        gender = tx.putAttributeType("gender", AttributeType.DataType.STRING).regex("(fe)?male");
-        realName = tx.putAttributeType("real-name", AttributeType.DataType.STRING);
-        name = tx.putAttributeType("name", AttributeType.DataType.STRING);
-        provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+        tmdbVoteCount = tx.putAttributeType("tmdb-vote-count", AttributeType.ValueType.LONG);
+        tmdbVoteAverage = tx.putAttributeType("tmdb-vote-average", AttributeType.ValueType.DOUBLE);
+        releaseDate = tx.putAttributeType("release-date", AttributeType.ValueType.DATE);
+        runtime = tx.putAttributeType("runtime", AttributeType.ValueType.LONG);
+        gender = tx.putAttributeType("gender", AttributeType.ValueType.STRING).regex("(fe)?male");
+        realName = tx.putAttributeType("real-name", AttributeType.ValueType.STRING);
+        name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
+        provenance = tx.putAttributeType("provenance", AttributeType.ValueType.STRING);
 
         work = tx.putRole("work");
         author = tx.putRole("author");
@@ -109,7 +109,7 @@ public class MovieGraph {
         hasCluster = tx.putRelationType("has-cluster")
                 .relates(clusterOfProduction).relates(productionWithCluster);
 
-        title = tx.putAttributeType("title", AttributeType.DataType.STRING);
+        title = tx.putAttributeType("title", AttributeType.ValueType.STRING);
         title.has(title);
 
         production = tx.putEntityType("production")

--- a/test-integration/graql/planning/ConjunctionQueryTest.java
+++ b/test-integration/graql/planning/ConjunctionQueryTest.java
@@ -67,13 +67,13 @@ public class ConjunctionQueryTest {
         AttributeType resourceTypeWithoutSubTypesMock = mock(AttributeType.class);
         doAnswer((answer) -> Stream.of(resourceTypeWithoutSubTypesMock)).when(resourceTypeWithoutSubTypesMock).subs();
         when(resourceTypeWithoutSubTypesMock.label()).thenReturn(resourceTypeWithoutSubTypesLabel);
-        when(resourceTypeWithoutSubTypesMock.dataType()).thenReturn(AttributeType.DataType.STRING);
+        when(resourceTypeWithoutSubTypesMock.valueType()).thenReturn(AttributeType.ValueType.STRING);
 
         AttributeType resourceTypeWithSubTypesMock = mock(AttributeType.class);
         doAnswer((answer) -> Stream.of(resourceTypeWithoutSubTypesMock, resourceTypeWithSubTypesMock))
                 .when(resourceTypeWithSubTypesMock).subs();
         when(resourceTypeWithSubTypesMock.label()).thenReturn(resourceTypeWithSubTypesLabel);
-        when(resourceTypeWithSubTypesMock.dataType()).thenReturn(AttributeType.DataType.STRING);
+        when(resourceTypeWithSubTypesMock.valueType()).thenReturn(AttributeType.ValueType.STRING);
 
         when(conceptManager.getAttributeType(resourceTypeWithoutSubTypesLabel.getValue())).thenReturn(resourceTypeWithoutSubTypesMock);
         when(conceptManager.getSchemaConcept(resourceTypeWithoutSubTypesLabel)).thenReturn(resourceTypeWithoutSubTypesMock);

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -141,7 +141,7 @@ public class GraqlDefineIT {
     @Test
     public void testDefineValueType() {
         tx.execute(Graql.define(
-                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.LONG)
+                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.LONG)
         ));
 
         MatchClause match = Graql.match(var("x").type("my-type"));
@@ -153,7 +153,7 @@ public class GraqlDefineIT {
     @Test
     public void testDefineSubResourceType() {
         tx.execute(Graql.define(
-                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING),
+                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING),
                 type("sub-type").sub("my-type")
         ));
 
@@ -218,8 +218,8 @@ public class GraqlDefineIT {
 
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").has(resourceType),
-                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING),
-                type("an-unconnected-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.LONG)
+                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING),
+                type("an-unconnected-resource-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.LONG)
         ));
 
         // Make sure a-new-type can have the given resource type, but not other resource types
@@ -248,7 +248,7 @@ public class GraqlDefineIT {
 
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key(resourceType),
-                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
+                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING)
         ));
 
         // Make sure a-new-type can have the given resource type as a key or otherwise
@@ -273,7 +273,7 @@ public class GraqlDefineIT {
 
     @Test
     public void whenDefiningResourceTypeWithRegex_regexIsAppliedCorrectly() {
-        tx.execute(Graql.define(type("greeting").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("hello|good day")));
+        tx.execute(Graql.define(type("greeting").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING).regex("hello|good day")));
 
         MatchClause match = Graql.match(var("x").type("greeting"));
         assertEquals("hello|good day", tx.stream(match.get("x")).map(ans -> ans.get("x")).findFirst().get().asAttributeType().regex());
@@ -372,7 +372,7 @@ public class GraqlDefineIT {
                 GraqlSemanticException.insertPropertyOnExistingConcept("valuetype", AttributeType.ValueType.BOOLEAN, name).getMessage()
         );
 
-        tx.execute(Graql.define(type("name").valueType(Graql.Token.ValueType.BOOLEAN)));
+        tx.execute(Graql.define(type("name").value(Graql.Token.ValueType.BOOLEAN)));
     }
 
     @Test
@@ -382,7 +382,7 @@ public class GraqlDefineIT {
                 allOf(containsString("Unexpected property"), containsString("valuetype"), containsString("my-type"))
         );
 
-        tx.execute(Graql.define(type("my-type").sub("entity").valueType(Graql.Token.ValueType.BOOLEAN)));
+        tx.execute(Graql.define(type("my-type").sub("entity").value(Graql.Token.ValueType.BOOLEAN)));
     }
 
     @Test

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -139,28 +139,28 @@ public class GraqlDefineIT {
     }
 
     @Test
-    public void testDefineDataType() {
+    public void testDefineValueType() {
         tx.execute(Graql.define(
-                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.LONG)
+                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.LONG)
         ));
 
         MatchClause match = Graql.match(var("x").type("my-type"));
-        AttributeType.DataType datatype = tx.stream(match).iterator().next().get("x").asAttributeType().dataType();
+        AttributeType.ValueType valuetype = tx.stream(match).iterator().next().get("x").asAttributeType().valueType();
 
-        Assert.assertEquals(AttributeType.DataType.LONG, datatype);
+        Assert.assertEquals(AttributeType.ValueType.LONG, valuetype);
     }
 
     @Test
     public void testDefineSubResourceType() {
         tx.execute(Graql.define(
-                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING),
+                type("my-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING),
                 type("sub-type").sub("my-type")
         ));
 
         MatchClause match = Graql.match(var("x").type("sub-type"));
-        AttributeType.DataType datatype = tx.stream(match).iterator().next().get("x").asAttributeType().dataType();
+        AttributeType.ValueType valuetype = tx.stream(match).iterator().next().get("x").asAttributeType().valueType();
 
-        Assert.assertEquals(AttributeType.DataType.STRING, datatype);
+        Assert.assertEquals(AttributeType.ValueType.STRING, valuetype);
     }
 
     @Test
@@ -218,8 +218,8 @@ public class GraqlDefineIT {
 
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").has(resourceType),
-                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING),
-                type("an-unconnected-resource-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.LONG)
+                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING),
+                type("an-unconnected-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.LONG)
         ));
 
         // Make sure a-new-type can have the given resource type, but not other resource types
@@ -248,7 +248,7 @@ public class GraqlDefineIT {
 
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key(resourceType),
-                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING)
+                type(resourceType).sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
         ));
 
         // Make sure a-new-type can have the given resource type as a key or otherwise
@@ -273,7 +273,7 @@ public class GraqlDefineIT {
 
     @Test
     public void whenDefiningResourceTypeWithRegex_regexIsAppliedCorrectly() {
-        tx.execute(Graql.define(type("greeting").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING).regex("hello|good day")));
+        tx.execute(Graql.define(type("greeting").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("hello|good day")));
 
         MatchClause match = Graql.match(var("x").type("greeting"));
         assertEquals("hello|good day", tx.stream(match.get("x")).map(ans -> ans.get("x")).findFirst().get().asAttributeType().regex());
@@ -327,10 +327,10 @@ public class GraqlDefineIT {
     }
 
     @Test
-    public void whenDefiningAttributeTypeWithoutDataType_weThrow() {
+    public void whenDefiningAttributeTypeWithoutValueType_weThrow() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("my-resource"), containsString("datatype"), containsString("resource"))
+                allOf(containsString("my-resource"), containsString("valuetype"), containsString("resource"))
         );
         tx.execute(Graql.define(type("my-resource").sub(Graql.Token.Type.ATTRIBUTE)));
     }
@@ -364,25 +364,25 @@ public class GraqlDefineIT {
     }
 
     @Test
-    public void whenSpecifyingExistingTypeWithIncorrectDataType_Throw() {
+    public void whenSpecifyingExistingTypeWithIncorrectValueType_Throw() {
         AttributeType name = tx.getAttributeType("name");
 
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                GraqlSemanticException.insertPropertyOnExistingConcept("datatype", AttributeType.DataType.BOOLEAN, name).getMessage()
+                GraqlSemanticException.insertPropertyOnExistingConcept("valuetype", AttributeType.ValueType.BOOLEAN, name).getMessage()
         );
 
-        tx.execute(Graql.define(type("name").datatype(Graql.Token.DataType.BOOLEAN)));
+        tx.execute(Graql.define(type("name").valueType(Graql.Token.ValueType.BOOLEAN)));
     }
 
     @Test
-    public void whenSpecifyingDataTypeOnAnEntityType_Throw() {
+    public void whenSpecifyingValueTypeOnAnEntityType_Throw() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("Unexpected property"), containsString("datatype"), containsString("my-type"))
+                allOf(containsString("Unexpected property"), containsString("valuetype"), containsString("my-type"))
         );
 
-        tx.execute(Graql.define(type("my-type").sub("entity").datatype(Graql.Token.DataType.BOOLEAN)));
+        tx.execute(Graql.define(type("my-type").sub("entity").valueType(Graql.Token.ValueType.BOOLEAN)));
     }
 
     @Test

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -330,9 +330,9 @@ public class GraqlDefineIT {
     public void whenDefiningAttributeTypeWithoutValueType_weThrow() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("my-resource"), containsString("value type"), containsString("resource"))
+                allOf(containsString("my-att"), containsString("value"), containsString("attribute"))
         );
-        tx.execute(Graql.define(type("my-resource").sub(Graql.Token.Type.ATTRIBUTE)));
+        tx.execute(Graql.define(type("my-att").sub(Graql.Token.Type.ATTRIBUTE)));
     }
 
     @Test
@@ -379,7 +379,7 @@ public class GraqlDefineIT {
     public void whenSpecifyingValueTypeOnAnEntityType_Throw() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("Unexpected property"), containsString("value type"), containsString("my-type"))
+                allOf(containsString("Unexpected property"), containsString("value"), containsString("my-type"))
         );
 
         tx.execute(Graql.define(type("my-type").sub("entity").value(Graql.Token.ValueType.BOOLEAN)));

--- a/test-integration/graql/query/GraqlDefineIT.java
+++ b/test-integration/graql/query/GraqlDefineIT.java
@@ -330,7 +330,7 @@ public class GraqlDefineIT {
     public void whenDefiningAttributeTypeWithoutValueType_weThrow() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("my-resource"), containsString("valuetype"), containsString("resource"))
+                allOf(containsString("my-resource"), containsString("value type"), containsString("resource"))
         );
         tx.execute(Graql.define(type("my-resource").sub(Graql.Token.Type.ATTRIBUTE)));
     }
@@ -369,7 +369,7 @@ public class GraqlDefineIT {
 
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                GraqlSemanticException.insertPropertyOnExistingConcept("valuetype", AttributeType.ValueType.BOOLEAN, name).getMessage()
+                GraqlSemanticException.insertPropertyOnExistingConcept("value", AttributeType.ValueType.BOOLEAN, name).getMessage()
         );
 
         tx.execute(Graql.define(type("name").value(Graql.Token.ValueType.BOOLEAN)));
@@ -379,7 +379,7 @@ public class GraqlDefineIT {
     public void whenSpecifyingValueTypeOnAnEntityType_Throw() {
         exception.expect(GraqlSemanticException.class);
         exception.expectMessage(
-                allOf(containsString("Unexpected property"), containsString("valuetype"), containsString("my-type"))
+                allOf(containsString("Unexpected property"), containsString("value type"), containsString("my-type"))
         );
 
         tx.execute(Graql.define(type("my-type").sub("entity").value(Graql.Token.ValueType.BOOLEAN)));

--- a/test-integration/graql/query/GraqlDeleteIT.java
+++ b/test-integration/graql/query/GraqlDeleteIT.java
@@ -305,10 +305,10 @@ public class GraqlDeleteIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
 
         tx.execute(Graql.parse("define" +
-                "    unique-key sub attribute, valuetype long;" +
-                "    name sub attribute, valuetype string," +
+                "    unique-key sub attribute, value long;" +
+                "    name sub attribute, value string," +
                 "        key unique-key;" +
-                "    region-code sub attribute, valuetype long," +
+                "    region-code sub attribute, value long," +
                 "        key unique-key;" +
                 "    road sub entity," +
                 "        plays endpoint," +

--- a/test-integration/graql/query/GraqlDeleteIT.java
+++ b/test-integration/graql/query/GraqlDeleteIT.java
@@ -42,7 +42,6 @@ import graql.lang.pattern.Pattern;
 import graql.lang.query.MatchClause;
 import graql.lang.statement.Statement;
 import graql.lang.statement.StatementThing;
-import graql.lang.statement.Variable;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -306,10 +305,10 @@ public class GraqlDeleteIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
 
         tx.execute(Graql.parse("define" +
-                "    unique-key sub attribute, datatype long;" +
-                "    name sub attribute, datatype string," +
+                "    unique-key sub attribute, valuetype long;" +
+                "    name sub attribute, valuetype string," +
                 "        key unique-key;" +
-                "    region-code sub attribute, datatype long," +
+                "    region-code sub attribute, valuetype long," +
                 "        key unique-key;" +
                 "    road sub entity," +
                 "        plays endpoint," +
@@ -361,8 +360,8 @@ public class GraqlDeleteIT {
         Session session = graknServer.sessionWithNewKeyspace();
         Transaction tx = session.transaction(Transaction.Type.WRITE);
 
-        AttributeType<String> name = tx.putAttributeType("name", AttributeType.DataType.STRING);
-        AttributeType<Long> year = tx.putAttributeType("year", AttributeType.DataType.LONG);
+        AttributeType<String> name = tx.putAttributeType("name", AttributeType.ValueType.STRING);
+        AttributeType<Long> year = tx.putAttributeType("year", AttributeType.ValueType.LONG);
         Role work = tx.putRole("work");
         EntityType somework = tx.putEntityType("somework").plays(work);
         Role author = tx.putRole("author");
@@ -401,7 +400,7 @@ public class GraqlDeleteIT {
         RelationType authoredBy = tx.putRelationType("authored-by").relates(author).relates(work);
         EntityType person = tx.putEntityType("person").plays(author);
         EntityType production = tx.putEntityType("production").plays(work);
-        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.ValueType.STRING);
         authoredBy.has(provenance);
 
         Entity aPerson = person.create();
@@ -435,7 +434,7 @@ public class GraqlDeleteIT {
         RelationType authoredBy = tx.putRelationType("authored-by").relates(author).relates(work);
         EntityType person = tx.putEntityType("person").plays(author);
         EntityType production = tx.putEntityType("production").plays(work);
-        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.ValueType.STRING);
         authoredBy.has(provenance);
 
         Entity aPerson = person.create();

--- a/test-integration/graql/query/GraqlGetIT.java
+++ b/test-integration/graql/query/GraqlGetIT.java
@@ -301,7 +301,7 @@ public class GraqlGetIT {
 
     @Test
     public void testSumNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .sum("y");
 
@@ -326,7 +326,7 @@ public class GraqlGetIT {
 
     @Test
     public void testMaxNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .max("y");
 
@@ -343,7 +343,7 @@ public class GraqlGetIT {
 
     @Test
     public void testMinNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .min("y");
 
@@ -361,7 +361,7 @@ public class GraqlGetIT {
 
     @Test
     public void testMeanNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .mean("y");
 
@@ -390,7 +390,7 @@ public class GraqlGetIT {
 
     @Test
     public void testMedianNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .median("y");
 
@@ -425,7 +425,7 @@ public class GraqlGetIT {
 
     @Test
     public void testStdNull() {
-        tx.putAttributeType("random", AttributeType.DataType.INTEGER);
+        tx.putAttributeType("random", AttributeType.ValueType.INTEGER);
         GraqlGet.Aggregate query = Graql.match(var("x").isa("movie"), var().rel("x").rel("y"), var("y").isa("random")).get()
                 .std("y");
 
@@ -456,7 +456,7 @@ public class GraqlGetIT {
     }
 
     @Test(expected = Exception.class)
-    public void testIncorrectResourceDataType() {
+    public void testIncorrectAttributeValueType() {
         tx.execute(Graql.match(var("x").isa("movie").has("title", var("y"))).get().sum("y"));
     }
 
@@ -484,7 +484,7 @@ public class GraqlGetIT {
         EntityType somework = tx.putEntityType("somework").plays(work);
         Role author = tx.putRole("author");
         EntityType person = tx.putEntityType("person").plays(author);
-        AttributeType<Long> year = tx.putAttributeType("year", AttributeType.DataType.LONG);
+        AttributeType<Long> year = tx.putAttributeType("year", AttributeType.ValueType.LONG);
         tx.putRelationType("authored-by").relates(work).relates(author).has(year);
 
         Stream<ConceptMap> answers = tx.stream(Graql.parse("insert $x isa person;" +

--- a/test-integration/graql/query/GraqlInsertIT.java
+++ b/test-integration/graql/query/GraqlInsertIT.java
@@ -294,7 +294,7 @@ public class GraqlInsertIT {
     public void testKeyCorrectUsage() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
-                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
+                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(var().isa("a-new-type").has("a-new-resource-type", "hello")));
@@ -304,7 +304,7 @@ public class GraqlInsertIT {
     public void whenInsertingAThingWithTwoKeyResources_Throw() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-attribute-type"),
-                type("a-new-attribute-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
+                type("a-new-attribute-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(
@@ -322,7 +322,7 @@ public class GraqlInsertIT {
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
                 type("a-new-resource-type")
                         .sub(Graql.Token.Type.ATTRIBUTE)
-                        .valueType(Graql.Token.ValueType.STRING)
+                        .value(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(
@@ -338,7 +338,7 @@ public class GraqlInsertIT {
     public void testKeyRequiredOwner() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
-                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
+                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(var().isa("a-new-type")));

--- a/test-integration/graql/query/GraqlInsertIT.java
+++ b/test-integration/graql/query/GraqlInsertIT.java
@@ -294,7 +294,7 @@ public class GraqlInsertIT {
     public void testKeyCorrectUsage() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
-                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING)
+                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(var().isa("a-new-type").has("a-new-resource-type", "hello")));
@@ -304,7 +304,7 @@ public class GraqlInsertIT {
     public void whenInsertingAThingWithTwoKeyResources_Throw() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-attribute-type"),
-                type("a-new-attribute-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING)
+                type("a-new-attribute-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(
@@ -322,7 +322,7 @@ public class GraqlInsertIT {
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
                 type("a-new-resource-type")
                         .sub(Graql.Token.Type.ATTRIBUTE)
-                        .datatype(Graql.Token.DataType.STRING)
+                        .valueType(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(
@@ -338,7 +338,7 @@ public class GraqlInsertIT {
     public void testKeyRequiredOwner() throws InvalidKBException {
         tx.execute(Graql.define(
                 type("a-new-type").sub("entity").key("a-new-resource-type"),
-                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING)
+                type("a-new-resource-type").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
         ));
 
         tx.execute(Graql.insert(var().isa("a-new-type")));

--- a/test-integration/graql/query/GraqlUndefineIT.java
+++ b/test-integration/graql/query/GraqlUndefineIT.java
@@ -97,7 +97,7 @@ public class GraqlUndefineIT {
 
     @Test
     public void whenUndefiningValueType_DoNothing() {
-        tx.execute(Graql.undefine(type("name").valueType(Graql.Token.ValueType.STRING)));
+        tx.execute(Graql.undefine(type("name").value(Graql.Token.ValueType.STRING)));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
         assertEquals(AttributeType.ValueType.STRING, tx.getAttributeType("name").valueType());
@@ -222,7 +222,7 @@ public class GraqlUndefineIT {
 
     @Test
     public void whenUndefiningRegexProperty_TheAttributeTypeHasNoRegex() {
-        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("abc")));
+        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).value(Graql.Token.ValueType.STRING).regex("abc")));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
         assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
@@ -235,7 +235,7 @@ public class GraqlUndefineIT {
 
     @Test
     public void whenUndefiningRegexPropertyWithWrongRegex_DoNothing() {
-        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("abc")));
+        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).value(Graql.Token.ValueType.STRING).regex("abc")));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
         assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
@@ -305,7 +305,7 @@ public class GraqlUndefineIT {
     public void undefineTypeAndTheirAttributes() {
         tx.execute(Graql.define(
                 type("company").sub("entity").has("registration"),
-                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING)
+                type("registration").sub("attribute").value(Graql.Token.ValueType.STRING)
         ));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
@@ -328,7 +328,7 @@ public class GraqlUndefineIT {
     public void undefineTypeAndTheirAttributeAndRolesAndRelations() {
         Collection<Statement> schema = ImmutableList.of(
                 type("pokemon").sub(ENTITY).has("pokedex-no").plays("ancestor").plays("descendant"),
-                type("pokedex-no").sub(ATTRIBUTE).valueType(Graql.Token.ValueType.LONG),
+                type("pokedex-no").sub(ATTRIBUTE).value(Graql.Token.ValueType.LONG),
                 type("evolution").sub(RELATION).relates("ancestor").relates("descendant"),
                 type("ancestor").sub(ROLE),
                 type("descendant").sub(ROLE)
@@ -361,7 +361,7 @@ public class GraqlUndefineIT {
     @Test
     public void undefineTypeAndTheirAttributeWhenThereIsAnInstanceOfThem_Throw() {
         tx.execute(Graql.define(
-                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                type("registration").sub("attribute").value(Graql.Token.ValueType.STRING),
                 type("company").sub("entity").has("registration")
         ));
         tx.execute(Graql.insert(
@@ -382,7 +382,7 @@ public class GraqlUndefineIT {
     @Test
     public void whenUndefiningATypeAndTheirInheritedAttribute_Throw() {
         tx.execute(Graql.define(
-                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                type("registration").sub("attribute").value(Graql.Token.ValueType.STRING),
                 type("company").sub("entity").has("registration"),
                 type("sub-company").sub("company")
         ));

--- a/test-integration/graql/query/GraqlUndefineIT.java
+++ b/test-integration/graql/query/GraqlUndefineIT.java
@@ -96,11 +96,11 @@ public class GraqlUndefineIT {
     }
 
     @Test
-    public void whenUndefiningDataType_DoNothing() {
-        tx.execute(Graql.undefine(type("name").datatype(Graql.Token.DataType.STRING)));
+    public void whenUndefiningValueType_DoNothing() {
+        tx.execute(Graql.undefine(type("name").valueType(Graql.Token.ValueType.STRING)));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
-        assertEquals(AttributeType.DataType.STRING, tx.getAttributeType("name").dataType());
+        assertEquals(AttributeType.ValueType.STRING, tx.getAttributeType("name").valueType());
     }
 
     @Test
@@ -222,7 +222,7 @@ public class GraqlUndefineIT {
 
     @Test
     public void whenUndefiningRegexProperty_TheAttributeTypeHasNoRegex() {
-        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).datatype(Graql.Token.DataType.STRING).regex("abc")));
+        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("abc")));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
         assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
@@ -235,7 +235,7 @@ public class GraqlUndefineIT {
 
     @Test
     public void whenUndefiningRegexPropertyWithWrongRegex_DoNothing() {
-        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).datatype(Graql.Token.DataType.STRING).regex("abc")));
+        tx.execute(Graql.define(type(NEW_TYPE.getValue()).sub(ATTRIBUTE).valueType(Graql.Token.ValueType.STRING).regex("abc")));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
         assertEquals("abc", tx.<AttributeType>getType(NEW_TYPE).regex());
@@ -305,7 +305,7 @@ public class GraqlUndefineIT {
     public void undefineTypeAndTheirAttributes() {
         tx.execute(Graql.define(
                 type("company").sub("entity").has("registration"),
-                type("registration").sub("attribute").datatype(Graql.Token.DataType.STRING)
+                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING)
         ));
         tx.commit();
         tx = session.transaction(Transaction.Type.WRITE);
@@ -328,7 +328,7 @@ public class GraqlUndefineIT {
     public void undefineTypeAndTheirAttributeAndRolesAndRelations() {
         Collection<Statement> schema = ImmutableList.of(
                 type("pokemon").sub(ENTITY).has("pokedex-no").plays("ancestor").plays("descendant"),
-                type("pokedex-no").sub(ATTRIBUTE).datatype(Graql.Token.DataType.LONG),
+                type("pokedex-no").sub(ATTRIBUTE).valueType(Graql.Token.ValueType.LONG),
                 type("evolution").sub(RELATION).relates("ancestor").relates("descendant"),
                 type("ancestor").sub(ROLE),
                 type("descendant").sub(ROLE)
@@ -361,7 +361,7 @@ public class GraqlUndefineIT {
     @Test
     public void undefineTypeAndTheirAttributeWhenThereIsAnInstanceOfThem_Throw() {
         tx.execute(Graql.define(
-                type("registration").sub("attribute").datatype(Graql.Token.DataType.STRING),
+                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING),
                 type("company").sub("entity").has("registration")
         ));
         tx.execute(Graql.insert(
@@ -382,7 +382,7 @@ public class GraqlUndefineIT {
     @Test
     public void whenUndefiningATypeAndTheirInheritedAttribute_Throw() {
         tx.execute(Graql.define(
-                type("registration").sub("attribute").datatype(Graql.Token.DataType.STRING),
+                type("registration").sub("attribute").valueType(Graql.Token.ValueType.STRING),
                 type("company").sub("entity").has("registration"),
                 type("sub-company").sub("company")
         ));

--- a/test-integration/graql/query/NumberCastingIT.java
+++ b/test-integration/graql/query/NumberCastingIT.java
@@ -156,7 +156,7 @@ public class NumberCastingIT {
         double value = 10000000.0;
         Pattern pattern = Graql.var("x").val(value).isa("attr-date");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of value [java.time.LocalDateTime]");
+        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of value type [java.time.LocalDateTime]");
         verifyWrite(session, pattern);
     }
 

--- a/test-integration/graql/query/NumberCastingIT.java
+++ b/test-integration/graql/query/NumberCastingIT.java
@@ -156,7 +156,7 @@ public class NumberCastingIT {
         double value = 10000000.0;
         Pattern pattern = Graql.var("x").val(value).isa("attr-date");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of valuetype [java.time.LocalDateTime]");
+        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of value [java.time.LocalDateTime]");
         verifyWrite(session, pattern);
     }
 
@@ -165,7 +165,7 @@ public class NumberCastingIT {
         boolean value = true;
         Pattern pattern = Graql.var("x").val(value).isa("attr-double");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Boolean] must be of valuetype [java.lang.Double]");
+        expectedException.expectMessage("The value [" + value + "] of type [Boolean] must be of value type [java.lang.Double]");
         verifyWrite(session, pattern);
     }
 
@@ -174,7 +174,7 @@ public class NumberCastingIT {
         double value = 10.1;
         Pattern pattern = Graql.var("x").val(value).isa("attr-long");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of valuetype [java.lang.Long]");
+        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of value type [java.lang.Long]");
         verifyWrite(session, pattern);
     }
 

--- a/test-integration/graql/query/NumberCastingIT.java
+++ b/test-integration/graql/query/NumberCastingIT.java
@@ -52,9 +52,9 @@ public class NumberCastingIT {
     public void newSession() {
         session = graknServer.sessionWithNewKeyspace();
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.putAttributeType("attr-long", AttributeType.DataType.LONG);
-            tx.putAttributeType("attr-double", AttributeType.DataType.DOUBLE);
-            tx.putAttributeType("attr-date", AttributeType.DataType.DATE);
+            tx.putAttributeType("attr-long", AttributeType.ValueType.LONG);
+            tx.putAttributeType("attr-double", AttributeType.ValueType.DOUBLE);
+            tx.putAttributeType("attr-date", AttributeType.ValueType.DATE);
             tx.commit();
         }
     }
@@ -156,7 +156,7 @@ public class NumberCastingIT {
         double value = 10000000.0;
         Pattern pattern = Graql.var("x").val(value).isa("attr-date");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of datatype [java.time.LocalDateTime]");
+        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of valuetype [java.time.LocalDateTime]");
         verifyWrite(session, pattern);
     }
 
@@ -165,7 +165,7 @@ public class NumberCastingIT {
         boolean value = true;
         Pattern pattern = Graql.var("x").val(value).isa("attr-double");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Boolean] must be of datatype [java.lang.Double]");
+        expectedException.expectMessage("The value [" + value + "] of type [Boolean] must be of valuetype [java.lang.Double]");
         verifyWrite(session, pattern);
     }
 
@@ -174,7 +174,7 @@ public class NumberCastingIT {
         double value = 10.1;
         Pattern pattern = Graql.var("x").val(value).isa("attr-long");
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of datatype [java.lang.Long]");
+        expectedException.expectMessage("The value [" + value + "] of type [Double] must be of valuetype [java.lang.Long]");
         verifyWrite(session, pattern);
     }
 

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -187,7 +187,7 @@ public class QueryErrorIT {
         try (Transaction newTx = newSession.transaction(Transaction.Type.WRITE)) {
             newTx.execute(Graql.define(
                     type("person").sub("entity"),
-                    type("name").sub(Graql.Token.Type.ATTRIBUTE).datatype(Graql.Token.DataType.STRING)
+                    type("name").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
             ));
 
             exception.expect(GraknConceptException.class);

--- a/test-integration/graql/query/QueryErrorIT.java
+++ b/test-integration/graql/query/QueryErrorIT.java
@@ -187,7 +187,7 @@ public class QueryErrorIT {
         try (Transaction newTx = newSession.transaction(Transaction.Type.WRITE)) {
             newTx.execute(Graql.define(
                     type("person").sub("entity"),
-                    type("name").sub(Graql.Token.Type.ATTRIBUTE).valueType(Graql.Token.ValueType.STRING)
+                    type("name").sub(Graql.Token.Type.ATTRIBUTE).value(Graql.Token.ValueType.STRING)
             ));
 
             exception.expect(GraknConceptException.class);

--- a/test-integration/graql/query/QueryPlannerIT.java
+++ b/test-integration/graql/query/QueryPlannerIT.java
@@ -90,7 +90,7 @@ public class QueryPlannerIT {
         EntityType entityType3 = graph.putEntityType(thingy3);
         EntityType entityType4 = graph.putEntityType(thingy4);
 
-        AttributeType<String> attributeType = graph.putAttributeType(resourceType, AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = graph.putAttributeType(resourceType, AttributeType.ValueType.STRING);
         entityType4.has(attributeType);
 
         EntityType superType1 = graph.putEntityType(thingy);

--- a/test-integration/graql/query/QueryValidityIT.java
+++ b/test-integration/graql/query/QueryValidityIT.java
@@ -52,7 +52,7 @@ public class QueryValidityIT {
                 "someRel sub relation, relates anotherRole; " +
                 "anotherNoRoleEntity sub entity, plays role1;" +
                 "binary sub relation, relates role1;" +
-                "name sub attribute, datatype string;").asDefine());
+                "name sub attribute, valuetype string;").asDefine());
         tx.commit();
         tx = genericSchemaSession.transaction(Transaction.Type.WRITE);
     }

--- a/test-integration/graql/query/QueryValidityIT.java
+++ b/test-integration/graql/query/QueryValidityIT.java
@@ -52,7 +52,7 @@ public class QueryValidityIT {
                 "someRel sub relation, relates anotherRole; " +
                 "anotherNoRoleEntity sub entity, plays role1;" +
                 "binary sub relation, relates role1;" +
-                "name sub attribute, valuetype string;").asDefine());
+                "name sub attribute, value string;").asDefine());
         tx.commit();
         tx = genericSchemaSession.transaction(Transaction.Type.WRITE);
     }

--- a/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test-integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -157,14 +157,14 @@ public class AtomicEquivalenceIT {
         atomicEquality(pattern, pattern8, false, reasonerQueryFactory);
     }
 
-    private static Map<AttributeType.DataType<?>, Object> testValues = ImmutableMap.<AttributeType.DataType<?>, Object>builder()
-            .put(AttributeType.DataType.BOOLEAN, true)
-            .put(AttributeType.DataType.DATE, LocalDateTime.now())
-            .put(AttributeType.DataType.DOUBLE, 10.0)
-            .put(AttributeType.DataType.FLOAT, 10.0)
-            .put(AttributeType.DataType.INTEGER, 10)
-            .put(AttributeType.DataType.LONG, 10L)
-            .put(AttributeType.DataType.STRING, "10")
+    private static Map<AttributeType.ValueType<?>, Object> testValues = ImmutableMap.<AttributeType.ValueType<?>, Object>builder()
+            .put(AttributeType.ValueType.BOOLEAN, true)
+            .put(AttributeType.ValueType.DATE, LocalDateTime.now())
+            .put(AttributeType.ValueType.DOUBLE, 10.0)
+            .put(AttributeType.ValueType.FLOAT, 10.0)
+            .put(AttributeType.ValueType.INTEGER, 10)
+            .put(AttributeType.ValueType.LONG, 10L)
+            .put(AttributeType.ValueType.STRING, "10")
             .build();
 
     @Test
@@ -174,17 +174,17 @@ public class AtomicEquivalenceIT {
 
         ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
 
-        AttributeType.DataType.values().stream()
-                .filter(dataType -> attributeTypes.stream().anyMatch(t -> t.dataType() != null && t.dataType().equals(dataType)))
-                .forEach(dataType -> {
-                    Object value = testValues.get(dataType);
+        AttributeType.ValueType.values().stream()
+                .filter(valueType -> attributeTypes.stream().anyMatch(t -> t.valueType() != null && t.valueType().equals(valueType)))
+                .forEach(valueType -> {
+                    Object value = testValues.get(valueType);
                     attributeTypes.stream()
-                            .filter(t -> Objects.nonNull(t.dataType()))
-                            .filter(t -> t.dataType().equals(dataType)).forEach(attributeType -> {
+                            .filter(t -> Objects.nonNull(t.valueType()))
+                            .filter(t -> t.valueType().equals(valueType)).forEach(attributeType -> {
 
                         Pattern basePattern = Graql.parsePattern("$x has " + attributeType.label().getValue() + " " + value + ";");
-                        dataType.comparableDataTypes().forEach(comparableDataType -> {
-                            AttributeValueConverter<Object, ?> converter = AttributeValueConverter.of(comparableDataType);
+                        valueType.comparableValueTypes().forEach(comparableValueType -> {
+                            AttributeValueConverter<Object, ?> converter = AttributeValueConverter.of(comparableValueType);
                             Pattern convertedPattern = Graql.parsePattern("$x has " + attributeType.label().getValue() + " " + converter.convert(value) + ";");
                             atomicEquivalence(basePattern.toString(), convertedPattern.toString(), true, AtomicEquivalence.AlphaEquivalence, reasonerQueryFactory);
                             atomicEquivalence(basePattern.toString(), convertedPattern.toString(), true, AtomicEquivalence.StructuralEquivalence, reasonerQueryFactory);

--- a/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
+++ b/test-integration/graql/reasoner/benchmark/BenchmarkBigIT.java
@@ -22,7 +22,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import grakn.client.GraknClient;
 import grakn.client.answer.ConceptMap;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.ConceptId;
 import grakn.client.concept.Label;
@@ -162,7 +162,7 @@ public class BenchmarkBigIT {
             try (GraknClient.Transaction transaction = session.transaction().write()) {
                 Role fromRole = transaction.putRole(fromRoleLabel);
                 Role toRole = transaction.putRole(toRoleLabel);
-                AttributeType<String> index = transaction.putAttributeType(attributeLabel, DataType.STRING);
+                AttributeType<String> index = transaction.putAttributeType(attributeLabel,  ValueType.STRING);
                 transaction.putEntityType(entityLabel)
                         .plays(fromRole)
                         .plays(toRole)

--- a/test-integration/graql/reasoner/benchmark/RuleScalingIT.java
+++ b/test-integration/graql/reasoner/benchmark/RuleScalingIT.java
@@ -58,8 +58,8 @@ public class RuleScalingIT {
                             "   has inferredAttribute, has anotherInferredAttribute," +
                             "   relates someRole, relates anotherRole;" +
                             "indexingRelation sub relation, relates someRole, relates anotherRole;" +
-                            "inferredAttribute sub attribute, valuetype string;" +
-                            "anotherInferredAttribute sub attribute, valuetype string;"
+                            "inferredAttribute sub attribute, value string;" +
+                            "anotherInferredAttribute sub attribute, value string;"
             ));
 
             for (int i = 0; i < N; i++) {

--- a/test-integration/graql/reasoner/benchmark/RuleScalingIT.java
+++ b/test-integration/graql/reasoner/benchmark/RuleScalingIT.java
@@ -58,8 +58,8 @@ public class RuleScalingIT {
                             "   has inferredAttribute, has anotherInferredAttribute," +
                             "   relates someRole, relates anotherRole;" +
                             "indexingRelation sub relation, relates someRole, relates anotherRole;" +
-                            "inferredAttribute sub attribute, datatype string;" +
-                            "anotherInferredAttribute sub attribute, datatype string;"
+                            "inferredAttribute sub attribute, valuetype string;" +
+                            "anotherInferredAttribute sub attribute, valuetype string;"
             ));
 
             for (int i = 0; i < N; i++) {

--- a/test-integration/graql/reasoner/cache/RuleCacheIT.java
+++ b/test-integration/graql/reasoner/cache/RuleCacheIT.java
@@ -222,8 +222,8 @@ public class RuleCacheIT {
     public void whenRulesWithPositiveAndNegativePremiseArePresent_lackOfInstancesOnlyPrunesOne(){
         Session session = SessionUtil.serverlessSessionWithNewKeyspace(storage.createCompatibleServerConfig());
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<String> resource = tx.putAttributeType("resource", AttributeType.DataType.STRING);
-            AttributeType<String> derivedResource = tx.putAttributeType("derivedResource", AttributeType.DataType.STRING);
+            AttributeType<String> resource = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
+            AttributeType<String> derivedResource = tx.putAttributeType("derivedResource", AttributeType.ValueType.STRING);
             tx.putEntityType("someEntity").has(resource).has(derivedResource);
             tx.putEntityType("derivedEntity");
             tx.putRule("positiveRule",

--- a/test-integration/graql/reasoner/graph/GeoGraph.java
+++ b/test-integration/graql/reasoner/graph/GeoGraph.java
@@ -60,7 +60,7 @@ public class GeoGraph {
     }
 
     private void buildSchema() {
-        key = tx.putAttributeType("name", AttributeType.DataType.STRING);
+        key = tx.putAttributeType("name", AttributeType.ValueType.STRING);
 
         geoEntity = tx.putRole("geo-entity");
         entityLocation = tx.putRole("entity-location");

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -227,7 +227,7 @@ public class QueryIT {
                 tx.execute(Graql.parse("define " +
                         "someEntity sub entity," +
                         "has derivedResource;" +
-                        "derivedResource sub attribute, valuetype long;" +
+                        "derivedResource sub attribute, value long;" +
                         "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};"
                 ).asDefine());
                 tx.execute(Graql.parse("insert " +

--- a/test-integration/graql/reasoner/query/QueryIT.java
+++ b/test-integration/graql/reasoner/query/QueryIT.java
@@ -227,7 +227,7 @@ public class QueryIT {
                 tx.execute(Graql.parse("define " +
                         "someEntity sub entity," +
                         "has derivedResource;" +
-                        "derivedResource sub attribute, datatype long;" +
+                        "derivedResource sub attribute, valuetype long;" +
                         "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};"
                 ).asDefine());
                 tx.execute(Graql.parse("insert " +
@@ -255,7 +255,7 @@ public class QueryIT {
         try (Session session = SessionUtil.serverlessSessionWithNewKeyspace(mockServerConfig)) {
             try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
 
-                AttributeType<Long> resource = tx.putAttributeType("resource", AttributeType.DataType.LONG);
+                AttributeType<Long> resource = tx.putAttributeType("resource", AttributeType.ValueType.LONG);
                 resource.create(1337L);
                 resource.create(1667L);
                 tx.putEntityType("someEntity")

--- a/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test-integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -73,7 +73,7 @@ public class AttributeAttachmentIT {
 
     @Test
     //Expected result: When the head of a rule contains attribute assertions, the respective unique attributes should be generated or reused.
-    public void whenUsingNonPersistedDataType_noDuplicatesAreCreated() {
+    public void whenUsingNonPersistedValueType_noDuplicatesAreCreated() {
         try(Transaction tx = attributeAttachmentSession.transaction(Transaction.Type.WRITE)) {
 
             String queryString = "match $x isa genericEntity, has reattachable-resource-string $y; get;";

--- a/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
+++ b/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
@@ -29,7 +29,6 @@ import grakn.core.graql.reasoner.query.ReasonerQueryEquivalence;
 import grakn.core.graql.reasoner.query.ReasonerQueryFactory;
 import grakn.core.graql.reasoner.query.ReasonerQueryImpl;
 import grakn.core.graql.reasoner.query.ResolvableQuery;
-import grakn.core.graql.reasoner.utils.ReasonerUtils;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.server.Session;
@@ -86,7 +85,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, datatype long;" +
+                    "derivedResource sub attribute, valuetype long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};" +
                     "rule3 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1997;};"
@@ -144,7 +143,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, datatype long;" +
+                    "derivedResource sub attribute, valuetype long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};"
 
@@ -217,7 +216,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, datatype long;" +
+                    "derivedResource sub attribute, valuetype long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};" +
                     "rule3 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1997;};"

--- a/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
+++ b/test-integration/graql/reasoner/reasoning/ValuePredicateIT.java
@@ -85,7 +85,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, valuetype long;" +
+                    "derivedResource sub attribute, value long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};" +
                     "rule3 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1997;};"
@@ -143,7 +143,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, valuetype long;" +
+                    "derivedResource sub attribute, value long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};"
 
@@ -216,7 +216,7 @@ public class ValuePredicateIT {
             tx.execute(Graql.parse("define " +
                     "someEntity sub entity," +
                     "has derivedResource;" +
-                    "derivedResource sub attribute, valuetype long;" +
+                    "derivedResource sub attribute, value long;" +
                     "rule1 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1337;};" +
                     "rule2 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1667;};" +
                     "rule3 sub rule, when{ $x isa someEntity;}, then { $x has derivedResource 1997;};"

--- a/test-integration/graql/reasoner/resources/diagonalTest.gql
+++ b/test-integration/graql/reasoner/resources/diagonalTest.gql
@@ -19,7 +19,7 @@ diagonal sub relation,
 
 rel-from sub role;
 rel-to sub role;
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 rule-1 sub rule,
 when {

--- a/test-integration/graql/reasoner/resources/diagonalTest.gql
+++ b/test-integration/graql/reasoner/resources/diagonalTest.gql
@@ -19,7 +19,7 @@ diagonal sub relation,
 
 rel-from sub role;
 rel-to sub role;
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 rule-1 sub rule,
 when {

--- a/test-integration/graql/reasoner/resources/dualLinearTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/dualLinearTransitivity.gql
@@ -37,7 +37,7 @@ P-from sub role;
 P-to sub role;
 P sub relation, relates P-from, relates P-to;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/dualLinearTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/dualLinearTransitivity.gql
@@ -37,7 +37,7 @@ P-from sub role;
 P-to sub role;
 P sub relation, relates P-from, relates P-to;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/genericSchema.gql
+++ b/test-integration/graql/reasoner/resources/genericSchema.gql
@@ -89,17 +89,17 @@ ternary sub baseRelation,
 
 #Resources
 
-resource sub attribute, valuetype string,
+resource sub attribute, value string,
     plays baseRole1,
     plays baseRole2;
 
-resource-long sub attribute, valuetype long,
+resource-long sub attribute, value long,
     plays baseRole1,
     plays baseRole2;
 
-resource-double sub attribute, valuetype double;
-resource-date sub attribute, valuetype date;
-resource-boolean sub attribute, valuetype boolean;
+resource-double sub attribute, value double;
+resource-date sub attribute, value date;
+resource-boolean sub attribute, value boolean;
 
 
 binarySymmetricity sub rule,

--- a/test-integration/graql/reasoner/resources/genericSchema.gql
+++ b/test-integration/graql/reasoner/resources/genericSchema.gql
@@ -89,17 +89,17 @@ ternary sub baseRelation,
 
 #Resources
 
-resource sub attribute, datatype string,
+resource sub attribute, valuetype string,
     plays baseRole1,
     plays baseRole2;
 
-resource-long sub attribute, datatype long,
+resource-long sub attribute, valuetype long,
     plays baseRole1,
     plays baseRole2;
 
-resource-double sub attribute, datatype double;
-resource-date sub attribute, datatype date;
-resource-boolean sub attribute, datatype boolean;
+resource-double sub attribute, valuetype double;
+resource-date sub attribute, valuetype date;
+resource-boolean sub attribute, valuetype boolean;
 
 
 binarySymmetricity sub rule,

--- a/test-integration/graql/reasoner/resources/linearTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/linearTransitivity.gql
@@ -24,7 +24,7 @@ S-from sub role;
 S-to sub role;
 S sub relation, relates S-from, relates S-to;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/linearTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/linearTransitivity.gql
@@ -24,7 +24,7 @@ S-from sub role;
 S-to sub role;
 S sub relation, relates S-from, relates S-to;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/materialisationTest.gql
+++ b/test-integration/graql/reasoner/resources/materialisationTest.gql
@@ -23,11 +23,11 @@ someRelation sub relation,
     has resource-string;
 
 #Resources
-resource-string sub attribute, valuetype string;
-resource-long sub attribute, valuetype long;
-resource-double sub attribute, valuetype double;
-resource-boolean sub attribute, valuetype boolean;
-resource-date sub attribute, valuetype date;
+resource-string sub attribute, value string;
+resource-long sub attribute, value long;
+resource-double sub attribute, value double;
+resource-boolean sub attribute, value boolean;
+resource-date sub attribute, value date;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/materialisationTest.gql
+++ b/test-integration/graql/reasoner/resources/materialisationTest.gql
@@ -23,11 +23,11 @@ someRelation sub relation,
     has resource-string;
 
 #Resources
-resource-string sub attribute, datatype string;
-resource-long sub attribute, datatype long;
-resource-double sub attribute, datatype double;
-resource-boolean sub attribute, datatype boolean;
-resource-date sub attribute, datatype date;
+resource-string sub attribute, valuetype string;
+resource-long sub attribute, valuetype long;
+resource-double sub attribute, valuetype double;
+resource-boolean sub attribute, valuetype boolean;
+resource-date sub attribute, valuetype date;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/multiJoin.gql
+++ b/test-integration/graql/reasoner/resources/multiJoin.gql
@@ -22,7 +22,7 @@ C4 sub relation, relates fromRole, relates toRole;
 D1 sub relation, relates fromRole, relates toRole;
 D2 sub relation, relates fromRole, relates toRole;
 
-index sub attribute, valuetype long;
+index sub attribute, value long;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/multiJoin.gql
+++ b/test-integration/graql/reasoner/resources/multiJoin.gql
@@ -22,7 +22,7 @@ C4 sub relation, relates fromRole, relates toRole;
 D1 sub relation, relates fromRole, relates toRole;
 D2 sub relation, relates fromRole, relates toRole;
 
-index sub attribute, datatype long;
+index sub attribute, valuetype long;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/pathTest-symmetric.gql
+++ b/test-integration/graql/reasoner/resources/pathTest-symmetric.gql
@@ -18,7 +18,7 @@ path sub relation, relates coordinate;
 vertex plays coordinate;
 start-vertex plays coordinate;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/pathTest-symmetric.gql
+++ b/test-integration/graql/reasoner/resources/pathTest-symmetric.gql
@@ -18,7 +18,7 @@ path sub relation, relates coordinate;
 vertex plays coordinate;
 start-vertex plays coordinate;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/pathTest.gql
+++ b/test-integration/graql/reasoner/resources/pathTest.gql
@@ -21,7 +21,7 @@ path sub relation, relates path-from, relates path-to;
 vertex plays path-from, plays path-to;
 start-vertex plays path-from;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/pathTest.gql
+++ b/test-integration/graql/reasoner/resources/pathTest.gql
@@ -21,7 +21,7 @@ path sub relation, relates path-from, relates path-to;
 vertex plays path-from, plays path-to;
 start-vertex plays path-from;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/quadraticTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/quadraticTransitivity.gql
@@ -14,7 +14,7 @@ Q-from sub role;
 Q-to sub role;
 Q sub relation, relates Q-from, relates Q-to;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/quadraticTransitivity.gql
+++ b/test-integration/graql/reasoner/resources/quadraticTransitivity.gql
@@ -14,7 +14,7 @@ Q-from sub role;
 Q-to sub role;
 Q sub relation, relates Q-from, relates Q-to;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/ancestor-friend.gql
+++ b/test-integration/graql/reasoner/resources/recursion/ancestor-friend.gql
@@ -22,7 +22,7 @@ ancestor-friend sub role;
 Ancestor-friend sub relation, relates ancestor, relates ancestor-friend;
 person plays ancestor, plays ancestor-friend;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/ancestor-friend.gql
+++ b/test-integration/graql/reasoner/resources/recursion/ancestor-friend.gql
@@ -22,7 +22,7 @@ ancestor-friend sub role;
 Ancestor-friend sub relation, relates ancestor, relates ancestor-friend;
 person plays ancestor, plays ancestor-friend;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/ancestor.gql
+++ b/test-integration/graql/reasoner/resources/recursion/ancestor.gql
@@ -18,7 +18,7 @@ descendant sub role;
 Ancestor sub relation, relates ancestor, relates descendant;
 person plays ancestor, plays descendant;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/ancestor.gql
+++ b/test-integration/graql/reasoner/resources/recursion/ancestor.gql
@@ -18,7 +18,7 @@ descendant sub role;
 Ancestor sub relation, relates ancestor, relates descendant;
 person plays ancestor, plays descendant;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/nguyen.gql
+++ b/test-integration/graql/reasoner/resources/recursion/nguyen.gql
@@ -30,7 +30,7 @@ P-rB sub role;
 P sub relation, relates P-rA, relates P-rB;
 entity2 plays P-rA, plays P-rB;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/nguyen.gql
+++ b/test-integration/graql/reasoner/resources/recursion/nguyen.gql
@@ -30,7 +30,7 @@ P-rB sub role;
 P sub relation, relates P-rA, relates P-rB;
 entity2 plays P-rA, plays P-rB;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/reachability-symmetric.gql
+++ b/test-integration/graql/reasoner/resources/recursion/reachability-symmetric.gql
@@ -14,7 +14,7 @@ vertex plays coordinate;
 reachable sub relation, relates coordinate;
 vertex plays coordinate;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/reachability-symmetric.gql
+++ b/test-integration/graql/reasoner/resources/recursion/reachability-symmetric.gql
@@ -14,7 +14,7 @@ vertex plays coordinate;
 reachable sub relation, relates coordinate;
 vertex plays coordinate;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/reachability.gql
+++ b/test-integration/graql/reasoner/resources/recursion/reachability.gql
@@ -15,7 +15,7 @@ indirect-link sub relation, relates from, relates to;
 reachable sub relation, relates from, relates to;
 unreachable sub relation, relates from, relates to;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 reachability-transitivityA
 when {

--- a/test-integration/graql/reasoner/resources/recursion/reachability.gql
+++ b/test-integration/graql/reasoner/resources/recursion/reachability.gql
@@ -15,7 +15,7 @@ indirect-link sub relation, relates from, relates to;
 reachable sub relation, relates from, relates to;
 unreachable sub relation, relates from, relates to;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 reachability-transitivityA
 when {

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-rsg.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-rsg.gql
@@ -32,7 +32,7 @@ flat-to sub role;
 flat sub relation, relates flat-to, relates flat-from;
 person plays flat-from, plays flat-to;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-rsg.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-rsg.gql
@@ -32,7 +32,7 @@ flat-to sub role;
 flat sub relation, relates flat-to, relates flat-from;
 person plays flat-from, plays flat-to;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-sg.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-sg.gql
@@ -17,7 +17,7 @@ SG-role sub role;
 SameGen sub relation, relates SG-role;
 entity2 plays SG-role;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-sg.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-sg.gql
@@ -17,7 +17,7 @@ SG-role sub role;
 SameGen sub relation, relates SG-role;
 entity2 plays SG-role;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-tc.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-tc.gql
@@ -23,7 +23,7 @@ P-roleB sub role;
 P sub relation, relates P-roleA, relates P-roleB;
 entity2 plays P-roleA, plays P-roleB;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/recursivity-tc.gql
+++ b/test-integration/graql/reasoner/resources/recursion/recursivity-tc.gql
@@ -23,7 +23,7 @@ P-roleB sub role;
 P sub relation, relates P-roleA, relates P-roleB;
 entity2 plays P-roleA, plays P-roleB;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/same-generation.gql
+++ b/test-integration/graql/reasoner/resources/recursion/same-generation.gql
@@ -22,7 +22,7 @@ SG-role-B sub role;
 SameGen sub relation, relates SG-role-A, relates SG-role-B;
 person plays SG-role-A, plays SG-role-B;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/same-generation.gql
+++ b/test-integration/graql/reasoner/resources/recursion/same-generation.gql
@@ -22,7 +22,7 @@ SG-role-B sub role;
 SameGen sub relation, relates SG-role-A, relates SG-role-B;
 person plays SG-role-A, plays SG-role-B;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
+++ b/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
@@ -19,7 +19,7 @@ Q-to sub role;
 Q sub relation, relates Q-from, relates Q-to;
 entity2 plays Q-from, plays Q-to;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
+++ b/test-integration/graql/reasoner/resources/recursion/tail-recursion.gql
@@ -19,7 +19,7 @@ Q-to sub role;
 Q sub relation, relates Q-from, relates Q-to;
 entity2 plays Q-from, plays Q-to;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 ####################################################
 ##################RULES#############################

--- a/test-integration/graql/reasoner/resources/recursion/transitivity.gql
+++ b/test-integration/graql/reasoner/resources/recursion/transitivity.gql
@@ -32,7 +32,7 @@ H-role-B sub role;
 H sub relation, relates H-role-A, relates H-role-B;
 entity2 plays H-role-A, plays H-role-B;
 
-index sub attribute, datatype string;
+index sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/recursion/transitivity.gql
+++ b/test-integration/graql/reasoner/resources/recursion/transitivity.gql
@@ -32,7 +32,7 @@ H-role-B sub role;
 H sub relation, relates H-role-A, relates H-role-B;
 entity2 plays H-role-A, plays H-role-B;
 
-index sub attribute, valuetype string;
+index sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/reifiedResourceApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/reifiedResourceApplicabilityTest.gql
@@ -9,13 +9,13 @@ someEntity sub entity,
 
 
 #Resources
-res-string sub attribute, datatype string,
+res-string sub attribute, valuetype string,
     plays resource-value;
-res-double sub attribute, datatype double,
+res-double sub attribute, valuetype double,
     plays resource-value;
-res-long sub attribute, datatype long,
+res-long sub attribute, valuetype long,
     plays resource-value;
-res-boolean sub attribute, datatype boolean,
+res-boolean sub attribute, valuetype boolean,
     plays resource-value;
 
 resource-owner sub role;

--- a/test-integration/graql/reasoner/resources/reifiedResourceApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/reifiedResourceApplicabilityTest.gql
@@ -9,13 +9,13 @@ someEntity sub entity,
 
 
 #Resources
-res-string sub attribute, valuetype string,
+res-string sub attribute, value string,
     plays resource-value;
-res-double sub attribute, valuetype double,
+res-double sub attribute, value double,
     plays resource-value;
-res-long sub attribute, valuetype long,
+res-long sub attribute, value long,
     plays resource-value;
-res-boolean sub attribute, valuetype boolean,
+res-boolean sub attribute, value boolean,
     plays resource-value;
 
 resource-owner sub role;

--- a/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
+++ b/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
@@ -46,11 +46,11 @@ anotherDerivedRelation sub relation,
     relates otherRole;
 
 
-resource sub attribute, datatype string;
-anotherResource sub attribute, datatype string;
-yetAnotherResource sub attribute, datatype string;
-derivedResource sub attribute, datatype string;
-anotherDerivedResource sub attribute, datatype string;
+resource sub attribute, valuetype string;
+anotherResource sub attribute, valuetype string;
+yetAnotherResource sub attribute, valuetype string;
+derivedResource sub attribute, valuetype string;
+anotherDerivedResource sub attribute, valuetype string;
 
 simple-relation-rule
 when {

--- a/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
+++ b/test-integration/graql/reasoner/resources/resolutionPlanTest.gql
@@ -46,11 +46,11 @@ anotherDerivedRelation sub relation,
     relates otherRole;
 
 
-resource sub attribute, valuetype string;
-anotherResource sub attribute, valuetype string;
-yetAnotherResource sub attribute, valuetype string;
-derivedResource sub attribute, valuetype string;
-anotherDerivedResource sub attribute, valuetype string;
+resource sub attribute, value string;
+anotherResource sub attribute, value string;
+yetAnotherResource sub attribute, value string;
+derivedResource sub attribute, value string;
+anotherDerivedResource sub attribute, value string;
 
 simple-relation-rule
 when {

--- a/test-integration/graql/reasoner/resources/resourceApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/resourceApplicabilityTest.gql
@@ -10,11 +10,11 @@ anotherEntity sub entity,
     has resource;
 
 #Resources
-resource sub attribute, datatype string;
-res-string sub attribute, datatype string;
-res-double sub attribute, datatype double;
-res-long sub attribute, datatype long;
-res-boolean sub attribute, datatype boolean;
+resource sub attribute, valuetype string;
+res-string sub attribute, valuetype string;
+res-double sub attribute, valuetype double;
+res-long sub attribute, valuetype long;
+res-boolean sub attribute, valuetype boolean;
 
 #Rules
 

--- a/test-integration/graql/reasoner/resources/resourceApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/resourceApplicabilityTest.gql
@@ -10,11 +10,11 @@ anotherEntity sub entity,
     has resource;
 
 #Resources
-resource sub attribute, valuetype string;
-res-string sub attribute, valuetype string;
-res-double sub attribute, valuetype double;
-res-long sub attribute, valuetype long;
-res-boolean sub attribute, valuetype boolean;
+resource sub attribute, value string;
+res-string sub attribute, value string;
+res-double sub attribute, value double;
+res-long sub attribute, value long;
+res-boolean sub attribute, value boolean;
 
 #Rules
 

--- a/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
@@ -97,10 +97,10 @@ attributed-relation sub relation,
     relates anotherRole;
 
 #Resources
-    resource-string sub attribute, valuetype string;
-    resource-long sub attribute, valuetype long;
-    name sub attribute, valuetype string;
-    description sub attribute, valuetype string;
+    resource-string sub attribute, value string;
+    resource-long sub attribute, value long;
+    name sub attribute, value string;
+    description sub attribute, value string;
 
 ##Rules
 

--- a/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
+++ b/test-integration/graql/reasoner/resources/ruleApplicabilityTest.gql
@@ -97,10 +97,10 @@ attributed-relation sub relation,
     relates anotherRole;
 
 #Resources
-    resource-string sub attribute, datatype string;
-    resource-long sub attribute, datatype long;
-    name sub attribute, datatype string;
-    description sub attribute, datatype string;
+    resource-string sub attribute, valuetype string;
+    resource-long sub attribute, valuetype long;
+    name sub attribute, valuetype string;
+    description sub attribute, valuetype string;
 
 ##Rules
 

--- a/test-integration/graql/reasoner/resources/unificationWithTypesTest.gql
+++ b/test-integration/graql/reasoner/resources/unificationWithTypesTest.gql
@@ -48,7 +48,7 @@ ternary sub relation,
     relates role2,
     relates role3;
 
-resource sub attribute, valuetype string;
+resource sub attribute, value string;
 
 insert
 

--- a/test-integration/graql/reasoner/resources/unificationWithTypesTest.gql
+++ b/test-integration/graql/reasoner/resources/unificationWithTypesTest.gql
@@ -48,7 +48,7 @@ ternary sub relation,
     relates role2,
     relates role3;
 
-resource sub attribute, datatype string;
+resource sub attribute, valuetype string;
 
 insert
 

--- a/test-integration/graql/reasoner/stubs/appendingRPs.gql
+++ b/test-integration/graql/reasoner/stubs/appendingRPs.gql
@@ -26,7 +26,7 @@ baseEntity sub entity,
 someEntity sub baseEntity,
     plays inferredRole;
 
-resource sub attribute, valuetype string;
+resource sub attribute, value string;
 
 appendRole sub rule,
 when {

--- a/test-integration/graql/reasoner/stubs/appendingRPs.gql
+++ b/test-integration/graql/reasoner/stubs/appendingRPs.gql
@@ -26,7 +26,7 @@ baseEntity sub entity,
 someEntity sub baseEntity,
     plays inferredRole;
 
-resource sub attribute, datatype string;
+resource sub attribute, valuetype string;
 
 appendRole sub rule,
 when {

--- a/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
+++ b/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
@@ -8,9 +8,9 @@ baseEntity sub entity,
 startEntity sub baseEntity;
 bulkEntity sub baseEntity;
 
-index sub attribute, datatype long;
-nonInferredAttribute sub attribute, datatype string;
-inferredAttribute sub attribute, datatype string, plays anotherRole;
+index sub attribute, valuetype long;
+nonInferredAttribute sub attribute, valuetype string;
+inferredAttribute sub attribute, valuetype string, plays anotherRole;
 
 inferredRelation sub relation, has inferredAttribute, relates someRole, relates anotherRole;
 

--- a/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
+++ b/test-integration/graql/reasoner/stubs/duplicateMaterialisation.gql
@@ -8,9 +8,9 @@ baseEntity sub entity,
 startEntity sub baseEntity;
 bulkEntity sub baseEntity;
 
-index sub attribute, valuetype long;
-nonInferredAttribute sub attribute, valuetype string;
-inferredAttribute sub attribute, valuetype string, plays anotherRole;
+index sub attribute, value long;
+nonInferredAttribute sub attribute, value string;
+inferredAttribute sub attribute, value string, plays anotherRole;
 
 inferredRelation sub relation, has inferredAttribute, relates someRole, relates anotherRole;
 

--- a/test-integration/graql/reasoner/stubs/explanations.gql
+++ b/test-integration/graql/reasoner/stubs/explanations.gql
@@ -28,7 +28,7 @@ inferredRelation sub relation,
 
 #Resources
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 rule-1 sub rule,
     when {
@@ -88,7 +88,7 @@ owns sub relation,
     relates owned,
     relates owner;
 
-value sub attribute, datatype string;
+value sub attribute, valuetype string;
 
 carryRelation sub rule,
 when {
@@ -131,7 +131,7 @@ tagging sub relation,
 same-tag-column-link sub relation,
     relates linked-column;
 
-tag-type sub attribute, datatype string;
+tag-type sub attribute, valuetype string;
 
 same-tag-column-linking sub rule,
 when {

--- a/test-integration/graql/reasoner/stubs/explanations.gql
+++ b/test-integration/graql/reasoner/stubs/explanations.gql
@@ -28,7 +28,7 @@ inferredRelation sub relation,
 
 #Resources
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 rule-1 sub rule,
     when {
@@ -88,7 +88,7 @@ owns sub relation,
     relates owned,
     relates owner;
 
-value sub attribute, valuetype string;
+value sub attribute, value string;
 
 carryRelation sub rule,
 when {
@@ -131,7 +131,7 @@ tagging sub relation,
 same-tag-column-link sub relation,
     relates linked-column;
 
-tag-type sub attribute, valuetype string;
+tag-type sub attribute, value string;
 
 same-tag-column-linking sub rule,
 when {

--- a/test-integration/graql/reasoner/stubs/negation.gql
+++ b/test-integration/graql/reasoner/stubs/negation.gql
@@ -36,12 +36,12 @@ derived-ternary sub relation,
     relates anotherRole;
 
 #Resources
-resource-string sub attribute, datatype string;
-resource-long sub attribute, datatype long;
-absent-resource sub attribute, datatype string;
+resource-string sub attribute, valuetype string;
+resource-long sub attribute, valuetype long;
+absent-resource sub attribute, valuetype string;
 
-derived-resource-string sub attribute, datatype string;
-derived-resource-boolean sub attribute, datatype boolean;
+derived-resource-string sub attribute, valuetype string;
+derived-resource-boolean sub attribute, valuetype boolean;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/negation.gql
+++ b/test-integration/graql/reasoner/stubs/negation.gql
@@ -36,12 +36,12 @@ derived-ternary sub relation,
     relates anotherRole;
 
 #Resources
-resource-string sub attribute, valuetype string;
-resource-long sub attribute, valuetype long;
-absent-resource sub attribute, valuetype string;
+resource-string sub attribute, value string;
+resource-long sub attribute, value long;
+absent-resource sub attribute, value string;
 
-derived-resource-string sub attribute, valuetype string;
-derived-resource-boolean sub attribute, valuetype boolean;
+derived-resource-string sub attribute, value string;
+derived-resource-boolean sub attribute, value boolean;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/recipeTest.gql
+++ b/test-integration/graql/reasoner/stubs/recipeTest.gql
@@ -27,7 +27,7 @@ containes sub relation,
     relates contained-ingredient,
     relates containing-pantry;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 
 available-ingredient-occuring-in-recipe sub ingredientBase;

--- a/test-integration/graql/reasoner/stubs/recipeTest.gql
+++ b/test-integration/graql/reasoner/stubs/recipeTest.gql
@@ -27,7 +27,7 @@ containes sub relation,
     relates contained-ingredient,
     relates containing-pantry;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 
 available-ingredient-occuring-in-recipe sub ingredientBase;

--- a/test-integration/graql/reasoner/stubs/resourceAttachment.gql
+++ b/test-integration/graql/reasoner/stubs/resourceAttachment.gql
@@ -24,11 +24,11 @@ relation0 sub relation,
     has reattachable-resource-string;
 
 #Resources
-derivable-resource-string sub attribute, valuetype string;
-reattachable-resource-string sub derivable-resource-string, valuetype string;
-derived-resource-string sub derivable-resource-string, valuetype string;
-resource-long sub attribute, valuetype long;
-derived-resource-boolean sub attribute, valuetype boolean;
+derivable-resource-string sub attribute, value string;
+reattachable-resource-string sub derivable-resource-string, value string;
+derived-resource-string sub derivable-resource-string, value string;
+resource-long sub attribute, value long;
+derived-resource-boolean sub attribute, value boolean;
 subResource sub reattachable-resource-string;
 
 #Rules

--- a/test-integration/graql/reasoner/stubs/resourceAttachment.gql
+++ b/test-integration/graql/reasoner/stubs/resourceAttachment.gql
@@ -24,11 +24,11 @@ relation0 sub relation,
     has reattachable-resource-string;
 
 #Resources
-derivable-resource-string sub attribute, datatype string;
-reattachable-resource-string sub derivable-resource-string, datatype string;
-derived-resource-string sub derivable-resource-string, datatype string;
-resource-long sub attribute, datatype long;
-derived-resource-boolean sub attribute, datatype boolean;
+derivable-resource-string sub attribute, valuetype string;
+reattachable-resource-string sub derivable-resource-string, valuetype string;
+derived-resource-string sub derivable-resource-string, valuetype string;
+resource-long sub attribute, valuetype long;
+derived-resource-boolean sub attribute, valuetype boolean;
 subResource sub reattachable-resource-string;
 
 #Rules

--- a/test-integration/graql/reasoner/stubs/resourceDirectionality.gql
+++ b/test-integration/graql/reasoner/stubs/resourceDirectionality.gql
@@ -1,8 +1,8 @@
 define
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
-indicator sub attribute, datatype string,
+indicator sub attribute, valuetype string,
   plays action;
 
 specific-indicator sub indicator;

--- a/test-integration/graql/reasoner/stubs/resourceDirectionality.gql
+++ b/test-integration/graql/reasoner/stubs/resourceDirectionality.gql
@@ -1,8 +1,8 @@
 define
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
-indicator sub attribute, valuetype string,
+indicator sub attribute, value string,
   plays action;
 
 specific-indicator sub indicator;

--- a/test-integration/graql/reasoner/stubs/resourceHierarchy.gql
+++ b/test-integration/graql/reasoner/stubs/resourceHierarchy.gql
@@ -11,15 +11,15 @@ genericRole sub role;
 relation0 sub relation,
     relates genericRole;
 
-baseResource sub attribute, valuetype string,
+baseResource sub attribute, value string,
     plays genericRole;
 
-extendedResource sub baseResource, valuetype string;
-anotherExtendedResource sub baseResource, valuetype string;
+extendedResource sub baseResource, value string;
+anotherExtendedResource sub baseResource, value string;
 
-furtherExtendedResource sub extendedResource, valuetype string;
+furtherExtendedResource sub extendedResource, value string;
 
-simpleResource sub attribute, valuetype string;
+simpleResource sub attribute, value string;
 
 
 insert

--- a/test-integration/graql/reasoner/stubs/resourceHierarchy.gql
+++ b/test-integration/graql/reasoner/stubs/resourceHierarchy.gql
@@ -11,15 +11,15 @@ genericRole sub role;
 relation0 sub relation,
     relates genericRole;
 
-baseResource sub attribute, datatype string,
+baseResource sub attribute, valuetype string,
     plays genericRole;
 
-extendedResource sub baseResource, datatype string;
-anotherExtendedResource sub baseResource, datatype string;
+extendedResource sub baseResource, valuetype string;
+anotherExtendedResource sub baseResource, valuetype string;
 
-furtherExtendedResource sub extendedResource, datatype string;
+furtherExtendedResource sub extendedResource, valuetype string;
 
-simpleResource sub attribute, datatype string;
+simpleResource sub attribute, valuetype string;
 
 
 insert

--- a/test-integration/graql/reasoner/stubs/resourceOwnership.gql
+++ b/test-integration/graql/reasoner/stubs/resourceOwnership.gql
@@ -3,7 +3,7 @@ define
 someEntity sub entity,
   has name;
 
-name sub attribute, datatype string,
+name sub attribute, valuetype string,
   plays applicable-name;
 
 step sub entity,

--- a/test-integration/graql/reasoner/stubs/resourceOwnership.gql
+++ b/test-integration/graql/reasoner/stubs/resourceOwnership.gql
@@ -3,7 +3,7 @@ define
 someEntity sub entity,
   has name;
 
-name sub attribute, valuetype string,
+name sub attribute, value string,
   plays applicable-name;
 
 step sub entity,

--- a/test-integration/graql/reasoner/stubs/resourcesAsRolePlayers.gql
+++ b/test-integration/graql/reasoner/stubs/resourcesAsRolePlayers.gql
@@ -4,8 +4,8 @@ generic-entity sub entity,
     has detailed-resource,
     plays resource-owner;
 
-detailed-resource sub attribute, valuetype long;
-resource sub attribute, valuetype string,
+detailed-resource sub attribute, value long;
+resource sub attribute, value string,
     plays resource-value;
 
 resource-owner sub role;

--- a/test-integration/graql/reasoner/stubs/resourcesAsRolePlayers.gql
+++ b/test-integration/graql/reasoner/stubs/resourcesAsRolePlayers.gql
@@ -4,8 +4,8 @@ generic-entity sub entity,
     has detailed-resource,
     plays resource-owner;
 
-detailed-resource sub attribute, datatype long;
-resource sub attribute, datatype string,
+detailed-resource sub attribute, valuetype long;
+resource sub attribute, valuetype string,
     plays resource-value;
 
 resource-owner sub role;

--- a/test-integration/graql/reasoner/stubs/testSet19-recursive.gql
+++ b/test-integration/graql/reasoner/stubs/testSet19-recursive.gql
@@ -24,7 +24,7 @@ relation2 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet19-recursive.gql
+++ b/test-integration/graql/reasoner/stubs/testSet19-recursive.gql
@@ -24,7 +24,7 @@ relation2 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet19.gql
+++ b/test-integration/graql/reasoner/stubs/testSet19.gql
@@ -24,7 +24,7 @@ relation2 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet19.gql
+++ b/test-integration/graql/reasoner/stubs/testSet19.gql
@@ -24,7 +24,7 @@ relation2 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet25.gql
+++ b/test-integration/graql/reasoner/stubs/testSet25.gql
@@ -26,7 +26,7 @@ message-succession sub relation,
     relates predecessor,
     relates successor;
 
-creation-date sub attribute, valuetype long;
+creation-date sub attribute, value long;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet25.gql
+++ b/test-integration/graql/reasoner/stubs/testSet25.gql
@@ -26,7 +26,7 @@ message-succession sub relation,
     relates predecessor,
     relates successor;
 
-creation-date sub attribute, datatype long;
+creation-date sub attribute, valuetype long;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet26.gql
+++ b/test-integration/graql/reasoner/stubs/testSet26.gql
@@ -27,8 +27,8 @@ relation3 sub relation,
     relates role1,
     relates role2;
 
-res1 sub attribute, datatype string;
-res2 sub attribute, datatype string;
+res1 sub attribute, valuetype string;
+res2 sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet26.gql
+++ b/test-integration/graql/reasoner/stubs/testSet26.gql
@@ -27,8 +27,8 @@ relation3 sub relation,
     relates role1,
     relates role2;
 
-res1 sub attribute, valuetype string;
-res2 sub attribute, valuetype string;
+res1 sub attribute, value string;
+res2 sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet27.gql
+++ b/test-integration/graql/reasoner/stubs/testSet27.gql
@@ -21,7 +21,7 @@ prior sub relation,
 holds sub relation,
     relates related-state;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 rule-1 sub rule,
     when {

--- a/test-integration/graql/reasoner/stubs/testSet27.gql
+++ b/test-integration/graql/reasoner/stubs/testSet27.gql
@@ -21,7 +21,7 @@ prior sub relation,
 holds sub relation,
     relates related-state;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 rule-1 sub rule,
     when {

--- a/test-integration/graql/reasoner/stubs/testSet28.gql
+++ b/test-integration/graql/reasoner/stubs/testSet28.gql
@@ -27,8 +27,8 @@ relation3 sub relation,
     relates role3,
     relates role4;
 
-res1 sub attribute, datatype string;
-res2 sub attribute, datatype string;
+res1 sub attribute, valuetype string;
+res2 sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet28.gql
+++ b/test-integration/graql/reasoner/stubs/testSet28.gql
@@ -27,8 +27,8 @@ relation3 sub relation,
     relates role3,
     relates role4;
 
-res1 sub attribute, valuetype string;
-res2 sub attribute, valuetype string;
+res1 sub attribute, value string;
+res2 sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet28b.gql
+++ b/test-integration/graql/reasoner/stubs/testSet28b.gql
@@ -33,7 +33,7 @@ relation1 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet28b.gql
+++ b/test-integration/graql/reasoner/stubs/testSet28b.gql
@@ -33,7 +33,7 @@ relation1 sub relation,
     relates role1,
     relates role2;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet29.gql
+++ b/test-integration/graql/reasoner/stubs/testSet29.gql
@@ -48,7 +48,7 @@ quaternary sub quaternary-base,
     relates role3,
     relates role4;
 
-name sub attribute, valuetype string;
+name sub attribute, value string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet29.gql
+++ b/test-integration/graql/reasoner/stubs/testSet29.gql
@@ -48,7 +48,7 @@ quaternary sub quaternary-base,
     relates role3,
     relates role4;
 
-name sub attribute, datatype string;
+name sub attribute, valuetype string;
 
 #Rules
 

--- a/test-integration/graql/reasoner/stubs/testSet30.gql
+++ b/test-integration/graql/reasoner/stubs/testSet30.gql
@@ -29,8 +29,8 @@ pair sub relation,
     has typ,
     has name;
 
-name sub attribute, datatype string;
-typ sub attribute, datatype string;
+name sub attribute, valuetype string;
+typ sub attribute, valuetype string;
 
 ##################################################################
 # Inference: all pairs;

--- a/test-integration/graql/reasoner/stubs/testSet30.gql
+++ b/test-integration/graql/reasoner/stubs/testSet30.gql
@@ -29,8 +29,8 @@ pair sub relation,
     has typ,
     has name;
 
-name sub attribute, valuetype string;
-typ sub attribute, valuetype string;
+name sub attribute, value string;
+typ sub attribute, value string;
 
 ##################################################################
 # Inference: all pairs;

--- a/test-integration/graql/reasoner/stubs/typeDerivationFromAttribute.gql
+++ b/test-integration/graql/reasoner/stubs/typeDerivationFromAttribute.gql
@@ -6,7 +6,7 @@ baseEntity sub entity,
 derivedEntity sub entity,
     has baseAttribute;
 
-baseAttribute sub attribute, datatype string;
+baseAttribute sub attribute, valuetype string;
 
 rule1
     when {

--- a/test-integration/graql/reasoner/stubs/typeDerivationFromAttribute.gql
+++ b/test-integration/graql/reasoner/stubs/typeDerivationFromAttribute.gql
@@ -6,7 +6,7 @@ baseEntity sub entity,
 derivedEntity sub entity,
     has baseAttribute;
 
-baseAttribute sub attribute, valuetype string;
+baseAttribute sub attribute, value string;
 
 rule1
     when {

--- a/test-integration/keyspace/AttributeManagerIT.java
+++ b/test-integration/keyspace/AttributeManagerIT.java
@@ -60,7 +60,7 @@ public class AttributeManagerIT {
     @Test
     public void whenTxsInsertDifferentAttributes_weDontLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").has(someAttribute);
             tx.commit();
         }
@@ -94,7 +94,7 @@ public class AttributeManagerIT {
     @Test
     public void whenTxsInsertDifferentKeys_weDontLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").key(someAttribute);
             tx.commit();
         }
@@ -128,7 +128,7 @@ public class AttributeManagerIT {
     @Test
     public void whenMultipleTxsInsertDifferentAttributesAsAKeyOrNot_weDontLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").has(someAttribute);
             tx.putEntityType("keyEntity").key(someAttribute);
             tx.commit();
@@ -165,7 +165,7 @@ public class AttributeManagerIT {
     @Test
     public void whenMultipleTxsInsertExistingAttributes_weDontLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").has(someAttribute);
             someAttribute.create(1337L);
             someAttribute.create(1667L);
@@ -203,7 +203,7 @@ public class AttributeManagerIT {
     @Test
     public void whenMultipleTxsInsertSameAttribute_weLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").has(someAttribute);
             tx.commit();
         }
@@ -237,7 +237,7 @@ public class AttributeManagerIT {
     @Test
     public void whenMultipleTxsInsertSameAttributeAsAKeyOrNot_weLock() throws ExecutionException, InterruptedException {
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").has(someAttribute);
             tx.putEntityType("keyEntity").key(someAttribute);
             tx.commit();
@@ -277,7 +277,7 @@ public class AttributeManagerIT {
     public void whenMultipleTxsAttachExistingAttributesAsKeys_weLock() throws ExecutionException, InterruptedException {
         int threads = 8;
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.LONG);
+            AttributeType<Long> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.LONG);
             tx.putEntityType("someEntity").key(someAttribute);
             for (int threadNo = 0; threadNo < threads; threadNo++) {
                 GraqlInsert query = Graql.parse("insert $x " + threadNo + " isa someAttribute;").asInsert();

--- a/test-integration/keyspace/KeyspaceStatisticsIT.java
+++ b/test-integration/keyspace/KeyspaceStatisticsIT.java
@@ -97,7 +97,7 @@ public class KeyspaceStatisticsIT {
     @Test
     public void keyspaceStatisticsUpdatedOnCommit() {
         Transaction tx = localSession.transaction(Transaction.Type.WRITE);
-        AttributeType ageType = tx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType ageType = tx.putAttributeType("age", AttributeType.ValueType.LONG);
         Role friend = tx.putRole("friend");
         EntityType personType = tx.putEntityType("person").plays(friend).has(ageType);
         RelationType friendshipType = tx.putRelationType("friendship").relates(friend);
@@ -185,7 +185,7 @@ public class KeyspaceStatisticsIT {
     @Test
     public void keyspaceStatisticsNotUpdatedIfNotcommitted() {
         Transaction tx = localSession.transaction(Transaction.Type.WRITE);
-        AttributeType ageType = tx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType ageType = tx.putAttributeType("age", AttributeType.ValueType.LONG);
         Role friend = tx.putRole("friend");
         EntityType personType = tx.putEntityType("person").plays(friend).has(ageType);
         RelationType friendshipType = tx.putRelationType("friendship").relates(friend);
@@ -227,7 +227,7 @@ public class KeyspaceStatisticsIT {
     @Test
     public void reopeningSessionRetrievesStatistics() {
         Transaction tx = localSession.transaction(Transaction.Type.WRITE);
-        AttributeType ageType = tx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType ageType = tx.putAttributeType("age", AttributeType.ValueType.LONG);
         Role friend = tx.putRole("friend");
         EntityType personType = tx.putEntityType("person").plays(friend).has(ageType);
         RelationType friendshipType = tx.putRelationType("friendship").relates(friend);
@@ -292,7 +292,7 @@ public class KeyspaceStatisticsIT {
     @Test
     public void concurrentTransactionsUpdateStatisticsCorrectly() throws InterruptedException, ExecutionException {
         TestTransactionProvider.TestTransaction testTx = (TestTransactionProvider.TestTransaction)localSession.transaction(Transaction.Type.WRITE);
-        AttributeType ageType = testTx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType ageType = testTx.putAttributeType("age", AttributeType.ValueType.LONG);
         Role friend = testTx.putRole("friend");
         EntityType personType = testTx.putEntityType("person").plays(friend).has(ageType);
         RelationType friendshipType = testTx.putRelationType("friendship").relates(friend);
@@ -364,7 +364,7 @@ public class KeyspaceStatisticsIT {
     public void attachingAttributesViaRulesDoesntAlterConceptCountsAfterCommit() {
         // test concept API insertion
         Transaction tx = localSession.transaction(Transaction.Type.WRITE);
-        AttributeType<Long> age = tx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType<Long> age = tx.putAttributeType("age", AttributeType.ValueType.LONG);
         EntityType person = tx.putEntityType("person").has(age);
 
         person.create();

--- a/test-integration/keyspace/StatisticsDeltaIT.java
+++ b/test-integration/keyspace/StatisticsDeltaIT.java
@@ -52,7 +52,7 @@ public class StatisticsDeltaIT {
     public void setUp() {
         session = SessionUtil.serverlessSessionWithNewKeyspace(storage.createCompatibleServerConfig());
         tx = session.transaction(Transaction.Type.WRITE);
-        AttributeType age = tx.putAttributeType("age", AttributeType.DataType.LONG);
+        AttributeType age = tx.putAttributeType("age", AttributeType.ValueType.LONG);
         Role friend = tx.putRole("friend");
         EntityType personType = tx.putEntityType("person").plays(friend).has(age);
         RelationType friendshipType = tx.putRelationType("friendship").relates(friend);

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -101,7 +101,7 @@ public class AttributeUniquenessIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
         tx.execute(Graql.parse("define \n" +
                 "name sub attribute, \n" +
-                "    valuetype string;\n" +
+                "    value string;\n" +
                 "person sub entity, \n" +
                 "    key name;").asDefine());
         tx.commit();
@@ -129,7 +129,7 @@ public class AttributeUniquenessIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
         tx.execute(Graql.parse("define \n" +
                 "name sub attribute, \n" +
-                "    valuetype string;\n" +
+                "    value string;\n" +
                 "person sub entity, \n" +
                 "    key name;").asDefine());
         tx.commit();

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -78,7 +78,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 
@@ -101,7 +101,7 @@ public class AttributeUniquenessIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
         tx.execute(Graql.parse("define \n" +
                 "name sub attribute, \n" +
-                "    datatype string;\n" +
+                "    valuetype string;\n" +
                 "person sub entity, \n" +
                 "    key name;").asDefine());
         tx.commit();
@@ -129,7 +129,7 @@ public class AttributeUniquenessIT {
         Transaction tx = session.transaction(Transaction.Type.WRITE);
         tx.execute(Graql.parse("define \n" +
                 "name sub attribute, \n" +
-                "    datatype string;\n" +
+                "    valuetype string;\n" +
                 "person sub entity, \n" +
                 "    key name;").asDefine());
         tx.commit();
@@ -164,7 +164,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -202,8 +202,8 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING),
-                    type(ownerLabel).sub("attribute").datatype(Graql.Token.DataType.STRING).has(ownedAttributeLabel)
+                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type(ownerLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING).has(ownedAttributeLabel)
             ));
             tx.commit();
         }
@@ -239,7 +239,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -275,7 +275,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -314,7 +314,7 @@ public class AttributeUniquenessIT {
             tx.execute(Graql.define(
                     type("owner").sub("relation").relates("entity-role-player").relates("attribute-role-player"),
                     type("owned-entity").sub("entity").plays("entity-role-player"),
-                    type(ownedAttributeLabel).sub("attribute").plays("attribute-role-player").datatype(Graql.Token.DataType.STRING)
+                    type(ownedAttributeLabel).sub("attribute").plays("attribute-role-player").valueType(Graql.Token.ValueType.STRING)
             ));
             tx.commit();
         }
@@ -350,7 +350,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 
@@ -386,7 +386,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
         String oldAttributeId;
@@ -418,7 +418,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 

--- a/test-integration/server/AttributeUniquenessIT.java
+++ b/test-integration/server/AttributeUniquenessIT.java
@@ -78,7 +78,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 
@@ -164,7 +164,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -202,8 +202,8 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
-                    type(ownerLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING).has(ownedAttributeLabel)
+                    type(ownedAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING),
+                    type(ownerLabel).sub("attribute").value(Graql.Token.ValueType.STRING).has(ownedAttributeLabel)
             ));
             tx.commit();
         }
@@ -239,7 +239,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -275,7 +275,7 @@ public class AttributeUniquenessIT {
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.execute(Graql.define(
-                    type(ownedAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING),
+                    type(ownedAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING),
                     type("owner").sub("entity").has(ownedAttributeLabel)
             ));
             tx.commit();
@@ -314,7 +314,7 @@ public class AttributeUniquenessIT {
             tx.execute(Graql.define(
                     type("owner").sub("relation").relates("entity-role-player").relates("attribute-role-player"),
                     type("owned-entity").sub("entity").plays("entity-role-player"),
-                    type(ownedAttributeLabel).sub("attribute").plays("attribute-role-player").valueType(Graql.Token.ValueType.STRING)
+                    type(ownedAttributeLabel).sub("attribute").plays("attribute-role-player").value(Graql.Token.ValueType.STRING)
             ));
             tx.commit();
         }
@@ -350,7 +350,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 
@@ -386,7 +386,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
         String oldAttributeId;
@@ -418,7 +418,7 @@ public class AttributeUniquenessIT {
 
         // define the schema
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
+            tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING)));
             tx.commit();
         }
 

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -231,7 +231,7 @@ public class GraknClientIT {
     public void explanationIsGivenWithRule() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").valueType("string"),
+                    type("name").sub("attribute").value("string"),
                     type("content").sub("entity").key("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")
@@ -277,7 +277,7 @@ public class GraknClientIT {
     public void testExecutingAQuery_ExplanationsAreReturned() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").valueType("string"),
+                    type("name").sub("attribute").value("string"),
                     type("content").sub("entity").has("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")
@@ -321,7 +321,7 @@ public class GraknClientIT {
     public void testExecutingAlphaEquivalentQueries_CorrectPatternsAreReturned() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").valueType("string"),
+                    type("name").sub("attribute").value("string"),
                     type("content").sub("entity").has("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -36,7 +36,7 @@ import grakn.client.concept.thing.Attribute;
 import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.DataType;
+import grakn.client.concept.ValueType;
 import grakn.client.concept.thing.Entity;
 import grakn.client.concept.type.EntityType;
 import grakn.client.concept.Label;
@@ -759,11 +759,11 @@ public class GraknClientIT {
              Transaction localTx = localSession.transaction(Transaction.Type.READ)
         ) {
             GraqlGet query = Graql.match(var("x").type("title")).get();
-            AttributeType.Remote<String> remoteConcept = (AttributeType.Remote<String>) remoteTx.stream(query).findAny().get().get("x").asAttributeType().asRemote(remoteTx);
+            AttributeType.Remote<String> remoteConcept = remoteTx.stream(query).findAny().get().get("x").<String>asAttributeType().asRemote(remoteTx);
             grakn.core.kb.concept.api.ConceptId localId = grakn.core.kb.concept.api.ConceptId.of(remoteConcept.id().getValue());
             grakn.core.kb.concept.api.AttributeType<String> localConcept = localTx.getConcept(localId).asAttributeType();
 
-            assertEquals(localConcept.valueType().valueClass(), remoteConcept.dataType().dataClass());
+            assertEquals(localConcept.valueType().valueClass(), remoteConcept.valueType().valueClass());
             assertEquals(localConcept.regex(), remoteConcept.regex());
             assertEquals(
                     localConcept.attribute("The Muppets").id().toString(),
@@ -811,7 +811,7 @@ public class GraknClientIT {
             grakn.core.kb.concept.api.ConceptId localId = grakn.core.kb.concept.api.ConceptId.of(remoteConcept.id().getValue());
             grakn.core.kb.concept.api.Attribute<?> localConcept = localTx.getConcept(localId).asAttribute();
 
-            assertEquals(localConcept.valueType().valueClass(), remoteConcept.dataType().dataClass());
+            assertEquals(localConcept.valueType().valueClass(), remoteConcept.valueType().valueClass());
             assertEquals(localConcept.value(), remoteConcept.value());
             assertEquals(localConcept.owner().id().toString(), remoteConcept.owners().findFirst().get().id().toString());
             assertEqualConcepts(localConcept, remoteConcept,
@@ -895,9 +895,9 @@ public class GraknClientIT {
     public void testExecutingAggregateQueries_theResultsAreCorrect() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             EntityType.Remote person = tx.putEntityType("person");
-            AttributeType.Remote<String> name = tx.putAttributeType("name", DataType.STRING);
-            AttributeType.Remote<Integer> age = tx.putAttributeType("age", DataType.INTEGER);
-            AttributeType.Remote<Double> rating = tx.putAttributeType("rating", DataType.DOUBLE);
+            AttributeType.Remote<String> name = tx.putAttributeType("name",  ValueType.STRING);
+            AttributeType.Remote<Integer> age = tx.putAttributeType("age",  ValueType.INTEGER);
+            AttributeType.Remote<Double> rating = tx.putAttributeType("rating",  ValueType.DOUBLE);
 
             person.has(name).has(age).has(rating);
 
@@ -1014,9 +1014,9 @@ public class GraknClientIT {
             dog.plays(chaser);
             cat.plays(chased);
 
-            AttributeType.Remote<String> name = tx.putAttributeType("name", DataType.STRING);
-            AttributeType.Remote<String> id = tx.putAttributeType("id", DataType.STRING).regex("(good|bad)-dog");
-            AttributeType.Remote<Long> age = tx.putAttributeType("age", DataType.LONG);
+            AttributeType.Remote<String> name = tx.putAttributeType("name",  ValueType.STRING);
+            AttributeType.Remote<String> id = tx.putAttributeType("id",  ValueType.STRING).regex("(good|bad)-dog");
+            AttributeType.Remote<Long> age = tx.putAttributeType("age",  ValueType.LONG);
 
             animal.has(name);
             animal.key(id);
@@ -1210,8 +1210,8 @@ public class GraknClientIT {
         EntityType.Remote company = tx1.putEntityType("company");
         EntityType.Remote person = tx2.putEntityType("person");
 
-        AttributeType.Remote<String> name1 = tx1.putAttributeType("name", DataType.STRING);
-        AttributeType.Remote<String> name2 = tx2.putAttributeType("name", DataType.STRING);
+        AttributeType.Remote<String> name1 = tx1.putAttributeType("name",  ValueType.STRING);
+        AttributeType.Remote<String> name2 = tx2.putAttributeType("name",  ValueType.STRING);
 
         company.has(name1);
         person.has(name2);
@@ -1241,7 +1241,7 @@ public class GraknClientIT {
     @Test
     public void setAttributeValueWithDatatypeDate() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
-            AttributeType.Remote<LocalDateTime> birthDateType = tx.putAttributeType("birth-date", DataType.DATE);
+            AttributeType.Remote<LocalDateTime> birthDateType = tx.putAttributeType("birth-date",  ValueType.DATE);
             LocalDateTime date = LocalDateTime.now();
             Attribute<LocalDateTime> dateAttribute = birthDateType.create(date);
             assertEquals(date, dateAttribute.value());

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -231,7 +231,7 @@ public class GraknClientIT {
     public void explanationIsGivenWithRule() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").datatype("string"),
+                    type("name").sub("attribute").valueType("string"),
                     type("content").sub("entity").key("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")
@@ -277,7 +277,7 @@ public class GraknClientIT {
     public void testExecutingAQuery_ExplanationsAreReturned() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").datatype("string"),
+                    type("name").sub("attribute").valueType("string"),
                     type("content").sub("entity").has("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")
@@ -321,7 +321,7 @@ public class GraknClientIT {
     public void testExecutingAlphaEquivalentQueries_CorrectPatternsAreReturned() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             tx.execute(Graql.define(
-                    type("name").sub("attribute").datatype("string"),
+                    type("name").sub("attribute").valueType("string"),
                     type("content").sub("entity").has("name").plays("contained").plays("container"),
                     type("contains").sub("relation").relates("contained").relates("container"),
                     type("transitive-location").sub("rule")
@@ -466,8 +466,8 @@ public class GraknClientIT {
     public void testExecutingDeleteQueries_ConceptsAreDeleted() {
         try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
             grakn.core.kb.concept.api.EntityType person = tx.putEntityType("person");
-            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
-            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
+            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             grakn.core.kb.concept.api.Role actor = tx.putRole("actor");
             grakn.core.kb.concept.api.Role characterBeingPlayed = tx.putRole("character-being-played");
             grakn.core.kb.concept.api.RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
@@ -495,8 +495,8 @@ public class GraknClientIT {
     public void testGettingARelation_TheInformationOnTheRelationIsCorrect() {
         try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
             grakn.core.kb.concept.api.EntityType person = tx.putEntityType("person");
-            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
-            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
+            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             grakn.core.kb.concept.api.Role actor = tx.putRole("actor");
             grakn.core.kb.concept.api.Role characterBeingPlayed = tx.putRole("character-being-played");
             grakn.core.kb.concept.api.RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
@@ -571,8 +571,8 @@ public class GraknClientIT {
     public void testGettingAThing_TheInformationOnTheThingIsCorrect() {
         try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
             grakn.core.kb.concept.api.EntityType person = tx.putEntityType("person");
-            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
-            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            grakn.core.kb.concept.api.AttributeType name = tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
+            grakn.core.kb.concept.api.AttributeType email = tx.putAttributeType("email", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             grakn.core.kb.concept.api.Role actor = tx.putRole("actor");
             grakn.core.kb.concept.api.Role characterBeingPlayed = tx.putRole("character-being-played");
             grakn.core.kb.concept.api.RelationType hasCast = tx.putRelationType("has-cast").relates(actor).relates(characterBeingPlayed);
@@ -618,8 +618,8 @@ public class GraknClientIT {
             tx.putRelationType("has-cast").relates(productionWithCast).relates(actor).relates(characterBeingPlayed);
             grakn.core.kb.concept.api.EntityType person = tx.putEntityType("person").plays(actor).plays(characterBeingPlayed);
 
-            person.has(tx.putAttributeType("gender", grakn.core.kb.concept.api.AttributeType.DataType.STRING));
-            person.has(tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING));
+            person.has(tx.putAttributeType("gender", grakn.core.kb.concept.api.AttributeType.ValueType.STRING));
+            person.has(tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING));
 
             person.create();
             person.create();
@@ -679,7 +679,7 @@ public class GraknClientIT {
     @Test
     public void testGettingARule_TheInformationOnTheRuleIsCorrect() {
         try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
-            tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            tx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             Pattern when = Graql.parsePattern("$x has name 'expectation-when';");
             Pattern then = Graql.parsePattern("$x has name 'expectation-then';");
 
@@ -751,7 +751,7 @@ public class GraknClientIT {
     @Test
     public void testGettingAnAttributeType_TheInformationOnTheAttributeTypeIsCorrect() {
         try (Transaction localTx = localSession.transaction(Transaction.Type.WRITE)) {
-            grakn.core.kb.concept.api.AttributeType title = localTx.putAttributeType("title", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            grakn.core.kb.concept.api.AttributeType title = localTx.putAttributeType("title", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             title.create("The Muppets");
             localTx.commit();
         }
@@ -763,7 +763,7 @@ public class GraknClientIT {
             grakn.core.kb.concept.api.ConceptId localId = grakn.core.kb.concept.api.ConceptId.of(remoteConcept.id().getValue());
             grakn.core.kb.concept.api.AttributeType<String> localConcept = localTx.getConcept(localId).asAttributeType();
 
-            assertEquals(localConcept.dataType().dataClass(), remoteConcept.dataType().dataClass());
+            assertEquals(localConcept.valueType().valueClass(), remoteConcept.dataType().dataClass());
             assertEquals(localConcept.regex(), remoteConcept.regex());
             assertEquals(
                     localConcept.attribute("The Muppets").id().toString(),
@@ -796,7 +796,7 @@ public class GraknClientIT {
     public void testGettingAnAttribute_TheInformationOnTheAttributeIsCorrect() {
         try (Transaction localTx = localSession.transaction(Transaction.Type.WRITE)) {
             grakn.core.kb.concept.api.EntityType person = localTx.putEntityType("person");
-            grakn.core.kb.concept.api.AttributeType<String> name = localTx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.DataType.STRING);
+            grakn.core.kb.concept.api.AttributeType<String> name = localTx.putAttributeType("name", grakn.core.kb.concept.api.AttributeType.ValueType.STRING);
             person.has(name);
             grakn.core.kb.concept.api.Attribute<String> alice = name.create("Alice");
             person.create().has(alice);
@@ -811,7 +811,7 @@ public class GraknClientIT {
             grakn.core.kb.concept.api.ConceptId localId = grakn.core.kb.concept.api.ConceptId.of(remoteConcept.id().getValue());
             grakn.core.kb.concept.api.Attribute<?> localConcept = localTx.getConcept(localId).asAttribute();
 
-            assertEquals(localConcept.dataType().dataClass(), remoteConcept.dataType().dataClass());
+            assertEquals(localConcept.valueType().valueClass(), remoteConcept.dataType().dataClass());
             assertEquals(localConcept.value(), remoteConcept.value());
             assertEquals(localConcept.owner().id().toString(), remoteConcept.owners().findFirst().get().id().toString());
             assertEqualConcepts(localConcept, remoteConcept,
@@ -830,7 +830,7 @@ public class GraknClientIT {
             grakn.core.kb.concept.api.EntityType animal = tx.putEntityType("animal").plays(pet);
             grakn.core.kb.concept.api.EntityType human = tx.putEntityType("human").plays(owner);
             grakn.core.kb.concept.api.RelationType petOwnership = tx.putRelationType("pet-ownership").relates(pet).relates(owner);
-            grakn.core.kb.concept.api.AttributeType<Long> age = tx.putAttributeType("age", grakn.core.kb.concept.api.AttributeType.DataType.LONG);
+            grakn.core.kb.concept.api.AttributeType<Long> age = tx.putAttributeType("age", grakn.core.kb.concept.api.AttributeType.ValueType.LONG);
             human.has(age);
 
             grakn.core.kb.concept.api.Entity coco = animal.create();

--- a/test-integration/server/RuleValidationIT.java
+++ b/test-integration/server/RuleValidationIT.java
@@ -367,7 +367,7 @@ public class RuleValidationIT {
         );
         validateIllegalHead(
                 Graql.parsePattern("$x has someAttribute $y;"),
-                Graql.parsePattern("$y valuetype string;"),
+                Graql.parsePattern("$y value string;"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalHead(

--- a/test-integration/server/RuleValidationIT.java
+++ b/test-integration/server/RuleValidationIT.java
@@ -367,7 +367,7 @@ public class RuleValidationIT {
         );
         validateIllegalHead(
                 Graql.parsePattern("$x has someAttribute $y;"),
-                Graql.parsePattern("$y datatype string;"),
+                Graql.parsePattern("$y valuetype string;"),
                 ErrorMessage.VALIDATION_RULE_ILLEGAL_ATOMIC_IN_HEAD
         );
         validateIllegalHead(
@@ -943,9 +943,9 @@ public class RuleValidationIT {
     }
 
     private void initTx(Transaction tx) {
-        AttributeType<Integer> someAttribute = tx.putAttributeType("someAttribute", AttributeType.DataType.INTEGER);
-        AttributeType<Integer> anotherAttribute = tx.putAttributeType("anotherAttribute", AttributeType.DataType.INTEGER);
-        AttributeType<String> stringAttribute = tx.putAttributeType("stringAttribute", AttributeType.DataType.STRING);
+        AttributeType<Integer> someAttribute = tx.putAttributeType("someAttribute", AttributeType.ValueType.INTEGER);
+        AttributeType<Integer> anotherAttribute = tx.putAttributeType("anotherAttribute", AttributeType.ValueType.INTEGER);
+        AttributeType<String> stringAttribute = tx.putAttributeType("stringAttribute", AttributeType.ValueType.STRING);
         Role someRole = tx.putRole("someRole");
         Role anotherRole = tx.putRole("anotherRole");
         Role singleRole = tx.putRole("singleRole");

--- a/test-integration/server/ValidatorIT.java
+++ b/test-integration/server/ValidatorIT.java
@@ -599,7 +599,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysInOneCommit() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").datatype("string"),
+                type("email").sub("attribute").valueType("string"),
                 type("person").sub("entity").key("email")
         );
         tx.execute(define);
@@ -617,7 +617,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysInSeparateCommits() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").datatype("string"),
+                type("email").sub("attribute").valueType("string"),
                 type("person").sub("entity").key("email")
         );
         tx.execute(define);
@@ -638,7 +638,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysAmongSubTypes() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").datatype("string"),
+                type("email").sub("attribute").valueType("string"),
                 type("person").sub("entity").key("email"),
                 type("man").sub("person"),
                 type("woman").sub("person")

--- a/test-integration/server/ValidatorIT.java
+++ b/test-integration/server/ValidatorIT.java
@@ -599,7 +599,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysInOneCommit() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").valueType("string"),
+                type("email").sub("attribute").value("string"),
                 type("person").sub("entity").key("email")
         );
         tx.execute(define);
@@ -617,7 +617,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysInSeparateCommits() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").valueType("string"),
+                type("email").sub("attribute").value("string"),
                 type("person").sub("entity").key("email")
         );
         tx.execute(define);
@@ -638,7 +638,7 @@ public class ValidatorIT {
     @Test
     public void testInsertDuplicateUseOfKeysAmongSubTypes() {
         GraqlDefine define = Graql.define(
-                type("email").sub("attribute").valueType("string"),
+                type("email").sub("attribute").value("string"),
                 type("person").sub("entity").key("email"),
                 type("man").sub("person"),
                 type("woman").sub("person")

--- a/test-integration/server/session/TransactionIT.java
+++ b/test-integration/server/session/TransactionIT.java
@@ -136,8 +136,8 @@ public class TransactionIT {
         String targetValue = "Geralt";
         assertTrue(tx.getAttributesByValue(targetValue).isEmpty());
 
-        AttributeType<String> t1 = tx.putAttributeType("Parent 1", AttributeType.DataType.STRING);
-        AttributeType<String> t2 = tx.putAttributeType("Parent 2", AttributeType.DataType.STRING);
+        AttributeType<String> t1 = tx.putAttributeType("Parent 1", AttributeType.ValueType.STRING);
+        AttributeType<String> t2 = tx.putAttributeType("Parent 2", AttributeType.ValueType.STRING);
 
         Attribute<String> r1 = t1.create(targetValue);
         Attribute<String> r2 = t2.create(targetValue);
@@ -163,7 +163,7 @@ public class TransactionIT {
         EntityType entityType = tx.putEntityType(entityTypeLabel);
         RelationType relationType = tx.putRelationType(relationTypeLabel);
         Role role = tx.putRole(roleTypeLabel);
-        AttributeType attributeType = tx.putAttributeType(resourceTypeLabel, AttributeType.DataType.STRING);
+        AttributeType attributeType = tx.putAttributeType(resourceTypeLabel, AttributeType.ValueType.STRING);
 
         assertEquals(entityType, tx.getEntityType(entityTypeLabel));
         assertEquals(relationType, tx.getRelationType(relationTypeLabel));
@@ -515,7 +515,7 @@ public class TransactionIT {
         String entityLabel = "someEntity";
         String attributeLabel = "someAttribute";
         try(Transaction tx = session.transaction(Transaction.Type.WRITE)){
-            AttributeType<Long> someAtttribute = tx.putAttributeType(attributeLabel, AttributeType.DataType.LONG);
+            AttributeType<Long> someAtttribute = tx.putAttributeType(attributeLabel, AttributeType.ValueType.LONG);
             tx.putEntityType(entityLabel).has(someAtttribute);
             tx.commit();
         }
@@ -551,9 +551,9 @@ public class TransactionIT {
         executor.submit(() -> {
             //Resources
             try (Transaction tx = localSession.transaction(Transaction.Type.WRITE)) {
-                AttributeType<Long> int_ = tx.putAttributeType("int", AttributeType.DataType.LONG);
-                AttributeType<Long> foo = tx.putAttributeType("foo", AttributeType.DataType.LONG).sup(int_);
-                tx.putAttributeType("bar", AttributeType.DataType.LONG).sup(int_);
+                AttributeType<Long> int_ = tx.putAttributeType("int", AttributeType.ValueType.LONG);
+                AttributeType<Long> foo = tx.putAttributeType("foo", AttributeType.ValueType.LONG).sup(int_);
+                tx.putAttributeType("bar", AttributeType.ValueType.LONG).sup(int_);
                 tx.putEntityType("FOO").has(foo);
 
                 tx.commit();
@@ -630,8 +630,8 @@ public class TransactionIT {
     public void whenCommitingInferredConcepts_InferredConceptsAreNotPersisted(){
         tx.execute(Graql.<GraqlDefine>parse(
                     "define " +
-                            "name sub attribute, datatype string;" +
-                            "score sub attribute, datatype double;" +
+                            "name sub attribute, valuetype string;" +
+                            "score sub attribute, valuetype double;" +
                             "person sub entity, has name, has score;" +
                             "infer-attr sub rule," +
                             "when {" +
@@ -660,7 +660,7 @@ public class TransactionIT {
     public void whenCommitingInferredAttributeEdge_EdgeIsNotPersisted(){
         tx.execute(Graql.<GraqlDefine>parse(
                 "define " +
-                        "score sub attribute, datatype double;" +
+                        "score sub attribute, valuetype double;" +
                         "person sub entity, has score;" +
                         "infer-attr sub rule," +
                         "when {" +
@@ -692,8 +692,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, datatype string;" +
-                "inferrableAttribute sub attribute, datatype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, valuetype string;" +
+                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
                 "inferrableRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +
@@ -811,8 +811,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, datatype string;" +
-                "inferrableAttribute sub attribute, datatype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, valuetype string;" +
+                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
                 "someRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +
@@ -858,8 +858,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, datatype string;" +
-                "inferrableAttribute sub attribute, datatype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, valuetype string;" +
+                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
                 "someRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +

--- a/test-integration/server/session/TransactionIT.java
+++ b/test-integration/server/session/TransactionIT.java
@@ -630,8 +630,8 @@ public class TransactionIT {
     public void whenCommitingInferredConcepts_InferredConceptsAreNotPersisted(){
         tx.execute(Graql.<GraqlDefine>parse(
                     "define " +
-                            "name sub attribute, valuetype string;" +
-                            "score sub attribute, valuetype double;" +
+                            "name sub attribute, value string;" +
+                            "score sub attribute, value double;" +
                             "person sub entity, has name, has score;" +
                             "infer-attr sub rule," +
                             "when {" +
@@ -660,7 +660,7 @@ public class TransactionIT {
     public void whenCommitingInferredAttributeEdge_EdgeIsNotPersisted(){
         tx.execute(Graql.<GraqlDefine>parse(
                 "define " +
-                        "score sub attribute, valuetype double;" +
+                        "score sub attribute, value double;" +
                         "person sub entity, has score;" +
                         "infer-attr sub rule," +
                         "when {" +
@@ -692,8 +692,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, valuetype string;" +
-                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, value string;" +
+                "inferrableAttribute sub attribute, value string, plays anotherRole;" +
                 "inferrableRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +
@@ -811,8 +811,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, valuetype string;" +
-                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, value string;" +
+                "inferrableAttribute sub attribute, value string, plays anotherRole;" +
                 "someRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +
@@ -858,8 +858,8 @@ public class TransactionIT {
         String inferrableSchema = "define " +
                 "baseEntity sub entity, has inferrableAttribute, has nonInferrableAttribute, plays someRole, plays anotherRole;" +
                 "someEntity sub baseEntity;" +
-                "nonInferrableAttribute sub attribute, valuetype string;" +
-                "inferrableAttribute sub attribute, valuetype string, plays anotherRole;" +
+                "nonInferrableAttribute sub attribute, value string;" +
+                "inferrableAttribute sub attribute, value string, plays anotherRole;" +
                 "someRelation sub relation, has nonInferrableAttribute, relates someRole, relates anotherRole;" +
 
                 "infer-attr sub rule," +

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -227,7 +227,7 @@ public class TransactionCacheIT {
         String index = Schema.generateAttributeIndex(Label.of(testAttributeLabel), testAttributeValue);
 
         // define the schema
-        tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
+        tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").value(Graql.Token.ValueType.STRING)));
         tx.commit();
 
 

--- a/test-integration/server/session/cache/TransactionCacheIT.java
+++ b/test-integration/server/session/cache/TransactionCacheIT.java
@@ -227,7 +227,7 @@ public class TransactionCacheIT {
         String index = Schema.generateAttributeIndex(Label.of(testAttributeLabel), testAttributeValue);
 
         // define the schema
-        tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").datatype(Graql.Token.DataType.STRING)));
+        tx.execute(Graql.define(type(testAttributeLabel).sub("attribute").valueType(Graql.Token.ValueType.STRING)));
         tx.commit();
 
 
@@ -252,7 +252,7 @@ public class TransactionCacheIT {
 
         Role work = tx.putRole("work");
         Role author = tx.putRole("author");
-        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.ValueType.STRING);
         EntityType somework = tx.putEntityType("somework").plays(work);
         EntityType person = tx.putEntityType("person").plays(author);
         RelationType authoredBy = tx.putRelationType("authored-by").relates(work).relates(author).has(provenance);
@@ -307,7 +307,7 @@ public class TransactionCacheIT {
 
         Role work = tx.putRole("work");
         Role author = tx.putRole("author");
-        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.DataType.STRING);
+        AttributeType<String> provenance = tx.putAttributeType("provenance", AttributeType.ValueType.STRING);
         EntityType somework = tx.putEntityType("somework").plays(work);
         EntityType person = tx.putEntityType("person").plays(author);
         RelationType authoredBy = tx.putRelationType("authored-by").relates(work).relates(author).has(provenance);
@@ -370,7 +370,7 @@ public class TransactionCacheIT {
 
     @Test
     public void whenInsertingAndDeletingInferredAttribute_instanceIsTracked(){
-        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
         Attribute attribute = attributeType.putAttributeInferred("banana");
         assertTrue(tx.cache().getInferredInstances().anyMatch(inst -> inst.equals(attribute)));
         attribute.delete();
@@ -379,7 +379,7 @@ public class TransactionCacheIT {
 
     @Test
     public void whenInsertingAndDeletingAttribute_attributeCachedIsUpdated(){
-        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
         String value = "banana";
         Attribute attribute = attributeType.create(value);
         String index = Schema.generateAttributeIndex(attributeType.label(), value);
@@ -395,7 +395,7 @@ public class TransactionCacheIT {
 
     @Test
     public void whenInsertingAndDeletingInferredImplicitRelation_instanceIsTracked(){
-        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.DataType.STRING);
+        AttributeType<String> attributeType = tx.putAttributeType("resource", AttributeType.ValueType.STRING);
         EntityType someEntity = tx.putEntityType("someEntity").has(attributeType);
         Entity owner = someEntity.create();
         Attribute<String> attribute = attributeType.create("banana");


### PR DESCRIPTION
## What is the goal of this PR?

We are replacing the term `DataType` in `AttributeType` with `ValueType`). Previously, an `AttributeType` has a `DataType`. And an `Attribute` has `Value`. The type of `Value` is defined by `DataType`. We can see the inconsistency there. Now, `AttributeType` has `ValueType`, and `Attribute` has `Value`. The type of `Value` is `ValueType`. So it's all consistent.

## What are the changes implemented in this PR?

- Renamed the `DataType` class to `ValueType`
- Renamed method names
- Renamed method arguments
- Renamed variable names
- Updated comments