### PR TITLE
Bump Graql Dependency and use `DateTime`

### DIFF
--- a/core/AttributeSerialiser.java
+++ b/core/AttributeSerialiser.java
@@ -46,7 +46,7 @@ public abstract class AttributeSerialiser<DESERIALISED, SERIALISED> {
 
     private static Map<AttributeType.ValueType<?>, AttributeSerialiser<?, ?>> serialisers = map(
             pair(AttributeType.ValueType.BOOLEAN, BOOLEAN),
-            pair(AttributeType.ValueType.DATE, DATE),
+            pair(AttributeType.ValueType.DATETIME, DATE),
             pair(AttributeType.ValueType.DOUBLE, DOUBLE),
             pair(AttributeType.ValueType.FLOAT, FLOAT),
             pair(AttributeType.ValueType.INTEGER, INTEGER),

--- a/core/AttributeValueConverter.java
+++ b/core/AttributeValueConverter.java
@@ -33,7 +33,7 @@ public abstract class AttributeValueConverter<SOURCE, TARGET>{
 
     private static Map<AttributeType.ValueType<?>, AttributeValueConverter<?, ?>> converters = ImmutableMap.<AttributeType.ValueType<?>, AttributeValueConverter<?, ?>>builder()
             .put(AttributeType.ValueType.BOOLEAN, new IdentityConverter<Boolean, Boolean>())
-            .put(AttributeType.ValueType.DATE, new DateConverter())
+            .put(AttributeType.ValueType.DATETIME, new DateConverter())
             .put(AttributeType.ValueType.DOUBLE, new DoubleConverter())
             .put(AttributeType.ValueType.FLOAT, new FloatConverter())
             .put(AttributeType.ValueType.INTEGER, new IntegerConverter())

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -226,7 +226,7 @@ public final class Schema {
 
         private static Map<AttributeType.ValueType, VertexProperty> valueTypeVertexProperty = map(
                 pair(AttributeType.ValueType.BOOLEAN, VertexProperty.VALUE_BOOLEAN),
-                pair(AttributeType.ValueType.DATE, VertexProperty.VALUE_DATE),
+                pair(AttributeType.ValueType.DATETIME, VertexProperty.VALUE_DATE),
                 pair(AttributeType.ValueType.DOUBLE, VertexProperty.VALUE_DOUBLE),
                 pair(AttributeType.ValueType.FLOAT, VertexProperty.VALUE_FLOAT),
                 pair(AttributeType.ValueType.INTEGER, VertexProperty.VALUE_INTEGER),

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -35,7 +35,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "9441a23346177e2605b607e6dfab01869cd40530",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "64bb847b36f2c0a78e62d3f13483af6f26a36f22",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/graql/executor/property/ValueTypeExecutor.java
+++ b/graql/executor/property/ValueTypeExecutor.java
@@ -60,7 +60,7 @@ public class ValueTypeExecutor implements PropertyExecutor.Definable {
     private static ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes() {
         ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes = new ImmutableMap.Builder<>();
         valueTypes.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
-        valueTypes.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATE);
+        valueTypes.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATETIME);
         valueTypes.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
         valueTypes.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
         valueTypes.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);

--- a/graql/executor/property/ValueTypeExecutor.java
+++ b/graql/executor/property/ValueTypeExecutor.java
@@ -51,16 +51,16 @@ public class ValueTypeExecutor implements PropertyExecutor.Definable {
         }
         this.property = property;
 
-        if (!VALUE_TYPES.containsKey(property.valueType())) {
+        if (!VALUE_TYPES.containsKey(property.ValueType())) {
             throw new IllegalArgumentException("Unrecognised Attribute value type");
         }
-        this.valueType = VALUE_TYPES.get(property.valueType());
+        this.valueType = VALUE_TYPES.get(property.ValueType());
     }
 
     private static ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes() {
         ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes = new ImmutableMap.Builder<>();
         valueTypes.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
-        valueTypes.put(Graql.Token.ValueType.DATE, AttributeType.ValueType.DATE);
+        valueTypes.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATE);
         valueTypes.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
         valueTypes.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
         valueTypes.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -276,12 +276,12 @@ public class PropertyAtomicFactory {
     private ValueTypeAtom valueType(Variable var, ValueTypeProperty property, ReasonerQuery parent) {
         ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypesBuilder = new ImmutableMap.Builder<>();
         valueTypesBuilder.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
-        valueTypesBuilder.put(Graql.Token.ValueType.DATE, AttributeType.ValueType.DATE);
+        valueTypesBuilder.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATE);
         valueTypesBuilder.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
         valueTypesBuilder.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
         valueTypesBuilder.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);
         ImmutableMap<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypes = valueTypesBuilder.build();
-        return ValueTypeAtom.create(var, property, parent, valueTypes.get(property.valueType()));
+        return ValueTypeAtom.create(var, property, parent, valueTypes.get(property.ValueType()));
     }
 
     private Atomic isAbstract(Variable var, ReasonerQuery parent) {

--- a/graql/reasoner/atom/PropertyAtomicFactory.java
+++ b/graql/reasoner/atom/PropertyAtomicFactory.java
@@ -276,7 +276,7 @@ public class PropertyAtomicFactory {
     private ValueTypeAtom valueType(Variable var, ValueTypeProperty property, ReasonerQuery parent) {
         ImmutableMap.Builder<Graql.Token.ValueType, AttributeType.ValueType<?>> valueTypesBuilder = new ImmutableMap.Builder<>();
         valueTypesBuilder.put(Graql.Token.ValueType.BOOLEAN, AttributeType.ValueType.BOOLEAN);
-        valueTypesBuilder.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATE);
+        valueTypesBuilder.put(Graql.Token.ValueType.DATETIME, AttributeType.ValueType.DATETIME);
         valueTypesBuilder.put(Graql.Token.ValueType.DOUBLE, AttributeType.ValueType.DOUBLE);
         valueTypesBuilder.put(Graql.Token.ValueType.LONG, AttributeType.ValueType.LONG);
         valueTypesBuilder.put(Graql.Token.ValueType.STRING, AttributeType.ValueType.STRING);

--- a/graql/reasoner/atom/property/ValueTypeAtom.java
+++ b/graql/reasoner/atom/property/ValueTypeAtom.java
@@ -40,7 +40,7 @@ public class ValueTypeAtom extends AtomicBase {
 
     public static ValueTypeAtom create(Variable var, ValueTypeProperty prop, ReasonerQuery parent, AttributeType.ValueType<?> valueType) {
         Variable varName = var.asReturnedVar();
-        return new ValueTypeAtom(varName, new Statement(varName).value(prop.valueType()), parent, valueType);
+        return new ValueTypeAtom(varName, new Statement(varName).value(prop.ValueType()), parent, valueType);
     }
 
     private static ValueTypeAtom create(ValueTypeAtom a, ReasonerQuery parent) {

--- a/kb/concept/api/AttributeType.java
+++ b/kb/concept/api/AttributeType.java
@@ -233,9 +233,9 @@ public interface AttributeType<D> extends Type {
             @Override
             public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.BOOLEAN); }
         };
-        public static final ValueType<LocalDateTime> DATE = new ValueType<LocalDateTime>(LocalDateTime.class){
+        public static final ValueType<LocalDateTime> DATETIME = new ValueType<LocalDateTime>(LocalDateTime.class){
             @Override
-            public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.DATE); }
+            public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.DATETIME); }
         };
         public static final ValueType<Double> DOUBLE = new ValueType<Double>(Double.class){
             @Override
@@ -269,7 +269,7 @@ public interface AttributeType<D> extends Type {
             public Set<ValueType<?>> comparableValueTypes() { return Collections.singleton(ValueType.STRING); }
         };
 
-        private static final List<ValueType<?>> values = list(BOOLEAN, DATE, DOUBLE, FLOAT, INTEGER, LONG, STRING);
+        private static final List<ValueType<?>> values = list(BOOLEAN, DATETIME, DOUBLE, FLOAT, INTEGER, LONG, STRING);
 
         private final Class<D> dataClass;
 

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -247,7 +247,7 @@ public class ResponseBuilder {
                 return ConceptProto.AttributeType.VALUE_TYPE.FLOAT;
             } else if (valueType.equals(AttributeType.ValueType.DOUBLE)) {
                 return ConceptProto.AttributeType.VALUE_TYPE.DOUBLE;
-            } else if (valueType.equals(AttributeType.ValueType.DATE)) {
+            } else if (valueType.equals(AttributeType.ValueType.DATETIME)) {
                 return ConceptProto.AttributeType.VALUE_TYPE.DATE;
             } else {
                 throw GraknServerException.unreachableStatement("Unrecognised " + valueType);
@@ -269,7 +269,7 @@ public class ResponseBuilder {
                 case DOUBLE:
                     return AttributeType.ValueType.DOUBLE;
                 case DATE:
-                    return AttributeType.ValueType.DATE;
+                    return AttributeType.ValueType.DATETIME;
                 default:
                 case UNRECOGNIZED:
                     throw new IllegalArgumentException("Unrecognised " + valueType);

--- a/test/integration/concept/AttributeIT.java
+++ b/test/integration/concept/AttributeIT.java
@@ -184,9 +184,9 @@ public class AttributeIT {
     @Test
     public void whenCreatingResourceWithAnInvalidValueTypeOnADate_Throw() {
         String invalidThing = "Invalid Thing";
-        AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.ValueType.DATE);
+        AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.ValueType.DATETIME);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.ValueType.DATE).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.ValueType.DATETIME).getMessage());
         dateAttributeType.create(invalidThing);
     }
 
@@ -211,7 +211,7 @@ public class AttributeIT {
     @Test
     public void whenSavingDateIntoResource_DateIsReturnedInSameFormat() {
         LocalDateTime date = LocalDateTime.now();
-        AttributeType<LocalDateTime> attributeType = tx.putAttributeType("My Birthday", AttributeType.ValueType.DATE);
+        AttributeType<LocalDateTime> attributeType = tx.putAttributeType("My Birthday", AttributeType.ValueType.DATETIME);
         Attribute<LocalDateTime> myBirthday = attributeType.create(date);
 
         assertEquals(date, myBirthday.value());

--- a/test/integration/concept/AttributeTypeIT.java
+++ b/test/integration/concept/AttributeTypeIT.java
@@ -176,7 +176,7 @@ public class AttributeTypeIT {
         // now add the timezone to the graph
         try (Session session = server.sessionWithNewKeyspace()) {
             try (Transaction graph = session.transaction(Transaction.Type.WRITE)) {
-                AttributeType<LocalDateTime> aTime = graph.putAttributeType("aTime", AttributeType.ValueType.DATE);
+                AttributeType<LocalDateTime> aTime = graph.putAttributeType("aTime", AttributeType.ValueType.DATETIME);
                 aTime.create(rightNow);
                 graph.commit();
             }

--- a/test/integration/graql/graph/MovieGraph.java
+++ b/test/integration/graql/graph/MovieGraph.java
@@ -77,7 +77,7 @@ public class MovieGraph {
 
         tmdbVoteCount = tx.putAttributeType("tmdb-vote-count", AttributeType.ValueType.LONG);
         tmdbVoteAverage = tx.putAttributeType("tmdb-vote-average", AttributeType.ValueType.DOUBLE);
-        releaseDate = tx.putAttributeType("release-date", AttributeType.ValueType.DATE);
+        releaseDate = tx.putAttributeType("release-date", AttributeType.ValueType.DATETIME);
         runtime = tx.putAttributeType("runtime", AttributeType.ValueType.LONG);
         gender = tx.putAttributeType("gender", AttributeType.ValueType.STRING).regex("(fe)?male");
         realName = tx.putAttributeType("real-name", AttributeType.ValueType.STRING);

--- a/test/integration/graql/query/NumberCastingIT.java
+++ b/test/integration/graql/query/NumberCastingIT.java
@@ -55,7 +55,7 @@ public class NumberCastingIT {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             tx.putAttributeType("attr-long", AttributeType.ValueType.LONG);
             tx.putAttributeType("attr-double", AttributeType.ValueType.DOUBLE);
-            tx.putAttributeType("attr-date", AttributeType.ValueType.DATE);
+            tx.putAttributeType("attr-date", AttributeType.ValueType.DATETIME);
             tx.commit();
         }
     }

--- a/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -159,7 +159,7 @@ public class AtomicEquivalenceIT {
 
     private static Map<AttributeType.ValueType<?>, Object> testValues = ImmutableMap.<AttributeType.ValueType<?>, Object>builder()
             .put(AttributeType.ValueType.BOOLEAN, true)
-            .put(AttributeType.ValueType.DATE, LocalDateTime.now())
+            .put(AttributeType.ValueType.DATETIME, LocalDateTime.now())
             .put(AttributeType.ValueType.DOUBLE, 10.0)
             .put(AttributeType.ValueType.FLOAT, 10.0)
             .put(AttributeType.ValueType.INTEGER, 10)

--- a/test/integration/graql/reasoner/resources/genericSchema.gql
+++ b/test/integration/graql/reasoner/resources/genericSchema.gql
@@ -98,7 +98,7 @@ resource-long sub attribute, value long,
     plays baseRole2;
 
 resource-double sub attribute, value double;
-resource-date sub attribute, value date;
+resource-date sub attribute, value datetime;
 resource-boolean sub attribute, value boolean;
 
 

--- a/test/integration/graql/reasoner/resources/materialisationTest.gql
+++ b/test/integration/graql/reasoner/resources/materialisationTest.gql
@@ -27,7 +27,7 @@ resource-string sub attribute, value string;
 resource-long sub attribute, value long;
 resource-double sub attribute, value double;
 resource-boolean sub attribute, value boolean;
-resource-date sub attribute, value date;
+resource-date sub attribute, value datetime;
 
 insert
 

--- a/test/test-fixtures/basic-genealogy.gql
+++ b/test/test-fixtures/basic-genealogy.gql
@@ -27,8 +27,8 @@ surname sub attribute, value string;
 middlename sub attribute, value string;
 picture sub attribute, value string;
 age sub attribute, value long;
-birth-date sub attribute, value date;
-death-date sub attribute, value date;
+birth-date sub attribute, value datetime;
+death-date sub attribute, value datetime;
 gender sub attribute, value string;
 
 # Roles and Relations


### PR DESCRIPTION
## What is the goal of this PR?
Re-synchronise dependencies to use `master` of different repositories. This change includes using `datetime` instead of `date` for the Date attribute type.


## What are the changes implemented in this PR?
* Bump depedencies to latest Graql
* use `datetime` instead of `date` for attribute types