### PR TITLE
Remote building with BuildBarn

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,15 +1,13 @@
 # what is defined in this section will be applied at all times
-build --workspace_status_command bin/workspace_status.sh --show_result=0 --show_progress=no --incompatible_strict_action_env
+build --workspace_status_command bin/workspace_status.sh --incompatible_strict_action_env
 test --show_result=0 --show_progress=no --incompatible_strict_action_env
 run --show_result=0 --show_progress=no --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
-build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
-build:rbe --remote_cache=remotebuildexecution.googleapis.com
-build:rbe --remote_executor=remotebuildexecution.googleapis.com
-build:rbe --bes_backend="buildeventservice.googleapis.com"
-build:rbe --bes_results_url="https://source.cloud.google.com/results/invocations/"
+build:rbe --remote_instance_name=remote-execution
+build:rbe --remote_executor=grpc://bazel.grakn.ai
+build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
+build:rbe --bes_backend=grpcs://events.buildbuddy.io:1986
 build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
 build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
 build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
@@ -22,12 +20,4 @@ build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/ba
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
 build:rbe --bes_timeout=60s
-build:rbe --tls_enabled=true
-build:rbe --auth_enabled=true
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build:rbe --experimental_strict_action_env=true

--- a/test/behaviour/connection/keyspace/BUILD
+++ b/test/behaviour/connection/keyspace/BUILD
@@ -60,6 +60,10 @@ java_test(
     ],
     classpath_resources = ["//test/resources:logback-test"],
     size = "large",
+    # TODO: due to DriverTimeoutException this test is not executed remotely
+    # (though still cached). Remove this tag once test is split into
+    # small chunks and takes less time to execute
+    tags = ["no-remote-exec"]
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

As Google is going to shut down hosted solution for remote builds (RBE), we're migrating to our own self-hosted solution, BuildBarn. This PR updates URLs to point at it instead of RBE.


## What are the changes implemented in this PR?

Update `.bazelrc` to new URLs