### PR TITLE
Re-enable copying attribute values across types

### DIFF
--- a/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
@@ -59,8 +59,7 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
         }
 
         AttributeAtom parent = (AttributeAtom) parentAtom;
-        Unifier unifier = binarySemanticProcessor.getUnifier(childAtom.attributeIsa(), parent.attributeIsa(), unifierType, ctx);
-        if (unifier == null) return UnifierImpl.nonExistent();
+        Unifier unifier = new UnifierImpl(ImmutableMap.of(childAtom.getAttributeVariable(), parent.getAttributeVariable()));
 
         //unify owner isa
         Unifier ownerUnifier = binarySemanticProcessor.getUnifier(childAtom.ownerIsa(), parent.ownerIsa(), unifierType, ctx);
@@ -71,7 +70,7 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
         Variable childRelationVarName = childAtom.getRelationVariable();
         Variable parentRelationVarName = parent.getRelationVariable();
         if (parentRelationVarName.isReturned()){
-            unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(childRelationVarName, parentRelationVarName)));
+            unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(parentRelationVarName, childRelationVarName)));
         }
 
         return AtomicUtil.isPredicateCompatible(childAtom, parentAtom, unifier, unifierType, ctx.conceptManager())?

--- a/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/AttributeSemanticProcessor.java
@@ -70,7 +70,7 @@ public class AttributeSemanticProcessor implements SemanticProcessor<AttributeAt
         Variable childRelationVarName = childAtom.getRelationVariable();
         Variable parentRelationVarName = parent.getRelationVariable();
         if (parentRelationVarName.isReturned()){
-            unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(parentRelationVarName, childRelationVarName)));
+            unifier = unifier.merge(new UnifierImpl(ImmutableMap.of(childRelationVarName, parentRelationVarName)));
         }
 
         return AtomicUtil.isPredicateCompatible(childAtom, parentAtom, unifier, unifierType, ctx.conceptManager())?

--- a/graql/reasoner/atom/task/relate/TypeAtomSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/TypeAtomSemanticProcessor.java
@@ -62,8 +62,8 @@ public class TypeAtomSemanticProcessor implements SemanticProcessor<TypeAtom> {
 
         //check for incompatibilities
         if( !unifierType.typeCompatibility(
-                parentType != null? Collections.singleton(parentType) : Collections.emptySet(),
-                childType != null? Collections.singleton(childType) : Collections.emptySet())
+                    parentType != null? Collections.singleton(parentType) : Collections.emptySet(),
+                    childType != null? Collections.singleton(childType) : Collections.emptySet())
                 || !unifierType.typeCompatibility(parentTypes, childTypes)
                 || !unifierType.typePlayabilityWithInsertSemantics(childAtom, childAtom.getVarName(), parentTypes)
                 || !unifierType.typeDirectednessCompatibility(parentAtom, childAtom)){

--- a/test/integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
+++ b/test/integration/graql/reasoner/reasoning/AttributeAttachmentIT.java
@@ -124,9 +124,9 @@ public class AttributeAttachmentIT {
 
     @Test
     //Expected result: When the head of a rule contains attribute assertions, the respective unique attributes should be generated or reused.
-    public void reusingAttributes_usingExistingAttributeToDefineSubAttribute() {
+    public void reusingAttributes_usingExistingAttributeToCreateSubAttribute() {
         try(Transaction tx = attributeAttachmentSession.transaction(Transaction.Type.WRITE)) {
-                        String queryString = "match $x isa genericEntity, has subResource $y; get;";
+            String queryString = "match $x isa genericEntity, has subResource $y; get;";
             List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
             assertEquals(tx.getEntityType("genericEntity").instances().count(), answers.size());
 
@@ -144,6 +144,30 @@ public class AttributeAttachmentIT {
             assertTrue(answers3.iterator().next().get("y").isAttribute());
         }
     }
+
+    @Test
+    //Expected result: When the head of a rule contains attribute assertions, the respective unique attributes should be generated or reused.
+    public void reusingAttributes_usingExistingAttributeToCreateUnrelatedAttribute() {
+        try(Transaction tx = attributeAttachmentSession.transaction(Transaction.Type.WRITE)) {
+            String queryString = "match $x isa genericEntity, has unrelated-reattachable-string $y; get;";
+            List<ConceptMap> answers = tx.execute(Graql.parse(queryString).asGet());
+            assertEquals(tx.getEntityType("genericEntity").instances().count(), answers.size());
+
+            String queryString2 = "match $x isa unrelated-reattachable-string; get;";
+            List<ConceptMap> answers2 = tx.execute(Graql.parse(queryString2).asGet());
+            assertEquals(1, answers2.size());
+            assertTrue(answers2.iterator().next().get("x").isAttribute());
+
+            String queryString3 = "match $x isa reattachable-resource-string; $y isa unrelated-reattachable-string;get;";
+            List<ConceptMap> answers3 = tx.execute(Graql.parse(queryString3).asGet());
+            //2 RRS instances - one base, one sub hence two answers
+            assertEquals(2, answers3.size());
+
+            assertTrue(answers3.iterator().next().get("x").isAttribute());
+            assertTrue(answers3.iterator().next().get("y").isAttribute());
+        }
+    }
+
 
     @Test
     public void whenReasoningWithAttributesInRelationForm_ResultsAreComplete() {

--- a/test/integration/graql/reasoner/stubs/resourceAttachment.gql
+++ b/test/integration/graql/reasoner/stubs/resourceAttachment.gql
@@ -31,7 +31,7 @@ derived-resource-string sub derivable-resource-string, value string;
 resource-long sub attribute, value long;
 derived-resource-boolean sub attribute, value boolean;
 subResource sub reattachable-resource-string;
-unrelated-reattachable-string sub derivable-resource-string, value string;
+unrelated-reattachable-string sub attribute, value string;
 
 #Rules
 

--- a/test/integration/graql/reasoner/stubs/resourceAttachment.gql
+++ b/test/integration/graql/reasoner/stubs/resourceAttachment.gql
@@ -7,6 +7,7 @@ genericEntity sub entity,
     plays someRole,
     plays otherRole,
     has reattachable-resource-string,
+    has unrelated-reattachable-string,
     has subResource,
     has resource-long,
     has derived-resource-boolean;
@@ -30,6 +31,7 @@ derived-resource-string sub derivable-resource-string, value string;
 resource-long sub attribute, value long;
 derived-resource-boolean sub attribute, value boolean;
 subResource sub reattachable-resource-string;
+unrelated-reattachable-string sub derivable-resource-string, value string;
 
 #Rules
 
@@ -51,13 +53,22 @@ transferResourceToRelation sub rule,
         $z has reattachable-resource-string $y;
     };
 
-attachResourceValueToResourceOfDifferentType sub rule,
+attachResourceValueToResourceOfDifferentSubtype sub rule,
 	when {
 		$x isa genericEntity, has reattachable-resource-string $r1;
 	},
 	then {
 		$x has subResource $r1;
 	};
+
+attachResourceValueToResourceOfUnrelatedType sub rule,
+	when {
+		$x isa genericEntity, has reattachable-resource-string $r1;
+	},
+	then {
+		$x has unrelated-reattachable-string $r1;
+	};
+
 
 setResourceFlagBasedOnOtherResourceValue sub rule,
     when {


### PR DESCRIPTION
## What is the goal of this PR?
Allow copying an attribute value across types, using a rule. This was enabled in the past, but at some point between 1.6.2 and 1.7.1, a refactor accidentally caused this feature to be lost. This PR re-adds it by relaxing overly-strict constraints in `AttributeSemanticProcessor`, and adds a test for this case.

## What are the changes implemented in this PR?
* Relax unifier computation between Attribute atoms, allowing unification without applying any constraints to the attribute variable themselves -- we assume the type is compatible due to commit time rule validation
* Add a test for copying attribute values across unrelated types