### PR TITLE
Conclusion refactor

### DIFF
--- a/logic/BUILD
+++ b/logic/BUILD
@@ -30,32 +30,32 @@ package(
 
 native_java_libraries(
     name = "logic",
-    srcs = glob(["*.java", "tool/*.java", "**/*.java"], exclude = ["*Test.java", "*/*Test.java"],),
-    deps = [
-        # Internal dependencies
-        "//common:common",
-        "//graph:graph",
-
-        # Internal Repository Dependencies
-        "@graknlabs_common//:common",
-        "@graknlabs_graql//java/common:common",
-        "@graknlabs_graql//java/pattern:pattern",
-
-        # External Maven Dependencies
-        "@maven//:com_google_code_findbugs_jsr305",
-    ],
+    srcs = glob(["*.java", "tool/*.java", "**/*.java"], exclude = ["*Test.java", "*/*Test.java"]),
     native_libraries_deps = [
         "//concept:concept",
         "//pattern:pattern",
         "//traversal:traversal",
     ],
+    deps = [
+        # Internal dependencies
+        "//common",
+        "//graph",
+
+        # Internal Repository Dependencies
+        "@graknlabs_common//:common",
+        "@graknlabs_graql//java/common",
+        "@graknlabs_graql//java/pattern",
+
+        # External Maven Dependencies
+        "@maven//:com_google_code_findbugs_jsr305",
+    ],
     tags = ["maven_coordinates=io.grakn.core:grakn-logic:{pom_version}"],
     visibility = ["//visibility:public"],
+
 )
 
 host_compatible_java_test(
     name = "test-concludable",
-    test_class = "grakn.core.logic.resolvable.ConcludableTest",
     srcs = [
         "resolvable/ConcludableTest.java",
     ],
@@ -63,12 +63,12 @@ host_compatible_java_test(
         "//logic:logic",
         "//pattern:pattern",
     ],
+    test_class = "grakn.core.logic.resolvable.ConcludableTest",
     deps = [
         # Internal dependencies
 
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",
-        "@graknlabs_graql//java/common",
         "@graknlabs_graql//java/pattern",
         "@graknlabs_graql//java:graql",
     ],
@@ -76,7 +76,6 @@ host_compatible_java_test(
 
 host_compatible_java_test(
     name = "test-retrievable",
-    test_class = "grakn.core.logic.resolvable.RetrievableTest",
     srcs = [
         "resolvable/RetrievableTest.java",
     ],
@@ -84,6 +83,7 @@ host_compatible_java_test(
         "//logic:logic",
         "//pattern:pattern",
     ],
+    test_class = "grakn.core.logic.resolvable.RetrievableTest",
     deps = [
         # Internal dependencies
 

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -222,10 +222,6 @@ public class Rule {
             return false;
         }
 
-        public boolean isHas() {
-            return false;
-        }
-
         public boolean isIsa() {
             return false;
         }
@@ -235,19 +231,15 @@ public class Rule {
         }
 
         public boolean isExplicitHas() {
-            return false; // TODO Implement in subclass
+            return false;
         }
 
         public boolean isVariableHas() {
-            return false; // TODO Implement in subclass
+            return false;
         }
 
         public Relation asRelation() {
             throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Relation.class));
-        }
-
-        public Has asHas() {
-            throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Has.class));
         }
 
         public Isa asIsa() {
@@ -256,6 +248,14 @@ public class Rule {
 
         public Value asValue() {
             throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Value.class));
+        }
+
+        public Has.Variable asVariableHas() {
+            throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Has.Variable.class));
+        }
+
+        public Has.Explicit asExplicitHas() {
+            throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Has.Explicit.class));
         }
 
         public static class Relation extends Conclusion<RelationConstraint> {
@@ -312,16 +312,6 @@ public class Rule {
                 return null;
             }
 
-            @Override
-            public boolean isHas() {
-                return true;
-            }
-
-            @Override
-            public Has asHas() {
-                return this;
-            }
-
             public static class Explicit extends Has {
 
                 private final IsaConstraint isaConstraint;
@@ -336,6 +326,11 @@ public class Rule {
                 public boolean isExplicitHas() {
                     return true;
                 }
+
+                @Override
+                public Has.Explicit asExplicitHas() {
+                    return this;
+                }
             }
 
             public static class Variable extends Has {
@@ -346,6 +341,11 @@ public class Rule {
                 @Override
                 public boolean isVariableHas() {
                     return true;
+                }
+
+                @Override
+                public Variable asVariableHas() {
+                    return this;
                 }
             }
 

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -198,8 +198,6 @@ public class Rule {
 
     public static abstract class Conclusion<CONSTRAINT extends Constraint> {
 
-        public abstract CONSTRAINT constraint();
-
         public static Conclusion<?> create(Conjunction then) {
             return Iterators.iterate(then.variables()).filter(Variable::isThing).map(Variable::asThing)
                     .flatMap(variable -> Iterators.iterate(variable.constraints()).map(constraint -> {
@@ -278,10 +276,6 @@ public class Rule {
                 this.isa = isa;
             }
 
-            public RelationConstraint constraint() {
-                return relation;
-            }
-
             @Override
             public Map<Identifier, Concept> putConclusion(ConceptManager conceptMgr) {
                 /*
@@ -321,11 +315,6 @@ public class Rule {
                 this.has = has;
             }
 
-            @Override
-            public HasConstraint constraint() {
-                return has;
-            }
-
             public HasConstraint has() {
                 return has;
             }
@@ -342,6 +331,7 @@ public class Rule {
 
                 Explicit(HasConstraint has, IsaConstraint isa, ValueConstraint<?> value) {
                     super(has);
+                    assert isa.type().label().isPresent();
                     this.isa = isa;
                     this.value = value;
                 }
@@ -394,8 +384,7 @@ public class Rule {
                 this.isa = isa;
             }
 
-            @Override
-            public IsaConstraint constraint() {
+            public IsaConstraint isa() {
                 return isa;
             }
 
@@ -427,8 +416,7 @@ public class Rule {
                 this.value = value;
             }
 
-            @Override
-            public ValueConstraint<?> constraint() {
+            public ValueConstraint<?> value() {
                 return value;
             }
 

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -361,7 +361,6 @@ public class Rule {
                     this.value = value;
                 }
 
-
                 @Override
                 public boolean isExplicitHas() {
                     return true;

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -67,7 +67,7 @@ public class Rule {
 //        this.then = logicManager.typeHinter().computeHintsExhaustive(thenPattern(structure.then()));
         this.when = whenPattern(structure.when());
         this.then = thenPattern(structure.then());
-        pruneThenTypeHints();
+        pruneThenResolvedTypes();
         this.conclusion = Conclusion.create(this.then);
         this.requiredWhenConcludables = Concludable.create(this.when);
     }
@@ -83,7 +83,7 @@ public class Rule {
         this.when = whenPattern(structure.when());
         this.then = thenPattern(structure.then());
         validateSatisfiable();
-        pruneThenTypeHints();
+        pruneThenResolvedTypes();
 
         this.conclusion = Conclusion.create(this.then);
         this.requiredWhenConcludables = Concludable.create(this.when);
@@ -169,7 +169,7 @@ public class Rule {
     /**
      * Remove type hints in the `then` pattern that are not valid in the `when` pattern
      */
-    private void pruneThenTypeHints() {
+    private void pruneThenResolvedTypes() {
         // TODO name is inconsistent with elsewhere
         then.variables().stream().filter(variable -> variable.id().isNamedReference())
                 .forEach(thenVar ->

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -360,8 +360,8 @@ public class Rule {
                 public static Optional<Explicit> of(Conjunction conjunction) {
                     return Iterators.iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
-                            .flatMap(variable -> Iterators.iterate(variable.constraints())
-                                    .filter(ThingConstraint::isHas)
+                            .flatMap(variable -> Iterators.iterate(variable.constraints()).filter(ThingConstraint::isHas)
+                                    .filter(constraint -> constraint.asHas().attribute().id().reference().isAnonymous())
                                     .map(constraint -> {
                                         assert constraint.asHas().attribute().isa().isPresent();
                                         assert constraint.asHas().attribute().isa().get().type().label().isPresent();
@@ -413,8 +413,8 @@ public class Rule {
                 public static Optional<Variable> of(Conjunction conjunction) {
                     return Iterators.iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
-                            .flatMap(variable -> Iterators.iterate(variable.constraints())
-                                    .filter(ThingConstraint::isHas)
+                            .flatMap(variable -> Iterators.iterate(variable.constraints()).filter(ThingConstraint::isHas)
+                                    .filter(constraint -> constraint.asHas().attribute().id().isNamedReference())
                                     .map(constraint -> {
                                         assert !constraint.asHas().attribute().isa().isPresent();
                                         assert constraint.asHas().attribute().value().size() == 0;

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -361,7 +361,7 @@ public class Rule {
                     return Iterators.iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
                             .flatMap(variable -> Iterators.iterate(variable.constraints())
-                                    .filter(ThingConstraint::isRelation)
+                                    .filter(ThingConstraint::isHas)
                                     .map(constraint -> {
                                         assert constraint.asHas().attribute().isa().isPresent();
                                         assert constraint.asHas().attribute().isa().get().type().label().isPresent();
@@ -414,7 +414,7 @@ public class Rule {
                     return Iterators.iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
                             .flatMap(variable -> Iterators.iterate(variable.constraints())
-                                    .filter(ThingConstraint::isRelation)
+                                    .filter(ThingConstraint::isHas)
                                     .map(constraint -> {
                                         assert !constraint.asHas().attribute().isa().isPresent();
                                         assert constraint.asHas().attribute().value().size() == 0;

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -254,7 +254,6 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
             }
 
             if (constraint().owner().isa().isPresent()) {
-                assert relationConclusion.relation().owner().isa().isPresent(); // due to known shapes of rule conclusions
                 TypeVariable concludableRelationType = constraint().owner().isa().get().type();
                 TypeVariable conclusionRelationType = relationConclusion.relation().owner().isa().get().type();
                 if (unificationSatisfiable(concludableRelationType, conclusionRelationType, conceptMgr)) {

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -135,9 +135,9 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         else throw GraknException.of(ILLEGAL_STATE);
     }
 
-    AlphaEquivalence alphaEquals(Concludable.Relation that) { return null; }
+    AlphaEquivalence alphaEquals(Relation that) { return null; }
 
-    AlphaEquivalence alphaEquals(Concludable.Has that) { return null; }
+    AlphaEquivalence alphaEquals(Has that) { return null; }
 
     AlphaEquivalence alphaEquals(Isa that) { return null; }
 
@@ -341,7 +341,7 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         }
 
         @Override
-        AlphaEquivalence alphaEquals(Concludable.Relation that) {
+        AlphaEquivalence alphaEquals(Relation that) {
             return constraint().alphaEquals(that.constraint());
         }
     }
@@ -440,7 +440,7 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         }
 
         @Override
-        AlphaEquivalence alphaEquals(Concludable.Has that) {
+        AlphaEquivalence alphaEquals(Has that) {
             return constraint().alphaEquals(that.constraint());
         }
 
@@ -575,12 +575,12 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         }
 
         public void fromConstraint(RelationConstraint relationConstraint) {
-            concludables.add(new Concludable.Relation(relationConstraint, relationConstraint.owner().isa().orElse(null)));
+            concludables.add(new Relation(relationConstraint, relationConstraint.owner().isa().orElse(null)));
             isaOwnersToSkip.add(relationConstraint.owner());
         }
 
         private void fromConstraint(HasConstraint hasConstraint) {
-            concludables.add(new Concludable.Has(hasConstraint, hasConstraint.attribute().isa().orElse(null), hasConstraint.attribute().value()));
+            concludables.add(new Has(hasConstraint, hasConstraint.attribute().isa().orElse(null), hasConstraint.attribute().value()));
             isaOwnersToSkip.add(hasConstraint.attribute());
             if (hasConstraint.attribute().isa().isPresent()) valueOwnersToSkip.add(hasConstraint.attribute());
         }

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -244,21 +244,21 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
 
         @Override
         public ResourceIterator<Unifier> unify(Rule.Conclusion.Relation relationConclusion, ConceptManager conceptMgr) {
-            if (this.constraint().players().size() > relationConclusion.constraint().players().size())
+            if (this.constraint().players().size() > relationConclusion.relation().players().size())
                 return Iterators.empty();
             Unifier.Builder unifierBuilder = Unifier.builder();
 
             if (!constraint().owner().reference().isAnonymous()) {
                 assert constraint().owner().reference().isName();
-                if (unificationSatisfiable(constraint().owner(), relationConclusion.constraint().owner())) {
-                    unifierBuilder.add(constraint().owner().id(), relationConclusion.constraint().owner().id());
+                if (unificationSatisfiable(constraint().owner(), relationConclusion.relation().owner())) {
+                    unifierBuilder.add(constraint().owner().id(), relationConclusion.relation().owner().id());
                 } else return Iterators.empty();
             }
 
             if (constraint().owner().isa().isPresent()) {
-                assert relationConclusion.constraint().owner().isa().isPresent(); // due to known shapes of rule conclusions
+                assert relationConclusion.relation().owner().isa().isPresent(); // due to known shapes of rule conclusions
                 TypeVariable concludableRelationType = constraint().owner().isa().get().type();
-                TypeVariable conclusionRelationType = relationConclusion.constraint().owner().isa().get().type();
+                TypeVariable conclusionRelationType = relationConclusion.relation().owner().isa().get().type();
                 if (unificationSatisfiable(concludableRelationType, conclusionRelationType, conceptMgr)) {
                     unifierBuilder.add(concludableRelationType.id(), conclusionRelationType.id());
 
@@ -273,7 +273,7 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
 
             // TODO this will work for now, but we should rewrite using role player `repetition`
             List<RolePlayer> conjRolePlayers = list(constraint().players());
-            List<RolePlayer> thenRolePlayers = list(relationConclusion.constraint().players());
+            List<RolePlayer> thenRolePlayers = list(relationConclusion.relation().players());
 
             return matchRolePlayerIndices(conjRolePlayers, thenRolePlayers, new HashMap<>(), conceptMgr)
                     .map(indexMap -> rolePlayerMappingToUnifier(indexMap, thenRolePlayers, unifierBuilder.duplicate(), conceptMgr));
@@ -357,13 +357,13 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         @Override
         public ResourceIterator<Unifier> unify(Rule.Conclusion.Has hasConclusion, ConceptManager conceptMgr) {
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(constraint().owner(), hasConclusion.constraint().owner())) {
-                unifierBuilder.add(constraint().owner().id(), hasConclusion.constraint().owner().id());
+            if (unificationSatisfiable(constraint().owner(), hasConclusion.has().owner())) {
+                unifierBuilder.add(constraint().owner().id(), hasConclusion.has().owner().id());
             } else return Iterators.empty();
 
             ThingVariable attr = constraint().attribute();
-            if (unificationSatisfiable(attr, hasConclusion.constraint().attribute())) {
-                unifierBuilder.add(attr.id(), hasConclusion.constraint().attribute().id());
+            if (unificationSatisfiable(attr, hasConclusion.has().attribute())) {
+                unifierBuilder.add(attr.id(), hasConclusion.has().attribute().id());
                 if (attr.reference().isAnonymous()) {
                     // form: $x has age 10 -> require ISA age and PREDICATE =10
                     assert attr.isa().isPresent() && attr.isa().get().type().label().isPresent();
@@ -462,13 +462,13 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         @Override
         ResourceIterator<Unifier> unify(Rule.Conclusion.Isa isaConclusion, ConceptManager conceptMgr) {
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(constraint().owner(), isaConclusion.constraint().owner())) {
-                unifierBuilder.add(constraint().owner().id(), isaConclusion.constraint().owner().id());
+            if (unificationSatisfiable(constraint().owner(), isaConclusion.isa().owner())) {
+                unifierBuilder.add(constraint().owner().id(), isaConclusion.isa().owner().id());
             } else return Iterators.empty();
 
             TypeVariable type = constraint().type();
-            if (unificationSatisfiable(type, isaConclusion.constraint().type(), conceptMgr)) {
-                unifierBuilder.add(type.id(), isaConclusion.constraint().type().id());
+            if (unificationSatisfiable(type, isaConclusion.isa().type(), conceptMgr)) {
+                unifierBuilder.add(type.id(), isaConclusion.isa().type().id());
 
                 if (type.reference().isLabel()) {
                     // form: $r isa friendship -> require type subs(friendship) for anonymous type variable
@@ -505,8 +505,8 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
         @Override
         ResourceIterator<Unifier> unify(Rule.Conclusion.Value valueConclusion, ConceptManager conceptMgr) {
             Unifier.Builder unifierBuilder = Unifier.builder();
-            if (unificationSatisfiable(constraint().owner(), valueConclusion.constraint().owner())) {
-                unifierBuilder.add(constraint().owner().id(), valueConclusion.constraint().owner().id());
+            if (unificationSatisfiable(constraint().owner(), valueConclusion.value().owner())) {
+                unifierBuilder.add(constraint().owner().id(), valueConclusion.value().owner().id());
             } else return Iterators.empty();
 
             /*
@@ -521,8 +521,8 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
             if (constraint().isVariable()) {
                 assert constraint().value() instanceof ThingVariable;
                 ThingVariable value = (ThingVariable) constraint().value();
-                if (unificationSatisfiable(constraint().predicate(), valueConclusion.constraint().predicate())) {
-                    unifierBuilder.add(value.id(), valueConclusion.constraint().owner().id());
+                if (unificationSatisfiable(constraint().predicate(), valueConclusion.value().predicate())) {
+                    unifierBuilder.add(value.id(), valueConclusion.value().owner().id());
                 } else return Iterators.empty();
                 // } else {
                 // form: $x > 10 -> require $x to satisfy predicate > 10

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -105,8 +105,7 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
     private void computeApplicableRules(ConceptManager conceptMgr, LogicManager logicMgr) {
         assert applicableRules == null;
         applicableRules = new HashMap<>();
-        logicMgr.rules().forEachRemaining(rule -> Iterators.iterate(rule.possibleConclusions())
-                .flatMap(conclusion -> unify(conclusion, conceptMgr))
+        logicMgr.rules().forEachRemaining(rule -> Iterators.iterate(unify(rule.conclusion(), conceptMgr))
                 .forEachRemaining(unifier -> {
                     applicableRules.putIfAbsent(rule, new HashSet<>());
                     applicableRules.get(rule).add(unifier);

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -114,7 +114,8 @@ public abstract class Concludable<CONSTRAINT extends Constraint> extends Resolva
 
     private ResourceIterator<Unifier> unify(Rule.Conclusion<?> conclusion, ConceptManager conceptMgr) {
         if (conclusion.isRelation()) return unify(conclusion.asRelation(), conceptMgr);
-        else if (conclusion.isHas()) return unify(conclusion.asHas(), conceptMgr);
+        else if (conclusion.isExplicitHas()) return unify(conclusion.asExplicitHas(), conceptMgr);
+        else if (conclusion.isVariableHas()) return unify(conclusion.asVariableHas(), conceptMgr);
         else if (conclusion.isIsa()) return unify(conclusion.asIsa(), conceptMgr);
         else if (conclusion.isValue()) return unify(conclusion.asValue(), conceptMgr);
         else throw GraknException.of(ILLEGAL_STATE);

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -55,7 +55,7 @@ public class ConcludableTest {
         return concludables.stream().filter(Concludable::isIsa).count();
     }
 
-    private long valueConcludablesCount(Set<Concludable<?>> concludables) {
+    private long attributeConcludablesCount(Set<Concludable<?>> concludables) {
         return concludables.stream().filter(Concludable::isAttribute).count();
     }
 
@@ -66,7 +66,7 @@ public class ConcludableTest {
         assertEquals(1, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -76,7 +76,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -96,7 +96,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(1, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(1, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(1, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ConcludableTest {
         assertEquals(1, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -136,7 +136,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(1, valueConcludablesCount(concludables));
+        assertEquals(1, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -147,7 +147,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(3, hasConcludablesCount(concludables));
         assertEquals(2, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -157,7 +157,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(2, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -167,7 +167,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -177,7 +177,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(2, valueConcludablesCount(concludables));
+        assertEquals(2, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -187,7 +187,7 @@ public class ConcludableTest {
         assertEquals(0, isaConcludablesCount(concludables));
         assertEquals(0, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(2, valueConcludablesCount(concludables));
+        assertEquals(2, attributeConcludablesCount(concludables));
     }
 
     @Test
@@ -197,7 +197,7 @@ public class ConcludableTest {
         assertEquals(1, isaConcludablesCount(concludables));
         assertEquals(1, hasConcludablesCount(concludables));
         assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, valueConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
     }
 
     @Test

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -256,44 +256,4 @@ public class ConcludableTest {
             assertTrue(hasConcludable.constraint().owner().isa().isPresent());
         });
     }
-
-    // --------------- Head concludables ---------------
-
-    @Test
-    public void test_isa_owner_has_value() {
-        Conjunction conjunction = parseConjunction("{ $a 5; $a isa age; }");
-        ThingVariable variable = parseThingVariable("$a isa age", "a");
-        IsaConstraint isaConstraint = variable.isa().get();
-        Rule.Conclusion.Isa isaConcludable = new Rule.Conclusion.Isa(isaConstraint, conjunction.variables());
-        assertEquals(5, isaConcludable.constraint().owner().value().iterator().next().asLong().value().longValue());
-    }
-
-    @Test
-    public void test_isa_owner_has_value_predicate() {
-        Conjunction conjunction = parseConjunction("{ $a > 5; $a isa age; }");
-        ThingVariable variable = parseThingVariable("$a isa age", "a");
-        IsaConstraint isaConstraint = variable.isa().get();
-        Rule.Conclusion.Isa isaConcludable = new Rule.Conclusion.Isa(isaConstraint, conjunction.variables());
-        assertEquals(5, isaConcludable.constraint().owner().value().iterator().next().asLong().value().longValue());
-        assertEquals(GT, isaConcludable.constraint().owner().value().iterator().next().asLong().predicate().asEquality());
-    }
-
-    @Test
-    public void test_has_concludable_gathers_owner_type_label() {
-        ThingVariable variable = parseThingVariable("$x has $a", "x");
-        HasConstraint hasConstraint = variable.has().iterator().next();
-        Set<Variable> contextVariables = parseConjunction("{ $x isa $p; $p type person; }").variables();
-        Rule.Conclusion.Has hasConcludable = new Rule.Conclusion.Has(hasConstraint, contextVariables);
-        assertEquals("person", hasConcludable.constraint().owner().isa().get().type().label().get().label());
-    }
-
-    @Test
-    public void test_type_label_constraint_passed_to_concludable() {
-        ThingVariable variable = parseThingVariable("$diag(patient: $per) isa $diagnosis", "diag");
-        RelationConstraint relationConstraint = variable.relation().iterator().next();
-        Set<Variable> contextVariables = parseConjunction("{ $per isa $person; $person type person-type; }").variables();
-        Rule.Conclusion.Relation relationConcludable = new Rule.Conclusion.Relation(relationConstraint, contextVariables);
-        assertEquals("person-type", list(relationConcludable.constraint().players()).get(0).player().isa().get()
-                .type().label().get().label());
-    }
 }

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -17,14 +17,11 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.logic.Rule;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
-import grakn.core.pattern.constraint.thing.HasConstraint;
 import grakn.core.pattern.constraint.thing.IsaConstraint;
 import grakn.core.pattern.constraint.thing.RelationConstraint;
 import grakn.core.pattern.variable.ThingVariable;
-import grakn.core.pattern.variable.Variable;
 import graql.lang.Graql;
 import graql.lang.pattern.variable.Reference;
 import org.junit.Test;
@@ -33,7 +30,6 @@ import java.util.Set;
 
 import static grakn.common.collection.Collections.list;
 import static grakn.core.pattern.variable.VariableRegistry.createFromThings;
-import static graql.lang.common.GraqlToken.Predicate.Equality.GT;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
 

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -56,7 +56,7 @@ public class ConcludableTest {
     }
 
     private long valueConcludablesCount(Set<Concludable<?>> concludables) {
-        return concludables.stream().filter(Concludable::isValue).count();
+        return concludables.stream().filter(Concludable::isAttribute).count();
     }
 
     @Test

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -125,6 +125,7 @@ public class Conjunction implements Pattern, Cloneable {
         if (this == obj) return true;
         if (obj == null || obj.getClass() != getClass()) return false;
         final Conjunction that = (Conjunction) obj;
+        // TODO This doesn't work! It doesn't compare constraints
         return (this.variables.equals(that.variables()) &&
                 this.negations.equals(that.negations()));
     }

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Paths;
 import java.util.Set;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 public class RuleTest {
     private static Path directory = Paths.get(System.getProperty("user.dir")).resolve("rule-test");
@@ -54,22 +55,6 @@ public class RuleTest {
 
     private long valueConcludablesCount(Set<Concludable<?>> concludables) {
         return concludables.stream().filter(Concludable::isValue).count();
-    }
-
-    private long isaHeadConcludablesCount(Set<Rule.Conclusion<?>> concludables) {
-        return concludables.stream().filter(Rule.Conclusion::isIsa).count();
-    }
-
-    private long hasHeadConcludablesCount(Set<Rule.Conclusion<?>> concludables) {
-        return concludables.stream().filter(Rule.Conclusion::isHas).count();
-    }
-
-    private long relationHeadConcludablesCount(Set<Rule.Conclusion<?>> concludables) {
-        return concludables.stream().filter(Rule.Conclusion::isRelation).count();
-    }
-
-    private long valueHeadConcludablesCount(Set<Rule.Conclusion<?>> concludables) {
-        return concludables.stream().filter(Rule.Conclusion::isValue).count();
     }
 
     @Test
@@ -100,12 +85,7 @@ public class RuleTest {
                     final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("marriage-is-friendship");
 
-                    Set<Rule.Conclusion<?>> conclusions = rule.possibleConclusions();
-                    assertEquals(1, isaHeadConcludablesCount(conclusions));
-                    assertEquals(0, hasHeadConcludablesCount(conclusions));
-                    assertEquals(1, relationHeadConcludablesCount(conclusions));
-                    assertEquals(0, valueHeadConcludablesCount(conclusions));
-
+                    assertTrue(rule.conclusion().isRelation());
                     Set<Concludable<?>> bodyConcludables = rule.whenConcludables();
                     assertEquals(2, isaConcludablesCount(bodyConcludables));
                     assertEquals(0, hasConcludablesCount(bodyConcludables));
@@ -143,12 +123,7 @@ public class RuleTest {
                     final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("old-milk-is-not-good");
 
-                    Set<Rule.Conclusion<?>> conclusions = rule.possibleConclusions();
-                    assertEquals(1, isaHeadConcludablesCount(conclusions));
-                    assertEquals(1, hasHeadConcludablesCount(conclusions));
-                    assertEquals(0, relationHeadConcludablesCount(conclusions));
-                    assertEquals(1, valueHeadConcludablesCount(conclusions));
-
+                    assertTrue(rule.conclusion().isExplicitHas());
                     Set<Concludable<?>> bodyConcludables = rule.whenConcludables();
                     assertEquals(1, isaConcludablesCount(bodyConcludables));
                     assertEquals(1, hasConcludablesCount(bodyConcludables));
@@ -185,12 +160,7 @@ public class RuleTest {
                     final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("old-milk-is-not-good");
 
-                    Set<Rule.Conclusion<?>> conclusions = rule.possibleConclusions();
-                    assertEquals(0, isaHeadConcludablesCount(conclusions));
-                    assertEquals(1, hasHeadConcludablesCount(conclusions));
-                    assertEquals(0, relationHeadConcludablesCount(conclusions));
-                    assertEquals(0, valueHeadConcludablesCount(conclusions));
-
+                    assertTrue(rule.conclusion().isVariableHas());
                     Set<Concludable<?>> bodyConcludables = rule.whenConcludables();
                     assertEquals(2, isaConcludablesCount(bodyConcludables));
                     assertEquals(0, hasConcludablesCount(bodyConcludables));

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -53,7 +53,7 @@ public class RuleTest {
         return concludables.stream().filter(Concludable::isRelation).count();
     }
 
-    private long valueConcludablesCount(Set<Concludable<?>> concludables) {
+    private long attributeConcludablesCount(Set<Concludable<?>> concludables) {
         return concludables.stream().filter(Concludable::isAttribute).count();
     }
 
@@ -90,7 +90,7 @@ public class RuleTest {
                     assertEquals(2, isaConcludablesCount(bodyConcludables));
                     assertEquals(0, hasConcludablesCount(bodyConcludables));
                     assertEquals(1, relationConcludablesCount(bodyConcludables));
-                    assertEquals(0, valueConcludablesCount(bodyConcludables));
+                    assertEquals(0, attributeConcludablesCount(bodyConcludables));
                 }
             }
         }
@@ -127,7 +127,7 @@ public class RuleTest {
                     assertEquals(1, isaConcludablesCount(bodyConcludables));
                     assertEquals(1, hasConcludablesCount(bodyConcludables));
                     assertEquals(0, relationConcludablesCount(bodyConcludables));
-                    assertEquals(0, valueConcludablesCount(bodyConcludables));
+                    assertEquals(0, attributeConcludablesCount(bodyConcludables));
                 }
             }
         }
@@ -164,7 +164,7 @@ public class RuleTest {
                     assertEquals(2, isaConcludablesCount(bodyConcludables));
                     assertEquals(0, hasConcludablesCount(bodyConcludables));
                     assertEquals(0, relationConcludablesCount(bodyConcludables));
-                    assertEquals(0, valueConcludablesCount(bodyConcludables));
+                    assertEquals(0, attributeConcludablesCount(bodyConcludables));
                 }
             }
         }

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -54,7 +54,7 @@ public class RuleTest {
     }
 
     private long valueConcludablesCount(Set<Concludable<?>> concludables) {
-        return concludables.stream().filter(Concludable::isValue).count();
+        return concludables.stream().filter(Concludable::isAttribute).count();
     }
 
     @Test

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -119,7 +119,6 @@ public class RuleTest {
                     txn.commit();
                 }
                 try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.READ)) {
-                    final ConceptManager conceptMgr = txn.concepts();
                     final LogicManager logicMgr = txn.logic();
                     final Rule rule = logicMgr.getRule("old-milk-is-not-good");
 

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -18,8 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn;
-import grakn.core.common.iterator.Iterators;
+import grakn.core.Grakn.Transaction;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptManager;
@@ -30,7 +29,6 @@ import grakn.core.logic.LogicManager;
 import grakn.core.logic.Rule;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
-import grakn.core.pattern.constraint.thing.IsaConstraint;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
 import grakn.core.rocks.RocksTransaction;
@@ -123,7 +121,7 @@ public class UnifyAttributeConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
             Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
                                          Graql.parseVariable(thenThingPattern).asThing());
             txn.commit();

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -18,6 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
+import grakn.core.Grakn;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.concept.Concept;
@@ -121,12 +122,13 @@ public class UnifyAttributeConcludableTest {
         return logicMgr.typeResolver().resolveLabels(conjunction);
     }
 
-    private IsaConstraint findIsaConstraint(Conjunction conjunction) {
-        List<IsaConstraint> isas = Iterators.iterate(conjunction.variables()).flatMap(var -> Iterators.iterate(var.constraints()))
-                .filter(constraint -> constraint.isThing() && constraint.asThing().isIsa())
-                .map(constraint -> constraint.asThing().asIsa()).toList();
-        assert isas.size() == 1 : "More than 1 isa constraint in conjunction to search";
-        return isas.get(0);
+    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
+        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+            Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                         Graql.parseVariable(thenThingPattern).asThing());
+            txn.commit();
+            return rule;
+        }
     }
 
     @Ignore // TODO enable when we have the final structure of conclusions and concludable in place
@@ -134,15 +136,11 @@ public class UnifyAttributeConcludableTest {
     public void literal_predicates_unify_and_filter_answers() {
         String conjunction = "{ $a > 'b'; $a < 'y'; }";
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
-        Concludable.Value queryConcludable = concludables.iterator().next().asValue();
+        Concludable.Attribute queryConcludable = concludables.iterator().next().asAttribute();
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        IsaConstraint thenHasNameIsa = findIsaConstraint(thenHasNameJohn);
-        Rule.Conclusion.Isa hasIsaConclusion = Rule.Conclusion.Isa.create(thenHasNameIsa, whenHasName.variables()); // TODO this will become a Has conclusion
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasIsaConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asIsa(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -186,7 +184,7 @@ public class UnifyAttributeConcludableTest {
         String conjunction = "{ $x > $y; }";
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         assertEquals(2, concludables.size());
-        Concludable.Value queryConcludable = concludables.iterator().next().asValue();
+        Concludable.Attribute queryConcludable = concludables.iterator().next().asAttribute();
 
         /*
         TODO build attribute concludables (2) out of the conjunction
@@ -194,13 +192,9 @@ public class UnifyAttributeConcludableTest {
         and nothing else
         */
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        IsaConstraint thenHasNameIsa = findIsaConstraint(thenHasNameJohn);
-        Rule.Conclusion.Isa hasIsaConclusion = Rule.Conclusion.Isa.create(thenHasNameIsa, whenHasName.variables()); // TODO refactor in new structure
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasIsaConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asIsa(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -214,13 +208,9 @@ public class UnifyAttributeConcludableTest {
         assertEquals(0, unifier.requirements().isaExplicit().size());
         assertEquals(0, unifier.requirements().predicates().size());
 
-        // rule: when { $x isa person; } then { (employee: $x) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x) isa employment; }");
-        IsaConstraint thenEmploymentIsa = findIsaConstraint(thenExactRelation);
-        Rule.Conclusion.Isa relationIsaExactConclusion = Rule.Conclusion.Isa.create(thenEmploymentIsa, whenExactRelation.variables());
+        Rule rule2 = createRule("isa-rule-2", "{ $x isa person; }", "(employee: $x) isa employment");
 
-        unifiers = queryConcludable.unify(relationIsaExactConclusion, conceptMgr).toList();
+        unifiers = queryConcludable.unify(rule2.conclusion().asIsa(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
     }
 

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -18,7 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn;
+import grakn.core.Grakn.Transaction;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Label;
@@ -138,7 +138,7 @@ public class UnifyHasConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
             Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
                                          Graql.parseVariable(thenThingPattern).asThing());
             txn.commit();
@@ -487,5 +487,4 @@ public class UnifyHasConcludableTest {
         assertEquals(set(Label.of("self-owning-attribute")), unifier.requirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.requirements().predicates().size());
     }
-
 }

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -156,7 +156,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name 'john'");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -206,7 +206,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -263,7 +263,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -296,7 +296,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -329,7 +329,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -371,7 +371,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -413,7 +413,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -437,7 +437,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -472,7 +472,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -18,8 +18,8 @@
 
 package grakn.core.logic.resolvable;
 
+import grakn.core.Grakn;
 import grakn.core.common.exception.GraknException;
-import grakn.core.common.iterator.Iterators;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Label;
 import grakn.core.concept.Concept;
@@ -32,7 +32,6 @@ import grakn.core.logic.LogicManager;
 import grakn.core.logic.Rule;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
-import grakn.core.pattern.constraint.thing.HasConstraint;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
 import grakn.core.rocks.RocksTransaction;
@@ -138,12 +137,13 @@ public class UnifyHasConcludableTest {
         return logicMgr.typeResolver().resolveLabels(conjunction);
     }
 
-    private HasConstraint findHasConstraint(Conjunction conjunction) {
-        List<HasConstraint> has = Iterators.iterate(conjunction.variables()).flatMap(var -> Iterators.iterate(var.constraints()))
-                .filter(constraint -> constraint.isThing() && constraint.asThing().isHas())
-                .map(constraint -> constraint.asThing().asHas()).toList();
-        assert has.size() == 1 : "More than 1 has constraint in conjunction to search";
-        return has.get(0);
+    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
+        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+            Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                         Graql.parseVariable(thenThingPattern).asThing());
+            txn.commit();
+            return rule;
+        }
     }
 
     //TODO: create more tests when type inference is working to test unifier pruning
@@ -154,13 +154,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        HasConstraint thenHasNameIsa = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasNameIsa, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name 'john'");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -208,13 +204,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; $a isa first-name; } then { $x has $a; }
-        Conjunction whenHasName = parseConjunction("{ $x isa person; $a isa first-name; }");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has $a; }");
-        HasConstraint thenHasNamehas = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasNamehas, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -269,13 +261,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        HasConstraint thenHasNameHas = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasNameHas, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -306,13 +294,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; $a isa first-name; } then { $x has $a; }
-        Conjunction whenHasName = parseConjunction("{$x isa person; $a isa first-name;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has $a; }");
-        HasConstraint thenHasNameHas = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasNameHas, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -343,13 +327,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        HasConstraint thenHasName = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasName, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -389,13 +369,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; $a isa first-name; } then { $x has $a; }
-        Conjunction whenHasName = parseConjunction("{ $x isa person; $a isa first-name; }");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has $a; }");
-        HasConstraint thenHasNameHas = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasNameHas, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -435,13 +411,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $a isa self-owning-attr; } then { $a has $a; }
-        Conjunction whenHasName = parseConjunction("{ $a isa self-owning-attribute; }");
-        Conjunction thenHasNameJohn = parseConjunction("{ $a has $a; }");
-        HasConstraint thenHasName = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasName, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -463,13 +435,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $x isa person; } then { $x has first-name "john"; }
-        Conjunction whenHasName = parseConjunction("{$x isa person;}");
-        Conjunction thenHasNameJohn = parseConjunction("{ $x has first-name 'john'; }");
-        HasConstraint thenHasName = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasName, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -502,13 +470,9 @@ public class UnifyHasConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        // rule: when { $a isa self-owning-attr; } then { $a has $a; }
-        Conjunction whenHasName = parseConjunction("{ $a isa self-owning-attribute; }");
-        Conjunction thenHasNameJohn = parseConjunction("{ $a has $a; }");
-        HasConstraint thenHasName = findHasConstraint(thenHasNameJohn);
-        Rule.Conclusion.Has hasConclusion = Rule.Conclusion.Has.create(thenHasName, whenHasName.variables());
+        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(hasConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -523,4 +487,5 @@ public class UnifyHasConcludableTest {
         assertEquals(set(Label.of("self-owning-attribute")), unifier.requirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.requirements().predicates().size());
     }
+
 }

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -156,7 +156,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name 'john'");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -206,7 +206,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -263,7 +263,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -296,7 +296,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -329,7 +329,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -371,7 +371,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -413,7 +413,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -437,7 +437,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asExplicitHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -472,7 +472,7 @@ public class UnifyHasConcludableTest {
 
         Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
 
-        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asHas(), conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asVariableHas(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -18,7 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn;
+import grakn.core.Grakn.Transaction;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Label;
@@ -137,7 +137,7 @@ public class UnifyIsaConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
             Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
                                          Graql.parseVariable(thenThingPattern).asThing());
             txn.commit();

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -18,7 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn;
+import grakn.core.Grakn.Transaction;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
@@ -36,7 +36,6 @@ import grakn.core.logic.LogicManager;
 import grakn.core.logic.Rule;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
-import grakn.core.pattern.constraint.thing.RelationConstraint;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
 import grakn.core.rocks.RocksTransaction;
@@ -156,7 +155,7 @@ public class UnifyRelationConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
             Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
                                     Graql.parseVariable(thenThingPattern).asThing());
             txn.commit();

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -155,14 +155,6 @@ public class UnifyRelationConcludableTest {
         return logicMgr.typeResolver().resolveLabels(conjunction);
     }
 
-    private RelationConstraint findRelationConstraint(Conjunction conjunction) {
-        List<RelationConstraint> rels = Iterators.iterate(conjunction.variables()).flatMap(var -> Iterators.iterate(var.constraints()))
-                .filter(constraint -> constraint.isThing() && constraint.asThing().isRelation())
-                .map(constraint -> constraint.asThing().asRelation()).toList();
-        assert rels.size() == 1 : "More than 1 relation constraint in conjunction to search";
-        return rels.get(0);
-    }
-
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
         try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
             Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -18,6 +18,7 @@
 
 package grakn.core.logic.resolvable;
 
+import grakn.core.Grakn;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
@@ -162,19 +163,25 @@ public class UnifyRelationConcludableTest {
         return rels.get(0);
     }
 
+    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
+        try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+            Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                    Graql.parseVariable(thenThingPattern).asThing());
+            txn.commit();
+            return rule;
+        }
+    }
+
     @Test
     public void relation_and_player_unifies_rule_relation_exact() {
         String conjunction = "{ $r (employee: $y) isa employment; }";
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; } then { (employee: $x) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("people-are-employed", "{ $x isa person; }",
+                               " (employee: $x) isa employment ");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -231,13 +238,10 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; } then { (employee: $x) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("people-are-employed", "{ $x isa person; }",
+                               " (employee: $x) isa employment ");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -291,13 +295,10 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; } then { (employee: $x) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("people-are-employed", "{ $x isa person; }",
+                               " (employee: $x) isa employment ");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -351,13 +352,10 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; } then { (employee: $x) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("people-are-employed", "{ $x isa person; }",
+                               " (employee: $x) isa employment ");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
         Unifier unifier = unifiers.get(0);
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
@@ -381,13 +379,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; $y isa person; $z isa person; } then { (employee: $x, employee: $y, employee: $z) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; $y isa person; $z isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x, employee: $y, employee: $z) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("three-people-are-employed",
+                               "{ $x isa person; $y isa person; $z isa person; }",
+                               "(employee: $x, employee: $y, employee: $z) isa employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -410,19 +406,17 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
     }
 
-
     @Test
     public void relation_variable_multiple_identical_unifiers() {
         String conjunction = "{ (employee: $p) isa employment; }";
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $x) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("the-same-person-is-employed-twice",
+                               "{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }",
+                               "($employee: $x, $employee: $x) isa $employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -441,13 +435,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        // rule: when { $x isa person; $y isa person; $z isa person; } then { (employee: $x, employee: $y, employee: $z) isa employment; }
-        Conjunction whenExactRelation = parseConjunction("{ $x isa person; $y isa person; $z isa person; }");
-        Conjunction thenExactRelation = parseConjunction("{ (employee: $x, employee: $y, employee: $z) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(thenExactRelation);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, whenExactRelation.variables());
+        Rule rule = createRule("three-people-are-employed",
+                               "{ $x isa person; $y isa person; $z isa person; }",
+                               "(employee: $x, employee: $y, employee: $z) isa employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -497,13 +489,12 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; $employment type employment; " +
-                                                    "$employee type employment:employee; $employer type employment:employer; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $y) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed",
+                               "{ $x isa person; $y isa person; $employment type employment; " +
+                                       "$employee type employment:employee; $employer type employment:employer; }",
+                               "($employee: $x, $employee: $y) isa $employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -527,12 +518,12 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $y) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed",
+                               "{ $x isa person; $y isa person; $employment type employment; " +
+                                       "$employee type employment:employee; }",
+                               "($employee: $x, $employee: $y) isa $employment");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -595,12 +586,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; }");
-        Conjunction then = parseConjunction("{ (employee: $x, employer: $x, employee: $y) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
+                               "{ $x isa person; $y isa person; }",
+                               "(employee: $x, employer: $x, employee: $y) isa employment");
 
-        List<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         List<Map<String, Set<String>>> result = Iterators.iterate(unifier).map(u -> getStringMapping(u.mapping())).toList();
 
         List<Map<String, Set<String>>> expected = list(
@@ -628,12 +618,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; }");
-        Conjunction then = parseConjunction("{ (employee: $x, employer: $x, employee: $y) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
+                               "{ $x isa person; $y isa person; }",
+                               "(employee: $x, employer: $x, employee: $y) isa employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -676,12 +665,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; }");
-        Conjunction then = parseConjunction("{ (employee: $x, employer: $x, employee: $y) isa employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
+                               "{ $x isa person; $y isa person; }",
+                               "(employee: $x, employer: $x, employee: $y) isa employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -716,12 +704,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $y) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("two-people-are-employed",
+                               "{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }",
+                               "($employee: $x, $employee: $y) isa $employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -740,12 +727,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $employment type employment; $employee type employment:employee; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $x) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("a-person-is-employed-twice",
+                               "{ $x isa person; $employment type employment; $employee type employment:employee; }",
+                               "($employee: $x, $employee: $x) isa $employment");
 
-        List<Unifier> unifiers = queryConcludable.unify(relationConclusion, conceptMgr).toList();
+        List<Unifier> unifiers = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr).toList();
         Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -792,12 +778,11 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $employment type employment; $employee type employment:employee; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employee: $x) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("a-person-is-employed-twice",
+                               "{ $x isa person; $employment type employment; $employee type employment:employee; }",
+                               "($employee: $x, $employee: $x) isa $employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = set(
@@ -816,12 +801,12 @@ public class UnifyRelationConcludableTest {
         Set<Concludable<?>> concludables = Concludable.create(parseConjunction(conjunction));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
-        Conjunction when = parseConjunction("{ $x isa person; $y isa company; $employment sub employment; $employee sub employment:employee; $employer sub employment:employer; }");
-        Conjunction then = parseConjunction("{ ($employee: $x, $employer: $y) isa $employment; }");
-        RelationConstraint thenEmploymentRelation = findRelationConstraint(then);
-        Rule.Conclusion.Relation relationConclusion = Rule.Conclusion.Relation.create(thenEmploymentRelation, when.variables());
+        Rule rule = createRule("one-employee-one-employer",
+                               "{ $x isa person; $y isa company; $employment sub employment; " +
+                                       "$employee sub employment:employee; $employer sub employment:employer; }",
+                               "($employee: $x, $employer: $y) isa $employment");
 
-        ResourceIterator<Unifier> unifier = queryConcludable.unify(relationConclusion, conceptMgr);
+        ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion().asRelation(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
 
         Set<Map<String, Set<String>>> expected = Collections.emptySet();


### PR DESCRIPTION
## What is the goal of this PR?

Refactor a Rule to have only one conclusion, one of: relation, variable has, explicit has. This is in response to additional challenges in unification which required a re-think of the approach, with architectural ramifications.

## What are the changes implemented in this PR?
- Rule only returns one `Conclusion`
- Change possible Conclusions to `Rule.Conclusion.Has.Explicit`, `Rule.Conclusion.Has.Variable`, `Rule.Conclusion.Relation`
- `Rule.Conclusion.Relation` can be unified with `Concludable.Relation`
- `Rule.Conclusion.Has` can be unified with `Concludable.Has`
- `Rule.Conclusion.Has.Explicit` and `Rule.Conclusion.Relation` implement `Rule.Conclusion.Isa`, so they can be unified with `Concludable.Isa`
- `Rule.Conclusion.Has.Explicit` implements `Rule.Conclusion.Value`, so it can be unified with `Concludable.Attribute`
