### PR TITLE
Do not send super type in response when super type is null

### DIFF
--- a/server/rpc/concept/TypeHandler.java
+++ b/server/rpc/concept/TypeHandler.java
@@ -209,9 +209,7 @@ public class TypeHandler {
     private void getSupertype(Transaction.Req request, Type type) {
         ConceptProto.Type.GetSupertype.Res.Builder getSupertypeRes = ConceptProto.Type.GetSupertype.Res.newBuilder();
         Type superType = type.getSupertype();
-        if (superType != null) {
-            getSupertypeRes.setType(type(superType));
-        }
+        if (superType != null) getSupertypeRes.setType(type(superType));
         final ConceptProto.Type.Res.Builder response = ConceptProto.Type.Res.newBuilder()
                 .setTypeGetSupertypeRes(getSupertypeRes);
         transactionRPC.respond(response(request, response));

--- a/server/rpc/concept/TypeHandler.java
+++ b/server/rpc/concept/TypeHandler.java
@@ -207,9 +207,13 @@ public class TypeHandler {
     }
 
     private void getSupertype(Transaction.Req request, Type type) {
+        ConceptProto.Type.GetSupertype.Res.Builder getSupertypeRes = ConceptProto.Type.GetSupertype.Res.newBuilder();
+        Type superType = type.getSupertype();
+        if (superType != null) {
+            getSupertypeRes.setType(type(superType));
+        }
         final ConceptProto.Type.Res.Builder response = ConceptProto.Type.Res.newBuilder()
-                .setTypeGetSupertypeRes(ConceptProto.Type.GetSupertype.Res.newBuilder()
-                                                .setType(type(type.getSupertype())));
+                .setTypeGetSupertypeRes(getSupertypeRes);
         transactionRPC.respond(response(request, response));
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

When we ask for the super type of `thing`, the concept API returns null correctly, yet we need to do a null check to make sure we don't add the null in response which throws null pointer exception.

## What are the changes implemented in this PR?

- null check the super type that concept API returns.