### PR TITLE
Removed left over usage of the term 'DataType'

### DIFF
--- a/concept/impl/AttributeImpl.java
+++ b/concept/impl/AttributeImpl.java
@@ -38,7 +38,7 @@ import java.util.stream.Stream;
  * 1. It is unique to its AttributeType based on it's value.
  * 2. It has a AttributeType.ValueType associated with it which constrains the allowed values.
  *
- * @param <D> The data type of this resource type.
+ * @param <D> The value type of this attribute type.
  *            Supported Types include: String, Long, Double, and Boolean
  */
 public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> implements Attribute<D> {
@@ -51,7 +51,7 @@ public class AttributeImpl<D> extends ThingImpl<Attribute<D>, AttributeType<D>> 
     }
 
     /**
-     * @return The data type of this Attribute's AttributeType.
+     * @return The value type of this Attribute's AttributeType.
      */
     @Override
     public AttributeType.ValueType<D> valueType() {

--- a/concept/impl/AttributeTypeImpl.java
+++ b/concept/impl/AttributeTypeImpl.java
@@ -35,11 +35,11 @@ import java.util.regex.Pattern;
  * An ontological element which models and categorises the various Attribute in the graph.
  * This ontological element behaves similarly to Type when defining how it relates to other
  * types. It has two additional functions to be aware of:
- * 1. It has a AttributeType.ValueType constraining the data types of the values it's instances may take.
+ * 1. It has a AttributeType.ValueType constraining the value types of the values it's instances may take.
  * 2. Any of it's instances are unique to the type.
  * For example if you have a AttributeType modelling month throughout the year there can only be one January.
  *
- * @param <D> The data type of this resource type.
+ * @param <D> The value type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
  */
 public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D>> implements AttributeType<D> {
@@ -167,7 +167,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Nullable
     @Override
     public ValueType<D> valueType() {
-        String className = vertex().property(Schema.VertexProperty.DATA_TYPE);
+        String className = vertex().property(Schema.VertexProperty.VALUE_TYPE);
         if (className == null) return null;
 
         try {

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -153,7 +153,7 @@ public class ConceptManagerImpl implements ConceptManager {
     @Override
     public <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.ValueType<V> valueType) {
         VertexElement vertexElement = createSchemaVertex(label, ATTRIBUTE_TYPE, false);
-        vertexElement.propertyImmutable(Schema.VertexProperty.DATA_TYPE, valueType, null, AttributeType.ValueType::name);
+        vertexElement.propertyImmutable(Schema.VertexProperty.VALUE_TYPE, valueType, null, AttributeType.ValueType::name);
         AttributeType<V> attributeType = new AttributeTypeImpl<>(vertexElement, this, conceptNotificationChannel);
         attributeType.createShard();
         attributeType.sup(superType);
@@ -261,18 +261,18 @@ public class ConceptManagerImpl implements ConceptManager {
 
         VertexElement vertex = createInstanceVertex(ATTRIBUTE, isInferred);
 
-        AttributeType.ValueType<V> dataType = type.valueType();
+        AttributeType.ValueType<V> valueType = type.valueType();
 
         V convertedValue;
         try {
             convertedValue = AttributeValueConverter.of(type.valueType()).convert(value);
         } catch (ClassCastException e){
-            throw GraknConceptException.invalidAttributeValue(type, value, dataType);
+            throw GraknConceptException.invalidAttributeValue(type, value, valueType);
         }
 
         // set persisted value
-        Object valueToPersist = AttributeSerialiser.of(dataType).serialise(convertedValue);
-        Schema.VertexProperty property = Schema.VertexProperty.ofValueType(dataType);
+        Object valueToPersist = AttributeSerialiser.of(valueType).serialise(convertedValue);
+        Schema.VertexProperty property = Schema.VertexProperty.ofValueType(valueType);
         vertex.propertyImmutable(property, valueToPersist, null);
 
         // set unique index - combination of type and value to an indexed Janus property, used for lookups

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -198,7 +198,7 @@ public final class Schema {
         SCHEMA_LABEL(String.class), LABEL_ID(Integer.class), INSTANCE_COUNT(Long.class), TYPE_SHARD_CHECKPOINT(Long.class), IS_ABSTRACT(Boolean.class),
 
         // Attribute schema concept properties
-        REGEX(String.class), DATA_TYPE(String.class),
+        REGEX(String.class), VALUE_TYPE(String.class),
 
         // Attribute concept properties
         INDEX(String.class),
@@ -215,7 +215,7 @@ public final class Schema {
         // Relation properties
         IS_IMPLICIT(Boolean.class),
 
-        //Supported Data Types
+        //Supported Value Types
         VALUE_STRING(String.class), VALUE_LONG(Long.class),
         VALUE_DOUBLE(Double.class), VALUE_BOOLEAN(Boolean.class),
         VALUE_INTEGER(Integer.class), VALUE_FLOAT(Float.class),

--- a/graql/analytics/GraknMapReduce.java
+++ b/graql/analytics/GraknMapReduce.java
@@ -40,7 +40,7 @@ import java.util.Set;
 public abstract class GraknMapReduce<T> extends CommonOLAP
         implements MapReduce<Serializable, T, Serializable, T, Map<Serializable, T>> {
 
-    private static final String RESOURCE_DATA_TYPE_KEY = "RESOURCE_DATA_TYPE_KEY";
+    private static final String ATTRIBUTE_VALUE_TYPE_KEY = "ATTRIBUTE_VALUE_TYPE_KEY";
 
     // In MapReduce, vertex emits type label id, but has-resource edge can not. Instead, a message is sent via the edge,
     // and a vertex property is added. So the resource vertex can emit an extra key value pair, key being this constant.
@@ -53,7 +53,7 @@ public abstract class GraknMapReduce<T> extends CommonOLAP
 
     GraknMapReduce(Set<LabelId> selectedTypes, AttributeType.ValueType valueType) {
         this(selectedTypes);
-        persistentProperties.put(RESOURCE_DATA_TYPE_KEY, valueType.name());
+        persistentProperties.put(ATTRIBUTE_VALUE_TYPE_KEY, valueType.name());
     }
 
     // Needed internally for OLAP tasks
@@ -136,6 +136,6 @@ public abstract class GraknMapReduce<T> extends CommonOLAP
     }
 
     final boolean usingLong() {
-        return persistentProperties.get(RESOURCE_DATA_TYPE_KEY).equals(AttributeType.ValueType.LONG.name());
+        return persistentProperties.get(ATTRIBUTE_VALUE_TYPE_KEY).equals(AttributeType.ValueType.LONG.name());
     }
 }

--- a/graql/executor/ComputeExecutorImpl.java
+++ b/graql/executor/ComputeExecutorImpl.java
@@ -243,7 +243,7 @@ public class ComputeExecutorImpl implements ComputeExecutor {
     }
 
     /**
-     * Helper method to validate that the target types are of one data type, and get that data type
+     * Helper method to validate that the target types are of one value type, and get that value type
      *
      * @return the ValueType of the target types
      */
@@ -255,13 +255,13 @@ public class ComputeExecutorImpl implements ComputeExecutor {
             if (!type.isAttributeType()) throw GraqlSemanticException.mustBeAttributeType(type.label());
             AttributeType<?> attributeType = type.asAttributeType();
             if (valueType == null) {
-                // check if the attribute type has data-type LONG or DOUBLE
+                // check if the attribute type has value type LONG or DOUBLE
                 valueType = attributeType.valueType();
                 if (!valueType.equals(AttributeType.ValueType.LONG) && !valueType.equals(AttributeType.ValueType.DOUBLE)) {
                     throw GraqlSemanticException.attributeMustBeANumber(valueType, attributeType.label());
                 }
             } else {
-                // check if all the attribute types have the same data-type
+                // check if all the attribute types have the same value type
                 if (!valueType.equals(attributeType.valueType())) {
                     throw GraqlSemanticException.attributesWithDifferentValueTypes(query.of());
                 }
@@ -275,7 +275,7 @@ public class ComputeExecutorImpl implements ComputeExecutor {
      *
      * @param query          representing the compute query
      * @param targetTypes    representing the attribute types in which the statistics computation is targeted for
-     * @param targetValueType representing the data type of the target attribute types
+     * @param targetValueType representing the value type of the target attribute types
      * @return an object which is a subclass of VertexProgram
      */
     private VertexProgram initStatisticsVertexProgram(GraqlCompute query, Set<LabelId> targetTypes, AttributeType.ValueType<?> targetValueType) {
@@ -287,7 +287,7 @@ public class ComputeExecutorImpl implements ComputeExecutor {
      * Helper method to initialise the MapReduce algorithm for compute statistics queries
      *
      * @param targetTypes    representing the attribute types in which the statistics computation is targeted for
-     * @param targetValueType representing the data type of the target attribute types
+     * @param targetValueType representing the value type of the target attribute types
      * @return an object which is a subclass of StatisticsMapReduce
      */
     private StatisticsMapReduce<?> initStatisticsMapReduce(GraqlCompute.Statistics.Value query,

--- a/graql/executor/ConceptBuilderImpl.java
+++ b/graql/executor/ConceptBuilderImpl.java
@@ -149,7 +149,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
 
     @Override
     public ConceptBuilder valueType(AttributeType.ValueType<?> valueType) {
-        return set(DATA_TYPE, valueType);
+        return set(VALUE_TYPE, valueType);
     }
 
     @Override
@@ -275,7 +275,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
     private static final BuilderParam<Label> LABEL = BuilderParam.of(Graql.Token.Property.TYPE);
     private static final BuilderParam<ConceptId> ID = BuilderParam.of(Graql.Token.Property.ID);
     private static final BuilderParam<Object> VALUE = BuilderParam.of(Graql.Token.Property.VALUE);
-    private static final BuilderParam<AttributeType.ValueType<?>> DATA_TYPE = BuilderParam.of(Graql.Token.Property.VALUE_TYPE);
+    private static final BuilderParam<AttributeType.ValueType<?>> VALUE_TYPE = BuilderParam.of(Graql.Token.Property.VALUE_TYPE);
     private static final BuilderParam<Pattern> WHEN = BuilderParam.of(Graql.Token.Property.WHEN);
     private static final BuilderParam<Pattern> THEN = BuilderParam.of(Graql.Token.Property.THEN);
     private static final BuilderParam<Unit> IS_ROLE = BuilderParam.of("role"); // TODO: replace this with a value registered in an enum
@@ -340,7 +340,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
         validateParam(concept, LABEL, SchemaConcept.class, SchemaConcept::label);
         validateParam(concept, ID, Concept.class, Concept::id);
         validateParam(concept, VALUE, Attribute.class, Attribute::value);
-        validateParam(concept, DATA_TYPE, AttributeType.class, AttributeType::valueType);
+        validateParam(concept, VALUE_TYPE, AttributeType.class, AttributeType::valueType);
         validateParam(concept, WHEN, Rule.class, Rule::when);
         validateParam(concept, THEN, Rule.class, Rule::then);
     }
@@ -394,7 +394,7 @@ public class ConceptBuilderImpl implements ConceptBuilder {
             concept = putSchemaConcept(label, () -> conceptManager.createRole(label, superConcept.asRole()), Role.class);
         } else if (superConcept.isAttributeType()) {
             AttributeType attributeType = superConcept.asAttributeType();
-            AttributeType.ValueType<?> valueType = useOrDefault(DATA_TYPE, attributeType.valueType());
+            AttributeType.ValueType<?> valueType = useOrDefault(VALUE_TYPE, attributeType.valueType());
             concept = putSchemaConcept(label, () -> conceptManager.createAttributeType(label, superConcept.asAttributeType(), valueType), AttributeType.class);
         } else if (superConcept.isRule()) {
             concept = putSchemaConcept(label, () -> conceptManager.createRule(label, use(WHEN), use(THEN), superConcept.asRule()), Rule.class);

--- a/graql/executor/QueryExecutorImpl.java
+++ b/graql/executor/QueryExecutorImpl.java
@@ -353,7 +353,7 @@ public class QueryExecutorImpl implements QueryExecutor {
         return answerGroups;
     }
 
-    @SuppressWarnings("unchecked") // All attribute values are comparable data types
+    @SuppressWarnings("unchecked") // All attribute values are comparable value types
     private Stream<ConceptMap> filter(Filterable query, Stream<ConceptMap> answers) {
         if (query.sort().isPresent()) {
             Variable var = query.sort().get().var();

--- a/graql/executor/property/ValueTypeExecutor.java
+++ b/graql/executor/property/ValueTypeExecutor.java
@@ -38,7 +38,7 @@ public class ValueTypeExecutor implements PropertyExecutor.Definable {
     private final Variable var;
     private final ValueTypeProperty property;
     private final AttributeType.ValueType valueType;
-    private static final ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> DATA_TYPES = valueTypes();
+    private static final ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> VALUE_TYPES = valueTypes();
 
     ValueTypeExecutor(Variable var, ValueTypeProperty property) {
         if (var == null) {
@@ -51,10 +51,10 @@ public class ValueTypeExecutor implements PropertyExecutor.Definable {
         }
         this.property = property;
 
-        if (!DATA_TYPES.containsKey(property.valueType())) {
+        if (!VALUE_TYPES.containsKey(property.valueType())) {
             throw new IllegalArgumentException("Unrecognised Attribute value type");
         }
-        this.valueType = DATA_TYPES.get(property.valueType());
+        this.valueType = VALUE_TYPES.get(property.valueType());
     }
 
     private static ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes() {

--- a/graql/planning/gremlin/fragment/FragmentImpl.java
+++ b/graql/planning/gremlin/fragment/FragmentImpl.java
@@ -88,7 +88,7 @@ public abstract class FragmentImpl implements Fragment {
     static final double COST_NODE_INDEX_VALUE = -Math.log(NUM_INSTANCES_PER_TYPE / NUM_RESOURCES_PER_VALUE);
 
     static final double COST_NODE_NEQ = -Math.log(2D);
-    static final double COST_NODE_DATA_TYPE = -Math.log(AttributeType.ValueType.values().size() / 2D);
+    static final double COST_NODE_VALUE_TYPE = -Math.log(AttributeType.ValueType.values().size() / 2D);
     static final double COST_NODE_UNSPECIFIC_PREDICATE = -Math.log(2D);
     static final double COST_NODE_REGEX = -Math.log(2D);
     static final double COST_NODE_NOT_INTERNAL = -Math.log(1.1D);

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Objects;
 
-import static grakn.core.core.Schema.VertexProperty.DATA_TYPE;
+import static grakn.core.core.Schema.VertexProperty.VALUE_TYPE;
 
 class ValueTypeFragment extends FragmentImpl {
 
@@ -47,7 +47,7 @@ class ValueTypeFragment extends FragmentImpl {
     @Override
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return traversal.has(DATA_TYPE.name(), valueType().name());
+        return traversal.has(VALUE_TYPE.name(), valueType().name());
     }
 
     @Override
@@ -57,7 +57,7 @@ class ValueTypeFragment extends FragmentImpl {
 
     @Override
     public double internalFragmentCost() {
-        return COST_NODE_DATA_TYPE;
+        return COST_NODE_VALUE_TYPE;
     }
 
     @Override

--- a/graql/planning/gremlin/sets/EquivalentFragmentSets.java
+++ b/graql/planning/gremlin/sets/EquivalentFragmentSets.java
@@ -148,7 +148,7 @@ public class EquivalentFragmentSets {
     }
 
     /**
-     * An EquivalentFragmentSet that indicates a variable representing a resource type with a data-type.
+     * An EquivalentFragmentSet that indicates a variable representing a resource type with a value type.
      */
     public static EquivalentFragmentSet valueType(VarProperty varProperty, Variable resourceType, AttributeType.ValueType<?> valueType) {
         return new ValueTypeFragmentSet(varProperty, resourceType, valueType);

--- a/graql/planning/gremlin/sets/ValueTypeFragmentSet.java
+++ b/graql/planning/gremlin/sets/ValueTypeFragmentSet.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * see EquivalentFragmentSets#valueType(VarProperty, Variable, AttributeType.DataType)
+ * see EquivalentFragmentSets#valueType(VarProperty, Variable, AttributeType.ValueType)
  *
  */
 class ValueTypeFragmentSet extends EquivalentFragmentSetImpl {

--- a/graql/reasoner/atom/property/ValueTypeAtom.java
+++ b/graql/reasoner/atom/property/ValueTypeAtom.java
@@ -38,9 +38,9 @@ public class ValueTypeAtom extends AtomicBase {
         this.valueType = valueType;
     }
 
-    public static ValueTypeAtom create(Variable var, ValueTypeProperty prop, ReasonerQuery parent, AttributeType.ValueType<?> dataType) {
+    public static ValueTypeAtom create(Variable var, ValueTypeProperty prop, ReasonerQuery parent, AttributeType.ValueType<?> valueType) {
         Variable varName = var.asReturnedVar();
-        return new ValueTypeAtom(varName, new Statement(varName).value(prop.valueType()), parent, dataType);
+        return new ValueTypeAtom(varName, new Statement(varName).value(prop.valueType()), parent, valueType);
     }
 
     private static ValueTypeAtom create(ValueTypeAtom a, ReasonerQuery parent) {

--- a/kb/concept/api/Attribute.java
+++ b/kb/concept/api/Attribute.java
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  * 1. It is unique to its AttributeType based on it's value.
  * 2. It has an AttributeType.ValueType associated with it which constrains the allowed values.
  *
- * @param <D> The data type of this resource type.
+ * @param <D> The value type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
  */
 public interface Attribute<D> extends Thing {
@@ -52,9 +52,9 @@ public interface Attribute<D> extends Thing {
     AttributeType<D> type();
 
     /**
-     * Retrieves the data type of this Attribute's AttributeType.
+     * Retrieves the value type of this Attribute's AttributeType.
      *
-     * @return The data type of this Attribute's type.
+     * @return The value type of this Attribute's type.
      */
     @CheckReturnValue
     AttributeType.ValueType<D> valueType();

--- a/kb/concept/api/AttributeType.java
+++ b/kb/concept/api/AttributeType.java
@@ -34,11 +34,11 @@ import static grakn.common.util.Collections.set;
  * An ontological element which models and categorises the various Attribute in the graph.
  * This ontological element behaves similarly to Type when defining how it relates to other
  * types. It has two additional functions to be aware of:
- * 1. It has a ValueType constraining the data types of the values it's instances may take.
+ * 1. It has a ValueType constraining the value types of the values it's instances may take.
  * 2. Any of it's instances are unique to the type.
  * For example if you have an AttributeType modelling month throughout the year there can only be one January.
  *
- * @param <D> The data type of this resource type.
+ * @param <D> The value type of this resource type.
  *            Supported Types include: String, Long, Double, and Boolean
  */
 public interface AttributeType<D> extends Type {
@@ -187,9 +187,9 @@ public interface AttributeType<D> extends Type {
     Stream<Attribute<D>> instances();
 
     /**
-     * Get the data type to which instances of the AttributeType must conform.
+     * Get the value type to which instances of the AttributeType must conform.
      *
-     * @return The data type to which instances of this Attribute  must conform.
+     * @return The value type to which instances of this Attribute  must conform.
      */
     @Nullable
     @CheckReturnValue
@@ -223,10 +223,10 @@ public interface AttributeType<D> extends Type {
     }
 
     /**
-     * A class used to hold the supported data types of resources and any other concepts.
-     * This is used tp constrain value data types to only those we explicitly support.
+     * A class used to hold the supported value types of resources and any other concepts.
+     * This is used tp constrain value value types to only those we explicitly support.
      *
-     * @param <D> The data type.
+     * @param <D> The value type.
      */
     abstract class ValueType<D> {
         public static final ValueType<Boolean> BOOLEAN = new ValueType<Boolean>(Boolean.class){

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -71,7 +71,7 @@ public class GraknConceptException extends GraknException {
 
     /**
      * Thrown when attempting to set a regex on a Attribute whose type AttributeType is not of the
-     * data type AttributeType.ValueType#STRING
+     * value type AttributeType.ValueType#STRING
      */
     public static GraknConceptException cannotSetRegex(AttributeType attributeType) {
         return create(REGEX_NOT_STRING.getMessage(attributeType.label()));
@@ -109,7 +109,7 @@ public class GraknConceptException extends GraknException {
 
 
     /**
-     * Thrown when creating an Attribute whose value Object does not match attribute data type
+     * Thrown when creating an Attribute whose value Object does not match attribute value type
      */
     public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object, AttributeType.ValueType valueType) {
         return create(ErrorMessage.INVALID_VALUETYPE.getMessage(object, object.getClass().getSimpleName(), valueType.name(), attributeType.label()));

--- a/kb/graql/exception/GraqlSemanticException.java
+++ b/kb/graql/exception/GraqlSemanticException.java
@@ -222,11 +222,11 @@ public class GraqlSemanticException extends GraknException {
     }
 
     public static GraqlSemanticException attributeMustBeANumber(AttributeType.ValueType valueType, Label attributeType) {
-        return new GraqlSemanticException(attributeType + " must have data type of `long` or `double`, but was " + valueType.name());
+        return new GraqlSemanticException(attributeType + " must have value type of `long` or `double`, but was " + valueType.name());
     }
 
     public static GraqlSemanticException attributesWithDifferentValueTypes(Collection<String> attributeTypes) {
-        return new GraqlSemanticException("resource types " + attributeTypes + " have different data types");
+        return new GraqlSemanticException("resource types " + attributeTypes + " have different value types");
     }
 
     public static GraqlSemanticException usingNegationWithReasoningOff(Pattern pattern) {

--- a/kb/server/Transaction.java
+++ b/kb/server/Transaction.java
@@ -182,10 +182,10 @@ public interface Transaction extends AutoCloseable {
 
     /**
      * @param label    A unique label for the AttributeType
-     * @param valueType The data type of the AttributeType.
+     * @param valueType The value type of the AttributeType.
      *                 Supported types include: ValueType.STRING, ValueType.LONG, ValueType.DOUBLE, and ValueType.BOOLEAN
      * @param <V>
-     * @return A new or existing AttributeType with the provided label and data type.
+     * @return A new or existing AttributeType with the provided label and value type.
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
      * @throws GraknElementException if the {@param label} is already in use by an existing AttributeType which is

--- a/mapreduce/ModifiableConfigurationHadoop.java
+++ b/mapreduce/ModifiableConfigurationHadoop.java
@@ -147,7 +147,7 @@ public class ModifiableConfigurationHadoop extends ModifiableConfiguration {
                         throw new IllegalArgumentException("Cannot parse time duration from: " + s);
                 }
                 return (O) Duration.of(Long.valueOf(comps[0]), unit);
-            } else throw new IllegalArgumentException("Unsupported data type: " + dataType);
+            } else throw new IllegalArgumentException("Unsupported value type: " + dataType);
         }
 
         @Override
@@ -206,7 +206,7 @@ public class ModifiableConfigurationHadoop extends ModifiableConfiguration {
                 // This is a conceptual leak; the config layer should ideally only handle standard library types
                 String millis = String.valueOf(((Duration) value).toMillis());
                 config.set(internalKey, millis);
-            } else throw new IllegalArgumentException("Unsupported data type: " + dataType);
+            } else throw new IllegalArgumentException("Unsupported value type: " + dataType);
         }
 
         @Override

--- a/server/session/TransactionImpl.java
+++ b/server/session/TransactionImpl.java
@@ -789,10 +789,10 @@ public class TransactionImpl implements Transaction {
 
     /**
      * @param label    A unique label for the AttributeType
-     * @param valueType The data type of the AttributeType.
+     * @param valueType The value type of the AttributeType.
      *                 Supported types include: ValueType.STRING, ValueType.LONG, ValueType.DOUBLE, and ValueType.BOOLEAN
      * @param <V>
-     * @return A new or existing AttributeType with the provided label and data type.
+     * @return A new or existing AttributeType with the provided label and value type.
      * @throws TransactionException       if the graph is closed
      * @throws PropertyNotUniqueException if the {@param label} is already in use by an existing non-AttributeType.
      * @throws GraknElementException       if the {@param label} is already in use by an existing AttributeType which is
@@ -812,7 +812,7 @@ public class TransactionImpl implements Transaction {
             if (Schema.MetaSchema.isMetaLabel(label)) {
                 throw GraknConceptException.metaTypeImmutable(label);
             } else if (!valueType.equals(attributeType.valueType())) {
-                throw GraknElementException.immutableProperty(attributeType.valueType(), valueType, Schema.VertexProperty.DATA_TYPE);
+                throw GraknElementException.immutableProperty(attributeType.valueType(), valueType, Schema.VertexProperty.VALUE_TYPE);
             }
         }
 

--- a/test-integration/graql/analytics/StatisticsIT.java
+++ b/test-integration/graql/analytics/StatisticsIT.java
@@ -99,7 +99,7 @@ public class StatisticsIT {
             assertExceptionThrown(tx, Graql.compute().std().in(thing));
             assertExceptionThrown(tx, Graql.compute().median().in(thing));
 
-            // if it's not a resource-type
+            // if it's not an attribute-type
             assertExceptionThrown(tx, Graql.compute().max().of(thing));
             assertExceptionThrown(tx, Graql.compute().min().of(thing));
             assertExceptionThrown(tx, Graql.compute().mean().of(thing));
@@ -107,7 +107,7 @@ public class StatisticsIT {
             assertExceptionThrown(tx, Graql.compute().std().of(thing));
             assertExceptionThrown(tx, Graql.compute().median().of(thing));
 
-            // resource-type has no instance
+            // attribute-type has no instance
             assertTrue(tx.execute(Graql.compute().max().of(resourceType7)).isEmpty());
             assertTrue(tx.execute(Graql.compute().min().of(resourceType7)).isEmpty());
             assertTrue(tx.execute(Graql.compute().sum().of(resourceType7)).isEmpty());
@@ -115,7 +115,7 @@ public class StatisticsIT {
             assertTrue(tx.execute(Graql.compute().median().of(resourceType7)).isEmpty());
             assertTrue(tx.execute(Graql.compute().mean().of(resourceType7)).isEmpty());
 
-            // resources are not connected to any entities
+            // attributes are not connected to any entities
             assertTrue(tx.execute(Graql.compute().max().of(resourceType3)).isEmpty());
             assertTrue(tx.execute(Graql.compute().min().of(resourceType3)).isEmpty());
             assertTrue(tx.execute(Graql.compute().sum().of(resourceType3)).isEmpty());
@@ -123,7 +123,7 @@ public class StatisticsIT {
             assertTrue(tx.execute(Graql.compute().median().of(resourceType3)).isEmpty());
             assertTrue(tx.execute(Graql.compute().mean().of(resourceType3)).isEmpty());
 
-            // resource-type has incorrect data type
+            // attribute-type has incorrect value type
             assertExceptionThrown(tx, Graql.compute().max().of(resourceType4));
             assertExceptionThrown(tx, Graql.compute().min().of(resourceType4));
             assertExceptionThrown(tx, Graql.compute().mean().of(resourceType4));
@@ -131,7 +131,7 @@ public class StatisticsIT {
             assertExceptionThrown(tx, Graql.compute().std().of(resourceType4));
             assertExceptionThrown(tx, Graql.compute().median().of(resourceType4));
 
-            // resource-types have different data types
+            // attribute-types have different value types
             Set<String> resourceTypes = Sets.newHashSet(resourceType1, resourceType2);
             assertExceptionThrown(tx, Graql.compute().max().of(resourceTypes));
             assertExceptionThrown(tx, Graql.compute().min().of(resourceTypes));
@@ -156,7 +156,7 @@ public class StatisticsIT {
     public void testMinAndMax() {
         List<Numeric> result;
 
-        // resource-type has no instance
+        // attribute-type has no instance
         addSchemaAndEntities();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -195,7 +195,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // add resources, but resources are not connected to any entities
+        // add attributes, but attributes are not connected to any entities
         addResourcesInstances();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -218,7 +218,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // connect entity and resources
+        // connect entity and attributes
         addResourceRelations();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -248,7 +248,7 @@ public class StatisticsIT {
     public void testSum() {
         List<Numeric> result;
 
-        // resource-type has no instance
+        // attribute-type has no instance
         addSchemaAndEntities();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -270,7 +270,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // add resources, but resources are not connected to any entities
+        // add attributes, but attributes are not connected to any entities
         addResourcesInstances();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -284,7 +284,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // connect entity and resources
+        // connect entity and attributes
         addResourceRelations();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -305,7 +305,7 @@ public class StatisticsIT {
     public void testMean() {
         List<Numeric> result;
 
-        // resource-type has no instance
+        // attribute-type has no instance
         addSchemaAndEntities();
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
             result = tx.execute(Graql.compute().mean().of(resourceType1).in(Collections.emptyList()));
@@ -326,7 +326,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // add resources, but resources are not connected to any entities
+        // add attributes, but attributes are not connected to any entities
         addResourcesInstances();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -340,7 +340,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // connect entity and resources
+        // connect entity and attributes
         addResourceRelations();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -361,7 +361,7 @@ public class StatisticsIT {
     public void testStd() {
         List<Numeric> result;
 
-        // resource-type has no instance
+        // attribute-type has no instance
         addSchemaAndEntities();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -383,7 +383,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // add resources, but resources are not connected to any entities
+        // add attributes, but attributes are not connected to any entities
         addResourcesInstances();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -397,7 +397,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // connect entity and resources
+        // connect entity and attributes
         addResourceRelations();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -431,7 +431,7 @@ public class StatisticsIT {
     public void testMedian() {
         List<Numeric> result;
 
-        // resource-type has no instance
+        // attribute-type has no instance
         addSchemaAndEntities();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -453,7 +453,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // add resources, but resources are not connected to any entities
+        // add attributes, but attributes are not connected to any entities
         addResourcesInstances();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -467,7 +467,7 @@ public class StatisticsIT {
             assertTrue(result.isEmpty());
         }
 
-        // connect entity and resources
+        // connect entity and attributes
         addResourceRelations();
 
         try (Transaction tx = session.transaction(Transaction.Type.READ)) {
@@ -706,7 +706,7 @@ public class StatisticsIT {
                     .assign(resourceOwner6, entity4)
                     .assign(resourceValue6, tx.<Double>getAttributeType(resourceType6).create(7.5));
 
-            // some resources in, but not connect them to any instances
+            // some attributes in, but not connect them to any instances
             tx.<Double>getAttributeType(resourceType1).create(2.8);
             tx.<Long>getAttributeType(resourceType2).create(-5L);
             tx.<Long>getAttributeType(resourceType5).create(10L);

--- a/test-integration/server/GraknClientIT.java
+++ b/test-integration/server/GraknClientIT.java
@@ -1239,7 +1239,7 @@ public class GraknClientIT {
     }
 
     @Test
-    public void setAttributeValueWithDatatypeDate() {
+    public void setAttributeValueWithValueTypeDate() {
         try (GraknClient.Transaction tx = remoteSession.transaction().write()) {
             AttributeType.Remote<LocalDateTime> birthDateType = tx.putAttributeType("birth-date",  ValueType.DATE);
             LocalDateTime date = LocalDateTime.now();


### PR DESCRIPTION
## What is the goal of this PR?

We are replacing the term `DataType` in `AttributeType` with `ValueType`). Previously, an `AttributeType` has a `DataType`. And an `Attribute` has `Value`. The type of `Value` is defined by `DataType`. We can see the inconsistency there. Now, `AttributeType` has `ValueType`, and `Attribute` has `Value`. The type of `Value` is `ValueType`. So it's all consistent.

## What are the changes implemented in this PR?

- Renamed the `DataType` class to `ValueType`
- Renamed method names
- Renamed method arguments
- Renamed variable names
- Updated comments