### PR TITLE
Fix Docker image test

### DIFF
--- a/test/assembly/docker.py
+++ b/test/assembly/docker.py
@@ -1,9 +1,24 @@
 #!/usr/bin/env python
 
 import os
+import socket
 import subprocess as sp
 import sys
 import time
+
+
+def wait_for_port(port, host='localhost', timeout=30.0):
+    start_time = time.perf_counter()
+    while True:
+        try:
+            with socket.create_connection((host, port), timeout=timeout):
+                break
+        except OSError as ex:
+            time.sleep(0.01)
+            if time.perf_counter() - start_time >= timeout:
+                raise TimeoutError('Waited too long for the port {} on host {} to start accepting '
+                                   'connections.'.format(port, host)) from ex
+
 
 print('Building the image...')
 sp.check_call(['bazel', 'run', '//:assemble-docker'])
@@ -17,12 +32,7 @@ sys.stdout.write('Waiting for the instance to be ready')
 sys.stdout.flush()
 timeout = 0 # TODO: add timeout
 # TODO: fail if the docker image is dead
-# upon a successful gRPC connection, the curl returns 0 in linux, and 8 in mac
-while sp.call(['curl', '--output', '/dev/null', '--silent', '--head', '--fail', 'localhost:48555']) not in {0, 8}:
-    sys.stdout.write('.')
-    sys.stdout.flush()
-    time.sleep(1)
-print()
+wait_for_port(48555)
 
 print('Running the test...')
 sp.check_call(['bazel', 'test', '//test/common:grakn-application-test', '--test_output=streamed',


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `test-assembly-docker` depends on `curl` built in a specific way (with HTTP/2 support). This is not always the case, so test might silently timeout (underlying `curl` command fails with `Received HTTP/0.9 when not allowed`)

## What are the changes implemented in this PR?

Refactor `test/assembly/docker.py` to use native Python `socket` module to test for Grakn readiness