### PR TITLE
Background counter thread only needs to run once on server starts

### DIFF
--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -317,7 +317,7 @@ public class RocksDatabase implements Grakn.Database {
 
         StatisticsBackgroundCounter(RocksSession.Data session) {
             this.session = session;
-            countJobNotifications = new Semaphore(1);
+            countJobNotifications = new Semaphore(0);
             thread = NamedThreadFactory.create(session.database.name + "::statistics-background-counter")
                     .newThread(this::countFn);
             thread.start();


### PR DESCRIPTION
## What is the goal of this PR?

Recently we refactored the background counter loop to be a `do...while` loop instead of `while` loop, therefore the initial value of semaphore (which controls if there're counting work to do) doesn't need to be `1` anymore. Since when server starts, the background counter thread already must do work once due to the effect of `do...while` loop.

## What are the changes implemented in this PR?

- Set the initial count of background counter thread semaphore to be `0`.