### PR TITLE
Make repeated fields pluralised in protocol

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "df46da1b83c17e1ec37b433a7d1432a37ccba7b1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "6bf8c601ecd57a2869cde56c17eec8784a9a2804", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/alexjpwalker/protocol",
-        commit = "6bf8c601ecd57a2869cde56c17eec8784a9a2804", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "1d807aeaf9e3d4939bd3d7767e5c3898103e3e82", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/server/rpc/concept/ThingHandler.java
+++ b/server/rpc/concept/ThingHandler.java
@@ -162,7 +162,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, attributes.iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setThingGetHasRes(
-                        ConceptProto.Thing.GetHas.Res.newBuilder().addAllAttribute(
+                        ConceptProto.Thing.GetHas.Res.newBuilder().addAllAttributes(
                                 cons.stream().map(ResponseBuilder.Concept::thing).collect(Collectors.toList()))))
         );
     }
@@ -175,7 +175,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, concepts.iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setThingGetRelationsRes(
-                        ConceptProto.Thing.GetRelations.Res.newBuilder().addAllRelation(
+                        ConceptProto.Thing.GetRelations.Res.newBuilder().addAllRelations(
                                 cons.stream().map(ResponseBuilder.Concept::thing).collect(Collectors.toList()))))
         );
     }
@@ -185,7 +185,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, roleTypes.iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setThingGetPlaysRes(
-                        ConceptProto.Thing.GetPlays.Res.newBuilder().addAllRoleType(
+                        ConceptProto.Thing.GetPlays.Res.newBuilder().addAllRoleTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -217,7 +217,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, responses.build().iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setRelationGetPlayersByRoleTypeRes(
-                        ConceptProto.Relation.GetPlayersByRoleType.Res.newBuilder().addAllRoleTypeWithPlayer(
+                        ConceptProto.Relation.GetPlayersByRoleType.Res.newBuilder().addAllRoleTypesWithPlayers(
                                 cons.stream().map(con -> ConceptProto.Relation.GetPlayersByRoleType.RoleTypeWithPlayer.newBuilder()
                                         .setRoleType(type(con.first()))
                                         .setPlayer(thing(con.second())).build()).collect(Collectors.toList()))))
@@ -233,7 +233,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, things.iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setRelationGetPlayersRes(
-                        ConceptProto.Relation.GetPlayers.Res.newBuilder().addAllThing(
+                        ConceptProto.Relation.GetPlayers.Res.newBuilder().addAllThings(
                                 cons.stream().map(ResponseBuilder.Concept::thing).collect(Collectors.toList()))))
         );
     }
@@ -270,7 +270,7 @@ public class ThingHandler {
         transactionRPC.respond(
                 request, things.iterator(),
                 cons -> response(request, ConceptProto.Thing.Res.newBuilder().setAttributeGetOwnersRes(
-                        ConceptProto.Attribute.GetOwners.Res.newBuilder().addAllThing(
+                        ConceptProto.Attribute.GetOwners.Res.newBuilder().addAllThings(
                                 cons.stream().map(ResponseBuilder.Concept::thing).collect(Collectors.toList()))))
         );
     }

--- a/server/rpc/concept/TypeHandler.java
+++ b/server/rpc/concept/TypeHandler.java
@@ -234,7 +234,7 @@ public class TypeHandler {
     private void getSupertypes(Transaction.Req request, Type type) {
         transactionRPC.respond(request, type.getSupertypes().iterator(), cons ->
                 response(request, ConceptProto.Type.Res.newBuilder().setTypeGetSupertypesRes(
-                        ConceptProto.Type.GetSupertypes.Res.newBuilder().addAllType(
+                        ConceptProto.Type.GetSupertypes.Res.newBuilder().addAllTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList())))));
     }
 
@@ -242,7 +242,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, type.getSubtypes().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setTypeGetSubtypesRes(
-                        ConceptProto.Type.GetSubtypes.Res.newBuilder().addAllType(
+                        ConceptProto.Type.GetSubtypes.Res.newBuilder().addAllTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -251,7 +251,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, thingType.getInstances().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setThingTypeGetInstancesRes(
-                        ConceptProto.ThingType.GetInstances.Res.newBuilder().addAllThing(
+                        ConceptProto.ThingType.GetInstances.Res.newBuilder().addAllThings(
                                 cons.stream().map(ResponseBuilder.Concept::thing).collect(Collectors.toList()))))
         );
     }
@@ -274,7 +274,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, thingType.getOwns(keysOnly).iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setThingTypeGetOwnsRes(
-                        ConceptProto.ThingType.GetOwns.Res.newBuilder().addAllAttributeType(
+                        ConceptProto.ThingType.GetOwns.Res.newBuilder().addAllAttributeTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -283,7 +283,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, thingType.getOwns(valueType, keysOnly).iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setThingTypeGetOwnsRes(
-                        ConceptProto.ThingType.GetOwns.Res.newBuilder().addAllAttributeType(
+                        ConceptProto.ThingType.GetOwns.Res.newBuilder().addAllAttributeTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -292,7 +292,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, thingType.getPlays().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setThingTypeGetPlaysRes(
-                        ConceptProto.ThingType.GetPlays.Res.newBuilder().addAllRole(
+                        ConceptProto.ThingType.GetPlays.Res.newBuilder().addAllRoles(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -352,7 +352,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, attributeType.getOwners(onlyKey).iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setAttributeTypeGetOwnersRes(
-                        ConceptProto.AttributeType.GetOwners.Res.newBuilder().addAllOwner(
+                        ConceptProto.AttributeType.GetOwners.Res.newBuilder().addAllOwners(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -447,7 +447,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, relationType.getRelates().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setRelationTypeGetRelatesRes(
-                        ConceptProto.RelationType.GetRelates.Res.newBuilder().addAllRole(
+                        ConceptProto.RelationType.GetRelates.Res.newBuilder().addAllRoles(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -487,7 +487,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, roleType.getRelationTypes().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setRoleTypeGetRelationTypesRes(
-                        ConceptProto.RoleType.GetRelationTypes.Res.newBuilder().addAllRelationType(
+                        ConceptProto.RoleType.GetRelationTypes.Res.newBuilder().addAllRelationTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }
@@ -496,7 +496,7 @@ public class TypeHandler {
         transactionRPC.respond(
                 request, roleType.getPlayers().iterator(),
                 cons -> response(request, ConceptProto.Type.Res.newBuilder().setRoleTypeGetPlayersRes(
-                        ConceptProto.RoleType.GetPlayers.Res.newBuilder().addAllThingType(
+                        ConceptProto.RoleType.GetPlayers.Res.newBuilder().addAllThingTypes(
                                 cons.stream().map(ResponseBuilder.Concept::type).collect(Collectors.toList()))))
         );
     }

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -83,7 +83,7 @@ public class QueryHandler {
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setMatchRes(
-                        QueryProto.Graql.Match.Res.newBuilder().addAllAnswer(
+                        QueryProto.Graql.Match.Res.newBuilder().addAllAnswers(
                                 as.stream().map(ResponseBuilder.Answer::conceptMap).collect(toList()))))
         );
     }
@@ -94,7 +94,7 @@ public class QueryHandler {
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setInsertRes(
-                        QueryProto.Graql.Insert.Res.newBuilder().addAllAnswer(
+                        QueryProto.Graql.Insert.Res.newBuilder().addAllAnswers(
                                 as.stream().map(ResponseBuilder.Answer::conceptMap).collect(toList()))))
         );
     }


### PR DESCRIPTION
## What is the goal of this PR?

We updated our repeated field names in our protocol, ensuring they are consistently pluralised in line with the Protocol Buffers style guide.

## What are the changes implemented in this PR?

- Make all repeated protocol fields pluralised
