### PR TITLE
Type resolver will not run on schema queries

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -54,6 +54,7 @@ def graknlabs_grabl_tracing():
     )
 
 def graknlabs_behaviour():
+#    TODO: change this once behaviour PR is merged.
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -54,9 +54,8 @@ def graknlabs_grabl_tracing():
     )
 
 def graknlabs_behaviour():
-#    TODO: change this once behaviour PR is merged.
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "9d0b2f5233438b287be2b15c7cad27728db7443c", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "e1db016c66d24df58df3165b457079f78db29507", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -88,6 +88,7 @@ public class TypeResolver {
 
     public Conjunction resolve(Conjunction conjunction) {
         resolveLabels(conjunction);
+        if (iterate(conjunction.variables()).noneMatch(Variable::isThing)) return conjunction;
         TraversalBuilder traversalConstructor = new TraversalBuilder(conjunction, conceptMgr);
 
         Map<Reference, Set<Label>> resolvedLabels = executeResolverTraversals(traversalConstructor);


### PR DESCRIPTION
## What is the goal of this PR?

When running `resolve()`, it will not run if the `Conjunction` is already entirely TypeVariables.
This fixes a bug where schema look-ups were failing instead of returning empty,

## What are the changes implemented in this PR?

`resolve()` in `TypeResolver` now returns the `conjunction` immediately after it resolves labels if the `conjunction` contains no `ThingVariables`.
