### PR TITLE
Fix issues with deploying Mac and Windows artifacts

### DIFF
--- a/server/BUILD
+++ b/server/BUILD
@@ -221,7 +221,7 @@ deploy_artifact(
     name = "deploy-mac-zip",
     target = ":assemble-mac-zip",
     artifact_group = "graknlabs_grakn_core",
-    artifact_name = "grakn-core-server-mac-{version}.tar.gz",
+    artifact_name = "grakn-core-server-mac-{version}.zip",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )
@@ -230,7 +230,7 @@ deploy_artifact(
     name = "deploy-windows-zip",
     target = ":assemble-windows-zip",
     artifact_group = "graknlabs_grakn_core",
-    artifact_name = "grakn-core-server-windows-{version}.tar.gz",
+    artifact_name = "grakn-core-server-windows-{version}.zip",
     release = deployment['artifact.release'],
     snapshot = deployment['artifact.snapshot'],
 )


### PR DESCRIPTION
## What is the goal of this PR?

Currently, artifacts for Windows and Mac are deployed with incorrect names - ZIP archives are named with `.tar.gz` suffix.

## What are the changes implemented in this PR?

Change the suffix of deployed Windows and Mac artifacts to be correct (`.zip` in both cases)