### PR TITLE
Remove ErrorMessage assertion error

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -106,15 +106,9 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
 
         private static final String codePrefix = "DBS";
         private static final String messagePrefix = "Invalid Database Operations";
-        private int number;
 
         Database(int number, String message) {
             super(codePrefix, number, messagePrefix, message);
-            this.number = number;
-        }
-
-        public Database args(Object... parameters) {
-            return new Database(number, message(parameters));
         }
     }
 

--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -18,53 +18,63 @@
 
 package grakn.core.common.exception;
 
+import grakn.common.collection.Pair;
+
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+import static grakn.common.collection.Collections.pair;
+
 public class GraknException extends RuntimeException {
     @Nullable
     private final ErrorMessage errorMessage;
+    @Nullable
+    private final Object[] parameters;
 
     // TODO replace usages with GraknException.of()
     public GraknException(String error) {
         super(error);
         errorMessage = null;
+        parameters = null;
     }
 
     // TODO replace usages with GraknException.of()
-    public GraknException(ErrorMessage error) {
-        super(error.toString());
+    public GraknException(ErrorMessage error, Object... parameters) {
+        super(error.message(parameters));
         assert !getMessage().contains("%s");
         this.errorMessage = error;
+        this.parameters = parameters;
     }
 
     // TODO replace usages with GraknException.of()
     public GraknException(Exception e) {
         super(e);
         errorMessage = null;
+        parameters = null;
     }
 
     // TODO replace usages with GraknException.of()
     public GraknException(List<GraknException> exceptions) {
         super(getMessages(exceptions));
         errorMessage = null;
+        parameters = null;
     }
 
     public static GraknException of(Exception e) {
         return new GraknException(e);
     }
 
-    public static GraknException of(ErrorMessage errorMessage) {
-        return new GraknException(errorMessage);
+    public static GraknException of(ErrorMessage errorMessage, Object... parameters) {
+        return new GraknException(errorMessage, parameters);
     }
 
     public static GraknException of(String error) {
         return new GraknException(error);
     }
 
-    public Optional<ErrorMessage> errorMessage() {
-        return Optional.ofNullable(errorMessage);
+    public Optional<String> code() {
+        return Optional.ofNullable(errorMessage).map(e -> e.code());
     }
 
     public static String getMessages(List<GraknException> exceptions) {

--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -18,13 +18,9 @@
 
 package grakn.core.common.exception;
 
-import grakn.common.collection.Pair;
-
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
-
-import static grakn.common.collection.Collections.pair;
 
 public class GraknException extends RuntimeException {
     @Nullable

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -125,7 +125,7 @@ public class RocksDatabase implements Grakn.Database {
     }
 
     RocksSession createAndOpenSession(Arguments.Session.Type type, Options.Session options) {
-        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED.args(name));
+        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED, name);
 
         long lock = 0;
         final RocksSession session;
@@ -144,7 +144,7 @@ public class RocksDatabase implements Grakn.Database {
     }
 
     synchronized Cache borrowCache() {
-        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED.args(name));
+        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED, name);
 
         if (cache == null) cache = new Cache(this);
         cache.borrow();
@@ -156,7 +156,7 @@ public class RocksDatabase implements Grakn.Database {
     }
 
     synchronized void invalidateCache() {
-        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED.args(name));
+        if (!isOpen.get()) throw GraknException.of(DATABASE_CLOSED, name);
 
         if (cache != null) {
             cache.invalidate();
@@ -334,7 +334,7 @@ public class RocksDatabase implements Grakn.Database {
                     tx.graphMgr.data().stats().processCountJobs();
                     tx.commit();
                 } catch (GraknException e) {
-                    if (e.errorMessage().isPresent() && e.errorMessage().get().code().equals(DATABASE_CLOSED.code())) {
+                    if (e.code().isPresent() && e.code().get().equals(DATABASE_CLOSED.code())) {
                         break;
                     }
                     else {


### PR DESCRIPTION
## What is the goal of this PR?

Currently there's an assertion in the `graknlabs/common`  `ErrorMessage` class that checks to make sure we will only have singleton combination of code prefix and code number. https://github.com/graknlabs/common/blob/cfd261fd5412a0b45cb5494555e4491dd3ce5f64/exception/ErrorMessage.java#L39

We cannot clone the `ErrorMessage` class, therefore for the `ErrorMessage` that needs parameters, we instantiate the parameters at `GraknException` level.

## What are the changes implemented in this PR?

- Allow `GraknException` to take in `Object... parameters` and create a corresponding error message.