### PR TITLE
Remove specialised getSupertypes() implementation in AttributeTypeImpl

### DIFF
--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -279,11 +279,6 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
         public void setSupertype(AttributeType superType) { throw exception(GraknException.of(ROOT_TYPE_MUTATION)); }
 
         @Override
-        public Stream<AttributeTypeImpl> getSupertypes() {
-            return Stream.of(this);
-        }
-
-        @Override
         public Stream<AttributeTypeImpl> getSubtypes() {
             return getSubtypes(v -> {
                 switch (v.valueType()) {

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -113,7 +113,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
     }
 
     @Override
-    public Stream<? extends ThingTypeImpl> getSupertypes() {
+    public Stream<ThingTypeImpl> getSupertypes() {
         return loop(vertex, Objects::nonNull, v -> v.outs().edge(SUB).to().firstOrNull())
                 .map(v -> ThingTypeImpl.of(graphMgr, v)).stream();
     }


### PR DESCRIPTION
## What is the goal of this PR?

We've removed an inappropriate specialisation of `getSupertypes` in `AttributeTypeImpl`.

## What are the changes implemented in this PR?

- Remove `getSupertypes` specialisation from `AttributeTypeImpl`
- Remove unneeded parameter bounds since `getSupertypes` is no longer specialised by any of the subclasses