### PR TITLE
Ensure that two double attributes inserted with the same long value create a single concept

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,9 @@ commands:
       command:
           type: string
     steps:
-      - run: bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- << parameters.command >>
+      - run:
+          command: bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- << parameters.command >>
+          no_output_timeout: 30m
 
 jobs:
   build:
@@ -136,8 +138,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/define:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-delete:
     machine:
@@ -148,8 +148,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/delete:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-get:
     machine: true
@@ -159,8 +157,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/get:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-insert:
     machine:
@@ -171,8 +167,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/insert:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-match:
     machine:
@@ -183,8 +177,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/match:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-undefine:
     machine:
@@ -195,8 +187,6 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/undefine:test --test_output=errors
-      - run:
-          no_output_timeout: 30m
 
   test-behaviour-graql-explanation:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/define:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-delete:
@@ -147,6 +148,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/delete:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-get:
@@ -157,6 +159,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/get:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-insert:
@@ -168,6 +171,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/insert:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-match:
@@ -179,6 +183,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/match:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-undefine:
@@ -190,6 +195,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/undefine:test --test_output=errors
+      - run:
           no_output_timeout: 30m
 
   test-behaviour-graql-explanation:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/define:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-delete:
     machine:
@@ -146,6 +147,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/delete:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-get:
     machine: true
@@ -155,6 +157,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/get:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-insert:
     machine:
@@ -165,6 +168,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/insert:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-match:
     machine:
@@ -175,6 +179,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/match:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-undefine:
     machine:
@@ -185,6 +190,7 @@ jobs:
       - checkout
       - run-bazel:
           command: bazel test //test/behaviour/graql/language/undefine:test --test_output=errors
+          no_output_timeout: 30m
 
   test-behaviour-graql-explanation:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ commands:
     steps:
       - run:
           command: bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- << parameters.command >>
-          no_output_timeout: 30m
+          no_output_timeout: 60m
 
 jobs:
   build:

--- a/concept/impl/AttributeTypeImpl.java
+++ b/concept/impl/AttributeTypeImpl.java
@@ -18,6 +18,7 @@
 
 package grakn.core.concept.impl;
 
+import grakn.core.core.AttributeValueConverter;
 import grakn.core.core.Schema;
 import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.AttributeType;
@@ -167,7 +168,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
     @Override
     @Nullable
     public Attribute<D> attribute(D value) {
-        String index = Schema.generateAttributeIndex(label(), value.toString());
+        String index = Schema.generateAttributeIndex(label(), AttributeValueConverter.tryConvert(this, value).toString());
         Attribute<D> concept = conceptManager.getCachedAttribute(index);
         if (concept != null) return concept;
         return conceptManager.getConcept(Schema.VertexProperty.INDEX, index);
@@ -177,7 +178,7 @@ public class AttributeTypeImpl<D> extends TypeImpl<AttributeType<D>, Attribute<D
      * This is only used when checking if attribute exists before trying to create a new one.
      */
     private Attribute<D> getAttribute(D value) {
-        String index = Schema.generateAttributeIndex(label(), value.toString());
+        String index = Schema.generateAttributeIndex(label(), AttributeValueConverter.tryConvert(this, value).toString());
         return conceptManager.getAttribute(index);
     }
 

--- a/concept/manager/ConceptManagerImpl.java
+++ b/concept/manager/ConceptManagerImpl.java
@@ -235,12 +235,7 @@ public class ConceptManagerImpl implements ConceptManager {
 
         AttributeType.ValueType<V> valueType = type.valueType();
 
-        V convertedValue;
-        try {
-            convertedValue = AttributeValueConverter.of(type.valueType()).convert(value);
-        } catch (ClassCastException e){
-            throw GraknConceptException.invalidAttributeValue(type, value, valueType);
-        }
+        V convertedValue = AttributeValueConverter.tryConvert(type, value);
 
         // set persisted value
         Object valueToPersist = AttributeSerialiser.of(valueType).serialise(convertedValue);
@@ -248,13 +243,13 @@ public class ConceptManagerImpl implements ConceptManager {
         vertex.propertyImmutable(property, valueToPersist, null);
 
         // set unique index - combination of type and value to an indexed Janus property, used for lookups
-        String index = Schema.generateAttributeIndex(type.label(), convertedValue.toString());
-        vertex.property(Schema.VertexProperty.INDEX, index);
+        String uniqueIndex = Schema.generateAttributeIndex(type.label(), convertedValue.toString());
+        vertex.property(Schema.VertexProperty.INDEX, uniqueIndex);
 
         AttributeImpl<V> newAttribute = new AttributeImpl<>(vertex, this, conceptNotificationChannel);
         newAttribute.type(TypeImpl.from(type));
 
-        conceptNotificationChannel.attributeCreated(newAttribute, value, isInferred);
+        conceptNotificationChannel.attributeCreated(newAttribute, uniqueIndex, isInferred);
         return newAttribute;
     }
 

--- a/concept/manager/ConceptNotificationChannelImpl.java
+++ b/concept/manager/ConceptNotificationChannelImpl.java
@@ -97,8 +97,8 @@ public class ConceptNotificationChannelImpl implements ConceptNotificationChanne
     }
 
     @Override
-    public <D> void attributeCreated(Attribute<D> attribute, D value, boolean isInferred) {
-        conceptListener.attributeCreated(attribute, value, isInferred);
+    public <D> void attributeCreated(Attribute<D> attribute, String uniqueIndex, boolean isInferred) {
+        conceptListener.attributeCreated(attribute, uniqueIndex, isInferred);
     }
 
     @Override

--- a/core/Schema.java
+++ b/core/Schema.java
@@ -263,7 +263,7 @@ public final class Schema {
 
     /**
      * @param label The AttributeType label
-     * @param value The value of the Attribute
+     * @param value The computed value of the Attribute
      * @return A unique id for the Attribute
      */
     @CheckReturnValue

--- a/graql/planning/gremlin/sets/AttributeIndexFragmentSet.java
+++ b/graql/planning/gremlin/sets/AttributeIndexFragmentSet.java
@@ -19,6 +19,7 @@ package grakn.core.graql.planning.gremlin.sets;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import grakn.core.core.AttributeValueConverter;
 import grakn.core.graql.planning.gremlin.fragment.Fragments;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.Label;
@@ -109,17 +110,9 @@ public class AttributeIndexFragmentSet extends EquivalentFragmentSetImpl {
             throw new IllegalStateException("This optimisation should contain equalValues in equalValueFragments method");
         }
 
-        Object value = valueSet.operation().value();
-
-        AttributeType.ValueType<?> valueType = conceptManager.getAttributeType(label.getValue()).valueType();
-        if (Number.class.isAssignableFrom(valueType.valueClass())) {
-            if (valueType.valueClass() == Long.class && value instanceof Double && ((Double) value % 1 == 0)) {
-                value = ((Double) value).longValue();
-            } else if (valueType.valueClass() == Double.class && value instanceof Long) {
-                value = ((Long) value).doubleValue();
-            }
-        }
-        AttributeIndexFragmentSet indexFragmentSet = new AttributeIndexFragmentSet(attribute, label, value);
+        AttributeType<?> type = conceptManager.getAttributeType(label.getValue());
+        final Object convertedValue = AttributeValueConverter.tryConvert(type, valueSet.operation().value());
+        AttributeIndexFragmentSet indexFragmentSet = new AttributeIndexFragmentSet(attribute, label, convertedValue);
         fragmentSets.add(indexFragmentSet);
     }
 

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -41,6 +41,7 @@ import grakn.core.graql.reasoner.atom.task.validate.AttributeAtomValidator;
 import grakn.core.graql.reasoner.cache.SemanticDifference;
 import grakn.core.graql.reasoner.unifier.MultiUnifierImpl;
 import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.AttributeType;
 import grakn.core.kb.concept.api.Label;
 import grakn.core.kb.concept.api.Role;
@@ -145,12 +146,7 @@ public class AttributeAtom extends Atom{
         Set<ValuePredicate> newMultiPredicate = this.getMultiPredicate().stream().map(vp -> {
             Object value = vp.getPredicate().value();
             if (value == null) return vp;
-            Object convertedValue;
-            try {
-                convertedValue = AttributeValueConverter.of(valueType).convert(value);
-            } catch (ClassCastException e){
-                throw GraqlSemanticException.incompatibleAttributeValue(valueType, value);
-            }
+            Object convertedValue = AttributeValueConverter.tryConvert(attributeType, value);
             ValueProperty.Operation operation = ValueProperty.Operation.Comparison.of(vp.getPredicate().comparator(), convertedValue);
             return ValuePredicate.create(vp.getVarName(), operation, getParentQuery());
         }).collect(Collectors.toSet());

--- a/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
+++ b/graql/reasoner/atom/task/materialise/AttributeMaterialiser.java
@@ -53,7 +53,7 @@ public class AttributeMaterialiser implements AtomMaterialiser<AttributeAtom> {
         if (atom.isValueEquality()) {
             ValuePredicate vp = Iterables.getOnlyElement(atom.getMultiPredicate());
             Object value = vp.getPredicate().value();
-            Object persistedValue = AttributeValueConverter.of(attributeType.valueType()).convert(value);
+            Object persistedValue = AttributeValueConverter.tryConvert(attributeType, value);
             Attribute existingAttribute = attributeType.attribute(persistedValue);
             attribute = existingAttribute == null ? attributeType.putAttributeInferred(persistedValue) : existingAttribute;
         } else {

--- a/kb/concept/api/GraknConceptException.java
+++ b/kb/concept/api/GraknConceptException.java
@@ -111,7 +111,8 @@ public class GraknConceptException extends GraknException {
     /**
      * Thrown when creating an Attribute whose value Object does not match attribute value type
      */
-    public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object, AttributeType.ValueType valueType) {
+    public static GraknConceptException invalidAttributeValue(AttributeType attributeType, Object object) {
+        AttributeType.ValueType valueType = attributeType.valueType();
         return create(ErrorMessage.INVALID_VALUETYPE.getMessage(object, object.getClass().getSimpleName(), valueType.name(), attributeType.label()));
     }
 

--- a/kb/concept/manager/ConceptListener.java
+++ b/kb/concept/manager/ConceptListener.java
@@ -47,7 +47,7 @@ public interface ConceptListener {
 
     void schemaConceptDeleted(SchemaConcept schemaConcept);
 
-    <D> void attributeCreated(Attribute<D> attribute, D value, boolean isInferred);
+    <D> void attributeCreated(Attribute<D> attribute, String uniqueIndex, boolean isInferred);
 
     void relationCreated(Relation relation, boolean isInferred);
 

--- a/kb/concept/manager/ConceptNotificationChannel.java
+++ b/kb/concept/manager/ConceptNotificationChannel.java
@@ -57,7 +57,7 @@ public interface ConceptNotificationChannel {
     void roleUndefined(Role role);
     void relationRoleUnrelated(RelationType relationType, Role role, List<Casting> conceptsPlayingRole);
 
-    <D> void attributeCreated(Attribute<D> attribute, D value, boolean isInferred);
+    <D> void attributeCreated(Attribute<D> attribute, String uniqueIndex, boolean isInferred);
     void relationCreated(Relation relation, boolean isInferred);
     void entityCreated(Entity entity, boolean isInferred);
     void hasAttributeCreated(Thing owner, Attribute attribute, boolean isInferred);

--- a/kb/graql/exception/GraqlSemanticException.java
+++ b/kb/graql/exception/GraqlSemanticException.java
@@ -223,10 +223,6 @@ public class GraqlSemanticException extends GraknException {
         return new GraqlSemanticException(ErrorMessage.K_SMALLER_THAN_TWO.getMessage());
     }
 
-    public static GraqlSemanticException incompatibleAttributeValue(AttributeType.ValueType valueType, Object value) {
-        return new GraqlSemanticException("Value " + value + " is not compatible with attribute value type: " + valueType.name());
-    }
-
     public static GraqlSemanticException attributeMustBeANumber(AttributeType.ValueType valueType, Label attributeType) {
         return new GraqlSemanticException(attributeType + " must have value type of `long` or `double`, but was " + valueType.name());
     }

--- a/kb/server/cache/TransactionCache.java
+++ b/kb/server/cache/TransactionCache.java
@@ -155,7 +155,7 @@ public class TransactionCache {
             Attribute<?> attr = concept.asAttribute();
             // this is probably slower than reading index from vertex but we don't have access to AttributeImpl here (cyclic dep)
             Label attrLabel = attr.type().label();
-            String attrIndex = Schema.generateAttributeIndex(attrLabel, AttributeValueConverter.tryConvert(attr.type(), attr.value()).toString());
+            String attrIndex = Schema.generateAttributeIndex(attrLabel, attr.value().toString());
             newAttributes.remove(new Pair<>(attrLabel, attrIndex));
             attributeCache.remove(attrIndex);
             removedAttributes.add(attrIndex);

--- a/kb/server/cache/TransactionCache.java
+++ b/kb/server/cache/TransactionCache.java
@@ -20,6 +20,7 @@ package grakn.core.kb.server.cache;
 
 import com.google.common.annotations.VisibleForTesting;
 import grakn.common.util.Pair;
+import grakn.core.core.AttributeValueConverter;
 import grakn.core.core.Schema;
 import grakn.core.kb.concept.api.Attribute;
 import grakn.core.kb.concept.api.Concept;
@@ -154,7 +155,7 @@ public class TransactionCache {
             Attribute<?> attr = concept.asAttribute();
             // this is probably slower than reading index from vertex but we don't have access to AttributeImpl here (cyclic dep)
             Label attrLabel = attr.type().label();
-            String attrIndex = Schema.generateAttributeIndex(attrLabel, attr.value().toString());
+            String attrIndex = Schema.generateAttributeIndex(attrLabel, AttributeValueConverter.tryConvert(attr.type(), attr.value()).toString());
             newAttributes.remove(new Pair<>(attrLabel, attrIndex));
             attributeCache.remove(attrIndex);
             removedAttributes.add(attrIndex);
@@ -195,7 +196,7 @@ public class TransactionCache {
         }
         if (concept.isAttribute()){
             Attribute<Object> attribute = concept.asAttribute();
-            String index = Schema.generateAttributeIndex(attribute.type().label(), attribute.value().toString());
+            String index = Schema.generateAttributeIndex(attribute.type().label(), AttributeValueConverter.tryConvert(attribute.type(), attribute.value()).toString());
             attributeCache.put(index, attribute);
         }
     }

--- a/test/integration/concept/AttributeIT.java
+++ b/test/integration/concept/AttributeIT.java
@@ -166,7 +166,7 @@ public class AttributeIT {
         String invalidThing = "Invalid Thing";
         AttributeType longAttributeType = tx.putAttributeType("long", AttributeType.ValueType.LONG);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(longAttributeType, invalidThing, AttributeType.ValueType.LONG).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(longAttributeType, invalidThing).getMessage());
         longAttributeType.create(invalidThing);
     }
 
@@ -177,7 +177,7 @@ public class AttributeIT {
         String invalidThing = "Invalid Thing";
         AttributeType dateAttributeType = tx.putAttributeType("date", AttributeType.ValueType.DATETIME);
         expectedException.expect(GraknConceptException.class);
-        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing, AttributeType.ValueType.DATETIME).getMessage());
+        expectedException.expectMessage(GraknConceptException.invalidAttributeValue(dateAttributeType, invalidThing).getMessage());
         dateAttributeType.create(invalidThing);
     }
 

--- a/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -170,7 +170,7 @@ public class AtomicEquivalenceIT {
     @Test
     public void testEquivalence_AttributesWithEquivalentValues() {
         AttributeType<?> metaAttributeType = tx.getMetaAttributeType();
-        Set<AttributeType> attributeTypes = metaAttributeType.subs().collect(toSet());
+        Set<AttributeType<?>> attributeTypes = metaAttributeType.subs().collect(toSet());
 
         ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();
 
@@ -184,8 +184,7 @@ public class AtomicEquivalenceIT {
 
                         Pattern basePattern = Graql.parsePattern("$x has " + attributeType.label().getValue() + " " + value + ";");
                         valueType.comparableValueTypes().forEach(comparableValueType -> {
-                            AttributeValueConverter<Object, ?> converter = AttributeValueConverter.of(comparableValueType);
-                            Pattern convertedPattern = Graql.parsePattern("$x has " + attributeType.label().getValue() + " " + converter.convert(value) + ";");
+                            Pattern convertedPattern = Graql.parsePattern("$x has " + attributeType.label().getValue() + " " + AttributeValueConverter.tryConvert(attributeType, value) + ";");
                             atomicEquivalence(basePattern.toString(), convertedPattern.toString(), true, AtomicEquivalence.AlphaEquivalence, reasonerQueryFactory);
                             atomicEquivalence(basePattern.toString(), convertedPattern.toString(), true, AtomicEquivalence.StructuralEquivalence, reasonerQueryFactory);
                         });

--- a/test/integration/graql/reasoner/query/AtomicQueryIT.java
+++ b/test/integration/graql/reasoner/query/AtomicQueryIT.java
@@ -22,6 +22,7 @@ import grakn.core.common.config.Config;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.graql.reasoner.atom.Atom;
 import grakn.core.graql.reasoner.unifier.UnifierType;
+import grakn.core.kb.concept.api.GraknConceptException;
 import grakn.core.kb.graql.exception.GraqlSemanticException;
 import grakn.core.kb.graql.reasoner.unifier.MultiUnifier;
 import grakn.core.kb.server.Session;
@@ -80,7 +81,7 @@ public class AtomicQueryIT {
         }
     }
 
-    @Test(expected = GraqlSemanticException.class)
+    @Test(expected = GraknConceptException.class)
     public void whenCreatingAttributeQueryWithInvalidValueType_ExceptionIsThrown() {
         try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
             ReasonerQueryFactory reasonerQueryFactory = ((TestTransactionProvider.TestTransaction)tx).reasonerQueryFactory();

--- a/test/integration/graql/reasoner/query/BUILD
+++ b/test/integration/graql/reasoner/query/BUILD
@@ -48,6 +48,7 @@ java_test(
         "//dependencies/maven/artifacts/com/google/guava",
         "//dependencies/maven/artifacts/org/hamcrest:hamcrest-library",
         "//graql/reasoner",
+        "//kb/concept/api",
         "//kb/graql/exception",
         "//kb/graql/reasoner",
         "//kb/server",


### PR DESCRIPTION
## What is the goal of this PR?

Previously, given: `define length sub attribute, value double`, when you did:

```
insert
$x 2 isa length;
$y 2 isa length;
```

**two** concepts were created instead of one. Now, only a single concept is created.

## What are the changes implemented in this PR?

The value of a `double` attribute needs to be normalised in order to accurately check for equality. This was handled effectively by the `AttributeValueConverter`, which provides a mechanism for taking in an attribute value and its type, and returning the value in a normalised form that ensures, for example, that `2`, `2.0` and `2.000` are all converted to the same output value because they represent the same value.

However, the `AttributeValueConverter` was only used in a small fraction of all the instances where we need to generate the "unique index" used by JanusGraph for deduplication. The method used to generate this index is at a very high level, in `Schema.java`, and cannot be easily replaced. Therefore, this PR aims to address the issue by ensuring that we pass in the correct `value` parameter to `Schema.java` every time, by consistently using `AttributeValueConverter.tryConvert` to convert the attribute value to normal form before it is used.

Also, it has a try-catch block in it which ensures we consistently throw the same error if the conversion could not be performed (e.g: attempting to parse "banana" as a `long`).