### PR TITLE
Type resolution correctly handles explicitly labelled roles

### DIFF
--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -38,6 +38,7 @@ import grakn.core.pattern.constraint.type.PlaysConstraint;
 import grakn.core.pattern.constraint.type.RegexConstraint;
 import grakn.core.pattern.constraint.type.RelatesConstraint;
 import grakn.core.pattern.constraint.type.SubConstraint;
+import grakn.core.pattern.constraint.type.TypeConstraint;
 import grakn.core.pattern.constraint.type.ValueTypeConstraint;
 import grakn.core.pattern.variable.SystemReference;
 import grakn.core.pattern.variable.ThingVariable;
@@ -179,14 +180,19 @@ public class TypeResolver {
             resolverRegister.put(var.id(), resolver);
             variableRegister.putIfAbsent(resolver.reference(), var);
             if (!var.resolvedTypes().isEmpty()) traversal.labels(resolver.id(), var.resolvedTypes());
-            resolver.abstractConstraint().ifPresent(constraint -> registerAbstract(resolver));
-            resolver.is().forEach(constraint -> registerIsType(resolver, constraint));
-            resolver.owns().forEach(constraint -> registerOwns(resolver, constraint));
-            resolver.plays().forEach(constraint -> registerPlays(resolver, constraint));
-            resolver.regex().ifPresent(constraint -> registerRegex(resolver, constraint));
-            resolver.relates().forEach(constraint -> registerRelates(resolver, constraint));
-            resolver.sub().ifPresent(constraint -> registerSub(resolver, constraint));
-            resolver.valueType().ifPresent(constraint -> registerValueType(resolver, constraint));
+
+            for (TypeConstraint constraint : var.constraints()) {
+                if (constraint.isAbstract()) registerAbstract(resolver);
+                else if (constraint.isIs()) registerIsType(resolver, constraint.asIs());
+                else if (constraint.isOwns()) registerOwns(resolver, constraint.asOwns());
+                else if (constraint.isPlays()) registerPlays(resolver, constraint.asPlays());
+                else if (constraint.isRegex()) registerRegex(resolver, constraint.asRegex());
+                else if (constraint.isRelates()) registerRelates(resolver, constraint.asRelates());
+                else if (constraint.isSub()) registerSub(resolver, constraint.asSub());
+                else if (constraint.asValueType()) registerValueType(resolver, constraint.asValueType());
+                else throw GraknException.of(ILLEGAL_STATE);
+            }
+
             return resolver;
         }
 

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -22,7 +22,6 @@ import grakn.common.collection.Bytes;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Label;
 import grakn.core.concept.ConceptManager;
-import grakn.core.concept.type.Type;
 import grakn.core.graph.common.Encoding;
 import grakn.core.graph.vertex.TypeVertex;
 import grakn.core.logic.LogicCache;
@@ -62,7 +61,6 @@ import static grakn.core.common.exception.ErrorMessage.ThingRead.THING_NOT_FOUND
 import static grakn.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static grakn.core.common.iterator.Iterators.iterate;
-import static grakn.core.common.iterator.Iterators.tree;
 import static graql.lang.common.GraqlToken.Type.ATTRIBUTE;
 
 public class TypeResolver {

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -22,6 +22,7 @@ import grakn.common.collection.Bytes;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Label;
 import grakn.core.concept.ConceptManager;
+import grakn.core.concept.type.Type;
 import grakn.core.graph.common.Encoding;
 import grakn.core.graph.vertex.TypeVertex;
 import grakn.core.logic.LogicCache;
@@ -32,6 +33,12 @@ import grakn.core.pattern.constraint.thing.IsConstraint;
 import grakn.core.pattern.constraint.thing.IsaConstraint;
 import grakn.core.pattern.constraint.thing.RelationConstraint;
 import grakn.core.pattern.constraint.thing.ValueConstraint;
+import grakn.core.pattern.constraint.type.OwnsConstraint;
+import grakn.core.pattern.constraint.type.PlaysConstraint;
+import grakn.core.pattern.constraint.type.RegexConstraint;
+import grakn.core.pattern.constraint.type.RelatesConstraint;
+import grakn.core.pattern.constraint.type.SubConstraint;
+import grakn.core.pattern.constraint.type.ValueTypeConstraint;
 import grakn.core.pattern.variable.SystemReference;
 import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.pattern.variable.TypeVariable;
@@ -54,6 +61,7 @@ import static grakn.core.common.exception.ErrorMessage.ThingRead.THING_NOT_FOUND
 import static grakn.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_NOT_FOUND;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.TYPE_NOT_FOUND;
 import static grakn.core.common.iterator.Iterators.iterate;
+import static grakn.core.common.iterator.Iterators.tree;
 import static graql.lang.common.GraqlToken.Type.ATTRIBUTE;
 
 public class TypeResolver {
@@ -110,15 +118,15 @@ public class TypeResolver {
         return conjunction;
     }
 
-    private Map<Reference, Set<Label>> executeResolverTraversals(TraversalBuilder traversalConstructor) {
-        return logicCache.resolver().get(traversalConstructor.traversal(), traversal -> {
+    private Map<Reference, Set<Label>> executeResolverTraversals(TraversalBuilder traversalBuilder) {
+        return logicCache.resolver().get(traversalBuilder.traversal(), traversal -> {
             Map<Reference, Set<Label>> mapping = new HashMap<>();
             traversalEng.iterator(traversal).forEachRemaining(
                     result -> result.forEach((ref, vertex) -> {
                         mapping.putIfAbsent(ref, new HashSet<>());
                         assert vertex.isType();
                         // TODO: This filter should not be needed if we enforce traversal only to return non-abstract
-                        if (!(vertex.asType().isAbstract() && traversalConstructor.getVariable(ref).isThing()))
+                        if (!(vertex.asType().isAbstract() && traversalBuilder.getVariable(ref).isThing()))
                             mapping.get(ref).add(vertex.asType().properLabel());
                     })
             );
@@ -170,8 +178,50 @@ public class TypeResolver {
             }
             resolverRegister.put(var.id(), resolver);
             variableRegister.putIfAbsent(resolver.reference(), var);
+            if (!var.resolvedTypes().isEmpty()) traversal.labels(resolver.id(), var.resolvedTypes());
+            resolver.abstractConstraint().ifPresent(constraint -> registerAbstract(resolver));
+            resolver.is().forEach(constraint -> registerIsType(resolver, constraint));
+            resolver.owns().forEach(constraint -> registerOwns(resolver, constraint));
+            resolver.plays().forEach(constraint -> registerPlays(resolver, constraint));
+            resolver.regex().ifPresent(constraint -> registerRegex(resolver, constraint));
+            resolver.relates().forEach(constraint -> registerRelates(resolver, constraint));
+            resolver.sub().ifPresent(constraint -> registerSub(resolver, constraint));
+            resolver.valueType().ifPresent(constraint -> registerValueType(resolver, constraint));
+
             resolver.addTo(traversal);
             return resolver;
+        }
+
+        private void registerAbstract(TypeVariable resolver) {
+            traversal.isAbstract(resolver.id());
+        }
+
+        private void registerIsType(TypeVariable resolver, grakn.core.pattern.constraint.type.IsConstraint isConstraint) {
+            traversal.equalTypes(resolver.id(), register(isConstraint.variable()).id());
+        }
+
+        private void registerOwns(TypeVariable resolver, OwnsConstraint ownsConstraint) {
+            traversal.owns(resolver.id(), register(ownsConstraint.attribute()).id(), ownsConstraint.isKey());
+        }
+
+        private void registerPlays(TypeVariable resolver, PlaysConstraint playsConstraint) {
+            traversal.plays(resolver.id(), register(playsConstraint.role()).id());
+        }
+
+        private void registerRegex(TypeVariable resolver, RegexConstraint regexConstraint) {
+            traversal.regex(resolver.id(), regexConstraint.regex().pattern());
+        }
+
+        private void registerRelates(TypeVariable resolver, RelatesConstraint relatesConstraint) {
+            traversal.relates(resolver.id(), register(relatesConstraint.role()).id());
+        }
+
+        private void registerSub(TypeVariable resolver, SubConstraint subConstraint) {
+            traversal.sub(resolver.id(), register(subConstraint.type()).id(), !subConstraint.isExplicit());
+        }
+
+        private void registerValueType(TypeVariable resolver, ValueTypeConstraint valueTypeConstraint) {
+            traversal.valueType(resolver.id(), valueTypeConstraint.valueType());
         }
 
         private TypeVariable register(ThingVariable var) {
@@ -186,38 +236,38 @@ public class TypeResolver {
             // have resolved its valueType, so we execute convertValue first.
             var.value().forEach(constraint -> registerValue(resolver, constraint));
             var.isa().ifPresent(constraint -> registerIsa(resolver, constraint));
-            var.is().forEach(constraint -> registerIs(resolver, constraint));
+            var.is().forEach(constraint -> registerIsThing(resolver, constraint));
             var.has().forEach(constraint -> registerHas(resolver, constraint));
             var.relation().forEach(constraint -> registerRelation(resolver, constraint));
             var.iid().ifPresent(constraint -> registerIID(resolver, constraint));
             return resolver;
         }
 
-        private void registerIID(TypeVariable owner, IIDConstraint iidConstraint) {
+        private void registerIID(TypeVariable resolver, IIDConstraint iidConstraint) {
             if (conceptMgr.getThing(iidConstraint.iid()) == null)
                 throw GraknException.of(THING_NOT_FOUND, Bytes.bytesToHexString(iidConstraint.iid()));
-            traversal.labels(owner.id(), conceptMgr.getThing(iidConstraint.iid()).getType().getLabel());
+            traversal.labels(resolver.id(), conceptMgr.getThing(iidConstraint.iid()).getType().getLabel());
         }
 
-        private void registerIsa(TypeVariable owner, IsaConstraint isaConstraint) {
+        private void registerIsa(TypeVariable resolver, IsaConstraint isaConstraint) {
             if (!isaConstraint.isExplicit())
-                traversal.sub(owner.id(), register(isaConstraint.type()).id(), true);
+                traversal.sub(resolver.id(), register(isaConstraint.type()).id(), true);
             else if (isaConstraint.type().reference().isName())
-                traversal.equalTypes(owner.id(), register(isaConstraint.type()).id());
+                traversal.equalTypes(resolver.id(), register(isaConstraint.type()).id());
             else if (isaConstraint.type().label().isPresent())
-                traversal.labels(owner.id(), isaConstraint.type().label().get().properLabel());
+                traversal.labels(resolver.id(), isaConstraint.type().label().get().properLabel());
             else throw GraknException.of(ILLEGAL_STATE);
         }
 
-        private void registerIs(TypeVariable owner, IsConstraint isConstraint) {
-            traversal.equalTypes(owner.id(), register(isConstraint.variable()).id());
+        private void registerIsThing(TypeVariable resolver, IsConstraint isConstraint) {
+            traversal.equalTypes(resolver.id(), register(isConstraint.variable()).id());
         }
 
-        private void registerHas(TypeVariable owner, HasConstraint hasConstraint) {
-            traversal.owns(owner.id(), register(hasConstraint.attribute()).id(), false);
+        private void registerHas(TypeVariable resolver, HasConstraint hasConstraint) {
+            traversal.owns(resolver.id(), register(hasConstraint.attribute()).id(), false);
         }
 
-        private void registerRelation(TypeVariable owner, RelationConstraint constraint) {
+        private void registerRelation(TypeVariable resolver, RelationConstraint constraint) {
             for (RelationConstraint.RolePlayer rolePlayer : constraint.players()) {
                 TypeVariable playerResolver = register(rolePlayer.player());
                 TypeVariable actingRoleResolver = register(new TypeVariable(newSystemId()));
@@ -225,12 +275,12 @@ public class TypeResolver {
                     TypeVariable roleTypeResolver = register(rolePlayer.roleType().get());
                     traversal.sub(actingRoleResolver.id(), roleTypeResolver.id(), true);
                 }
-                traversal.relates(owner.id(), actingRoleResolver.id());
+                traversal.relates(resolver.id(), actingRoleResolver.id());
                 traversal.plays(playerResolver.id(), actingRoleResolver.id());
             }
         }
 
-        private void registerValue(TypeVariable owner, ValueConstraint<?> constraint) {
+        private void registerValue(TypeVariable resolver, ValueConstraint<?> constraint) {
             Set<ValueType> valueTypes;
             if (constraint.isVariable()) {
                 TypeVariable comparableVar = register(constraint.asVariable().value());
@@ -242,13 +292,13 @@ public class TypeResolver {
                         .map(Encoding.ValueType::graqlValueType).toSet();
             }
 
-            if (valueTypeRegister.get(owner.id()).isEmpty()) {
-                valueTypes.forEach(valueType -> traversal.valueType(owner.id(), valueType));
-                valueTypeRegister.put(owner.id(), valueTypes);
-            } else if (!valueTypeRegister.get(owner.id()).containsAll(valueTypes)) {
+            if (valueTypeRegister.get(resolver.id()).isEmpty()) {
+                valueTypes.forEach(valueType -> traversal.valueType(resolver.id(), valueType));
+                valueTypeRegister.put(resolver.id(), valueTypes);
+            } else if (!valueTypeRegister.get(resolver.id()).containsAll(valueTypes)) {
                 throw GraknException.of(UNSATISFIABLE_CONJUNCTION, constraint);
             }
-            registerSubAttribute(owner.id());
+            registerSubAttribute(resolver.id());
         }
 
         private void registerSubAttribute(Identifier.Variable variable) {

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -189,8 +189,8 @@ public class TypeResolver {
                 else if (constraint.isRegex()) registerRegex(resolver, constraint.asRegex());
                 else if (constraint.isRelates()) registerRelates(resolver, constraint.asRelates());
                 else if (constraint.isSub()) registerSub(resolver, constraint.asSub());
-                else if (constraint.asValueType()) registerValueType(resolver, constraint.asValueType());
-                else throw GraknException.of(ILLEGAL_STATE);
+                else if (constraint.isValueType()) registerValueType(resolver, constraint.asValueType());
+                else if (!constraint.isLabel()) throw GraknException.of(ILLEGAL_STATE);
             }
 
             return resolver;

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -187,8 +187,6 @@ public class TypeResolver {
             resolver.relates().forEach(constraint -> registerRelates(resolver, constraint));
             resolver.sub().ifPresent(constraint -> registerSub(resolver, constraint));
             resolver.valueType().ifPresent(constraint -> registerValueType(resolver, constraint));
-
-            resolver.addTo(traversal);
             return resolver;
         }
 

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -999,5 +999,4 @@ public class TypeResolverTest {
 
         assertEquals(expectedResolvedTypes, getHintMap(conjunction).get("$_relation:partner"));
     }
-
 }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -52,7 +51,6 @@ import static grakn.core.common.test.Util.assertThrows;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class TypeResolverTest {
     private static Path directory = Paths.get(System.getProperty("user.dir")).resolve("type-resolver-test");
@@ -97,8 +95,8 @@ public class TypeResolverTest {
     }
 
     private Map<String, Set<String>> getHintMap(Conjunction conjunction) {
-        return conjunction.variables().stream().filter(variable -> variable.reference().isName()).collect(Collectors.toMap(
-                variable -> variable.reference().syntax(),
+        return conjunction.variables().stream().collect(Collectors.toMap(
+                variable -> variable.id().toString(),
                 variable -> variable.resolvedTypes().stream().map(Label::scopedName).collect(Collectors.toSet())
         ));
     }
@@ -122,6 +120,7 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("person", "man", "woman"));
+            put("$_person", set("person"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -137,6 +136,7 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("person"));
+            put("$_person", set("person"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -157,6 +157,8 @@ public class TypeResolverTest {
         Map<String, Set<String>> expectedExhaustive = new HashMap<String, Set<String>>() {{
             put("$p", set("mammal", "person", "man", "woman", "dog"));
             put("$q", set("mammal", "person", "man", "woman", "dog"));
+            put("$_entity", set("entity"));
+            put("$_mammal", set("mammal"));
         }};
 
         assertEquals(expectedExhaustive, getHintMap(conjunction));
@@ -173,6 +175,8 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("person", "man", "woman", "dog"));
+            put("$_name", set("name"));
+            put("$_0", set("name"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -253,6 +257,7 @@ public class TypeResolverTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("person", "man", "woman", "dog"));
             put("$a", set("name"));
+            put("$_name", set("name"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -272,6 +277,7 @@ public class TypeResolverTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("triangle", "right-angled-triangle", "square"));
             put("$a", set("perimeter", "area", "label", "hypotenuse-length"));
+            put("$_shape", set("shape"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -334,6 +340,8 @@ public class TypeResolverTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$yoko", set("woman"));
             put("$r", set("marriage"));
+            put("$_marriage:wife", set("marriage:wife"));
+            put("$_marriage", set("marriage"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -352,6 +360,7 @@ public class TypeResolverTest {
             put("$yoko", set("person", "man", "woman"));
             put("$role", set("marriage:husband", "marriage:wife", "marriage:spouse", "relation:role"));
             put("$r", set("marriage"));
+            put("$_marriage", set("marriage"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -370,6 +379,7 @@ public class TypeResolverTest {
             put("$yoko", set("woman"));
             put("$r", set("marriage"));
             put("$m", set("marriage", "relation", "thing"));
+            put("$_relation:wife", set("marriage:wife"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -408,6 +418,8 @@ public class TypeResolverTest {
             put("$role", set("hetero-marriage:husband", "marriage:spouse", "partnership:partner", "relation:role"));
             put("$r", set("hetero-marriage", "marriage"));
             put("$m", set("hetero-marriage", "marriage", "partnership", "relation", "thing"));
+            put("$_relation:spouse", set("marriage:spouse"));
+            put("$_man", set("man"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -424,6 +436,8 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$yoko", set("woman"));
+            put("$_0", set("marriage"));
+            put("$_relation:wife", set("marriage:wife"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -440,6 +454,8 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$yoko", set("man", "woman", "person"));
+            put("$_0", set("marriage"));
+            put("$_marriage", set("marriage"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -460,6 +476,8 @@ public class TypeResolverTest {
             put("$role", set("marriage:husband", "marriage:wife", "marriage:spouse", "relation:role"));
             put("$r", set("marriage"));
             put("$a", set("person", "man", "woman"));
+            put("$_marriage:husband", set("marriage:husband"));
+            put("$_marriage", set("marriage"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -479,6 +497,7 @@ public class TypeResolverTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$a", set("name", "email"));
             put("$p", set("person"));
+            put("$_person", set("person"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -496,6 +515,7 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("person", "man", "woman"));
+            put("$_person", set("person"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -521,6 +541,7 @@ public class TypeResolverTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$p", set("man", "greek", "socrates"));
             put("$q", set("thing", "entity", "animal", "person", "man"));
+            put("$_man", set("man"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -539,7 +560,7 @@ public class TypeResolverTest {
             put("$t", set("shape"));
         }};
 
-        assertTrue(getHintMap(conjunction).entrySet().containsAll(expected.entrySet()));
+        assertEquals(expected, getHintMap(conjunction));
     }
 
     @Test
@@ -552,6 +573,9 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$john", set("person", "man", "woman"));
+            put("$_0", set("marriage"));
+            put("$_marriage:spouse", set("marriage:spouse"));
+            put("$_marriage", set("marriage"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -581,6 +605,9 @@ public class TypeResolverTest {
             put("$b", set("person", "chair"));
             put("$c", set("leg-weight"));
             put("$p", set("animal", "person", "dog", "chair"));
+            put("$_0", set("leg-weight"));
+            put("$_weight", set("weight"));
+            put("$_leg-weight", set("leg-weight"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -614,7 +641,8 @@ public class TypeResolverTest {
         Conjunction conjunction = resolveConjunction(typeResolver, queryString);
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
-            put("$x", Collections.emptySet());
+            put("$x", set());
+            put("$_thing", set("thing"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -641,6 +669,10 @@ public class TypeResolverTest {
             put("$x", set("man"));
             put("$y", set("woman"));
             put("$t", set("thing", "entity", "person"));
+            put("$_0", set("man-name"));
+            put("$_1", set("woman-name"));
+            put("$_man-name", set("man-name"));
+            put("$_woman-name", set("woman-name"));
         }};
 
         assertEquals(expectedExhaustive, getHintMap(conjunction));
@@ -670,6 +702,7 @@ public class TypeResolverTest {
             put("$y", set("person", "man", "greek", "socrates"));
             put("$z", set("person", "man", "greek", "socrates"));
             put("$w", set("person", "man", "greek", "socrates"));
+            put("$_person", set("person"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -731,6 +764,10 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$a", set("dog"));
+            put("$_name", set("name"));
+            put("$_label", set("label"));
+            put("$_0", set("name"));
+            put("$_1", set("label"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
@@ -767,6 +804,8 @@ public class TypeResolverTest {
             put("$x", set("person"));
             put("$y", set("person"));
             put("$m", set("marriage", "hetero-marriage"));
+            put("$_marriage:spouse", set("marriage:spouse"));
+            put("$_marriage", set("marriage"));
         }};
         assertEquals(expected, getHintMap(conjunction));
     }
@@ -780,6 +819,7 @@ public class TypeResolverTest {
         Conjunction relationConjunction = resolveConjunction(typeResolver, relationString);
         Map<String, Set<String>> relationExpected = new HashMap<String, Set<String>>() {{
             put("$x", set("friendship", "employment"));
+            put("$_relation", set("relation"));
         }};
         assertEquals(relationExpected, getHintMap(relationConjunction));
 
@@ -787,6 +827,7 @@ public class TypeResolverTest {
         Conjunction attributeConjunction = resolveConjunction(typeResolver, attributeString);
         Map<String, Set<String>> attributeExpected = new HashMap<String, Set<String>>() {{
             put("$x", set("name", "age", "ref"));
+            put("$_attribute", set("attribute"));
         }};
 
         assertEquals(attributeExpected, getHintMap(attributeConjunction));
@@ -795,6 +836,7 @@ public class TypeResolverTest {
         Conjunction entityConjunction = resolveConjunction(typeResolver, entityString);
         Map<String, Set<String>> entityExpected = new HashMap<String, Set<String>>() {{
             put("$x", set("person", "company"));
+            put("$_entity", set("entity"));
         }};
         assertEquals(entityExpected, getHintMap(entityConjunction));
 
@@ -803,6 +845,8 @@ public class TypeResolverTest {
         Map<String, Set<String>> roleExpected = new HashMap<String, Set<String>>() {{
             put("$role", set("friendship:friend", "employment:employer", "employment:employee", "relation:role"));
             put("$x", set("person", "company"));
+            put("$_0", set("friendship", "employment"));
+            put("$_relation", set("relation"));
         }};
         assertEquals(roleExpected, getHintMap(roleConjunction));
 
@@ -810,6 +854,7 @@ public class TypeResolverTest {
         Conjunction thingConjunction = resolveConjunction(typeResolver, thingString);
         Map<String, Set<String>> thingExpected = new HashMap<String, Set<String>>() {{
             put("$x", set());
+            put("$_thing", set("thing"));
         }};
         assertEquals(thingExpected, getHintMap(thingConjunction));
     }
@@ -925,9 +970,33 @@ public class TypeResolverTest {
 
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$x", set("person"));
+            put("$_0", set("name"));
+            put("$_name", set("name"));
         }};
 
         assertEquals(expected, getHintMap(conjunction));
     }
 
+    @Test
+    public void role_labels_infer_further() {
+        define_custom_schema("define" +
+                                     " person sub entity, plays partnership:partner;" +
+                                     " partnership sub relation, relates partner;" +
+                                     " business sub relation, relates partner;"
+        );
+
+        TypeResolver typeResolver = transaction.logic().typeResolver();
+        String queryString = "match (partner: $x);";
+        Conjunction conjunction = createConjunction(queryString);
+        typeResolver.resolveLabels(conjunction);
+
+        Set<String> expectedLabels = set("partnership:partner", "business:partner");
+
+        assertEquals(expectedLabels, getHintMap(conjunction).get("$_relation:partner"));
+
+        typeResolver.resolve(conjunction);
+        Set<String> expectedResolvedTypes = set("partnership:partner");
+
+        assertEquals(expectedResolvedTypes, getHintMap(conjunction).get("$_relation:partner"));
+    }
 }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -999,4 +999,25 @@ public class TypeResolverTest {
 
         assertEquals(expectedResolvedTypes, getHintMap(conjunction).get("$_relation:partner"));
     }
+
+    @Test
+    public void james_test() {
+        define_custom_schema("define" +
+                                     " number-of-letters sub attribute, value long; " +
+                                     " number-of-letters owns number-of-letters; " +
+                                     " person sub entity;"
+        );
+
+        TypeResolver typeResolver = transaction.logic().typeResolver();
+        String queryString = "match $a has $b;";
+        Conjunction conjunction = resolveConjunction(typeResolver, queryString);
+        Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
+            put("$a", set("number-of-letters"));
+            put("$b", set("number-of-letters"));
+        }};
+
+        assertEquals(expected, getHintMap(conjunction));
+
+    }
+
 }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -978,7 +978,7 @@ public class TypeResolverTest {
     }
 
     @Test
-    public void role_labels_infer_further() {
+    public void role_labels_reduced_by_full_type_resolver() {
         define_custom_schema("define" +
                                      " person sub entity, plays partnership:partner;" +
                                      " partnership sub relation, relates partner;" +

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -1000,24 +1000,4 @@ public class TypeResolverTest {
         assertEquals(expectedResolvedTypes, getHintMap(conjunction).get("$_relation:partner"));
     }
 
-    @Test
-    public void james_test() {
-        define_custom_schema("define" +
-                                     " number-of-letters sub attribute, value long; " +
-                                     " number-of-letters owns number-of-letters; " +
-                                     " person sub entity;"
-        );
-
-        TypeResolver typeResolver = transaction.logic().typeResolver();
-        String queryString = "match $a has $b;";
-        Conjunction conjunction = resolveConjunction(typeResolver, queryString);
-        Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
-            put("$a", set("number-of-letters"));
-            put("$b", set("number-of-letters"));
-        }};
-
-        assertEquals(expected, getHintMap(conjunction));
-
-    }
-
 }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -999,4 +999,20 @@ public class TypeResolverTest {
 
         assertEquals(expectedResolvedTypes, getHintMap(conjunction).get("$_relation:partner"));
     }
+
+    @Test
+    public void roles_can_handle_type_constraints() throws IOException {
+        define_standard_schema("basic-schema");
+        String queryString = "match ($role: $x) isa $y; $role type marriage:wife;";
+        TypeResolver typeResolver = transaction.logic().typeResolver();
+        Conjunction conjunction = resolveConjunction(typeResolver, queryString);
+        HashMap<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
+            put("$y", set("marriage", "relation", "thing"));
+            put("$x", set("woman"));
+            put("$role", set("marriage:wife"));
+            put("$_0", set("marriage"));
+        }};
+
+        assertEquals(expected, getHintMap(conjunction));
+    }
 }


### PR DESCRIPTION
## What is the goal of this PR?

`TypeResolver` can now handle `TypeVariable` within a query. We no longer use the `Variable` method `addTo()`. This will fix a bug where explicitly labelled `roleTypes` were not dealt with properly. The test have also been improved, so that it checks which `resolvedTypes` are added to Anonymous and Labels Variables as well as Named Variables.

## What are the changes implemented in this PR?

* `TypeResolver` now adds to the `Traversal` directly
* This ensures the correct `resolvers` are added to the `traversal`, which is important when the `resolvers` are `SystemReference`
* Changed Tests so that all variables are checked, not just named ones
* Added test to ensure resolved Types on labelled roles are further pruned by the full `resolve()` function.
