### PR TITLE
System Reference Class Refactor

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -39,10 +39,16 @@ def graknlabs_graql():
 #        tag = "2.0.0-alpha-2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
 #    )
 
-    native.local_repository(
+    git_repository(
         name = "graknlabs_graql",
-        path = "//users/max/programming/graql",
+        remote = "https://github.com/maxbaxt/graql",
+        commit = "1339ddaac2abc304e71f69bf1a144562b6f3d514" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
+
+#    native.local_repository(
+#        name = "graknlabs_graql",
+#        path = "//users/max/programming/graql",
+#    )
 
 def graknlabs_protocol():
     git_repository(

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -33,10 +33,15 @@ def graknlabs_common():
 
 
 def graknlabs_graql():
-    git_repository(
+#    git_repository(
+#        name = "graknlabs_graql",
+#        remote = "https://github.com/graknlabs/graql",
+#        tag = "2.0.0-alpha-2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+#    )
+
+    native.local_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        tag = "2.0.0-alpha-2" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        path = "//users/max/programming/graql",
     )
 
 def graknlabs_protocol():

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -480,7 +480,7 @@ public class TypeResolver {
         }
 
         private Identifier.Variable newSystemVariable() {
-            return Identifier.Variable.of(SystemReference.of(sysVarCounter++));
+            return Identifier.Variable.of(SystemReference.System(sysVarCounter++));
         }
 
         boolean contains(Variable variable) {

--- a/pattern/variable/SystemReference.java
+++ b/pattern/variable/SystemReference.java
@@ -27,9 +27,35 @@ public class SystemReference extends Reference.Referrable {
     public final static String PREFIX = "$/";
 
     private final int id;
+    private final int hash;
 
-    public SystemReference(int id) {
-        super();
+    SystemReference(int id) {
+        super(Type.SYSTEM, true);
+        this.id = id;
+        this.hash = Objects.hash(SystemReference.class, id);
+    }
+
+    @Override
+    public String syntax() {
+        return PREFIX + id;
+    }
+
+    public static SystemReference of(int id) {
+        return new SystemReference(id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SystemReference that = (SystemReference) o;
+        return this.id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
     }
 
 }

--- a/pattern/variable/SystemReference.java
+++ b/pattern/variable/SystemReference.java
@@ -22,7 +22,7 @@ import graql.lang.pattern.variable.Reference;
 
 import java.util.Objects;
 
-public class SystemReference extends Reference.Referrable {
+public class SystemReference extends Reference.Referable {
 
     public final static String PREFIX = "$/";
 
@@ -30,7 +30,7 @@ public class SystemReference extends Reference.Referrable {
     private final int hash;
 
     SystemReference(int id) {
-        super(Type.SYSTEM, true);
+        super(Reference.Type.SYSTEM, true);
         this.id = id;
         this.hash = Objects.hash(SystemReference.class, id);
     }
@@ -40,7 +40,7 @@ public class SystemReference extends Reference.Referrable {
         return PREFIX + id;
     }
 
-    public static SystemReference of(int id) {
+    public static SystemReference System(int id) {
         return new SystemReference(id);
     }
 

--- a/pattern/variable/SystemReference.java
+++ b/pattern/variable/SystemReference.java
@@ -22,39 +22,51 @@ import graql.lang.pattern.variable.Reference;
 
 import java.util.Objects;
 
-public class SystemReference extends Reference.Name {
+public class SystemReference extends Reference.Referrable {
 
-    public static String PREFIX = "$/";
+    public final static String PREFIX = "$/";
 
     private final int id;
-    private final int hash;
 
     public SystemReference(int id) {
-        super("sys" + id); // TODO: why are we we doing this? Why does this class have to extend Reference.Name?
-        this.id = id;
-        this.hash = Objects.hash(SystemReference.class, id);
+        super();
     }
 
-    public static SystemReference of(int id) {
-        return new SystemReference(id);
-    }
-
-    @Override
-    public String syntax() {
-        return PREFIX + name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        SystemReference that = (SystemReference) o;
-        return this.id == that.id;
-    }
-
-    @Override
-    public int hashCode() {
-        return hash;
-    }
 }
+
+//public class SystemReference extends Reference.Name {
+//
+//    public static String PREFIX = "$/";
+//
+//    private final int id;
+//    private final int hash;
+//
+//    public SystemReference(int id) {
+//        super("sys" + id); // TODO: why are we we doing this? Why does this class have to extend Reference.Name?
+//        this.id = id;
+//        this.hash = Objects.hash(SystemReference.class, id);
+//    }
+//
+//    public static SystemReference of(int id) {
+//        return new SystemReference(id);
+//    }
+//
+//    @Override
+//    public String syntax() {
+//        return PREFIX + name;
+//    }
+//
+//    @Override
+//    public boolean equals(Object o) {
+//        if (this == o) return true;
+//        if (o == null || getClass() != o.getClass()) return false;
+//
+//        SystemReference that = (SystemReference) o;
+//        return this.id == that.id;
+//    }
+//
+//    @Override
+//    public int hashCode() {
+//        return hash;
+//    }
+//}

--- a/pattern/variable/VariableRegistry.java
+++ b/pattern/variable/VariableRegistry.java
@@ -101,7 +101,7 @@ public class VariableRegistry {
         } else if (types.containsKey(graqlVar.reference())) {
             return types.get(graqlVar.reference()).constrainConcept(graqlVar.constraints(), this);
         } else if (bounds != null && bounds.contains(graqlVar.reference())) {
-            Reference.Referrable ref = graqlVar.reference().asReferrable();
+            Reference.Referable ref = graqlVar.reference().asReferable();
             if (bounds.get(graqlVar.reference()).isThing()) {
                 things.put(ref, new ThingVariable(Identifier.Variable.of(ref)));
                 return things.get(ref).constrainConcept(graqlVar.constraints(), this);
@@ -117,7 +117,7 @@ public class VariableRegistry {
     public TypeVariable register(graql.lang.pattern.variable.TypeVariable graqlVar) {
         if (graqlVar.reference().isAnonymous()) throw GraknException.of(ANONYMOUS_TYPE_VARIABLE);
         return computeTypeIfAbsent(
-                graqlVar.reference(), ref -> new TypeVariable(Identifier.Variable.of(ref.asReferrable()))
+                graqlVar.reference(), ref -> new TypeVariable(Identifier.Variable.of(ref.asReferable()))
         ).constrainType(graqlVar.constraints(), this);
     }
 
@@ -127,7 +127,7 @@ public class VariableRegistry {
             graknVar = new ThingVariable(Identifier.Variable.of(graqlVar.reference().asAnonymous(), anonymous.size()));
             anonymous.add(graknVar);
         } else {
-            graknVar = computeThingIfAbsent(graqlVar.reference(), r -> new ThingVariable(Identifier.Variable.of(r.asReferrable())));
+            graknVar = computeThingIfAbsent(graqlVar.reference(), r -> new ThingVariable(Identifier.Variable.of(r.asReferable())));
         }
         return graknVar.constrainThing(graqlVar.constraints(), this);
     }

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -116,7 +116,7 @@ public abstract class Identifier {
             this.hash = Objects.hash(Variable.class, this.reference, this.id);
         }
 
-        public static Referrable of(Reference.Referrable reference) {
+        public static Referable of(Reference.Referable reference) {
             if (reference.isLabel()) return new Label(reference.asLabel());
             else if (reference.isName()) return new Name(reference.asName());
             else assert false;
@@ -127,11 +127,11 @@ public abstract class Identifier {
             return new Anonymous(reference, id);
         }
 
-        public static Referrable name(String name) {
+        public static Referable name(String name) {
             return Variable.of(Reference.named(name));
         }
 
-        public static Referrable label(String label) {
+        public static Referable label(String label) {
             return Variable.of(Reference.label(label));
         }
 
@@ -168,19 +168,19 @@ public abstract class Identifier {
             return hash;
         }
 
-        static class Referrable extends Variable {
+        static class Referable extends Variable {
 
-            Referrable(Reference reference) {
+            Referable(Reference reference) {
                 super(reference, null);
             }
 
             @Override
-            public Reference.Referrable reference() {
-                return reference.asReferrable();
+            public Reference.Referable reference() {
+                return reference.asReferable();
             }
         }
 
-        static class Name extends Referrable {
+        static class Name extends Referable {
 
             private Name(Reference.Name reference) {
                 super(reference);
@@ -192,7 +192,7 @@ public abstract class Identifier {
             }
         }
 
-        static class Label extends Referrable {
+        static class Label extends Referable {
 
             private Label(Reference.Label reference) {
                 super(reference);


### PR DESCRIPTION
## What is the goal of this PR?

* Make `System` a direct subclass of `Referable` instead of `Name`
* This ensures a cleaner class hierarchy for Variable References

## What are the changes implemented in this PR?

* Made `System` extend `Referable`
* Adjusted the API to make it conform with the other subclasses of `Reference`
* Fixed "Referable" typo misspelt as "Referrable" 