### PR TITLE
Disable derivation recording in Resolution

### DIFF
--- a/reasoner/resolution/ResolutionRecorder.java
+++ b/reasoner/resolution/ResolutionRecorder.java
@@ -19,6 +19,7 @@
 package grakn.core.reasoner.resolution;
 
 import grakn.core.common.concurrent.actor.Actor;
+import grakn.core.common.exception.GraknException;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.reasoner.resolution.framework.ResolutionAnswer;
 import grakn.core.reasoner.resolution.framework.Resolver;
@@ -28,6 +29,8 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+
+import static grakn.core.common.exception.ErrorMessage.Internal.UNIMPLEMENTED;
 
 public class ResolutionRecorder extends Actor.State<ResolutionRecorder> {
     private static final Logger LOG = LoggerFactory.getLogger(ResolutionRecorder.class);
@@ -47,7 +50,8 @@ public class ResolutionRecorder extends Actor.State<ResolutionRecorder> {
     }
 
     public void record(ResolutionAnswer answer) {
-        merge(answer);
+        throw GraknException.of(UNIMPLEMENTED);
+//        merge(answer);
     }
 
     /**

--- a/reasoner/resolution/framework/ResolutionAnswer.java
+++ b/reasoner/resolution/framework/ResolutionAnswer.java
@@ -21,6 +21,7 @@ package grakn.core.reasoner.resolution.framework;
 import grakn.core.common.concurrent.actor.Actor;
 import grakn.core.reasoner.resolution.answer.AnswerState.UpstreamVars.Derived;
 
+import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -35,7 +36,7 @@ public class ResolutionAnswer {
 
     public ResolutionAnswer(Derived answer,
                             String patternAnswered,
-                            Derivation derivation,
+                            @Nullable Derivation derivation,
                             Actor<? extends Resolver<?>> producer,
                             boolean isInferred) {
         this.answer = answer;

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -34,12 +34,14 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     private final Map<Request, Request> requestRouter;
     protected final ResolverRegistry registry;
     protected final TraversalEngine traversalEngine;
+    private final boolean explanations;
 
-    protected Resolver(Actor<T> self, String name, ResolverRegistry registry, TraversalEngine traversalEngine) {
+    protected Resolver(Actor<T> self, String name, ResolverRegistry registry, TraversalEngine traversalEngine, boolean explanations) {
         super(self);
         this.name = name;
         this.registry = registry;
         this.traversalEngine = traversalEngine;
+        this.explanations = explanations;
         this.requestRouter = new HashMap<>();
         // Note: initialising downstream actors in constructor will create all actors ahead of time, so it is non-lazy
         // additionally, it can cause deadlock within ResolverRegistry as different threads initialise actors
@@ -48,6 +50,8 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     public String name() {
         return name;
     }
+
+    protected boolean explanations() { return explanations; }
 
     public abstract void receiveRequest(Request fromUpstream, int iteration);
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -105,7 +105,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
             responseProducer.recordProduced(conceptMap);
 
             ResolutionAnswer.Derivation derivation;
-            if (explanations()) {
+            if (explanations()) { // TODO this way of turning explanations on and off is both error prone and unelegant - can we centralise?
                 // update partial derivation provided from upstream to carry derivations sideways
                 derivation = new ResolutionAnswer.Derivation(map(pair(fromDownstream.sourceRequest().receiver(),
                                                                       fromDownstream.answer())));

--- a/reasoner/resolution/resolver/ResolvableResolver.java
+++ b/reasoner/resolution/resolver/ResolvableResolver.java
@@ -23,7 +23,7 @@ import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.traversal.TraversalEngine;
 
 public abstract class ResolvableResolver<T extends ResolvableResolver<T>> extends Resolver<T> {
-    public ResolvableResolver(Actor<T> self, String name, ResolverRegistry registry, TraversalEngine traversalEngine) {
-        super(self, name, registry, traversalEngine);
+    public ResolvableResolver(Actor<T> self, String name, ResolverRegistry registry, TraversalEngine traversalEngine, boolean explanations) {
+        super(self, name, registry, traversalEngine, explanations);
     }
 }

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
 public class RetrievableResolver extends ResolvableResolver<RetrievableResolver> {
     private static final Logger LOG = LoggerFactory.getLogger(RetrievableResolver.class);
 
-    public RetrievableResolver(Actor<RetrievableResolver> self, Retrievable retrievable, ResolverRegistry registry, TraversalEngine traversalEngine) {
-        super(self, RetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable + ")", registry, traversalEngine);
+    public RetrievableResolver(Actor<RetrievableResolver> self, Retrievable retrievable, ResolverRegistry registry, TraversalEngine traversalEngine, boolean explanations) {
+        super(self, RetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable + ")", registry, traversalEngine, explanations);
     }
 
 

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -68,8 +68,8 @@ public class RuleResolver extends Resolver<RuleResolver> {
     private boolean isInitialised;
 
     public RuleResolver(Actor<RuleResolver> self, Rule rule, ResolverRegistry registry, TraversalEngine traversalEngine,
-                        ConceptManager conceptMgr, LogicManager logicMgr) {
-        super(self, RuleResolver.class.getSimpleName() + "(rule:" + rule + ")", registry, traversalEngine);
+                        ConceptManager conceptMgr, LogicManager logicMgr, boolean explanations) {
+        super(self, RuleResolver.class.getSimpleName() + "(rule:" + rule + ")", registry, traversalEngine, explanations);
         this.conceptMgr = conceptMgr;
         this.logicMgr = logicMgr;
         this.responseProducers = new HashMap<>();
@@ -104,9 +104,14 @@ public class RuleResolver extends Resolver<RuleResolver> {
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
-        ResolutionAnswer.Derivation derivation = fromDownstream.sourceRequest().partialResolutions();
-        if (fromDownstream.answer().isInferred()) {
-            derivation = derivation.withAnswer(fromDownstream.sourceRequest().receiver(), fromDownstream.answer());
+        ResolutionAnswer.Derivation derivation;
+        if (explanations()) {
+            derivation = fromDownstream.sourceRequest().partialResolutions();
+            if (fromDownstream.answer().isInferred()) {
+                derivation = derivation.withAnswer(fromDownstream.sourceRequest().receiver(), fromDownstream.answer());
+            }
+        } else {
+            derivation = null;
         }
 
         ConceptMap whenAnswer = fromDownstream.answer().derived().withInitial();

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -83,9 +83,9 @@ public class ResolutionTest {
                 transaction.commit();
             }
         }
-        long retrievableAnswerCount = 0L; // technically 3, but get deduplicated
+        long atomicTraversalAnswerCount = 3L;
         long conjunctionTraversalAnswerCount = 3L;
-        long answerCount = retrievableAnswerCount + conjunctionTraversalAnswerCount;
+        long answerCount = atomicTraversalAnswerCount + conjunctionTraversalAnswerCount;
         Conjunction conjunctionPattern = parseConjunction("{ $p1 has age 24; }");
         createRootAndAssertResponses(conjunctionPattern, answerCount);
     }

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -83,9 +83,9 @@ public class ResolutionTest {
                 transaction.commit();
             }
         }
-        long atomicTraversalAnswerCount = 3L;
+        long retrievableAnswerCount = 0L; // technically 3, but get deduplicated
         long conjunctionTraversalAnswerCount = 3L;
-        long answerCount = atomicTraversalAnswerCount + conjunctionTraversalAnswerCount;
+        long answerCount = retrievableAnswerCount + conjunctionTraversalAnswerCount;
         Conjunction conjunctionPattern = parseConjunction("{ $p1 has age 24; }");
         createRootAndAssertResponses(conjunctionPattern, answerCount);
     }


### PR DESCRIPTION
## What is the goal of this PR?
As we are not working towards enabling explanations in 2.0.0, we are disable code that mostly supports collecting explanations, but is out of date by about 3 months. We will go back and enable the ignored code paths when fleshing out Explanations fully.

## What are the changes implemented in this PR?
* `ResolverRegistry` takes a `explanations` boolean, that should be set at the _transaction_ level, not query level
* Pass `explanations` boolean into each resolver.
* each resolver no longer accumulates answers into derivations, when explanations() = false