### PR TITLE
changed all occurrences of "predicateVar" to "typeVar"

### DIFF
--- a/graql/reasoner/atom/Atom.java
+++ b/graql/reasoner/atom/Atom.java
@@ -281,7 +281,7 @@ public abstract class Atom extends AtomicBase {
     /**
      * @return value variable name
      */
-    public abstract Variable getPredicateVariable();
+    public abstract Variable getTypeVariable();
 
     public abstract Stream<Predicate> getInnerPredicates();
 
@@ -390,8 +390,8 @@ public abstract class Atom extends AtomicBase {
      * @return rewritten atom
      */
     public Atom rewriteWithTypeVariable(Atom parentAtom) {
-        if (parentAtom.getPredicateVariable().isReturned()
-                && !this.getPredicateVariable().isReturned()
+        if (parentAtom.getTypeVariable().isReturned()
+                && !this.getTypeVariable().isReturned()
                 && this.getClass() == parentAtom.getClass()) {
             return rewriteWithTypeVariable();
         }

--- a/graql/reasoner/atom/binary/AttributeAtom.java
+++ b/graql/reasoner/atom/binary/AttributeAtom.java
@@ -83,7 +83,7 @@ import static grakn.core.graql.reasoner.utils.ReasonerUtils.isEquivalentCollecti
  * or in graql terms:
  *
  * $varName has <type> $attributeVariable;
- * $attributeVariable isa $predicateVariable; [$predicateVariable/<type id>]
+ * $attributeVariable isa $typeVariable; [$typeVariable/<type id>]
  *
  * </p>
  *
@@ -106,13 +106,13 @@ public class AttributeAtom extends Atom{
             Statement pattern,
             ReasonerQuery parentQuery,
             @Nullable Label label,
-            Variable predicateVariable,
+            Variable typeVariable,
             Variable attributeVariable,
             ImmutableSet<ValuePredicate> multiPredicate,
             ReasoningContext ctx) {
         super(parentQuery, varName, pattern, label, ctx);
         this.ownerIsa = IsaAtom.create(varName, new Variable(), label, false, parentQuery, ctx);
-        this.attributeIsa = IsaAtom.create(attributeVariable, predicateVariable, label, false, parentQuery, ctx);
+        this.attributeIsa = IsaAtom.create(attributeVariable, typeVariable, label, false, parentQuery, ctx);
         this.attributeVariable = attributeVariable;
         this.multiPredicate = multiPredicate;
     }
@@ -125,14 +125,14 @@ public class AttributeAtom extends Atom{
     }
 
     public static AttributeAtom create(Statement pattern, Variable attributeVariable,
-                                       Variable predicateVariable, @Nullable Label label,
+                                       Variable typeVariable, @Nullable Label label,
                                        Set<ValuePredicate> ps, ReasonerQuery parent, ReasoningContext ctx) {
-        return new AttributeAtom(pattern.var(), pattern, parent, label, predicateVariable,
+        return new AttributeAtom(pattern.var(), pattern, parent, label, typeVariable,
                 attributeVariable, ImmutableSet.copyOf(ps), ctx);
     }
 
     private static AttributeAtom create(AttributeAtom a, ReasonerQuery parent) {
-        return create(a.getPattern(), a.getAttributeVariable(), a.getPredicateVariable(),
+        return create(a.getPattern(), a.getAttributeVariable(), a.getTypeVariable(),
                 a.getTypeLabel(), a.getMultiPredicate(), parent, a.context());
     }
 
@@ -154,7 +154,7 @@ public class AttributeAtom extends Atom{
             ValueProperty.Operation operation = ValueProperty.Operation.Comparison.of(vp.getPredicate().comparator(), convertedValue);
             return ValuePredicate.create(vp.getVarName(), operation, getParentQuery());
         }).collect(Collectors.toSet());
-        return create(getPattern(), getAttributeVariable(), getPredicateVariable(),
+        return create(getPattern(), getAttributeVariable(), getTypeVariable(),
                 getTypeLabel(), newMultiPredicate, getParentQuery(), context());
     }
 
@@ -199,8 +199,8 @@ public class AttributeAtom extends Atom{
     }
 
     @Override
-    public Variable getPredicateVariable() {
-        return attributeIsa.getPredicateVariable();
+    public Variable getTypeVariable() {
+        return attributeIsa.getTypeVariable();
     }
 
     @Override
@@ -362,7 +362,7 @@ public class AttributeAtom extends Atom{
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getPattern(), getAttributeVariable(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getMultiPredicate(), getParentQuery(), context());
+        return create(getPattern(), getAttributeVariable(), getTypeVariable().asReturnedVar(), getTypeLabel(), getMultiPredicate(), getParentQuery(), context());
     }
 
     @Override

--- a/graql/reasoner/atom/binary/IsaAtom.java
+++ b/graql/reasoner/atom/binary/IsaAtom.java
@@ -61,21 +61,21 @@ public class IsaAtom extends TypeAtom {
     private int hashCode;
     private boolean hashCodeMemoised;
 
-    private IsaAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label, Variable predicateVariable,
+    private IsaAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label, Variable typeVariable,
                     ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
+        super(varName, pattern, reasonerQuery, label, typeVariable, ctx);
     }
 
-    public static IsaAtom create(Variable var, Variable predicateVar, @Nullable Label label, boolean isDirect, ReasonerQuery parent,
+    public static IsaAtom create(Variable var, Variable typeVar, @Nullable Label label, boolean isDirect, ReasonerQuery parent,
                                  ReasoningContext ctx) {
         Statement pattern = isDirect?
-                new Statement(var).isaX(new Statement(predicateVar)) :
-                new Statement(var).isa(new Statement(predicateVar));
-        return new IsaAtom(var, pattern, parent, label, predicateVar, ctx);
+                new Statement(var).isaX(new Statement(typeVar)) :
+                new Statement(var).isa(new Statement(typeVar));
+        return new IsaAtom(var, pattern, parent, label, typeVar, ctx);
     }
 
     private static IsaAtom create(IsaAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), a.isDirect(), parent, a.context());
+        return create(a.getVarName(), a.getTypeVariable(), a.getTypeLabel(), a.isDirect(), parent, a.context());
     }
 
     @Override
@@ -116,16 +116,16 @@ public class IsaAtom extends TypeAtom {
         Label typeLabel = getTypeLabel();
         String typeString = (typeLabel != null? typeLabel : "") + "(" + getVarName() + ")";
         return typeString +
-                (getPredicateVariable().isReturned()? "(" + getPredicateVariable() + ")" : "") +
+                (getTypeVariable().isReturned()? "(" + getTypeVariable() + ")" : "") +
                 (isDirect()? "!" : "") +
                 getPredicates().map(Predicate::toString).collect(Collectors.joining(""));
     }
 
     @Override
     protected Pattern createCombinedPattern(){
-        if (getPredicateVariable().isReturned()) return super.createCombinedPattern();
+        if (getTypeVariable().isReturned()) return super.createCombinedPattern();
         return getTypeLabel() == null?
-                new Statement(getVarName()).isa(new Statement(getPredicateVariable())) :
+                new Statement(getVarName()).isa(new Statement(getTypeVariable())) :
                 isDirect()?
                         new Statement(getVarName()).isaX(getTypeLabel().getValue()) :
                         new Statement(getVarName()).isa(getTypeLabel().getValue()) ;
@@ -134,7 +134,7 @@ public class IsaAtom extends TypeAtom {
     @Override
     public IsaAtom addType(SchemaConcept type) {
         if (getTypeLabel() != null) return this;
-        return create(getVarName(), getPredicateVariable(), type.label(), this.isDirect(), this.getParentQuery(), this.context());
+        return create(getVarName(), getTypeVariable(), type.label(), this.isDirect(), this.getParentQuery(), this.context());
     }
 
     @Override
@@ -165,7 +165,7 @@ public class IsaAtom extends TypeAtom {
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getVarName(), getPredicateVariable().asReturnedVar(), getTypeLabel(), this.isDirect(), getParentQuery(), this.context());
+        return create(getVarName(), getTypeVariable().asReturnedVar(), getTypeLabel(), this.isDirect(), getParentQuery(), this.context());
     }
 
     @Override
@@ -192,7 +192,7 @@ public class IsaAtom extends TypeAtom {
         return vars.isEmpty()?
                 Collections.singleton(this) :
                 vars.stream()
-                        .map(v -> IsaAtom.create(v, getPredicateVariable(), getTypeLabel(), this.isDirect(), this.getParentQuery(), this.context()))
+                        .map(v -> IsaAtom.create(v, getTypeVariable(), getTypeLabel(), this.isDirect(), this.getParentQuery(), this.context()))
                         .collect(Collectors.toSet());
     }
 }

--- a/graql/reasoner/atom/binary/OntologicalAtom.java
+++ b/graql/reasoner/atom/binary/OntologicalAtom.java
@@ -75,21 +75,21 @@ public class OntologicalAtom extends TypeAtom {
     private final OntologicalAtomType atomType;
 
     private OntologicalAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
-                            Variable predicateVariable, OntologicalAtomType type, ReasoningContext ctx) {
-        super(varName, pattern, reasonerQuery, label, predicateVariable, ctx);
+                            Variable typeVariable, OntologicalAtomType type, ReasoningContext ctx) {
+        super(varName, pattern, reasonerQuery, label, typeVariable, ctx);
         this.atomType = type;
     }
 
     public static OntologicalAtom create(Variable var, Variable pVar, @Nullable Label label, ReasonerQuery parent, OntologicalAtomType type,
                                          ReasoningContext ctx) {
         Variable varName = var.asReturnedVar();
-        Variable predicateVar = pVar.asReturnedVar();
+        Variable typeVar = pVar.asReturnedVar();
         Statement statement = type.statementFunction().apply(new Pair<>(var, pVar), label);
-        return new OntologicalAtom(varName, statement, parent, label, predicateVar, type, ctx);
+        return new OntologicalAtom(varName, statement, parent, label, typeVar, type, ctx);
     }
 
     private static OntologicalAtom create(OntologicalAtom a, ReasonerQuery parent) {
-        return create(a.getVarName(), a.getPredicateVariable(), a.getTypeLabel(), parent, a.atomType(), a.context());
+        return create(a.getVarName(), a.getTypeVariable(), a.getTypeLabel(), parent, a.atomType(), a.context());
     }
 
     @Override
@@ -135,18 +135,18 @@ public class OntologicalAtom extends TypeAtom {
         Collection<Variable> vars = u.get(getVarName());
         return vars.isEmpty() ?
                 Collections.singleton(this) :
-                vars.stream().map(v -> create(v, getPredicateVariable(), getTypeLabel(), this.getParentQuery(), atomType(), context())).collect(Collectors.toSet());
+                vars.stream().map(v -> create(v, getTypeVariable(), getTypeLabel(), this.getParentQuery(), atomType(), context())).collect(Collectors.toSet());
     }
 
     @Override
     public Atom rewriteWithTypeVariable() {
-        return create(getVarName(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getParentQuery(), atomType(), context());
+        return create(getVarName(), getTypeVariable().asReturnedVar(), getTypeLabel(), getParentQuery(), atomType(), context());
     }
 
     @Override
     public Atom rewriteToUserDefined(Atom parentAtom) {
-        return parentAtom.getPredicateVariable().isReturned() ?
-                create(getVarName(), getPredicateVariable().asReturnedVar(), getTypeLabel(), getParentQuery(), atomType(), context()) :
+        return parentAtom.getTypeVariable().isReturned() ?
+                create(getVarName(), getTypeVariable().asReturnedVar(), getTypeLabel(), getParentQuery(), atomType(), context()) :
                 this;
     }
 

--- a/graql/reasoner/atom/binary/TypeAtom.java
+++ b/graql/reasoner/atom/binary/TypeAtom.java
@@ -52,7 +52,7 @@ import javax.annotation.Nullable;
  *
  * Atom implementation defining type atoms of the general form:
  *
- * {isa|sub|plays|relates|has}($varName, $predicateVariable), type($predicateVariable)
+ * {isa|sub|plays|relates|has}($varName, $typeVariable), type($typeVariable)
  *
  * Type atoms correspond to the following respective graql properties:
  * IsaProperty,
@@ -66,20 +66,20 @@ import javax.annotation.Nullable;
  */
 public abstract class TypeAtom extends Atom {
 
-    private final Variable predicateVariable;
+    private final Variable typeVariable;
     private final SemanticProcessor<TypeAtom> semanticProcessor = new TypeAtomSemanticProcessor();
 
     private SchemaConcept type = null;
     private IdPredicate typePredicate = null;
 
     TypeAtom(Variable varName, Statement pattern, ReasonerQuery reasonerQuery, @Nullable Label label,
-           Variable predicateVariable, ReasoningContext ctx) {
+           Variable typeVariable, ReasoningContext ctx) {
         super(reasonerQuery, varName, pattern, label, ctx);
-        this.predicateVariable = predicateVariable;
+        this.typeVariable = typeVariable;
     }
 
-    public Variable getPredicateVariable() {
-        return predicateVariable;
+    public Variable getTypeVariable() {
+        return typeVariable;
     }
 
     public boolean isDirect(){
@@ -91,7 +91,7 @@ public abstract class TypeAtom extends Atom {
     public IdPredicate getTypePredicate(){
         if (typePredicate == null && getTypeLabel() != null) {
             ConceptId typeId = context().conceptManager().getSchemaConcept(getTypeLabel()).id();
-            typePredicate = IdPredicate.create(new Statement(getPredicateVariable()).id(typeId.getValue()), getParentQuery());
+            typePredicate = IdPredicate.create(new Statement(getTypeVariable()).id(typeId.getValue()), getParentQuery());
         }
         return typePredicate;
     }
@@ -166,7 +166,7 @@ public abstract class TypeAtom extends Atom {
         if (obj == this) return true;
         TypeAtom that = (TypeAtom) obj;
         return (this.isUserDefined() == that.isUserDefined())
-                && (this.getPredicateVariable().isReturned() == that.getPredicateVariable().isReturned())
+                && (this.getTypeVariable().isReturned() == that.getTypeVariable().isReturned())
                 && this.isDirect() == that.isDirect()
                 && Objects.equals(this.getTypeLabel(), that.getTypeLabel());
     }
@@ -175,7 +175,7 @@ public abstract class TypeAtom extends Atom {
     public Set<Variable> getVarNames() {
         Set<Variable> vars = new HashSet<>();
         if (getVarName().isReturned()) vars.add(getVarName());
-        if (getPredicateVariable().isReturned()) vars.add(getPredicateVariable());
+        if (getTypeVariable().isReturned()) vars.add(getTypeVariable());
         return vars;
     }
 

--- a/graql/reasoner/atom/predicate/NeqIdPredicate.java
+++ b/graql/reasoner/atom/predicate/NeqIdPredicate.java
@@ -39,19 +39,19 @@ import java.util.stream.Collectors;
 
 public class NeqIdPredicate extends VariablePredicate {
 
-    private NeqIdPredicate(Variable varName, Variable predicateVar, Statement pattern, ReasonerQuery parentQuery) {
-        super(varName, predicateVar, pattern, parentQuery);
+    private NeqIdPredicate(Variable varName, Variable typeVar, Statement pattern, ReasonerQuery parentQuery) {
+        super(varName, typeVar, pattern, parentQuery);
     }
 
     public static NeqIdPredicate create(Statement pattern, ReasonerQuery parent) {
-        return new NeqIdPredicate(pattern.var(), extractPredicateVariable(pattern), pattern, parent);
+        return new NeqIdPredicate(pattern.var(), extractTypeVariable(pattern), pattern, parent);
     }
     public static NeqIdPredicate create(Variable varName, NeqProperty prop, ReasonerQuery parent) {
         Statement pattern = new Statement(varName).not(prop);
         return create(pattern, parent);
     }
 
-    private static Variable extractPredicateVariable(Statement pattern) {
+    private static Variable extractTypeVariable(Statement pattern) {
         return Iterables.getOnlyElement(pattern.getProperties(NeqProperty.class).collect(Collectors.toSet())).statement().var();
     }
 

--- a/graql/reasoner/atom/predicate/ValuePredicate.java
+++ b/graql/reasoner/atom/predicate/ValuePredicate.java
@@ -54,8 +54,8 @@ public class ValuePredicate extends Predicate<ValueProperty.Operation> {
     }
 
     public static ValuePredicate neq(Variable varName, @Nullable Variable var, @Nullable Object value, ReasonerQuery parent){
-        Variable predicateVar = var != null? var : Graql.var().var().asReturnedVar();
-        ValueProperty.Operation.Comparison<?> op = ValueProperty.Operation.Comparison.of(Graql.Token.Comparator.NEQV, value != null ? value : Graql.var(predicateVar));
+        Variable typeVar = var != null? var : Graql.var().var().asReturnedVar();
+        ValueProperty.Operation.Comparison<?> op = ValueProperty.Operation.Comparison.of(Graql.Token.Comparator.NEQV, value != null ? value : Graql.var(typeVar));
         return create(varName, op, parent);
     }
 

--- a/graql/reasoner/atom/predicate/VariablePredicate.java
+++ b/graql/reasoner/atom/predicate/VariablePredicate.java
@@ -29,8 +29,8 @@ import java.util.Set;
 
 public abstract class VariablePredicate extends Predicate<Variable> {
 
-    VariablePredicate(Variable varName, Variable predicateVar, Statement pattern, ReasonerQuery parentQuery) {
-        super(varName, pattern, predicateVar, parentQuery);
+    VariablePredicate(Variable varName, Variable typeVar, Statement pattern, ReasonerQuery parentQuery) {
+        super(varName, pattern, typeVar, parentQuery);
     }
 
     private boolean predicateBindingsEquivalent(VariablePredicate that, Equivalence<Atomic> equiv){

--- a/graql/reasoner/atom/predicate/VariableValuePredicate.java
+++ b/graql/reasoner/atom/predicate/VariableValuePredicate.java
@@ -49,8 +49,8 @@ public class VariableValuePredicate extends VariablePredicate {
 
     private final ValueProperty.Operation op;
 
-    private VariableValuePredicate(Variable varName, Variable predicateVar, ValueProperty.Operation op, Statement pattern, ReasonerQuery parentQuery) {
-        super(varName, predicateVar, pattern, parentQuery);
+    private VariableValuePredicate(Variable varName, Variable typeVar, ValueProperty.Operation op, Statement pattern, ReasonerQuery parentQuery) {
+        super(varName, typeVar, pattern, parentQuery);
         this.op = op;
     }
 
@@ -58,9 +58,9 @@ public class VariableValuePredicate extends VariablePredicate {
         Statement innerStatement = op.innerStatement();
         //comparisons only valid for variable predicates (ones having a reference variable)
         Preconditions.checkNotNull(innerStatement);
-        Variable predicateVar = innerStatement.var();
+        Variable typeVar = innerStatement.var();
         Statement pattern = new Statement(varName).operation(op);
-        return new VariableValuePredicate(varName, predicateVar, op, pattern, parent);
+        return new VariableValuePredicate(varName, typeVar, op, pattern, parent);
     }
 
     public static VariableValuePredicate fromValuePredicate(ValuePredicate predicate){

--- a/graql/reasoner/atom/task/infer/IsaTypeReasoner.java
+++ b/graql/reasoner/atom/task/infer/IsaTypeReasoner.java
@@ -44,7 +44,7 @@ public class IsaTypeReasoner implements TypeReasoner<IsaAtom> {
     @Override
     public IsaAtom inferTypes(IsaAtom atom, ConceptMap sub, ReasoningContext ctx) {
         if (atom.getTypePredicate() != null) return atom;
-        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
+        if (sub.containsVar(atom.getTypeVariable())) return atom.addType(sub.get(atom.getTypeVariable()).asType());
         return atom;
     }
 
@@ -53,7 +53,7 @@ public class IsaTypeReasoner implements TypeReasoner<IsaAtom> {
         ConceptManager conceptManager = ctx.conceptManager();
         SchemaConcept type = atom.getSchemaConcept();
         if (type != null) return ImmutableList.of(type.asType());
-        if (sub.containsVar(atom.getPredicateVariable())) return ImmutableList.of(sub.get(atom.getPredicateVariable()).asType());
+        if (sub.containsVar(atom.getTypeVariable())) return ImmutableList.of(sub.get(atom.getTypeVariable()).asType());
 
         Variable varName = atom.getVarName();
         //determine compatible types from played roles

--- a/graql/reasoner/atom/task/infer/RelationTypeReasoner.java
+++ b/graql/reasoner/atom/task/infer/RelationTypeReasoner.java
@@ -205,7 +205,7 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
      */
     private RelationAtom inferType(RelationAtom atom, ConceptMap sub, ReasoningContext ctx) {
         if (atom.getTypeLabel() != null) return atom;
-        if (sub.containsVar(atom.getPredicateVariable())) return atom.addType(sub.get(atom.getPredicateVariable()).asType());
+        if (sub.containsVar(atom.getTypeVariable())) return atom.addType(sub.get(atom.getTypeVariable()).asType());
         List<Type> relationTypes = inferPossibleTypes(atom, sub, ctx);
         if (relationTypes.size() == 1) return atom.addType(Iterables.getOnlyElement(relationTypes));
         return atom;
@@ -295,10 +295,10 @@ public class RelationTypeReasoner implements TypeReasoner<RelationAtom> {
         Statement relationPattern = RelationAtom.relationPattern(atom.getVarName(), inferredRelationPlayers);
         Statement newPattern =
                 (atom.isDirect() ?
-                        relationPattern.isaX(new Statement(atom.getPredicateVariable())) :
-                        relationPattern.isa(new Statement(atom.getPredicateVariable()))
+                        relationPattern.isaX(new Statement(atom.getTypeVariable())) :
+                        relationPattern.isa(new Statement(atom.getTypeVariable()))
                 );
 
-        return RelationAtom.create(newPattern, atom.getPredicateVariable(), atom.getTypeLabel(), atom.getPossibleTypes(), atom.getParentQuery(), atom.context());
+        return RelationAtom.create(newPattern, atom.getTypeVariable(), atom.getTypeLabel(), atom.getPossibleTypes(), atom.getParentQuery(), atom.context());
     }
 }

--- a/graql/reasoner/atom/task/relate/TypeAtomSemanticProcessor.java
+++ b/graql/reasoner/atom/task/relate/TypeAtomSemanticProcessor.java
@@ -53,8 +53,8 @@ public class TypeAtomSemanticProcessor implements SemanticProcessor<TypeAtom> {
         boolean inferTypes = unifierType.inferTypes();
         Variable childVarName = childAtom.getVarName();
         Variable parentVarName = parentAtom.getVarName();
-        Variable childPredicateVarName = childAtom.getPredicateVariable();
-        Variable parentPredicateVarName = parentAtom.getPredicateVariable();
+        Variable childTypeVarName = childAtom.getTypeVariable();
+        Variable parentTypeVarName = parentAtom.getTypeVariable();
         Set<Type> parentTypes = parentAtom.getParentQuery().getVarTypeMap(inferTypes).get(parentVarName);
         Set<Type> childTypes = childAtom.getParentQuery().getVarTypeMap(inferTypes).get(childAtom.getVarName());
 
@@ -77,8 +77,8 @@ public class TypeAtomSemanticProcessor implements SemanticProcessor<TypeAtom> {
         if (parentVarName.isReturned()) {
             varMappings.put(childVarName, parentVarName);
         }
-        if (parentPredicateVarName.isReturned()) {
-            varMappings.put(childPredicateVarName, parentPredicateVarName);
+        if (parentTypeVarName.isReturned()) {
+            varMappings.put(childTypeVarName, parentTypeVarName);
         }
 
         UnifierImpl unifier = new UnifierImpl(varMappings);

--- a/graql/reasoner/rule/InferenceRule.java
+++ b/graql/reasoner/rule/InferenceRule.java
@@ -247,7 +247,7 @@ public class InferenceRule {
                 // TODO revert this to old implementation of instantiating without copy constructor
                 // or do it properly with a factory
                 headAtom = AttributeAtom.create(resourceHead.getPattern(), resourceHead.getAttributeVariable(),
-                        resourceHead.getPredicateVariable(),
+                        resourceHead.getTypeVariable(),
                         resourceHead.getTypeLabel(),
                         innerVps,
                         resourceHead.getParentQuery(),

--- a/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
+++ b/test/integration/graql/reasoner/atomic/AtomicEquivalenceIT.java
@@ -217,7 +217,7 @@ public class AtomicEquivalenceIT {
     }
 
     @Test
-    public void testEquivalence_DifferentNonVariablePredicateVariants() {
+    public void testEquivalence_DifferentNonVariableTypeVariants() {
         Statement value = Graql.var("value");
         final String bound = "value";
         ArrayList<Statement> variablePredicates = Lists.newArrayList(
@@ -254,7 +254,7 @@ public class AtomicEquivalenceIT {
     }
 
     @Test
-    public void testEquivalence_DifferentVariablePredicateVariants() {
+    public void testEquivalence_DifferentVariableTypeVariants() {
         Statement value = Graql.var("value");
         Statement anotherValue = Graql.var("anotherValue");
         ArrayList<Statement> variablePredicates = Lists.newArrayList(

--- a/test/integration/graql/reasoner/query/AtomicQueryUnificationIT.java
+++ b/test/integration/graql/reasoner/query/AtomicQueryUnificationIT.java
@@ -1111,7 +1111,7 @@ public class AtomicQueryUnificationIT {
         assertTrue(!unifiedAnswers.isEmpty());
         assertTrue(!parentAnswers.isEmpty());
 
-        Set<Variable> parentNonTypeVariables = Sets.difference(parent.getAtom().getVarNames(), Sets.newHashSet(parent.getAtom().getPredicateVariable()));
+        Set<Variable> parentNonTypeVariables = Sets.difference(parent.getAtom().getVarNames(), Sets.newHashSet(parent.getAtom().getTypeVariable()));
         if (!checkEquality) {
             if (!ignoreTypes) {
                 assertTrue(parentAnswers.containsAll(unifiedAnswers));
@@ -1128,7 +1128,7 @@ public class AtomicQueryUnificationIT {
                 List<ConceptMap> parentToChild = parentAnswers.stream().map(inverse::apply).collect(Collectors.toList());
                 assertCollectionsNonTriviallyEqual(parentToChild, childAnswers);
             } else {
-                Set<Variable> childNonTypeVariables = Sets.difference(child.getAtom().getVarNames(), Sets.newHashSet(child.getAtom().getPredicateVariable()));
+                Set<Variable> childNonTypeVariables = Sets.difference(child.getAtom().getVarNames(), Sets.newHashSet(child.getAtom().getTypeVariable()));
                 List<ConceptMap> projectedParentAnswers = parentAnswers.stream().map(ans -> ans.project(parentNonTypeVariables)).collect(Collectors.toList());
                 List<ConceptMap> projectedUnified = unifiedAnswers.stream().map(ans -> ans.project(parentNonTypeVariables)).collect(Collectors.toList());
                 List<ConceptMap> projectedChild = childAnswers.stream().map(ans -> ans.project(childNonTypeVariables)).collect(Collectors.toList());


### PR DESCRIPTION

## What is the goal of this PR?

Changed all occurrences of "predicateVar" to "typeVar". This is a more accurate description, since a predicate variable is impossible in first order logic

This will make rewriting of the reasoner easier in the next few months.

## What are the changes implemented in this PR?

This won't cause any functional changes.
