### PR TITLE
Fix bug of string length deserialization

### DIFF
--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -169,8 +169,12 @@ public class Bytes {
     }
 
     public static String bytesToString(byte[] bytes, Charset encoding) {
-        final byte[] x = Arrays.copyOfRange(bytes, 1, 1 + bytes[0]);
+        final byte[] x = Arrays.copyOfRange(bytes, 1, 1 + unsignedByteToInt(bytes[0]));
         return new String(x, encoding);
+    }
+
+    public static int unsignedByteToInt(byte x) {
+        return x & 0xff;
     }
 
     public static byte booleanToByte(boolean value) {

--- a/graph/iid/VertexIID.java
+++ b/graph/iid/VertexIID.java
@@ -39,6 +39,7 @@ import static grakn.core.common.collection.Bytes.sortedBytesToDouble;
 import static grakn.core.common.collection.Bytes.sortedBytesToLong;
 import static grakn.core.common.collection.Bytes.sortedBytesToShort;
 import static grakn.core.common.collection.Bytes.stringToBytes;
+import static grakn.core.common.collection.Bytes.unsignedByteToInt;
 import static grakn.core.common.exception.ErrorMessage.Internal.UNRECOGNISED_VALUE;
 import static grakn.core.common.exception.ErrorMessage.ThingRead.INVALID_THING_IID_CASTING;
 import static grakn.core.graph.util.Encoding.STRING_ENCODING;
@@ -384,7 +385,7 @@ public abstract class VertexIID extends IID {
             }
 
             public static VertexIID.Attribute.String extract(byte[] bytes, int from) {
-                final int valueLength = bytes[from + VALUE_INDEX] + 1;
+                final int valueLength = unsignedByteToInt(bytes[from + VALUE_INDEX]) + 1;
                 return new VertexIID.Attribute.String(copyOfRange(bytes, from, from + PREFIX_W_TYPE_LENGTH + VALUE_TYPE_LENGTH + valueLength));
             }
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently we save the string length as an unsigned byte (0-255). When we deserialize it, we cannot simply get the number as a byte, otherwise it will be treated as negative number during comparison.

## What are the changes implemented in this PR?

- Convert unsigned byte to int during deserialization.