### PR TITLE
Collect `match` clause before execute `delete`

### DIFF
--- a/concept/manager/ConceptListenerImpl.java
+++ b/concept/manager/ConceptListenerImpl.java
@@ -193,9 +193,6 @@ public class ConceptListenerImpl implements ConceptListener {
         transactionCache.trackForValidation(relationType);
     }
 
-    /*
-    TODO this pair of methods might be combinable somehow
-     */
     @Override
     public void labelRemoved(SchemaConcept schemaConcept) {
         transactionCache.remove(schemaConcept);

--- a/graql/executor/QueryExecutorImpl.java
+++ b/graql/executor/QueryExecutorImpl.java
@@ -229,10 +229,11 @@ public class QueryExecutorImpl implements QueryExecutor {
             }
         }
 
-        get(query.match().get()).forEach(answer -> {
+        List<ConceptMap> toDelete = get(query.match().get()).collect(toList());
+        toDelete.forEach(answer -> {
             WriteExecutorImpl.create(conceptManager, executors.build()).write(answer);
         });
-        return new Void("Delete successful.");
+        return new Void(String.format("Deleted facts from %s matched answers.", toDelete.size()));
     }
 
     @Override

--- a/test/integration/graql/query/GraqlGetIT.java
+++ b/test/integration/graql/query/GraqlGetIT.java
@@ -510,13 +510,7 @@ public class GraqlGetIT {
         assertEquals(answersById.size(), 1);
 
         // clean up, delete the IDs we inserted for this test
-
-        // TODO re-enable batch deletion when we no longer have `via` and implicit attribute relations
-//        tx.execute(Graql.match(idPatterns).delete(deletePatterns));
-
-        for (int i = 0; i < insertedIds.size(); i++) {
-            tx.execute(Graql.match(idPatterns.get(i)).delete(deletePatterns.get(i)));
-        }
+        tx.execute(Graql.match(idPatterns).delete(deletePatterns));
         tx.commit();
     }
 }

--- a/test/integration/graql/query/GraqlInsertIT.java
+++ b/test/integration/graql/query/GraqlInsertIT.java
@@ -716,17 +716,8 @@ public class GraqlInsertIT {
             assertExists(tx, var);
         }
 
-        // TODO restore prior implementation when we can delete and read at the same time
-//        for (Statement statement: vars) {
-//            tx.execute(Graql.match(statement).delete(Graql.var(statement.var()).isa("thing")));
-//        }
-
-        // Delete all vars
-        for (Statement statement : vars) {
-            // if we delete by ID instead of full traversal, traversals don't support modifications and deletions at the same time
-            Variable var = statement.var();
-            tx.execute(Graql.match(Graql.var(var).id(answer.get(var).id().toString()))
-                    .delete(Graql.var(var).isa("thing")));
+        for (Statement statement: vars) {
+            tx.execute(Graql.match(statement).delete(Graql.var(statement.var()).isa("thing")));
         }
 
         // Make sure vars don't exist


### PR DESCRIPTION
## What is the goal of this PR?
To avoid modifying iterators while traversing, we collect all answers from the `match` clause, closing the iterator, and perform deletions on all the found concept maps

## What are the changes implemented in this PR?
* un-ignore all tests that were failing due to modifying data during traversal
* collect all concept maps, then operate delete
* in completion message, return number of `matched` answers to user as a hint of what happened (want users to be specific as possible)