### PR TITLE
RPC implementation for receiving match aggregate, match group, and match group aggregate queries

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "20792156b1b83ffe753b49d6706c6a8eb2856ca3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "aaf44f38a71289e494128ad0ddf39c233f6984a4", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -20,10 +20,14 @@ package grakn.core.server.rpc.query;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.common.parameters.Options;
+import grakn.core.concept.answer.AnswerGroup;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.answer.Numeric;
 import grakn.core.query.QueryManager;
 import grakn.core.server.rpc.TransactionRPC;
 import grakn.core.server.rpc.util.ResponseBuilder;
+import grakn.protocol.AnswerProto;
+import grakn.protocol.ConceptProto;
 import grakn.protocol.QueryProto;
 import grakn.protocol.TransactionProto;
 import grakn.protocol.TransactionProto.Transaction;
@@ -64,6 +68,15 @@ public class QueryHandler {
             case MATCH_REQ:
                 this.match(request, req.getMatchReq(), options);
                 return;
+            case MATCH_AGGREGATE_REQ:
+                this.match(request, req.getMatchAggregateReq(), options);
+                return;
+            case MATCH_GROUP_REQ:
+                this.match(request, req.getMatchGroupReq(), options);
+                return;
+            case MATCH_GROUP_AGGREGATE_REQ:
+                this.match(request, req.getMatchGroupAggregateReq(), options);
+                return;
             case INSERT_REQ:
                 this.insert(request, req.getInsertReq(), options);
                 return;
@@ -77,43 +90,77 @@ public class QueryHandler {
         return TransactionProto.Transaction.Res.newBuilder().setId(request.getId()).setQueryRes(response).build();
     }
 
-    private void match(Transaction.Req request, QueryProto.Graql.Match.Req req, Options.Query options) {
+    private void match(Transaction.Req request, QueryProto.Query.Match.Req req, Options.Query options) {
         final GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
         final ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setMatchRes(
-                        QueryProto.Graql.Match.Res.newBuilder().addAllAnswers(
+                        QueryProto.Query.Match.Res.newBuilder().addAllAnswers(
                                 as.stream().map(ResponseBuilder.Answer::conceptMap).collect(toList()))))
         );
     }
 
-    private void insert(Transaction.Req request, QueryProto.Graql.Insert.Req req, Options.Query options) {
+    private void match(Transaction.Req request, QueryProto.Query.MatchAggregate.Req req, Options.Query options) {
+        final GraqlMatch.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchAggregate();
+        final Numeric answer = queryManager.match(query, options);
+        transactionRPC.respond(
+                response(request, QueryProto.Query.Res.newBuilder().setMatchAggregateRes(
+                        QueryProto.Query.MatchAggregate.Res.newBuilder().setAnswer(ResponseBuilder.Answer.number(answer.number()))))
+        );
+    }
+
+    private void match(Transaction.Req request, QueryProto.Query.MatchGroup.Req req, Options.Query options) {
+        final GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
+        ResourceIterator<AnswerGroup<ConceptMap>> answers = queryManager.match(query, options);
+        transactionRPC.respond(
+                request, answers, options,
+                as -> response(request, QueryProto.Query.Res.newBuilder().setMatchGroupRes(
+                        QueryProto.Query.MatchGroup.Res.newBuilder()
+                                .addAllAnswers(as.stream().map(ResponseBuilder.Answer::conceptMapGroup).collect(toList())))
+                )
+        );
+    }
+
+    private void match(Transaction.Req request, QueryProto.Query.MatchGroupAggregate.Req req, Options.Query options) {
+        final GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
+        ResourceIterator<AnswerGroup<Numeric>> answers = queryManager.match(query, options);
+        transactionRPC.respond(
+                request, answers, options,
+                as -> response(request, QueryProto.Query.Res.newBuilder().setMatchGroupAggregateRes(
+                        QueryProto.Query.MatchGroupAggregate.Res.newBuilder().addAllAnswers(
+                                as.stream().map(ResponseBuilder.Answer::numberGroup).collect(toList())
+                        )
+                ))
+        );
+    }
+
+    private void insert(Transaction.Req request, QueryProto.Query.Insert.Req req, Options.Query options) {
         final GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
         final ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setInsertRes(
-                        QueryProto.Graql.Insert.Res.newBuilder().addAllAnswers(
+                        QueryProto.Query.Insert.Res.newBuilder().addAllAnswers(
                                 as.stream().map(ResponseBuilder.Answer::conceptMap).collect(toList()))))
         );
     }
 
-    private void delete(Transaction.Req request, QueryProto.Graql.Delete.Req req, Options.Query options) {
+    private void delete(Transaction.Req request, QueryProto.Query.Delete.Req req, Options.Query options) {
         final GraqlDelete query = Graql.parseQuery(req.getQuery()).asDelete();
         queryManager.delete(query, options);
-        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setDeleteRes(QueryProto.Graql.Delete.Res.getDefaultInstance())));
+        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setDeleteRes(QueryProto.Query.Delete.Res.getDefaultInstance())));
     }
 
-    private void define(Transaction.Req request, QueryProto.Graql.Define.Req req) {
+    private void define(Transaction.Req request, QueryProto.Query.Define.Req req) {
         final GraqlDefine query = Graql.parseQuery(req.getQuery()).asDefine();
         queryManager.define(query);
-        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setDefineRes(QueryProto.Graql.Define.Res.getDefaultInstance())));
+        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setDefineRes(QueryProto.Query.Define.Res.getDefaultInstance())));
     }
 
-    private void undefine(Transaction.Req request, QueryProto.Graql.Undefine.Req req) {
+    private void undefine(Transaction.Req request, QueryProto.Query.Undefine.Req req) {
         final GraqlUndefine query = Graql.parseQuery(req.getQuery()).asUndefine();
         queryManager.undefine(query);
-        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setUndefineRes(QueryProto.Graql.Undefine.Res.getDefaultInstance())));
+        transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setUndefineRes(QueryProto.Query.Undefine.Res.getDefaultInstance())));
     }
 }

--- a/server/rpc/util/ResponseBuilder.java
+++ b/server/rpc/util/ResponseBuilder.java
@@ -22,6 +22,7 @@ import grakn.core.common.exception.ErrorMessage;
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.answer.AnswerGroup;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concept.answer.Numeric;
 import grakn.core.concept.thing.Attribute;
 import grakn.core.concept.thing.Entity;
 import grakn.core.concept.thing.Relation;
@@ -36,6 +37,7 @@ import grakn.core.logic.Rule;
 import grakn.protocol.AnswerProto;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.LogicProto;
+import grakn.protocol.QueryProto;
 import grakn.protocol.TransactionProto;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -47,6 +49,7 @@ import static grakn.common.util.Objects.className;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Server.BAD_VALUE_TYPE;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_ANSWER_TYPE;
+import static java.util.stream.Collectors.toList;
 
 public class ResponseBuilder {
 
@@ -262,29 +265,29 @@ public class ResponseBuilder {
      */
     public static class Answer {
 
-        public static AnswerProto.Answer answer(Object object) {
-            final AnswerProto.Answer.Builder answer = AnswerProto.Answer.newBuilder();
-
-            if (object instanceof AnswerGroup) {
-                answer.setAnswerGroup(answerGroup((AnswerGroup<?>) object));
-            } else if (object instanceof ConceptMap) {
-                answer.setConceptMap(conceptMap((ConceptMap) object));
-            } else if (object instanceof Number) {
-                answer.setNumber(number((Number) object));
-            } else {
-                throw GraknException.of(UNKNOWN_ANSWER_TYPE, className(object.getClass()));
-            }
-
-            return answer.build();
-        }
-
-        public static AnswerProto.AnswerGroup answerGroup(AnswerGroup<?> answer) {
-            final AnswerProto.AnswerGroup.Builder answerGroupProto = AnswerProto.AnswerGroup.newBuilder()
-                    .setOwner(ResponseBuilder.Concept.concept(answer.owner()))
-                    .addAllAnswers(answer.answers().stream().map(Answer::answer).collect(Collectors.toList()));
-
-            return answerGroupProto.build();
-        }
+//        public static AnswerProto.Answer answer(Object object) {
+//            final AnswerProto.Answer.Builder answer = AnswerProto.Answer.newBuilder();
+//
+//            if (object instanceof AnswerGroup) {
+//                answer.setAnswerGroup(answerGroup((AnswerGroup<?>) object));
+//            } else if (object instanceof ConceptMap) {
+//                answer.setConceptMap(conceptMap((ConceptMap) object));
+//            } else if (object instanceof Number) {
+//                answer.setNumber(number((Number) object));
+//            } else {
+//                throw GraknException.of(UNKNOWN_ANSWER_TYPE, className(object.getClass()));
+//            }
+//
+//            return answer.build();
+//        }
+//
+//        public static AnswerProto.AnswerGroup answerGroup(AnswerGroup<?> answer) {
+//            final AnswerProto.AnswerGroup.Builder answerGroupProto = AnswerProto.AnswerGroup.newBuilder()
+//                    .setOwner(ResponseBuilder.Concept.concept(answer.owner()))
+//                    .addAllAnswers(answer.answers().stream().map(Answer::answer).collect(Collectors.toList()));
+//
+//            return answerGroupProto.build();
+//        }
 
         public static AnswerProto.ConceptMap conceptMap(ConceptMap answer) {
             final AnswerProto.ConceptMap.Builder conceptMapProto = AnswerProto.ConceptMap.newBuilder();
@@ -307,8 +310,21 @@ public class ResponseBuilder {
             return conceptMapProto.build();
         }
 
+        public static AnswerProto.ConceptMapGroup conceptMapGroup(AnswerGroup<ConceptMap> answer) {
+            return AnswerProto.ConceptMapGroup.newBuilder()
+                    .setOwner(ResponseBuilder.Concept.concept(answer.owner()))
+                    .addAllConceptMaps(answer.answers().stream().map(ResponseBuilder.Answer::conceptMap).collect(toList()))
+                    .build();
+        }
+
         public static AnswerProto.Number number(Number number) {
             return AnswerProto.Number.newBuilder().setValue(number.toString()).build();
+        }
+
+        public static AnswerProto.NumberGroup numberGroup(AnswerGroup<Numeric> a) {
+            return AnswerProto.NumberGroup.newBuilder().setOwner(ResponseBuilder.Concept.concept(a.owner()))
+                    .addAllNumbers(a.answers().stream().map(n -> ResponseBuilder.Answer.number(n.number())).collect(toList()))
+                    .build();
         }
     }
 }

--- a/server/rpc/util/ResponseBuilder.java
+++ b/server/rpc/util/ResponseBuilder.java
@@ -265,30 +265,6 @@ public class ResponseBuilder {
      */
     public static class Answer {
 
-//        public static AnswerProto.Answer answer(Object object) {
-//            final AnswerProto.Answer.Builder answer = AnswerProto.Answer.newBuilder();
-//
-//            if (object instanceof AnswerGroup) {
-//                answer.setAnswerGroup(answerGroup((AnswerGroup<?>) object));
-//            } else if (object instanceof ConceptMap) {
-//                answer.setConceptMap(conceptMap((ConceptMap) object));
-//            } else if (object instanceof Number) {
-//                answer.setNumber(number((Number) object));
-//            } else {
-//                throw GraknException.of(UNKNOWN_ANSWER_TYPE, className(object.getClass()));
-//            }
-//
-//            return answer.build();
-//        }
-//
-//        public static AnswerProto.AnswerGroup answerGroup(AnswerGroup<?> answer) {
-//            final AnswerProto.AnswerGroup.Builder answerGroupProto = AnswerProto.AnswerGroup.newBuilder()
-//                    .setOwner(ResponseBuilder.Concept.concept(answer.owner()))
-//                    .addAllAnswers(answer.answers().stream().map(Answer::answer).collect(Collectors.toList()));
-//
-//            return answerGroupProto.build();
-//        }
-
         public static AnswerProto.ConceptMap conceptMap(ConceptMap answer) {
             final AnswerProto.ConceptMap.Builder conceptMapProto = AnswerProto.ConceptMap.newBuilder();
             // TODO: needs testing


### PR DESCRIPTION
## What is the goal of this PR?

We have implemented RPC support for receiving match aggregate, match group, and match group aggregate queries from clients.

## What are the changes implemented in this PR?

1. Update `@graknlabs_protocol` to the version that supports the new queries.
2. Update `QueryHandler` to support processing the new queries
3. Implement the helper methods for building `ConceptMapGroup` and `NumberGroup` protobuf objects