### PR TITLE
Reinstate missing role validation rules

### DIFF
--- a/graql/reasoner/query/ReasonerQueryImpl.java
+++ b/graql/reasoner/query/ReasonerQueryImpl.java
@@ -369,18 +369,10 @@ public class ReasonerQueryImpl extends ResolvableQuery {
     }
 
     private Stream<Pair<Variable, Type>> typeMappings(){
-//        Stream<Pair<Variable, Type>> typesById = getIdPredicates().stream()
-//                .filter(id -> !id.isPlaceholder())
-//                .map(id -> {
-//                    Concept concept = context().conceptManager().getConcept(id.getPredicate());
-//                    Type type = concept.isThing() ? concept.asThing().type() : concept.asType();
-//                    return new Pair<>(id.getVarName(), type);
-//                });
-        Stream<Pair<Variable, Type>> typesByIsa = isas()
+        return isas()
                 .filter(at -> Objects.nonNull(at.getSchemaConcept()))
                 .filter(at -> at.getSchemaConcept().isType())
                 .map(at -> new Pair<>(at.getVarName(), at.getSchemaConcept().asType()));
-        return Streams.concat(typesByIsa);
     }
 
     private Stream<Pair<Variable, Type>> inferEntityTypes(ConceptMap sub) {

--- a/server/ValidateGlobalRules.java
+++ b/server/ValidateGlobalRules.java
@@ -206,6 +206,32 @@ public class ValidateGlobalRules {
 
         Set<String> errorMessages = new HashSet<>();
 
+        Collection<Role> superRelates = superRelationType.roles().collect(Collectors.toSet());
+        Collection<Role> relates = relationType.roles().collect(Collectors.toSet());
+        Set<Label> relatesLabels = relates.stream().map(SchemaConcept::label).collect(Collectors.toSet());
+
+        //TODO: Determine if this check is redundant
+        //Check 1) Every role of relationTypes is the sub of a role which is in the relates of it's supers
+        if (!superRelationType.isAbstract()) {
+            Set<Label> allSuperRolesPlayed = new HashSet<>();
+            superRelationType.sups().forEach(rel -> rel.roles().forEach(roleType -> allSuperRolesPlayed.add(roleType.label())));
+
+            for (Role relate : relates) {
+                boolean validRoleTypeFound = SchemaConceptImpl.from(relate).sups().
+                        anyMatch(superRole -> allSuperRolesPlayed.contains(superRole.label()));
+
+                if (!validRoleTypeFound) {
+                    errorMessages.add(VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(relate.label(), relationType.label(), "super", "super", superRelationType.label()));
+                }
+            }
+        }
+        //Check 2) Every role of superRelationType has a sub role which is in the relates of relationTypes
+        for (Role superRelate : superRelates) {
+            boolean subRoleNotFoundInRelates = superRelate.subs().noneMatch(sub -> relatesLabels.contains(sub.label()));
+            if (subRoleNotFoundInRelates) {
+                errorMessages.add(VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(superRelate.label(), superRelationType.label(), "sub", "sub", relationType.label()));
+            }
+        }
 
         // TODO implement the new validation behaviours:
         // newly declared roles may not clash with any other roles that exist

--- a/test/integration/server/ValidatorIT.java
+++ b/test/integration/server/ValidatorIT.java
@@ -464,6 +464,48 @@ public class ValidatorIT {
     }
 
     @Test
+    public void whenCreatingRelationWithSubTypeHierarchyAndNoMatchingRoleTypeHierarchy_Throw1() throws InvalidKBException {
+        Role pChild = tx.putRole("pChild");
+        Role fChild = tx.putRole("fChild").sup(pChild);
+        Role parent = tx.putRole("parent");
+        Role father = tx.putRole("father").sup(parent);
+        Role inContext = tx.putRole("in-context");
+
+        tx.putEntityType("animal").plays(parent).plays(father).plays(pChild).plays(fChild);
+        tx.putEntityType("context").plays(inContext);
+
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild);
+        RelationType fatherhood = tx.putRelationType("fatherhood").sup(parenthood).relates(father).relates(fChild).relates(inContext);
+
+        exception.expect(InvalidKBException.class);
+        exception.expectMessage(
+                ErrorMessage.VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(inContext.label(), fatherhood.label(), "super", "super", parenthood.label()));
+
+        tx.commit();
+    }
+
+    @Test
+    public void whenCreatingRelationWithSubTypeHierarchyAndNoMatchingRoleTypeHierarchy_Throw2() throws InvalidKBException {
+        Role parent = tx.putRole("parent");
+        Role father = tx.putRole("father").sup(parent);
+        Role pChild = tx.putRole("pChild");
+        Role fChild = tx.putRole("fChild").sup(pChild);
+        Role inContext = tx.putRole("in-context");
+
+        tx.putEntityType("animal").plays(parent).plays(father).plays(pChild).plays(fChild);
+        tx.putEntityType("context").plays(inContext);
+
+        RelationType parenthood = tx.putRelationType("parenthood").relates(parent).relates(pChild).relates(inContext);
+        RelationType fatherhood = tx.putRelationType("fatherhood").sup(parenthood).relates(father).relates(fChild);
+
+        exception.expect(InvalidKBException.class);
+        exception.expectMessage(
+                ErrorMessage.VALIDATION_RELATION_TYPES_ROLES_SCHEMA.getMessage(inContext.label(), parenthood.label(), "sub", "sub", fatherhood.label()));
+
+        tx.commit();
+    }
+
+    @Test
     public void checkRoleTypeValidSuperOfSelfTypeWhenLinkedToRelationsWhichAreSubsOfEachOther() throws InvalidKBException {
         Role insurer = tx.putRole("insurer");
         Role monoline = tx.putRole("monoline").sup(insurer);


### PR DESCRIPTION
## What is the goal of this PR?
To put back the two role validation rules that were accidentally removed in #5827.

## What are the changes implemented in this PR?
Brought back the role validation rules in `ValidateGlobalRules` and associated tests in `ValidatorIT`.