### PR TITLE
Enable Graql Define tests in CI

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -76,7 +76,8 @@ build:
         bazel test //test/behaviour/concept/... --test_output=streamed
         bazel test //test/behaviour/graql/language/match/... --test_output=streamed
         bazel test //test/behaviour/graql/language/get/... --test_output=streamed
-      # bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/define/... --test_output=streamed
+      # TODO: add more Graql Language tests as they are fixed
     test-assembly-linux-targz:
       image: graknlabs-ubuntu-20.04
       filter:

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -57,5 +57,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "fa553e334432ba6516e55163105847a34b79740e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "bedf7a7bdc5f34302221e3f2769063609a5117ff", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )


### PR DESCRIPTION
## What is the goal of this PR?

Our Graql Define tests were not being run in CI because some of them were failing. Given it was a relatively small number (8), we decided to ignore the failing tests for now, allowing us to add the passing ones to CI. This helps to guard against regressions.

## What are the changes implemented in this PR?

- Enable Graql Define tests in CI
