### PR TITLE
Add new configs that speed up JanusGraph

### DIFF
--- a/server/conf/grakn.properties
+++ b/server/conf/grakn.properties
@@ -70,3 +70,10 @@ cache.db-cache=false
 cache.db-cache-size=0.35
 cache.tx-cache-size=30000
 cache.tx-dirty-size=4096
+
+# The number of milliseconds that the JanusGraph id pool manager will wait before
+# giving up on allocating a new block of ids
+root.ids.renew-timeout=10
+
+# The number of milliseconds the system waits for an ID block reservation to be acknowledged by the storage backend
+ids.authority.wait-time=10


### PR DESCRIPTION
## What is the goal of this PR?

To sharply improve the performance of Graql `insert` queries.

We found a number of points in the JanusGraph internal code that were blocking the main thread for no apparent purpose. These configuration settings patch out those blocks - or rather, drastically reduce their blocking times.

## What are the changes implemented in this PR?

We add two new configuration settings to `grakn.properties`:

- `root.ids.renew-timeout=10` - The number of milliseconds that the JanusGraph id pool manager will wait before giving up on allocating a new block of ids (default value is 300ms)
- `ids.authority.wait-time=10` - The number of milliseconds the system waits for an ID block reservation to be acknowledged by the storage backend (default value is 300ms)
