### PR TITLE
Fix test-deployment-rpm due to missing python3 dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,260 +503,266 @@ jobs:
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/grakn $CIRCLE_BRANCH
 
 workflows:
-  grakn-core:
+  test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - build-checkstyle:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - build-analysis:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-      - test-common:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-server:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-graql:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-connection:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-define:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-delete:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-insert:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-match:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-undefine:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour-graql-reasoner:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-concept:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-keyspace:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-reasoner:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration-analytics:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-assembly:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-            - test-behaviour-graql-reasoner
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-integration-concept
-            - test-integration-keyspace
-      - test-assembly-mac-zip:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-            - test-behaviour-graql-reasoner
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-integration-concept
-            - test-integration-keyspace
-      - test-assembly-windows-zip:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-            - test-behaviour-graql-reasoner
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-integration-concept
-            - test-integration-keyspace
-      - test-assembly-linux-targz:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-            - test-behaviour-graql-reasoner
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-integration-concept
-            - test-integration-keyspace
-      - test-assembly-docker:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour-connection
-            - test-behaviour-graql-define
-            - test-behaviour-graql-delete
-            - test-behaviour-graql-insert
-            - test-behaviour-graql-match
-            - test-behaviour-graql-undefine
-            - test-behaviour-graql-reasoner
-            - test-integration
-            - test-integration-reasoner
-            - test-integration-analytics
-            - test-integration-concept
-            - test-integration-keyspace
-      - deploy-apt-snapshot:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
-            - test-assembly
-      - deploy-rpm-snapshot:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - test-assembly-mac-zip
-            - test-assembly-windows-zip
-            - test-assembly-linux-targz
-            - test-assembly-docker
-            - test-assembly
-      - test-deployment-linux-apt:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-            - deploy-apt-snapshot
+      - deploy-rpm-snapshot
       - test-deployment-linux-rpm:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
           requires:
             - deploy-rpm-snapshot
-      - sync-dependencies-snapshot:
-          filters:
-            branches:
-              only: master
-          requires:
-            - test-deployment-linux-apt
-            - test-deployment-linux-rpm
-      - release-approval:
-          filters:
-            branches:
-              only: master
-          requires:
-            - sync-dependencies-snapshot
+  # grakn-core:
+  #   jobs:
+  #     - build:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - build-checkstyle:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - build-analysis:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #     - test-common:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-server:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-graql:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-connection:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-define:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-delete:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-insert:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-match:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-undefine:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-behaviour-graql-reasoner:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-concept:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-keyspace:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-reasoner:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-integration-analytics:
+  #         filters:
+  #           branches:
+  #             ignore: grakn-release-branch
+  #     - test-assembly:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - build
+  #           - build-checkstyle
+  #           - build-analysis
+  #           - test-common
+  #           - test-server
+  #           - test-graql
+  #           - test-behaviour-connection
+  #           - test-behaviour-graql-define
+  #           - test-behaviour-graql-delete
+  #           - test-behaviour-graql-insert
+  #           - test-behaviour-graql-match
+  #           - test-behaviour-graql-undefine
+  #           - test-behaviour-graql-reasoner
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-integration-concept
+  #           - test-integration-keyspace
+  #     - test-assembly-mac-zip:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - build
+  #           - build-checkstyle
+  #           - build-analysis
+  #           - test-common
+  #           - test-server
+  #           - test-graql
+  #           - test-behaviour-connection
+  #           - test-behaviour-graql-define
+  #           - test-behaviour-graql-delete
+  #           - test-behaviour-graql-insert
+  #           - test-behaviour-graql-match
+  #           - test-behaviour-graql-undefine
+  #           - test-behaviour-graql-reasoner
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-integration-concept
+  #           - test-integration-keyspace
+  #     - test-assembly-windows-zip:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - build
+  #           - build-checkstyle
+  #           - build-analysis
+  #           - test-common
+  #           - test-server
+  #           - test-graql
+  #           - test-behaviour-connection
+  #           - test-behaviour-graql-define
+  #           - test-behaviour-graql-delete
+  #           - test-behaviour-graql-insert
+  #           - test-behaviour-graql-match
+  #           - test-behaviour-graql-undefine
+  #           - test-behaviour-graql-reasoner
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-integration-concept
+  #           - test-integration-keyspace
+  #     - test-assembly-linux-targz:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - build
+  #           - build-checkstyle
+  #           - build-analysis
+  #           - test-common
+  #           - test-server
+  #           - test-graql
+  #           - test-behaviour-connection
+  #           - test-behaviour-graql-define
+  #           - test-behaviour-graql-delete
+  #           - test-behaviour-graql-insert
+  #           - test-behaviour-graql-match
+  #           - test-behaviour-graql-undefine
+  #           - test-behaviour-graql-reasoner
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-integration-concept
+  #           - test-integration-keyspace
+  #     - test-assembly-docker:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - build
+  #           - build-checkstyle
+  #           - build-analysis
+  #           - test-common
+  #           - test-server
+  #           - test-graql
+  #           - test-behaviour-connection
+  #           - test-behaviour-graql-define
+  #           - test-behaviour-graql-delete
+  #           - test-behaviour-graql-insert
+  #           - test-behaviour-graql-match
+  #           - test-behaviour-graql-undefine
+  #           - test-behaviour-graql-reasoner
+  #           - test-integration
+  #           - test-integration-reasoner
+  #           - test-integration-analytics
+  #           - test-integration-concept
+  #           - test-integration-keyspace
+  #     - deploy-apt-snapshot:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - test-assembly-mac-zip
+  #           - test-assembly-windows-zip
+  #           - test-assembly-linux-targz
+  #           - test-assembly-docker
+  #           - test-assembly
+  #     - deploy-rpm-snapshot:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - test-assembly-mac-zip
+  #           - test-assembly-windows-zip
+  #           - test-assembly-linux-targz
+  #           - test-assembly-docker
+  #           - test-assembly
+  #     - test-deployment-linux-apt:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - deploy-apt-snapshot
+  #     - test-deployment-linux-rpm:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master
+  #               - rewrite
+  #         requires:
+  #           - deploy-rpm-snapshot
+  #     - sync-dependencies-snapshot:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - test-deployment-linux-apt
+  #           - test-deployment-linux-rpm
+  #     - release-approval:
+  #         filters:
+  #           branches:
+  #             only: master
+  #         requires:
+  #           - sync-dependencies-snapshot
 
   grakn-core-release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,266 +503,260 @@ jobs:
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/grakn $CIRCLE_BRANCH
 
 workflows:
-  test:
+  grakn-core:
     jobs:
-      - deploy-rpm-snapshot
+      - build:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - build-checkstyle:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - build-analysis:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+      - test-common:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-server:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-graql:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-connection:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-define:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-delete:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-insert:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-match:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-undefine:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour-graql-reasoner:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-concept:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-keyspace:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-reasoner:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration-analytics:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-assembly:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour-connection
+            - test-behaviour-graql-define
+            - test-behaviour-graql-delete
+            - test-behaviour-graql-insert
+            - test-behaviour-graql-match
+            - test-behaviour-graql-undefine
+            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-integration-concept
+            - test-integration-keyspace
+      - test-assembly-mac-zip:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour-connection
+            - test-behaviour-graql-define
+            - test-behaviour-graql-delete
+            - test-behaviour-graql-insert
+            - test-behaviour-graql-match
+            - test-behaviour-graql-undefine
+            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-integration-concept
+            - test-integration-keyspace
+      - test-assembly-windows-zip:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour-connection
+            - test-behaviour-graql-define
+            - test-behaviour-graql-delete
+            - test-behaviour-graql-insert
+            - test-behaviour-graql-match
+            - test-behaviour-graql-undefine
+            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-integration-concept
+            - test-integration-keyspace
+      - test-assembly-linux-targz:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour-connection
+            - test-behaviour-graql-define
+            - test-behaviour-graql-delete
+            - test-behaviour-graql-insert
+            - test-behaviour-graql-match
+            - test-behaviour-graql-undefine
+            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-integration-concept
+            - test-integration-keyspace
+      - test-assembly-docker:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour-connection
+            - test-behaviour-graql-define
+            - test-behaviour-graql-delete
+            - test-behaviour-graql-insert
+            - test-behaviour-graql-match
+            - test-behaviour-graql-undefine
+            - test-behaviour-graql-reasoner
+            - test-integration
+            - test-integration-reasoner
+            - test-integration-analytics
+            - test-integration-concept
+            - test-integration-keyspace
+      - deploy-apt-snapshot:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-docker
+            - test-assembly
+      - deploy-rpm-snapshot:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - test-assembly-mac-zip
+            - test-assembly-windows-zip
+            - test-assembly-linux-targz
+            - test-assembly-docker
+            - test-assembly
+      - test-deployment-linux-apt:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+            - deploy-apt-snapshot
       - test-deployment-linux-rpm:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
           requires:
             - deploy-rpm-snapshot
-  # grakn-core:
-  #   jobs:
-  #     - build:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - build-checkstyle:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - build-analysis:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #     - test-common:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-server:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-graql:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-connection:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-define:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-delete:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-insert:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-match:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-undefine:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-behaviour-graql-reasoner:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-concept:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-keyspace:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-reasoner:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-integration-analytics:
-  #         filters:
-  #           branches:
-  #             ignore: grakn-release-branch
-  #     - test-assembly:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - build
-  #           - build-checkstyle
-  #           - build-analysis
-  #           - test-common
-  #           - test-server
-  #           - test-graql
-  #           - test-behaviour-connection
-  #           - test-behaviour-graql-define
-  #           - test-behaviour-graql-delete
-  #           - test-behaviour-graql-insert
-  #           - test-behaviour-graql-match
-  #           - test-behaviour-graql-undefine
-  #           - test-behaviour-graql-reasoner
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-integration-concept
-  #           - test-integration-keyspace
-  #     - test-assembly-mac-zip:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - build
-  #           - build-checkstyle
-  #           - build-analysis
-  #           - test-common
-  #           - test-server
-  #           - test-graql
-  #           - test-behaviour-connection
-  #           - test-behaviour-graql-define
-  #           - test-behaviour-graql-delete
-  #           - test-behaviour-graql-insert
-  #           - test-behaviour-graql-match
-  #           - test-behaviour-graql-undefine
-  #           - test-behaviour-graql-reasoner
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-integration-concept
-  #           - test-integration-keyspace
-  #     - test-assembly-windows-zip:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - build
-  #           - build-checkstyle
-  #           - build-analysis
-  #           - test-common
-  #           - test-server
-  #           - test-graql
-  #           - test-behaviour-connection
-  #           - test-behaviour-graql-define
-  #           - test-behaviour-graql-delete
-  #           - test-behaviour-graql-insert
-  #           - test-behaviour-graql-match
-  #           - test-behaviour-graql-undefine
-  #           - test-behaviour-graql-reasoner
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-integration-concept
-  #           - test-integration-keyspace
-  #     - test-assembly-linux-targz:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - build
-  #           - build-checkstyle
-  #           - build-analysis
-  #           - test-common
-  #           - test-server
-  #           - test-graql
-  #           - test-behaviour-connection
-  #           - test-behaviour-graql-define
-  #           - test-behaviour-graql-delete
-  #           - test-behaviour-graql-insert
-  #           - test-behaviour-graql-match
-  #           - test-behaviour-graql-undefine
-  #           - test-behaviour-graql-reasoner
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-integration-concept
-  #           - test-integration-keyspace
-  #     - test-assembly-docker:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - build
-  #           - build-checkstyle
-  #           - build-analysis
-  #           - test-common
-  #           - test-server
-  #           - test-graql
-  #           - test-behaviour-connection
-  #           - test-behaviour-graql-define
-  #           - test-behaviour-graql-delete
-  #           - test-behaviour-graql-insert
-  #           - test-behaviour-graql-match
-  #           - test-behaviour-graql-undefine
-  #           - test-behaviour-graql-reasoner
-  #           - test-integration
-  #           - test-integration-reasoner
-  #           - test-integration-analytics
-  #           - test-integration-concept
-  #           - test-integration-keyspace
-  #     - deploy-apt-snapshot:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - test-assembly-mac-zip
-  #           - test-assembly-windows-zip
-  #           - test-assembly-linux-targz
-  #           - test-assembly-docker
-  #           - test-assembly
-  #     - deploy-rpm-snapshot:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - test-assembly-mac-zip
-  #           - test-assembly-windows-zip
-  #           - test-assembly-linux-targz
-  #           - test-assembly-docker
-  #           - test-assembly
-  #     - test-deployment-linux-apt:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - deploy-apt-snapshot
-  #     - test-deployment-linux-rpm:
-  #         filters:
-  #           branches:
-  #             only:
-  #               - master
-  #               - rewrite
-  #         requires:
-  #           - deploy-rpm-snapshot
-  #     - sync-dependencies-snapshot:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - test-deployment-linux-apt
-  #           - test-deployment-linux-rpm
-  #     - release-approval:
-  #         filters:
-  #           branches:
-  #             only: master
-  #         requires:
-  #           - sync-dependencies-snapshot
+      - sync-dependencies-snapshot:
+          filters:
+            branches:
+              only: master
+          requires:
+            - test-deployment-linux-apt
+            - test-deployment-linux-rpm
+      - release-approval:
+          filters:
+            branches:
+              only: master
+          requires:
+            - sync-dependencies-snapshot
 
   grakn-core-release:
     jobs:

--- a/test/deployment/rpm/test.py
+++ b/test/deployment/rpm/test.py
@@ -97,7 +97,7 @@ try:
     lprint('Installing dependencies')
     gcloud_ssh(instance, 'sudo yum install -y http://opensource.wandisco.com/centos/7/git/x86_64/wandisco-git-release-7-2.noarch.rpm')
     gcloud_ssh(instance, 'sudo yum update -y')
-    gcloud_ssh(instance, 'sudo yum install -y sudo procps which gcc gcc-c++ python-devel unzip git java-1.8.0-openjdk-devel rpm-build yum-utils')
+    gcloud_ssh(instance, 'sudo yum install -y sudo procps which gcc gcc-c++ python-devel python3 unzip git java-1.8.0-openjdk-devel rpm-build yum-utils')
     gcloud_ssh(instance, 'curl -OL https://raw.githubusercontent.com/graknlabs/build-tools/master/ci/install-bazel-linux.sh')
     gcloud_ssh(instance, 'sudo bash ./install-bazel-linux.sh')
 


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed test-deployment-rpm caused by missing python3 dependencies.