### PR TITLE
Read buffered rules and persisted rules together

### DIFF
--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -169,7 +169,7 @@ public class SchemaGraph implements Graph {
         Encoding.Prefix index = IndexIID.Rule.prefix();
         ResourceIterator<RuleStructure> persistedRules = storage.iterate(index.bytes(), (key, value) ->
                 convert(StructureIID.Rule.of(value)));
-        return link(list(persistedRules, Iterators.iterate(rulesByIID.values()))).distinct();
+        return link(list(Iterators.iterate(rulesByIID.values()), persistedRules)).distinct();
     }
 
     public ResourceIterator<TypeVertex> thingTypes() {

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -41,7 +41,7 @@ public class LogicCache  {
         ruleCache = new CommonCache<>(size, timeOutMinutes);
     }
 
-    CommonCache<Conjunction, Map<Reference, Set<Label>>> hinter() { return typeHinterCache; }
+    public CommonCache<Conjunction, Map<Reference, Set<Label>>> hinter() { return typeHinterCache; }
 
     CommonCache<String, Rule> rule() { return ruleCache; }
 }

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -55,7 +55,7 @@ public class LogicManager {
         this.graphMgr = graphMgr;
         this.conceptMgr = conceptMgr;
         this.logicCache = logicCache;
-        this.typeHinter = new TypeHinter(conceptMgr, traversalEng, logicCache.hinter());
+        this.typeHinter = new TypeHinter(conceptMgr, traversalEng, logicCache);
     }
 
     public Rule putRule(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {

--- a/logic/tool/TypeHinter.java
+++ b/logic/tool/TypeHinter.java
@@ -18,12 +18,12 @@
 
 package grakn.core.logic.tool;
 
-import grakn.core.common.cache.CommonCache;
 import grakn.core.common.concurrent.ExecutorService;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Label;
 import grakn.core.concept.ConceptManager;
 import grakn.core.concept.type.Type;
+import grakn.core.logic.LogicCache;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.constraint.thing.HasConstraint;
 import grakn.core.pattern.constraint.thing.IsaConstraint;
@@ -59,13 +59,12 @@ public class TypeHinter {
 
     private final ConceptManager conceptMgr;
     private final TraversalEngine traversalEng;
-    private final CommonCache<Conjunction, Map<Reference, Set<Label>>> cache;
+    private final LogicCache logicCache;
 
-    public TypeHinter(ConceptManager conceptMgr, TraversalEngine traversalEng,
-                      CommonCache<Conjunction, Map<Reference, Set<Label>>> cache) {
+    public TypeHinter(ConceptManager conceptMgr, TraversalEngine traversalEng, LogicCache logicCache) {
         this.conceptMgr = conceptMgr;
         this.traversalEng = traversalEng;
-        this.cache = cache;
+        this.logicCache = logicCache;
     }
 
     public Conjunction computeHintsExhaustive(Conjunction conjunction) {
@@ -271,7 +270,7 @@ public class TypeHinter {
 
     private Map<Reference, Set<Label>> retrieveVariableHints(Set<Variable> varHints, int parallelisation) {
         Conjunction varHintsConjunction = new Conjunction(varHints, Collections.emptySet());
-        return cache.get(varHintsConjunction, conjunction -> {
+        return logicCache.hinter().get(varHintsConjunction, conjunction -> {
             Map<Reference, Set<Label>> mapping = new HashMap<>();
             buffer(traversalEng.execute(conjunction.traversal(), parallelisation)).iterator().forEachRemaining(
                     result -> result.forEach((ref, vertex) -> {


### PR DESCRIPTION
## What is the goal of this PR?

In  https://github.com/graknlabs/grakn/pull/5923, we missed out that uncommitted rules should also be read when reading ALL rules, instead of just returning persisted rules. We also pass in the `LogicCache` into `TypeHinter` instead of extracting out an inner cache to pass in.

## What are the changes implemented in this PR?

* Combine buffered and persisted rules into a single distict iterator when returning all rule structures from `SchemaGraph`
* Pass in the full `LogicCache` to `TypeHinter` instead of extracting just the internal `CommonCache` required for `TypeHinter`