### PR TITLE
Fix data being cleaned on every upgrade

### DIFF
--- a/config/brew/grakn-core.rb
+++ b/config/brew/grakn-core.rb
@@ -8,20 +8,18 @@ class GraknCore < Formula
 
   depends_on :java => "1.8"
 
+  def setup_directory(dir)
+    grakn_dir = var/name/dir
+    grakn_dir.mkpath
+    orig_dir = libexec/"server"/dir
+    rm_rf orig_dir
+    ln_s grakn_dir, orig_dir
+  end
+
   def install
-    # unpack Grakn Core distribution
     libexec.install Dir["*"]
-    # set up db directory
-    dbpath = (var/name/"db/")
-    dbpath.mkpath
-    rm_rf libexec/"server/db"
-    ln_s dbpath, libexec/"server/db"
-    # set up logs directory
-    logpath = (var/name/"log/")
-    logpath.mkpath
-    rm_rf libexec/"server/logs"
-    ln_s logpath, libexec/"server/logs"
-    # install grakn as system-wide command
+    setup_directory "db"
+    setup_directory "logs" 
     bin.install libexec/"grakn"
     bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
   end
@@ -30,3 +28,4 @@ class GraknCore < Formula
     assert_match /RUNNING/i, shell_output("#{bin}/grakn server status")
   end
 end
+

--- a/config/brew/grakn-core.rb
+++ b/config/brew/grakn-core.rb
@@ -10,6 +10,14 @@ class GraknCore < Formula
 
   def install
     libexec.install Dir["*"]
+    dbpath = (var/name/"db/")
+    dbpath.mkpath
+    logpath = (var/name/"log/")
+    logpath.mkpath
+    rm_rf libexec/"server/db"
+    rm_rf libexec/"server/logs"
+    ln_s dbpath, libexec/"server/db"
+    ln_s logpath, libexec/"server/logs"
     bin.install libexec/"grakn"
     bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
   end

--- a/config/brew/grakn-core.rb
+++ b/config/brew/grakn-core.rb
@@ -9,15 +9,19 @@ class GraknCore < Formula
   depends_on :java => "1.8"
 
   def install
+    # unpack Grakn Core distribution
     libexec.install Dir["*"]
+    # set up db directory
     dbpath = (var/name/"db/")
     dbpath.mkpath
+    rm_rf libexec/"server/db"
+    ln_s dbpath, libexec/"server/db"
+    # set up logs directory
     logpath = (var/name/"log/")
     logpath.mkpath
-    rm_rf libexec/"server/db"
     rm_rf libexec/"server/logs"
-    ln_s dbpath, libexec/"server/db"
     ln_s logpath, libexec/"server/logs"
+    # install grakn as system-wide command
     bin.install libexec/"grakn"
     bin.env_script_all_files(libexec, Language::Java.java_home_env("1.8"))
   end


### PR DESCRIPTION
## What is the goal of this PR?

Fix #5882 

Previously, every update/reinstall of `grakn-core` formula would lead to cleaning of Grakn data, which is obvously an undesired experience.

## What are the changes implemented in this PR?

On installing, create separate directories for logs and data and symlink default directories to them