### PR TITLE
Fix Docker test to wait fixed time

### DIFF
--- a/test/assembly/docker.py
+++ b/test/assembly/docker.py
@@ -6,20 +6,6 @@ import subprocess as sp
 import sys
 import time
 
-
-def wait_for_port(port, host='localhost', timeout=30.0):
-    start_time = time.time()
-    while True:
-        try:
-            socket.create_connection((host, port), timeout=timeout)
-            return
-        except OSError as ex:
-            time.sleep(0.01)
-            if time.time() - start_time >= timeout:
-                raise TimeoutError('Waited too long for the port {} on host {} to start accepting '
-                                   'connections.'.format(port, host))
-
-
 print('Building the image...')
 sp.check_call(['bazel', 'run', '//:assemble-docker'])
 
@@ -28,11 +14,8 @@ sp.check_call(['docker', 'run', '-v', '{}:/grakn-core-all-linux/logs/'.format(os
 print('Docker status:')
 sp.check_call(['docker', 'ps'])
 
-sys.stdout.write('Waiting for the instance to be ready')
-sys.stdout.flush()
-timeout = 0 # TODO: add timeout
-# TODO: fail if the docker image is dead
-wait_for_port(48555)
+print('Waiting 30s for the instance to be ready')
+time.sleep(30)
 
 print('Running the test...')
 sp.check_call(['bazel', 'test', '//test/common:grakn-application-test', '--test_output=streamed',


### PR DESCRIPTION
## What is the goal of this PR?

Waiting for Grakn port to be open didn't prove to be the best strategy: test executing queries failed even though the port was already opened. Instead, we're opting in to wait a fixed amount of time. This strategy is also using in [`docs`](https://github.com/graknlabs/docs/blob/316b27ba1bdc69e6bbd0c6af8645320b2a492144/.circleci/config.yml#L41) where Grakn server is also started.

## What are the changes implemented in this PR?

Wait a fixed amount of time (30s) which should be plenty for Grakn to bootup.