### PR TITLE
Parallelised commit validation of data writes

### DIFF
--- a/common/iterator/AbstractResourceIterator.java
+++ b/common/iterator/AbstractResourceIterator.java
@@ -62,6 +62,11 @@ public abstract class AbstractResourceIterator<T> implements ResourceIterator<T>
     }
 
     @Override
+    public ResourceIterator<ResourceIterator<T>> split(int count) {
+        return new SplitIterator<>(this, count);
+    }
+
+    @Override
     public ResourceIterator<T> filter(Predicate<T> predicate) {
         return new FilteredIterator<>(this, predicate);
     }

--- a/common/iterator/Iterators.java
+++ b/common/iterator/Iterators.java
@@ -84,7 +84,7 @@ public class Iterators {
         return new TreeIterator<>(root, childrenFn);
     }
 
-    public static <T> ResourceIterator<T> synchronised(ResourceIterator<T> iterator) {
+    public static <T> SynchronisedIterator<T> synchronised(ResourceIterator<T> iterator) {
         return new SynchronisedIterator<>(iterator);
     }
 

--- a/common/iterator/ResourceIterator.java
+++ b/common/iterator/ResourceIterator.java
@@ -39,6 +39,8 @@ public interface ResourceIterator<T> extends Iterator<T> {
 
     <U> ResourceIterator<U> flatMap(Function<T, ResourceIterator<U>> flatMappingFn);
 
+    ResourceIterator<ResourceIterator<T>> split(int count);
+
     ResourceIterator<T> filter(Predicate<T> predicate);
 
     ResourceIterator<T> offset(long offset);

--- a/common/iterator/SplitIterator.java
+++ b/common/iterator/SplitIterator.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.common.iterator;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+
+import static grakn.core.common.iterator.Iterators.iterate;
+import static grakn.core.common.iterator.Iterators.synchronised;
+
+public class SplitIterator<T>
+        extends AbstractResourceIterator<ResourceIterator<T>>
+        implements ResourceIterator<ResourceIterator<T>> {
+
+    private final SynchronisedIterator<T> sourceIterator;
+    private final ResourceIterator<ResourceIterator<T>> splitIterators;
+
+    SplitIterator(ResourceIterator<T> iterator, int count) {
+        this.sourceIterator = synchronised(iterator);
+        ArrayList<ResourceIterator<T>> iterators = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            iterators.add(new AbstractResourceIterator<T>() {
+                T next = null;
+
+                @Override
+                public boolean hasNext() {
+                    return next != null || (next = sourceIterator.atomicNext()) != null;
+                }
+
+                @Override
+                public T next() {
+                    if (!hasNext()) throw new NoSuchElementException();
+                    T result = next;
+                    next = null;
+                    return result;
+                }
+
+                @Override
+                public void recycle() {
+                    sourceIterator.recycle();
+                }
+            });
+        }
+        this.splitIterators = iterate(iterators);
+    }
+
+    @Override
+    public boolean hasNext() {
+        return splitIterators.hasNext();
+    }
+
+    @Override
+    public ResourceIterator<T> next() {
+        return splitIterators.next();
+    }
+
+    @Override
+    public void recycle() {
+        sourceIterator.recycle();
+    }
+}

--- a/concept/BUILD
+++ b/concept/BUILD
@@ -38,6 +38,7 @@ native_java_libraries(
     deps = [
         # Internal dependencies
         "//common:common",
+        "//concurrent:concurrent",
         "//graph:graph",
 
         # Internal Repository Dependencies

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -183,7 +183,7 @@ public final class ConceptManager {
                 .filter(v -> !v.isInferred() && v.isModified() && !v.encoding().equals(ROLE))
                 .map(v -> { ThingImpl.of(v).validate(); return (Void) null; }).split(PARALLELISATION_FACTOR);
         ProducerIterator<Void> validations = produce(async(toValidate, PARALLELISATION_FACTOR));
-        while (validations.hasNext()) {validations.next();}
+        while (validations.hasNext()) validations.next();
     }
 
     public GraknException exception(ErrorMessage error) {

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -63,6 +63,7 @@ import static grakn.core.graph.common.Encoding.Prefix.VERTEX_ENTITY_TYPE;
 import static grakn.core.graph.common.Encoding.Prefix.VERTEX_RELATION_TYPE;
 import static grakn.core.graph.common.Encoding.Statistics.JobOperation.CREATED;
 import static grakn.core.graph.common.Encoding.Statistics.JobOperation.DELETED;
+import static grakn.core.graph.common.Encoding.Status.BUFFERED;
 import static grakn.core.graph.common.Encoding.ValueType.STRING_MAX_SIZE;
 import static grakn.core.graph.common.Encoding.Vertex.Thing.ATTRIBUTE;
 import static grakn.core.graph.common.StatisticsBytes.attributeCountJobKey;
@@ -429,7 +430,8 @@ public class DataGraph implements Graph {
      */
     @Override
     public void commit() {
-        thingsByIID.values().parallelStream().filter(v -> v.status().equals(Encoding.Status.BUFFERED) && !v.isInferred()).forEach(
+        // TODO: replace this parallel stream with our AsyncProducer
+        thingsByIID.values().parallelStream().filter(v -> v.status().equals(BUFFERED) && !v.isInferred()).forEach(
                 vertex -> vertex.iid(generate(storage.dataKeyGenerator(), vertex.type().iid(), vertex.type().properLabel()))
         ); // thingByIID no longer contains valid mapping from IID to TypeVertex
         thingsByIID.values().stream().filter(v -> !v.isInferred()).forEach(Vertex::commit);

--- a/rocks/RocksIterator.java
+++ b/rocks/RocksIterator.java
@@ -72,20 +72,6 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
     }
 
     @Override
-    public void recycle() {
-        close();
-    }
-
-    @Override
-    public void close() {
-        if (isOpen.compareAndSet(true, false)) {
-            if (state != State.INIT) storage.recycle(internalRocksIterator);
-            state = State.COMPLETED;
-            storage.remove(this);
-        }
-    }
-
-    @Override
     public final boolean hasNext() {
         switch (state) {
             case COMPLETED:
@@ -107,5 +93,19 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
         if (!hasNext()) throw new NoSuchElementException();
         state = State.EMPTY;
         return next;
+    }
+
+    @Override
+    public void recycle() {
+        close();
+    }
+
+    @Override
+    public void close() {
+        if (isOpen.compareAndSet(true, false)) {
+            if (state != State.INIT) storage.recycle(internalRocksIterator);
+            state = State.COMPLETED;
+            storage.remove(this);
+        }
     }
 }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -84,7 +84,7 @@ public class RocksStorage implements Storage {
     public byte[] get(byte[] key) {
         validateTransactionIsOpen();
         try {
-            // We don't need to check isOpen.get() as tx.commit() does not involve this method
+            // We don't need to check isOpen() as tx.commit() does not involve this method
             if (!isReadOnly) readWriteLock.lockRead();
             return storageTransaction.get(readOptions, key);
         } catch (RocksDBException | InterruptedException e) {
@@ -112,12 +112,12 @@ public class RocksStorage implements Storage {
     public void delete(byte[] key) {
         validateTransactionIsOpen();
         try {
-            if (isOpen.get()) readWriteLock.lockWrite();
+            if (isOpen()) readWriteLock.lockWrite();
             storageTransaction.delete(key);
         } catch (RocksDBException | InterruptedException e) {
             throw exception(e);
         } finally {
-            if (isOpen.get()) readWriteLock.unlockWrite();
+            if (isOpen()) readWriteLock.unlockWrite();
         }
     }
 
@@ -130,12 +130,12 @@ public class RocksStorage implements Storage {
     public void put(byte[] key, byte[] value) {
         validateTransactionIsOpen();
         try {
-            if (isOpen.get()) readWriteLock.lockWrite();
+            if (isOpen()) readWriteLock.lockWrite();
             storageTransaction.put(key, value);
         } catch (RocksDBException | InterruptedException e) {
             throw exception(e);
         } finally {
-            if (isOpen.get()) readWriteLock.unlockWrite();
+            if (isOpen()) readWriteLock.unlockWrite();
         }
     }
 
@@ -148,7 +148,7 @@ public class RocksStorage implements Storage {
     public void putUntracked(byte[] key, byte[] value) {
         validateTransactionIsOpen();
         try {
-            readWriteLock.lockWrite();
+            if (isOpen()) readWriteLock.lockWrite();
             storageTransaction.putUntracked(key, value);
         } catch (RocksDBException | InterruptedException e) {
             throw exception(e);
@@ -161,7 +161,7 @@ public class RocksStorage implements Storage {
     public void mergeUntracked(byte[] key, byte[] value) {
         validateTransactionIsOpen();
         try {
-            readWriteLock.lockWrite();
+            if (isOpen()) readWriteLock.lockWrite();
             storageTransaction.mergeUntracked(key, value);
         } catch (RocksDBException | InterruptedException e) {
             throw exception(e);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -192,19 +192,6 @@ public class RocksStorage implements Storage {
         return e;
     }
 
-    @Override
-    public void close() {
-        if (isOpen.compareAndSet(true, false)) {
-            iterators.parallelStream().forEach(RocksIterator::close);
-            recycled.forEach(AbstractImmutableNativeReference::close);
-            snapshot.close();
-            storageTransaction.close();
-            transactionOptions.close();
-            readOptions.close();
-            writeOptions.close();
-        }
-    }
-
     void validateTransactionIsOpen() {
         if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
     }
@@ -223,6 +210,19 @@ public class RocksStorage implements Storage {
 
     void remove(RocksIterator<?> iterator) {
         iterators.remove(iterator);
+    }
+
+    @Override
+    public void close() {
+        if (isOpen.compareAndSet(true, false)) {
+            iterators.parallelStream().forEach(RocksIterator::close);
+            recycled.forEach(AbstractImmutableNativeReference::close);
+            snapshot.close();
+            storageTransaction.close();
+            transactionOptions.close();
+            readOptions.close();
+            writeOptions.close();
+        }
     }
 
     static abstract class TransactionBounded extends RocksStorage {


### PR DESCRIPTION
## What is the goal of this PR?

When data writes get committed to the database, we perform some validation on each concept to make sure they remain compliant to the Grakn knowledge representation system, as well as the schema specification. Previously, the commit validation was executed only on one thread. This change improves this behaviour by parallelising the validation execution on as many threads as available to the server.

## What are the changes implemented in this PR?

- Introduce the ability to split a `ResourceIterator<T>` into multiple iterators: `ResourceIterator<ResourceIterator<T>`. We do so by calling, e.g. `resourceIterator.split(8)`, which will produce a `SplitIterator<T>` (which implements `ResourceIterator<ResourceIterator<T>>`.
- Reimplement `ConceptManager.validateThings()` to 