### PR TITLE
Improve performance of data transactions

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -153,14 +153,16 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Transaction(5, "The transaction has been closed and no further operation is allowed.");
         public static final Transaction ILLEGAL_COMMIT =
                 new Transaction(6, "Only write transactions can be committed.");
+        public static final Transaction SCHEMA_READ_VIOLATION =
+                new Transaction(7, "Attempted schema writes when session and transaction types do not allow.");
         public static final Transaction SESSION_DATA_VIOLATION =
-                new Transaction(7, "Attempted schema writes when session type does not allow.");
+                new Transaction(8, "Attempted schema writes when session type does not allow.");
         public static final Transaction SESSION_SCHEMA_VIOLATION =
-                new Transaction(8, "Attempted data writes when session type does not allow.");
+                new Transaction(9, "Attempted data writes when session type does not allow.");
         public static final Transaction MISSING_TRANSACTION =
-                new Transaction(9, "Transaction can not be null.");
+                new Transaction(10, "Transaction can not be null.");
         public static final Transaction BAD_TRANSACTION_TYPE =
-                new Transaction(10, "The transaction type '%s' was not recognised.");
+                new Transaction(11, "The transaction type '%s' was not recognised.");
 
         private static final String codePrefix = "TXN";
         private static final String messagePrefix = "Invalid Transaction Operation";

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -20,6 +20,7 @@ package grakn.core.common.iterator;
 
 import grakn.common.collection.Either;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -54,21 +55,23 @@ public class Iterators {
         return new BaseIterator<>(Either.second(iterator));
     }
 
-    public static <T> ResourceIterator<T> link(Iterator<T> iter1, Iterator<T> iter2) {
+    public static <T> ResourceIterator<T> link(Iterator<? extends T> iter1, Iterator<? extends T> iter2) {
         return link(list(iter1, iter2));
     }
 
-    public static <T> ResourceIterator<T> link(Iterator<T> iter1, Iterator<T> iter2, Iterator<T> iter3) {
+    public static <T> ResourceIterator<T> link(Iterator<? extends T> iter1, Iterator<? extends T> iter2,
+                                               Iterator<? extends T> iter3) {
         return link(list(iter1, iter2, iter3));
     }
 
-    public static <T> ResourceIterator<T> link(List<? extends Iterator<T>> iterators) {
-        final LinkedList<ResourceIterator<T>> converted = new LinkedList<>();
+    @SuppressWarnings("unchecked")
+    public static <T> ResourceIterator<T> link(List<? extends Iterator<? extends T>> iterators) {
+        final List<ResourceIterator<T>> converted = new ArrayList<>();
         iterators.forEach(iterator -> {
             if (iterator instanceof AbstractResourceIterator<?>) {
-                converted.addLast((ResourceIterator<T>) iterator);
+                converted.add((ResourceIterator<T>) iterator);
             } else {
-                converted.addLast(iterate(iterator));
+                converted.add(iterate((Iterator<T>) iterator));
             }
         });
         return new LinkedIterators<>(converted);
@@ -90,7 +93,8 @@ public class Iterators {
         return new ParallelIterators<>(iterators, bufferSize);
     }
 
-    public static <T> ResourceIterator<T> parallel(List<ResourceIterator<T>> iterators, int bufferSize, int bufferMultiplier) {
+    public static <T> ResourceIterator<T> parallel(List<ResourceIterator<T>> iterators,
+                                                   int bufferSize, int bufferMultiplier) {
         return new ParallelIterators<>(iterators, bufferSize, bufferMultiplier);
     }
 

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -175,9 +175,9 @@ public final class ConceptManager {
     }
 
     public void validateThings() {
-        graphMgr.data().vertices().parallel()
+        graphMgr.data().vertices()
                 .filter(v -> !v.isInferred() && v.isModified() && !v.encoding().equals(Encoding.Vertex.Thing.ROLE))
-                .forEach(v -> ThingImpl.of(v).validate());
+                .forEachRemaining(v -> ThingImpl.of(v).validate());
     }
 
     public GraknException exception(ErrorMessage error) {

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -57,5 +57,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "16b658c447392aba161c0f20f9e18475f6b0ee50", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "7160e46660b4d6174c580844e2de5a096861cf9f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -22,7 +22,6 @@ import grakn.common.collection.Pair;
 import grakn.core.common.concurrent.ConcurrentSet;
 import grakn.core.common.exception.GraknCheckedException;
 import grakn.core.common.exception.GraknException;
-import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.common.parameters.Label;
 import grakn.core.graph.iid.EdgeIID;
@@ -39,11 +38,7 @@ import grakn.core.graph.vertex.Vertex;
 import grakn.core.graph.vertex.impl.AttributeVertexImpl;
 import grakn.core.graph.vertex.impl.ThingVertexImpl;
 
-import javax.annotation.Resource;
-import java.io.Serializable;
 import java.time.LocalDateTime;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -60,7 +55,6 @@ import static grakn.core.common.collection.Bytes.longToBytes;
 import static grakn.core.common.collection.Bytes.stripPrefix;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
 import static grakn.core.common.exception.ErrorMessage.ThingWrite.ILLEGAL_STRING_SIZE;
-import static grakn.core.common.iterator.Iterators.iterate;
 import static grakn.core.common.iterator.Iterators.link;
 import static grakn.core.common.iterator.Iterators.tree;
 import static grakn.core.graph.iid.VertexIID.Thing.generate;
@@ -80,7 +74,6 @@ import static grakn.core.graph.util.StatisticsBytes.hasEdgeTotalCountKey;
 import static grakn.core.graph.util.StatisticsBytes.snapshotKey;
 import static grakn.core.graph.util.StatisticsBytes.vertexCountKey;
 import static grakn.core.graph.util.StatisticsBytes.vertexTransitiveCountKey;
-import static java.util.stream.Stream.concat;
 
 public class DataGraph implements Graph {
 

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -110,7 +110,7 @@ public class DataGraph implements Graph {
     }
 
     public ResourceIterator<ThingVertex> vertices() {
-        return link(thingsByIID.values().iterator(), attributesByIID.valueIterator());
+        return link(thingsByIID.values().iterator(), attributesByIID.valuesIterator());
     }
 
     public ThingVertex get(VertexIID.Thing iid) {
@@ -433,7 +433,7 @@ public class DataGraph implements Graph {
                 vertex -> vertex.iid(generate(storage.dataKeyGenerator(), vertex.type().iid(), vertex.type().properLabel()))
         ); // thingByIID no longer contains valid mapping from IID to TypeVertex
         thingsByIID.values().stream().filter(v -> !v.isInferred()).forEach(Vertex::commit);
-        attributesByIID.valueIterator().forEachRemaining(Vertex::commit);
+        attributesByIID.valuesIterator().forEachRemaining(Vertex::commit);
         statistics.commit();
 
         clear(); // we now flush the indexes after commit, and we do not expect this Graph.Thing to be used again
@@ -455,7 +455,7 @@ public class DataGraph implements Graph {
             dateTimes = new ConcurrentHashMap<>();
         }
 
-        ResourceIterator<AttributeVertex<?>> valueIterator() {
+        ResourceIterator<AttributeVertex<?>> valuesIterator() {
             return link(list(
                     booleans.values().iterator(),
                     longs.values().iterator(),

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 import static grakn.common.collection.Collections.list;
 import static grakn.common.collection.Collections.pair;
 import static grakn.core.common.exception.ErrorMessage.SchemaGraph.INVALID_SCHEMA_WRITE;
-import static grakn.core.common.exception.ErrorMessage.Transaction.SESSION_SCHEMA_VIOLATION;
+import static grakn.core.common.exception.ErrorMessage.Transaction.SCHEMA_READ_VIOLATION;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static grakn.core.common.iterator.Iterators.iterate;
 import static grakn.core.common.iterator.Iterators.link;
@@ -333,7 +333,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex create(Encoding.Vertex.Type encoding, String label, @Nullable String scope) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         final String scopedLabel = scopedLabel(label, scope);
         try { // we intentionally use READ on multiLabelLock, as put() only concerns one label
             multiLabelLock.lockRead();
@@ -354,7 +354,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure create(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         try {
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(label, x -> new ManagedReadWriteLock()).lockWrite();
@@ -374,7 +374,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex update(TypeVertex vertex, String oldLabel, @Nullable String oldScope, String newLabel, @Nullable String newScope) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         final String oldScopedLabel = scopedLabel(oldLabel, oldScope);
         final String newScopedLabel = scopedLabel(newLabel, newScope);
         try {
@@ -393,7 +393,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure update(RuleStructure vertex, String oldLabel, String newLabel) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         try {
             final RuleStructure rule = getRule(newLabel);
             multiLabelLock.lockWrite();
@@ -410,7 +410,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(TypeVertex vertex) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(vertex.scopedLabel(), x -> new ManagedReadWriteLock()).lockWrite();
@@ -427,7 +427,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(RuleStructure vertex) {
         assert storage.isOpen();
-        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SCHEMA_READ_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             // TODO do we need all these locks here? Are they applicable for this method?
             multiLabelLock.lockRead();

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -48,6 +48,7 @@ import java.util.stream.Stream;
 import static grakn.common.collection.Collections.list;
 import static grakn.common.collection.Collections.pair;
 import static grakn.core.common.exception.ErrorMessage.SchemaGraph.INVALID_SCHEMA_WRITE;
+import static grakn.core.common.exception.ErrorMessage.Transaction.SESSION_SCHEMA_VIOLATION;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static grakn.core.common.iterator.Iterators.iterate;
 import static grakn.core.common.iterator.Iterators.link;
@@ -332,7 +333,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex create(Encoding.Vertex.Type encoding, String label, @Nullable String scope) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         final String scopedLabel = scopedLabel(label, scope);
         try { // we intentionally use READ on multiLabelLock, as put() only concerns one label
             multiLabelLock.lockRead();
@@ -353,7 +354,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure create(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try {
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(label, x -> new ManagedReadWriteLock()).lockWrite();
@@ -373,7 +374,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex update(TypeVertex vertex, String oldLabel, @Nullable String oldScope, String newLabel, @Nullable String newScope) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         final String oldScopedLabel = scopedLabel(oldLabel, oldScope);
         final String newScopedLabel = scopedLabel(newLabel, newScope);
         try {
@@ -392,7 +393,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure update(RuleStructure vertex, String oldLabel, String newLabel) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try {
             final RuleStructure rule = getRule(newLabel);
             multiLabelLock.lockWrite();
@@ -409,7 +410,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(TypeVertex vertex) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(vertex.scopedLabel(), x -> new ManagedReadWriteLock()).lockWrite();
@@ -426,7 +427,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(RuleStructure vertex) {
         assert storage.isOpen();
-        assert !isReadOnly;
+        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             // TODO do we need all these locks here? Are they applicable for this method?
             multiLabelLock.lockRead();

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -333,7 +333,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex create(Encoding.Vertex.Type encoding, String label, @Nullable String scope) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         final String scopedLabel = scopedLabel(label, scope);
         try { // we intentionally use READ on multiLabelLock, as put() only concerns one label
             multiLabelLock.lockRead();
@@ -354,7 +354,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure create(String label, Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try {
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(label, x -> new ManagedReadWriteLock()).lockWrite();
@@ -374,7 +374,7 @@ public class SchemaGraph implements Graph {
 
     public TypeVertex update(TypeVertex vertex, String oldLabel, @Nullable String oldScope, String newLabel, @Nullable String newScope) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         final String oldScopedLabel = scopedLabel(oldLabel, oldScope);
         final String newScopedLabel = scopedLabel(newLabel, newScope);
         try {
@@ -393,7 +393,7 @@ public class SchemaGraph implements Graph {
 
     public RuleStructure update(RuleStructure vertex, String oldLabel, String newLabel) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try {
             final RuleStructure rule = getRule(newLabel);
             multiLabelLock.lockWrite();
@@ -410,7 +410,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(TypeVertex vertex) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             multiLabelLock.lockRead();
             singleLabelLocks.computeIfAbsent(vertex.scopedLabel(), x -> new ManagedReadWriteLock()).lockWrite();
@@ -427,7 +427,7 @@ public class SchemaGraph implements Graph {
 
     public void delete(RuleStructure vertex) {
         assert storage.isOpen();
-        if (!isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
+        if (isReadOnly) throw GraknException.of(SESSION_SCHEMA_VIOLATION);
         try { // we intentionally use READ on multiLabelLock, as delete() only concerns one label
             // TODO do we need all these locks here? Are they applicable for this method?
             multiLabelLock.lockRead();


### PR DESCRIPTION
## What is the goal of this PR?

We improved two aspects of data transaction behaviour. First, we removed unnecessary locking when the schema graph is in "read-only" mode. Second, we improved the performance of commit validation by reducing unnecessary stream parallelisation.

## What are the changes implemented in this PR?

- Cached schema graph doesn't need to be locked for read-write access, so we remove unnecessary locks.
- Remove parallel stream that makes commit validation slow.