### PR TITLE
Force ErrorMessage static constants to all be loaded at bootup

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -24,6 +24,16 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         super(codePrefix, codeNumber, messagePrefix, messageBody);
     }
 
+    public static void loadConstants() {
+        for (Class<?> innerClass: ErrorMessage.class.getDeclaredClasses()) {
+            try {
+                Class.forName(innerClass.getName(), true, innerClass.getClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw GraknException.of(e);
+            }
+        }
+    }
+
     public static class Server extends ErrorMessage {
         public static final Server DATA_DIRECTORY_NOT_FOUND =
                 new Server(1, "The expected data directory '%s' does not exist.");

--- a/rocks/RocksGrakn.java
+++ b/rocks/RocksGrakn.java
@@ -21,6 +21,7 @@ package grakn.core.rocks;
 import com.google.ortools.Loader;
 import grakn.core.Grakn;
 import grakn.core.common.concurrent.ExecutorService;
+import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Options;
@@ -40,6 +41,7 @@ public class RocksGrakn implements Grakn {
     static {
         RocksDB.loadLibrary();
         Loader.loadNativeLibraries();
+        ErrorMessage.loadConstants();
     }
 
     private final Path directory;


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed the issue where the error code may look inconsistent. The inconsistency was caused by the fact that the prefix may not be correctly computed due to lazy loading of static classes in Java.

## What are the changes implemented in this PR?

- Force load the static declaration of error messages in the inner classes of `ErrorMessage` using reflection.