### PR TITLE
Block gRPC request observer thread to get back-pressure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -454,6 +454,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
       - test-common:
           filters:
             branches:
@@ -496,6 +497,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - build
             - build-checkstyle
@@ -512,6 +514,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - build
             - build-checkstyle
@@ -528,6 +531,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - build
             - build-checkstyle
@@ -544,6 +548,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - build
             - build-checkstyle
@@ -560,6 +565,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -571,6 +577,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - test-assembly-mac-zip
             - test-assembly-windows-zip
@@ -582,6 +589,7 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - deploy-apt-snapshot
       - test-deployment-linux-rpm:
@@ -590,19 +598,24 @@ workflows:
               only:
                 - master
                 - rewrite
+                - 1.7.2
           requires:
             - deploy-rpm-snapshot
       - sync-dependencies-snapshot:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - 1.7.2
           requires:
             - test-deployment-linux-apt
             - test-deployment-linux-rpm
       - release-approval:
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - 1.7.2
           requires:
             - sync-dependencies-snapshot
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "git@github.com:graknlabs/verification.git",
-        commit = "6f9a547f840c8cfe5589450b62cee4c9899dea28",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "20d11701e37fc80fdc33d084e3972c61ec144903",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "git@github.com:graknlabs/verification.git",
-        commit = "57bd3d144835b494512a35c442b49e789788900d",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "6f9a547f840c8cfe5589450b62cee4c9899dea28",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -41,6 +41,7 @@ import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
 import graql.lang.query.GraqlQuery;
 import io.grpc.Status;
+import io.grpc.StatusException;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +55,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
@@ -180,12 +182,12 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
                 String rootId = metadata.get("traceRootId");
                 String parentId = metadata.get("traceParentId");
                 if (rootId != null && parentId != null) {
-                    submit(() -> handleRequest(request, GrablTracingThreadStatic.getGrablTracing()
+                    process(() -> handleRequest(request, GrablTracingThreadStatic.getGrablTracing()
                             .trace(UUID.fromString(rootId), UUID.fromString(parentId), "received")));
                     return;
                 }
             }
-            submit(() -> handleRequest(request));
+            process(() -> handleRequest(request));
         }
 
         @Override
@@ -315,8 +317,12 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             }
         }
 
-        private void submit(Runnable runnable) {
-            threadExecutor.submit(runnable);
+        private void process(Runnable runnable) {
+            try {
+                threadExecutor.submit(runnable).get();
+            } catch (InterruptedException | ExecutionException ex) {
+                // Exception will have been handled already
+            }
         }
 
         private void open(Transaction.Open.Req request) {


### PR DESCRIPTION
## What is the goal of this PR?

Fix #5726 by allowing gRPC's natural back-pressure (automatic flow control) to take place.

## What are the changes implemented in this PR?

Request messages are no longer eagerly queued asynchronously for processing in the TransactionService, and instead are blocked by waiting on the returned future when submitting them. This blocks the gRPC thread, which prevents the server buffer from being depleted and allows gRPC to control the back-pressure.

Also fixed dependency on a now non-existent commit of verification (due to a rebase).