### PR TITLE
Allow tests to print stack traces

### DIFF
--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -17,12 +17,17 @@
 
 package grakn.core.common.exception;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Root Grakn Exception
  * Encapsulates any exception which is thrown by the Grakn stack.
  * This includes failures server side, failed graph mutations, and failed querying attempts
  */
 public abstract class GraknException extends RuntimeException {
+    private static final Logger LOG = LoggerFactory.getLogger(GraknException.class);
+    private static boolean logStackTraces = LOG.isDebugEnabled() || LOG.isTraceEnabled();
 
     protected GraknException(String error) {
         super(error);
@@ -32,8 +37,8 @@ public abstract class GraknException extends RuntimeException {
         super(error, e);
     }
 
-    protected GraknException(String error, Exception e, boolean enableSuppression, boolean writableStackTrace) {
-        super(error, e, enableSuppression, writableStackTrace);
+    protected GraknException(String error, Exception e, boolean enableSuppression) {
+        super(error, e, enableSuppression, logStackTraces);
     }
 
     public abstract String getName();

--- a/kb/graql/exception/GraqlSemanticException.java
+++ b/kb/graql/exception/GraqlSemanticException.java
@@ -54,11 +54,11 @@ public class GraqlSemanticException extends GraknException {
     private final String NAME = "GraqlSemanticException";
 
     private GraqlSemanticException(String error) {
-        super(error, null, false, false);
+        super(error, null, false);
     }
 
     private GraqlSemanticException(String error, Exception cause) {
-        super(error, cause, false, false);
+        super(error, cause, false);
     }
 
     @Override

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -44,13 +44,5 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-<!--    <logger name="org.eclipse.jetty" level="ERROR">-->
-<!--        <appender-ref ref="MAIN"/>-->
-<!--    </logger>-->
-
-<!--    &lt;!&ndash;Only show ERROR logs from apache classes&ndash;&gt;-->
-<!--    <logger name="org.apache" level="ERROR">-->
-<!--        <appender-ref ref="MAIN"/>-->
-<!--    </logger>-->
 
 </configuration>

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -26,17 +26,31 @@
         <appender-ref ref="STDOUT"/>
     </root>
 
-    <logger name="grakn.core" level="INFO" additivity="false">
+    <logger name="grakn.core" level="DEBUG" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
 
-    <logger name="server.Server" level="WARN">
+    <!-- Use this to suppress excess JanusGraph logging -->
+    <logger name="grakn.core.graph" level="INFO" additivity="false">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="server.Server" level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </logger>
 
     <!-- Increase this if wanting to see more verbose reasoner output -->
-    <logger name="grakn.core.graql.reasoner" level="INFO" additivity="false">
+    <logger name="grakn.core.graql.reasoner" level="DEBUG" additivity="false">
         <appender-ref ref="STDOUT"/>
     </logger>
+
+<!--    <logger name="org.eclipse.jetty" level="ERROR">-->
+<!--        <appender-ref ref="MAIN"/>-->
+<!--    </logger>-->
+
+<!--    &lt;!&ndash;Only show ERROR logs from apache classes&ndash;&gt;-->
+<!--    <logger name="org.apache" level="ERROR">-->
+<!--        <appender-ref ref="MAIN"/>-->
+<!--    </logger>-->
 
 </configuration>


### PR DESCRIPTION
## What is the goal of this PR?
Allow tests to print stack traces -- this should automatically apply to all `GraknExceptions` and its subtypes.

## What are the changes implemented in this PR?
Re-enable stack traces during DEBUG level logging, and update test logback to use DEBUG by default. 