### PR TITLE
Add role downward inference when getting relations or castings

### DIFF
--- a/concept/impl/RelationImpl.java
+++ b/concept/impl/RelationImpl.java
@@ -141,16 +141,17 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
      */
     @Override
     public Stream<Casting> castingsRelation(Role... roles) {
-        Set<Role> roleSet = new HashSet<>(Arrays.asList(roles));
-        if (roleSet.isEmpty()) {
+        Set<Integer> roleTypeIdSet = Arrays.stream(roles)
+                .flatMap(Role::subs)
+                .map(r -> r.labelId().getValue())
+                .collect(Collectors.toSet());
+        if (roleTypeIdSet.isEmpty()) {
             return vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ROLE_PLAYER)
                     .map(edge -> CastingImpl.withRelation(edge, this, conceptManager));
         }
 
         //Traversal is used so we can potentially optimise on the index
-        Set<Integer> roleTypesIds = roleSet.stream().map(r -> r.labelId().getValue()).collect(Collectors.toSet());
-
-        Stream<EdgeElement> castingsEdges = vertex().roleCastingsEdges(type().labelId().getValue(), roleTypesIds);
+        Stream<EdgeElement> castingsEdges = vertex().roleCastingsEdges(type().labelId().getValue(), roleTypeIdSet);
         return castingsEdges.map(edge -> CastingImpl.withRelation(edge, this, conceptManager));
     }
 

--- a/concept/impl/RelationImpl.java
+++ b/concept/impl/RelationImpl.java
@@ -95,7 +95,7 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
     /**
      * Remove this relation if there are no more role player present
      */
-    void cleanUp() {
+    private void cleanUp() {
         boolean performDeletion = !rolePlayers().findAny().isPresent();
         if (performDeletion) delete();
     }
@@ -109,16 +109,18 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
     /**
      * Remove a single single instance of specific role player playing a given role in this relation
      * We could have duplicates, so we only operate on a single casting that is found
+     * returns True if a role player was deleted
      */
     private void removeRolePlayerIfPresent(Role role, Thing thing) {
-        castingsRelation(role)
-                .filter(casting -> casting.getRole().equals(role) && casting.getRolePlayer().equals(thing))
+        castingsRelationDirect(role)
+                .filter(casting -> casting.getRolePlayer().equals(thing))
                 .findAny()
                 .ifPresent(casting -> {
                     casting.delete();
                     conceptNotificationChannel.castingDeleted(casting);
                 });
     }
+
     private void addRolePlayer(Role role, Thing thing) {
         Objects.requireNonNull(role);
         Objects.requireNonNull(thing);
@@ -145,6 +147,18 @@ public class RelationImpl extends ThingImpl<Relation, RelationType> implements R
                 .flatMap(Role::subs)
                 .map(r -> r.labelId().getValue())
                 .collect(Collectors.toSet());
+        if (roleTypeIdSet.isEmpty()) {
+            return vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ROLE_PLAYER)
+                    .map(edge -> CastingImpl.withRelation(edge, this, conceptManager));
+        }
+
+        //Traversal is used so we can potentially optimise on the index
+        Stream<EdgeElement> castingsEdges = vertex().roleCastingsEdges(type().labelId().getValue(), roleTypeIdSet);
+        return castingsEdges.map(edge -> CastingImpl.withRelation(edge, this, conceptManager));
+    }
+
+    private Stream<Casting> castingsRelationDirect(Role... roles) {
+        Set<Integer> roleTypeIdSet = Arrays.stream(roles).map(r -> r.labelId().getValue()).collect(Collectors.toSet());
         if (roleTypeIdSet.isEmpty()) {
             return vertex().getEdgesOfType(Direction.OUT, Schema.EdgeLabel.ROLE_PLAYER)
                     .map(edge -> CastingImpl.withRelation(edge, this, conceptManager));

--- a/concept/impl/ThingImpl.java
+++ b/concept/impl/ThingImpl.java
@@ -166,9 +166,11 @@ public abstract class ThingImpl<T extends Thing, V extends Type> extends Concept
      */
     @Override
     public Stream<Relation> relations(Role... roles) {
-        Set<Integer> roleIds = Arrays.stream(roles).map(role -> role.labelId().getValue()).collect(Collectors.toSet());
+        Set<Integer> roleIds = Arrays.stream(roles)
+                .flatMap(Role::subs)
+                .map(role -> role.labelId().getValue()).collect(Collectors.toSet());
         Stream<VertexElement> relationVertices = vertex().relations(roleIds);
-        return relationVertices.map(vertexElement -> conceptManager.buildConcept(vertexElement));
+        return relationVertices.map(conceptManager::buildConcept);
     }
 
     private void deleteAttributeOwnerships() {

--- a/graql/executor/property/RelationExecutor.java
+++ b/graql/executor/property/RelationExecutor.java
@@ -220,8 +220,9 @@ public class RelationExecutor implements PropertyExecutor.Insertable, PropertyEx
                 Thing rolePlayer = executor.getConcept(rolePlayerVar).asThing();
 
                 // find the first role subtype that is the actual role being played
-                Optional<Role> concreteRolePlayed = requiredRole.subs()
-                        .filter(role -> relation.rolePlayers(role).anyMatch(rolePlayer::equals))
+                Optional<Role> concreteRolePlayed = relation.castingsRelation(requiredRole)
+                        .filter(casting -> casting.getRolePlayer().equals(rolePlayer))
+                        .map(casting -> casting.getRole())
                         .findFirst();
 
                 if (!concreteRolePlayed.isPresent()) {

--- a/kb/concept/api/Relation.java
+++ b/kb/concept/api/Relation.java
@@ -82,11 +82,12 @@ public interface Relation extends Thing {
     Relation assign(Role role, Thing player);
 
     /**
-     * Removes the Thing which is playing a Role in this Relation.
+     * Removes the Thing which is playing a exact Role in this Relation.
      * If the Thing is not playing any Role in this Relation nothing happens.
      *
      * @param role   The Role being played by the Thing
      * @param player The Thing playing the Role in this Relation
+     * @return whether the player was unassigned over the role or a subtype of the role
      */
     void unassign(Role role, Thing player);
 


### PR DESCRIPTION
## What is the goal of this PR?
To ensure that the methods in Concept API present a consistent behaviour, we implement downward type inference when retrieving role players or relations over a given role. We always perform downward type inference in Concept API read operations.

Before, we only searched for role players or relations playing the exact role without checking the role subtypes. This aligns with attribute ownership and owned-ness - we can ask for `name` owned by a thing and we get back `first-name` and `last-name` instances as well. 

## What are the changes implemented in this PR?
* Implement a call to `role.subs()` when retrieving role players
* Implement a call to `role.subs()` when retrieving relations that a thing plays a role in
* Correspondingly update the role player delete executors