### PR TITLE
Upgrade grabl tracing verison

### DIFF
--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -69,6 +69,6 @@ def graknlabs_verification():
 def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
-        remote = "https://github.com/graknlabs/grabl-tracing",
-        commit = "d298333d93e9ca30d7899862738e6cb175eaf6df"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        remote = "https://github.com/lriuui0x0/grabl-tracing",
+        commit = "227fe895ec64dec22d609b746265542bab2d6488"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,5 +70,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/lriuui0x0/grabl-tracing",
-        commit = "227fe895ec64dec22d609b746265542bab2d6488"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        commit = "2ec7099c97b94eac3caa089f08ee59ca4e4978ea"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -70,5 +70,5 @@ def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
         remote = "https://github.com/lriuui0x0/grabl-tracing",
-        commit = "2ec7099c97b94eac3caa089f08ee59ca4e4978ea"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        commit = "334a39c1ea98eea1c828190c72f15e4c234f00ea"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )

--- a/dependencies/graknlabs/dependencies.bzl
+++ b/dependencies/graknlabs/dependencies.bzl
@@ -69,6 +69,6 @@ def graknlabs_verification():
 def graknlabs_grabl_tracing():
     git_repository(
         name = "graknlabs_grabl_tracing",
-        remote = "https://github.com/lriuui0x0/grabl-tracing",
-        commit = "334a39c1ea98eea1c828190c72f15e4c234f00ea"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
+        remote = "https://github.com/graknlabs/grabl-tracing",
+        commit = "38dc7e195c67a669b69b0bfedc8a7c6032201c2f"  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_grabl_tracing
     )


### PR DESCRIPTION
## What is the goal of this PR?

We recently updated `grabl-tracing` to fix an issue of not being able to perform grakn tracing. Update the `grabl-tracing` version so that we can use the latest grakn for grakn tracing.

