### PR TITLE
Update circle ci file for incorrect behavior steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -502,9 +502,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
-            - test-behavior-connection
-            - test-behavior-graql-language
-            - test-behavior-graql-reasoner
+            - test-behaviour-connection
+            - test-behaviour-graql-language
+            - test-behaviour-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -521,9 +521,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
-            - test-behavior-connection
-            - test-behavior-graql-language
-            - test-behavior-graql-reasoner
+            - test-behaviour-connection
+            - test-behaviour-graql-language
+            - test-behaviour-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -540,9 +540,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
-            - test-behavior-connection
-            - test-behavior-graql-language
-            - test-behavior-graql-reasoner
+            - test-behaviour-connection
+            - test-behaviour-graql-language
+            - test-behaviour-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -559,9 +559,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
-            - test-behavior-connection
-            - test-behavior-graql-language
-            - test-behavior-graql-reasoner
+            - test-behaviour-connection
+            - test-behaviour-graql-language
+            - test-behaviour-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
       - run-bazel-rbe:
           command: bazel test //common/... --test_output=errors
 
-  test-behavior-connection:
+  test-behaviour-connection:
     machine: true
     working_directory: ~/grakn
     steps:
@@ -100,7 +100,7 @@ jobs:
       - run-bazel-rbe:
           command: bazel test //test/behaviour/connection/transaction:test --test_output=errors
 
-  test-behavior-graql:
+  test-behaviour-graql-language:
     machine: true
     working_directory: ~/grakn
     steps:
@@ -109,13 +109,13 @@ jobs:
       - run-bazel-rbe:
           command: bazel test //test/behaviour/graql/language/define:test --test_output=errors
       - run-bazel-rbe:
-          command: bazel test //test/behaviour/connection/transaction:test --test_output=errors
+          command: bazel test //test/behaviour/graql/language/undefine:test --test_output=errors
       - run-bazel-rbe:
           command: bazel test //test/behaviour/graql/language/insert:test --test_output=errors
       - run-bazel-rbe:
           command: bazel test //test/behaviour/graql/language/match:test --test_output=errors
 
-  test-behavior-reasoner:
+  test-behaviour-graql-reasoner:
     machine: true
     working_directory: ~/grakn
     steps:
@@ -458,15 +458,15 @@ workflows:
           filters:
             branches:
               ignore: grakn-release-branch
-      - test-behavior-connection:
+      - test-behaviour-connection:
           filters:
             branches:
               ignore: grakn-release-branch
-      - test-behavior-graql:
+      - test-behaviour-graql-language:
           filters:
             branches:
               ignore: grakn-release-branch
-      - test-behavior-reasoner:
+      - test-behaviour-graql-reasoner:
           filters:
             branches:
               ignore: grakn-release-branch
@@ -502,6 +502,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
+            - test-behavior-connection
+            - test-behavior-graql-language
+            - test-behavior-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -518,6 +521,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
+            - test-behavior-connection
+            - test-behavior-graql-language
+            - test-behavior-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -534,6 +540,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
+            - test-behavior-connection
+            - test-behavior-graql-language
+            - test-behavior-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics
@@ -550,6 +559,9 @@ workflows:
             - build-analysis
             - test-common
             - test-server
+            - test-behavior-connection
+            - test-behavior-graql-language
+            - test-behavior-graql-reasoner
             - test-integration
             - test-integration-reasoner
             - test-integration-analytics

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification.git",
-        commit = "39d50403ee4a30674e1c4f4f9ac29ec920e4a20d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "6086526d6f09376c561d20a51926d22b11f27179",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -155,8 +155,7 @@ public class GraqlSteps {
         } else if (graqlQuery instanceof GraqlInsert) {
             answers = tx.execute(graqlQuery.asInsert());
         } else {
-            // TODO specialise exception
-            throw new RuntimeException("Only match-get and inserted supported for now");
+            throw new ScenarioDefinitionException("Only match-get and inserted supported for now");
         }
     }
 
@@ -184,7 +183,7 @@ public class GraqlSteps {
                     identifierChecks.put(identifier, new LabelUniquenessCheck(value));
                     break;
                 default:
-                    throw new RuntimeException(String.format("Unrecognised identifier check \"%s\"", check));
+                    throw new ScenarioDefinitionException(String.format("Unrecognised identifier check \"%s\"", check));
             }
         }
     }
@@ -247,7 +246,7 @@ public class GraqlSteps {
             }
 
             if(!identifierChecks.containsKey(identifier)) {
-                throw new RuntimeException(String.format("Identifier \"%s\" hasn't previously been declared", identifier));
+                throw new ScenarioDefinitionException(String.format("Identifier \"%s\" hasn't previously been declared", identifier));
             }
 
             if(!identifierChecks.get(identifier).check(answer.get(varName))) {
@@ -274,7 +273,7 @@ public class GraqlSteps {
         String[] children = explanationEntry.get("children").split(", ");
 
         if (vars.length != identifiers.length) {
-            throw new RuntimeException(String.format("vars and identifiers do not correspond for explanation entry %d. Found %d vars and %s identifiers", entryId, vars.length, identifiers.length));
+            throw new ScenarioDefinitionException(String.format("vars and identifiers do not correspond for explanation entry %d. Found %d vars and %s identifiers", entryId, vars.length, identifiers.length));
         }
 
         Map<String, String> answerIdentifiers = IntStream.range(0, vars.length).boxed().collect(Collectors.toMap(i -> vars[i], i -> identifiers[i]));
@@ -349,14 +348,14 @@ public class GraqlSteps {
         while (matcher.find()) {
             String matched = matcher.group(0);
             String requiredVariable = variableFromTemplatePlaceholder(matched.substring(1, matched.length() - 1));
-            Concept concept = templateFiller.get(requiredVariable);
 
-            builder.append(template, i, matcher.start());
-            if (concept == null) {
-                throw new RuntimeException(String.format("No ID available for template placeholder: %s", matched));
-            } else {
+            builder.append(template.substring(i, matcher.start()));
+            if (templateFiller.map().containsKey(new Variable(requiredVariable))) {
+                Concept concept = templateFiller.get(requiredVariable);
                 String conceptId = concept.id().toString();
                 builder.append(conceptId);
+            } else {
+                throw new ScenarioDefinitionException(String.format("No ID available for template placeholder: %s", matched));
             }
             i = matcher.end();
         }
@@ -370,10 +369,15 @@ public class GraqlSteps {
             String withoutPrefix = stripped.replace("answer.", "");
             return withoutPrefix;
         } else {
-            throw new RuntimeException("Cannot replace template not based on ID");
+            throw new ScenarioDefinitionException("Cannot replace template not based on ID");
         }
     }
 
+    private static class ScenarioDefinitionException extends RuntimeException {
+        ScenarioDefinitionException(String message) {
+            super(message);
+        }
+    }
 
     private interface UniquenessCheck {
         boolean check(Concept concept);
@@ -391,10 +395,8 @@ public class GraqlSteps {
         public boolean check(Concept concept) {
             if (concept.isSchemaConcept()) {
                 return label.equals(concept.asSchemaConcept().label().toString());
-            } else if (concept.isRole()) {
-                return label.equals(concept.asRole().label().toString());
             } else {
-                throw new RuntimeException("Concept was checked for label uniqueness, but it is neither a schema concept nor a type.");
+                throw new ScenarioDefinitionException("Concept was checked for label uniqueness, but it is not a schema concept.");
             }
         }
     }

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -389,12 +389,12 @@ public class GraqlSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (concept.isType()) {
-                return label.equals(concept.asType().label().toString());
+            if (concept.isSchemaConcept()) {
+                return label.equals(concept.asSchemaConcept().label().toString());
             } else if (concept.isRole()) {
                 return label.equals(concept.asRole().label().toString());
             } else {
-                throw new RuntimeException("Concept was checked for label uniqueness, but it is neither a role nor a type.");
+                throw new RuntimeException("Concept was checked for label uniqueness, but it is neither a schema concept nor a type.");
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?
Fix the CI file that ran the `transaction` behaviour tests twice and not the `undefine` behaviour tests at all.

## What are the changes implemented in this PR?
* Add test for `undefine` behaviour
* remove test for extra `transaction` behaviour
* rename `behavior` to `behaviour` throughout  (British spelling)
* Add behaviour tests to requirements for other steps
* borrow updated exception handling from updated client-java changes