### PR TITLE
Fix bug of string length deserialization

### DIFF
--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -77,7 +77,7 @@ public class Bytes {
 
     public static int unsignedBytesToShort(byte[] bytes) {
         assert bytes.length == SHORT_SIZE;
-        return ((bytes[0] << 8) | bytes[1]) & 0xffff;
+        return ((bytes[0] << 8) & 0xff00) | (bytes[1] & 0xff);
     }
 
     public static byte[] shortToSortedBytes(int num) {


### PR DESCRIPTION
## What is the goal of this PR?

This PR fixes an bug in https://github.com/graknlabs/grakn/pull/5943

Recently we have changed the string length deserialization using two bytes to unsigned short. However, Java performs numeric promotion during integer operations (see [ref](https://docs.oracle.com/javase/specs/jls/se7/html/jls-5.html#jls-5.6.2)). Byte value `0xff` will be converted implicitly into `0xffffffff` unless you explicitly clear the bits. For example:

- `0 | (byte)0xff => 0xffffffff`
- `0 | ((byte)0xff & 0xff) => 0x000000ff`

## What are the changes implemented in this PR?

- Force clear unrelated bytes during unsigned short deserialization.
