### PR TITLE
In BDD, split Match step into Aggregate, Group etc

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,6 +56,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/alexjpwalker/behaviour",
-        commit = "a2b28f54e41d027e0ab2854019bd0b84fb2367f3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/graknlabs/behaviour",
+        commit = "fa553e334432ba6516e55163105847a34b79740e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,6 +56,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "2279d3a284d53fdd989885c06f3c50f00f930a63", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/alexjpwalker/behaviour",
+        commit = "a2b28f54e41d027e0ab2854019bd0b84fb2367f3", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )


### PR DESCRIPTION
## What is the goal of this PR?

The `get answers of graql query` step was problematic for Clients Python and NodeJS, because they don't have Graql parsing libraries - meaning they can't reliably figure out which query type the raw String corresponds to (from the feature file) To mitigate the issue, we split the step up into multiple steps: `get answers of graql match aggregate`, `get answers of graql match group`... and so on, and implemented the new steps in Grakn Core.

## What are the changes implemented in this PR?

- Split 'get answers of graql query' step into match, aggregate, group, group aggregate