### PR TITLE
Rewritten Producers to be thread-safe with a clean algorithm

### DIFF
--- a/common/concurrent/ExecutorService.java
+++ b/common/concurrent/ExecutorService.java
@@ -22,10 +22,9 @@ import grakn.core.common.concurrent.actor.EventLoopGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-
-import static java.util.concurrent.ForkJoinPool.defaultForkJoinWorkerThreadFactory;
 
 public class ExecutorService {
 
@@ -39,8 +38,7 @@ public class ExecutorService {
     private final ScheduledThreadPoolExecutor scheduledThreadPool;
 
     private ExecutorService(int parallelisation) {
-        forkJoinPool = new ForkJoinPool(parallelisation, defaultForkJoinWorkerThreadFactory,
-                                        (t, e) -> LOG.error(e.getMessage(), e), true);
+        forkJoinPool = (ForkJoinPool) Executors.newWorkStealingPool(parallelisation);
         eventLoopGroup = new EventLoopGroup(parallelisation, "grakn-elg");
         scheduledThreadPool = new ScheduledThreadPoolExecutor(1);
         scheduledThreadPool.setRemoveOnCancelPolicy(true);

--- a/common/concurrent/ExecutorService.java
+++ b/common/concurrent/ExecutorService.java
@@ -19,12 +19,17 @@
 package grakn.core.common.concurrent;
 
 import grakn.core.common.concurrent.actor.EventLoopGroup;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import static java.util.concurrent.ForkJoinPool.defaultForkJoinWorkerThreadFactory;
+
 public class ExecutorService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutorService.class);
 
     public static int PARALLELISATION_FACTOR = -1;
     private static ExecutorService singleton = null;
@@ -33,9 +38,10 @@ public class ExecutorService {
     private final EventLoopGroup eventLoopGroup;
     private final ScheduledThreadPoolExecutor scheduledThreadPool;
 
-    private ExecutorService(int parallelisationFactor) {
-        forkJoinPool = (ForkJoinPool) Executors.newWorkStealingPool(parallelisationFactor);
-        eventLoopGroup = new EventLoopGroup(parallelisationFactor, "grakn-elg");
+    private ExecutorService(int parallelisation) {
+        forkJoinPool = new ForkJoinPool(parallelisation, defaultForkJoinWorkerThreadFactory,
+                                        (t, e) -> LOG.error(e.getMessage(), e), true);
+        eventLoopGroup = new EventLoopGroup(parallelisation, "grakn-elg");
         scheduledThreadPool = new ScheduledThreadPoolExecutor(1);
         scheduledThreadPool.setRemoveOnCancelPolicy(true);
     }

--- a/common/producer/BaseProducer.java
+++ b/common/producer/BaseProducer.java
@@ -20,42 +20,53 @@ package grakn.core.common.producer;
 
 import grakn.core.common.iterator.ResourceIterator;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static grakn.core.common.concurrent.ExecutorService.forkJoinPool;
 
+@ThreadSafe
 public class BaseProducer<T> implements Producer<T> {
 
     private final ResourceIterator<T> iterator;
+    private final AtomicBoolean isDone;
     private CompletableFuture<Void> future;
 
     BaseProducer(ResourceIterator<T> iterator) {
         this.iterator = iterator;
+        this.isDone = new AtomicBoolean(false);
         this.future = CompletableFuture.completedFuture(null);
     }
 
     @Override
     public synchronized void produce(Queue<T> queue, int request) {
-        future = future.thenRunAsync(() -> produceAsync(queue, request), forkJoinPool());
+        if (isDone.get()) return;
+        future = future.thenRunAsync(() -> {
+            try {
+                int i = 0;
+                for (; i < request && iterator.hasNext() && !isDone.get(); i++) queue.put(iterator.next());
+                if (i < request && !isDone.get()) done(queue);
+            } catch (Throwable e) {
+                queue.done(e);
+            }
+        }, forkJoinPool());
     }
 
-    private void produceAsync(Queue<T> queue, int count) {
-        try {
-            for (int i = 0; i < count; i++) {
-                if (iterator.hasNext()) {
-                    queue.put(iterator.next());
-                } else {
-                    queue.done();
-                    break;
-                }
-            }
-        } catch (Throwable e) {
+    private void done(Queue<T> queue) {
+        if (isDone.compareAndSet(false, true)) {
+            queue.done();
+        }
+    }
+
+    private void done(Queue<T> queue, Throwable e) {
+        if (isDone.compareAndSet(false, true)) {
             queue.done(e);
         }
     }
 
     @Override
-    public void recycle() {
+    public synchronized void recycle() {
         iterator.recycle();
     }
 }

--- a/common/producer/BaseProducer.java
+++ b/common/producer/BaseProducer.java
@@ -35,8 +35,8 @@ public class BaseProducer<T> implements Producer<T> {
     }
 
     @Override
-    public synchronized void produce(Queue<T> queue, int count) {
-        future = future.thenRunAsync(() -> produceAsync(queue, count), forkJoinPool());
+    public synchronized void produce(Queue<T> queue, int request) {
+        future = future.thenRunAsync(() -> produceAsync(queue, request), forkJoinPool());
     }
 
     private void produceAsync(Queue<T> queue, int count) {
@@ -45,12 +45,12 @@ public class BaseProducer<T> implements Producer<T> {
                 if (iterator.hasNext()) {
                     queue.put(iterator.next());
                 } else {
-                    queue.done(this);
+                    queue.done();
                     break;
                 }
             }
         } catch (Throwable e) {
-            queue.done(this, e);
+            queue.done(e);
         }
     }
 

--- a/common/producer/BaseProducer.java
+++ b/common/producer/BaseProducer.java
@@ -44,9 +44,9 @@ public class BaseProducer<T> implements Producer<T> {
         if (isDone.get()) return;
         future = future.thenRunAsync(() -> {
             try {
-                int i = 0;
-                for (; i < request && iterator.hasNext() && !isDone.get(); i++) queue.put(iterator.next());
-                if (i < request && !isDone.get()) done(queue);
+                int unfulfilled = request;
+                for (; unfulfilled > 0 && iterator.hasNext() && !isDone.get(); unfulfilled--) queue.put(iterator.next());
+                if (unfulfilled > 0 && !isDone.get()) done(queue);
             } catch (Throwable e) {
                 queue.done(e);
             }

--- a/common/producer/FilteredProducer.java
+++ b/common/producer/FilteredProducer.java
@@ -18,8 +18,10 @@
 
 package grakn.core.common.producer;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.function.Predicate;
 
+@ThreadSafe
 public class FilteredProducer<T> implements Producer<T> {
 
     private final Producer<T> baseProducer;
@@ -40,6 +42,7 @@ public class FilteredProducer<T> implements Producer<T> {
         baseProducer.recycle();
     }
 
+    @ThreadSafe
     private class Queue implements Producer.Queue<T> {
 
         private final Producer.Queue<T> baseQueue;

--- a/common/producer/FilteredProducer.java
+++ b/common/producer/FilteredProducer.java
@@ -31,8 +31,8 @@ public class FilteredProducer<T> implements Producer<T> {
     }
 
     @Override
-    public void produce(Producer.Queue<T> queue, int count) {
-        baseProducer.produce(new Queue(queue), count);
+    public void produce(Producer.Queue<T> queue, int request) {
+        baseProducer.produce(new Queue(queue), request);
     }
 
     @Override
@@ -55,13 +55,13 @@ public class FilteredProducer<T> implements Producer<T> {
         }
 
         @Override
-        public void done(Producer<T> producer) {
-            baseQueue.done(FilteredProducer.this);
+        public void done() {
+            baseQueue.done();
         }
 
         @Override
-        public void done(Producer<T> producer, Throwable e) {
-            baseQueue.done(FilteredProducer.this, e);
+        public void done(Throwable e) {
+            baseQueue.done(e);
         }
     }
 }

--- a/common/producer/MappedProducer.java
+++ b/common/producer/MappedProducer.java
@@ -18,8 +18,10 @@
 
 package grakn.core.common.producer;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.function.Function;
 
+@ThreadSafe
 public class MappedProducer<T, U> implements Producer<U> {
 
     private final Producer<T> baseProducer;
@@ -40,6 +42,7 @@ public class MappedProducer<T, U> implements Producer<U> {
         baseProducer.recycle();
     }
 
+    @ThreadSafe
     private class Queue implements Producer.Queue<T> {
 
         private final Producer.Queue<U> baseQueue;

--- a/common/producer/MappedProducer.java
+++ b/common/producer/MappedProducer.java
@@ -31,8 +31,8 @@ public class MappedProducer<T, U> implements Producer<U> {
     }
 
     @Override
-    public void produce(Producer.Queue<U> queue, int count) {
-        baseProducer.produce(new Queue(queue), count);
+    public void produce(Producer.Queue<U> queue, int request) {
+        baseProducer.produce(new Queue(queue), request);
     }
 
     @Override
@@ -54,13 +54,13 @@ public class MappedProducer<T, U> implements Producer<U> {
         }
 
         @Override
-        public void done(Producer<T> producer) {
-            baseQueue.done(MappedProducer.this);
+        public void done() {
+            baseQueue.done();
         }
 
         @Override
-        public void done(Producer<T> producer, Throwable e) {
-            baseQueue.done(MappedProducer.this, e);
+        public void done(Throwable e) {
+            baseQueue.done(e);
         }
     }
 }

--- a/common/producer/Producer.java
+++ b/common/producer/Producer.java
@@ -22,7 +22,7 @@ import java.util.function.Predicate;
 
 public interface Producer<T> {
 
-    void produce(Queue<T> queue, int count);
+    void produce(Queue<T> queue, int request);
 
     void recycle();
 
@@ -38,8 +38,8 @@ public interface Producer<T> {
 
         void put(U item);
 
-        void done(Producer<U> producer);
+        void done();
 
-        void done(Producer<U> producer, Throwable e);
+        void done(Throwable e);
     }
 }

--- a/common/producer/Producer.java
+++ b/common/producer/Producer.java
@@ -17,9 +17,11 @@
 
 package grakn.core.common.producer;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+@ThreadSafe
 public interface Producer<T> {
 
     void produce(Queue<T> queue, int request);
@@ -34,6 +36,7 @@ public interface Producer<T> {
         return new FilteredProducer<>(this, predicate);
     }
 
+    @ThreadSafe
     interface Queue<U> {
 
         void put(U item);

--- a/common/producer/ProducerIterator.java
+++ b/common/producer/ProducerIterator.java
@@ -30,7 +30,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class IterableProducer<T> {
+public class ProducerIterator<T> {
 
     private static final int BUFFER_MIN_SIZE = 32;
     private static final int BUFFER_MAX_SIZE = 64;
@@ -39,11 +39,11 @@ public class IterableProducer<T> {
     private final Queue queue;
     private final Iterator iterator;
 
-    public IterableProducer(List<Producer<T>> producers) {
+    public ProducerIterator(List<Producer<T>> producers) {
         this(producers, BUFFER_MIN_SIZE, BUFFER_MAX_SIZE);
     }
 
-    public IterableProducer(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
+    public ProducerIterator(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
         // TODO: Could we optimise IterableProducer by accepting ResourceIterator<Producer<T>> instead?
         assert !producers.isEmpty();
         this.producers = new LinkedList<>(producers);
@@ -51,7 +51,7 @@ public class IterableProducer<T> {
         this.iterator = new Iterator();
     }
 
-    public IterableProducer<T>.Iterator iterator() {
+    public ProducerIterator<T>.Iterator iterator() {
         return iterator;
     }
 

--- a/common/producer/ProducerIterator.java
+++ b/common/producer/ProducerIterator.java
@@ -167,17 +167,12 @@ public class ProducerIterator<T> implements ResourceIterator<T> {
             assert !producers.isEmpty();
             producers.removeFirst();
             pending = 0;
-
             try {
-                if (error != null) {
-                    blockingQueue.put(Either.second(Done.error(error)));
-                } else if (producers.isEmpty()) {
-                    blockingQueue.put(Either.second(Done.success()));
-                } else {
-                    mayProduce();
-                }
+                if (error != null) blockingQueue.put(Either.second(Done.error(error)));
+                else if (producers.isEmpty()) blockingQueue.put(Either.second(Done.success()));
+                else mayProduce();
             } catch (InterruptedException e) {
-                e.printStackTrace();
+                throw GraknException.of(e);
             }
         }
 

--- a/common/producer/Producers.java
+++ b/common/producer/Producers.java
@@ -33,19 +33,19 @@ public class Producers {
         return new BaseProducer<>(iterator);
     }
 
-    public static <T> ProducerIterator<T> iterable(Producer<T> producer) {
+    public static <T> ProducerIterator<T> produce(Producer<T> producer) {
         return new ProducerIterator<>(list(producer));
     }
 
-    public static <T> ProducerIterator<T> iterable(Producer<T> producer, int bufferMinSize, int bufferMaxSize) {
+    public static <T> ProducerIterator<T> produce(Producer<T> producer, int bufferMinSize, int bufferMaxSize) {
         return new ProducerIterator<>(list(producer), bufferMinSize, bufferMaxSize);
     }
 
-    public static <T> ProducerIterator<T> iterable(List<Producer<T>> producers) {
+    public static <T> ProducerIterator<T> produce(List<Producer<T>> producers) {
         return new ProducerIterator<>(producers);
     }
 
-    public static <T> ProducerIterator<T> iterable(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
+    public static <T> ProducerIterator<T> produce(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
         return new ProducerIterator<>(producers, bufferMinSize, bufferMaxSize);
     }
 }

--- a/common/producer/Producers.java
+++ b/common/producer/Producers.java
@@ -33,19 +33,19 @@ public class Producers {
         return new BaseProducer<>(iterator);
     }
 
-    public static <T> IterableProducer<T> iterable(Producer<T> producer) {
-        return new IterableProducer<>(list(producer));
+    public static <T> ProducerIterator<T> iterable(Producer<T> producer) {
+        return new ProducerIterator<>(list(producer));
     }
 
-    public static <T> IterableProducer<T> iterable(Producer<T> producer, int bufferMinSize, int bufferMaxSize) {
-        return new IterableProducer<>(list(producer), bufferMinSize, bufferMaxSize);
+    public static <T> ProducerIterator<T> iterable(Producer<T> producer, int bufferMinSize, int bufferMaxSize) {
+        return new ProducerIterator<>(list(producer), bufferMinSize, bufferMaxSize);
     }
 
-    public static <T> IterableProducer<T> iterable(List<Producer<T>> producers) {
-        return new IterableProducer<>(producers);
+    public static <T> ProducerIterator<T> iterable(List<Producer<T>> producers) {
+        return new ProducerIterator<>(producers);
     }
 
-    public static <T> IterableProducer<T> iterable(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
-        return new IterableProducer<>(producers, bufferMinSize, bufferMaxSize);
+    public static <T> ProducerIterator<T> iterable(List<Producer<T>> producers, int bufferMinSize, int bufferMaxSize) {
+        return new ProducerIterator<>(producers, bufferMinSize, bufferMaxSize);
     }
 }

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -50,8 +50,8 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
 
     final ThingVertex owner;
     final Encoding.Direction.Adjacency direction;
-    final ConcurrentMap<InfixIID.Thing, Set<InfixIID.Thing>> infixes;
-    final ConcurrentMap<InfixIID.Thing, Map<EdgeIID.Thing, ThingEdge>> edges;
+    final ConcurrentMap<InfixIID.Thing, ConcurrentHashMap.KeySetView<InfixIID.Thing, Boolean>> infixes;
+    final ConcurrentMap<InfixIID.Thing, ConcurrentMap<EdgeIID.Thing, ThingEdge>> edges;
 
     ThingAdjacencyImpl(ThingVertex owner, Encoding.Direction.Adjacency direction) {
         this.owner = owner;
@@ -141,7 +141,7 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
             );
         }
 
-        Map<EdgeIID.Thing, ThingEdge> edgesByOutIID = edges.computeIfAbsent(infixIID, iid -> new HashMap<>());
+        Map<EdgeIID.Thing, ThingEdge> edgesByOutIID = edges.computeIfAbsent(infixIID, iid -> new ConcurrentHashMap<>());
         if (edgesByOutIID.containsKey(edge.outIID())) {
             ThingEdge thingEdge = edgesByOutIID.get(edge.outIID());
             if (thingEdge.isInferred() && !edge.isInferred()) thingEdge.isInferred(false);

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -43,10 +43,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
-import static grakn.common.collection.Collections.list;
 import static grakn.core.common.exception.ErrorMessage.Transaction.SESSION_DATA_VIOLATION;
 import static grakn.core.common.exception.ErrorMessage.Transaction.SESSION_SCHEMA_VIOLATION;
 import static grakn.core.common.iterator.Iterators.iterate;
+import static grakn.core.common.iterator.Iterators.single;
 
 public class QueryManager {
 
@@ -163,7 +163,7 @@ public class QueryManager {
                         conceptMgr, query.variables(), answer, context
                 ).execute()).toList());
             } else {
-                return iterate(list(Inserter.create(conceptMgr, query.variables(), context).execute()));
+                return single(Inserter.create(conceptMgr, query.variables(), context).execute());
             }
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -44,10 +44,10 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     }
 
     @Override
-    public void produce(Queue<ConceptMap> queue, int count) {
+    public void produce(Queue<ConceptMap> queue, int request) {
         assert this.queue == null || this.queue == queue;
         this.queue = queue;
-        for (int i = 0; i < count; i++) {
+        for (int i = 0; i < request; i++) {
             requestAnswer();
         }
     }
@@ -70,7 +70,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
             // fully terminated finding answers
             if (!done) {
                 done = true;
-                queue.done(this);
+                queue.done();
             }
         } else {
             // straggler request failing from prior iteration

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -26,21 +26,26 @@ import grakn.core.reasoner.resolution.framework.Request;
 import grakn.core.reasoner.resolution.framework.ResolutionAnswer;
 import grakn.core.reasoner.resolution.resolver.RootResolver;
 
-import static grakn.core.reasoner.resolution.answer.AnswerState.DownstreamVars.Root;
+import javax.annotation.concurrent.ThreadSafe;
 
+import static grakn.core.reasoner.resolution.answer.AnswerState.DownstreamVars.Root;
+import static grakn.core.reasoner.resolution.framework.ResolutionAnswer.Derivation.EMPTY;
+
+@ThreadSafe // TODO: verify
 public class ReasonerProducer implements Producer<ConceptMap> {
 
     private final Actor<RootResolver> rootResolver;
+    private Queue<ConceptMap> queue;
     private Request resolveRequest;
-    private boolean done;
-    private Queue<ConceptMap> queue = null;
-    private int iteration;
     private boolean iterationInferredAnswer;
+    private boolean done;
+    private int iteration;
 
     public ReasonerProducer(Conjunction conjunction, ResolverRegistry resolverRegistry) {
         this.rootResolver = resolverRegistry.createRoot(conjunction, this::requestAnswered, this::requestFailed);
+        this.resolveRequest = new Request(new Request.Path(rootResolver), Root.create(), EMPTY);
+        this.queue = null;
         this.iteration = 0;
-        this.resolveRequest = new Request(new Request.Path(rootResolver), Root.create(), ResolutionAnswer.Derivation.EMPTY);
     }
 
     @Override
@@ -80,7 +85,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
 
     private void nextIteration() {
         iteration++;
-        resolveRequest = new Request(new Request.Path(rootResolver), Root.create(), ResolutionAnswer.Derivation.EMPTY);
+        resolveRequest = new Request(new Request.Path(rootResolver), Root.create(), EMPTY);
     }
 
     private boolean mustReiterate() {

--- a/rocks/BUILD
+++ b/rocks/BUILD
@@ -41,6 +41,7 @@ native_java_libraries(
         "@maven//:com_google_code_findbugs_jsr305",
         # "@maven//:org_rocksdb_rocksdbjni_dev", # Use this JAR for debugging RocksDB on Mac
         "@maven//:org_rocksdb_rocksdbjni",
+        "@maven//:org_slf4j_slf4j_api"
     ],
     native_libraries_deps = [
         "//:grakn",

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -32,6 +32,8 @@ import org.rocksdb.RocksDBException;
 import org.rocksdb.Snapshot;
 import org.rocksdb.Transaction;
 import org.rocksdb.WriteOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -46,6 +48,8 @@ import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_C
 public class RocksStorage implements Storage {
 
     private static final byte[] EMPTY_ARRAY = new byte[]{};
+
+    private static final Logger LOG = LoggerFactory.getLogger(RocksStorage.class);
 
     protected final Transaction storageTransaction;
     private final boolean isReadOnly;
@@ -175,15 +179,18 @@ public class RocksStorage implements Storage {
         return iterator;
     }
 
-    @Override
     public GraknException exception(ErrorMessage error) {
-        return GraknException.of(error);
+        GraknException e = GraknException.of(error);
+        LOG.error(e.getMessage(), e);
+        return e;
     }
 
-    @Override
     public GraknException exception(Exception exception) {
-        if (exception instanceof GraknException) return (GraknException) exception;
-        else return GraknException.of(exception);
+        GraknException e;
+        if (exception instanceof GraknException) e = (GraknException) exception;
+        else e = GraknException.of(exception);
+        LOG.error(e.getMessage(), e);
+        return e;
     }
 
     @Override

--- a/server/GraknServer.java
+++ b/server/GraknServer.java
@@ -85,17 +85,19 @@ public class GraknServer implements AutoCloseable {
         configureAndVerifyDataDir();
         configureTracing();
 
-        if (command.debug()) {
-            LOG.info("Running Grakn Core Server in debug mode.");
-        }
+        if (command.debug()) LOG.info("Running Grakn Core Server in debug mode.");
 
         grakn = RocksGrakn.open(command.dataDir());
         graknRPCService = new GraknRPCService(grakn);
         migratorRPCService = new MigratorRPCService(grakn);
 
         server = rpcServer();
-        Runtime.getRuntime().addShutdownHook(NamedThreadFactory.create(GraknServer.class, "shutdown").newThread(this::close));
-        Thread.setDefaultUncaughtExceptionHandler((Thread t, Throwable e) -> LOG.error(UNCAUGHT_EXCEPTION.message(t.getName()), e));
+        Thread.setDefaultUncaughtExceptionHandler(
+                (t, e) -> LOG.error(UNCAUGHT_EXCEPTION.message(t.getName() + ": " + e.getMessage()), e)
+        );
+        Runtime.getRuntime().addShutdownHook(
+                NamedThreadFactory.create(GraknServer.class, "shutdown").newThread(this::close)
+        );
     }
 
     private int port() {

--- a/traversal/Traversal.java
+++ b/traversal/Traversal.java
@@ -53,7 +53,6 @@ import static grakn.common.collection.Collections.pair;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.iterator.Iterators.cartesian;
 import static grakn.core.common.iterator.Iterators.iterate;
-import static grakn.core.common.producer.Producers.iterable;
 import static grakn.core.graph.util.Encoding.Edge.ISA;
 import static grakn.core.graph.util.Encoding.Edge.Thing.HAS;
 import static grakn.core.graph.util.Encoding.Edge.Thing.PLAYING;
@@ -121,7 +120,7 @@ public class Traversal {
             return Producers.producer(cartesian(planners.parallelStream().map(planner -> {
                 planner.tryOptimise(graphMgr);
                 return planner.procedure().producer(graphMgr, parameters, filter, parallelisation);
-            }).map(p -> iterable(p).iterator()).collect(toList())).map(partialAnswers -> {
+            }).map(Producers::produce).collect(toList())).map(partialAnswers -> {
                 Map<Reference, Vertex<?, ?>> combinedAnswers = new HashMap<>();
                 partialAnswers.forEach(p -> combinedAnswers.putAll(p.map()));
                 return VertexMap.of(combinedAnswers);

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -27,6 +27,7 @@ import grakn.core.traversal.common.Identifier;
 import grakn.core.traversal.common.VertexMap;
 import grakn.core.traversal.procedure.GraphProcedure;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static grakn.core.common.concurrent.ExecutorService.forkJoinPool;
 
+@ThreadSafe
 public class GraphProducer implements Producer<VertexMap> {
 
     private final int parallelisation;

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -99,10 +99,18 @@ public class GraphProducer implements Producer<VertexMap> {
 
     private synchronized void transition(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {
         if (!iterator.hasNext()) {
-            if (runningJobs.containsKey(iterator) && start.hasNext()) replace(queue, iterator, unfulfilled);
-            else if (!runningJobs.isEmpty() && unfulfilled > 0) distribute(queue, unfulfilled);
-            else if (runningJobs.isEmpty()) done(queue);
-            else assert unfulfilled == 0;
+            if (runningJobs.containsKey(iterator) && start.hasNext()) {
+                replace(queue, iterator, unfulfilled);
+            } else if (!runningJobs.isEmpty() && unfulfilled > 0) {
+                runningJobs.remove(iterator);
+                distribute(queue, unfulfilled);
+            } else if (runningJobs.isEmpty()) {
+                done(queue);
+            } else {
+                assert unfulfilled == 0;
+            }
+        } else {
+            assert unfulfilled == 0;
         }
     }
 

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -74,7 +74,7 @@ public class GraphProducer implements Producer<VertexMap> {
         for (int i = 0; i < parallelisation && start.hasNext(); i++) {
             ResourceIterator<VertexMap> iter =
                     new GraphIterator(graphMgr, start.next(), procedure, params, filter).distinct(produced);
-            runningJobs.put(iter, CompletableFuture.runAsync(() -> {}, forkJoinPool()));
+            runningJobs.put(iter, CompletableFuture.completedFuture(null));
         }
         isInitialised = true;
         if (runningJobs.isEmpty()) done(queue);
@@ -87,7 +87,7 @@ public class GraphProducer implements Producer<VertexMap> {
         for (ResourceIterator<VertexMap> iterator : runningJobs.keySet()) {
             int requestSplit = Math.min(requestSplitMax, request - requestSent);
             runningJobs.computeIfPresent(iterator, (iter, asyncJob) -> asyncJob.thenRunAsync(
-                    () -> job(queue, iter, requestSplit)
+                    () -> job(queue, iter, requestSplit), forkJoinPool()
             ));
             requestSent += requestSplit;
             if (requestSent == request) break;

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -119,13 +119,13 @@ public class GraphProducer implements Producer<VertexMap> {
 
     private void job(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int request) {
         try {
-            int i = 0;
+            int unfulfilled = request;
             if (runningJobs.containsKey(iterator)) {
-                for (; i < request && iterator.hasNext() && !isDone.get(); i++) {
+                for (; unfulfilled > 0 && iterator.hasNext() && !isDone.get(); unfulfilled--) {
                     queue.put(iterator.next());
                 }
             }
-            if (!isDone.get()) transition(queue, iterator, request - i);
+            if (!isDone.get()) transition(queue, iterator, unfulfilled);
         } catch (Throwable e) {
             done(queue, e);
         }

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -121,7 +121,7 @@ public class GraphProducer implements Producer<VertexMap> {
     private void job(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int request) {
         try {
             int i = 0;
-            if (!runningJobs.containsKey(iterator)) {
+            if (runningJobs.containsKey(iterator)) {
                 for (; i < request && iterator.hasNext() && !isDone.get(); i++) {
                     queue.put(iterator.next());
                 }

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -51,7 +51,8 @@ public class GraphProducer implements Producer<VertexMap> {
     private final AtomicBoolean isDone;
     private boolean isInitialised;
 
-    public GraphProducer(GraphManager graphMgr, GraphProcedure procedure, Traversal.Parameters params, List<Identifier.Variable.Name> filter, int parallelisation) {
+    public GraphProducer(GraphManager graphMgr, GraphProcedure procedure, Traversal.Parameters params,
+                         List<Identifier.Variable.Name> filter, int parallelisation) {
         assert parallelisation > 0;
         this.graphMgr = graphMgr;
         this.procedure = procedure;

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -99,16 +99,10 @@ public class GraphProducer implements Producer<VertexMap> {
 
     private synchronized void transition(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {
         if (!iterator.hasNext()) {
-            if (runningJobs.containsKey(iterator) && start.hasNext()) {
-                replace(queue, iterator, unfulfilled);
-            } else if (!runningJobs.isEmpty() && unfulfilled > 0) {
-                runningJobs.remove(iterator);
-                distribute(queue, unfulfilled);
-            } else if (runningJobs.isEmpty()) {
-                done(queue);
-            } else {
-                assert unfulfilled == 0;
-            }
+            if (runningJobs.remove(iterator) != null && start.hasNext()) replace(queue, iterator, unfulfilled);
+            else if (!runningJobs.isEmpty() && unfulfilled > 0) distribute(queue, unfulfilled);
+            else if (runningJobs.isEmpty()) done(queue);
+            else assert unfulfilled == 0;
         } else {
             assert unfulfilled == 0;
         }

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -98,10 +98,12 @@ public class GraphProducer implements Producer<VertexMap> {
     }
 
     private synchronized void transition(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {
-        if (iterator.hasNext()) return;
-        if (runningJobs.containsKey(iterator) && start.hasNext()) replace(queue, iterator, unfulfilled);
-        else if (!runningJobs.isEmpty() && unfulfilled > 0) distribute(queue, unfulfilled);
-        else if (runningJobs.isEmpty()) done(queue);
+        if (!iterator.hasNext()) {
+            if (runningJobs.containsKey(iterator) && start.hasNext()) replace(queue, iterator, unfulfilled);
+            else if (!runningJobs.isEmpty() && unfulfilled > 0) distribute(queue, unfulfilled);
+            else if (runningJobs.isEmpty()) done(queue);
+            else assert unfulfilled == 0;
+        }
     }
 
     private synchronized void replace(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -109,7 +109,7 @@ public class GraphProducer implements Producer<VertexMap> {
                     new GraphIterator(graphMgr, start.next(), procedure, params, filter).distinct(produced);
             CompletableFuture<Void> asyncJob = unfulfilled > 0
                     ? CompletableFuture.runAsync(() -> job(queue, newIter, unfulfilled), forkJoinPool())
-                    : CompletableFuture.runAsync(() -> {}, forkJoinPool());
+                    : CompletableFuture.completedFuture(null);
             runningJobs.put(newIter, asyncJob);
         } else if (!runningJobs.isEmpty() && unfulfilled > 0) {
             distribute(queue, unfulfilled);

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -121,7 +121,11 @@ public class GraphProducer implements Producer<VertexMap> {
     private void job(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int request) {
         try {
             int i = 0;
-            for (; i < request && iterator.hasNext() && !isDone.get(); i++) queue.put(iterator.next());
+            if (!runningJobs.containsKey(iterator)) {
+                for (; i < request && iterator.hasNext() && !isDone.get(); i++) {
+                    queue.put(iterator.next());
+                }
+            }
             if (!isDone.get()) transition(queue, iterator, request - i);
         } catch (Throwable e) {
             done(queue, e);

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -103,8 +103,8 @@ public class GraphProducer implements Producer<VertexMap> {
             return;
         }
 
-        runningJobs.remove(iterator);
-        if (start.hasNext()) {
+        if (runningJobs.containsKey(iterator) && start.hasNext()) {
+            runningJobs.remove(iterator);
             ResourceIterator<VertexMap> newIter =
                     new GraphIterator(graphMgr, start.next(), procedure, params, filter).distinct(produced);
             CompletableFuture<Void> asyncJob = unfulfilled > 0

--- a/traversal/producer/GraphProducer.java
+++ b/traversal/producer/GraphProducer.java
@@ -99,7 +99,7 @@ public class GraphProducer implements Producer<VertexMap> {
 
     private synchronized void transition(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {
         if (!iterator.hasNext()) {
-            if (runningJobs.remove(iterator) != null && start.hasNext()) replace(queue, iterator, unfulfilled);
+            if (runningJobs.remove(iterator) != null && start.hasNext()) compensate(queue, unfulfilled);
             else if (!runningJobs.isEmpty() && unfulfilled > 0) distribute(queue, unfulfilled);
             else if (runningJobs.isEmpty()) done(queue);
             else assert unfulfilled == 0;
@@ -108,8 +108,7 @@ public class GraphProducer implements Producer<VertexMap> {
         }
     }
 
-    private synchronized void replace(Queue<VertexMap> queue, ResourceIterator<VertexMap> iterator, int unfulfilled) {
-        runningJobs.remove(iterator);
+    private synchronized void compensate(Queue<VertexMap> queue, int unfulfilled) {
         ResourceIterator<VertexMap> newIter =
                 new GraphIterator(graphMgr, start.next(), procedure, params, filter).distinct(produced);
         CompletableFuture<Void> asyncJob = unfulfilled > 0


### PR DESCRIPTION
## What is the goal of this PR?

The first draft of the Async Producer, that came out with 2.0.0-alpha release, was not yet fully thread-safe, which cause plenty of bugs that were all caused by various race conditions. It also caused "thread leaks" that overburdened the CPU to the point of unusable over time. We have now fixed this problem by rewriting the Async Producer to be thread-safe from the start, with an algorithm that is much easier to follow, which allows us to easily improve it in the future.

## What are the changes implemented in this PR?

Fixes #6042 