### PR TITLE
Simplify Query Traversal Generics

### DIFF
--- a/graql/planning/gremlin/fragment/AbstractFragment.java
+++ b/graql/planning/gremlin/fragment/AbstractFragment.java
@@ -22,7 +22,6 @@ import grakn.core.kb.concept.manager.ConceptManager;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/AbstractFragment.java
+++ b/graql/planning/gremlin/fragment/AbstractFragment.java
@@ -36,8 +36,8 @@ class AbstractFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
         return traversal.has(Schema.VertexProperty.IS_ABSTRACT.name(), true);
     }

--- a/graql/planning/gremlin/fragment/AttributeIndexFragment.java
+++ b/graql/planning/gremlin/fragment/AttributeIndexFragment.java
@@ -48,8 +48,8 @@ public class AttributeIndexFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
         return traversal.has(INDEX.name(), attributeIndex());
     }

--- a/graql/planning/gremlin/fragment/AttributeIndexFragment.java
+++ b/graql/planning/gremlin/fragment/AttributeIndexFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.keyspace.KeyspaceStatistics;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/FragmentImpl.java
+++ b/graql/planning/gremlin/fragment/FragmentImpl.java
@@ -199,8 +199,8 @@ public abstract class FragmentImpl implements Fragment {
      * @param traversal the traversal to extend with this Fragment
      */
     @Override
-    public final GraphTraversal<Vertex, ? extends Element> applyTraversal(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager,
+    public final GraphTraversal<Vertex, Vertex> applyTraversal(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager,
             Collection<Variable> vars, Variable currentVar) {
 
 
@@ -235,7 +235,7 @@ public abstract class FragmentImpl implements Fragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> selectVariable(GraphTraversal<Vertex, ? extends Element> traversal) {
+    public GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal) {
         traversal.as(start().symbol());
         return traversal;
     }
@@ -255,8 +255,8 @@ public abstract class FragmentImpl implements Fragment {
      * @param conceptManager
      * @param vars
      */
-    abstract GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars);
+    abstract GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars);
 
 
     /**

--- a/graql/planning/gremlin/fragment/FragmentImpl.java
+++ b/graql/planning/gremlin/fragment/FragmentImpl.java
@@ -33,7 +33,6 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;
@@ -211,13 +210,12 @@ public abstract class FragmentImpl implements Fragment {
                     traversal.select(start().symbol());
                 } else {
                     // Restart traversal when fragments are disconnected
-                    traversal.V();
-                    selectVariable(traversal);
+                    traversal.V().as(start().symbol());
                 }
             }
         } else {
             // this is the very start of the traversal, record the step using `as` as we haven't visited the variable yet
-            selectVariable(traversal);
+            traversal.as(start().symbol());
         }
 
         vars.add(start());
@@ -231,12 +229,6 @@ public abstract class FragmentImpl implements Fragment {
 
         vars.addAll(vars());
 
-        return traversal;
-    }
-
-    @Override
-    public GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal) {
-        traversal.as(start().symbol());
         return traversal;
     }
 

--- a/graql/planning/gremlin/fragment/IdFragment.java
+++ b/graql/planning/gremlin/fragment/IdFragment.java
@@ -53,12 +53,6 @@ class IdFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal) {
-        traversal.as(start().symbol());
-        return traversal;
-    }
-
-    @Override
     public GraphTraversal<Vertex, Vertex> applyTraversalInner(
             GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.hasId(Schema.elementId(id()));

--- a/graql/planning/gremlin/fragment/IdFragment.java
+++ b/graql/planning/gremlin/fragment/IdFragment.java
@@ -28,7 +28,6 @@ import graql.lang.property.IdProperty;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;
@@ -54,14 +53,14 @@ class IdFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> selectVariable(GraphTraversal<Vertex, ? extends Element> traversal) {
+    public GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal) {
         traversal.as(start().symbol());
         return traversal;
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.hasId(Schema.elementId(id()));
     }
 

--- a/graql/planning/gremlin/fragment/InAttributeFragment.java
+++ b/graql/planning/gremlin/fragment/InAttributeFragment.java
@@ -18,7 +18,6 @@
 
 package grakn.core.graql.planning.gremlin.fragment;
 
-import com.google.common.collect.ImmutableSet;
 import grakn.core.core.Schema;
 import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.planning.spanningtree.graph.InstanceNode;
@@ -27,9 +26,7 @@ import grakn.core.kb.graql.planning.spanningtree.graph.NodeId;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collection;

--- a/graql/planning/gremlin/fragment/InAttributeFragment.java
+++ b/graql/planning/gremlin/fragment/InAttributeFragment.java
@@ -40,7 +40,6 @@ import java.util.Collection;
  */
 public class InAttributeFragment extends EdgeFragment {
     private Variable edgeVariable;
-    // for backwards compatibility
 
     public InAttributeFragment(VarProperty varProperty, Variable attribute, Variable owner, Variable edge) {
         super(varProperty, attribute, owner);
@@ -63,22 +62,19 @@ public class InAttributeFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, ? extends Element> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // (start) ATTR <-[edge] - OWNER
-        return Fragments.union(
-                Fragments.isVertex(traversal),
-                ImmutableSet.of(attributeToOwners())
-        );
+        return attributeToOwners(traversal);
     }
 
-    private GraphTraversal<Vertex, Vertex> attributeToOwners() {
-        GraphTraversal<Vertex, Edge> edgeTraversal = __.inE(Schema.EdgeLabel.ATTRIBUTE.getLabel());
+    private GraphTraversal<Vertex, Vertex> attributeToOwners(GraphTraversal<Vertex, Vertex> traversal) {
+        GraphTraversal<Vertex, Edge> edgeTraversal = traversal.inE(Schema.EdgeLabel.ATTRIBUTE.getLabel());
         return edgeTraversal.outV();
     }
 
     @Override
     public String name() {
-        return "<-[has-xxx]-";
+        return "<-[has]-";
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/InHasFragment.java
+++ b/graql/planning/gremlin/fragment/InHasFragment.java
@@ -60,14 +60,14 @@ public class InHasFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // anyone that can own this directly or any of their subs is a valid owner
         return Fragments.inSubs(traversal.in(Schema.EdgeLabel.HAS.getLabel(), Schema.EdgeLabel.KEY.getLabel()));
    }
 
     @Override
     public String name() {
-        return "<-[has]-";
+        return "<-[has/key]-";
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/InHasFragment.java
+++ b/graql/planning/gremlin/fragment/InHasFragment.java
@@ -26,7 +26,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/InIsaFragment.java
+++ b/graql/planning/gremlin/fragment/InIsaFragment.java
@@ -52,14 +52,8 @@ public class InIsaFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-
-        GraphTraversal<Vertex, Vertex> vertexTraversal = Fragments.isVertex(traversal);
-        return toVertexInstances(vertexTraversal);
-    }
-
-    private <S> GraphTraversal<S, Vertex> toVertexInstances(GraphTraversal<S, Vertex> traversal) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.in(SHARD.getLabel()).in(ISA.getLabel());
     }
 

--- a/graql/planning/gremlin/fragment/InIsaFragment.java
+++ b/graql/planning/gremlin/fragment/InIsaFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/InKeyFragment.java
+++ b/graql/planning/gremlin/fragment/InKeyFragment.java
@@ -26,7 +26,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Arrays;

--- a/graql/planning/gremlin/fragment/InKeyFragment.java
+++ b/graql/planning/gremlin/fragment/InKeyFragment.java
@@ -55,7 +55,7 @@ public class InKeyFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, ? extends Element> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // anyone that can be keyed this directly or any of their subs is a valid owner
         return Fragments.inSubs(traversal.in(Schema.EdgeLabel.KEY.getLabel()));
     }

--- a/graql/planning/gremlin/fragment/InPlaysFragment.java
+++ b/graql/planning/gremlin/fragment/InPlaysFragment.java
@@ -54,16 +54,15 @@ class InPlaysFragment extends EdgeFragment {
 
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        GraphTraversal<Vertex, Vertex> vertexTraversal = Fragments.isVertex(traversal);
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         if (required()) {
-            vertexTraversal.inE(PLAYS.getLabel()).has(Schema.EdgeProperty.REQUIRED.name()).otherV();
+            traversal.inE(PLAYS.getLabel()).has(Schema.EdgeProperty.REQUIRED.name()).otherV();
         } else {
-            vertexTraversal.in(PLAYS.getLabel());
+            traversal.in(PLAYS.getLabel());
         }
 
-        return Fragments.inSubs(vertexTraversal);
+        return Fragments.inSubs(traversal);
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/InPlaysFragment.java
+++ b/graql/planning/gremlin/fragment/InPlaysFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/InRelatesFragment.java
+++ b/graql/planning/gremlin/fragment/InRelatesFragment.java
@@ -24,7 +24,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/InRelatesFragment.java
+++ b/graql/planning/gremlin/fragment/InRelatesFragment.java
@@ -45,9 +45,9 @@ class InRelatesFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return Fragments.isVertex(traversal).in(RELATES.getLabel());
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+        return traversal.in(RELATES.getLabel());
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/InRolePlayerFragment.java
+++ b/graql/planning/gremlin/fragment/InRolePlayerFragment.java
@@ -25,7 +25,6 @@ import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/InRolePlayerFragment.java
+++ b/graql/planning/gremlin/fragment/InRolePlayerFragment.java
@@ -90,12 +90,10 @@ class InRolePlayerFragment extends AbstractRolePlayerFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
-        return Fragments.union(Fragments.isVertex(traversal), ImmutableSet.of(
-                relationTraversal(conceptManager, vars)
-        ));
+        return Fragments.union(traversal, ImmutableSet.of(relationTraversal(conceptManager, vars)));
     }
 
     private GraphTraversal<Vertex, Vertex> relationTraversal(ConceptManager conceptManager, Collection<Variable> vars) {

--- a/graql/planning/gremlin/fragment/InSubFragment.java
+++ b/graql/planning/gremlin/fragment/InSubFragment.java
@@ -57,9 +57,9 @@ public class InSubFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return Fragments.inSubs(Fragments.isVertex(traversal), subTraversalDepthLimit());
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+        return Fragments.inSubs(traversal, subTraversalDepthLimit());
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/InSubFragment.java
+++ b/graql/planning/gremlin/fragment/InSubFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/LabelFragment.java
+++ b/graql/planning/gremlin/fragment/LabelFragment.java
@@ -60,8 +60,8 @@ public class LabelFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
         Set<Integer> labelIds =
                 labels().stream().map(label -> conceptManager.convertToId(label).getValue()).collect(toSet());

--- a/graql/planning/gremlin/fragment/LabelFragment.java
+++ b/graql/planning/gremlin/fragment/LabelFragment.java
@@ -29,7 +29,6 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/NeqFragment.java
+++ b/graql/planning/gremlin/fragment/NeqFragment.java
@@ -24,7 +24,6 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/NeqFragment.java
+++ b/graql/planning/gremlin/fragment/NeqFragment.java
@@ -61,10 +61,7 @@ public class NeqFragment extends FragmentImpl {
         // recall the start variable, compare it to the other variable
         // and restore the traversal point
 
-        Variable checkpoint = new Variable();
-        traversal.as(checkpoint.symbol());
         traversal.select(start().symbol()).where(P.neq(other().symbol()));
-        traversal.select(checkpoint.symbol());
         return traversal;
     }
 

--- a/graql/planning/gremlin/fragment/NeqFragment.java
+++ b/graql/planning/gremlin/fragment/NeqFragment.java
@@ -56,12 +56,9 @@ public class NeqFragment extends FragmentImpl {
     public GraphTraversal<Vertex, Vertex> applyTraversalInner(
             GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
-        // neq may be between two edges
-        // we save the point the traversal was at
-        // recall the start variable, compare it to the other variable
-        // and restore the traversal point
-
-        traversal.select(start().symbol()).where(P.neq(other().symbol()));
+        // the caller will ensure that start() is active on the traversal
+        // NOTE: generics are broken, since the variable can refer to an edge!!
+        traversal.where(P.neq(other().symbol()));
         return traversal;
     }
 

--- a/graql/planning/gremlin/fragment/NeqFragment.java
+++ b/graql/planning/gremlin/fragment/NeqFragment.java
@@ -53,9 +53,19 @@ public class NeqFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return traversal.where(P.neq(other().symbol()));
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+
+        // neq may be between two edges
+        // we save the point the traversal was at
+        // recall the start variable, compare it to the other variable
+        // and restore the traversal point
+
+        Variable checkpoint = new Variable();
+        traversal.as(checkpoint.symbol());
+        traversal.select(start().symbol()).where(P.neq(other().symbol()));
+        traversal.select(checkpoint.symbol());
+        return traversal;
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/NotShardFragment.java
+++ b/graql/planning/gremlin/fragment/NotShardFragment.java
@@ -37,8 +37,8 @@ class NotShardFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.not(__.hasLabel(Schema.BaseType.SHARD.name()));
     }
 

--- a/graql/planning/gremlin/fragment/NotShardFragment.java
+++ b/graql/planning/gremlin/fragment/NotShardFragment.java
@@ -23,7 +23,6 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/OutAttributeFragment.java
+++ b/graql/planning/gremlin/fragment/OutAttributeFragment.java
@@ -69,16 +69,13 @@ public class OutAttributeFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, ? extends Element> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // (start) ATTR <-[edge]- OWNER (START)
-        return Fragments.union(
-                Fragments.isVertex(traversal),
-                ImmutableSet.of(edgeRelationTraversal(conceptManager))
-        );
+        return edgeRelationTraversal(traversal, conceptManager);
     }
 
-    private GraphTraversal<Vertex, Vertex> edgeRelationTraversal(ConceptManager conceptManager) {
-        GraphTraversal<Vertex, Edge> edgeTraversal = __.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel());
+    private GraphTraversal<Vertex, Vertex> edgeRelationTraversal(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager) {
+        GraphTraversal<Vertex, Edge> edgeTraversal = traversal.outE(Schema.EdgeLabel.ATTRIBUTE.getLabel());
 
         Set<Label> labelsWithSubtypes = attributeTypeLabels
                 .stream()

--- a/graql/planning/gremlin/fragment/OutAttributeFragment.java
+++ b/graql/planning/gremlin/fragment/OutAttributeFragment.java
@@ -29,9 +29,7 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Collection;

--- a/graql/planning/gremlin/fragment/OutHasFragment.java
+++ b/graql/planning/gremlin/fragment/OutHasFragment.java
@@ -60,16 +60,15 @@ public class OutHasFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // a type can own any attribute that any of its parents (self inclusive) can own
-        return Fragments
-                .outSubs(Fragments.isVertex(traversal))
+        return Fragments.outSubs(traversal)
                 .out(Schema.EdgeLabel.HAS.getLabel(), Schema.EdgeLabel.KEY.getLabel());
     }
 
     @Override
     public String name() {
-        return "-[has]->";
+        return "-[has/key]->";
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/OutHasFragment.java
+++ b/graql/planning/gremlin/fragment/OutHasFragment.java
@@ -26,7 +26,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/OutIsaFragment.java
+++ b/graql/planning/gremlin/fragment/OutIsaFragment.java
@@ -56,19 +56,18 @@ public class OutIsaFragment extends EdgeFragment {
 
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
         // from the traversal, branch to take either of these paths
-        return Fragments.union(traversal, ImmutableSet.of(
-                Fragments.isVertex(__.start()).out(ISA.getLabel()).out(SHARD.getLabel()),
-                edgeTraversal() // what is this doing?
-        ));
+        return traversal.out(ISA.getLabel()).out(SHARD.getLabel());
+//                edgeTraversal() // what is this doing?
+//        ));
     }
-
-    private GraphTraversal<Element, Vertex> edgeTraversal() {
-        return Fragments.traverseSchemaConceptFromEdge(Fragments.isEdge(__.start()), RELATION_TYPE_LABEL_ID);
-    }
+//
+//    private GraphTraversal<Element, Vertex> edgeTraversal() {
+//        return Fragments.traverseSchemaConceptFromEdge(Fragments.isEdge(__.start()), RELATION_TYPE_LABEL_ID);
+//    }
 
     @Override
     public String name() {

--- a/graql/planning/gremlin/fragment/OutIsaFragment.java
+++ b/graql/planning/gremlin/fragment/OutIsaFragment.java
@@ -17,7 +17,6 @@
 
 package grakn.core.graql.planning.gremlin.fragment;
 
-import com.google.common.collect.ImmutableSet;
 import grakn.core.kb.concept.manager.ConceptManager;
 import grakn.core.kb.graql.planning.spanningtree.graph.InstanceNode;
 import grakn.core.kb.graql.planning.spanningtree.graph.Node;
@@ -26,8 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;
@@ -38,7 +35,6 @@ import java.util.Objects;
 
 import static grakn.core.core.Schema.EdgeLabel.ISA;
 import static grakn.core.core.Schema.EdgeLabel.SHARD;
-import static grakn.core.core.Schema.EdgeProperty.RELATION_TYPE_LABEL_ID;
 
 /**
  * A fragment representing traversing an isa edge from instance to type.
@@ -61,13 +57,8 @@ public class OutIsaFragment extends EdgeFragment {
 
         // from the traversal, branch to take either of these paths
         return traversal.out(ISA.getLabel()).out(SHARD.getLabel());
-//                edgeTraversal() // what is this doing?
-//        ));
     }
-//
-//    private GraphTraversal<Element, Vertex> edgeTraversal() {
-//        return Fragments.traverseSchemaConceptFromEdge(Fragments.isEdge(__.start()), RELATION_TYPE_LABEL_ID);
-//    }
+
 
     @Override
     public String name() {

--- a/graql/planning/gremlin/fragment/OutKeyFragment.java
+++ b/graql/planning/gremlin/fragment/OutKeyFragment.java
@@ -55,11 +55,12 @@ public class OutKeyFragment extends EdgeFragment {
     }
 
     @Override
-    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    GraphTraversal<Vertex, Vertex> applyTraversalInner(GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         // a type can be keyed by any attribute that any of its parents (self inclusive) is keyed by
         return Fragments
-                .outSubs(Fragments.isVertex(traversal))
-                .out(Schema.EdgeLabel.KEY.getLabel());    }
+                .outSubs(traversal)
+                .out(Schema.EdgeLabel.KEY.getLabel());
+    }
 
     @Override
     public String name() {

--- a/graql/planning/gremlin/fragment/OutKeyFragment.java
+++ b/graql/planning/gremlin/fragment/OutKeyFragment.java
@@ -26,7 +26,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Arrays;

--- a/graql/planning/gremlin/fragment/OutPlaysFragment.java
+++ b/graql/planning/gremlin/fragment/OutPlaysFragment.java
@@ -54,10 +54,10 @@ class OutPlaysFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
-        GraphTraversal<Vertex, Vertex> vertexTraversal = Fragments.outSubs(Fragments.isVertex(traversal));
+        GraphTraversal<Vertex, Vertex> vertexTraversal = Fragments.outSubs(traversal);
 
         if (required()) {
             return vertexTraversal.outE(PLAYS.getLabel()).has(Schema.EdgeProperty.REQUIRED.name()).otherV();

--- a/graql/planning/gremlin/fragment/OutPlaysFragment.java
+++ b/graql/planning/gremlin/fragment/OutPlaysFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/OutRelatesFragment.java
+++ b/graql/planning/gremlin/fragment/OutRelatesFragment.java
@@ -45,10 +45,9 @@ class OutRelatesFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-
-        return Fragments.isVertex(traversal).out(RELATES.getLabel());
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+        return traversal.out(RELATES.getLabel());
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/OutRelatesFragment.java
+++ b/graql/planning/gremlin/fragment/OutRelatesFragment.java
@@ -24,7 +24,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/OutRolePlayerFragment.java
+++ b/graql/planning/gremlin/fragment/OutRolePlayerFragment.java
@@ -25,7 +25,6 @@ import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.apache.tinkerpop.gremlin.structure.Edge;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/OutRolePlayerFragment.java
+++ b/graql/planning/gremlin/fragment/OutRolePlayerFragment.java
@@ -90,18 +90,16 @@ public class OutRolePlayerFragment extends AbstractRolePlayerFragment {
 
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
 
         return Fragments.union(traversal, ImmutableSet.of(
                 relationTraversal(conceptManager, vars)
         ));
     }
 
-    private GraphTraversal<Element, Vertex> relationTraversal(ConceptManager conceptManager, Collection<Variable> vars) {
-        GraphTraversal<Element, Vertex> traversal = Fragments.isVertex(__.identity());
-
-        GraphTraversal<Element, Edge> edgeTraversal = traversal.outE(ROLE_PLAYER.getLabel()).as(edge().symbol());
+    private GraphTraversal<Vertex, Vertex> relationTraversal(ConceptManager conceptManager, Collection<Variable> vars) {
+        GraphTraversal<Vertex, Edge> edgeTraversal = __.outE(ROLE_PLAYER.getLabel()).as(edge().symbol());
 
         // Filter by any provided type labels
         applyLabelsToTraversal(edgeTraversal, ROLE_LABEL_ID, roleLabels(), conceptManager);

--- a/graql/planning/gremlin/fragment/OutSubFragment.java
+++ b/graql/planning/gremlin/fragment/OutSubFragment.java
@@ -57,9 +57,9 @@ public class OutSubFragment extends EdgeFragment {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-        return Fragments.outSubs(Fragments.isVertex(traversal), this.subTraversalDepthLimit());
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+        return Fragments.outSubs(traversal, this.subTraversalDepthLimit());
     }
 
     @Override

--- a/graql/planning/gremlin/fragment/OutSubFragment.java
+++ b/graql/planning/gremlin/fragment/OutSubFragment.java
@@ -25,7 +25,6 @@ import grakn.core.kb.graql.planning.spanningtree.graph.SchemaNode;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/RegexFragment.java
+++ b/graql/planning/gremlin/fragment/RegexFragment.java
@@ -22,7 +22,6 @@ import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import graql.lang.util.StringUtil;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/RegexFragment.java
+++ b/graql/planning/gremlin/fragment/RegexFragment.java
@@ -44,9 +44,8 @@ class RegexFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
-
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.has(REGEX.name(), regex());
     }
 

--- a/graql/planning/gremlin/fragment/ValueFragment.java
+++ b/graql/planning/gremlin/fragment/ValueFragment.java
@@ -26,7 +26,6 @@ import grakn.core.kb.keyspace.KeyspaceStatistics;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/fragment/ValueFragment.java
+++ b/graql/planning/gremlin/fragment/ValueFragment.java
@@ -54,8 +54,8 @@ public class ValueFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return predicate().apply(traversal);
     }
 

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -45,8 +45,8 @@ class ValueTypeFragment extends FragmentImpl {
     }
 
     @Override
-    public GraphTraversal<Vertex, ? extends Element> applyTraversalInner(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
+    public GraphTraversal<Vertex, Vertex> applyTraversalInner(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager, Collection<Variable> vars) {
         return traversal.has(VALUE_TYPE.name(), valueType().name());
     }
 

--- a/graql/planning/gremlin/fragment/ValueTypeFragment.java
+++ b/graql/planning/gremlin/fragment/ValueTypeFragment.java
@@ -22,7 +22,6 @@ import grakn.core.kb.concept.manager.ConceptManager;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import javax.annotation.Nullable;

--- a/graql/planning/gremlin/sets/IsaFragmentSet.java
+++ b/graql/planning/gremlin/sets/IsaFragmentSet.java
@@ -19,7 +19,6 @@ package grakn.core.graql.planning.gremlin.sets;
 
 import com.google.common.collect.ImmutableSet;
 import grakn.core.graql.planning.gremlin.fragment.Fragments;
-import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.graql.planning.gremlin.Fragment;
 import graql.lang.property.VarProperty;
 import graql.lang.statement.Variable;
@@ -27,9 +26,6 @@ import graql.lang.statement.Variable;
 import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Set;
-
-import static grakn.core.graql.planning.gremlin.sets.EquivalentFragmentSets.fragmentSetOfType;
-import static grakn.core.graql.planning.gremlin.sets.EquivalentFragmentSets.labelOf;
 
 /**
  * see EquivalentFragmentSets#isa(VarProperty, Variable, Variable, boolean)

--- a/graql/planning/gremlin/sets/KeyFragmentSet.java
+++ b/graql/planning/gremlin/sets/KeyFragmentSet.java
@@ -19,9 +19,7 @@
 package grakn.core.graql.planning.gremlin.sets;
 
 import com.google.common.collect.ImmutableSet;
-import grakn.core.graql.planning.gremlin.fragment.InHasFragment;
 import grakn.core.graql.planning.gremlin.fragment.InKeyFragment;
-import grakn.core.graql.planning.gremlin.fragment.OutHasFragment;
 import grakn.core.graql.planning.gremlin.fragment.OutKeyFragment;
 import grakn.core.kb.graql.planning.gremlin.Fragment;
 import graql.lang.property.VarProperty;

--- a/graql/test/planning/gremlin/fragment/InPlaysFragmentTest.java
+++ b/graql/test/planning/gremlin/fragment/InPlaysFragmentTest.java
@@ -46,7 +46,6 @@ public class InPlaysFragmentTest {
         fragment.applyTraversalInner(traversal, null, ImmutableSet.of());
 
         GraphTraversal<Object, Object> expected = __.V()
-                .filter(e -> e.get() instanceof Edge)
                 .in(PLAYS.getLabel())
                 .union(__.<Vertex>not(__.has(THING_TYPE_LABEL_ID.name())).not(__.hasLabel(Schema.BaseType.SHARD.name())), __.<Vertex>until(__.loops().is(Fragments.TRAVERSE_ALL_SUB_EDGES)).repeat(__.in(SUB.getLabel())).emit()).unfold();;
 

--- a/graql/test/planning/gremlin/fragment/OutPlaysFragmentTest.java
+++ b/graql/test/planning/gremlin/fragment/OutPlaysFragmentTest.java
@@ -48,8 +48,6 @@ public class OutPlaysFragmentTest {
                         __.<Vertex>until(__.loops().is(Fragments.TRAVERSE_ALL_SUB_EDGES)).repeat(__.out(SUB.getLabel())).emit())
                 .unfold()
                 .out(PLAYS.getLabel());
-        // Make sure we check this is a vertex, then traverse upwards subs once and plays
-        // NB: we are using lambda filter steps now and these are not comparable
         assertEquals(expected.toString(), traversal.toString());
     }
 }

--- a/graql/test/planning/gremlin/fragment/OutPlaysFragmentTest.java
+++ b/graql/test/planning/gremlin/fragment/OutPlaysFragmentTest.java
@@ -39,13 +39,11 @@ public class OutPlaysFragmentTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testApplyTraversalFollowsSubsUpwards() {
-        // TODO fix this explicit cast when have a better testing mechanism for fragments
-        fragment = (FragmentImpl) Fragments.outPlays(null , start, end, false);
+        fragment = new OutPlaysFragment(null, start, end,false);
         GraphTraversal<Vertex, Vertex> traversal = __.V();
         fragment.applyTraversalInner(traversal, null, ImmutableSet.of());
 
         GraphTraversal<Object, Vertex> expected = __.V()
-                .filter(e -> e.get() instanceof Vertex)
                 .union(__.<Vertex>not(__.has(THING_TYPE_LABEL_ID.name())).not(__.hasLabel(Schema.BaseType.SHARD.name())),
                         __.<Vertex>until(__.loops().is(Fragments.TRAVERSE_ALL_SUB_EDGES)).repeat(__.out(SUB.getLabel())).emit())
                 .unfold()

--- a/kb/graql/planning/gremlin/Fragment.java
+++ b/kb/graql/planning/gremlin/Fragment.java
@@ -102,11 +102,11 @@ public interface Fragment {
     /**
      * @param traversal the traversal to extend with this Fragment
      */
-    GraphTraversal<Vertex, ? extends Element> applyTraversal(
-            GraphTraversal<Vertex, ? extends Element> traversal, ConceptManager conceptManager,
+    GraphTraversal<Vertex, Vertex> applyTraversal(
+            GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager,
             Collection<Variable> vars, Variable currentVar);
 
-    GraphTraversal<Vertex, ? extends Element> selectVariable(GraphTraversal<Vertex, ? extends Element> traversal);
+    GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal);
 
     /**
      * The name of the fragment

--- a/kb/graql/planning/gremlin/Fragment.java
+++ b/kb/graql/planning/gremlin/Fragment.java
@@ -106,8 +106,6 @@ public interface Fragment {
             GraphTraversal<Vertex, Vertex> traversal, ConceptManager conceptManager,
             Collection<Variable> vars, Variable currentVar);
 
-    GraphTraversal<Vertex, Vertex> selectVariable(GraphTraversal<Vertex, Vertex> traversal);
-
     /**
      * The name of the fragment
      */

--- a/test/integration/graql/query/GraqlInsertIT.java
+++ b/test/integration/graql/query/GraqlInsertIT.java
@@ -33,7 +33,6 @@ import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -52,10 +51,7 @@ import static grakn.core.test.common.GraqlTestUtil.assertNotExists;
 import static graql.lang.Graql.type;
 import static graql.lang.Graql.var;
 import static graql.lang.exception.ErrorMessage.NO_PATTERNS;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.isOneOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "Duplicates"})
 public class GraqlInsertIT {
@@ -80,7 +76,7 @@ public class GraqlInsertIT {
     @BeforeClass
     public static void newSession() {
         session = graknServer.sessionWithNewKeyspace();
-//        MovieGraph.load(session);
+        MovieGraph.load(session);
     }
 
     @Before
@@ -97,75 +93,6 @@ public class GraqlInsertIT {
     public static void closeSession() {
         session.close();
     }
-
-    @Test
-    public void test() {
-        tx.execute(Graql.parse("define\n" +
-                "\n" +
-                "closed_space sub entity,\n" +
-                "    plays from_space,\n" +
-                "    plays to_space;\n" +
-                "\n" +
-                "kitchen sub closed_space;\n" +
-                "living sub closed_space;\n" +
-                "hall sub closed_space;\n" +
-                "\n" +
-                "door sub entity,\n" +
-                "    plays connection;\n" +
-                "living_door sub door;\n" +
-                "kitchen_door sub door;\n" +
-                "\n" +
-                "closed_space_connecting sub relation,\n" +
-                "    relates connection,\n" +
-                "    relates from_space,\n" +
-                "    relates to_space;").asDefine());
-        tx.execute(Graql.parse("insert\n" +
-                "$l isa living;\n" +
-                "$k isa kitchen;\n" +
-                "$h isa hall;\n" +
-                "$ld isa living_door;\n" +
-                "$kd isa kitchen_door;\n" +
-                "(from_space: $l, to_space: $h, connection: $ld) isa closed_space_connecting;\n" +
-                "(from_space: $h, to_space: $l, connection: $ld) isa closed_space_connecting;\n" +
-                "\n" +
-                "(from_space: $k, to_space: $h, connection: $kd) isa closed_space_connecting;\n" +
-                "(from_space: $h, to_space: $k, connection: $kd) isa closed_space_connecting;").asInsert());
-        tx.commit();
-
-
-        newTransaction();
-        List<ConceptMap> answers = tx.execute(Graql.parse("match\n" +
-                "$x isa closed_space;\n" +
-                "$y isa closed_space;\n" +
-                "$z isa closed_space;\n" +
-                "$d1 isa door;\n" +
-                "$d2 isa door;\n" +
-                "(from_space: $x, to_space: $y, connection: $d1) isa closed_space_connecting;\n" +
-                "(from_space: $y, to_space: $z, connection: $d2) isa closed_space_connecting;\n" +
-                "$x != $z;\n" +
-                "get $x, $z;").asGet());
-        System.out.println(answers);
-        tx.close();
-
-        newTransaction();
-        List<ConceptMap> insertAnswers = tx.execute(Graql.parse("match\n" +
-                "$x isa closed_space;\n" +
-                "$y isa closed_space;\n" +
-                "$z isa closed_space;\n" +
-                "$d1 isa door;\n" +
-                "$d2 isa door;\n" +
-                "(from_space: $x, to_space: $y, connection: $d1) isa closed_space_connecting;\n" +
-                "(from_space: $y, to_space: $z, connection: $d2) isa closed_space_connecting;\n" +
-                "$x != $z;\n" +
-                "#$d1 != $d2;\n" +
-                "insert (from_space: $x, to_space: $z, connection: $d1, connection: $d2) isa closed_space_connecting;").asInsert());
-
-        for (ConceptMap ans : insertAnswers) {
-            String xLabel = ans.get("x").asThing().type().label().toString();
-            assertTrue(xLabel.equals("kitchen") || xLabel.equals("living"));
-        }
-    }
-
 
     @Test
     public void testMatchInsertShouldInsertDataEvenWhenResultsAreNotCollected() {
@@ -311,7 +238,7 @@ public class GraqlInsertIT {
             assertExists(tx, var);
         }
 
-        for (Statement statement : vars) {
+        for (Statement statement: vars) {
             tx.execute(Graql.match(statement).delete(Graql.var(statement.var()).isa("thing")));
         }
 

--- a/test/integration/graql/query/GraqlInsertIT.java
+++ b/test/integration/graql/query/GraqlInsertIT.java
@@ -33,6 +33,7 @@ import graql.lang.statement.Statement;
 import graql.lang.statement.Variable;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -51,7 +52,10 @@ import static grakn.core.test.common.GraqlTestUtil.assertNotExists;
 import static graql.lang.Graql.type;
 import static graql.lang.Graql.var;
 import static graql.lang.exception.ErrorMessage.NO_PATTERNS;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings({"OptionalGetWithoutIsPresent", "Duplicates"})
 public class GraqlInsertIT {
@@ -96,55 +100,70 @@ public class GraqlInsertIT {
 
     @Test
     public void test() {
-        try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            tx.execute(Graql.parse("define\n" +
-                    "\n" +
-                    "closed_space sub entity,\n" +
-                    "    plays from_space,\n" +
-                    "    plays to_space;\n" +
-                    "\n" +
-                    "kitchen sub closed_space;\n" +
-                    "living sub closed_space;\n" +
-                    "hall sub closed_space;\n" +
-                    "\n" +
-                    "door sub entity,\n" +
-                    "    plays connection;\n" +
-                    "living_door sub door;\n" +
-                    "kitchen_door sub door;\n" +
-                    "\n" +
-                    "closed_space_connecting sub relation,\n" +
-                    "    relates connection,\n" +
-                    "    relates from_space,\n" +
-                    "    relates to_space;").asDefine());
-            tx.execute(Graql.parse("insert\n" +
-                    "$l isa living;\n" +
-                    "$k isa kitchen;\n" +
-                    "$h isa hall;\n" +
-                    "$ld isa living_door;\n" +
-                    "$kd isa kitchen_door;\n" +
-                    "(from_space: $l, to_space: $h, connection: $ld) isa closed_space_connecting;\n" +
-                    "(from_space: $h, to_space: $l, connection: $ld) isa closed_space_connecting;\n" +
-                    "\n" +
-                    "(from_space: $k, to_space: $h, connection: $kd) isa closed_space_connecting;\n" +
-                    "(from_space: $h, to_space: $k, connection: $kd) isa closed_space_connecting;").asInsert());
-            tx.commit();
+        tx.execute(Graql.parse("define\n" +
+                "\n" +
+                "closed_space sub entity,\n" +
+                "    plays from_space,\n" +
+                "    plays to_space;\n" +
+                "\n" +
+                "kitchen sub closed_space;\n" +
+                "living sub closed_space;\n" +
+                "hall sub closed_space;\n" +
+                "\n" +
+                "door sub entity,\n" +
+                "    plays connection;\n" +
+                "living_door sub door;\n" +
+                "kitchen_door sub door;\n" +
+                "\n" +
+                "closed_space_connecting sub relation,\n" +
+                "    relates connection,\n" +
+                "    relates from_space,\n" +
+                "    relates to_space;").asDefine());
+        tx.execute(Graql.parse("insert\n" +
+                "$l isa living;\n" +
+                "$k isa kitchen;\n" +
+                "$h isa hall;\n" +
+                "$ld isa living_door;\n" +
+                "$kd isa kitchen_door;\n" +
+                "(from_space: $l, to_space: $h, connection: $ld) isa closed_space_connecting;\n" +
+                "(from_space: $h, to_space: $l, connection: $ld) isa closed_space_connecting;\n" +
+                "\n" +
+                "(from_space: $k, to_space: $h, connection: $kd) isa closed_space_connecting;\n" +
+                "(from_space: $h, to_space: $k, connection: $kd) isa closed_space_connecting;").asInsert());
+        tx.commit();
+
+
+        newTransaction();
+        List<ConceptMap> answers = tx.execute(Graql.parse("match\n" +
+                "$x isa closed_space;\n" +
+                "$y isa closed_space;\n" +
+                "$z isa closed_space;\n" +
+                "$d1 isa door;\n" +
+                "$d2 isa door;\n" +
+                "(from_space: $x, to_space: $y, connection: $d1) isa closed_space_connecting;\n" +
+                "(from_space: $y, to_space: $z, connection: $d2) isa closed_space_connecting;\n" +
+                "$x != $z;\n" +
+                "get $x, $z;").asGet());
+        System.out.println(answers);
+        tx.close();
+
+        newTransaction();
+        List<ConceptMap> insertAnswers = tx.execute(Graql.parse("match\n" +
+                "$x isa closed_space;\n" +
+                "$y isa closed_space;\n" +
+                "$z isa closed_space;\n" +
+                "$d1 isa door;\n" +
+                "$d2 isa door;\n" +
+                "(from_space: $x, to_space: $y, connection: $d1) isa closed_space_connecting;\n" +
+                "(from_space: $y, to_space: $z, connection: $d2) isa closed_space_connecting;\n" +
+                "$x != $z;\n" +
+                "#$d1 != $d2;\n" +
+                "insert (from_space: $x, to_space: $z, connection: $d1, connection: $d2) isa closed_space_connecting;").asInsert());
+
+        for (ConceptMap ans : insertAnswers) {
+            String xLabel = ans.get("x").asThing().type().label().toString();
+            assertTrue(xLabel.equals("kitchen") || xLabel.equals("living"));
         }
-
-        try (Transaction tx = session.transaction(Transaction.Type.WRITE)) {
-            List<ConceptMap> answers = tx.execute(Graql.parse("match\n" +
-                    "$x isa closed_space;\n" +
-                    "$y isa closed_space;\n" +
-                    "$z isa closed_space;\n" +
-                    "$d1 isa door;\n" +
-                    "$d2 isa door;\n" +
-                    "(from_space: $x, to_space: $y, connection: $d1) isa closed_space_connecting;\n" +
-                    "(from_space: $y, to_space: $z, connection: $d2) isa closed_space_connecting;\n" +
-                    "$x != $z;\n" +
-                    "get $x, $z;").asGet());
-            System.out.println(answers);
-        }
-
-
     }
 
 


### PR DESCRIPTION
## What is the goal of this PR?
To simplify the understanding and usability of fragments, and gremlin traversals, we specialise generics and and remove the previously required `Fragments.isVertex(traversal)` calls.

One consequence is that we break Generic type safety in `NeqFragment`, where the traversal may be on an `Edge`, not guaranteed a `Vertex`.

## What are the changes implemented in this PR?
* Fix generics like `? extends Element` to `Vertex` - removing reified attribute relations means we no longer have to operate over edges analogously to Vertices
* Remove the then-redundant operations `Fragments.isVertex(traversal)`, and a bunch of other extra traversal steps we no longer require