### PR TITLE
Reduce code duplication between graql query steps in BDD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,8 @@ jobs:
           command: bazel test //test/behaviour/graql/language/delete:test --test_output=errors
 
   test-behaviour-graql-get:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     working_directory: ~/grakn
     steps:
       - install-bazel-linux

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -33,11 +33,9 @@ import grakn.core.kb.server.Transaction;
 import grakn.core.test.behaviour.connection.ConnectionSteps;
 import graql.lang.Graql;
 import graql.lang.pattern.Pattern;
-import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlGet;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlQuery;
-import graql.lang.query.GraqlUndefine;
 import graql.lang.statement.Variable;
 import io.cucumber.java.After;
 import io.cucumber.java.en.Given;
@@ -52,6 +50,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -88,126 +87,67 @@ public class GraqlSteps {
 
     @Given("the integrity is validated")
     public void integrity_is_validated(){
-
         // TODO
-
     }
 
     @Given("graql define")
-    public void graql_define(String defineQueryStatements) {
-        GraqlDefine graqlQuery = Graql.parse(String.join("\n", defineQueryStatements)).asDefine();
-        tx.execute(graqlQuery);
-        tx.commit();
-        tx = session.transaction(Transaction.Type.WRITE);
+    public void graql_define(String queryStatements) {
+        executeGraqlQuery(queryStatements, GraqlQuery::asDefine);
     }
 
     @Given("graql define without commit")
-    public void graql_define_without_commit(String defineQueryStatements) {
-        GraqlDefine graqlQuery = Graql.parse(String.join("\n", defineQueryStatements)).asDefine();
-        tx.execute(graqlQuery);
+    public void graql_define_without_commit(String queryStatements) {
+        executeGraqlQueryWithoutCommit(queryStatements, GraqlQuery::asDefine);
     }
 
     @Given("graql define throws")
-    public void graql_define_throws(String defineQueryStatements) {
-        boolean threw = false;
-        try {
-            GraqlDefine graqlQuery = Graql.parse(String.join("\n", defineQueryStatements)).asDefine();
-            tx.execute(graqlQuery);
-            tx.commit();
-        } catch (RuntimeException e) {
-            threw = true;
-        } finally {
-            tx.close();
-            tx = session.transaction(Transaction.Type.WRITE);
-        }
-
-        assertTrue(threw);
-    }
-
-    @Given("graql undefine")
-    public void graql_undefine(String undefineQueryStatements) {
-        GraqlUndefine graqlQuery = Graql.parse(String.join("\n", undefineQueryStatements)).asUndefine();
-        tx.execute(graqlQuery);
-        tx.commit();
-        tx = session.transaction(Transaction.Type.WRITE);
-    }
-
-    @Given("graql undefine without commit")
-    public void graql_undefine_without_commit(String undefineQueryStatements) {
-        GraqlUndefine graqlQuery = Graql.parse(String.join("\n", undefineQueryStatements)).asUndefine();
-        tx.execute(graqlQuery);
-    }
-
-    @Given("graql undefine throws")
-    public void graql_undefine_throws(String undefineQueryStatements) {
-        boolean threw = false;
-        try {
-            GraqlUndefine graqlQuery = Graql.parse(String.join("\n", undefineQueryStatements)).asUndefine();
-            tx.execute(graqlQuery);
-            tx.commit();
-        } catch (RuntimeException e) {
-            threw = true;
-        } finally {
-            tx.close();
-            tx = session.transaction(Transaction.Type.WRITE);
-        }
-
-        assertTrue(threw);
+    public void graql_define_throws(String queryStatements) {
+        assertGraqlQueryThrows(queryStatements, GraqlQuery::asDefine);
     }
 
     @Given("graql insert")
-    public void graql_insert(String insertQueryStatements) {
-        GraqlQuery graqlQuery = Graql.parse(String.join("\n", insertQueryStatements));
-        tx.execute(graqlQuery, true, true); // always use inference and have explanations
-        tx.commit();
-        tx = session.transaction(Transaction.Type.WRITE);
+    public void graql_insert(String queryStatements) {
+        executeGraqlQuery(queryStatements, GraqlQuery::asInsert);
     }
 
     @Given("graql insert without commit")
-    public void graql_insert_without_commit(String insertQueryStatements) {
-        GraqlQuery graqlQuery = Graql.parse(String.join("\n", insertQueryStatements));
-        tx.execute(graqlQuery);
+    public void graql_insert_without_commit(String queryStatements) {
+        executeGraqlQueryWithoutCommit(queryStatements, GraqlQuery::asInsert);
     }
 
     @Given("graql insert throws")
-    public void graql_insert_throws(String insertQueryStatements) {
-        boolean threw = false;
-        try {
-            GraqlQuery graqlQuery = Graql.parse(String.join("\n", insertQueryStatements));
-            tx.execute(graqlQuery);
-            tx.commit();
-        } catch (RuntimeException e) {
-            threw = true;
-        } finally {
-            tx.close();
-            tx = session.transaction(Transaction.Type.WRITE);
-        }
-        assertTrue(threw);
+    public void graql_insert_throws(String queryStatements) {
+        assertGraqlQueryThrows(queryStatements, GraqlQuery::asInsert);
+    }
+
+    @Given("graql undefine")
+    public void graql_undefine(String queryStatements) {
+        executeGraqlQuery(queryStatements, GraqlQuery::asUndefine);
+    }
+
+    @Given("graql undefine without commit")
+    public void graql_undefine_without_commit(String queryStatements) {
+        executeGraqlQueryWithoutCommit(queryStatements, GraqlQuery::asUndefine);
+    }
+
+    @Given("graql undefine throws")
+    public void graql_undefine_throws(String queryStatements) {
+        assertGraqlQueryThrows(queryStatements, GraqlQuery::asUndefine);
     }
 
     @Given("graql delete")
-    public void graql_delete(String deleteQueryStatements) {
-        GraqlQuery graqlQuery = Graql.parse(String.join("\n", deleteQueryStatements));
-        tx.execute(graqlQuery);
-        tx.commit();
-        tx = session.transaction(Transaction.Type.WRITE);
+    public void graql_delete(String queryStatements) {
+        executeGraqlQuery(queryStatements, GraqlQuery::asDelete);
     }
 
+    @Given("graql delete without commit")
+    public void graql_delete_without_commit(String queryStatements) {
+        executeGraqlQueryWithoutCommit(queryStatements, GraqlQuery::asDelete);
+    }
 
     @Given("graql delete throws")
-    public void graql_delete_throws(String deleteQueryStatements) {
-        boolean threw = false;
-        try {
-            GraqlQuery graqlQuery = Graql.parse(String.join("\n", deleteQueryStatements));
-            tx.execute(graqlQuery);
-            tx.commit();
-        } catch (RuntimeException e) {
-            threw = true;
-        } finally {
-            tx.close();
-            tx = session.transaction(Transaction.Type.WRITE);
-        }
-        assertTrue(threw);
+    public void graql_delete_throws(String queryStatements) {
+        assertGraqlQueryThrows(queryStatements, GraqlQuery::asDelete);
     }
 
     @When("get answers of graql insert")
@@ -249,26 +189,11 @@ public class GraqlSteps {
 
     @When("graql get throws")
     public void graql_get_throws(String graqlQueryStatements) {
-        boolean threw = true;
+        boolean threw = false;
         try {
-            GraqlQuery graqlQuery = Graql.parse(String.join("\n", graqlQueryStatements));
-            if (graqlQuery instanceof GraqlGet) {
-                tx.execute(graqlQuery.asGet());
-            } else if (graqlQuery instanceof GraqlGet.Aggregate) {
-                tx.execute(graqlQuery.asGetAggregate());
-            } else if (graqlQuery instanceof GraqlGet.Group) {
-                tx.execute(graqlQuery.asGetGroup());
-            } else if (graqlQuery instanceof GraqlGet.Group.Aggregate) {
-                tx.execute(graqlQuery.asGetGroupAggregate());
-            } else {
-                throw new ScenarioDefinitionException("Expected a match-get, aggregate, group or group aggregate query, but got a different query type");
-            }
-            tx.commit();
+            graql_query(graqlQueryStatements);
         } catch (RuntimeException e) {
             threw = true;
-        } finally {
-            tx.close();
-            tx = session.transaction(Transaction.Type.WRITE);
         }
         assertTrue(threw);
     }
@@ -277,7 +202,6 @@ public class GraqlSteps {
     public void answer_quantity_assertion(int expectedAnswers) {
         assertEquals(expectedAnswers, answers.size());
     }
-
 
     @Then("concept identifiers are")
     public void concept_identifiers_are(Map<String, Map<String, String>> identifiers) {
@@ -304,9 +228,10 @@ public class GraqlSteps {
 
     @Then("answers are labeled")
     public void answers_satisfy_labels(List<Map<String, String>> conceptLabels) {
-        assertEquals(conceptLabels.size(), answers.size());
+        assertNotNull(getAnswers());
+        assertEquals(conceptLabels.size(), getAnswers().size());
 
-        for (ConceptMap answer : answers) {
+        for (final ConceptMap answer : getAnswers()) {
 
             // convert the concept map into a map from variable to type label
             Map<String, String> answerAsLabels = new HashMap<>();
@@ -327,13 +252,14 @@ public class GraqlSteps {
 
     @Then("uniquely identify answer concepts")
     public void uniquely_identify_answer_concepts(List<Map<String, String>> answersIdentifiers) {
+        assertNotNull(getAnswers());
         assertEquals(
                 String.format("The number of identifier entries (rows) should match the number of answers, but found %d identifier entries and %d answers",
-                        answersIdentifiers.size(), answers.size()),
-                answersIdentifiers.size(), answers.size()
+                        answersIdentifiers.size(), getAnswers().size()),
+                answersIdentifiers.size(), getAnswers().size()
         );
 
-        for (ConceptMap answer : answers) {
+        for (final ConceptMap answer : getAnswers()) {
             List<Map<String, String>> matchingIdentifiers1 = new ArrayList<>();
 
             for (Map<String, String> answerIdentifiers : answersIdentifiers) {
@@ -352,14 +278,15 @@ public class GraqlSteps {
 
     @Then("order of answer concepts is")
     public void order_of_answer_concepts_is(List<Map<String, String>> answersIdentifiers) {
+        assertNotNull(getAnswers());
         assertEquals(
                 String.format("The number of identifier entries (rows) should match the number of answers, but found %d identifier entries and %d answers",
-                        answersIdentifiers.size(), answers.size()),
-                answersIdentifiers.size(), answers.size()
+                        answersIdentifiers.size(), getAnswers().size()),
+                answersIdentifiers.size(), getAnswers().size()
         );
 
-        for (int i = 0; i < answers.size(); i++) {
-            final ConceptMap answer = answers.get(i);
+        for (int i = 0; i < getAnswers().size(); i++) {
+            final ConceptMap answer = getAnswers().get(i);
             final Map<String, String> answerIdentifiers = answersIdentifiers.get(i);
             assertTrue(
                     String.format("The answer at index %d does not match the identifier entry (row) at index %d", i, i),
@@ -370,18 +297,18 @@ public class GraqlSteps {
 
     @Then("aggregate value is: {double}")
     public void aggregate_value_is(double expectedAnswer) {
-        assertNotNull("The last executed query was not an aggregate query", numericAnswers);
-        assertEquals(String.format("Expected 1 answer, but got %d answers", numericAnswers.size()), 1, numericAnswers.size());
-        assertEquals(String.format("Expected answer to equal %f, but it was %f", expectedAnswer, numericAnswers.get(0).number().doubleValue()),
+        assertNotNull("The last executed query was not an aggregate query", getNumericAnswers());
+        assertEquals(String.format("Expected 1 answer, but got %d answers", getNumericAnswers().size()), 1, getNumericAnswers().size());
+        assertEquals(String.format("Expected answer to equal %f, but it was %f", expectedAnswer, getNumericAnswers().get(0).number().doubleValue()),
                 expectedAnswer,
-                numericAnswers.get(0).number().doubleValue(),
+                getNumericAnswers().get(0).number().doubleValue(),
                 0.01);
     }
 
     @Then("aggregate answer is empty")
     public void aggregate_answer_is_empty() {
-        assertNotNull("The last executed query was not an aggregate query", numericAnswers);
-        assertEquals("Aggregate answer is not empty, it has a value", 0, numericAnswers.size());
+        assertNotNull("The last executed query was not an aggregate query", getNumericAnswers());
+        assertEquals("Aggregate answer is not empty, it has a value", 0, getNumericAnswers().size());
     }
 
     @Then("group identifiers are")
@@ -395,6 +322,7 @@ public class GraqlSteps {
 
     @Then("answer groups are")
     public void answer_groups_are(List<Map<String, String>> answerIdentifierTable) {
+        assertNotNull(getAnswerGroups());
         Set<AnswerIdentifierGroup> answerIdentifierGroups = answerIdentifierTable.stream()
                 .collect(Collectors.groupingBy(x -> x.get(AnswerIdentifierGroup.GROUP_COLUMN_NAME)))
                 .values()
@@ -403,13 +331,13 @@ public class GraqlSteps {
                 .collect(Collectors.toSet());
 
         assertEquals(String.format("Expected [%d] answer groups, but found [%d]",
-                answerIdentifierGroups.size(), answerGroups.size()),
-                answerIdentifierGroups.size(), answerGroups.size()
+                answerIdentifierGroups.size(), getAnswerGroups().size()),
+                answerIdentifierGroups.size(), getAnswerGroups().size()
         );
 
         for (AnswerIdentifierGroup answerIdentifierGroup : answerIdentifierGroups) {
             String groupOwnerIdentifier = answerIdentifierGroup.groupOwnerIdentifier;
-            AnswerGroup<ConceptMap> answerGroup = answerGroups.stream()
+            AnswerGroup<ConceptMap> answerGroup = getAnswerGroups().stream()
                     .filter(ag -> identifierChecks.get(groupOwnerIdentifier).check(ag.owner()))
                     .findAny()
                     .orElse(null);
@@ -436,6 +364,7 @@ public class GraqlSteps {
 
     @Then("group aggregate values are")
     public void group_aggregate_values_are(List<Map<String, String>> answerIdentifierTable) {
+        assertNotNull(getNumericAnswerGroups());
         Map<String, Double> expectations = new HashMap<>();
         for (Map<String, String> answerIdentifierRow : answerIdentifierTable) {
             String groupIdentifier = answerIdentifierRow.get(AnswerIdentifierGroup.GROUP_COLUMN_NAME);
@@ -445,14 +374,14 @@ public class GraqlSteps {
         }
 
         assertEquals(String.format("Expected [%d] answer groups, but found [%d]",
-                expectations.size(), numericAnswerGroups.size()),
-                expectations.size(), numericAnswerGroups.size()
+                expectations.size(), getNumericAnswerGroups().size()),
+                expectations.size(), getNumericAnswerGroups().size()
         );
 
         for (Map.Entry<String, Double> expectation : expectations.entrySet()) {
             String groupIdentifier = expectation.getKey();
             double expectedAnswer = expectation.getValue();
-            AnswerGroup<Numeric> answerGroup = numericAnswerGroups.stream()
+            AnswerGroup<Numeric> answerGroup = getNumericAnswerGroups().stream()
                     .filter(ag -> identifierChecks.get(groupIdentifier).check(ag.owner()))
                     .findAny()
                     .orElse(null);
@@ -469,7 +398,8 @@ public class GraqlSteps {
 
     @Then("number of groups is: {int}")
     public void number_of_groups_is(int expectedGroupCount) {
-        assertEquals(expectedGroupCount, answerGroups.size());
+        assertNotNull(getAnswerGroups());
+        assertEquals(expectedGroupCount, getAnswerGroups().size());
     }
 
     public static class AnswerIdentifierGroup {
@@ -526,7 +456,7 @@ public class GraqlSteps {
 
     @Then("answers contain explanation tree")
     public void answers_contain_explanation_tree(Map<Integer, Map<String, String>> explanationTree) {
-        checkExplanationEntry(answers, explanationTree, 0);
+        checkExplanationEntry(getAnswers(), explanationTree, 0);
     }
 
     private void checkExplanationEntry(List<ConceptMap> answers, Map<Integer, Map<String, String>> explanationTree, Integer entryId) {
@@ -598,12 +528,56 @@ public class GraqlSteps {
     @Then("each answer satisfies")
     public void each_answer_satisfies(String templatedGraqlQuery) {
         String templatedQuery = String.join("\n", templatedGraqlQuery);
-        for (ConceptMap answer : answers) {
+        for (ConceptMap answer : getAnswers()) {
             String query = applyQueryTemplate(templatedQuery, answer);
             GraqlQuery graqlQuery = Graql.parse(query);
             List<? extends Answer> answers = tx.execute(graqlQuery);
             assertEquals(1, answers.size());
         }
+    }
+
+    private <TQuery extends GraqlQuery> void executeGraqlQuery(
+            final String queryStatements,
+            final Function<GraqlQuery, TQuery> queryTypeFn) {
+        final TQuery graqlQuery = queryTypeFn.apply(Graql.parse(String.join("\n", queryStatements)));
+        tx.execute(graqlQuery);
+        tx.commit();
+        tx = session.transaction(Transaction.Type.WRITE);
+    }
+
+    private <TQuery extends GraqlQuery> void executeGraqlQueryWithoutCommit(
+            final String queryStatements,
+            final Function<GraqlQuery, TQuery> queryTypeFn) {
+        final TQuery graqlQuery = queryTypeFn.apply(Graql.parse(String.join("\n", queryStatements)));
+        tx.execute(graqlQuery);
+    }
+
+    private <TQuery extends GraqlQuery> void assertGraqlQueryThrows(
+            final String queryStatements,
+            final Function<GraqlQuery, TQuery> queryTypeFn) {
+        boolean threw = false;
+        try {
+            executeGraqlQuery(queryStatements, queryTypeFn);
+        } catch (RuntimeException e) {
+            threw = true;
+        }
+        assertTrue(threw);
+    }
+
+    private List<ConceptMap> getAnswers() {
+        return answers;
+    }
+
+    private List<AnswerGroup<ConceptMap>> getAnswerGroups() {
+        return answerGroups;
+    }
+
+    private List<Numeric> getNumericAnswers() {
+        return numericAnswers;
+    }
+
+    private List<AnswerGroup<Numeric>> getNumericAnswerGroups() {
+        return numericAnswerGroups;
     }
 
     private String applyQueryTemplate(String template, ConceptMap templateFiller) {

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -560,6 +560,9 @@ public class GraqlSteps {
             executeGraqlQuery(queryStatements, queryTypeFn);
         } catch (RuntimeException e) {
             threw = true;
+        } finally {
+            tx.close();
+            tx = session.transaction(Transaction.Type.WRITE);
         }
         assertTrue(threw);
     }


### PR DESCRIPTION
## What is the goal of this PR?

To reduce code duplication between graql query steps in BDD.

## What are the changes implemented in this PR?

We took the steps "graql define", "graql insert", "graql delete" etc. and refactored them, extracting a common method named "graql query". We repeated this process for "graql define without commit", and "graql define throws", and for the other query types.
