### PR TITLE
Persist statistics snapshot into database

### DIFF
--- a/graph/util/Encoding.java
+++ b/graph/util/Encoding.java
@@ -135,6 +135,7 @@ public class Encoding {
         STATISTICS_THINGS(50, PrefixType.STATISTICS),
         STATISTICS_COUNT_JOB(51, PrefixType.STATISTICS),
         STATISTICS_COUNTED(52, PrefixType.STATISTICS),
+        STATISTICS_SNAPSHOT(53, PrefixType.STATISTICS),
         VERTEX_THING_TYPE(100, PrefixType.TYPE),
         VERTEX_ENTITY_TYPE(110, PrefixType.TYPE),
         VERTEX_ATTRIBUTE_TYPE(120, PrefixType.TYPE),

--- a/graph/util/StatisticsBytes.java
+++ b/graph/util/StatisticsBytes.java
@@ -87,4 +87,8 @@ public class StatisticsBytes {
                 attIID.bytes()
         );
     }
+
+    public static byte[] snapshotKey() {
+        return Encoding.Prefix.STATISTICS_SNAPSHOT.bytes();
+    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

To make us recalculate query plan only when needed, we keep a snapshot version of the current statistics. Currently this snapshot is not persisted into database, which means we lost the information on if we should recalculate query plan across data transactions. Therefore we need to persist this snapshot number into database.

## What are the changes implemented in this PR?

- Save statistics snapshot number into database.