### PR TITLE
Fix deadlocks caused by recursive produce

### DIFF
--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -26,15 +26,15 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final int DEFAULT_BATCH_SIZE = 50;
-    public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10000;
-    public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10000;
+    public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
+    public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
 
     private PARENT parent;
     private Boolean infer = null;
     private Boolean explain = null;
     private Integer batchSize = null;
-    private Integer sessionIdlTimeoutMillis = 10000;
-    private Integer schemaLockAcquireTimeoutMillis = 10000;
+    private Integer sessionIdlTimeoutMillis = null;
+    private Integer schemaLockAcquireTimeoutMillis = null;
 
     abstract SELF getThis();
 

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -84,7 +84,7 @@ public class GraphProducer implements Producer<VertexMap> {
             if (i < parallelisation) produce(sink, (parallelisation - i) * splitCount);
         } else {
             for (ResourceIterator<VertexMap> iterator : futures.keySet()) {
-                futures.computeIfPresent(iterator, (k, v) -> v.thenRun(consume(k, splitCount, sink)));
+                futures.computeIfPresent(iterator, (k, v) -> v.thenRunAsync(consume(k, splitCount, sink), forkJoinPool()));
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

We see that sometimes the graph producer deadlocks, which is caused by we're appending calling `compute` method on a concurrent map in a recursive method, which will deadlock on trying to compute for the same key.

Also fixed another bug that the session time out default value should be set to null, so that we can properly return the parent's timeout value when the time out is not set.

## What are the changes implemented in this PR?

- Change `thenRun` to `thenRunAsync` so that we never run `compute` on the same thread recursively.