### PR TITLE
Fix Grakn Core distribution for Windows

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -65,13 +65,12 @@ permissions = {
 assemble_deps_common = [
     "//server:server-deps-dev",
 #    "//server:server-deps-prod",
-    "@graknlabs_common//binary:assemble-bash-targz",
     "@graknlabs_console_artifact//file"
 ]
 
 assemble_targz(
     name = "assemble-linux-targz",
-    targets = assemble_deps_common + ["//server:server-deps-linux"],
+    targets = assemble_deps_common + ["//server:server-deps-linux", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-linux",
@@ -79,7 +78,7 @@ assemble_targz(
 
 assemble_zip(
     name = "assemble-mac-zip",
-    targets = assemble_deps_common + ["//server:server-deps-mac"],
+    targets = assemble_deps_common + ["//server:server-deps-mac", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-mac",
@@ -87,7 +86,7 @@ assemble_zip(
 
 assemble_zip(
     name = "assemble-windows-zip",
-    targets = assemble_deps_common + ["//server:server-deps-windows"],
+    targets = assemble_deps_common + ["//server:server-deps-windows", "@graknlabs_common//binary:assemble-bat-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-windows",

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -28,7 +28,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        tag = "2.0.0-alpha-5" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        commit = "c30dc247977569a3022fb8e5fa9cbfc4964ba342" # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 

--- a/server/BUILD
+++ b/server/BUILD
@@ -191,7 +191,6 @@ java_deps(
 assemble_deps_common = [
     ":server-deps-dev",
 #    ":server-deps-prod",
-    "@graknlabs_common//binary:assemble-bash-targz",
 ]
 
 assemble_files = {
@@ -210,7 +209,7 @@ permissions = {
 
 assemble_targz(
     name = "assemble-linux-targz",
-    targets = assemble_deps_common + ["server-deps-linux"],
+    targets = assemble_deps_common + ["server-deps-linux", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-server-linux",
@@ -219,7 +218,7 @@ assemble_targz(
 
 assemble_zip(
     name = "assemble-mac-zip",
-    targets = assemble_deps_common + ["server-deps-mac"],
+    targets = assemble_deps_common + ["server-deps-mac", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-server-mac",
@@ -228,7 +227,7 @@ assemble_zip(
 
 assemble_zip(
     name = "assemble-windows-zip",
-    targets = assemble_deps_common + ["server-deps-windows"],
+    targets = assemble_deps_common + ["server-deps-windows", "@graknlabs_common//binary:assemble-bat-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-server-windows",


### PR DESCRIPTION
## What is the goal of this PR?

Make Grakn Core distributions for Windows operational by adding previously lacking `grakn.bat` (a Windows-specific script to interact with Server and Console).

## What are the changes implemented in this PR?

Correctly include Bash or Bat script based on platform for which distribution is being assembled on