### PR TITLE
Permit override of played roles in Plays constraints

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -36,7 +36,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/Phillammon/graql",
-        commit = "4415abe06af9e358051c0f98585b7276841726a7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "13d201e7e056aea7a664f1a4dd639ab4e648bd48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -36,7 +36,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/Phillammon/graql",
-        commit = "05746da0ebdd56e633c14f48cf29580fa1b57d3e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "4415abe06af9e358051c0f98585b7276841726a7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,8 +35,8 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        commit = "ae2ffdbd85e61812a0f5a597ee193310d6952ba5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        remote = "https://github.com/Phillammon/graql",
+        commit = "05746da0ebdd56e633c14f48cf29580fa1b57d3e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():
@@ -56,6 +56,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "e1db016c66d24df58df3165b457079f78db29507", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/Phillammon/behaviour",
+        commit = "e49acf7f8af427a7b1eee05f832a6df576b18552", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,7 +35,7 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/Phillammon/graql",
+        remote = "https://github.com/graknlabs/graql",
         commit = "13d201e7e056aea7a664f1a4dd639ab4e648bd48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,6 +56,6 @@ def graknlabs_grabl_tracing():
 def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/Phillammon/behaviour",
-        commit = "e49acf7f8af427a7b1eee05f832a6df576b18552", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        remote = "https://github.com/graknlabs/behaviour",
+        commit = "b36056a64f7923189c7e46f1fffa662e854849ed", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -243,7 +243,7 @@ public class Definer {
         }
     }
 
-    private void definePlays(ThingType thingType, Set<PlaysConstraint> playsConstraints){
+    private void definePlays(ThingType thingType, Set<PlaysConstraint> playsConstraints) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "defineplays")) {
             playsConstraints.forEach(plays -> {
                 define(plays.relation().get());

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -38,12 +38,23 @@ import grakn.core.pattern.variable.TypeVariable;
 import grakn.core.pattern.variable.VariableRegistry;
 import graql.lang.pattern.schema.Rule;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.Optional;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_SCOPE_IS_NOT_RELATION_TYPE;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
-import static grakn.core.common.exception.ErrorMessage.TypeWrite.*;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE_TYPE_DEFINED_NOT_ON_ATTRIBUTE_TYPE;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE_TYPE_MISSING;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE_TYPE_MODIFIED;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.CYCLIC_TYPE_HIERARCHY;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.INVALID_DEFINE_SUB;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.ROLE_DEFINED_OUTSIDE_OF_RELATION;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.TYPE_CONSTRAINT_UNACCEPTED;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.OVERRIDDEN_NOT_SUPERTYPE;
 import static graql.lang.common.GraqlToken.Constraint.IS;
 
 public class Definer {

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -28,6 +28,7 @@ import grakn.core.concept.thing.Relation;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
+import grakn.core.concept.type.RoleType;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
@@ -223,7 +224,7 @@ public class RuleTest {
 
                     Rule rule = txn.logic().getRule("marriage-is-friendship");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), people.get(0)),
-                                                               pair(Reference.name("y"), people.get(1))));
+                            pair(Reference.name("y"), people.get(1))));
 
                     Map<Identifier, Concept> thenConcepts = rule.putConclusion(whenAnswer, txn.traversal(), conceptMgr);
                     assertEquals(4, thenConcepts.size());
@@ -267,8 +268,8 @@ public class RuleTest {
                     final ConceptManager conceptMgr = txn.concepts();
                     RelationType friendship = conceptMgr.getRelationType("friendship");
                     txn.query().insert(Graql.parseQuery("insert $x isa person; $y isa person; " +
-                                                                "(spouse: $x, spouse: $y) isa marriage;" +
-                                                                "(friend: $x, friend: $y) isa friendship;").asInsert());
+                            "(spouse: $x, spouse: $y) isa marriage;" +
+                            "(friend: $x, friend: $y) isa friendship;").asInsert());
                     List<Relation> friendshipInstances = friendship.getInstances().collect(Collectors.toList());
                     assertEquals(1, friendshipInstances.size());
 
@@ -278,7 +279,7 @@ public class RuleTest {
 
                     Rule rule = txn.logic().getRule("marriage-is-friendship");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), people.get(0)),
-                                                               pair(Reference.name("y"), people.get(1))));
+                            pair(Reference.name("y"), people.get(1))));
 
                     Map<Identifier, Concept> thenConcepts = rule.putConclusion(whenAnswer, txn.traversal(), conceptMgr);
                     assertEquals(4, thenConcepts.size());
@@ -324,7 +325,7 @@ public class RuleTest {
 
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
                     ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), milkInst),
-                                                               pair(Reference.name("a"), ageInDays10)));
+                            pair(Reference.name("a"), ageInDays10)));
                     Map<Identifier, Concept> thenConcepts = rule.putConclusion(whenAnswer, txn.traversal(), conceptMgr);
                     assertEquals(2, thenConcepts.size());
 

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -28,7 +28,6 @@ import grakn.core.concept.thing.Relation;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
 import grakn.core.concept.type.RelationType;
-import grakn.core.concept.type.RoleType;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;


### PR DESCRIPTION
## What is the goal of this PR?

Specifying the scope of an overridden role is not allowed syntactically when specifying a Plays constraint in graql, and previously, it was not possible to infer a label appropriately for overridden roles. We added, in combination with some changes in graql, the ability to correctly infer the scope of the overridden type, allowing overridden types in definitions.

## What are the changes implemented in this PR?

Where an overridden type is supplied in a define query's plays clause, this is caught in definePlays and the overriding role's supertypes are scanned for an appropriately named roleType. If one is found, this roletype's relation is used as a scope for the overridden type, allowing it to be correctly added to the Grakn graph.
