### PR TITLE
Run reasoner in read transactions when enabled in query options

### DIFF
--- a/Grakn.java
+++ b/Grakn.java
@@ -19,6 +19,7 @@
 package grakn.core;
 
 import grakn.core.common.parameters.Arguments;
+import grakn.core.common.parameters.Context;
 import grakn.core.common.parameters.Options;
 import grakn.core.concept.ConceptManager;
 import grakn.core.logic.LogicManager;
@@ -108,7 +109,7 @@ public interface Grakn extends AutoCloseable {
 
         Arguments.Transaction.Type type();
 
-        Options.Transaction options();
+        Context.Transaction context();
 
         boolean isOpen();
 

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -73,7 +73,11 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
         }
 
         public boolean isSchemaWrite() {
-            return sessionType.isSchema() && this.transactionType.isWrite();
+            return sessionType.isSchema() && transactionType.isWrite();
+        }
+
+        public boolean isDataWrite() {
+            return sessionType.isData() && transactionType.isWrite();
         }
     }
 

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -37,7 +37,7 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
         }
     }
 
-    public OPTIONS options() {
+    OPTIONS options() {
         return options;
     }
 
@@ -71,6 +71,18 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
             this.transactionType = transactionType;
             return this;
         }
+
+        public boolean isWrite() {
+            return transactionType.isWrite();
+        }
+
+        public boolean infer() {
+            return options().infer() && !isWrite();
+        }
+
+        public int responseBatchSize() {
+            return options().responseBatchSize();
+        }
     }
 
     public static class Query extends Context<Context.Transaction, Options.Query> {
@@ -78,5 +90,10 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
         public Query(Context.Transaction context, Options.Query options) {
             super(context, options.parent(context.options()));
         }
+
+        public boolean parallel() {
+            return options().parallel();
+        }
+
     }
 }

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -71,10 +71,6 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
             this.transactionType = transactionType;
             return this;
         }
-
-        public boolean isWrite() {
-            return transactionType.isWrite();
-        }
     }
 
     public static class Query extends Context<Context.Transaction, Options.Query> {
@@ -82,5 +78,6 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
         public Query(Context.Transaction context, Options.Query options) {
             super(context, options.parent(context.options()));
         }
+
     }
 }

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -72,12 +72,8 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
             return this;
         }
 
-        public boolean isSchemaWrite() {
-            return sessionType.isSchema() && transactionType.isWrite();
-        }
-
-        public boolean isDataWrite() {
-            return sessionType.isData() && transactionType.isWrite();
+        public boolean isWrite() {
+            return transactionType.isWrite();
         }
     }
 

--- a/common/parameters/Context.java
+++ b/common/parameters/Context.java
@@ -78,6 +78,5 @@ public class Context<PARENT extends Context<?, ?>, OPTIONS extends Options<?, ?>
         public Query(Context.Transaction context, Options.Query options) {
             super(context, options.parent(context.options()));
         }
-
     }
 }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -25,6 +25,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_EXPLAIN = false;
+    public static final boolean DEFAULT_PARALLEL = true;
     public static final int DEFAULT_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
@@ -147,7 +148,8 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         }
 
         public boolean parallel() {
-            return parallel;
+            if (parallel != null) return parallel;
+            return DEFAULT_PARALLEL;
         }
 
         public Query parallel(boolean parallel) {

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -146,11 +146,11 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
             return this;
         }
 
-        public boolean isParallel() {
+        public boolean parallel() {
             return parallel;
         }
 
-        public Query isParallel(boolean parallel) {
+        public Query parallel(boolean parallel) {
             this.parallel = parallel;
             return getThis();
         }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -23,7 +23,7 @@ import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
 
-    public static final boolean DEFAULT_INFER = true;
+    public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -46,13 +46,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         return getThis();
     }
 
-    public boolean infer() {
+    public boolean isInfer() {
         if (infer != null) return infer;
-        else if (parent != null) return parent.infer();
+        else if (parent != null) return parent.isInfer();
         else return DEFAULT_INFER;
     }
 
-    public SELF infer(boolean infer) {
+    public SELF isInfer(boolean infer) {
         this.infer = infer;
         return getThis();
     }
@@ -141,9 +141,20 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public static class Query extends Options<Transaction, Query> {
 
+        private Boolean parallel = null;
+
         @Override
         Query getThis() {
             return this;
+        }
+
+        public boolean isParallel() {
+            return parallel;
+        }
+
+        public Query isParallel(boolean parallel) {
+            this.parallel = parallel;
+            return getThis();
         }
     }
 }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -26,7 +26,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;
-    public static final int DEFAULT_BATCH_SIZE = 50;
+    public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
 
@@ -67,13 +67,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         return getThis();
     }
 
-    public int batchSize() {
+    public int responseBatchSize() {
         if (batchSize != null) return batchSize;
-        else if (parent != null) return parent.batchSize();
-        else return DEFAULT_BATCH_SIZE;
+        else if (parent != null) return parent.responseBatchSize();
+        else return DEFAULT_RESPONSE_BATCH_SIZE;
     }
 
-    public SELF batchSize(int batchSize) {
+    public SELF responseBatchSize(int batchSize) {
         this.batchSize = batchSize;
         return getThis();
     }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -19,8 +19,6 @@ package grakn.core.common.parameters;
 
 import grakn.core.common.exception.GraknException;
 
-import java.util.Optional;
-
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
@@ -46,13 +44,13 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         return getThis();
     }
 
-    public boolean isInfer() {
+    public boolean infer() {
         if (infer != null) return infer;
-        else if (parent != null) return parent.isInfer();
+        else if (parent != null) return parent.infer();
         else return DEFAULT_INFER;
     }
 
-    public SELF isInfer(boolean infer) {
+    public SELF infer(boolean infer) {
         this.infer = infer;
         return getThis();
     }

--- a/query/Matcher.java
+++ b/query/Matcher.java
@@ -98,8 +98,8 @@ public class Matcher {
         return new Group.Aggregator(group, query);
     }
 
-    public ResourceIterator<ConceptMap> execute(boolean isParallel, boolean reasoning) {
-        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, isParallel, reasoning);
+    public ResourceIterator<ConceptMap> execute() {
+        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, options);
         if (query.sort().isPresent()) answers = sort(answers, query.sort().get());
         if (query.offset().isPresent()) answers = answers.offset(query.offset().get());
         if (query.limit().isPresent()) answers = answers.limit(query.limit().get());
@@ -155,8 +155,8 @@ public class Matcher {
             this.query = query;
         }
 
-        public Numeric execute(boolean isParallel, boolean reasoning) {
-            ResourceIterator<ConceptMap> answers = matcher.execute(isParallel, reasoning);
+        public Numeric execute() {
+            ResourceIterator<ConceptMap> answers = matcher.execute();
             GraqlToken.Aggregate.Method method = query.method();
             UnboundVariable var = query.var();
             return aggregate(answers, method, var);
@@ -569,10 +569,10 @@ public class Matcher {
             this.query = query;
         }
 
-        public ResourceIterator<ConceptMapGroup> execute(boolean isParallel, boolean reasoning) {
+        public ResourceIterator<ConceptMapGroup> execute() {
             // TODO: Replace this temporary implementation of Graql Match Group query with a native grouping traversal
             List<ConceptMapGroup> answerGroups = new ArrayList<>();
-            matcher.execute(isParallel, reasoning).stream().collect(groupingBy(a -> a.get(query.var())))
+            matcher.execute().stream().collect(groupingBy(a -> a.get(query.var())))
                     .forEach((o, cm) -> answerGroups.add(new ConceptMapGroup(o, cm)));
             return iterate(answerGroups);
         }
@@ -587,10 +587,10 @@ public class Matcher {
                 this.query = query;
             }
 
-            public ResourceIterator<NumericGroup> execute(boolean isParallel, boolean reasoning) {
+            public ResourceIterator<NumericGroup> execute() {
                 // TODO: Replace this temporary implementation of Graql Match Group query with a native grouping traversal
                 List<NumericGroup> numericGroups = new ArrayList<>();
-                group.matcher.execute(isParallel, reasoning).stream()
+                group.matcher.execute().stream()
                         .collect(groupingBy(a -> a.get(query.group().var()), aggregator(query.method(), query.var())))
                         .forEach((o, n) -> numericGroups.add(new NumericGroup(o, n)));
                 return iterate(numericGroups);

--- a/query/Matcher.java
+++ b/query/Matcher.java
@@ -98,8 +98,8 @@ public class Matcher {
         return new Group.Aggregator(group, query);
     }
 
-    public ResourceIterator<ConceptMap> execute(boolean isParallel) {
-        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, isParallel);
+    public ResourceIterator<ConceptMap> execute(boolean isParallel, boolean reasoning) {
+        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, isParallel, reasoning);
         if (query.sort().isPresent()) answers = sort(answers, query.sort().get());
         if (query.offset().isPresent()) answers = answers.offset(query.offset().get());
         if (query.limit().isPresent()) answers = answers.limit(query.limit().get());
@@ -155,8 +155,8 @@ public class Matcher {
             this.query = query;
         }
 
-        public Numeric execute(boolean isParallel) {
-            ResourceIterator<ConceptMap> answers = matcher.execute(isParallel);
+        public Numeric execute(boolean isParallel, boolean reasoning) {
+            ResourceIterator<ConceptMap> answers = matcher.execute(isParallel, reasoning);
             GraqlToken.Aggregate.Method method = query.method();
             UnboundVariable var = query.var();
             return aggregate(answers, method, var);
@@ -569,10 +569,10 @@ public class Matcher {
             this.query = query;
         }
 
-        public ResourceIterator<ConceptMapGroup> execute(boolean isParallel) {
+        public ResourceIterator<ConceptMapGroup> execute(boolean isParallel, boolean reasoning) {
             // TODO: Replace this temporary implementation of Graql Match Group query with a native grouping traversal
             List<ConceptMapGroup> answerGroups = new ArrayList<>();
-            matcher.execute(isParallel).stream().collect(groupingBy(a -> a.get(query.var())))
+            matcher.execute(isParallel, reasoning).stream().collect(groupingBy(a -> a.get(query.var())))
                     .forEach((o, cm) -> answerGroups.add(new ConceptMapGroup(o, cm)));
             return iterate(answerGroups);
         }
@@ -587,10 +587,10 @@ public class Matcher {
                 this.query = query;
             }
 
-            public ResourceIterator<NumericGroup> execute(boolean isParallel) {
+            public ResourceIterator<NumericGroup> execute(boolean isParallel, boolean reasoning) {
                 // TODO: Replace this temporary implementation of Graql Match Group query with a native grouping traversal
                 List<NumericGroup> numericGroups = new ArrayList<>();
-                group.matcher.execute(isParallel).stream()
+                group.matcher.execute(isParallel, reasoning).stream()
                         .collect(groupingBy(a -> a.get(query.group().var()), aggregator(query.method(), query.var())))
                         .forEach((o, n) -> numericGroups.add(new NumericGroup(o, n)));
                 return iterate(numericGroups);

--- a/query/Matcher.java
+++ b/query/Matcher.java
@@ -20,6 +20,7 @@ package grakn.core.query;
 
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.ResourceIterator;
+import grakn.core.common.parameters.Context;
 import grakn.core.common.parameters.Options;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.answer.ConceptMapGroup;
@@ -68,38 +69,38 @@ public class Matcher {
     private final GraqlMatch query;
     private final Disjunction disjunction;
     private final List<Identifier.Variable.Name> filter;
-    private final Options.Query options;
+    private final Context.Query context;
 
-    public Matcher(Reasoner reasoner, GraqlMatch query, Options.Query options) {
+    public Matcher(Reasoner reasoner, GraqlMatch query, Context.Query context) {
         this.reasoner = reasoner;
         this.query = query;
         this.disjunction = Disjunction.create(query.conjunction().normalise());
         this.filter = iterate(query.filter()).map(v -> Identifier.Variable.of(v.reference().asName())).toList();
-        this.options = options;
+        this.context = context;
     }
 
-    public static Matcher create(Reasoner reasoner, GraqlMatch query, Options.Query options) {
-        return new Matcher(reasoner, query, options);
+    public static Matcher create(Reasoner reasoner, GraqlMatch query, Context.Query context) {
+        return new Matcher(reasoner, query, context);
     }
 
-    public static Matcher.Aggregator create(Reasoner reasoner, GraqlMatch.Aggregate query, Options.Query options) {
-        Matcher matcher = new Matcher(reasoner, query.match(), options);
+    public static Matcher.Aggregator create(Reasoner reasoner, GraqlMatch.Aggregate query, Context.Query context) {
+        Matcher matcher = new Matcher(reasoner, query.match(), context);
         return new Aggregator(matcher, query);
     }
 
-    public static Matcher.Group create(Reasoner reasoner, GraqlMatch.Group query, Options.Query options) {
-        Matcher matcher = new Matcher(reasoner, query.match(), options);
+    public static Matcher.Group create(Reasoner reasoner, GraqlMatch.Group query, Context.Query context) {
+        Matcher matcher = new Matcher(reasoner, query.match(), context);
         return new Group(matcher, query);
     }
 
-    public static Matcher.Group.Aggregator create(Reasoner reasoner, GraqlMatch.Group.Aggregate query, Options.Query options) {
-        Matcher matcher = new Matcher(reasoner, query.group().match(), options);
+    public static Matcher.Group.Aggregator create(Reasoner reasoner, GraqlMatch.Group.Aggregate query, Context.Query context) {
+        Matcher matcher = new Matcher(reasoner, query.group().match(), context);
         Group group = new Group(matcher, query.group());
         return new Group.Aggregator(group, query);
     }
 
     public ResourceIterator<ConceptMap> execute() {
-        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, options);
+        ResourceIterator<ConceptMap> answers = reasoner.execute(disjunction, filter, context);
         if (query.sort().isPresent()) answers = sort(answers, query.sort().get());
         if (query.offset().isPresent()) answers = answers.offset(query.offset().get());
         if (query.limit().isPresent()) answers = answers.limit(query.limit().get());

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -65,7 +65,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query) {
-        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
+        Options.Query options = (new Options.Query()).parallel(true).infer(false);
         return match(query, options);
     }
 
@@ -78,7 +78,7 @@ public class QueryManager {
     }
 
     public Numeric match(GraqlMatch.Aggregate query) {
-        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
+        Options.Query options = (new Options.Query()).parallel(true).infer(false);
         return match(query, options);
     }
 
@@ -91,7 +91,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query) {
-        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
+        Options.Query options = (new Options.Query()).parallel(true).infer(false);
         return match(query, options);
     }
 
@@ -104,7 +104,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query) {
-        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
+        Options.Query options = (new Options.Query()).parallel(true).infer(false);
         return match(query, options);
     }
 

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -65,7 +65,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query) {
-        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
         return match(query, options);
     }
 
@@ -78,7 +78,7 @@ public class QueryManager {
     }
 
     public Numeric match(GraqlMatch.Aggregate query) {
-        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
         return match(query, options);
     }
 
@@ -91,7 +91,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query) {
-        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
         return match(query, options);
     }
 
@@ -104,7 +104,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query) {
-        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        Options.Query options = (new Options.Query()).isParallel(true).infer(false);
         return match(query, options);
     }
 

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -65,81 +65,52 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query) {
-        return match(query, true, false, new Options.Query());
-    }
-
-    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel, boolean reasoning) {
-        return match(query, isParallel, reasoning, new Options.Query());
+        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        return match(query, options);
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query, Options.Query options) {
-        return match(query, true, false, options);
-    }
-
-    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel, boolean reasoning, Options.Query options) {
-        // TODO: Note that Query Options are not yet utilised during match query
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public Numeric match(GraqlMatch.Aggregate query) {
-        return match(query, true, false, new Options.Query());
-    }
-
-    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel, boolean reasoning) {
-        return match(query, isParallel, reasoning, new Options.Query());
+        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        return match(query, options);
     }
 
     public Numeric match(GraqlMatch.Aggregate query, Options.Query options) {
-        return match(query, true, false, options);
-    }
-
-    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning);
+            return Matcher.create(reasoner, query, options).execute();
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query) {
-        return match(query, true, false, new Options.Query());
-    }
-
-    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel, boolean reasoning) {
-        return match(query, isParallel, reasoning, new Options.Query());
+        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        return match(query, options);
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, Options.Query options) {
-        return match(query, true, false, options);
-    }
-
-    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query) {
-        return match(query, true, false, new Options.Query());
-    }
-
-    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel, boolean reasoning) {
-        return match(query, isParallel, reasoning, new Options.Query());
+        Options.Query options = (new Options.Query()).isParallel(true).isInfer(false);
+        return match(query, options);
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, Options.Query options) {
-        return match(query, true, false, options);
-    }
-
-    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -104,8 +104,7 @@ public class QueryManager {
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query) {
-        Options.Query options = (new Options.Query()).parallel(true).infer(false);
-        return match(query, options);
+        return match(query, new Options.Query());
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, Options.Query options) {

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -65,39 +65,39 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query) {
-        Options.Query options = (new Options.Query()).parallel(true).infer(false);
-        return match(query, options);
+        return match(query, new Options.Query());
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match")) {
-            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
+            Context.Query context = new Context.Query(transactionCtx, options);
+            return Matcher.create(reasoner, query, context).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public Numeric match(GraqlMatch.Aggregate query) {
-        Options.Query options = (new Options.Query()).parallel(true).infer(false);
-        return match(query, options);
+        return match(query, new Options.Query());
     }
 
     public Numeric match(GraqlMatch.Aggregate query, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute();
+            Context.Query context = new Context.Query(transactionCtx, options);
+            return Matcher.create(reasoner, query, context).execute();
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query) {
-        Options.Query options = (new Options.Query()).parallel(true).infer(false);
-        return match(query, options);
+        return match(query, new Options.Query());
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group")) {
-            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
+            Context.Query context = new Context.Query(transactionCtx, options);
+            return Matcher.create(reasoner, query, context).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
@@ -110,7 +110,8 @@ public class QueryManager {
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute().onError(conceptMgr::exception);
+            Context.Query context = new Context.Query(transactionCtx, options);
+            return Matcher.create(reasoner, query, context).execute().onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }

--- a/query/QueryManager.java
+++ b/query/QueryManager.java
@@ -65,81 +65,81 @@ public class QueryManager {
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query) {
-        return match(query, true, new Options.Query());
+        return match(query, true, false, new Options.Query());
     }
 
-    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel) {
-        return match(query, isParallel, new Options.Query());
+    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel, boolean reasoning) {
+        return match(query, isParallel, reasoning, new Options.Query());
     }
 
     public ResourceIterator<ConceptMap> match(GraqlMatch query, Options.Query options) {
-        return match(query, true, options);
+        return match(query, true, false, options);
     }
 
-    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel, Options.Query options) {
+    public ResourceIterator<ConceptMap> match(GraqlMatch query, boolean isParallel, boolean reasoning, Options.Query options) {
         // TODO: Note that Query Options are not yet utilised during match query
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public Numeric match(GraqlMatch.Aggregate query) {
-        return match(query, true, new Options.Query());
+        return match(query, true, false, new Options.Query());
     }
 
-    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel) {
-        return match(query, isParallel, new Options.Query());
+    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel, boolean reasoning) {
+        return match(query, isParallel, reasoning, new Options.Query());
     }
 
     public Numeric match(GraqlMatch.Aggregate query, Options.Query options) {
-        return match(query, true, options);
+        return match(query, true, false, options);
     }
 
-    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel, Options.Query options) {
+    public Numeric match(GraqlMatch.Aggregate query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel);
+            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query) {
-        return match(query, true, new Options.Query());
+        return match(query, true, false, new Options.Query());
     }
 
-    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel) {
-        return match(query, isParallel, new Options.Query());
+    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel, boolean reasoning) {
+        return match(query, isParallel, reasoning, new Options.Query());
     }
 
     public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, Options.Query options) {
-        return match(query, true, options);
+        return match(query, true, false, options);
     }
 
-    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel, Options.Query options) {
+    public ResourceIterator<ConceptMapGroup> match(GraqlMatch.Group query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query) {
-        return match(query, true, new Options.Query());
+        return match(query, true, false, new Options.Query());
     }
 
-    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel) {
-        return match(query, isParallel, new Options.Query());
+    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel, boolean reasoning) {
+        return match(query, isParallel, reasoning, new Options.Query());
     }
 
     public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, Options.Query options) {
-        return match(query, true, options);
+        return match(query, true, false, options);
     }
 
-    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel, Options.Query options) {
+    public ResourceIterator<NumericGroup> match(GraqlMatch.Group.Aggregate query, boolean isParallel, boolean reasoning, Options.Query options) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "match_group_aggregate")) {
-            return Matcher.create(reasoner, query, options).execute(isParallel).onError(conceptMgr::exception);
+            return Matcher.create(reasoner, query, options).execute(isParallel, reasoning).onError(conceptMgr::exception);
         } catch (Exception exception) {
             throw conceptMgr.exception(exception);
         }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -79,7 +79,7 @@ public class Reasoner {
                                                 Options.Query options) {
         ResourceIterator<Conjunction> conjunctions = iterate(disjunction.conjunctions());
         if (!options.isParallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
-        else return produce(conjunctions.flatMap(conj -> producers(conj, filter)).toList()).distinct();
+        else return produce(conjunctions.flatMap(conj -> producers(conj, filter)).toList());
     }
 
     private ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction) {
@@ -94,7 +94,7 @@ public class Reasoner {
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answerProducers.add(traversalEng.producer(conj.traversal(filter), PARALLELISATION_FACTOR).map(conceptMgr::conceptMap));
-            if (context.options().isInfer() && !context.transactionType().isWrite())
+            if (context.options().infer() && !context.transactionType().isWrite())
                 answerProducers.add(this.resolve(conj));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {
@@ -128,7 +128,7 @@ public class Reasoner {
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
-            if (context.options().isInfer() && !context.transactionType().isWrite())
+            if (context.options().infer() && !context.transactionType().isWrite())
                 answers = link(answers, produce(resolve(conj)));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -78,7 +78,7 @@ public class Reasoner {
     public ResourceIterator<ConceptMap> execute(Disjunction disjunction, List<Identifier.Variable.Name> filter,
                                                 Options.Query options) {
         ResourceIterator<Conjunction> conjunctions = iterate(disjunction.conjunctions());
-        if (!options.isParallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
+        if (!options.parallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
         else return produce(conjunctions.flatMap(conj -> producers(conj, filter)).toList());
     }
 

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -76,9 +76,9 @@ public class Reasoner {
     }
 
     public ResourceIterator<ConceptMap> execute(Disjunction disjunction, List<Identifier.Variable.Name> filter,
-                                                Options.Query options) {
+                                                Context.Query context) {
         ResourceIterator<Conjunction> conjunctions = iterate(disjunction.conjunctions());
-        if (!options.parallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
+        if (!context.options().parallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
         else return produce(conjunctions.flatMap(conj -> producers(conj, filter)).toList());
     }
 

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -87,13 +87,13 @@ public class Reasoner {
 
     private ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction,
                                                              List<Identifier.Variable.Name> filter, boolean reasoning) {
-        if (context.isSchemaWrite() || context.isDataWrite()) LOG.warn("Reasoning is disabled in write transactions");
+        if (context.isWrite()) LOG.warn("Reasoning is disabled in write transactions");
 
         List<Producer<ConceptMap>> answerProducers = new ArrayList<>();
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answerProducers.add(traversalEng.producer(conj.traversal(filter), PARALLELISATION_FACTOR).map(conceptMgr::conceptMap));
-            if (reasoning && !context.isSchemaWrite() && !context.isDataWrite()) answerProducers.add(this.resolve(conj));
+            if (reasoning && !context.isWrite()) answerProducers.add(this.resolve(conj));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {
             throw GraknException.of(UNSATISFIABLE_CONJUNCTION, conjunction);
@@ -120,13 +120,13 @@ public class Reasoner {
     }
 
     private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, List<Identifier.Variable.Name> filter, boolean reasoning) {
-        if (context.isSchemaWrite() || context.isDataWrite()) LOG.warn("Reasoning is disabled in write transactions");
+        if (context.isWrite()) LOG.warn("Reasoning is disabled in write transactions");
 
         ResourceIterator<ConceptMap> answers;
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
-            if (reasoning && !context.isSchemaWrite() && !context.isDataWrite()) answers = link(answers, produce(resolve(conj)));
+            if (reasoning && !context.isWrite()) answers = link(answers, produce(resolve(conj)));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {
             throw GraknException.of(UNSATISFIABLE_CONJUNCTION, conjunction);

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -22,6 +22,7 @@ import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.common.parameters.Context;
+import grakn.core.common.parameters.Options;
 import grakn.core.concept.Concept;
 import grakn.core.concept.ConceptManager;
 import grakn.core.concept.answer.ConceptMap;
@@ -75,25 +76,26 @@ public class Reasoner {
     }
 
     public ResourceIterator<ConceptMap> execute(Disjunction disjunction, List<Identifier.Variable.Name> filter,
-                                                boolean isParallel, boolean reasoning) {
+                                                Options.Query options) {
         ResourceIterator<Conjunction> conjunctions = iterate(disjunction.conjunctions());
-        if (!isParallel) return conjunctions.flatMap(conj -> iterator(conj, filter, reasoning));
-        else return produce(conjunctions.flatMap(conj -> producers(conj, filter, reasoning)).toList());
+        if (!options.isParallel()) return conjunctions.flatMap(conj -> iterator(conj, filter));
+        else return produce(conjunctions.flatMap(conj -> producers(conj, filter)).toList()).distinct();
     }
 
-    private ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction, boolean reasoning) {
-        return producers(conjunction, list(), reasoning);
+    private ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction) {
+        return producers(conjunction, list());
     }
 
     private ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction,
-                                                             List<Identifier.Variable.Name> filter, boolean reasoning) {
-        if (context.isWrite()) LOG.warn("Reasoning is disabled in write transactions");
+                                                             List<Identifier.Variable.Name> filter) {
+        if (context.transactionType().isWrite()) LOG.warn("Reasoning is disabled in write transactions");
 
         List<Producer<ConceptMap>> answerProducers = new ArrayList<>();
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answerProducers.add(traversalEng.producer(conj.traversal(filter), PARALLELISATION_FACTOR).map(conceptMgr::conceptMap));
-            if (reasoning && !context.isWrite()) answerProducers.add(this.resolve(conj));
+            if (context.options().isInfer() && !context.transactionType().isWrite())
+                answerProducers.add(this.resolve(conj));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {
             throw GraknException.of(UNSATISFIABLE_CONJUNCTION, conjunction);
@@ -103,30 +105,31 @@ public class Reasoner {
 
         if (conjunction.negations().isEmpty()) return iterate(answerProducers);
         else return iterate(answerProducers).map(p -> p.filter(answer -> !produce(
-                iterate(conjunction.negations()).flatMap(n -> iterate(producers(n.disjunction(), answer, reasoning))).toList()
+                iterate(conjunction.negations()).flatMap(n -> iterate(producers(n.disjunction(), answer))).toList()
         ).hasNext()));
     }
 
-    private ResourceIterator<Producer<ConceptMap>> producers(Disjunction disjunction, ConceptMap bounds, boolean reasoning) {
-        return iterate(disjunction.conjunctions()).flatMap(conj -> iterate(producers(conj, bounds, reasoning)));
+    private ResourceIterator<Producer<ConceptMap>> producers(Disjunction disjunction, ConceptMap bounds) {
+        return iterate(disjunction.conjunctions()).flatMap(conj -> iterate(producers(conj, bounds)));
     }
 
-    public ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction, ConceptMap bounds, boolean reasoning) {
-        return producers(bound(conjunction, bounds), reasoning);
+    public ResourceIterator<Producer<ConceptMap>> producers(Conjunction conjunction, ConceptMap bounds) {
+        return producers(bound(conjunction, bounds));
     }
 
-    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, boolean reasoning) {
-        return iterator(conjunction, list(), reasoning);
+    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction) {
+        return iterator(conjunction, list());
     }
 
-    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, List<Identifier.Variable.Name> filter, boolean reasoning) {
-        if (context.isWrite()) LOG.warn("Reasoning is disabled in write transactions");
+    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, List<Identifier.Variable.Name> filter) {
+        if (context.transactionType().isWrite()) LOG.warn("Reasoning is disabled in write transactions");
 
         ResourceIterator<ConceptMap> answers;
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
             answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
-            if (reasoning && !context.isWrite()) answers = link(answers, produce(resolve(conj)));
+            if (context.options().isInfer() && !context.transactionType().isWrite())
+                answers = link(answers, produce(resolve(conj)));
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {
             throw GraknException.of(UNSATISFIABLE_CONJUNCTION, conjunction);
@@ -136,16 +139,16 @@ public class Reasoner {
 
         if (conjunction.negations().isEmpty()) return answers;
         else return answers.filter(answer -> !iterate(conjunction.negations()).flatMap(
-                negation -> iterator(negation.disjunction(), answer, reasoning)
+                negation -> iterator(negation.disjunction(), answer)
         ).hasNext());
     }
 
-    private ResourceIterator<ConceptMap> iterator(Disjunction disjunction, ConceptMap bounds, boolean reasoning) {
-        return iterate(disjunction.conjunctions()).flatMap(c -> iterator(c, bounds, reasoning));
+    private ResourceIterator<ConceptMap> iterator(Disjunction disjunction, ConceptMap bounds) {
+        return iterate(disjunction.conjunctions()).flatMap(c -> iterator(c, bounds));
     }
 
-    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, ConceptMap bounds, boolean reasoning) {
-        return iterator(bound(conjunction, bounds), reasoning);
+    private ResourceIterator<ConceptMap> iterator(Conjunction conjunction, ConceptMap bounds) {
+        return iterator(bound(conjunction, bounds));
     }
 
     private Conjunction bound(Conjunction conjunction, ConceptMap bounds) {

--- a/rocks/RocksTransaction.java
+++ b/rocks/RocksTransaction.java
@@ -84,11 +84,6 @@ public abstract class RocksTransaction implements Grakn.Transaction {
     }
 
     @Override
-    public Options.Transaction options() {
-        return context.options();
-    }
-
-    @Override
     public boolean isOpen() {
         return this.isOpen.get();
     }

--- a/server/rpc/TransactionRPC.java
+++ b/server/rpc/TransactionRPC.java
@@ -135,7 +135,7 @@ public class TransactionRPC {
     public <T> void respond(TransactionProto.Transaction.Req request, Iterator<T> iterator, Options.Query queryOptions,
                             Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
         assert queryOptions.prefetch() != null;
-        iterators.iterate(request, iterator, queryOptions.prefetch(), queryOptions.batchSize(), responseBuilderFn);
+        iterators.iterate(request, iterator, queryOptions.prefetch(), queryOptions.responseBatchSize(), responseBuilderFn);
     }
 
     private void commit(String requestId) {
@@ -189,7 +189,7 @@ public class TransactionRPC {
          * Spin up a new iterator and begin streaming responses immediately.
          */
         <T> void iterate(TransactionProto.Transaction.Req request, Iterator<T> iterator, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
-            iterate(request, iterator, true, transaction.options().batchSize(), responseBuilderFn);
+            iterate(request, iterator, true, transaction.context().responseBatchSize(), responseBuilderFn);
         }
 
         /**

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -35,7 +35,7 @@ public class RequestReader {
                                                          OptionsProto.Options requestOptions) {
         T options = optionsConstructor.get();
         if (requestOptions.getInferOptCase().equals(INFER)) {
-            options.isInfer(requestOptions.getInfer());
+            options.infer(requestOptions.getInfer());
         }
         if (requestOptions.getExplainOptCase().equals(EXPLAIN)) {
             options.explain(requestOptions.getExplain());

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -41,7 +41,7 @@ public class RequestReader {
             options.explain(requestOptions.getExplain());
         }
         if (requestOptions.getBatchSizeOptCase().equals(BATCH_SIZE)) {
-            options.batchSize(requestOptions.getBatchSize());
+            options.responseBatchSize(requestOptions.getBatchSize());
         }
         if (requestOptions.getPrefetchOptCase().equals(PREFETCH)) {
             options.prefetch(requestOptions.getPrefetch());

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -35,7 +35,7 @@ public class RequestReader {
                                                          OptionsProto.Options requestOptions) {
         T options = optionsConstructor.get();
         if (requestOptions.getInferOptCase().equals(INFER)) {
-            options.infer(requestOptions.getInfer());
+            options.isInfer(requestOptions.getInfer());
         }
         if (requestOptions.getExplainOptCase().equals(EXPLAIN)) {
             options.explain(requestOptions.getExplain());


### PR DESCRIPTION
## What is the goal of this PR?
To enable reasoner from certain tests, un-ignore the reasoning code paths, and add a boolean to enable or disable them 
instead. The default, for now, is to disable reasoner, as specified in query options.

We also disable reasoning in data write transactions; support for this will be addressed by the following issue in a future release of Grakn: github.com/graknlabs/grakn/issues/6076.


## What are the changes implemented in this PR?
* Add boolean `reasoner` flag in `Options` methods to enable or disable executing traversals in the reasoning engine.
* Log warning and disable reasoner in any write transactions
* Remove `Options.Transaction` from Transaction interface, and expose `Context.Transaction` instead