### PR TITLE
Bump @graknlabs_console artifact version

### DIFF
--- a/dependencies/graknlabs/artifacts.bzl
+++ b/dependencies/graknlabs/artifacts.bzl
@@ -25,5 +25,5 @@ def graknlabs_console_artifact():
         artifact_name = "console-artifact.tgz",
         tag_source = deployment["artifact.release"],
         commit_source = deployment["artifact.snapshot"],
-        commit = "0a5410a4dbd1e03a5d40e57639ec92ba37d22c98"
+        tag = "2.0.0-alpha",
     )


### PR DESCRIPTION
## What is the goal of this PR?

In order to produce correct APT package for `grakn-core-all`, we should depend on Console artifact that's available in release repo.

## What are the changes implemented in this PR?

Update reference to Console artifact to latest released tag