### PR TITLE
Propagate errors from our asynchronous producers to consumers

### DIFF
--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -38,12 +38,12 @@ public class GraknException extends RuntimeException {
         this.errorMessage = error;
     }
 
-    private GraknException(Exception e) {
+    private GraknException(Throwable e) {
         super(e);
         errorMessage = null;
     }
 
-    public static GraknException of(Exception e) {
+    public static GraknException of(Throwable e) {
         return new GraknException(e);
     }
 

--- a/common/producer/BaseProducer.java
+++ b/common/producer/BaseProducer.java
@@ -32,13 +32,19 @@ public class BaseProducer<T> implements Producer<T> {
     @Override
     public void produce(Sink<T> sink, int count) {
         ExecutorService.forkJoinPool().submit(() -> {
-            for (int i = 0; i < count; i++) {
-                if (iterator.hasNext()) {
-                    sink.put(iterator.next());
-                } else {
-                    sink.done(this);
-                    break;
+            try {
+                for (int i = 0; i < count; i++) {
+                    if (iterator.hasNext()) {
+                        sink.put(iterator.next());
+                    } else {
+                        sink.done(this);
+                        break;
+                    }
                 }
+            }
+            catch (Throwable e) {
+                sink.done(this, e);
+                throw e;
             }
         });
     }

--- a/common/producer/FilteredProducer.java
+++ b/common/producer/FilteredProducer.java
@@ -58,5 +58,10 @@ public class FilteredProducer<T> implements Producer<T> {
         public void done(Producer<T> producer) {
             baseSink.done(FilteredProducer.this);
         }
+
+        @Override
+        public void done(Producer<T> producer, Throwable e) {
+            baseSink.done(FilteredProducer.this, e);
+        }
     }
 }

--- a/common/producer/MappedProducer.java
+++ b/common/producer/MappedProducer.java
@@ -57,5 +57,10 @@ public class MappedProducer<T, U> implements Producer<U> {
         public void done(Producer<T> producer) {
             baseSink.done(MappedProducer.this);
         }
+
+        @Override
+        public void done(Producer<T> producer, Throwable e) {
+            baseSink.done(MappedProducer.this, e);
+        }
     }
 }

--- a/common/producer/Producer.java
+++ b/common/producer/Producer.java
@@ -39,5 +39,7 @@ public interface Producer<T> {
         void put(U item);
 
         void done(Producer<U> producer);
+
+        void done(Producer<U> producer, Throwable e);
     }
 }

--- a/test/integration/traversal/BUILD
+++ b/test/integration/traversal/BUILD
@@ -147,6 +147,7 @@ checkstyle_test(
     name = "checkstyle",
     include = glob([
         "*",
+        "TraversalTest8/world2.gql"
     ]),
     exclude = ["TraversalTest8/world2.data"],
     license_type = "agpl",

--- a/traversal/producer/VertexProducer.java
+++ b/traversal/producer/VertexProducer.java
@@ -45,7 +45,12 @@ public class VertexProducer implements Producer<VertexMap> {
 
     @Override
     public void produce(Sink<VertexMap> sink, int count) {
-        if (future == null) future = runAsync(consume(count, sink), forkJoinPool());
+        if (future == null) {
+            future = runAsync(consume(count, sink), forkJoinPool()).exceptionally(e -> {
+                sink.done(this, e);
+                return null;
+            });
+        }
         else future.thenRun(consume(count, sink));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed the issue where `Producer` implementations do not propagate errors to the consumers when they crash. Since the consumers aren't informed of the errors, they may stall forever waiting for results that will never arrive.

## What are the changes implemented in this PR?

- Update the `Done` object to allow for error propagation:
  - construct it with `Done.error(error)` to signal an error
  - otherwise, construct it with `Done.success()`
- Adds exception propagation across every implementation of `Producer.Sink`
- `GraknException`  now takes in `Throwable` rather than `Exception`. This would allow us to propagate not only exceptions but also errors such as `AssertionError`s.
