### PR TITLE
Revert VALUE_TYPE to DATA_TYPE 

### DIFF
--- a/concept/impl/AttributeTypeImpl.java
+++ b/concept/impl/AttributeTypeImpl.java
@@ -167,7 +167,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Nullable
     @Override
     public ValueType<D> valueType() {
-        String className = vertex().property(Schema.VertexProperty.VALUE_TYPE);
+        String className = vertex().property(Schema.VertexProperty.DATA_TYPE);
         if (className == null) return null;
 
         try {

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -153,7 +153,7 @@ public class ConceptManagerImpl implements ConceptManager {
     @Override
     public <V> AttributeType<V> createAttributeType(Label label, AttributeType<V> superType, AttributeType.ValueType<V> valueType) {
         VertexElement vertexElement = createSchemaVertex(label, ATTRIBUTE_TYPE, false);
-        vertexElement.propertyImmutable(Schema.VertexProperty.VALUE_TYPE, valueType, null, AttributeType.ValueType::name);
+        vertexElement.propertyImmutable(Schema.VertexProperty.DATA_TYPE, valueType, null, AttributeType.ValueType::name);
         AttributeType<V> attributeType = new AttributeTypeImpl<>(vertexElement, this, conceptNotificationChannel);
         attributeType.createShard();
         attributeType.sup(superType);

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -198,7 +198,8 @@ public final class Schema {
         SCHEMA_LABEL(String.class), LABEL_ID(Integer.class), INSTANCE_COUNT(Long.class), TYPE_SHARD_CHECKPOINT(Long.class), IS_ABSTRACT(Boolean.class),
 
         // Attribute schema concept properties
-        REGEX(String.class), VALUE_TYPE(String.class),
+        // TODO change to `VALUE_TYPE` when no longer require preserving DB compatibility
+        REGEX(String.class), DATA_TYPE(String.class),
 
         // Attribute concept properties
         INDEX(String.class),

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Objects;
 
-import static grakn.core.core.Schema.VertexProperty.VALUE_TYPE;
+import static grakn.core.core.Schema.VertexProperty.DATA_TYPE;
 
 class ValueTypeFragment extends FragmentImpl {
 
@@ -47,7 +47,7 @@ class ValueTypeFragment extends FragmentImpl {
     @Override
     public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
             GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return traversal.has(VALUE_TYPE.name(), valueType().name());
+        return traversal.has(DATA_TYPE.name(), valueType().name());
     }
 
     @Override

--- a/server/session/TransactionImpl.java
+++ b/server/session/TransactionImpl.java
@@ -812,7 +812,7 @@ public class TransactionImpl implements Transaction {
             if (Schema.MetaSchema.isMetaLabel(label)) {
                 throw GraknConceptException.metaTypeImmutable(label);
             } else if (!valueType.equals(attributeType.valueType())) {
-                throw GraknElementException.immutableProperty(attributeType.valueType(), valueType, Schema.VertexProperty.VALUE_TYPE);
+                throw GraknElementException.immutableProperty(attributeType.valueType(), valueType, Schema.VertexProperty.DATA_TYPE);
             }
         }
 


### PR DESCRIPTION
## What is the goal of this PR?
Retain DB compatibility as we have from version 1.5.x (ish? or even earlier?). Changing to new terminology `VALUE_TYPE` in the schema definition file `Schema.java` broke this backwards compatibility. We revert this in a few places that are critical, though the language elsewhere is retained.

## What are the changes implemented in this PR?
* Revert enum label `VALUE_TYPE to `DATA_TYPE` in `Schema.java` and the 5 users of that enum value