### PR TITLE
Rename logics() to logic() in Transaction API

### DIFF
--- a/Grakn.java
+++ b/Grakn.java
@@ -114,7 +114,7 @@ public interface Grakn extends AutoCloseable {
 
         ConceptManager concepts();
 
-        LogicManager logics();
+        LogicManager logic();
 
         QueryManager query();
 

--- a/rocks/RocksTransaction.java
+++ b/rocks/RocksTransaction.java
@@ -104,7 +104,7 @@ public abstract class RocksTransaction implements Grakn.Transaction {
     }
 
     @Override
-    public LogicManager logics() {
+    public LogicManager logic() {
         if (!isOpen.get()) throw GraknException.of(TRANSACTION_CLOSED);
         return logicMgr;
     }

--- a/server/rpc/TransactionRPC.java
+++ b/server/rpc/TransactionRPC.java
@@ -288,11 +288,11 @@ public class TransactionRPC {
 
         private RequestHandlers() {
             conceptManager = new ConceptManagerHandler(TransactionRPC.this, transaction.concepts());
-            logicManager = new LogicManagerHandler(TransactionRPC.this, transaction.logics());
+            logicManager = new LogicManagerHandler(TransactionRPC.this, transaction.logic());
             query = new QueryHandler(TransactionRPC.this, transaction.query());
             thing = new ThingHandler(TransactionRPC.this, transaction.concepts());
             type = new TypeHandler(TransactionRPC.this, transaction.concepts());
-            rule = new RuleHandler(TransactionRPC.this, transaction.logics());
+            rule = new RuleHandler(TransactionRPC.this, transaction.logic());
         }
     }
 }

--- a/test/integration/BasicTest.java
+++ b/test/integration/BasicTest.java
@@ -320,7 +320,7 @@ public class BasicTest {
             try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final AttributeType name = conceptMgr.putAttributeType("name", STRING);
                     final EntityType person = conceptMgr.putEntityType("person");
                     final RelationType friendship = conceptMgr.putRelationType("friendship");
@@ -334,7 +334,7 @@ public class BasicTest {
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final EntityType person = conceptMgr.getEntityType("person");
                     final AttributeType.String name = conceptMgr.getAttributeType("name").asString();
                     final RelationType friendship = conceptMgr.getRelationType("friendship");
@@ -359,7 +359,7 @@ public class BasicTest {
             try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
 
                     final EntityType person = conceptMgr.putEntityType("person");
                     final RelationType friendship = conceptMgr.putRelationType("friendship");
@@ -376,7 +376,7 @@ public class BasicTest {
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final EntityType person = conceptMgr.getEntityType("person");
                     final RelationType friendship = conceptMgr.getRelationType("friendship");
                     final RoleType friend = friendship.getRelates("friend");

--- a/test/integration/QueryTest.java
+++ b/test/integration/QueryTest.java
@@ -110,10 +110,10 @@ public class QueryTest {
                     assertTrue(user.getPlays().anyMatch(r -> r.equals(teamMember_member)));
 
                     // check first 4 rules
-                    assertNotNull(tx.logics().getRule("repo-fork-rule"));
-                    assertNotNull(tx.logics().getRule("repo-dependency-transitive-rule"));
-                    assertNotNull(tx.logics().getRule("repo-dependency-transitive-type-rule"));
-                    assertNotNull(tx.logics().getRule("repo-collaborator-org-rule"));
+                    assertNotNull(tx.logic().getRule("repo-fork-rule"));
+                    assertNotNull(tx.logic().getRule("repo-dependency-transitive-rule"));
+                    assertNotNull(tx.logic().getRule("repo-dependency-transitive-type-rule"));
+                    assertNotNull(tx.logic().getRule("repo-collaborator-org-rule"));
                 }
             }
         }
@@ -185,10 +185,10 @@ public class QueryTest {
                     final AttributeType index = tx.concepts().getAttributeType("index");
                     assertNull(index);
 
-                    assertNull(tx.logics().getRule("repo-fork-rule"));
-                    assertNull(tx.logics().getRule("repo-dependency-transitive-rule"));
-                    assertNull(tx.logics().getRule("repo-dependency-transitive-type-rule"));
-                    assertNull(tx.logics().getRule("repo-collaborator-org-rule"));
+                    assertNull(tx.logic().getRule("repo-fork-rule"));
+                    assertNull(tx.logic().getRule("repo-dependency-transitive-rule"));
+                    assertNull(tx.logic().getRule("repo-dependency-transitive-type-rule"));
+                    assertNull(tx.logic().getRule("repo-collaborator-org-rule"));
                 }
             }
         }

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -82,7 +82,7 @@ public class RuleTest {
             try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
 
                     final EntityType person = conceptMgr.putEntityType("person");
                     final RelationType friendship = conceptMgr.putRelationType("friendship");
@@ -98,7 +98,7 @@ public class RuleTest {
                     txn.commit();
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("marriage-is-friendship");
 
                     Set<HeadConcludable<?, ?>> headConcludables = rule.head();
@@ -126,7 +126,7 @@ public class RuleTest {
             try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
 
                     final EntityType milk = conceptMgr.putEntityType("milk");
                     final AttributeType ageInDays = conceptMgr.putAttributeType("age-in-days", AttributeType.ValueType.LONG);
@@ -141,7 +141,7 @@ public class RuleTest {
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("old-milk-is-not-good");
 
                     Set<HeadConcludable<?, ?>> headConcludables = rule.head();
@@ -169,7 +169,7 @@ public class RuleTest {
             try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
                     final ConceptManager conceptMgr = txn.concepts();
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
 
                     final EntityType milk = conceptMgr.putEntityType("milk");
                     final AttributeType ageInDays = conceptMgr.putAttributeType("age-in-days", AttributeType.ValueType.LONG);
@@ -183,7 +183,7 @@ public class RuleTest {
                     txn.commit();
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
-                    final LogicManager logicMgr = txn.logics();
+                    final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("old-milk-is-not-good");
 
                     Set<HeadConcludable<?, ?>> headConcludables = rule.head();

--- a/test/integration/logic/TypeHinterTest.java
+++ b/test/integration/logic/TypeHinterTest.java
@@ -141,7 +141,7 @@ public class TypeHinterTest {
     @Test
     public void isa_inference() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $p isa person; ";
         Conjunction exhaustiveConjunction = runExhaustiveHinter(typeHinter, queryString);
@@ -158,7 +158,7 @@ public class TypeHinterTest {
     @Test
     public void isa_explicit_inference() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $p isa! person; ";
         Conjunction exhaustiveConjunction = runExhaustiveHinter(typeHinter, queryString);
@@ -175,7 +175,7 @@ public class TypeHinterTest {
     @Test
     public void is_inference() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match" +
                 "  $p sub entity;" +
@@ -197,7 +197,7 @@ public class TypeHinterTest {
     @Test
     public void has_inference() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $p has name 'bob';";
 
@@ -215,7 +215,7 @@ public class TypeHinterTest {
     @Test
     public void has_inference_variable_with_attribute_type() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $p has name $a;";
 
@@ -233,7 +233,7 @@ public class TypeHinterTest {
     @Test
     public void has_inference_variable_without_attribute_type() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match" +
                 "  $p isa shape;" +
@@ -252,7 +252,7 @@ public class TypeHinterTest {
     @Test
     public void relation_concrete_role_concrete() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $r (wife: $yoko) isa marriage;";
 
@@ -278,7 +278,7 @@ public class TypeHinterTest {
     @Test
     public void relation_variable_role_concrete_relation_hidden_variable() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $r ($role: $yoko) isa marriage;";
 
@@ -305,7 +305,7 @@ public class TypeHinterTest {
     @Test
     public void relation_variable_role_variable_relation_named_variable() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $r (wife: $yoko) isa $m;";
 
@@ -331,7 +331,7 @@ public class TypeHinterTest {
     @Test
     public void minimal_relation() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $r (wife: $yoko);";
 
@@ -356,7 +356,7 @@ public class TypeHinterTest {
     @Test
     public void relation_multiple_roles() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $r (husband: $john, $role: $yoko, $a) isa marriage;";
 
@@ -385,7 +385,7 @@ public class TypeHinterTest {
     @Test
     public void has_reverse() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match" +
                 "  $p isa! person;" +
@@ -405,7 +405,7 @@ public class TypeHinterTest {
     @Test
     public void negations_ignored() throws IOException {
         define_standard_schema("basic-schema");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $p isa person;" +
                 "  not {$p isa man;};";
@@ -431,7 +431,7 @@ public class TypeHinterTest {
                         "  greek sub man;" +
                         "  socrates sub greek;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $p isa man;" +
                 "  man sub $q;";
@@ -457,7 +457,7 @@ public class TypeHinterTest {
                         "  weight sub attribute, value double;" +
                         "  name sub attribute, value string;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $p has $a;" +
                 "  $a='bob';";
@@ -485,7 +485,7 @@ public class TypeHinterTest {
                         "  weight sub attribute, value long;" +
                         "  leg-weight, sub weight;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $a has weight $c;" +
                 "  $b has leg-weight 5;" +
@@ -514,7 +514,7 @@ public class TypeHinterTest {
                         "  nickname sub attribute, value string, owns name;" +
                         "  surname sub attribute, value string, owns name;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $a has $b" +
                 "  $b has $a";
@@ -543,7 +543,7 @@ public class TypeHinterTest {
                         "  weight sub attribute, value double, owns measure-system;" +
                         "  measure-system sub attribute, owns conversion-rate;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match" +
                 "  $a has $b" +
                 "  $b has $c" +
@@ -567,7 +567,7 @@ public class TypeHinterTest {
     @Test
     public void you_know_the_thing() throws IOException {
         define_standard_schema("schema-basic");
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $x isa thing;";
 
@@ -592,7 +592,7 @@ public class TypeHinterTest {
                         "  greek sub man;" +
                         "  socrates sub greek;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match $x isa $y;" +
                 "  $y sub $z;" +
@@ -634,7 +634,7 @@ public class TypeHinterTest {
                         "  hand-weight sub weight;" +
                         "  tail-weight sub weight"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
 
         String queryString = "match" +
                 "  $a has $c;" +
@@ -674,7 +674,7 @@ public class TypeHinterTest {
                         "  marriage sub relation, relates husband, relates wife, owns marriage-attr; " +
                         "  ownership sub relation, relates pet, relates owner, owns ownership-attr;"
         );
-        TypeHinter typeHinter = transaction.logics().typeHinter();
+        TypeHinter typeHinter = transaction.logic().typeHinter();
         String queryString = "match " +
                 "  $a isa $t; " +
                 "  $b isa $t; " +


### PR DESCRIPTION
## What is the goal of this PR?

Based on the discussion between @alexjpwalker and @flyingsilverfin, `logics()` is not an English word and as an API it reads less nice compared with `logic()`. In the light of making our API read nice, we rename `logics()` to `logic()`.

## What are the changes implemented in this PR?

- Rename `logics()` to `logic()` in `Transaction` API.