### PR TITLE
Add prefetch option for queries, which defaults to false for inserts

### DIFF
--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -19,6 +19,8 @@ package grakn.core.common.parameters;
 
 import grakn.core.common.exception.GraknException;
 
+import java.util.Optional;
+
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
@@ -33,6 +35,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean infer = null;
     private Boolean explain = null;
     private Integer batchSize = null;
+    private Optional<Boolean> prefetch = null;
     private Integer sessionIdlTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
 
@@ -73,6 +76,15 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public SELF batchSize(int batchSize) {
         this.batchSize = batchSize;
+        return getThis();
+    }
+
+    public Optional<Boolean> prefetch() {
+        return prefetch;
+    }
+
+    public SELF prefetch(boolean prefetch) {
+        this.prefetch = Optional.of(prefetch);
         return getThis();
     }
 

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -35,7 +35,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean infer = null;
     private Boolean explain = null;
     private Integer batchSize = null;
-    private Optional<Boolean> prefetch = null;
+    private Boolean prefetch = null;
     private Integer sessionIdlTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
 
@@ -79,12 +79,12 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
         return getThis();
     }
 
-    public Optional<Boolean> prefetch() {
+    public Boolean prefetch() {
         return prefetch;
     }
 
     public SELF prefetch(boolean prefetch) {
-        this.prefetch = Optional.of(prefetch);
+        this.prefetch = prefetch;
         return getThis();
     }
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,8 +42,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0-alpha-6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "e5f1a1046c2696d7d7301f5688d9e33e7a38283e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/server/rpc/TransactionRPC.java
+++ b/server/rpc/TransactionRPC.java
@@ -134,8 +134,8 @@ public class TransactionRPC {
 
     public <T> void respond(TransactionProto.Transaction.Req request, Iterator<T> iterator, Options.Query queryOptions,
                             Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
-        assert queryOptions.prefetch().isPresent();
-        iterators.createNewIterator(request, iterator, queryOptions.prefetch().get(), queryOptions.batchSize(), responseBuilderFn);
+        assert queryOptions.prefetch() != null;
+        iterators.createNewIterator(request, iterator, queryOptions.prefetch(), queryOptions.batchSize(), responseBuilderFn);
     }
 
     private void commit(String requestId) {

--- a/server/rpc/TransactionRPC.java
+++ b/server/rpc/TransactionRPC.java
@@ -202,9 +202,9 @@ public class TransactionRPC {
          * @param <T> The type of answers being fetched.
          */
         <T> void createNewIterator(TransactionProto.Transaction.Req request, Iterator<T> iterator, boolean prefetch, int batchSize, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
-            final String requestId = request.getId();
-            final int latencyMillis = request.getLatencyMillis();
-            final BatchingIterator<T> batchingIterator = new BatchingIterator<>(requestId, iterator, responseBuilderFn, batchSize, latencyMillis);
+            String requestId = request.getId();
+            int latencyMillis = request.getLatencyMillis();
+            BatchingIterator<T> batchingIterator = new BatchingIterator<>(requestId, iterator, responseBuilderFn, batchSize, latencyMillis);
             iterators.compute(requestId, (key, oldValue) -> {
                 if (oldValue == null) return batchingIterator;
                 else throw GraknException.of(DUPLICATE_REQUEST, requestId);

--- a/server/rpc/TransactionRPC.java
+++ b/server/rpc/TransactionRPC.java
@@ -129,13 +129,13 @@ public class TransactionRPC {
 
     public <T> void respond(TransactionProto.Transaction.Req request, Iterator<T> iterator,
                             Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
-        iterators.createNewIterator(request, iterator, responseBuilderFn);
+        iterators.iterate(request, iterator, responseBuilderFn);
     }
 
     public <T> void respond(TransactionProto.Transaction.Req request, Iterator<T> iterator, Options.Query queryOptions,
                             Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
         assert queryOptions.prefetch() != null;
-        iterators.createNewIterator(request, iterator, queryOptions.prefetch(), queryOptions.batchSize(), responseBuilderFn);
+        iterators.iterate(request, iterator, queryOptions.prefetch(), queryOptions.batchSize(), responseBuilderFn);
     }
 
     private void commit(String requestId) {
@@ -188,8 +188,8 @@ public class TransactionRPC {
         /**
          * Spin up a new iterator and begin streaming responses immediately.
          */
-        <T> void createNewIterator(TransactionProto.Transaction.Req request, Iterator<T> iterator, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
-            createNewIterator(request, iterator, true, transaction.options().batchSize(), responseBuilderFn);
+        <T> void iterate(TransactionProto.Transaction.Req request, Iterator<T> iterator, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
+            iterate(request, iterator, true, transaction.options().batchSize(), responseBuilderFn);
         }
 
         /**
@@ -201,7 +201,7 @@ public class TransactionRPC {
          * @param responseBuilderFn The projection function that serialises raw answers to RPC messages.
          * @param <T> The type of answers being fetched.
          */
-        <T> void createNewIterator(TransactionProto.Transaction.Req request, Iterator<T> iterator, boolean prefetch, int batchSize, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
+        <T> void iterate(TransactionProto.Transaction.Req request, Iterator<T> iterator, boolean prefetch, int batchSize, Function<List<T>, TransactionProto.Transaction.Res> responseBuilderFn) {
             String requestId = request.getId();
             int latencyMillis = request.getLatencyMillis();
             BatchingIterator<T> batchingIterator = new BatchingIterator<>(requestId, iterator, responseBuilderFn, batchSize, latencyMillis);

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import static grakn.protocol.OptionsProto.Options.BatchSizeOptCase.BATCH_SIZE;
 import static grakn.protocol.OptionsProto.Options.ExplainOptCase.EXPLAIN;
 import static grakn.protocol.OptionsProto.Options.InferOptCase.INFER;
+import static grakn.protocol.OptionsProto.Options.PrefetchOptCase.PREFETCH;
 import static grakn.protocol.OptionsProto.Options.SchemaLockAcquireTimeoutOptCase.SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS;
 import static grakn.protocol.OptionsProto.Options.SessionIdleTimeoutOptCase.SESSION_IDLE_TIMEOUT_MILLIS;
 
@@ -41,6 +42,9 @@ public class RequestReader {
         }
         if (requestOptions.getBatchSizeOptCase().equals(BATCH_SIZE)) {
             options.batchSize(requestOptions.getBatchSize());
+        }
+        if (requestOptions.getPrefetchOptCase().equals(PREFETCH)) {
+            options.prefetch(requestOptions.getPrefetch());
         }
         if (requestOptions.getSessionIdleTimeoutOptCase().equals(SESSION_IDLE_TIMEOUT_MILLIS)) {
             options.sessionIdleTimeoutMillis(requestOptions.getSessionIdleTimeoutMillis());

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -35,6 +35,7 @@ import graql.lang.query.GraqlDefine;
 import graql.lang.query.GraqlDelete;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlMatch;
+import graql.lang.query.GraqlQuery;
 import graql.lang.query.GraqlUndefine;
 
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
@@ -90,8 +91,8 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.Match.Req req, Options.Query options) {
-        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
+        setPrefetchOption(options, query);
         ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -111,8 +112,8 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroup.Req req, Options.Query options) {
-        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
+        setPrefetchOption(options, query);
         ResourceIterator<ConceptMapGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -124,8 +125,8 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroupAggregate.Req req, Options.Query options) {
-        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
+        setPrefetchOption(options, query);
         ResourceIterator<NumericGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -138,8 +139,8 @@ public class QueryHandler {
     }
 
     private void insert(Transaction.Req request, QueryProto.Query.Insert.Req req, Options.Query options) {
-        if (options.prefetch() == null) options.prefetch(false);
         GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
+        setPrefetchOption(options, query);
         ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -165,5 +166,9 @@ public class QueryHandler {
         GraqlUndefine query = Graql.parseQuery(req.getQuery()).asUndefine();
         queryManager.undefine(query);
         transactionRPC.respond(response(request, QueryProto.Query.Res.newBuilder().setUndefineRes(QueryProto.Query.Undefine.Res.getDefaultInstance())));
+    }
+
+    private void setPrefetchOption(Options.Query options, GraqlQuery query) {
+        if (options.prefetch() == null) options.prefetch(!(query instanceof GraqlInsert));
     }
 }

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -90,7 +90,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.Match.Req req, Options.Query options) {
-        if (!options.prefetch().isPresent()) options.prefetch(true);
+        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
         ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -111,7 +111,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroup.Req req, Options.Query options) {
-        if (!options.prefetch().isPresent()) options.prefetch(true);
+        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
         ResourceIterator<ConceptMapGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -124,7 +124,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroupAggregate.Req req, Options.Query options) {
-        if (!options.prefetch().isPresent()) options.prefetch(true);
+        if (options.prefetch() == null) options.prefetch(true);
         GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
         ResourceIterator<NumericGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -138,7 +138,7 @@ public class QueryHandler {
     }
 
     private void insert(Transaction.Req request, QueryProto.Query.Insert.Req req, Options.Query options) {
-        if (!options.prefetch().isPresent()) options.prefetch(false);
+        if (options.prefetch() == null) options.prefetch(false);
         GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
         ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
         transactionRPC.respond(

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -91,8 +91,8 @@ public class QueryHandler {
 
     private void match(Transaction.Req request, QueryProto.Query.Match.Req req, Options.Query options) {
         if (!options.prefetch().isPresent()) options.prefetch(true);
-        final GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
-        final ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
+        GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
+        ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setMatchRes(
@@ -112,7 +112,7 @@ public class QueryHandler {
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroup.Req req, Options.Query options) {
         if (!options.prefetch().isPresent()) options.prefetch(true);
-        final GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
+        GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
         ResourceIterator<ConceptMapGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -125,7 +125,7 @@ public class QueryHandler {
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroupAggregate.Req req, Options.Query options) {
         if (!options.prefetch().isPresent()) options.prefetch(true);
-        final GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
+        GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
         ResourceIterator<NumericGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
                 request, answers, options,
@@ -139,8 +139,8 @@ public class QueryHandler {
 
     private void insert(Transaction.Req request, QueryProto.Query.Insert.Req req, Options.Query options) {
         if (!options.prefetch().isPresent()) options.prefetch(false);
-        final GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
-        final ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
+        GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
+        ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
         transactionRPC.respond(
                 request, answers, options,
                 as -> response(request, QueryProto.Query.Res.newBuilder().setInsertRes(

--- a/server/rpc/query/QueryHandler.java
+++ b/server/rpc/query/QueryHandler.java
@@ -90,6 +90,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.Match.Req req, Options.Query options) {
+        if (!options.prefetch().isPresent()) options.prefetch(true);
         final GraqlMatch query = Graql.parseQuery(req.getQuery()).asMatch();
         final ResourceIterator<ConceptMap> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -110,6 +111,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroup.Req req, Options.Query options) {
+        if (!options.prefetch().isPresent()) options.prefetch(true);
         final GraqlMatch.Group query = Graql.parseQuery(req.getQuery()).asMatchGroup();
         ResourceIterator<ConceptMapGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -122,6 +124,7 @@ public class QueryHandler {
     }
 
     private void match(Transaction.Req request, QueryProto.Query.MatchGroupAggregate.Req req, Options.Query options) {
+        if (!options.prefetch().isPresent()) options.prefetch(true);
         final GraqlMatch.Group.Aggregate query = Graql.parseQuery(req.getQuery()).asMatchGroupAggregate();
         ResourceIterator<NumericGroup> answers = queryManager.match(query, options);
         transactionRPC.respond(
@@ -135,6 +138,7 @@ public class QueryHandler {
     }
 
     private void insert(Transaction.Req request, QueryProto.Query.Insert.Req req, Options.Query options) {
+        if (!options.prefetch().isPresent()) options.prefetch(false);
         final GraqlInsert query = Graql.parseQuery(req.getQuery()).asInsert();
         final ResourceIterator<ConceptMap> answers = queryManager.insert(query, options);
         transactionRPC.respond(


### PR DESCRIPTION
## What is the goal of this PR?

On executing a Graql query, Grakn automatically streams the first batch of responses back to the client. This ensures they get their answers to a `match` query as fast as possible. But, for an `insert` query, they usually don't need those answers. And the CPU cost of compiling these unwanted response messages was inflicting a significant performance penalty. To remedy this, we made `prefetch` a configurable per-query option, which defaults to true, except for Insert queries where it defaults to false.

## What are the changes implemented in this PR?

- Don't prefetch responses to Insert queries unless specified with a configurable flag in QueryOptions (fixes https://github.com/graknlabs/grakn/issues/6072)