### PR TITLE
Enable async producer for match queries

### DIFF
--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -151,15 +151,15 @@ public class GraqlSteps {
         answerGroups = null;
         numericAnswerGroups = null;
         if (graqlQuery instanceof GraqlMatch) {
-            answers = tx().query().match(graqlQuery.asMatch(), false).toList();
+            answers = tx().query().match(graqlQuery.asMatch()).toList();
         } else if (graqlQuery instanceof GraqlInsert) {
             throw new ScenarioDefinitionException("Insert is not supported; use `get answers of graql insert` instead");
         } else if (graqlQuery instanceof GraqlMatch.Aggregate) {
-            numericAnswer = tx().query().match(graqlQuery.asMatchAggregate(), false);
+            numericAnswer = tx().query().match(graqlQuery.asMatchAggregate());
         } else if (graqlQuery instanceof GraqlMatch.Group) {
-            answerGroups = tx().query().match(graqlQuery.asMatchGroup(), false).toList();
+            answerGroups = tx().query().match(graqlQuery.asMatchGroup()).toList();
         } else if (graqlQuery instanceof GraqlMatch.Group.Aggregate) {
-            numericAnswerGroups = tx().query().match(graqlQuery.asMatchGroupAggregate(), false).toList();
+            numericAnswerGroups = tx().query().match(graqlQuery.asMatchGroupAggregate()).toList();
         } else {
             throw new ScenarioDefinitionException("Only match and insert supported for now");
         }

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -151,15 +151,15 @@ public class GraqlSteps {
         answerGroups = null;
         numericAnswerGroups = null;
         if (graqlQuery instanceof GraqlMatch) {
-            answers = tx().query().match(graqlQuery.asMatch()).toList();
+            answers = tx().query().match(graqlQuery.asMatch(), false).toList();
         } else if (graqlQuery instanceof GraqlInsert) {
             throw new ScenarioDefinitionException("Insert is not supported; use `get answers of graql insert` instead");
         } else if (graqlQuery instanceof GraqlMatch.Aggregate) {
-            numericAnswer = tx().query().match(graqlQuery.asMatchAggregate());
+            numericAnswer = tx().query().match(graqlQuery.asMatchAggregate(), false);
         } else if (graqlQuery instanceof GraqlMatch.Group) {
-            answerGroups = tx().query().match(graqlQuery.asMatchGroup()).toList();
+            answerGroups = tx().query().match(graqlQuery.asMatchGroup(), false).toList();
         } else if (graqlQuery instanceof GraqlMatch.Group.Aggregate) {
-            numericAnswerGroups = tx().query().match(graqlQuery.asMatchGroupAggregate()).toList();
+            numericAnswerGroups = tx().query().match(graqlQuery.asMatchGroupAggregate(), false).toList();
         } else {
             throw new ScenarioDefinitionException("Only match and insert supported for now");
         }

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -78,6 +78,7 @@ public class GraphProducer implements Producer<VertexMap> {
             if (i < parallelisation) produce(sink, (parallelisation - i) * splitCount);
         } else {
             for (ResourceIterator<VertexMap> iterator : futures.keySet()) {
+                // TODO: It's possible that futures.remove() happens here which causes not calling consume() when we should
                 futures.computeIfPresent(iterator, (k, v) -> v.thenRunAsync(consume(k, splitCount, sink), forkJoinPool()));
             }
         }
@@ -108,6 +109,7 @@ public class GraphProducer implements Producer<VertexMap> {
             return;
         }
 
+        // TODO: It's possible that we're just about to call futures.put() in another thread, which means we shouldn't call done() here
         if (futures.size() == 0) {
             done(sink);
         } else {

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -31,7 +31,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static grakn.core.common.concurrent.ExecutorService.forkJoinPool;
 import static grakn.core.common.iterator.Iterators.synchronised;
@@ -47,7 +46,6 @@ public class GraphProducer implements Producer<VertexMap> {
     private final ConcurrentMap<ResourceIterator<VertexMap>, CompletableFuture<Void>> futures;
     private final ConcurrentHashMap.KeySetView<VertexMap, Boolean> produced;
     private final AtomicBoolean isDone;
-    private final AtomicInteger runningJobs;
 
     public GraphProducer(GraphManager graphMgr, GraphProcedure procedure, Traversal.Parameters params, int parallelisation) {
         assert parallelisation > 0;
@@ -59,7 +57,6 @@ public class GraphProducer implements Producer<VertexMap> {
         this.futures = new ConcurrentHashMap<>();
         this.produced = ConcurrentHashMap.newKeySet();
         this.start = synchronised(procedure.startVertex().iterator(graphMgr, params));
-        this.runningJobs = new AtomicInteger(0);
     }
 
     @Override
@@ -67,7 +64,7 @@ public class GraphProducer implements Producer<VertexMap> {
         int p = futures.isEmpty() ? parallelisation : futures.size();
         int splitCount = (int) Math.ceil((double) count / p);
 
-        if (runningJobs.get() == 0) {
+        if (futures.size() == 0) {
             if (!start.hasNext()) {
                 done(sink);
                 return;
@@ -75,11 +72,8 @@ public class GraphProducer implements Producer<VertexMap> {
 
             int i = 0;
             for (; i < parallelisation && start.hasNext(); i++) {
-                runningJobs.incrementAndGet(); // TODO: still not right
                 ResourceIterator<VertexMap> iterator = new GraphIterator(graphMgr, start.next(), procedure, params).distinct(produced);
-                futures.computeIfAbsent(iterator, k ->
-                        runAsync(consume(iterator, splitCount, sink), forkJoinPool())
-                );
+                futures.put(iterator, runAsync(consume(iterator, splitCount, sink), forkJoinPool()));
             }
             if (i < parallelisation) produce(sink, (parallelisation - i) * splitCount);
         } else {
@@ -110,13 +104,11 @@ public class GraphProducer implements Producer<VertexMap> {
         Vertex<?, ?> next;
         if ((next = start.atomicNext()) != null) {
             ResourceIterator<VertexMap> iterator = new GraphIterator(graphMgr, next, procedure, params).distinct(produced);
-            futures.put(iterator,
-                        runAsync(consume(iterator, remaining, sink), forkJoinPool())
-            );
+            futures.put(iterator, runAsync(consume(iterator, remaining, sink), forkJoinPool()));
             return;
         }
 
-        if (runningJobs.decrementAndGet() == 0) {
+        if (futures.size() == 0) {
             done(sink);
         } else {
             produce(sink, remaining);


### PR DESCRIPTION
## What is the goal of this PR?

Fix a bug which causes `runningJobs` decremented more times than the `futures.remove()` is called. This can happen when there're two `consume` call batched on the same graph iterator and the iterator has been exhausted, so we decremented `runningJobs` twice when it should only be decremented once.

We removed `runningJobs` and use `futures.size() == 0` to check if we should call `done().` Although this fixes all async match tests, it's known that there're at least two other concurrency bugs with this approach.
 
## What are the changes implemented in this PR?

- Removed `runningJobs`.
- Added TODOs for the known concurrency bug cases.
