### PR TITLE
Resolve all labeled variables into `resolvedTypes`

### DIFF
--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -119,7 +119,7 @@ public class TypeResolver {
         return conjunction;
     }
 
-    public Conjunction resolveLabeledVarTypes(Conjunction conjunction) {
+    public Conjunction resolveLabeledVars(Conjunction conjunction) {
         iterate(conjunction.variables()).filter(v -> v.reference().isLabel())
                 .forEachRemaining(typeVar -> {
                     assert typeVar.isType() && typeVar.asType().label().isPresent();

--- a/pattern/variable/Variable.java
+++ b/pattern/variable/Variable.java
@@ -80,6 +80,10 @@ public abstract class Variable implements Pattern {
         throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(ThingVariable.class));
     }
 
+    public void addResolvedType(Label label) {
+        resolvedTypes.add(label);
+    }
+
     public void addResolvedTypes(Set<Label> labels) {
         resolvedTypes.addAll(labels);
     }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -63,7 +63,7 @@ public class Reasoner {
     }
 
     public ResourceIterator<ConceptMap> iteratorSync(Conjunction conjunction) {
-        conjunction = logicMgr.typeResolver().resolveRoleTypes(conjunction);
+        conjunction = logicMgr.typeResolver().resolveLabeledVarTypes(conjunction);
         // conjunction = logicMgr.typeResolver().resolveThingTypes(conjunction);
         return traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap);
     }
@@ -82,8 +82,8 @@ public class Reasoner {
     }
 
     public List<Producer<ConceptMap>> producers(Conjunction conjunction) {
-        conjunction = logicMgr.typeResolver().resolveRoleTypes(conjunction);
-        // conjunction = logicMgr.typeResolver().resolveThingTypes(conjunction);
+        conjunction = logicMgr.typeResolver().resolveLabeledVarTypes(conjunction);
+//         conjunction = logicMgr.typeResolver().resolveNamedVars(conjunction);
         Producer<ConceptMap> answers = traversalEng
                 .producer(conjunction.traversal(), PARALLELISATION_FACTOR)
                 .map(conceptMgr::conceptMap);

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -63,7 +63,7 @@ public class Reasoner {
     }
 
     public ResourceIterator<ConceptMap> iteratorSync(Conjunction conjunction) {
-        conjunction = logicMgr.typeResolver().resolveLabeledVarTypes(conjunction);
+        conjunction = logicMgr.typeResolver().resolveLabeledVars(conjunction);
         // conjunction = logicMgr.typeResolver().resolveThingTypes(conjunction);
         return traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap);
     }
@@ -82,7 +82,7 @@ public class Reasoner {
     }
 
     public List<Producer<ConceptMap>> producers(Conjunction conjunction) {
-        conjunction = logicMgr.typeResolver().resolveLabeledVarTypes(conjunction);
+        conjunction = logicMgr.typeResolver().resolveLabeledVars(conjunction);
 //         conjunction = logicMgr.typeResolver().resolveNamedVars(conjunction);
         Producer<ConceptMap> answers = traversalEng
                 .producer(conjunction.traversal(), PARALLELISATION_FACTOR)

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -121,7 +121,7 @@ public class TypeResolverTest {
     }
 
     private Conjunction runExhaustiveHinter(TypeResolver typeHinter, String matchString) {
-        return typeHinter.resolvedNamedVarsExhaustive(createConjunction(matchString));
+        return typeHinter.resolveNamedVarsExhaustive(createConjunction(matchString));
     }
 
     private Conjunction runSimpleHinter(TypeResolver typeHinter, String matchString) {

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -121,11 +121,11 @@ public class TypeResolverTest {
     }
 
     private Conjunction runExhaustiveHinter(TypeResolver typeHinter, String matchString) {
-        return typeHinter.computeHintsExhaustive(createConjunction(matchString));
+        return typeHinter.resolvedNamedVarsExhaustive(createConjunction(matchString));
     }
 
     private Conjunction runSimpleHinter(TypeResolver typeHinter, String matchString) {
-        return typeHinter.resolveThingTypes(createConjunction(matchString));
+        return typeHinter.resolveNamedVars(createConjunction(matchString));
     }
 
     @Test


### PR DESCRIPTION
## What is the goal of this PR?
We resolve all labels into `TypeVariable.resolvedTypes`, not just scoped labels that may require some work. The end result is that all labeled variables will contain the full set of possible labels within `resolvedTypes`, not just role type variables.

## What are the changes implemented in this PR?
* rename `TypeResolver.resolveRoleTypes()` to `TypeResolver.resolveLabeledVars()`
* rename  `TypeResolver.resolveThingTypes()` to `TypeResolver.resolveNamedVars()`
* `resolveLabeledVars()` now copies labels from any labeled variable into `resolvedTypes`, not just when they are scoped