### PR TITLE
Partially clean-up TypeResolver and disable it (temporarily)

### DIFF
--- a/common/iterator/ResourceIterator.java
+++ b/common/iterator/ResourceIterator.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -80,6 +81,10 @@ public interface ResourceIterator<T> extends Iterator<T> {
 
     default boolean noneMatch(Predicate<T> predicate) {
         return !anyMatch(predicate);
+    }
+
+    default Optional<T> first() {
+        return Optional.ofNullable(firstOrNull());
     }
 
     default T firstOrNull() {

--- a/pattern/variable/SystemReference.java
+++ b/pattern/variable/SystemReference.java
@@ -18,17 +18,43 @@
 
 package grakn.core.pattern.variable;
 
-import graql.lang.common.GraqlToken;
 import graql.lang.pattern.variable.Reference;
+
+import java.util.Objects;
 
 public class SystemReference extends Reference.Name {
 
-    public SystemReference(final String name) {
-        super(name);
+    public static String PREFIX = "$/";
+
+    private final int id;
+    private final int hash;
+
+    public SystemReference(int id) {
+        super("sys" + id); // TODO: why are we we doing this? Why does this class have to extend Reference.Name?
+        this.id = id;
+        this.hash = Objects.hash(SystemReference.class, id);
+    }
+
+    public static SystemReference of(int id) {
+        return new SystemReference(id);
     }
 
     @Override
     public String syntax() {
-        return GraqlToken.Char.$SYS + name;
+        return PREFIX + name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SystemReference that = (SystemReference) o;
+        return this.id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
     }
 }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -72,7 +72,7 @@ public class Reasoner {
 
     private List<Producer<ConceptMap>> producers(Conjunction conjunction) {
         conjunction = logicMgr.typeResolver().resolveLabels(conjunction);
-        conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
+        // TODO enable: conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
         Producer<ConceptMap> answers = traversalEng
                 .producer(conjunction.traversal(), PARALLELISATION_FACTOR)
                 .map(conceptMgr::conceptMap);
@@ -99,7 +99,7 @@ public class Reasoner {
 
     private ResourceIterator<ConceptMap> iterator(Conjunction conjunction) {
         conjunction = logicMgr.typeResolver().resolveLabels(conjunction);
-        conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
+        // TODO enable: conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
         ResourceIterator<ConceptMap> answers = traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap);
 
         // TODO: enable reasoner here


### PR DESCRIPTION
## What is the goal of this PR?

As I was debugging `TypeResolver` to fix some bugs that it causes to break Match BDD, I found myself having to interpret some code that is more convoluted than necessary, so I started cleaning them up. I haven't fully cleaned up the entire source code file of TypeResolver - I only managed to clean up `SystemReference`, `TypeResolver.ResolverVariables`, and a bit of `ConstraintMapper`. However, there are already a few glaring questions marks that need to be resolved, which I cannot do with more context TypeResolver. So I've disabled `TypeResolver.resolveVariable.resolveVariablesExhaustive()` from reasoner temporarily, to proceed with fixing the rest of match query bugs.
