### PR TITLE
Use debug logback configuration for flaky test

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -71,7 +71,7 @@ build:
     test-behaviour:
       image: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //test/behaviour/connection/... --test_output=errors
+        bazel test //test/behaviour/connection/... --test_output=streamed
         bazel test //test/behaviour/concept/... --test_output=errors
       # bazel test //test/behaviour/graql/language/define/... --test_output=errors
     test-assembly-linux-targz:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -47,7 +47,7 @@ build:
       script: |
         bazel build //...
         bazel run @graknlabs_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=errors
+        bazel test $(bazel query 'kind(checkstyle_test, //...)') --test_output=streamed
     build-dependency:
       image: graknlabs-ubuntu-20.04-java11
       script: |
@@ -57,23 +57,23 @@ build:
     test-unit:
       image: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //common/... --test_output=errors
-        bazel test //pattern/... --test_output=errors
-        bazel test //reasoner/... --test_output=errors
+        bazel test //common/... --test_output=streamed
+        bazel test //pattern/... --test_output=streamed
+        bazel test //reasoner/... --test_output=streamed
     test-integration:
       image: graknlabs-ubuntu-20.04-java11
       script: |
-        bazel test //test/integration:test-basic --test_output=errors
-        bazel test //test/integration:test-query --test_output=errors
-        bazel test //test/integration/migrator/... --test_output=errors
-        bazel test //test/integration/logic/... --test_output=errors
-      # bazel test //test/integration/traversal/... --test_output=errors
+        bazel test //test/integration:test-basic --test_output=streamed
+        bazel test //test/integration:test-query --test_output=streamed
+        bazel test //test/integration/migrator/... --test_output=streamed
+        bazel test //test/integration/logic/... --test_output=streamed
+      # bazel test //test/integration/traversal/... --test_output=streamed
     test-behaviour:
       image: graknlabs-ubuntu-20.04-java11
       script: |
         bazel test //test/behaviour/connection/... --test_output=streamed
-        bazel test //test/behaviour/concept/... --test_output=errors
-      # bazel test //test/behaviour/graql/language/define/... --test_output=errors
+        bazel test //test/behaviour/concept/... --test_output=streamed
+      # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
     test-assembly-linux-targz:
       image: graknlabs-ubuntu-20.04-java11
       filter:
@@ -83,7 +83,7 @@ build:
       script: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
-        bazel test //test/assembly:assembly --test_output=errors
+        bazel test //test/assembly:assembly --test_output=streamed
     test-assembly-docker:
       image: graknlabs-ubuntu-20.04-java11
       filter:

--- a/common/test/logback.xml
+++ b/common/test/logback.xml
@@ -15,34 +15,44 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<configuration>
+<configuration debug="true" scan="true" scanPeriod="10 seconds" packagingData="true">
+
+    <property resource="grakn.properties"/>
+    <property name="directory" value="${grakn.dir}/${server.logs}"/>
+    <property name="filename" value="grakn.log"/>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%date{ISO8601} [%thread] [%-5level] %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="ERROR">
-        <appender-ref ref="STDOUT"/>
-    </root>
+    <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${directory}/${filename}</file>
+        <encoder>
+            <pattern>%date{ISO8601} [%thread] [%-5level] %logger{36} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${filename}-%d{yyyy-MM}.%i.log.gz</fileNamePattern>
+            <maxFileSize>50MB</maxFileSize>
+            <maxHistory>120</maxHistory>
+            <totalSizeCap>2GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
 
-    <logger name="grakn.core" level="DEBUG" additivity="false">
+    <root level="DEBUG"/>
+
+    <!--    <logger name="grakn.core.server.rpc" level="DEBUG" />-->
+
+    <!--
+    TRACE: (Extremely verbose reporting events that gives complete traceability of a server operation)
+    DEBUG: (Verbose reporting events that gives a deeper understanding of server operations)
+    INFO:  (Reporting events that identifies the progress of server operations)
+    WARN:  (Unexpected events that are not recommended to have happened)
+    ERROR: (Incorrect events that disrupts the server operation, against user expectation)
+    -->
+    <logger name="grakn.core" level="DEBUG">
+        <appender-ref ref="LOGFILE"/>
         <appender-ref ref="STDOUT"/>
     </logger>
-
-    <!-- Use this to suppress excess JanusGraph logging -->
-    <logger name="grakn.core.graph" level="INFO" additivity="false">
-        <appender-ref ref="STDOUT"/>
-    </logger>
-
-    <logger name="server.Server" level="DEBUG">
-        <appender-ref ref="STDOUT"/>
-    </logger>
-
-    <!-- Increase this if wanting to see more verbose reasoner output -->
-    <logger name="grakn.core.graql.reasoner" level="DEBUG" additivity="false">
-        <appender-ref ref="STDOUT"/>
-    </logger>
-
-
 </configuration>

--- a/server/conf/BUILD
+++ b/server/conf/BUILD
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//server:__subpackages__", "//:__pkg__"])
+package(default_visibility = ["//server:__subpackages__", "//test:__subpackages__", "//:__pkg__"])
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 

--- a/server/conf/BUILD
+++ b/server/conf/BUILD
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//server:__subpackages__", "//test:__subpackages__", "//:__pkg__"])
+package(default_visibility = ["//server:__subpackages__", "//:__pkg__"])
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 

--- a/test/behaviour/concept/thing/attribute/BUILD
+++ b/test/behaviour/concept/thing/attribute/BUILD
@@ -65,6 +65,10 @@ java_test(
         "@graknlabs_behaviour//concept/thing:attribute.feature",
     ],
     size = "small",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/thing/entity/BUILD
+++ b/test/behaviour/concept/thing/entity/BUILD
@@ -66,6 +66,10 @@ java_test(
         "@graknlabs_behaviour//concept/thing:entity.feature",
     ],
     size = "small",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/thing/relation/BUILD
+++ b/test/behaviour/concept/thing/relation/BUILD
@@ -68,6 +68,10 @@ java_test(
         "@graknlabs_behaviour//concept/thing:relation.feature",
     ],
     size = "small",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/type/attributetype/BUILD
+++ b/test/behaviour/concept/type/attributetype/BUILD
@@ -61,6 +61,10 @@ java_test(
         "@graknlabs_behaviour//concept/type:attributetype.feature",
     ],
     size = "small",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/type/entitytype/BUILD
+++ b/test/behaviour/concept/type/entitytype/BUILD
@@ -52,6 +52,10 @@ java_test(
         "@graknlabs_behaviour//concept/type:entitytype.feature",
     ],
     size = "medium",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/type/relationtype/BUILD
+++ b/test/behaviour/concept/type/relationtype/BUILD
@@ -65,6 +65,10 @@ java_test(
         "@graknlabs_behaviour//concept/type:relationtype.feature",
     ],
     size = "medium",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/concept/type/thingtype/BUILD
+++ b/test/behaviour/concept/type/thingtype/BUILD
@@ -66,6 +66,10 @@ java_test(
         "@graknlabs_behaviour//concept/type:thingtype.feature",
     ],
     size = "medium",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -57,6 +57,8 @@ java_test(
         "@graknlabs_behaviour//connection:database.feature",
     ],
     size = "medium",
+    resources = [ "//server/conf:logback-debug.xml" ],
+    resource_strip_prefix = "server/conf/",
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/database/BUILD
+++ b/test/behaviour/connection/database/BUILD
@@ -57,8 +57,10 @@ java_test(
         "@graknlabs_behaviour//connection:database.feature",
     ],
     size = "medium",
-    resources = [ "//server/conf:logback-debug.xml" ],
-    resource_strip_prefix = "server/conf/",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/session/BUILD
+++ b/test/behaviour/connection/session/BUILD
@@ -62,6 +62,10 @@ java_test(
         "@graknlabs_behaviour//connection:session.feature",
     ],
     size = "medium",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/connection/transaction/BUILD
+++ b/test/behaviour/connection/transaction/BUILD
@@ -63,6 +63,10 @@ java_test(
         "@graknlabs_behaviour//connection:transaction.feature",
     ],
     size = "small",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/debug/BUILD
+++ b/test/behaviour/debug/BUILD
@@ -51,6 +51,10 @@ java_test(
         ":debug.feature",
     ],
     size = "medium",
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/explanation/language/BUILD
+++ b/test/behaviour/graql/explanation/language/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/explanation:language.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/explanation/reasoner/BUILD
+++ b/test/behaviour/graql/explanation/reasoner/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/explanation:reasoner.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/define/BUILD
+++ b/test/behaviour/graql/language/define/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:define.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/delete/BUILD
+++ b/test/behaviour/graql/language/delete/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:delete.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "small",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/get/BUILD
+++ b/test/behaviour/graql/language/get/BUILD
@@ -37,9 +37,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:get.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/insert/BUILD
+++ b/test/behaviour/graql/language/insert/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:insert.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 

--- a/test/behaviour/graql/language/match/BUILD
+++ b/test/behaviour/graql/language/match/BUILD
@@ -37,9 +37,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:match.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/graql/language/rule_validation/BUILD
+++ b/test/behaviour/graql/language/rule_validation/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:rule-validation.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "small",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 

--- a/test/behaviour/graql/language/undefine/BUILD
+++ b/test/behaviour/graql/language/undefine/BUILD
@@ -38,9 +38,12 @@ java_test(
     data = [
         "@graknlabs_behaviour//graql/language:undefine.feature",
     ],
-    classpath_resources = ["//common/test:logback"],
     size = "medium",
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -63,6 +63,10 @@ host_compatible_java_test(
         "@graknlabs_graql//java:graql",
     ],
     data = [":schema.gql"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -65,6 +65,10 @@ host_compatible_java_test(
         "@graknlabs_common//:common",
     ],
     data = [":basic-schema.gql"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 host_compatible_java_test(
@@ -83,6 +87,10 @@ host_compatible_java_test(
         "@graknlabs_graql//java:graql",
         "@graknlabs_graql//java/pattern",
     ],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(


### PR DESCRIPTION
## What is the goal of this PR?

In order to have more information when flaky test fails, we enable the debug logback configuration and print out output for bazel test.

## What are the changes implemented in this PR?

- Use `logback-debug.xml` for BDD database tests.
- Set `test_output=streamed` for CI job.