### PR TITLE
Update to common 0.2.4 and use console 1.0.8 artifact

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,12 @@ workflows:
     jobs:
       - deploy-apt-snapshot
       - deploy-rpm-snapshot
+      - test-deployment-linux-apt:
+          requires:
+            - deploy-apt-snapshot
+      - test-deployment-linux-rpm:
+          requires:
+            - deploy-rpm-snapshot
 #   grakn-core:
 #     jobs:
 #       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,172 +458,168 @@ jobs:
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/grakn $CIRCLE_BRANCH
 
 workflows:
-  test:
+  grakn-core:
     jobs:
-      - deploy-apt-snapshot
-      - deploy-rpm-snapshot
-#   grakn-core:
-#     jobs:
-#       - build:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - build-checkstyle:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - build-analysis:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#       - test-common:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - test-server:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - test-graql:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - test-behaviour:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - test-integration:
-#           filters:
-#             branches:
-#               ignore: grakn-release-branch
-#       - test-assembly:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-#             - build
-#             - build-checkstyle
-#             - build-analysis
-#             - test-common
-#             - test-server
-#             - test-graql
-#             - test-behaviour
-#             - test-integration
-# #      - test-assembly-mac-zip:
-# #          filters:
-# #            branches:
-# #              only:
-# #                - master
-# #          requires:
-# #            - build
-# #            - build-checkstyle
-# #            - build-analysis
-# #            - test-common
-# #            - test-server
-# #            - test-graql
-# #            - test-behaviour
-# #            - test-integration
-# #      - test-assembly-windows-zip:
-# #          filters:
-# #            branches:
-# #              only:
-# #                - master
-# #          requires:
-# #            - build
-# #            - build-checkstyle
-# #            - build-analysis
-# #            - test-common
-# #            - test-server
-# #            - test-graql
-# #            - test-behaviour
-# #            - test-integration
-# #      - test-assembly-linux-targz:
-# #          filters:
-# #            branches:
-# #              only:
-# #                - master
-# #          requires:
-# #            - build
-# #            - build-checkstyle
-# #            - build-analysis
-# #            - test-common
-# #            - test-server
-# #            - test-graql
-# #            - test-behaviour
-# #            - test-integration
-# #      - test-assembly-docker:
-# #          filters:
-# #            branches:
-# #              only:
-# #                - master
-# #          requires:
-# #            - build
-# #            - build-checkstyle
-# #            - build-analysis
-# #            - test-common
-# #            - test-server
-# #            - test-graql
-# #            - test-behaviour
-# #            - test-integration
-#       - deploy-artifact-snapshot:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#                 - rewrite
-#           requires:
-# #            - test-assembly-mac-zip
-# #            - test-assembly-windows-zip
-# #            - test-assembly-linux-targz
-# #            - test-assembly-docker
-#             - test-assembly
-#       - deploy-apt-snapshot:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-# #            - test-assembly-mac-zip
-# #            - test-assembly-windows-zip
-# #            - test-assembly-linux-targz
-# #            - test-assembly-docker
-#             - test-assembly
-#       - deploy-rpm-snapshot:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-# #            - test-assembly-mac-zip
-# #            - test-assembly-windows-zip
-# #            - test-assembly-linux-targz
-# #            - test-assembly-docker
-#             - test-assembly
-#       - test-deployment-linux-apt:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-#             - deploy-apt-snapshot
-#       - test-deployment-linux-rpm:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-#             - deploy-rpm-snapshot
-#       - release-approval:
-#           filters:
-#             branches:
-#               only:
-#                 - master
-#           requires:
-#             - deploy-artifact-snapshot
-#             - test-deployment-linux-apt
-#             - test-deployment-linux-rpm
+      - build:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - build-checkstyle:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - build-analysis:
+          filters:
+            branches:
+              only:
+                - master
+      - test-common:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-server:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-graql:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-behaviour:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-integration:
+          filters:
+            branches:
+              ignore: grakn-release-branch
+      - test-assembly:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - build
+            - build-checkstyle
+            - build-analysis
+            - test-common
+            - test-server
+            - test-graql
+            - test-behaviour
+            - test-integration
+#      - test-assembly-mac-zip:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#          requires:
+#            - build
+#            - build-checkstyle
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-graql
+#            - test-behaviour
+#            - test-integration
+#      - test-assembly-windows-zip:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#          requires:
+#            - build
+#            - build-checkstyle
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-graql
+#            - test-behaviour
+#            - test-integration
+#      - test-assembly-linux-targz:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#          requires:
+#            - build
+#            - build-checkstyle
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-graql
+#            - test-behaviour
+#            - test-integration
+#      - test-assembly-docker:
+#          filters:
+#            branches:
+#              only:
+#                - master
+#          requires:
+#            - build
+#            - build-checkstyle
+#            - build-analysis
+#            - test-common
+#            - test-server
+#            - test-graql
+#            - test-behaviour
+#            - test-integration
+      - deploy-artifact-snapshot:
+          filters:
+            branches:
+              only:
+                - master
+                - rewrite
+          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+            - test-assembly
+      - deploy-apt-snapshot:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+            - test-assembly
+      - deploy-rpm-snapshot:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+#            - test-assembly-mac-zip
+#            - test-assembly-windows-zip
+#            - test-assembly-linux-targz
+#            - test-assembly-docker
+            - test-assembly
+      - test-deployment-linux-apt:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - deploy-apt-snapshot
+      - test-deployment-linux-rpm:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - deploy-rpm-snapshot
+      - release-approval:
+          filters:
+            branches:
+              only:
+                - master
+          requires:
+            - deploy-artifact-snapshot
+            - test-deployment-linux-apt
+            - test-deployment-linux-rpm
 
   grakn-core-release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,12 +462,6 @@ workflows:
     jobs:
       - deploy-apt-snapshot
       - deploy-rpm-snapshot
-      - test-deployment-linux-apt:
-          requires:
-            - deploy-apt-snapshot
-      - test-deployment-linux-rpm:
-          requires:
-            - deploy-rpm-snapshot
 #   grakn-core:
 #     jobs:
 #       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,8 +275,9 @@ jobs:
       - run: echo 0.0.0-$CIRCLE_SHA1 > VERSION && cat VERSION
       - run: bazel run //test/deployment/apt:install
       - run: sudo chown -R circleci:circleci /opt/grakn/ # TODO: how do we avoid having to chown?
-      - run: nohup grakn server start
-      - run: grakn console  # we consider being able to start console a sufficient test
+      - run: |
+          nohup grakn server start
+          echo 'exit' | grakn console  # we consider being able to start console a sufficient test
       - run: grakn server stop
       - store_artifacts:
           path: /opt/grakn/core/logs/grakn.log

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,168 +457,172 @@ jobs:
       - run: git push --delete https://$REPO_GITHUB_TOKEN@github.com/graknlabs/grakn $CIRCLE_BRANCH
 
 workflows:
-  grakn-core:
+  test:
     jobs:
-      - build:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - build-checkstyle:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - build-analysis:
-          filters:
-            branches:
-              only:
-                - master
-      - test-common:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-server:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-graql:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-behaviour:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-integration:
-          filters:
-            branches:
-              ignore: grakn-release-branch
-      - test-assembly:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - build
-            - build-checkstyle
-            - build-analysis
-            - test-common
-            - test-server
-            - test-graql
-            - test-behaviour
-            - test-integration
-#      - test-assembly-mac-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#          requires:
-#            - build
-#            - build-checkstyle
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-graql
-#            - test-behaviour
-#            - test-integration
-#      - test-assembly-windows-zip:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#          requires:
-#            - build
-#            - build-checkstyle
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-graql
-#            - test-behaviour
-#            - test-integration
-#      - test-assembly-linux-targz:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#          requires:
-#            - build
-#            - build-checkstyle
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-graql
-#            - test-behaviour
-#            - test-integration
-#      - test-assembly-docker:
-#          filters:
-#            branches:
-#              only:
-#                - master
-#          requires:
-#            - build
-#            - build-checkstyle
-#            - build-analysis
-#            - test-common
-#            - test-server
-#            - test-graql
-#            - test-behaviour
-#            - test-integration
-      - deploy-artifact-snapshot:
-          filters:
-            branches:
-              only:
-                - master
-                - rewrite
-          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-            - test-assembly
-      - deploy-apt-snapshot:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-            - test-assembly
-      - deploy-rpm-snapshot:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-#            - test-assembly-mac-zip
-#            - test-assembly-windows-zip
-#            - test-assembly-linux-targz
-#            - test-assembly-docker
-            - test-assembly
-      - test-deployment-linux-apt:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - deploy-apt-snapshot
-      - test-deployment-linux-rpm:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - deploy-rpm-snapshot
-      - release-approval:
-          filters:
-            branches:
-              only:
-                - master
-          requires:
-            - deploy-artifact-snapshot
-            - test-deployment-linux-apt
-            - test-deployment-linux-rpm
+      - deploy-apt-snapshot
+      - deploy-rpm-snapshot
+#   grakn-core:
+#     jobs:
+#       - build:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - build-checkstyle:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - build-analysis:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#       - test-common:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - test-server:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - test-graql:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - test-behaviour:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - test-integration:
+#           filters:
+#             branches:
+#               ignore: grakn-release-branch
+#       - test-assembly:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+#             - build
+#             - build-checkstyle
+#             - build-analysis
+#             - test-common
+#             - test-server
+#             - test-graql
+#             - test-behaviour
+#             - test-integration
+# #      - test-assembly-mac-zip:
+# #          filters:
+# #            branches:
+# #              only:
+# #                - master
+# #          requires:
+# #            - build
+# #            - build-checkstyle
+# #            - build-analysis
+# #            - test-common
+# #            - test-server
+# #            - test-graql
+# #            - test-behaviour
+# #            - test-integration
+# #      - test-assembly-windows-zip:
+# #          filters:
+# #            branches:
+# #              only:
+# #                - master
+# #          requires:
+# #            - build
+# #            - build-checkstyle
+# #            - build-analysis
+# #            - test-common
+# #            - test-server
+# #            - test-graql
+# #            - test-behaviour
+# #            - test-integration
+# #      - test-assembly-linux-targz:
+# #          filters:
+# #            branches:
+# #              only:
+# #                - master
+# #          requires:
+# #            - build
+# #            - build-checkstyle
+# #            - build-analysis
+# #            - test-common
+# #            - test-server
+# #            - test-graql
+# #            - test-behaviour
+# #            - test-integration
+# #      - test-assembly-docker:
+# #          filters:
+# #            branches:
+# #              only:
+# #                - master
+# #          requires:
+# #            - build
+# #            - build-checkstyle
+# #            - build-analysis
+# #            - test-common
+# #            - test-server
+# #            - test-graql
+# #            - test-behaviour
+# #            - test-integration
+#       - deploy-artifact-snapshot:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#                 - rewrite
+#           requires:
+# #            - test-assembly-mac-zip
+# #            - test-assembly-windows-zip
+# #            - test-assembly-linux-targz
+# #            - test-assembly-docker
+#             - test-assembly
+#       - deploy-apt-snapshot:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+# #            - test-assembly-mac-zip
+# #            - test-assembly-windows-zip
+# #            - test-assembly-linux-targz
+# #            - test-assembly-docker
+#             - test-assembly
+#       - deploy-rpm-snapshot:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+# #            - test-assembly-mac-zip
+# #            - test-assembly-windows-zip
+# #            - test-assembly-linux-targz
+# #            - test-assembly-docker
+#             - test-assembly
+#       - test-deployment-linux-apt:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+#             - deploy-apt-snapshot
+#       - test-deployment-linux-rpm:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+#             - deploy-rpm-snapshot
+#       - release-approval:
+#           filters:
+#             branches:
+#               only:
+#                 - master
+#           requires:
+#             - deploy-artifact-snapshot
+#             - test-deployment-linux-apt
+#             - test-deployment-linux-rpm
 
   grakn-core-release:
     jobs:

--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -22,5 +22,5 @@ def graknlabs_console_artifact():
         name = "graknlabs_console_artifact",
         group_name = "graknlabs_console",
         artifact_name = "console-artifact.tgz",
-        tag = "1.0.7",
+        commit = "bb2af3c18a0beafd7371ac0461174d1d302baa32",
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,14 +21,14 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "7cc32e645201ef2c1e049c15ba2c108b17a80330",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "de4bc25bfbc7f640ac82cea9c629d51596479134",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        tag = "0.2.3" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        tag = "0.2.4" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_graql():

--- a/test/deployment/rpm/test.py
+++ b/test/deployment/rpm/test.py
@@ -115,7 +115,7 @@ try:
 
     gcloud_ssh(instance, 'grakn server start')
     # start console, should be good enough to confirm server starts and server starts
-    gcloud_ssh(instance, 'grakn console')
+    gcloud_ssh(instance, 'echo "exit" | grakn console')
     gcloud_ssh(instance, 'grakn server stop')
 
 finally:


### PR DESCRIPTION
## What is the goal of this PR?
Update to common 0.2.4 and use console 1.0.8 artifact, still ignoring assembly tests while allowing rpm and apt-deploymeny tests to continue in a basic form by booting console only.

## What are the changes implemented in this PR?
* Source the `grakn-bin` artifacts correctly from a deployed `commmon` version 0.2.4
* Use a new `console` 1.0.8 artifact for deployment tests in rpm and apt
* Fix errors in the deployment tests that prevented them from running console successfully
