### PR TITLE
Build remotely on Ubuntu 20.04

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -21,30 +21,13 @@ test --incompatible_strict_action_env
 
 # what is defined in this section will be applied when bazel is invoked like this: bazel ... --config=rbe ...
 build:rbe --project_id=grakn-dev
-build:rbe --remote_instance_name=projects/grakn-dev/instances/default_instance
 build:rbe --remote_cache=cloud.buildbuddy.io
 build:rbe --remote_executor=cloud.buildbuddy.io
 build:rbe --bes_backend=cloud.buildbuddy.io
 build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
-build:rbe --host_platform=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --extra_execution_platforms=@graknlabs_dependencies//image/rbe:ubuntu-1604
-build:rbe --host_javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --javabase=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/java:jdk
-build:rbe --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --java_toolchain=@bazel_tools//tools/jdk:toolchain_hostjdk8
-build:rbe --extra_toolchains=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/config:cc-toolchain
-build:rbe --crosstool_top=@bazel_toolchains//configs/ubuntu16_04_clang/11.0.0/bazel_3.0.0/cc:toolchain
+build:rbe --host_platform=@graknlabs_dependencies//image/buildbuddy:ubuntu-2004
 build:rbe --jobs=50
 build:rbe --remote_timeout=3600
-build:rbe --bes_timeout=600s
-build:rbe --spawn_strategy=remote
-build:rbe --strategy=Javac=remote
-build:rbe --strategy=Closure=remote
-build:rbe --genrule_strategy=remote
-build:rbe --define=EXECUTOR=remote
-build:rbe --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
-build:rbe --experimental_strict_action_env=true
 

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -73,8 +73,8 @@ build:
     test-assembly-linux-targz:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
@@ -83,16 +83,16 @@ build:
     test-assembly-docker:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
@@ -103,8 +103,8 @@ build:
     deploy-apt-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
@@ -119,8 +119,8 @@ build:
     deploy-rpm-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
@@ -130,16 +130,16 @@ build:
     test-deployment-apt:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [deploy-apt-snapshot]
       script: |
         bazel test //test/deployment:apt --action_env=GRABL_COMMIT --test_output=streamed
     test-deployment-rpm:
       machine: graknlabs-centos-8.2
       filter:
-        owner: vmax
-        branch: rbe-ubuntu20
+        owner: graknlabs
+        branch: master
       dependencies: [deploy-rpm-snapshot]
       script: |
         bazel test //test/deployment:rpm --action_env=GRABL_COMMIT --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -45,7 +45,7 @@ build:
     build:
       machine: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel build //...
+        bazel build --config=rbe //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
         bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
     build-dependency:
@@ -57,24 +57,24 @@ build:
     test-unit:
       machine: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //common/... --test_output=errors
-        bazel test //pattern/... --test_output=errors
-        bazel test //reasoner/... --test_output=errors
+        bazel test --config=rbe //common/... --test_output=errors
+        bazel test --config=rbe //pattern/... --test_output=errors
+        bazel test --config=rbe //reasoner/... --test_output=errors
     test-integration:
       machine: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //test/integration/... --test_output=errors
+        bazel test --config=rbe //test/integration/... --test_output=errors
     test-behaviour:
       machine: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //test/behaviour/connection/... --test_output=errors
-        bazel test //test/behaviour/concept/... --test_output=errors
-        bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel test --config=rbe //test/behaviour/connection/... --test_output=errors
+        bazel test --config=rbe //test/behaviour/concept/... --test_output=errors
+        bazel test --config=rbe //test/behaviour/graql/language/define/... --test_output=errors
     test-assembly-linux-targz:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
@@ -84,7 +84,7 @@ build:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
         bazel test //test/assembly:docker --test_output=streamed
@@ -92,7 +92,7 @@ build:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME
@@ -104,7 +104,7 @@ build:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
@@ -120,7 +120,7 @@ build:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
         export DEPLOY_RPM_USERNAME=$REPO_GRAKN_USERNAME
@@ -131,7 +131,7 @@ build:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [deploy-apt-snapshot]
       script: |
         bazel test //test/deployment:apt --action_env=GRABL_COMMIT --test_output=streamed
@@ -139,7 +139,7 @@ build:
       machine: graknlabs-centos-8.2
       filter:
         owner: graknlabs
-        branch: master
+        branch: rbe-ubuntu20
       dependencies: [deploy-rpm-snapshot]
       script: |
         bazel test //test/deployment:rpm --action_env=GRABL_COMMIT --test_output=streamed

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -73,7 +73,7 @@ build:
     test-assembly-linux-targz:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
@@ -83,7 +83,7 @@ build:
     test-assembly-docker:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
       script: |
@@ -91,7 +91,7 @@ build:
     deploy-artifact-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
@@ -103,7 +103,7 @@ build:
     deploy-apt-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
@@ -119,7 +119,7 @@ build:
     deploy-rpm-snapshot:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [test-assembly-linux-targz]
       script: |
@@ -130,7 +130,7 @@ build:
     test-deployment-apt:
       machine: graknlabs-ubuntu-20.04-java11
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [deploy-apt-snapshot]
       script: |
@@ -138,7 +138,7 @@ build:
     test-deployment-rpm:
       machine: graknlabs-centos-8.2
       filter:
-        owner: graknlabs
+        owner: vmax
         branch: rbe-ubuntu20
       dependencies: [deploy-rpm-snapshot]
       script: |

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "a4f56afaacd8d09cc62a6c2fc0fd55718eaa98c2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "6ed5b544d1ebd7f650763fbe1aec67d48909d842", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

In order to speed up our builds, we should do them remotely on BuildBuddy

## What are the changes implemented in this PR?

Tweak `.bazelrc` settings to build on BuildBuddy with our own Ubuntu 20.04 image