### PR TITLE
Apply correct tx type for incoming RPC transaction requests

### DIFF
--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -333,7 +333,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             if (type != null && type.equals(Transaction.Type.WRITE)) {
                 tx = session.transaction(grakn.core.kb.server.Transaction.Type.WRITE);
             } else if (type != null && type.equals(Transaction.Type.READ)) {
-                tx = session.transaction(grakn.core.kb.server.Transaction.Type.WRITE);
+                tx = session.transaction(grakn.core.kb.server.Transaction.Type.READ);
             } else {
                 throw TransactionException.create("Invalid Transaction Type");
             }

--- a/test/integration/server/GraknClientIT.java
+++ b/test/integration/server/GraknClientIT.java
@@ -32,20 +32,21 @@ import grakn.client.answer.ConceptMap;
 import grakn.client.answer.ConceptSet;
 import grakn.client.answer.ConceptSetMeasure;
 import grakn.client.answer.Numeric;
-import grakn.client.concept.thing.Attribute;
-import grakn.client.concept.type.AttributeType;
 import grakn.client.concept.Concept;
 import grakn.client.concept.ConceptId;
-import grakn.client.concept.ValueType;
-import grakn.client.concept.thing.Entity;
-import grakn.client.concept.type.EntityType;
 import grakn.client.concept.Label;
+import grakn.client.concept.SchemaConcept;
+import grakn.client.concept.ValueType;
+import grakn.client.concept.thing.Attribute;
+import grakn.client.concept.thing.Entity;
 import grakn.client.concept.thing.Relation;
+import grakn.client.concept.thing.Thing;
+import grakn.client.concept.type.AttributeType;
+import grakn.client.concept.type.EntityType;
 import grakn.client.concept.type.RelationType;
 import grakn.client.concept.type.Role;
-import grakn.client.concept.SchemaConcept;
-import grakn.client.concept.thing.Thing;
 import grakn.client.concept.type.Type;
+import grakn.client.exception.GraknClientException;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
 import grakn.core.kb.server.exception.SessionException;
@@ -154,6 +155,19 @@ public class GraknClientIT {
             }
         }
     }
+
+    @Test
+    public void whenOpeningReadTransaction_writeThrows() {
+        try (GraknClient.Session session = graknClient.session(localSession.keyspace().name())) {
+            try (GraknClient.Transaction tx = session.transaction().read()) {
+                exception.expect(GraknClientException.class);
+                exception.expectMessage("is read only");
+                tx.execute(Graql.parse("define newentity sub entity;").asDefine());
+                tx.commit();
+            }
+        }
+    }
+
 
     @Test
     public void testPuttingEntityType_EnsureItIsAdded() {


### PR DESCRIPTION
## What is the goal of this PR?
Previous PR had accidentally always returned a WRITE transaction regardless of what the client had requested. This PR adds another test for this situation that tests it via the RPC interface to Grakn Core, and resolves the issue.

## What are the changes implemented in this PR?
* Add new test for returning correct TX type
* Fix tx type that is returned