### PR TITLE
Clarify intent of resolution BDD steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,8 @@ jobs:
           command: bazel test //test/behaviour/graql/language/delete:test --test_output=errors
 
   test-behaviour-graql-get:
-    machine: true
+    machine:
+      image: ubuntu-1604:201903-01
     working_directory: ~/grakn
     steps:
       - install-bazel-linux

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,7 +70,7 @@ def graknlabs_verification():
     git_repository(
         name = "graknlabs_verification",
         remote = "https://github.com/graknlabs/verification",
-        commit = "34b5c64efe57919d170b212d1e231e11cf0e84e8",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
+        commit = "38f39e7ee2fdebec410a9ea93c3b29f6ebe4de29",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_verification
     )
 
 def graknlabs_grabl_tracing():

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -68,7 +68,7 @@ public class ResolutionSteps {
     }
 
     @When("materialised keyspace is completed")
-    public void reference_graph_is_materialised() {
+    public void materialised_keyspace_is_completed() {
         resolution = new Resolution(getMaterialisedSession(), getReasonedSession());
     }
 
@@ -78,19 +78,19 @@ public class ResolutionSteps {
     }
 
     @Then("in reasoned keyspace, answer size is: {number}")
-    public void answer_count_is(final int expectedCount) {
+    public void reasoned_keyspace_answer_size_is(final int expectedCount) {
         resolution.manuallyValidateAnswerSize(queryToTest, expectedCount);
     }
 
     @Then("in reasoned keyspace, all answers are correct")
-    public void all_answers_are_correct() {
+    public void reasoned_keyspace_all_answers_are_correct() {
         // TODO: refactor these into a single method that compares the set of expected answers to the actual answers
         resolution.testQuery(queryToTest);
         resolution.testResolution(queryToTest);
     }
 
     @Then("in reasoned keyspace, no answers are missing")
-    public void no_answers_are_missing() {
+    public void reasoned_keyspace_no_answers_are_missing() {
         resolution.testCompleteness();
     }
 

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -67,8 +67,8 @@ public class ResolutionSteps {
         setReasonedSession(reasonedSession);
     }
 
-    @When("reference kb is completed")
-    public void reference_kb_is_completed() {
+    @When("materialised keyspace is completed")
+    public void reference_graph_is_materialised() {
         resolution = new Resolution(getMaterialisedSession(), getReasonedSession());
     }
 
@@ -77,23 +77,20 @@ public class ResolutionSteps {
         queryToTest = Graql.parse(graqlQuery).asGet();
     }
 
-    @Then("for reasoned keyspace, answer size is: {number}")
+    @Then("in reasoned keyspace, answer size is: {number}")
     public void answer_count_is(final int expectedCount) {
         resolution.manuallyValidateAnswerSize(queryToTest, expectedCount);
     }
 
-    @Then("answer count is correct")
-    public void answer_count_is_correct() {
+    @Then("in reasoned keyspace, all answers are correct")
+    public void all_answers_are_correct() {
+        // TODO: refactor these into a single method that compares the set of expected answers to the actual answers
         resolution.testQuery(queryToTest);
-    }
-
-    @Then("answers resolution is correct")
-    public void answers_resolution_is_correct() {
         resolution.testResolution(queryToTest);
     }
 
-    @Then("test keyspace is complete")
-    public void test_keyspace_is_complete() {
+    @Then("in reasoned keyspace, no answers are missing")
+    public void no_answers_are_missing() {
         resolution.testCompleteness();
     }
 

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -89,8 +89,8 @@ public class ResolutionSteps {
         resolution.testResolution(queryToTest);
     }
 
-    @Then("in reasoned keyspace, no answers are missing")
-    public void reasoned_keyspace_no_answers_are_missing() {
+    @Then("materialised and reasoned keyspaces are the same size")
+    public void keyspaces_are_the_same_size() {
         resolution.testCompleteness();
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

To perform a code cleanup of the resolution BDD steps, setting a "second draft" of how we want the scenarios to look.

## What are the changes implemented in this PR?

- Previously, the graql query steps involved were called "graql define" and "graql insert". This was confusing as they had the same names as the relevant steps in GraqlSteps, but performed different actions - they operated across multiple sessions simultaneously. We renamed them to "for each session, graql define", etc.
- The step: "answer count is: {n}" was too unclear. Unlike the graql queries which operated across multiple keyspaces, this stopgap manual test operates against only one keyspace. To clarify the meaning, we renamed it to "for reasoned keyspace, answer size is: {n}".
- We renamed 'completion' and 'test' to the clearer terms: 'materialised' and 'reasoned' .
- We initialised two keyspaces in the background of each scenario, but it was not at all clear how these were used to derive which one was the 'test' keyspace and which one was the 'completion' one. Naturally, one might assume that it is based on the keyspace name; but in fact, it was simply based on the order of arguments passed to the "connection open sessions for keyspaces" step. This has now been refactored and split into multiple steps, which will look as follows in an actual scenario file:

```
Given connection open sessions for keyspaces:
      | materialised |
      | reasoned     |
Given materialised keyspace is named: materialised
Given reasoned keyspace is named: reasoned
```