### PR TITLE
Fix logic of setting abstract on attribute types

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -328,10 +328,10 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new TypeWrite(10, "An attribute value type (in this case '%s') can only be set onto an attribute type (in this case '%s') when it was defined for the first time.");
         public static final TypeWrite ATTRIBUTE_VALUE_TYPE_UNDEFINED =
                 new TypeWrite(11, "An attribute value type (in this case '%s') cannot be undefined. You can only undefine the attribute type (in this case '%s') itself.");
-        public static final TypeWrite ATTRIBUTE_SUBTYPE_NOT_ABSTRACT =
-                new TypeWrite(12, "The attribute type '%s' cannot be set to abstract as its subtypes are not abstract.");
-        public static final TypeWrite ATTRIBUTE_SUPERTYPE_NOT_ABSTRACT =
-                new TypeWrite(13, "The attribute type '%s' cannot be a subtyped as it is not abstract.");
+        public static final TypeWrite ATTRIBUTE_UNSET_ABSTRACT_HAS_SUBTYPES =
+                new TypeWrite(12, "The attribute type '%s' cannot be set to non abstract as it has subtypes.");
+        public static final TypeWrite ATTRIBUTE_NEW_SUPERTYPE_NOT_ABSTRACT =
+                new TypeWrite(13, "The attribute type '%s' cannot be subtyped as it is not abstract.");
         public static final TypeWrite ATTRIBUTE_REGEX_UNSATISFIES_INSTANCES =
                 new TypeWrite(14, "The attribute type '%s' cannot have regex '%s' as as it has an instance of value '%s'.");
         public static final TypeWrite ATTRIBUTE_VALUE_TYPE_DEFINED_NOT_ON_ATTRIBUTE_TYPE =

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -55,6 +55,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/VladGan/behaviour",
-        commit = "754afdade47a81652b487912eda5406fad8d8878", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/graknlabs/behaviour",
+        commit = "e972115804a0950110f244f5fd7b1992412d79a5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -55,6 +55,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "a5689e86fe816b10c6017281b4c2717bee47937e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/VladGan/behaviour",
+        commit = "754afdade47a81652b487912eda5406fad8d8878", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )


### PR DESCRIPTION
## What is the goal of this PR?

Redefining existing schema follows different logic to creating a fresh schema. There was a bug where Grakn would
falsely claim that an attribute type couldn't be set to abstract as its subtypes were not abstract, which was
only triggered when redefining existing schema.

Also, unsetting abstract now checks that there are no subtypes.

close https://github.com/graknlabs/grakn/issues/5955

## What are the changes implemented in this PR?

 - don't check subtypes when setting abstract on an attribute type;
 - check that there are no subtypes when unsetting abstract on attribute type.