### PR TITLE
Include protocol datetime instead of date

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification.git",
-        commit = "0d2632a7bb0cf299ec0a7f186456196415617618",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "3df342eaa066846ec9d076f9cd6934c7c39e3bd4",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -48,7 +48,7 @@ def graknlabs_protocol():
 def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
-        remote = "https://github.com/graknlabs/client-java",
+        remote = "https://github.com/flyingsilverfin/client-java",
         commit = "4415fb2f468f6c9471e975643923f3be854a2278",
     )
 

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "1683f498bf7236283888fe0f620ea4eb0df9c7cf",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "61b04688abf4d7537bd9a783f0161cf4e4c24559",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_client_java():

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -49,7 +49,7 @@ def graknlabs_client_java():
     git_repository(
         name = "graknlabs_client_java",
         remote = "https://github.com/flyingsilverfin/client-java",
-        commit = "4415fb2f468f6c9471e975643923f3be854a2278",
+        commit = "4da5fc30ca3bed2f7b8428098ccebb672d9004bd",
     )
 
 def graknlabs_console():

--- a/server/rpc/ConceptMethod.java
+++ b/server/rpc/ConceptMethod.java
@@ -645,8 +645,8 @@ public class ConceptMethod {
                     case BOOLEAN:
                         responseSender.accept(create(AttributeSerialiser.BOOLEAN.deserialise(protoValue.getBoolean())));
                         return;
-                    case DATE:
-                        responseSender.accept(create(AttributeSerialiser.DATE.deserialise(protoValue.getDate())));
+                    case DATETIME:
+                        responseSender.accept(create(AttributeSerialiser.DATE.deserialise(protoValue.getDatetime())));
                         return;
                     case DOUBLE:
                         responseSender.accept(create(AttributeSerialiser.DOUBLE.deserialise(protoValue.getDouble())));

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -245,7 +245,7 @@ public class ResponseBuilder {
             } else if (valueType.equals(AttributeType.ValueType.DOUBLE)) {
                 return ConceptProto.AttributeType.VALUE_TYPE.DOUBLE;
             } else if (valueType.equals(AttributeType.ValueType.DATETIME)) {
-                return ConceptProto.AttributeType.VALUE_TYPE.DATE;
+                return ConceptProto.AttributeType.VALUE_TYPE.DATETIME;
             } else {
                 throw GraknServerException.unreachableStatement("Unrecognised " + valueType);
             }
@@ -265,7 +265,7 @@ public class ResponseBuilder {
                     return AttributeType.ValueType.FLOAT;
                 case DOUBLE:
                     return AttributeType.ValueType.DOUBLE;
-                case DATE:
+                case DATETIME:
                     return AttributeType.ValueType.DATETIME;
                 default:
                 case UNRECOGNIZED:
@@ -288,7 +288,7 @@ public class ResponseBuilder {
             } else if (value instanceof Double) {
                 builder.setDouble((double) value);
             } else if (value instanceof LocalDateTime) {
-                builder.setDate(((LocalDateTime) value).atZone(ZoneId.of("Z")).toInstant().toEpochMilli());
+                builder.setDatetime(((LocalDateTime) value).atZone(ZoneId.of("Z")).toInstant().toEpochMilli());
             } else {
                 throw GraknServerException.unreachableStatement("Unrecognised " + value);
             }

--- a/test/behaviour/graql/language/define/BUILD
+++ b/test/behaviour/graql/language/define/BUILD
@@ -42,7 +42,7 @@ java_test(
         "@graknlabs_verification//behaviour/graql/language:define.feature",
     ],
     classpath_resources = ["//test/resources:logback-test"],
-    size = "medium",
+    size = "large",
     visibility = ["//visibility:public"]
 )
 


### PR DESCRIPTION
## What is the goal of this PR?
We update the protocol to include new usage of `datetime` instead of `date`, which is reflected here. https://github.com/graknlabs/protocol/pull/34 .

## What are the changes implemented in this PR?
* bump dependency
* use `datetime` instead of `date` in value enums