### PR TITLE
Fix a bug causing ConcurrentModificationException

### DIFF
--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -125,7 +125,7 @@ public class GraphProducer implements Producer<VertexMap> {
     }
 
     @Override
-    public void recycle() {
+    public synchronized void recycle() {
         start.recycle();
         iteratorJobs.keySet().forEach(ResourceIterator::recycle);
     }


### PR DESCRIPTION
## What is the goal of this PR?

We have fixed a bug which causes `ConcurrentModificationException` while executing queries with multithreading.

## What are the changes implemented in this PR?

- The `HashMap` under `GraphProducer` is not concurrent safe, and we need to protect it against multithreading access.
- Fix https://github.com/graknlabs/grakn/issues/6027