### PR TITLE
Fix console warnings caused by out of date dependency

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "f40b54f36acc91f1ef089058773ec0304dc38ce8", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "ca7d021093fe1308b7da52d45809bf06a1d95bc6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():
@@ -43,7 +43,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/graknlabs/protocol",
-        commit = "3b8f0d6dc7cd176e59b13e447c64ba41a2ecff7e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "dd72ce607c0c3ed91b93f5625afbce6033e82eb7", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -35,7 +35,7 @@
 @maven//:com_google_ortools_ortools_win32_x86_64_java
 @maven//:com_google_ortools_ortools_win32_x86_64_java_8_0_8283
 @maven//:com_google_protobuf_protobuf_java
-@maven//:com_google_protobuf_protobuf_java_3_5_1
+@maven//:com_google_protobuf_protobuf_java_3_14_0
 @maven//:commons_codec_commons_codec
 @maven//:commons_codec_commons_codec_1_11
 @maven//:commons_io_commons_io


### PR DESCRIPTION
## What is the goal of this PR?

Fix `WARNING: An illegal reflective access operation has occurred` warning caused by an out of date version of protobuf.

## What are the changes implemented in this PR?

- Update protobuf to latest.