### PR TITLE
Write schema transactions are exclusive

### DIFF
--- a/common/concurrent/ManagedLock.java
+++ b/common/concurrent/ManagedLock.java
@@ -22,7 +22,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.Semaphore;
 
 /**
- * A {@code Lock} that wrapped in a {@code ManagedBlocker}.
+ * A {@code Semaphore}-based locking mechanism that wrapped in a {@code ManagedBlocker}.
  * It is **NOT** re-entrant by design.
  *
  * When a thread is blocked while waiting to acquire a lock, this class will

--- a/common/concurrent/ManagedLock.java
+++ b/common/concurrent/ManagedLock.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.common.concurrent;
+
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.Semaphore;
+
+/**
+ * A {@code Lock} that wrapped in a {@code ManagedBlocker}.
+ * It is **NOT** re-entrant by design.
+ *
+ * When a thread is blocked while waiting to acquire a lock, this class will
+ * possibly arrange for a spare thread to be activated if necessary, to ensure
+ * sufficient parallelism while the current thread is blocked.
+ */
+public class ManagedLock {
+
+    private final Semaphore semaphore;
+    private final ThreadLocal<ManagedLock.Locker> locker;
+
+    public ManagedLock() {
+        semaphore = new Semaphore(1);
+        locker = ThreadLocal.withInitial(ManagedLock.Locker::new);
+    }
+
+    public void lock() throws InterruptedException {
+        ForkJoinPool.managedBlock(locker.get());
+    }
+
+    public void unlock() {
+        locker.get().unlock();
+    }
+
+    private class Locker implements ForkJoinPool.ManagedBlocker {
+
+        @Override
+        public boolean block() throws InterruptedException {
+            semaphore.acquire();
+            return true;
+        }
+
+        @Override
+        public boolean isReleasable() {
+            return false; // blocking is always necessary as this lock is not re-entrant
+        }
+
+        void unlock() {
+            semaphore.release();
+        }
+    }
+}

--- a/common/concurrent/ManagedReadWriteLock.java
+++ b/common/concurrent/ManagedReadWriteLock.java
@@ -29,7 +29,7 @@ import java.util.concurrent.locks.StampedLock;
  * possibly arrange for a spare thread to be activated if necessary, to ensure
  * sufficient parallelism while the current thread is blocked. There are 2 blocking
  * methods we would like to manage for a {@code ReadWriteLock}, they are
- * {@code lock.readLock().lock()} and {@code lock.writeLock().lock()}.
+ * {@code lock.asReadWriteLock().readLock().lock()} and {@code lock.asReadWriteLock().writeLock().lock()}.
  * Each of them needs to be wrapped in a {@code ManagedBlocker}, and every thread
  * needs to have one instance of each blocker. Thus, we hold each {@code ManagedBlocker}
  * in a {@code ThreadLocal} object.

--- a/common/concurrent/ManagedReadWriteLock.java
+++ b/common/concurrent/ManagedReadWriteLock.java
@@ -19,6 +19,7 @@
 package grakn.core.common.concurrent;
 
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 

--- a/common/concurrent/ManagedReadWriteLock.java
+++ b/common/concurrent/ManagedReadWriteLock.java
@@ -19,18 +19,17 @@
 package grakn.core.common.concurrent;
 
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
 /**
- * A {@code ReentrantReadWriteLock} that wrapped in a {@code ManagedBlocker}.
+ * A {@code ReadWriteLock} that wrapped in a {@code ManagedBlocker}.
+ * It is **NOT** re-entrant by design.
  *
  * When a thread is blocked while waiting to acquire a lock, this class will
  * possibly arrange for a spare thread to be activated if necessary, to ensure
  * sufficient parallelism while the current thread is blocked. There are 2 blocking
- * methods we would like to manage for a {@code ReentrantReadWriteLock}, they are
- * {@code lock.asReadWriteLock().readLock().lock()} and {@code lock.asReadWriteLock().writeLock().lock()}.
+ * methods we would like to manage for a {@code ReadWriteLock}, they are
+ * {@code lock.readLock().lock()} and {@code lock.writeLock().lock()}.
  * Each of them needs to be wrapped in a {@code ManagedBlocker}, and every thread
  * needs to have one instance of each blocker. Thus, we hold each {@code ManagedBlocker}
  * in a {@code ThreadLocal} object.

--- a/common/concurrent/ManagedReadWriteLock.java
+++ b/common/concurrent/ManagedReadWriteLock.java
@@ -19,7 +19,6 @@
 package grakn.core.common.concurrent;
 
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 

--- a/common/concurrent/ManagedReadWriteLock.java
+++ b/common/concurrent/ManagedReadWriteLock.java
@@ -19,7 +19,9 @@
 package grakn.core.common.concurrent;
 
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.StampedLock;
 
 /**
  * A {@code ReentrantReadWriteLock} that wrapped in a {@code ManagedBlocker}.
@@ -28,19 +30,19 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * possibly arrange for a spare thread to be activated if necessary, to ensure
  * sufficient parallelism while the current thread is blocked. There are 2 blocking
  * methods we would like to manage for a {@code ReentrantReadWriteLock}, they are
- * {@code reentrantLock.readLock().lock()} and {@code reentrantLock.writeLock().lock()}.
+ * {@code lock.asReadWriteLock().readLock().lock()} and {@code lock.asReadWriteLock().writeLock().lock()}.
  * Each of them needs to be wrapped in a {@code ManagedBlocker}, and every thread
  * needs to have one instance of each blocker. Thus, we hold each {@code ManagedBlocker}
  * in a {@code ThreadLocal} object.
  */
 public class ManagedReadWriteLock {
 
-    private final ReentrantReadWriteLock reentrantLock;
+    private final StampedLock lock;
     private final ThreadLocal<ReadLocker> localReadLocker;
     private final ThreadLocal<WriteLocker> localWriteLocker;
 
     public ManagedReadWriteLock() {
-        reentrantLock = new ReentrantReadWriteLock();
+        lock = new StampedLock();
         localReadLocker = ThreadLocal.withInitial(ReadLocker::new);
         localWriteLocker = ThreadLocal.withInitial(WriteLocker::new);
     }
@@ -63,43 +65,37 @@ public class ManagedReadWriteLock {
 
     private class ReadLocker implements ForkJoinPool.ManagedBlocker {
 
-        boolean hasLock = false;
-
         @Override
         public boolean block() {
-            if (!hasLock) reentrantLock.readLock().lock();
+            lock.asReadWriteLock().readLock().lock();
             return true;
         }
 
         @Override
         public boolean isReleasable() {
-            return hasLock || (hasLock = reentrantLock.readLock().tryLock());
+            return false;
         }
 
         void unlock() {
-            reentrantLock.readLock().unlock();
-            hasLock = false;
+            lock.asReadWriteLock().readLock().unlock();
         }
     }
 
     private class WriteLocker implements ForkJoinPool.ManagedBlocker {
 
-        boolean hasLock = false;
-
         @Override
         public boolean block() {
-            if (!hasLock) reentrantLock.writeLock().lock();
-            return true;
+            lock.asReadWriteLock().writeLock().lock(); // force block
+            return true; // if obtained lock, no further blocking necessary
         }
 
         @Override
         public boolean isReleasable() {
-            return hasLock || (hasLock = reentrantLock.writeLock().tryLock());
+            return false; // blocking is always necessary as this lock is not re-entrant
         }
 
         void unlock() {
-            reentrantLock.writeLock().unlock();
-            hasLock = false;
+            lock.asReadWriteLock().writeLock().unlock();
         }
     }
 }

--- a/common/exception/GraknException.java
+++ b/common/exception/GraknException.java
@@ -22,6 +22,10 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * TODO there is some technical debt in the way we throw and catch GraknException, which is a RuntimeException.
+ * see issue #6021
+ */
 public class GraknException extends RuntimeException {
 
     @Nullable

--- a/common/producer/Producers.java
+++ b/common/producer/Producers.java
@@ -18,6 +18,7 @@
 
 package grakn.core.common.producer;
 
+import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
 
 import java.util.List;
@@ -25,6 +26,8 @@ import java.util.List;
 import static grakn.common.collection.Collections.list;
 
 public class Producers {
+
+    public static <T> BaseProducer<T> empty() { return producer(Iterators.empty()); }
 
     public static <T> BaseProducer<T> producer(ResourceIterator<T> iterator) {
         return new BaseProducer<>(iterator);

--- a/concept/ConceptImpl.java
+++ b/concept/ConceptImpl.java
@@ -145,4 +145,5 @@ public abstract class ConceptImpl implements Concept {
     public RelationImpl asRelation() {
         throw exception(GraknException.of(INVALID_THING_CASTING, className(this.getClass()), className(Relation.class)));
     }
+
 }

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -66,10 +66,10 @@ public final class ConceptManager {
     public ConceptMap conceptMap(VertexMap vertexMap) {
         Map<Reference.Name, Concept> map = new HashMap<>();
         vertexMap.forEach((reference, vertex) -> {
-            if (!reference.isName()) throw GraknException.of(ILLEGAL_STATE);
+            if (!reference.isName()) throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
             if (vertex.isThing()) map.put(reference.asName(), ThingImpl.of(vertex.asThing()));
             else if (vertex.isType()) map.put(reference.asName(), TypeImpl.of(graphMgr, vertex.asType()));
-            else throw GraknException.of(ILLEGAL_STATE);
+            else graphMgr.exception(GraknException.of(ILLEGAL_STATE));
         });
         return new ConceptMap(map);
     }

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -69,7 +69,7 @@ public final class ConceptManager {
             if (!reference.isName()) throw exception(GraknException.of(ILLEGAL_STATE));
             if (vertex.isThing()) map.put(reference.asName(), ThingImpl.of(vertex.asThing()));
             else if (vertex.isType()) map.put(reference.asName(), TypeImpl.of(graphMgr, vertex.asType()));
-            else graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+            else throw exception(GraknException.of(ILLEGAL_STATE));
         });
         return new ConceptMap(map);
     }
@@ -77,25 +77,25 @@ public final class ConceptManager {
     public ThingType getRootThingType() {
         final TypeVertex vertex = graphMgr.schema().rootThingType();
         if (vertex != null) return new ThingTypeImpl.Root(graphMgr, vertex);
-        else throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+        else throw exception(GraknException.of(ILLEGAL_STATE));
     }
 
     public EntityType getRootEntityType() {
         final TypeVertex vertex = graphMgr.schema().rootEntityType();
         if (vertex != null) return EntityTypeImpl.of(graphMgr, vertex);
-        else throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+        else throw exception(GraknException.of(ILLEGAL_STATE));
     }
 
     public RelationType getRootRelationType() {
         final TypeVertex vertex = graphMgr.schema().rootRelationType();
         if (vertex != null) return RelationTypeImpl.of(graphMgr, vertex);
-        else throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+        else throw exception(GraknException.of(ILLEGAL_STATE));
     }
 
     public AttributeType getRootAttributeType() {
         final TypeVertex vertex = graphMgr.schema().rootAttributeType();
         if (vertex != null) return AttributeTypeImpl.of(graphMgr, vertex);
-        else throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+        else throw exception(GraknException.of(ILLEGAL_STATE));
     }
 
     public EntityType putEntityType(String label) {

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -66,7 +66,7 @@ public final class ConceptManager {
     public ConceptMap conceptMap(VertexMap vertexMap) {
         Map<Reference.Name, Concept> map = new HashMap<>();
         vertexMap.forEach((reference, vertex) -> {
-            if (!reference.isName()) throw graphMgr.exception(GraknException.of(ILLEGAL_STATE));
+            if (!reference.isName()) throw exception(GraknException.of(ILLEGAL_STATE));
             if (vertex.isThing()) map.put(reference.asName(), ThingImpl.of(vertex.asThing()));
             else if (vertex.isType()) map.put(reference.asName(), TypeImpl.of(graphMgr, vertex.asType()));
             else graphMgr.exception(GraknException.of(ILLEGAL_STATE));
@@ -123,8 +123,8 @@ public final class ConceptManager {
     }
 
     public AttributeType putAttributeType(String label, AttributeType.ValueType valueType) {
-        if (valueType == null) throw graphMgr.exception(GraknException.of(ATTRIBUTE_VALUE_TYPE_MISSING, label));
-        if (!valueType.isWritable()) throw graphMgr.exception(GraknException.of(UNSUPPORTED_OPERATION));
+        if (valueType == null) throw exception(GraknException.of(ATTRIBUTE_VALUE_TYPE_MISSING, label));
+        if (!valueType.isWritable()) throw exception(GraknException.of(UNSUPPORTED_OPERATION));
 
         final TypeVertex vertex = graphMgr.schema().getType(label);
         switch (valueType) {
@@ -144,7 +144,7 @@ public final class ConceptManager {
                 if (vertex != null) return AttributeTypeImpl.DateTime.of(graphMgr, vertex);
                 else return new AttributeTypeImpl.DateTime(graphMgr, label);
             default:
-                throw graphMgr.exception(GraknException.of(UNSUPPORTED_OPERATION, "putAttributeType", valueType.name()));
+                throw exception(GraknException.of(UNSUPPORTED_OPERATION, "putAttributeType", valueType.name()));
         }
     }
 
@@ -171,7 +171,7 @@ public final class ConceptManager {
                 .filter(Vertex::isModified)
                 .map(v -> TypeImpl.of(graphMgr, v).validate())
                 .collect(ArrayList::new, ArrayList::addAll, ArrayList::addAll);
-        if (!exceptions.isEmpty()) throw graphMgr.exception(GraknException.of(exceptions));
+        if (!exceptions.isEmpty()) throw exception(GraknException.of(exceptions));
     }
 
     public void validateThings() {

--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -70,7 +70,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
             case RELATION:
                 return RelationImpl.of(vertex);
             default:
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                throw vertex.graphs().exception(GraknException.of(UNRECOGNISED_VALUE));
         }
     }
 

--- a/concept/type/impl/AttributeTypeImpl.java
+++ b/concept/type/impl/AttributeTypeImpl.java
@@ -92,7 +92,7 @@ public abstract class AttributeTypeImpl extends ThingTypeImpl implements Attribu
             case DATETIME:
                 return AttributeTypeImpl.DateTime.of(graphMgr, vertex);
             default:
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                throw graphMgr.exception(GraknException.of(UNRECOGNISED_VALUE));
         }
     }
 

--- a/concept/type/impl/RoleTypeImpl.java
+++ b/concept/type/impl/RoleTypeImpl.java
@@ -116,7 +116,7 @@ public class RoleTypeImpl extends TypeImpl implements RoleType {
     @Override
     public void delete() {
         if (getInstances().findAny().isPresent()) {
-            throw GraknException.of(INVALID_UNDEFINE_RELATES_HAS_INSTANCES, getLabel());
+            throw exception(GraknException.of(INVALID_UNDEFINE_RELATES_HAS_INSTANCES, getLabel()));
         }
         vertex.delete();
     }

--- a/concept/type/impl/ThingTypeImpl.java
+++ b/concept/type/impl/ThingTypeImpl.java
@@ -89,7 +89,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
             case THING_TYPE:
                 return new ThingTypeImpl.Root(graphMgr, vertex);
             default:
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                throw graphMgr.exception(GraknException.of(UNRECOGNISED_VALUE));
         }
     }
 
@@ -151,7 +151,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         TypeEdge edge;
         final TypeVertex attVertex = ((AttributeTypeImpl) attributeType).vertex;
         if (getInstances().anyMatch(thing -> thing.getHas(attributeType).findAny().isPresent())) {
-            throw GraknException.of(INVALID_UNDEFINE_OWNS_HAS_INSTANCES, vertex.label(), attVertex.label());
+            throw exception(GraknException.of(INVALID_UNDEFINE_OWNS_HAS_INSTANCES, vertex.label(), attVertex.label()));
         }
         if ((edge = vertex.outs().edge(OWNS, attVertex)) != null) edge.delete();
         if ((edge = vertex.outs().edge(OWNS_KEY, attVertex)) != null) edge.delete();
@@ -323,7 +323,7 @@ public abstract class ThingTypeImpl extends TypeImpl implements ThingType {
         final TypeEdge edge = vertex.outs().edge(Encoding.Edge.Type.PLAYS, ((RoleTypeImpl) roleType).vertex);
         if (edge == null) return;
         if (getInstances().anyMatch(thing -> thing.getRelations(roleType).findAny().isPresent())) {
-            throw GraknException.of(INVALID_UNDEFINE_PLAYS_HAS_INSTANCES, vertex.label(), roleType.getLabel().toString());
+            throw exception(GraknException.of(INVALID_UNDEFINE_PLAYS_HAS_INSTANCES, vertex.label(), roleType.getLabel().toString()));
         }
         edge.delete();
     }

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -125,7 +125,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
             assert type.getSupertype() != null;
             type = (TypeImpl) type.getSupertype();
             if (!hierarchy.add(type.vertex.scopedLabel())) {
-                throw GraknException.of(CYCLIC_TYPE_HIERARCHY, hierarchy);
+                throw exception(GraknException.of(CYCLIC_TYPE_HIERARCHY, hierarchy));
             }
         }
     }

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -367,8 +367,8 @@ public class SchemaGraph implements Graph {
         final String oldScopedLabel = scopedLabel(oldLabel, oldScope);
         final String newScopedLabel = scopedLabel(newLabel, newScope);
         try {
-            multiLabelLock.lockWrite();
             final TypeVertex type = getType(newLabel, newScope);
+            multiLabelLock.lockWrite();
             if (type != null) throw GraknException.of(INVALID_SCHEMA_WRITE, newScopedLabel);
             typesByLabel.remove(oldScopedLabel);
             typesByLabel.put(newScopedLabel, vertex);
@@ -383,8 +383,8 @@ public class SchemaGraph implements Graph {
     public RuleStructure update(RuleStructure vertex, String oldLabel, String newLabel) {
         assert storage.isOpen();
         try {
-            multiLabelLock.lockWrite();
             final RuleStructure rule = getRule(newLabel);
+            multiLabelLock.lockWrite();
             if (rule != null) throw GraknException.of(INVALID_SCHEMA_WRITE, newLabel);
             rulesByLabel.remove(oldLabel);
             rulesByLabel.put(newLabel, vertex);

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -25,6 +25,7 @@ import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.common.parameters.Context;
 import grakn.core.common.producer.Producer;
+import grakn.core.common.producer.Producers;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptManager;
 import grakn.core.concept.answer.ConceptMap;
@@ -162,7 +163,9 @@ public class Reasoner {
         return resolverRegistry;
     }
 
-    private ReasonerProducer resolve(Conjunction conjunction) {
-        return new ReasonerProducer(conjunction, resolverRegistry);
+    private Producer<ConceptMap> resolve(Conjunction conjunction) {
+        return Producers.empty();
+        // TODO enable reasoner when ready!
+        // return new ReasonerProducer(conjunction, resolverRegistry);
     }
 }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -21,7 +21,9 @@ package grakn.core.reasoner;
 import grakn.core.common.concurrent.ExecutorService;
 import grakn.core.common.concurrent.actor.Actor;
 import grakn.core.common.exception.GraknException;
+import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
+import grakn.core.common.parameters.Context;
 import grakn.core.common.producer.Producer;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptManager;
@@ -33,6 +35,8 @@ import grakn.core.pattern.Negation;
 import grakn.core.reasoner.resolution.ResolutionRecorder;
 import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.traversal.TraversalEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Set;
@@ -44,21 +48,25 @@ import static grakn.core.common.concurrent.ExecutorService.PARALLELISATION_FACTO
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.ThingRead.CONTRADICTORY_BOUND_VARIABLE;
 import static grakn.core.common.iterator.Iterators.iterate;
+import static grakn.core.common.iterator.Iterators.link;
 import static grakn.core.common.producer.Producers.iterable;
 import static java.util.stream.Collectors.toList;
 
 public class Reasoner {
+    private static final Logger LOG = LoggerFactory.getLogger(Reasoner.class);
 
     private final TraversalEngine traversalEng;
     private final ConceptManager conceptMgr;
     private final LogicManager logicMgr;
+    private Context.Transaction context;
     private final ResolverRegistry resolverRegistry;
     private final Actor<ResolutionRecorder> resolutionRecorder; // for explanations
 
-    public Reasoner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr) {
+    public Reasoner(TraversalEngine traversalEng, ConceptManager conceptMgr, LogicManager logicMgr, Context.Transaction context) {
         this.conceptMgr = conceptMgr;
         this.traversalEng = traversalEng;
         this.logicMgr = logicMgr;
+        this.context = context;
         this.resolutionRecorder = Actor.create(ExecutorService.eventLoopGroup(), ResolutionRecorder::new);
         this.resolverRegistry = new ResolverRegistry(ExecutorService.eventLoopGroup(), resolutionRecorder, traversalEng, conceptMgr, logicMgr);
     }
@@ -80,15 +88,24 @@ public class Reasoner {
                 .producer(conjunction.traversal(), PARALLELISATION_FACTOR)
                 .map(conceptMgr::conceptMap);
 
-        // TODO enable reasoner here
+        boolean reasonerEnabled = true;
+        if (context.sessionType().isSchema() && context.transactionType().isWrite()) {
+            LOG.warn("Reasoning is disabled in schema write transactions");
+            reasonerEnabled = false;
+        }
+        // TODO check query options if reasoner is disabled
 
         Set<Negation> negations = conjunction.negations();
-        if (negations.isEmpty()) return list(answers);
+        if (negations.isEmpty()) {
+            return reasonerEnabled ? list(answers, resolve(conjunction)) : list(answers);
+        }
         else {
             Predicate<ConceptMap> predicate = answer -> !iterable(iterate(negations).flatMap(
                     n -> iterate(producers(n.disjunction(), answer))).toList()
             ).iterator().hasNext();
-            return list(answers.filter(predicate));
+            return reasonerEnabled ?
+                    list(answers.filter(predicate), resolve(conjunction).filter(predicate)) : // TODO remove filter after negation implemented in reasoner
+                    list(answers.filter(predicate));
         }
     }
 
@@ -103,12 +120,18 @@ public class Reasoner {
     private ResourceIterator<ConceptMap> iterator(Conjunction conjunction) {
         ResourceIterator<ConceptMap> answers = traversalEng.iterator(conjunction.traversal()).map(conceptMgr::conceptMap);
 
-        // TODO: enable reasoner here
-        //       ResourceIterator<ConceptMap> answers = link(answers, resolve(conjunctionResolvedTypes));
+        boolean reasonerEnabled = true;
+        if (context.sessionType().isSchema() && context.transactionType().isWrite()) {
+            LOG.warn("Reasoning is disabled in schema write transactions");
+            reasonerEnabled = false;
+        }
+        // TODO check query options if reasoner is disabled
+        ResourceIterator<ConceptMap> reasonerAnswers = reasonerEnabled ? iterable(resolve(conjunction)).iterator() : Iterators.empty();
 
+        // TODO remove reasoner answers negation filter after negation implemented in reasoner
         Set<Negation> negations = conjunction.negations();
-        if (negations.isEmpty()) return answers;
-        else return answers.filter(answer -> !iterate(negations).flatMap(
+        if (negations.isEmpty()) return link(answers, reasonerAnswers);
+        else return link(answers, reasonerAnswers).filter(answer -> !iterate(negations).flatMap(
                 negation -> iterator(negation.disjunction(), answer)
         ).hasNext());
     }

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -64,7 +64,7 @@ public class RocksDatabase implements Grakn.Database {
     protected RocksSession.Data statisticsBackgroundCounterSession;
     private final KeyGenerator.Schema.Persisted schemaKeyGenerator;
     private final KeyGenerator.Data.Persisted dataKeyGenerator;
-    private final StampedLock dataTxnSchemaLock;
+    private final StampedLock dataWriteSchemaLock;
     private final RocksGrakn grakn;
     private Cache cache;
 
@@ -78,7 +78,7 @@ public class RocksDatabase implements Grakn.Database {
         schemaKeyGenerator = new KeyGenerator.Schema.Persisted();
         dataKeyGenerator = new KeyGenerator.Data.Persisted();
         sessions = new ConcurrentHashMap<>();
-        dataTxnSchemaLock = new StampedLock();
+        dataWriteSchemaLock = new StampedLock();
 
         try {
             rocksSchema = OptimisticTransactionDB.open(this.grakn.rocksOptions(), directory().resolve(Encoding.ROCKS_SCHEMA).toString());
@@ -145,7 +145,7 @@ public class RocksDatabase implements Grakn.Database {
         RocksSession session;
 
         if (type.isSchema()) {
-            lock = dataTxnSchemaLock().writeLock();
+            lock = dataWriteSchemaLock().writeLock();
             session = sessionFactory.sessionSchema(this, options);
         } else if (type.isData()) {
             session = sessionFactory.sessionData(this, options);
@@ -233,8 +233,8 @@ public class RocksDatabase implements Grakn.Database {
      *
      * @return a {@code StampedLock} to protect data writes from concurrent schema modification
      */
-    StampedLock dataTxnSchemaLock() {
-        return dataTxnSchemaLock;
+    StampedLock dataWriteSchemaLock() {
+        return dataWriteSchemaLock;
     }
 
     @Override
@@ -261,7 +261,7 @@ public class RocksDatabase implements Grakn.Database {
     void remove(RocksSession session) {
         if (statisticsBackgroundCounterSession != session) {
             final long lock = sessions.remove(session.uuid()).second();
-            if (session.type().isSchema()) dataTxnSchemaLock().unlockWrite(lock);
+            if (session.type().isSchema()) dataWriteSchemaLock().unlockWrite(lock);
         }
     }
 

--- a/rocks/RocksTransaction.java
+++ b/rocks/RocksTransaction.java
@@ -65,7 +65,7 @@ public abstract class RocksTransaction implements Grakn.Transaction {
         traversalEng = new TraversalEngine(graphMgr, traversalCache);
         conceptMgr = new ConceptManager(graphMgr);
         logicMgr = new LogicManager(graphMgr, conceptMgr, traversalEng, logicCache);
-        reasoner = new Reasoner(traversalEng, conceptMgr, logicMgr);
+        reasoner = new Reasoner(traversalEng, conceptMgr, logicMgr, context);
         queryMgr = new QueryManager(conceptMgr, logicMgr, reasoner, context);
         isOpen = new AtomicBoolean(true);
     }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -31,7 +31,9 @@ import grakn.core.test.integration.util.Util;
 import graql.lang.Graql;
 import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlMatch;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -73,15 +75,23 @@ public class TypeResolverTest {
         grakn.close();
     }
 
-    private static void define_standard_schema(String fileName) throws IOException {
+    @Before
+    public void setup() {
         transaction = session.transaction(Arguments.Transaction.Type.WRITE);
+    }
+
+    @After
+    public void tearDown() {
+        transaction.close();
+    }
+
+    private static void define_standard_schema(String fileName) throws IOException {
         final GraqlDefine query = Graql.parseQuery(
                 new String(Files.readAllBytes(Paths.get("test/integration/logic/" + fileName + ".gql")), UTF_8));
         transaction.query().define(query);
     }
 
     private static void define_custom_schema(String schema) {
-        transaction = session.transaction(Arguments.Transaction.Type.WRITE);
         final GraqlDefine query = Graql.parseQuery(schema);
         transaction.query().define(query);
     }

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -18,7 +18,6 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn.Transaction;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Label;
@@ -39,7 +38,9 @@ import grakn.core.test.integration.util.Util;
 import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -71,8 +72,8 @@ public class UnifyHasConcludableTest {
     private static ConceptManager conceptMgr;
     private static LogicManager logicMgr;
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeClass
+    public static void setUp() throws IOException {
         Util.resetDirectory(directory);
         grakn = RocksGrakn.open(directory);
         grakn.databases().create(database);
@@ -97,14 +98,24 @@ public class UnifyHasConcludableTest {
                                                        "").asDefine());
             tx.commit();
         }
-        rocksTransaction = session.transaction(Arguments.Transaction.Type.READ);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        session.close();
+        grakn.close();
+    }
+
+    @Before
+    public void setupTransaction() {
+        rocksTransaction = session.transaction(Arguments.Transaction.Type.WRITE);
         conceptMgr = rocksTransaction.concepts();
         logicMgr = rocksTransaction.logic();
     }
 
     @After
-    public void tearDown() {
-        grakn.close();
+    public void tearDownTransaction() {
+        rocksTransaction.close();
     }
 
     private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
@@ -138,12 +149,8 @@ public class UnifyHasConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
-            Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                         Graql.parseVariable(thenThingPattern).asThing());
-            txn.commit();
-            return rule;
-        }
+        return logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                     Graql.parseVariable(thenThingPattern).asThing());
     }
 
     //TODO: create more tests when type inference is working to test unifier pruning

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -41,7 +41,6 @@ import grakn.core.rocks.RocksTransaction;
 import grakn.core.test.integration.util.Util;
 import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
-import graql.lang.pattern.variable.Reference;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -18,7 +18,6 @@
 
 package grakn.core.logic.resolvable;
 
-import grakn.core.Grakn.Transaction;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
@@ -43,7 +42,9 @@ import grakn.core.test.integration.util.Util;
 import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -76,8 +77,8 @@ public class UnifyRelationConcludableTest {
     private static ConceptManager conceptMgr;
     private static LogicManager logicMgr;
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeClass
+    public static void setUp() throws IOException {
         Util.resetDirectory(directory);
         grakn = RocksGrakn.open(directory);
         grakn.databases().create(database);
@@ -108,14 +109,24 @@ public class UnifyRelationConcludableTest {
                                                        "").asDefine());
             tx.commit();
         }
-        rocksTransaction = session.transaction(Arguments.Transaction.Type.READ);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        session.close();
+        grakn.close();
+    }
+
+    @Before
+    public void setUpTransaction() {
+        rocksTransaction = session.transaction(Arguments.Transaction.Type.WRITE);
         conceptMgr = rocksTransaction.concepts();
         logicMgr = rocksTransaction.logic();
     }
 
     @After
-    public void tearDown() {
-        grakn.close();
+    public void tearDownTransaction() {
+        rocksTransaction.close();
     }
 
     private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
@@ -155,12 +166,9 @@ public class UnifyRelationConcludableTest {
     }
 
     private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        try (Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
-            Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                         Graql.parseVariable(thenThingPattern).asThing());
-            txn.commit();
-            return rule;
-        }
+        Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                     Graql.parseVariable(thenThingPattern).asThing());
+        return rule;
     }
 
     @Test

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -41,6 +41,7 @@ import grakn.core.rocks.RocksTransaction;
 import grakn.core.test.integration.util.Util;
 import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
+import graql.lang.pattern.variable.Reference;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;


### PR DESCRIPTION
## What is the goal of this PR?
In order to prevent any read or write operations happening during a schema write transactions, where rule validity and rule indexing may be out of date, we make _all_ data transactions contend with schema sessions, via an established read-write lock. We also add a new read-write lock to only allow 1 schema write transaction at a time, which prevents other schema write or read transactions from opening.

## What are the changes implemented in this PR?
* Acquire the schema session's read-write lock's `readLock()` to block any data session transactions while a schema session is open
* Only allow 1 schema `write` transaction at a time, protected by a new read-write lock from other schema `read` transactions
* Reasoner is disabled if in a schema-write transaction
* `ManagedReadWriteLock` is now re-entrant, which showed us various points transactions were not closing on exception. We achieve this using a `StampedLock` instead of a `ReentrantReadWriteLock`