### PR TITLE
Graceful session error on server restart

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -54,6 +54,7 @@ public enum ErrorMessage {
     BACKEND_EXCEPTION("Backend Exception."),
     INITIALIZATION_EXCEPTION("Graph for keyspace [%s] not properly initialized. Missing keyspace name resource"),
     SESSION_CLOSED("The session for graph [%s] is closed. Create a new session to interact with the graph."),
+    SESSION_NOT_FOUND("The client session with session ID [%s] was not found. Create a new session to interact with the graph."),
     LOCKING_EXCEPTION("Internal locking exception. Please clear the transaction and try again."),
     CANNOT_BE_KEY_AND_ATTRIBUTE("The Type [%s] cannot have the Attribute Type [%s] as a key and as an attribute"),
     ILLEGAL_TYPE_UNHAS_ATTRIBUTE_WITH_INSTANCE("Failed to: undefine [%s] %s [%s]. There exists instance of this pattern."),

--- a/kb/server/exception/SessionException.java
+++ b/kb/server/exception/SessionException.java
@@ -18,6 +18,7 @@
 
 package grakn.core.kb.server.exception;
 
+import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
 
 public class SessionException extends GraknException {
@@ -30,4 +31,9 @@ public class SessionException extends GraknException {
     public String getName() {
         return this.getClass().getName();
     }
+
+    public static SessionException sessionNotFound(String sessionId) {
+        return new SessionException(ErrorMessage.SESSION_NOT_FOUND.getMessage(sessionId));
+    }
+
 }

--- a/server/rpc/ResponseBuilder.java
+++ b/server/rpc/ResponseBuilder.java
@@ -34,6 +34,7 @@ import grakn.core.kb.concept.structure.PropertyNotUniqueException;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.server.exception.GraknServerException;
 import grakn.core.kb.server.exception.InvalidKBException;
+import grakn.core.kb.server.exception.SessionException;
 import grakn.core.kb.server.exception.TemporaryWriteException;
 import grakn.core.kb.server.exception.TransactionException;
 import grakn.protocol.session.AnswerProto;
@@ -411,6 +412,8 @@ public class ResponseBuilder {
             } else if (e instanceof TransactionException | e instanceof GraqlSemanticException |
                     e instanceof GraqlException | e instanceof InvalidKBException) {
                 return exception(Status.INVALID_ARGUMENT, message);
+            } else if (e instanceof SessionException) {
+                return exception(Status.UNAVAILABLE, message);
             }
         } else if (e instanceof StatusRuntimeException) {
             return (StatusRuntimeException) e;

--- a/server/rpc/SessionService.java
+++ b/server/rpc/SessionService.java
@@ -32,6 +32,7 @@ import grakn.core.kb.concept.api.RelationType;
 import grakn.core.kb.concept.api.Role;
 import grakn.core.kb.concept.api.Rule;
 import grakn.core.kb.server.Session;
+import grakn.core.kb.server.exception.SessionException;
 import grakn.core.kb.server.exception.TransactionException;
 import grakn.protocol.session.AnswerProto;
 import grakn.protocol.session.SessionProto;
@@ -129,6 +130,9 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
     public void close(SessionProto.Session.Close.Req request, StreamObserver<SessionProto.Session.Close.Res> responseObserver) {
         try {
             String sessionId = request.getSessionId();
+            if (!transactionListeners.containsKey(sessionId)) {
+                throw SessionException.sessionNotFound(sessionId);
+            }
             transactionListeners.remove(sessionId).forEach(transactionListener -> transactionListener.close(null));
             openSessions.remove(sessionId).close();
             responseObserver.onNext(SessionProto.Session.Close.Res.newBuilder().build());
@@ -324,7 +328,11 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
                 throw ResponseBuilder.exception(Status.FAILED_PRECONDITION);
             }
 
+            // TODO throw a graceful exception if the session ID does not exist anymore -- server may have restarted
             sessionId = request.getSessionId();
+            if (!transactionListeners.containsKey(sessionId)) {
+                throw SessionException.sessionNotFound(sessionId);
+            }
             transactionListeners.get(sessionId).add(this);
 
             Session session = openSessions.get(sessionId);
@@ -339,7 +347,8 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
             }
 
             Transaction.Res response = ResponseBuilder.Transaction.open();
-            responseSender.onNext(response);        }
+            responseSender.onNext(response);
+        }
 
         private void commit() {
             tx().commit();
@@ -519,7 +528,7 @@ public class SessionService extends SessionServiceGrpc.SessionServiceImplBase {
 
             public void iterateBatch(@Nullable Transaction.Iter.Req.Options options) {
                 int batchSize = getSizeFrom(options);
-                for (int i = 0; i < batchSize && iterator.hasNext(); i++){
+                for (int i = 0; i < batchSize && iterator.hasNext(); i++) {
                     responseSender.accept(iterator.next());
                 }
 


### PR DESCRIPTION
## What is the goal of this PR?
When opening a session, restarting the server, and continuing to use the session, an null pointer/unknown exception is thrown. This PR improves the error messages reported to the user in cases where the session ID is no longer found on the server.

## What are the changes implemented in this PR?
* Add specialised server-side exceptions, and better messages, when using a session ID that is no longer valid.