### PR TITLE
Keep the protocol version in sync with Grakn Cluster

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -43,7 +43,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0-alpha-5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "f2765700ca66794064760f412acb9e6997bbedd2", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():


### PR DESCRIPTION
## What is the goal of this PR?

The protocol version included in Grakn Core has been kept in sync with what's needed by Grakn Cluster.

## What are the changes implemented in this PR?

- Update protocol version to the one that has client failover functionalities