### PR TITLE
Ability to change Storage startup timeout via ENV

### DIFF
--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -187,7 +187,7 @@ public class Storage {
      * @throws GraknDaemonException
      */
     private void start() {
-        System.out.print("Starting " + DISPLAY_NAME + "...");
+        System.out.println("Starting " + DISPLAY_NAME + "...");
         System.out.flush();
 
         // Consume configuration from Grakn config file into Cassandra config file
@@ -195,7 +195,16 @@ public class Storage {
 
         Future<Executor.Result> result = daemonExecutor.executeAsync(storageCommand(), graknHome.toFile());
 
-        LocalDateTime timeout = LocalDateTime.now().plusSeconds(STORAGE_STARTUP_TIMEOUT_SECOND);
+        // form storage timeout (default or ENV-value)
+        long startupTimeoutCalculated = STORAGE_STARTUP_TIMEOUT_SECOND;
+        String timeoutEnvValue = System.getenv("STORAGE_STARTUP_TIMEOUT_SECOND");
+        if (timeoutEnvValue != null && !timeoutEnvValue.isEmpty()) {
+          startupTimeoutCalculated = Long.parseLong(timeoutEnvValue, 10);
+        }
+        System.out.println(DISPLAY_NAME + " timeout is configured to " + startupTimeoutCalculated + " seconds");
+        System.out.flush();
+
+        LocalDateTime timeout = LocalDateTime.now().plusSeconds(startupTimeoutCalculated);
 
         while (LocalDateTime.now().isBefore(timeout) && !result.isDone()) {
             System.out.print(".");

--- a/daemon/executor/Storage.java
+++ b/daemon/executor/Storage.java
@@ -60,7 +60,7 @@ import static grakn.core.daemon.executor.Executor.WAIT_INTERVAL_SECOND;
 public class Storage {
 
     private static final String DISPLAY_NAME = "Storage";
-    private static final long STORAGE_STARTUP_TIMEOUT_SECOND = 60;
+    private static final long STORAGE_STARTUP_TIMEOUT_SECOND = 180;
     private static final Path STORAGE_PIDFILE = Paths.get(System.getProperty("java.io.tmpdir"), "grakn-storage.pid");
     private static final String JAVA_OPTS = SystemProperty.STORAGE_JAVAOPTS.value();
 


### PR DESCRIPTION
When running in docker-compose mode, if there are a lot of other docker-services, storage sometimes fails to start and throws error "Unable to start Storage". So, default timeout is increased from 60 to 180 seconds.
Also I've added ability to set custom startup timeout via environment variable STORAGE_STARTUP_TIMEOUT_SECOND