### PR TITLE
Refactor HasAttribute executors to use separate fragments

### DIFF
--- a/graql/executor/property/HasAttributeExecutor.java
+++ b/graql/executor/property/HasAttributeExecutor.java
@@ -116,8 +116,7 @@ public class HasAttributeExecutor  implements PropertyExecutor.Insertable, Prope
         public void execute(WriteExecutor executor) {
             Attribute attributeConcept = executor.getConcept(property.attribute().var()).asAttribute();
             Thing thing = executor.getConcept(var).asThing();
-            ConceptId relationId = thing.relhas(attributeConcept).id();
-            executor.getBuilder(property.relation().var()).id(relationId);
+            thing.has(attributeConcept);
         }
     }
 

--- a/graql/planning/gremlin/fragment/AbstractRolePlayerFragment.java
+++ b/graql/planning/gremlin/fragment/AbstractRolePlayerFragment.java
@@ -68,12 +68,12 @@ abstract class AbstractRolePlayerFragment extends EdgeFragment {
         String roleString = role != null ? " role:" + role.symbol() : "";
         String rels = displayOptionalTypeLabels("rels", relationTypeLabels());
         String roles = displayOptionalTypeLabels("roles", roleLabels());
-        return "[" + Schema.EdgeLabel.ROLE_PLAYER.getLabel() + ":" + edge().symbol() + roleString + rels + roles + "]";
+        return "[" + Schema.EdgeLabel.ROLE_PLAYER.getLabel() + ":" + roleString + rels + roles + "]";
     }
 
     @Override
     final ImmutableSet<Variable> otherVars() {
-        ImmutableSet.Builder<Variable> builder = ImmutableSet.<Variable>builder().add(edge());
+        ImmutableSet.Builder<Variable> builder = ImmutableSet.<Variable>builder();
         Variable role = role();
         if (role != null) builder.add(role);
         return builder.build();

--- a/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
+++ b/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
@@ -29,7 +29,6 @@ import grakn.core.graql.reasoner.atom.binary.AttributeAtom;
 import grakn.core.graql.reasoner.atom.predicate.ValuePredicate;
 import grakn.core.graql.reasoner.cache.MultilevelSemanticCache;
 import grakn.core.graql.reasoner.query.ReasonerAtomicQuery;
-import grakn.core.graql.reasoner.utils.AnswerUtil;
 import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.Concept;
@@ -78,10 +77,7 @@ public class AttributeMaterialiser implements AtomMaterialiser<AttributeAtom> {
                     resourceVariable, attribute)
             );
 
-            Relation relation = putImplicitRelation(atom, answer, owner, attribute, ctx);
-            if (atom.getRelationVariable().isReturned()) {
-                answer = AnswerUtil.joinAnswers(answer, new ConceptMap(ImmutableMap.of(atom.getRelationVariable(), relation)));
-            }
+            putAttributeOwnership(atom, answer, owner, attribute, ctx);
             return Stream.of(answer);
         }
         return Stream.empty();
@@ -122,12 +118,9 @@ public class AttributeMaterialiser implements AtomMaterialiser<AttributeAtom> {
      * @param sub       partial substitution
      * @param owner     attribute owner
      * @param attribute attribute concept
-     * @return inserted implicit relation if didn't exist, null otherwise
      */
-    private Relation putImplicitRelation(AttributeAtom atom, ConceptMap sub, Concept owner, Attribute attribute, ReasoningContext ctx) {
+    private void putAttributeOwnership(AttributeAtom atom, ConceptMap sub, Concept owner, Attribute attribute, ReasoningContext ctx) {
         ConceptMap answer = findAnswer(atom, sub, ctx);
-        if (answer == null) return attachAttribute(owner, attribute);
-        Variable relationVariable = atom.getRelationVariable();
-        return relationVariable.isReturned() ? answer.get(relationVariable).asRelation() : null;
+        if (answer == null) attachAttribute(owner, attribute);
     }
 }

--- a/graql/test/planning/gremlin/sets/RolePlayerFragmentSetTest.java
+++ b/graql/test/planning/gremlin/sets/RolePlayerFragmentSetTest.java
@@ -97,7 +97,7 @@ public class RolePlayerFragmentSetTest {
         Label magician = Label.of("magician");
 
         Collection<EquivalentFragmentSet> fragmentSets = Sets.newHashSet(
-                EquivalentFragmentSets.rolePlayer(null, a, b, c, d),
+                EquivalentFragmentSets.rolePlayer(null, a,  b, c, d),
                 EquivalentFragmentSets.label(null, d, ImmutableSet.of(magician))
         );
 

--- a/test/integration/graql/query/GraqlGetIT.java
+++ b/test/integration/graql/query/GraqlGetIT.java
@@ -96,6 +96,12 @@ public class GraqlGetIT {
     }
 
     @Test
+    public void test() {
+        List<ConceptMap> execute = tx.execute(Graql.parse("match $x has attribute $a; get;").asGet());
+        System.out.println(execute);
+    }
+
+    @Test
     public void testGetSort() {
         List<ConceptMap> answers = tx.execute(
                 Graql.match(var("x").isa("person").has("name", var("y")))


### PR DESCRIPTION
## What is the goal of this PR?
In process of splitting `Has` edges away from being proper relations, we create a new fragment for `HasAttribute` executors to utilise - `InHasAttribute` or `OutHasAttribute`.

## What are the changes implemented in this PR?
