### PR TITLE
Fix Bugs on Type Resolver

### DIFF
--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -85,7 +85,8 @@ public class TypeResolver {
                 // TODO: Can the error message be improved by saying more explicitly that the provided type did not make sense somehow?
                 // TODO: The error message is not quite accurate when querying a relation using an entity type,
                 //       e.g.: match ($x) isa person;
-                throw GraknException.of(TYPE_NOT_RESOLVABLE, variable.toString());
+//                throw GraknException.of(TYPE_NOT_RESOLVABLE, variable.toString());
+                continue;
             }
 
             if (variable.isThing()) {
@@ -210,6 +211,7 @@ public class TypeResolver {
     private Map<Reference, Set<Label>> retrieveResolveTypes(Set<Variable> resolveVars) {
         Conjunction resolveVariableConjunction = new Conjunction(resolveVars, Collections.emptySet());
         resolveVariableConjunction = resolveLabels(resolveVariableConjunction);
+        //TODO: if
         return logicCache.resolver().get(resolveVariableConjunction, conjunction -> {
             Map<Reference, Set<Label>> mapping = new HashMap<>();
             traversalEng.iterator(conjunction.traversal()).forEachRemaining(
@@ -397,15 +399,17 @@ public class TypeResolver {
             neighbours.computeIfAbsent(to, k -> new HashSet<>()).add(from);
         }
 
-        private void copyNeighbours(TypeVariable from, TypeVariable to) { // TODO: why is 'to' variable never used?
+        private void copyNeighbours(TypeVariable from, TypeVariable to) {
             for (TypeConstraint constraint : from.constraints()) {
-                if (constraint.isSub()) addNeighbours(from, constraint.asSub().type());
-                else if (constraint.isOwns()) addNeighbours(from, constraint.asOwns().attribute());
-                else if (constraint.isPlays()) addNeighbours(from, constraint.asPlays().role());
-                else if (constraint.isRelates()) addNeighbours(from, constraint.asRelates().role());
-                else if (constraint.isIs()) addNeighbours(from, constraint.asIs().variable());
+                if (constraint.isSub()) addNeighbours(to, constraint.asSub().type());
+                else if (constraint.isOwns()) addNeighbours(to, constraint.asOwns().attribute());
+                else if (constraint.isPlays()) addNeighbours(to, constraint.asPlays().role());
+                else if (constraint.isRelates()) addNeighbours(to, constraint.asRelates().role());
+                else if (constraint.isIs()) addNeighbours(to, constraint.asIs().variable());
                 // TODO: There are other constraints in a TypeVariable. Are we intentionally ignoring them?
                 //       Why do we not throw GraknException.of(ILLEGAL_STATE); ?
+                //This is correct: we are adding the neighbours that are adjacent via constraints. These are the
+                //ony Constraints that can contain another  variable
             }
         }
     }

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -81,9 +81,6 @@ public class TypeResolver {
             if (variable.reference().isLabel()) continue;
             Set<Label> resolveLabels = referenceResolversMapping.get(resolveeVars.get(variable.id()).reference());
             if (resolveLabels == null) {
-                // TODO: Can the error message be improved by saying more explicitly that the provided type did not make sense somehow?
-                // TODO: The error message is not quite accurate when querying a relation using an entity type,
-                //       e.g.: match ($x) isa person;
                 variable.setSatisfiable(false);
                 continue;
             }
@@ -297,9 +294,6 @@ public class TypeResolver {
 
 
             resolver = cloneVariable(variable);
-            // TODO: Why do we need `neighbours.putIfAbsent(resolver, new HashSet<>());` ?
-            //       Is this a patch for the fact that we forgot to use `to` variable in `copyNeighbours(from, to)` ?
-            //This is correct. There is no guarantee that cloning the variable
             neighbours.putIfAbsent(resolver, new HashSet<>());
             return resolver;
         }
@@ -408,20 +402,13 @@ public class TypeResolver {
                 else if (constraint.isOwns()) {
                     addNeighbours(to, constraint.asOwns().attribute());
                     constraint.asOwns().overridden().ifPresent(typeVariable -> addNeighbours(to, typeVariable));
-                }
-                else if (constraint.isPlays()) {
+                } else if (constraint.isPlays()) {
                     addNeighbours(to, constraint.asPlays().role());
                     constraint.asPlays().overridden().ifPresent(typeVariable -> addNeighbours(to, typeVariable));
-                }
-                else if (constraint.isRelates()) {
+                } else if (constraint.isRelates()) {
                     addNeighbours(to, constraint.asRelates().role());
                     constraint.asRelates().overridden().ifPresent(typeVariable -> addNeighbours(to, typeVariable));
-                }
-                else if (constraint.isIs()) addNeighbours(to, constraint.asIs().variable());
-                // TODO: There are other constraints in a TypeVariable. Are we intentionally ignoring them?
-                //       Why do we not throw GraknException.of(ILLEGAL_STATE); ?
-                //This is correct: we are adding the neighbours that are adjacent via constraints. These are the
-                //ony Constraints that can contain another  variable
+                } else if (constraint.isIs()) addNeighbours(to, constraint.asIs().variable());
             }
         }
 
@@ -490,7 +477,6 @@ public class TypeResolver {
                 TypeVariable newTypeVar;
                 if (variable.reference().isAnonymous()) newTypeVar = new TypeVariable(newSystemVariable());
                 else newTypeVar = new TypeVariable(variable.id());
-                if (variable.isType()) newTypeVar.copyConstraints(variable.asType());
                 return newTypeVar;
             });
         }
@@ -510,9 +496,6 @@ public class TypeResolver {
         TypeVariable resolver(Variable variable) {
             return typeResolvers.get(variable.id());
         }
-
-
-
 
 
     }

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -319,18 +319,24 @@ public class TypeResolver {
         private void convertRelation(TypeVariable owner, RelationConstraint relationConstraint) {
             if (hasNoInfo(owner)) addRootTypeVar(owner, rootRelationType);
             ThingVariable ownerThing = relationConstraint.owner();
-            if (ownerThing.isa().isPresent()) {
-                TypeVariable relationTypeVar = convert(ownerThing.isa().get().type());
-                if (hasNoInfo(relationTypeVar)) addRootTypeVar(relationTypeVar, rootRelationType);
-            }
+            if (ownerThing.isa().isPresent()) convert(ownerThing.isa().get().type());
             for (RelationConstraint.RolePlayer rolePlayer : relationConstraint.players()) {
                 TypeVariable playerType = convert(rolePlayer.player());
                 TypeVariable roleTypeVar = rolePlayer.roleType().orElse(null);
+//                rolePlayer.roleType().flatMap(var -> Optional.of(convert(var))).orElse(null);
+//                TypeVariable roleTypeVar;
+//                if (rolePlayer.roleType().isPresent()) roleTypeVar = convert(rolePlayer.roleType().get());
+//                else roleTypeVar = null;
+
+
 
                 if (roleTypeVar != null) {
+                    TypeVariable roleTypeVarSub = new TypeVariable(resolvers.newSystemVariable());
+
                     roleTypeVar = convert(roleTypeVar);
+                    roleTypeVarSub.sub(roleTypeVar, false);
                     if (hasNoInfo(roleTypeVar)) addRootTypeVar(roleTypeVar, rootRoleType);
-                    addRelatesConstraint(owner, roleTypeVar);
+                    addRelatesConstraint(owner, roleTypeVarSub);
                 }
 
                 if (roleTypeVar == null) {
@@ -345,6 +351,10 @@ public class TypeResolver {
                     addNeighbours(playerType, roleTypeVar);
                 }
             }
+        }
+
+        private void convertRolePlayer(RelationConstraint.RolePlayer rolePlayer) {
+
         }
 
         private void addRelatesConstraint(TypeVariable owner, TypeVariable roleType) {

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -135,34 +135,6 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         constraining.add(constraint);
     }
 
-    // TODO: This method is erroneous. It copies constraints from another variable,
-    //       which includes other variables that the constraints contain,
-    //       however these other variables are no longer part of the same graph as the variable that owns the constraints.
-    //       Should the usage of this method be replaced with VariableCloner?
-    public void copyConstraints(TypeVariable copyFrom) {
-        for (TypeConstraint constraint : copyFrom.constraints) {
-            if (constraint.isLabel()) {
-                this.label(constraint.asLabel().properLabel());
-            } else if (constraint.isValueType()) {
-                this.valueType(constraint.asValueType().valueType());
-            } else if (constraint.isRegex()) {
-                this.regex(constraint.asRegex().regex());
-            } else if (constraint.isAbstract()) {
-                this.setAbstract();
-            } else if (constraint.isSub()) {
-                this.sub(constraint.asSub().type(), constraint.asSub().isExplicit());
-            } else if (constraint.isOwns()) {
-                this.owns(constraint.asOwns().attribute(), constraint.asOwns().overridden().orElse(null), constraint.asOwns().isKey());
-            } else if (constraint.isPlays()) {
-                this.plays(constraint.asPlays().relation().orElse(null), constraint.asPlays().role(), constraint.asPlays().overridden().orElse(null));
-            } else if (constraint.isRelates()) {
-                this.relates(constraint.asRelates().role(), constraint.asRelates().overridden().orElse(null));
-            } else if (constraint.isIs()) {
-                this.is(constraint.asIs().variable());
-            } else throw GraknException.of(ILLEGAL_STATE);
-        }
-    }
-
     public Optional<LabelConstraint> label() {
         return Optional.ofNullable(labelConstraint);
     }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -72,6 +72,7 @@ public class Reasoner {
     private List<Producer<ConceptMap>> producers(Conjunction conjunction) {
         conjunction = logicMgr.typeResolver().resolveLabels(conjunction);
         // TODO enable: conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
+        conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
         Producer<ConceptMap> answers = traversalEng
                 .producer(conjunction.traversal(), PARALLELISATION_FACTOR)
                 .map(conceptMgr::conceptMap);
@@ -99,6 +100,7 @@ public class Reasoner {
     private ResourceIterator<ConceptMap> iterator(Conjunction conjunction) {
         conjunction = logicMgr.typeResolver().resolveLabels(conjunction);
         // TODO enable: conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
+        conjunction = logicMgr.typeResolver().resolveVariablesExhaustive(conjunction);
         ResourceIterator<ConceptMap> answers = traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap);
 
         // TODO: enable reasoner here

--- a/test/behaviour/debug/bugs/type-resolver-bugs.feature
+++ b/test/behaviour/debug/bugs/type-resolver-bugs.feature
@@ -62,6 +62,8 @@ Feature: Graql Match Query
       """
     Then answer size is: 0
 
+#      TODO: fix '$x relates _role' where _role is overridden in schema
+#  TODO: spouse is not seen as anonymous. Why?
   Scenario: Relations can be queried with pairings of relation and role types that are not directly related to each other
     Given graql define
       """
@@ -147,6 +149,7 @@ Feature: Graql Match Query
       """
     Then answer size is: 4
 
+#    TODO: need to fix '$x owns $x' in traversal
   Scenario: 'has' can match instances that have themselves
     Given graql define
       """
@@ -181,6 +184,7 @@ Feature: Graql Match Query
       """
     Then answer size is: 0
 
+#    TODO: how to we deal with valueType of {double or long}?
   Scenario: value comparisons can be performed between a 'double' and a 'long'
     Given graql define
       """
@@ -245,6 +249,7 @@ Feature: Graql Match Query
       """
     Then answer size is: 1
 
+    #    TODO: how to we deal with valueType of {double or long}?
   Scenario: when the answers of a value comparison include both a 'double' and a 'long', both answers are returned
     Given graql define
       """

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -64,7 +64,7 @@ host_compatible_java_test(
         "@graknlabs_graql//java:graql",
         "@graknlabs_common//:common",
     ],
-    data = [":basic-schema.gql"],
+    data = [":basic-schema.gql", ":test-schema.gql"],
     resources = [
         "//common/test:logback"
     ],

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -715,4 +715,35 @@ public class TypeResolverTest {
         assertEquals(expected, getHintMap(simpleConjunction));
     }
 
+//    Scenario: when matching a roleplayer in a relation that can't actually play that role, an empty result is returned
+    @Test
+    public void matching_rp_in_relation_that_cant_play_that_role_returns_empty_result() throws IOException {
+        define_standard_schema("test-schema");
+
+        TypeResolver typeResolver = transaction.logic().typeResolver();
+        String queryString = "match " +
+                " $x isa company;" +
+                " ($x) isa friendship;";
+
+        Conjunction exhaustiveConjunction = runExhaustiveHinter(typeResolver, queryString);
+
+        Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
+            put("$x", set());
+        }};
+        assertEquals(expected, getHintMap(exhaustiveConjunction));
+    }
+
+//    @Test
+//    public void matching_rp_in_relation_that_cant_play_that_role_returns_empty_result() throws IOException {
+//        define_standard_schema("test-schema");
+//
+//        TypeResolver typeResolver = transaction.logic().typeResolver();
+//        String queryString = "match ";
+//        Conjunction exhaustiveConjunction = runExhaustiveHinter(typeResolver, queryString);
+//
+//        Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
+//            put("$x", set());
+//        }};
+//        assertEquals(expected, getHintMap(exhaustiveConjunction));
+
 }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -23,7 +23,6 @@ import grakn.core.common.parameters.Label;
 import grakn.core.logic.tool.TypeResolver;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
-import grakn.core.pattern.variable.TypeVariable;
 import grakn.core.pattern.variable.Variable;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
@@ -764,9 +763,7 @@ public class TypeResolverTest {
         );
 
         TypeResolver typeResolver = transaction.logic().typeResolver();
-        String queryString = "match " +
-                "$x isa house-number; " +
-                "$x = 1.0;";
+        String queryString = "match $x = 1.0;";
 
         Conjunction exhaustiveConjunction = runExhaustiveHinter(typeResolver, queryString);
 

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -765,12 +765,13 @@ public class TypeResolverTest {
 
         TypeResolver typeResolver = transaction.logic().typeResolver();
         String queryString = "match " +
-                " $x >= 1;";
+                "$x isa house-number; " +
+                "$x = 1.0;";
 
         Conjunction exhaustiveConjunction = runExhaustiveHinter(typeResolver, queryString);
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
-            put("$x", set("house-number"));
+            put("$x", set("house-number", "length"));
         }};
         assertEquals(expected, getHintMap(exhaustiveConjunction));
 
@@ -847,6 +848,16 @@ public class TypeResolverTest {
             put("$x", set("person", "company"));
         }};
         assertEquals(entityExpected, getHintMap(entityConjunction));
+
+        String thingString = "match $x isa thing;";
+        Conjunction thingConjunction = runExhaustiveHinter(typeResolver, thingString);
+        Map<String, Set<String>> thingExpected = new HashMap<String, Set<String>>() {{
+            put("$x", set());
+        }};
+        assertEquals(thingExpected, getHintMap(thingConjunction));
+        for (Variable variable : thingConjunction.variables()) {
+            assertTrue(variable.isSatisfiable());
+        }
 
     }
 

--- a/test/integration/logic/test-schema.gql
+++ b/test/integration/logic/test-schema.gql
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+define
+
+person sub entity,
+  plays friendship:friend,
+  plays employment:employee,
+  owns name,
+  owns age,
+  owns ref @key;
+
+company sub entity,
+  plays employment:employer,
+  owns name,
+  owns ref @key;
+
+friendship sub relation,
+  relates friend,
+  owns ref @key;
+
+employment sub relation,
+  relates employee,
+  relates employer,
+  owns ref @key;
+
+name sub attribute, value string;
+
+age sub attribute, value long;
+
+ref sub attribute, value long;


### PR DESCRIPTION
## What is the goal of this PR?

Fixed bugs on TypeResolver, including: 
* TypeResolver no longer crashes if no types were possible for a query
* TypeResolver can infer relations that from roles that are not directly related (for example when they related to a sub of the given role in a query)
* when the answers of a value comparison include both a 'double' and a 'long', both value types are possible in the resolveTypes

## What are the changes implemented in this PR?
* resolver no longer throws an error for finding no results, instead it sets to `isSatisfiable` flag to false
* queries like `(friend: $x) isa $r` now traverse for (`$r relates $sys; $sys sub friend` in order to capture indirect relation-role connexions.
* `double` and `long` value types are now ignored. This is a stop-gap fix, a full fix will occur when `TypeResolver` is redone on the Traversal Structure
* The `isa` of a Relation Variable is no longer restricted to be `relation`, (as it was realised this excluded `thing`)
* `copyConstraints` rebranded as `cloneVariable` and is now recurse to avoid contaminating the query conjunction with the typeResolver Conjunction.