### PR TITLE
Fix to Schema Export so that rules are also exported

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,8 @@ jobs:
                   then
                     exit 0;
                   fi
-                  ((i--));
+                  echo $i;
+                  i=$((i--));
               done;
               exit 0;
           no_output_timeout: 1h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,22 +137,24 @@ jobs:
     steps:
       - install-bazel-linux
       - checkout
-      - run:
-          command: |
-              bash
-              i=2;
-              set +e;
-              while [ $i -ge  0 ]; do
-                  bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;
-                  if [ $? eq 0 ];
-                  then
-                    exit 0;
-                  fi
-                  echo $i;
-                  i=$((i-1));
-              done;
-              exit 0;
-          no_output_timeout: 1h
+      - run-bazel:
+          command: bazel test //test/integration/... --test_output=errors;
+#      - run:
+#          command: |
+#              bash
+#              i=2;
+#              set +e;
+#              while [ $i -ge  0 ]; do
+#                  bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;
+#                  if [ $? eq 0 ];
+#                  then
+#                    exit 0;
+#                  fi
+#                  echo $i;
+#                  i=$((i-1));
+#              done;
+#              exit 0;
+#          no_output_timeout: 1h
 
   # assembly tests
   test-assembly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,15 +139,15 @@ jobs:
       - checkout
       - run-bazel:
           command: |
-            set +e
             i=10
+            set +e
             while [$ -ge 0]; do
                 bazel test //test/integration/... --test_output=errors
                 if [$?==0]
                 then
                   exit 0
-                ((i++))
                 fi
+                ((i--))
             done;
 
   # assembly tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,17 @@ jobs:
       - install-bazel-linux
       - checkout
       - run-bazel:
-          command: bazel test //test/integration/... --test_output=errors
+          command: |
+            set +e
+            i=10
+            while [$ -ge 0]; do
+                bazel test //test/integration/... --test_output=errors
+                if [$?==0]
+                then
+                  exit 0
+                ((i++))
+                fi
+            done;
 
   # assembly tests
   test-assembly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,20 +137,19 @@ jobs:
     steps:
       - install-bazel-linux
       - checkout
-      - run-bazel:
-          command: |
-            bash
-            i=10;
-            set +e;
-            while [ $i -ge  0 ]; do
-                bazel test //test/integration/... --test_output=errors;
-                if [ $? eq 0 ];
-                then
-                  exit 0;
-                fi
-                ((i--));
-            done;
-            exit 0;
+      - run: |
+          bash
+          i=10;
+          set +e;
+          while [ $i -ge  0 ]; do
+              bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;
+              if [ $? eq 0 ];
+              then
+                exit 0;
+              fi
+              ((i--));
+          done;
+          exit 0;
 
   # assembly tests
   test-assembly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ jobs:
                     exit 0;
                   fi
                   echo $i;
-                  i=$((i--));
+                  i=$((i-1));
               done;
               exit 0;
           no_output_timeout: 1h

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
       - checkout
       - run: |
           bash
-          i=10;
+          i=2;
           set +e;
           while [ $i -ge  0 ]; do
               bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,15 +139,15 @@ jobs:
       - checkout
       - run-bazel:
           command: |
-            i=10
-            set +e
-            while [$ -ge 0]; do
-                bazel test //test/integration/... --test_output=errors
-                if [$?==0]
+            i=10;
+            set +e;
+            while [ $i -ge  0 ]; do
+                bazel test //test/integration/... --test_output=errors;
+                if [ $? eq 0 ];
                 then
-                  exit 0
+                  exit 0;
                 fi
-                ((i--))
+                ((i--));
             done;
 
   # assembly tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,19 +137,21 @@ jobs:
     steps:
       - install-bazel-linux
       - checkout
-      - run: |
-          bash
-          i=2;
-          set +e;
-          while [ $i -ge  0 ]; do
-              bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;
-              if [ $? eq 0 ];
-              then
-                exit 0;
-              fi
-              ((i--));
-          done;
-          exit 0;
+      - run:
+          command: |
+              bash
+              i=2;
+              set +e;
+              while [ $i -ge  0 ]; do
+                  bazel run @graknlabs_dependencies//tool/bazelrun:rbe -- bazel test //test/integration/... --test_output=errors;
+                  if [ $? eq 0 ];
+                  then
+                    exit 0;
+                  fi
+                  ((i--));
+              done;
+              exit 0;
+            no_output_timeout: 1h
 
   # assembly tests
   test-assembly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,6 +139,7 @@ jobs:
       - checkout
       - run-bazel:
           command: |
+            bash
             i=10;
             set +e;
             while [ $i -ge  0 ]; do
@@ -149,6 +150,7 @@ jobs:
                 fi
                 ((i--));
             done;
+            exit 0;
 
   # assembly tests
   test-assembly:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
                   ((i--));
               done;
               exit 0;
-            no_output_timeout: 1h
+          no_output_timeout: 1h
 
   # assembly tests
   test-assembly:

--- a/server/migrate/Schema.java
+++ b/server/migrate/Schema.java
@@ -88,6 +88,7 @@ public class Schema {
         printTypesHierarchically(writer, "attribute");
         printTypesHierarchically(writer, "entity");
         printTypesHierarchically(writer, "relation");
+        printTypesHierarchically(writer, "rule"); //This is the fix, I think
 
         tx.close();
     }

--- a/server/migrate/Schema.java
+++ b/server/migrate/Schema.java
@@ -88,7 +88,7 @@ public class Schema {
         printTypesHierarchically(writer, "attribute");
         printTypesHierarchically(writer, "entity");
         printTypesHierarchically(writer, "relation");
-        printTypesHierarchically(writer, "rule"); //This is the fix, I think
+        printTypesHierarchically(writer, "rule");
 
         tx.close();
     }

--- a/server/migrate/Schema.java
+++ b/server/migrate/Schema.java
@@ -333,13 +333,18 @@ public class Schema {
                 relates.print(writer);
             }
             if (when != null) {
+                writer.println(",");
                 when.print(writer);
             }
             if (then != null) {
                 writer.println(", then {");
                 writer.indent();
-                writer.println(then.toString());
+                String then_string = then.toString();
+                writer.println(then_string.substring(2, then_string.length() - 3));
                 writer.unindent();
+//                writer.indent();
+//                writer.println(then.toString().);
+//                writer.unindent();
                 writer.print("}");
             }
             writer.unindent();

--- a/server/migrate/Schema.java
+++ b/server/migrate/Schema.java
@@ -342,9 +342,6 @@ public class Schema {
                 String then_string = then.toString();
                 writer.println(then_string.substring(2, then_string.length() - 3));
                 writer.unindent();
-//                writer.indent();
-//                writer.println(then.toString().);
-//                writer.unindent();
                 writer.print("}");
             }
             writer.unindent();

--- a/server/migrate/Schema.java
+++ b/server/migrate/Schema.java
@@ -26,7 +26,9 @@ import grakn.core.kb.concept.api.SchemaConcept;
 import grakn.core.kb.concept.api.Type;
 import grakn.core.kb.server.Session;
 import grakn.core.kb.server.Transaction;
+import graql.lang.pattern.Negation;
 import graql.lang.pattern.Pattern;
+import graql.lang.statement.Statement;
 
 import java.io.Writer;
 import java.time.LocalDateTime;
@@ -155,6 +157,44 @@ public class Schema {
         }
     }
 
+    private class WhenDeclaration {
+        private final Set<Pattern> patterns;
+
+        WhenDeclaration(Pattern when) {
+            patterns = when.getNegationDNF().getPatterns().iterator().next().getPatterns();
+        }
+
+        public void print(IndentPrintWriter writer) {
+            writer.println("when {");
+            writer.indent();
+            for (Pattern pattern : patterns) {
+                printPattern(pattern, writer);
+            }
+            writer.unindent();
+            writer.print("}");
+        }
+
+
+
+        private void printPattern(Pattern pattern, IndentPrintWriter writer) {
+            if (pattern.isNegation() && pattern.asNegation().statements().size() > 1) {
+                printNegation(pattern.asNegation(), writer);
+            } else {
+                writer.println(pattern.toString());
+            }
+        }
+
+        private void printNegation(Negation negation, IndentPrintWriter writer) {
+            writer.println("not {");
+            writer.indent();
+            for (Statement statement : negation.statements()) {
+                writer.println(statement);
+            }
+            writer.unindent();
+            writer.println("};");
+        }
+    }
+
     List<String> order(Set<String> toOrder, List<String> master) {
         List<String> results = new ArrayList<>(toOrder.size());
         for (String s : master) {
@@ -174,7 +214,7 @@ public class Schema {
         private final Set<String> has;
         private final Set<String> plays;
         private final Set<RelatesDeclaration> relates;
-        private final Pattern when;
+        private final WhenDeclaration when;
         private final Pattern then;
 
         TypeDeclaration(SchemaConcept sc) {
@@ -248,7 +288,7 @@ public class Schema {
 
             if (sc.isRule()) {
                 Rule rule = sc.asRule();
-                when = rule.when();
+                when = new WhenDeclaration(rule.when());
                 then = rule.then();
             } else {
                 when = null;
@@ -293,16 +333,14 @@ public class Schema {
                 relates.print(writer);
             }
             if (when != null) {
-                writer.println(",");
-                writer.print("when ");
-                String ruleString = when.toString();
-                writer.print(ruleString.substring(0, ruleString.length() - 1));
+                when.print(writer);
             }
             if (then != null) {
-                writer.println(",");
-                writer.println("then ");
-                String ruleString = then.toString();
-                writer.print(ruleString.substring(0, ruleString.length() - 1));
+                writer.println(", then {");
+                writer.indent();
+                writer.println(then.toString());
+                writer.unindent();
+                writer.print("}");
             }
             writer.unindent();
             writer.println(";");

--- a/test/assembly/MigrationTest.java
+++ b/test/assembly/MigrationTest.java
@@ -47,6 +47,7 @@ public class MigrationTest {
     private static final Path DATA_ROOT = Paths.get("test", "assembly", "data");
     private static final Path SCHEMA = DATA_ROOT.resolve("schema.gql");
     private static final Path SCHEMA_PT2 = DATA_ROOT.resolve("schema-pt2.gql");
+    private static final Path TRUTH_SCHEMA = DATA_ROOT.resolve("schema_export_truth.gql");
     private static final Path IMPORT_PATH = DATA_ROOT.resolve("simulation.grakn");
     private static final Path SCHEMA_EXPORT_TRUTH = DATA_ROOT.resolve("schema_export_truth.gql");
 
@@ -95,7 +96,10 @@ public class MigrationTest {
 
     @Test
     public void testSchemaExport() throws InterruptedException, IOException, TimeoutException {
-        System.out.println("Loading schema... ");
+        System.out.println("Checking truth schema is valid...");
+        assertExecutes(GRAKN, "console", "-k", "schematest", "-f", TRUTH_SCHEMA.toString());
+
+        System.out.println("Loading test schema... ");
         loadSimulationSchema("schematest");
         System.out.println("Schema loaded, running export... ");
 
@@ -106,6 +110,8 @@ public class MigrationTest {
         String truth = Files.lines(SCHEMA_EXPORT_TRUTH, StandardCharsets.UTF_8).collect(Collectors.joining("\n"));
 
         assertThat(export, equalTo(truth));
+
+
         System.out.println("Schema export test completed!");
     }
 

--- a/test/assembly/MigrationTest.java
+++ b/test/assembly/MigrationTest.java
@@ -95,9 +95,12 @@ public class MigrationTest {
 
     @Test
     public void testSchemaExport() throws InterruptedException, IOException, TimeoutException {
+        System.out.println("Test is starting... :)");
         loadSimulationSchema("schematest");
+        System.out.println("Schema loaded... :)");
 
         ProcessResult result = assertExecutes(GRAKN, "server", "schema", "schematest");
+        System.out.println("Test is running... :)");
 
         String export = result.getOutput().getString();
         String truth = Files.lines(SCHEMA_EXPORT_TRUTH, StandardCharsets.UTF_8).collect(Collectors.joining("\n"));

--- a/test/assembly/MigrationTest.java
+++ b/test/assembly/MigrationTest.java
@@ -95,17 +95,18 @@ public class MigrationTest {
 
     @Test
     public void testSchemaExport() throws InterruptedException, IOException, TimeoutException {
-        System.out.println("Test is starting... :)");
+        System.out.println("Loading schema... ");
         loadSimulationSchema("schematest");
-        System.out.println("Schema loaded... :)");
+        System.out.println("Schema loaded, running export... ");
 
         ProcessResult result = assertExecutes(GRAKN, "server", "schema", "schematest");
-        System.out.println("Test is running... :)");
+        System.out.println("Checking results are equal..");
 
         String export = result.getOutput().getString();
         String truth = Files.lines(SCHEMA_EXPORT_TRUTH, StandardCharsets.UTF_8).collect(Collectors.joining("\n"));
 
         assertThat(export, equalTo(truth));
+        System.out.println("Schema export test completed!");
     }
 
     private void loadSimulationSchema(String keyspace) throws InterruptedException, TimeoutException, IOException {

--- a/test/assembly/data/schema_export_truth.gql
+++ b/test/assembly/data/schema_export_truth.gql
@@ -348,8 +348,7 @@ person-membership-of-organisation-means-relocation sub rule,
 
 person-membership-of-organisation-means-relocation-date sub rule,
     when { (membership_member: $person, membership_group: $group) isa membership, has start-date $membership-start-date; (locates_located: $group, locates_location: $location) isa locates; $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; },
-    then
-    { $rel has relocation-date $membership-start-date; };
+    then{ $rel has relocation-date $membership-start-date; };
 
 person-relocating-adds-new-residency sub rule,
     when { $rel (relocation_relocated-person: $person, relocation_new-location: $location) isa relocation; },

--- a/test/assembly/data/schema_export_truth.gql
+++ b/test/assembly/data/schema_export_truth.gql
@@ -306,5 +306,75 @@ transaction sub relation,
     relates transaction_merchandise,
     relates transaction_vendor;
 
+born-in-location-implies-residency sub rule,
+    when { $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in; },
+    then 
+    { (residency_resident: $person, residency_location: $location) isa residency; };
+
+born-in-location-implies-residency-date sub rule,
+    when { $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in; $person isa person, has date-of-birth $dob; $r (residency_resident: $person, residency_location: $location) isa residency; },
+    then 
+    { $r has start-date $dob; };
+
+contract-has-language-of-location-is-there-is-only-one-language sub rule,
+    when { $emp (employment_contract: $contract) isa employment; $contract isa employment-contract, has contract-content $content; ($emp, $location1) isa locates; $location1 has language $lang1; not { ($emp, $location2) isa locates; $location2 has language $lang2; $lang1 !== $lang2; }; },
+    then 
+    { $content has content-language $lang1; };
+
+contracted-hours-apply-to-employment sub rule,
+    when { $emp (employment_contract: $c) isa employment; $c isa employment-contract, has contracted-hours $hours; },
+    then 
+    { $emp has contracted-hours $hours; };
+
+label-non-current-residency sub rule,
+    when { $res isa residency, has end-date $end-date; },
+    then 
+    { $res has is-current false; };
+
+locates-transitive-with-location-hierarchy sub rule,
+    when { $loc (locates_located: $thing, locates_location: $a) isa locates; $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $a) isa location-hierarchy; },
+    then 
+    { (locates_located: $thing, locates_location: $b) isa locates; };
+
+location-hierarchy-transitivity sub rule,
+    when { $lh1 (location-hierarchy_superior: $a, location-hierarchy_subordinate: $b) isa location-hierarchy; $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $c) isa location-hierarchy; },
+    then 
+    { (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy; };
+
+person-membership-of-organisation-means-relocation sub rule,
+    when { (membership_member: $person, membership_group: $group) isa membership; (locates_located: $group, locates_location: $location) isa locates; },
+    then 
+    { (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; };
+
+person-membership-of-organisation-means-relocation-date sub rule,
+    when { (membership_member: $person, membership_group: $group) isa membership, has start-date $membership-start-date; (locates_located: $group, locates_location: $location) isa locates; $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; },
+    then
+    { $rel has relocation-date $membership-start-date; };
+
+person-relocating-adds-new-residency sub rule,
+    when { $rel (relocation_relocated-person: $person, relocation_new-location: $location) isa relocation; },
+    then 
+    { (residency_resident: $person, residency_location: $location) isa residency; };
+
+person-relocating-ends-old-residency sub rule,
+    when { $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation, has relocation-date $rel-date; $old-residency (residency_resident: $person, residency_location: $location) isa residency; },
+    then 
+    { $old-residency has end-date $rel-date; };
+
+person-with-no-active-employment-is-unemployed sub rule,
+    when { $p isa person; not { $e (employment_employee: $p) isa employment; }; },
+    then 
+    { $p isa unemployed-person; };
+
+residency-without-end-date-is-current sub rule,
+    when { $res (residency_resident: $person, residency_location: $location) isa residency; not { $res has end-date $rel-date; }; },
+    then 
+    { $res has is-current true; };
+
+transaction-currency-is-that-of-the-country sub rule,
+    when { $transaction isa transaction; $l (locates_located: $t, locates_location: $transaction-location) isa locates; $transaction-country isa country, has currency $currency; },
+    then 
+    { $transaction has currency $currency; };
+
 
 

--- a/test/assembly/data/schema_export_truth.gql
+++ b/test/assembly/data/schema_export_truth.gql
@@ -306,74 +306,110 @@ transaction sub relation,
     relates transaction_merchandise,
     relates transaction_vendor;
 
-born-in-location-implies-residency sub rule,
-    when { $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in; },
-    then 
-    { (residency_resident: $person, residency_location: $location) isa residency; };
+born-in-location-implies-residency sub rulewhen {
+        $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in;
+    }, then {
+        { (residency_resident: $person, residency_location: $location) isa residency; };
+    };
 
-born-in-location-implies-residency-date sub rule,
-    when { $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in; $person isa person, has date-of-birth $dob; $r (residency_resident: $person, residency_location: $location) isa residency; },
-    then 
-    { $r has start-date $dob; };
+born-in-location-implies-residency-date sub rulewhen {
+        $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in;
+        $person isa person, has date-of-birth $dob;
+        $r (residency_resident: $person, residency_location: $location) isa residency;
+    }, then {
+        { $r has start-date $dob; };
+    };
 
-contract-has-language-of-location-is-there-is-only-one-language sub rule,
-    when { $emp (employment_contract: $contract) isa employment; $contract isa employment-contract, has contract-content $content; ($emp, $location1) isa locates; $location1 has language $lang1; not { ($emp, $location2) isa locates; $location2 has language $lang2; $lang1 !== $lang2; }; },
-    then 
-    { $content has content-language $lang1; };
+contract-has-language-of-location-is-there-is-only-one-language sub rulewhen {
+        $emp (employment_contract: $contract) isa employment;
+        $contract isa employment-contract, has contract-content $content;
+        ($emp, $location1) isa locates;
+        $location1 has language $lang1;
+        not {
+            ($emp, $location2) isa locates;
+            $location2 has language $lang2;
+            $lang1 !== $lang2;
+        };
+    }, then {
+        { $content has content-language $lang1; };
+    };
 
-contracted-hours-apply-to-employment sub rule,
-    when { $emp (employment_contract: $c) isa employment; $c isa employment-contract, has contracted-hours $hours; },
-    then 
-    { $emp has contracted-hours $hours; };
+contracted-hours-apply-to-employment sub rulewhen {
+        $emp (employment_contract: $c) isa employment;
+        $c isa employment-contract, has contracted-hours $hours;
+    }, then {
+        { $emp has contracted-hours $hours; };
+    };
 
-label-non-current-residency sub rule,
-    when { $res isa residency, has end-date $end-date; },
-    then 
-    { $res has is-current false; };
+label-non-current-residency sub rulewhen {
+        $res isa residency, has end-date $end-date;
+    }, then {
+        { $res has is-current false; };
+    };
 
-locates-transitive-with-location-hierarchy sub rule,
-    when { $loc (locates_located: $thing, locates_location: $a) isa locates; $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $a) isa location-hierarchy; },
-    then 
-    { (locates_located: $thing, locates_location: $b) isa locates; };
+locates-transitive-with-location-hierarchy sub rulewhen {
+        $loc (locates_located: $thing, locates_location: $a) isa locates;
+        $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $a) isa location-hierarchy;
+    }, then {
+        { (locates_located: $thing, locates_location: $b) isa locates; };
+    };
 
-location-hierarchy-transitivity sub rule,
-    when { $lh1 (location-hierarchy_superior: $a, location-hierarchy_subordinate: $b) isa location-hierarchy; $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $c) isa location-hierarchy; },
-    then 
-    { (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy; };
+location-hierarchy-transitivity sub rulewhen {
+        $lh1 (location-hierarchy_superior: $a, location-hierarchy_subordinate: $b) isa location-hierarchy;
+        $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $c) isa location-hierarchy;
+    }, then {
+        { (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy; };
+    };
 
-person-membership-of-organisation-means-relocation sub rule,
-    when { (membership_member: $person, membership_group: $group) isa membership; (locates_located: $group, locates_location: $location) isa locates; },
-    then 
-    { (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; };
+person-membership-of-organisation-means-relocation sub rulewhen {
+        (membership_member: $person, membership_group: $group) isa membership;
+        (locates_located: $group, locates_location: $location) isa locates;
+    }, then {
+        { (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; };
+    };
 
-person-membership-of-organisation-means-relocation-date sub rule,
-    when { (membership_member: $person, membership_group: $group) isa membership, has start-date $membership-start-date; (locates_located: $group, locates_location: $location) isa locates; $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; },
-    then{ $rel has relocation-date $membership-start-date; };
+person-membership-of-organisation-means-relocation-date sub rulewhen {
+        (membership_member: $person, membership_group: $group) isa membership, has start-date $membership-start-date;
+        (locates_located: $group, locates_location: $location) isa locates;
+        $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation;
+    }, then {
+        { $rel has relocation-date $membership-start-date; };
+    };
 
-person-relocating-adds-new-residency sub rule,
-    when { $rel (relocation_relocated-person: $person, relocation_new-location: $location) isa relocation; },
-    then 
-    { (residency_resident: $person, residency_location: $location) isa residency; };
+person-relocating-adds-new-residency sub rulewhen {
+        $rel (relocation_relocated-person: $person, relocation_new-location: $location) isa relocation;
+    }, then {
+        { (residency_resident: $person, residency_location: $location) isa residency; };
+    };
 
-person-relocating-ends-old-residency sub rule,
-    when { $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation, has relocation-date $rel-date; $old-residency (residency_resident: $person, residency_location: $location) isa residency; },
-    then 
-    { $old-residency has end-date $rel-date; };
+person-relocating-ends-old-residency sub rulewhen {
+        $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation, has relocation-date $rel-date;
+        $old-residency (residency_resident: $person, residency_location: $location) isa residency;
+    }, then {
+        { $old-residency has end-date $rel-date; };
+    };
 
-person-with-no-active-employment-is-unemployed sub rule,
-    when { $p isa person; not { $e (employment_employee: $p) isa employment; }; },
-    then 
-    { $p isa unemployed-person; };
+person-with-no-active-employment-is-unemployed sub rulewhen {
+        $p isa person;
+        not { $e (employment_employee: $p) isa employment; };
+    }, then {
+        { $p isa unemployed-person; };
+    };
 
-residency-without-end-date-is-current sub rule,
-    when { $res (residency_resident: $person, residency_location: $location) isa residency; not { $res has end-date $rel-date; }; },
-    then 
-    { $res has is-current true; };
+residency-without-end-date-is-current sub rulewhen {
+        $res (residency_resident: $person, residency_location: $location) isa residency;
+        not { $res has end-date $rel-date; };
+    }, then {
+        { $res has is-current true; };
+    };
 
-transaction-currency-is-that-of-the-country sub rule,
-    when { $transaction isa transaction; $l (locates_located: $t, locates_location: $transaction-location) isa locates; $transaction-country isa country, has currency $currency; },
-    then 
-    { $transaction has currency $currency; };
+transaction-currency-is-that-of-the-country sub rulewhen {
+        $transaction isa transaction;
+        $l (locates_located: $t, locates_location: $transaction-location) isa locates;
+        $transaction-country isa country, has currency $currency;
+    }, then {
+        { $transaction has currency $currency; };
+    };
 
 
 

--- a/test/assembly/data/schema_export_truth.gql
+++ b/test/assembly/data/schema_export_truth.gql
@@ -306,21 +306,24 @@ transaction sub relation,
     relates transaction_merchandise,
     relates transaction_vendor;
 
-born-in-location-implies-residency sub rulewhen {
+born-in-location-implies-residency sub rule,
+    when {
         $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in;
     }, then {
-        { (residency_resident: $person, residency_location: $location) isa residency; };
+        (residency_resident: $person, residency_location: $location) isa residency;
     };
 
-born-in-location-implies-residency-date sub rulewhen {
+born-in-location-implies-residency-date sub rule,
+    when {
         $bi (born-in_place-of-birth: $location, born-in_child: $person) isa born-in;
         $person isa person, has date-of-birth $dob;
         $r (residency_resident: $person, residency_location: $location) isa residency;
     }, then {
-        { $r has start-date $dob; };
+        $r has start-date $dob;
     };
 
-contract-has-language-of-location-is-there-is-only-one-language sub rulewhen {
+contract-has-language-of-location-is-there-is-only-one-language sub rule,
+    when {
         $emp (employment_contract: $contract) isa employment;
         $contract isa employment-contract, has contract-content $content;
         ($emp, $location1) isa locates;
@@ -331,84 +334,95 @@ contract-has-language-of-location-is-there-is-only-one-language sub rulewhen {
             $lang1 !== $lang2;
         };
     }, then {
-        { $content has content-language $lang1; };
+        $content has content-language $lang1;
     };
 
-contracted-hours-apply-to-employment sub rulewhen {
+contracted-hours-apply-to-employment sub rule,
+    when {
         $emp (employment_contract: $c) isa employment;
         $c isa employment-contract, has contracted-hours $hours;
     }, then {
-        { $emp has contracted-hours $hours; };
+        $emp has contracted-hours $hours;
     };
 
-label-non-current-residency sub rulewhen {
+label-non-current-residency sub rule,
+    when {
         $res isa residency, has end-date $end-date;
     }, then {
-        { $res has is-current false; };
+        $res has is-current false;
     };
 
-locates-transitive-with-location-hierarchy sub rulewhen {
+locates-transitive-with-location-hierarchy sub rule,
+    when {
         $loc (locates_located: $thing, locates_location: $a) isa locates;
         $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $a) isa location-hierarchy;
     }, then {
-        { (locates_located: $thing, locates_location: $b) isa locates; };
+        (locates_located: $thing, locates_location: $b) isa locates;
     };
 
-location-hierarchy-transitivity sub rulewhen {
+location-hierarchy-transitivity sub rule,
+    when {
         $lh1 (location-hierarchy_superior: $a, location-hierarchy_subordinate: $b) isa location-hierarchy;
         $lh2 (location-hierarchy_superior: $b, location-hierarchy_subordinate: $c) isa location-hierarchy;
     }, then {
-        { (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy; };
+        (location-hierarchy_superior: $a, location-hierarchy_subordinate: $c) isa location-hierarchy;
     };
 
-person-membership-of-organisation-means-relocation sub rulewhen {
+person-membership-of-organisation-means-relocation sub rule,
+    when {
         (membership_member: $person, membership_group: $group) isa membership;
         (locates_located: $group, locates_location: $location) isa locates;
     }, then {
-        { (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation; };
+        (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation;
     };
 
-person-membership-of-organisation-means-relocation-date sub rulewhen {
+person-membership-of-organisation-means-relocation-date sub rule,
+    when {
         (membership_member: $person, membership_group: $group) isa membership, has start-date $membership-start-date;
         (locates_located: $group, locates_location: $location) isa locates;
         $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation;
     }, then {
-        { $rel has relocation-date $membership-start-date; };
+        $rel has relocation-date $membership-start-date;
     };
 
-person-relocating-adds-new-residency sub rulewhen {
+person-relocating-adds-new-residency sub rule,
+    when {
         $rel (relocation_relocated-person: $person, relocation_new-location: $location) isa relocation;
     }, then {
-        { (residency_resident: $person, residency_location: $location) isa residency; };
+        (residency_resident: $person, residency_location: $location) isa residency;
     };
 
-person-relocating-ends-old-residency sub rulewhen {
+person-relocating-ends-old-residency sub rule,
+    when {
         $rel (relocation_relocated-person: $person, relocation_previous-location: $location) isa relocation, has relocation-date $rel-date;
         $old-residency (residency_resident: $person, residency_location: $location) isa residency;
     }, then {
-        { $old-residency has end-date $rel-date; };
+        $old-residency has end-date $rel-date;
     };
 
-person-with-no-active-employment-is-unemployed sub rulewhen {
+person-with-no-active-employment-is-unemployed sub rule,
+    when {
         $p isa person;
         not { $e (employment_employee: $p) isa employment; };
     }, then {
-        { $p isa unemployed-person; };
+        $p isa unemployed-person;
     };
 
-residency-without-end-date-is-current sub rulewhen {
+residency-without-end-date-is-current sub rule,
+    when {
         $res (residency_resident: $person, residency_location: $location) isa residency;
         not { $res has end-date $rel-date; };
     }, then {
-        { $res has is-current true; };
+        $res has is-current true;
     };
 
-transaction-currency-is-that-of-the-country sub rulewhen {
+transaction-currency-is-that-of-the-country sub rule,
+    when {
         $transaction isa transaction;
         $l (locates_located: $t, locates_location: $transaction-location) isa locates;
         $transaction-country isa country, has currency $currency;
     }, then {
-        { $transaction has currency $currency; };
+        $transaction has currency $currency;
     };
 
 


### PR DESCRIPTION
## What is the goal of this PR?

We complete the the schema export functionality, including missing rules in the printed schema when calling `./grakn export [keyspace] [filename].grakn`

## What are the changes implemented in this PR?

Schema.java includes TypeHierachy of rules, and logic has been added to print rules in a consistent way.

schema_export_truth.gql updated in order to reflect new output
