### PR TITLE
Fix Docker test to be compatible with both Python 2 and Python 3

### DIFF
--- a/test/assembly/docker.py
+++ b/test/assembly/docker.py
@@ -8,16 +8,16 @@ import time
 
 
 def wait_for_port(port, host='localhost', timeout=30.0):
-    start_time = time.perf_counter()
+    start_time = time.time()
     while True:
         try:
-            with socket.create_connection((host, port), timeout=timeout):
-                break
+            socket.create_connection((host, port), timeout=timeout)
+            return
         except OSError as ex:
             time.sleep(0.01)
-            if time.perf_counter() - start_time >= timeout:
+            if time.time() - start_time >= timeout:
                 raise TimeoutError('Waited too long for the port {} on host {} to start accepting '
-                                   'connections.'.format(port, host)) from ex
+                                   'connections.'.format(port, host))
 
 
 print('Building the image...')


### PR DESCRIPTION
## What is the goal of this PR?

Previously, it was only possible to run `test-assembly-docker` with `python` pointing to `python3`. In order to be compatible with both Python 2 and Python 3, test shouldn't use any new language features.

## What are the changes implemented in this PR?

* Don't use `time.perf_counter`: it was introduced in 3.3
* Don't use `raise Exception() from ex` syntax
* Don't use `socket.create_connection` as context manager