### PR TITLE
Remove sync-dependencies from workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -956,7 +956,7 @@ workflows:
                 - rewrite
           requires:
             - deploy-rpm-snapshot
-      - sync-dependencies-snapshot:
+      - release-approval:
           filters:
             branches:
               only:
@@ -965,13 +965,6 @@ workflows:
             - deploy-artifact-snapshot
             - test-deployment-linux-apt
             - test-deployment-linux-rpm
-      - release-approval:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - sync-dependencies-snapshot
 
   grakn-core-release:
     jobs:
@@ -1022,7 +1015,7 @@ workflows:
               only: grakn-release-branch
           requires:
             - deploy-approval
-      - sync-dependencies-release:
+      - release-notification:
           filters:
             branches:
               only: grakn-release-branch
@@ -1031,12 +1024,6 @@ workflows:
             - deploy-rpm
             - deploy-brew
             - deploy-docker
-      - release-notification:
-          filters:
-            branches:
-              only: grakn-release-branch
-          requires:
-            - sync-dependencies-release
       - release-cleanup:
           filters:
             branches:


### PR DESCRIPTION
## What is the goal of this PR?

We have removed sync-dependencies completely. It will be replaced by Grabl 2.0's sync pipeline soon.