### PR TITLE
Type Hinter will no longer give abstract hints for Thing Variables

### DIFF
--- a/logic/tool/TypeHinter.java
+++ b/logic/tool/TypeHinter.java
@@ -222,6 +222,7 @@ public class TypeHinter {
     }
 
     private void removeAbstractHints(Set<Label> hints) {
+        //TODO: use .getType(label) once ConceptManager can handle labels
         hints.removeIf(label -> {
             Type type = conceptMgr.getType(label.scopedName());
             assert type != null;

--- a/logic/tool/TypeHinter.java
+++ b/logic/tool/TypeHinter.java
@@ -214,20 +214,12 @@ public class TypeHinter {
     }
 
     private void addInferredIsaLabels(ThingVariable variable, Set<Label> hints, Map<Label, TypeVariable> labelMap) {
-        removeAbstractHints(hints);
+        //TODO: use .getType(label) once ConceptManager can handle labels
+        hints.removeIf(label -> conceptMgr.getType(label.scopedName()).isAbstract());
         if (!variable.isa().isPresent()) {
             variable.isa(lowestCommonSuperType(hints, labelMap), false);
         }
         variable.isa().get().addHints(hints);
-    }
-
-    private void removeAbstractHints(Set<Label> hints) {
-        //TODO: use .getType(label) once ConceptManager can handle labels
-        hints.removeIf(label -> {
-            Type type = conceptMgr.getType(label.scopedName());
-            assert type != null;
-            return type.isAbstract();
-        });
     }
 
     private TypeVariable lowestCommonSuperType(Set<Label> labels, Map<Label, TypeVariable> labelMap) {


### PR DESCRIPTION
## What is the goal of this PR?

Type Hinter should no longer suggest an abstract type for any Thing Variable. This is because a Thing Variable cannot be a an instance of an abstract type. However, it is still true that a Type Variable can be. 

For example, if we `person sub entity, abstract;`, `man sub person;`, `woman sub person;`. Then `$x isa person;` should have Type Hints `{man, woman}`, whilst `$x sub person;` should have Type Hints `{man, woman, person}`.

## What are the changes implemented in this PR?

A new method in TypeHinter to check for abstract labels and used exclusively when dealing with Thing Variables