### PR TITLE
Fix bug of string length deserialization

### DIFF
--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -77,7 +77,7 @@ public class Bytes {
 
     public static int unsignedBytesToShort(byte[] bytes) {
         assert bytes.length == SHORT_SIZE;
-        return bytes[0] << 8 & 0xffff | bytes[1];
+        return ((bytes[0] << 8) | bytes[1]) & 0xffff;
     }
 
     public static byte[] shortToSortedBytes(int num) {


### PR DESCRIPTION
## What is the goal of this PR?

Recently we have changed the string length deserialization using two bytes to unsigned short. However, Java performs numeric promotion during integer operations (see [ref](https://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.6.2)), which means `0xff` of a byte value will be first promoted into `0xffffffff` of an int value before performing any operations. This results in the unexpected result of high order bytes not being cleared.

## What are the changes implemented in this PR?

- Force clear the high order bytes during unsigned short deserialization.