### PR TITLE
Port 1.8 resolution BDD tests without materialisation component

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -31,7 +31,6 @@ def graknlabs_common():
         tag = "2.0.0-alpha-6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
-
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
@@ -54,8 +53,12 @@ def graknlabs_grabl_tracing():
     )
 
 def graknlabs_behaviour():
-    git_repository(
+#    git_repository(
+#        name = "graknlabs_behaviour",
+#        remote = "https://github.com/graknlabs/behaviour",
+#        commit = "de69edaf88b4a130834094eee220365cc1a316aa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+#    )
+    native.local_repository(
         name = "graknlabs_behaviour",
-        remote = "https://github.com/graknlabs/behaviour",
-        commit = "de69edaf88b4a130834094eee220365cc1a316aa", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        path = "../behaviour",
     )

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -429,7 +429,6 @@ public class DataGraph implements Graph {
      */
     @Override
     public void commit() {
-        storage.lock()
         thingsByIID.values().parallelStream().filter(v -> v.status().equals(Encoding.Status.BUFFERED) && !v.isInferred()).forEach(
                 vertex -> vertex.iid(generate(storage.dataKeyGenerator(), vertex.type().iid(), vertex.type().properLabel()))
         ); // thingByIID no longer contains valid mapping from IID to TypeVertex

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -429,6 +429,7 @@ public class DataGraph implements Graph {
      */
     @Override
     public void commit() {
+        storage.lock()
         thingsByIID.values().parallelStream().filter(v -> v.status().equals(Encoding.Status.BUFFERED) && !v.isInferred()).forEach(
                 vertex -> vertex.iid(generate(storage.dataKeyGenerator(), vertex.type().iid(), vertex.type().properLabel()))
         ); // thingByIID no longer contains valid mapping from IID to TypeVertex

--- a/test/behaviour/exception/BUILD
+++ b/test/behaviour/exception/BUILD
@@ -15,40 +15,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
 host_compatible_java_library(
-    name = "steps",
+    name = "exception",
     srcs = [
-        "GraqlSteps.java"
+        "ScenarioDefinitionException.java"
     ],
-    deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
-        # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
-    ],
-    runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
-    ],
-    visibility = ["//visibility:public"],
 )
 
 checkstyle_test(

--- a/test/behaviour/exception/ScenarioDefinitionException.java
+++ b/test/behaviour/exception/ScenarioDefinitionException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.exception;
+
+public class ScenarioDefinitionException extends RuntimeException {
+    public ScenarioDefinitionException(String message) {
+        super(message);
+    }
+}

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -67,13 +67,6 @@ public class GraqlSteps {
     HashMap<String, UniquenessCheck> identifierChecks = new HashMap<>();
     private Map<String, Map<String, String>> rules;
 
-    @Given("the integrity is validated")
-    public void integrity_is_validated() {
-
-        // TODO
-
-    }
-
     @Given("graql define")
     public void graql_define(String defineQueryStatements) {
         GraqlDefine graqlQuery = Graql.parseQuery(String.join("\n", defineQueryStatements)).asDefine();

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -27,6 +27,7 @@ import grakn.core.concept.answer.NumericGroup;
 import grakn.core.concept.thing.Attribute;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Type;
+import grakn.core.test.behaviour.exception.ScenarioDefinitionException;
 import graql.lang.Graql;
 import graql.lang.pattern.variable.Reference;
 import graql.lang.query.GraqlDefine;
@@ -522,12 +523,6 @@ public class GraqlSteps {
         }
     }
 
-    private static class ScenarioDefinitionException extends RuntimeException {
-        ScenarioDefinitionException(String message) {
-            super(message);
-        }
-    }
-
     private interface UniquenessCheck {
         boolean check(Concept concept);
     }
@@ -601,7 +596,7 @@ public class GraqlSteps {
                     return dateTime.equals(attribute.asDateTime().getValue());
                 case OBJECT:
                 default:
-                    throw new GraqlSteps.ScenarioDefinitionException("Unrecognised value type " + attribute.getType().getValueType());
+                    throw new ScenarioDefinitionException("Unrecognised value type " + attribute.getType().getValueType());
             }
         }
     }
@@ -639,7 +634,7 @@ public class GraqlSteps {
                         break;
                     case OBJECT:
                     default:
-                        throw new GraqlSteps.ScenarioDefinitionException("Unrecognised value type " + key.getType().getValueType());
+                        throw new ScenarioDefinitionException("Unrecognised value type " + key.getType().getValueType());
                 }
 
                 keyMap.put(key.getType().getLabel().toString(), keyValue);

--- a/test/behaviour/resolution/BUILD
+++ b/test/behaviour/resolution/BUILD
@@ -15,21 +15,20 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
 load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
 host_compatible_java_library(
     name = "steps",
     srcs = [
-        "GraqlSteps.java"
+        "ResolutionSteps.java"
     ],
     deps = [
         # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
+        "//common",
         "//common/test:util",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/exception",
 
         # External dependencies from Grakn Labs
         "@graknlabs_graql//java:graql",
@@ -42,6 +41,7 @@ host_compatible_java_library(
         "@maven//:io_cucumber_cucumber_java",
     ],
     native_libraries_deps = [
+        "//:grakn",
         "//concept:concept",
     ],
     runtime_deps = [

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution;
+
+import grakn.core.Grakn;
+import grakn.core.common.parameters.Arguments;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.test.behaviour.exception.ScenarioDefinitionException;
+import graql.lang.Graql;
+import graql.lang.query.GraqlDefine;
+import graql.lang.query.GraqlInsert;
+import graql.lang.query.GraqlMatch;
+import graql.lang.query.GraqlQuery;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+import java.util.Set;
+
+import static grakn.core.test.behaviour.connection.ConnectionSteps.sessions;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ResolutionSteps {
+
+    private Grakn.Session reasonedSession;
+    private Grakn.Session materialisedSession;
+    private GraqlMatch queryToTest;
+    private Set<ConceptMap> answers;
+
+    @Given("for each session, graql define")
+    public void graql_define(String defineQueryStatements) {
+        graql_query(defineQueryStatements);
+    }
+
+    @Given("for each session, graql insert")
+    public void graql_insert(String insertQueryStatements) {
+        graql_query(insertQueryStatements);
+    }
+
+    @Given("materialised keyspace is named: {word}")
+    public void materialised_keyspace_is_named(String keyspaceName) {
+        Grakn.Session materialisedSession = sessions.stream()
+                .filter(s -> s.database().name().equals(keyspaceName))
+                .findAny()
+                .orElse(null);
+        setMaterialisedSession(materialisedSession);
+    }
+
+    @Given("reasoned keyspace is named: {word}")
+    public void reasoned_keyspace_is_named(String keyspaceName) {
+        Grakn.Session reasonedSession = sessions.stream()
+                .filter(s -> s.database().name().equals(keyspaceName))
+                .findAny()
+                .orElse(null);
+        setReasonedSession(reasonedSession);
+    }
+
+    @When("materialised keyspace is completed")
+    public void materialised_keyspace_is_completed() {
+        // TODO
+    }
+
+    @Then("for graql query")
+    public void for_graql_query(String graqlQuery) {
+        queryToTest = Graql.parseQuery(graqlQuery).asMatch();
+    }
+
+    @Then("answer size in reasoned keyspace is: {number}")
+    public void answer_size_in_reasoned_keyspace_is(int expectedCount) {
+        int resultCount;
+        try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
+            answers = transaction.query().match(queryToTest).toSet();
+            resultCount = answers.size();
+        }
+        if (expectedCount != resultCount) {
+            String msg = String.format("Query had an incorrect number of answers. Expected [%d] answers, " +
+                                               "but found [%d] answers, for query :\n %s", expectedCount, resultCount, queryToTest);
+//            throw new Resolution.CorrectnessException(msg);
+        }
+    }
+
+    @Then("answers are consistent across {int} executions in reasoned keyspace")
+    public void answers_are_consistent_across_n_executions_in_reasoned_keyspace(int executionCount) {
+        Set<ConceptMap> oldAnswers;
+        try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
+            oldAnswers = transaction.query().match(queryToTest).toSet();
+        }
+        for (int i = 0; i < executionCount - 1; i++) {
+            try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
+                Set<ConceptMap> answers = transaction.query().match(queryToTest).toSet();
+                assertEquals(oldAnswers, answers);
+            }
+        }
+    }
+
+    @Then("answer set is equivalent for graql query")
+    public void equivalent_answer_set(String equivalentQuery) {
+        assertNotNull("A graql query must have been previously loaded in order to test answer equivalence.", queryToTest);
+        assertNotNull("There are no previous answers to test against; was the reference query ever executed?", answers);
+        try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
+            Set<ConceptMap> newAnswers = transaction.query().match(Graql.parseQuery(equivalentQuery).asMatch()).toSet();
+            assertEquals(answers, newAnswers);
+        }
+    }
+
+    @Then("all answers are correct in reasoned keyspace")
+    public void reasoned_keyspace_all_answers_are_correct() {
+        // TODO
+    }
+
+    @Then("materialised and reasoned keyspaces are the same size")
+    public void keyspaces_are_the_same_size() {
+        // TODO
+    }
+
+    private void graql_query(String queryStatements) {
+        sessions.forEach(session -> {
+            Grakn.Transaction tx = session.transaction(Arguments.Transaction.Type.WRITE);
+            GraqlQuery query = Graql.parseQuery(String.join("\n", queryStatements));
+            if (query instanceof GraqlMatch) {
+                tx.query().match(query.asMatch());
+            } else if (query instanceof GraqlInsert) {
+                tx.query().insert(query.asInsert());
+            } else if (query instanceof GraqlDefine) {
+                tx.query().define(query.asDefine());
+            } else {
+                throw new ScenarioDefinitionException("Query not handled in ResolutionSteps" + queryStatements);
+            }
+            tx.commit();
+        });
+    }
+
+    private Grakn.Session getReasonedSession() {
+        return reasonedSession;
+    }
+
+    private Grakn.Session getMaterialisedSession() {
+        return materialisedSession;
+    }
+
+    private void setReasonedSession(Grakn.Session value) {
+        reasonedSession = value;
+    }
+
+    private void setMaterialisedSession(Grakn.Session value) {
+        materialisedSession = value;
+    }
+}

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -20,6 +20,7 @@ package grakn.core.test.behaviour.resolution;
 
 import grakn.core.Grakn;
 import grakn.core.common.parameters.Arguments;
+import grakn.core.common.parameters.Options;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.test.behaviour.exception.ScenarioDefinitionException;
 import graql.lang.Graql;
@@ -86,7 +87,7 @@ public class ResolutionSteps {
     public void answer_size_in_reasoned_keyspace_is(int expectedCount) {
         int resultCount;
         try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
-            answers = transaction.query().match(queryToTest).toSet();
+            answers = transaction.query().match(queryToTest, (new Options.Query().infer(true))).toSet();
             resultCount = answers.size();
         }
         if (expectedCount != resultCount) {
@@ -100,11 +101,11 @@ public class ResolutionSteps {
     public void answers_are_consistent_across_n_executions_in_reasoned_keyspace(int executionCount) {
         Set<ConceptMap> oldAnswers;
         try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
-            oldAnswers = transaction.query().match(queryToTest).toSet();
+            oldAnswers = transaction.query().match(queryToTest, (new Options.Query().infer(true))).toSet();
         }
         for (int i = 0; i < executionCount - 1; i++) {
             try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
-                Set<ConceptMap> answers = transaction.query().match(queryToTest).toSet();
+                Set<ConceptMap> answers = transaction.query().match(queryToTest, (new Options.Query().infer(true))).toSet();
                 assertEquals(oldAnswers, answers);
             }
         }
@@ -115,7 +116,8 @@ public class ResolutionSteps {
         assertNotNull("A graql query must have been previously loaded in order to test answer equivalence.", queryToTest);
         assertNotNull("There are no previous answers to test against; was the reference query ever executed?", answers);
         try (Grakn.Transaction transaction = reasonedSession.transaction(Arguments.Transaction.Type.READ)) {
-            Set<ConceptMap> newAnswers = transaction.query().match(Graql.parseQuery(equivalentQuery).asMatch()).toSet();
+            Set<ConceptMap> newAnswers = transaction.query().match(Graql.parseQuery(equivalentQuery).asMatch(),
+                                                                   (new Options.Query().infer(true))).toSet();
             assertEquals(answers, newAnswers);
         }
     }
@@ -135,7 +137,7 @@ public class ResolutionSteps {
             Grakn.Transaction tx = session.transaction(Arguments.Transaction.Type.WRITE);
             GraqlQuery query = Graql.parseQuery(String.join("\n", queryStatements));
             if (query instanceof GraqlMatch) {
-                tx.query().match(query.asMatch());
+                tx.query().match(query.asMatch(), (new Options.Query().infer(true)));
             } else if (query instanceof GraqlInsert) {
                 tx.query().insert(query.asInsert());
             } else if (query instanceof GraqlDefine) {

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -58,22 +58,22 @@ public class ResolutionSteps {
         graql_query(insertQueryStatements);
     }
 
-    @Given("materialised database is named: {word}")
-    public void materialised_database_is_named(String databaseName) {
+    @Given("materialised session has database name: {word}")
+    public void materialised_session_has_database_name(String databaseName) {
         Grakn.Session materialisedSession = sessions.stream()
                 .filter(s -> s.database().name().equals(databaseName))
                 .findAny()
                 .orElse(null);
-        setMaterialisedSession(materialisedSession);
+        this.materialisedSession = materialisedSession;
     }
 
-    @Given("reasoned database is named: {word}")
-    public void reasoned_database_is_named(String databaseName) {
+    @Given("reasoned session has database name: {word}")
+    public void reasoned_session_has_database_name(String databaseName) {
         Grakn.Session reasonedSession = sessions.stream()
                 .filter(s -> s.database().name().equals(databaseName))
                 .findAny()
                 .orElse(null);
-        setReasonedSession(reasonedSession);
+        this.reasonedSession = reasonedSession;
     }
 
     @When("materialised database is completed")
@@ -154,11 +154,4 @@ public class ResolutionSteps {
         return transactions.get(0);
     }
 
-    private void setReasonedSession(Grakn.Session value) {
-        reasonedSession = value;
-    }
-
-    private void setMaterialisedSession(Grakn.Session value) {
-        materialisedSession = value;
-    }
 }

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import static grakn.core.test.behaviour.connection.ConnectionSteps.sessions;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 public class ResolutionSteps {
 
@@ -93,7 +94,7 @@ public class ResolutionSteps {
         if (expectedCount != resultCount) {
             String msg = String.format("Query had an incorrect number of answers. Expected [%d] answers, " +
                                                "but found [%d] answers, for query :\n %s", expectedCount, resultCount, queryToTest);
-//            throw new Resolution.CorrectnessException(msg);
+            fail(msg);
         }
     }
 

--- a/test/behaviour/resolution/framework/BUILD
+++ b/test/behaviour/resolution/framework/BUILD
@@ -1,0 +1,26 @@
+#
+# Copyright (C) 2020 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+
+# TODO migrate from 1.8 when required
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob(["*"]),
+    license_type = "agpl",
+)

--- a/test/behaviour/resolution/tests/attribute_attachment/AttributeAttachmentTest.java
+++ b/test/behaviour/resolution/tests/attribute_attachment/AttributeAttachmentTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/attribute-attachment.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/attribute-attachment.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class AttributeAttachmentTest {

--- a/test/behaviour/resolution/tests/attribute_attachment/AttributeAttachmentTest.java
+++ b/test/behaviour/resolution/tests/attribute_attachment/AttributeAttachmentTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.attribute_attachment;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/attribute-attachment.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class AttributeAttachmentTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/attribute_attachment/BUILD
+++ b/test/behaviour/resolution/tests/attribute_attachment/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "AttributeAttachmentTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.attribute_attachment.AttributeAttachmentTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:attribute-attachment.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/attribute_attachment/BUILD
+++ b/test/behaviour/resolution/tests/attribute_attachment/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "AttributeAttachmentTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.attribute_attachment.AttributeAttachmentTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.attribute_attachment.AttributeAttachmentTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/concept_inequality/BUILD
+++ b/test/behaviour/resolution/tests/concept_inequality/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "ConceptInequalityTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.concept_inequality.ConceptInequalityTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:concept-inequality.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/concept_inequality/BUILD
+++ b/test/behaviour/resolution/tests/concept_inequality/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "ConceptInequalityTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.concept_inequality.ConceptInequalityTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.concept_inequality.ConceptInequalityTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/concept_inequality/ConceptInequalityTest.java
+++ b/test/behaviour/resolution/tests/concept_inequality/ConceptInequalityTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/concept-inequality.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/concept-inequality.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class ConceptInequalityTest {

--- a/test/behaviour/resolution/tests/concept_inequality/ConceptInequalityTest.java
+++ b/test/behaviour/resolution/tests/concept_inequality/ConceptInequalityTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.concept_inequality;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/concept-inequality.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class ConceptInequalityTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/negation/BUILD
+++ b/test/behaviour/resolution/tests/negation/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "NegationTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.negation.NegationTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.negation.NegationTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/negation/BUILD
+++ b/test/behaviour/resolution/tests/negation/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "NegationTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.negation.NegationTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:negation.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/negation/NegationTest.java
+++ b/test/behaviour/resolution/tests/negation/NegationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.negation;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/negation.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class NegationTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/negation/NegationTest.java
+++ b/test/behaviour/resolution/tests/negation/NegationTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/negation.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/negation.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class NegationTest {

--- a/test/behaviour/resolution/tests/recursion/BUILD
+++ b/test/behaviour/resolution/tests/recursion/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "RecursionTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.recursion.RecursionTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:recursion.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/recursion/BUILD
+++ b/test/behaviour/resolution/tests/recursion/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "RecursionTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.recursion.RecursionTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.recursion.RecursionTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/recursion/RecursionTest.java
+++ b/test/behaviour/resolution/tests/recursion/RecursionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.recursion;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/recursion.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class RecursionTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/recursion/RecursionTest.java
+++ b/test/behaviour/resolution/tests/recursion/RecursionTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/recursion.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/recursion.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class RecursionTest {

--- a/test/behaviour/resolution/tests/relation_inference/BUILD
+++ b/test/behaviour/resolution/tests/relation_inference/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "RelationInferenceTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.relation_inference.RelationInferenceTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.relation_inference.RelationInferenceTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/relation_inference/BUILD
+++ b/test/behaviour/resolution/tests/relation_inference/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,32 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "RelationInferenceTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.relation_inference.RelationInferenceTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
     ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:relation-inference.feature",
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/relation_inference/RelationInferenceTest.java
+++ b/test/behaviour/resolution/tests/relation_inference/RelationInferenceTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/relation-inference.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/relation-inference.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class RelationInferenceTest {

--- a/test/behaviour/resolution/tests/relation_inference/RelationInferenceTest.java
+++ b/test/behaviour/resolution/tests/relation_inference/RelationInferenceTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.relation_inference;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/relation-inference.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class RelationInferenceTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/resolution_test_framework/BUILD
+++ b/test/behaviour/resolution/tests/resolution_test_framework/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "ResolutionTestFrameworkTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.resolution_test_framework.ResolutionTestFrameworkTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.resolution_test_framework.ResolutionTestFrameworkTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/resolution_test_framework/BUILD
+++ b/test/behaviour/resolution/tests/resolution_test_framework/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "ResolutionTestFrameworkTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.resolution_test_framework.ResolutionTestFrameworkTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:resolution-test-framework.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/resolution_test_framework/ResolutionTestFrameworkTest.java
+++ b/test/behaviour/resolution/tests/resolution_test_framework/ResolutionTestFrameworkTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/resolution-test-framework.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/resolution-test-framework.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class ResolutionTestFrameworkTest {

--- a/test/behaviour/resolution/tests/resolution_test_framework/ResolutionTestFrameworkTest.java
+++ b/test/behaviour/resolution/tests/resolution_test_framework/ResolutionTestFrameworkTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.resolution_test_framework;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/resolution-test-framework.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class ResolutionTestFrameworkTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/schema_queries/BUILD
+++ b/test/behaviour/resolution/tests/schema_queries/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "SchemaQueriesTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.schema_queries.SchemaQueriesTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:schema-queries.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/schema_queries/BUILD
+++ b/test/behaviour/resolution/tests/schema_queries/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "SchemaQueriesTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.schema_queries.SchemaQueriesTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.schema_queries.SchemaQueriesTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/schema_queries/SchemaQueriesTest.java
+++ b/test/behaviour/resolution/tests/schema_queries/SchemaQueriesTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/schema-queries.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/schema-queries.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class SchemaQueriesTest {

--- a/test/behaviour/resolution/tests/schema_queries/SchemaQueriesTest.java
+++ b/test/behaviour/resolution/tests/schema_queries/SchemaQueriesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.schema_queries;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/schema-queries.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class SchemaQueriesTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/type_hierarchy/BUILD
+++ b/test/behaviour/resolution/tests/type_hierarchy/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "TypeHierarchyTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.type_hierarchy.TypeHierarchyTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.type_hierarchy.TypeHierarchyTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/type_hierarchy/BUILD
+++ b/test/behaviour/resolution/tests/type_hierarchy/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "TypeHierarchyTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.type_hierarchy.TypeHierarchyTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:type-hierarchy.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/type_hierarchy/TypeHierarchyTest.java
+++ b/test/behaviour/resolution/tests/type_hierarchy/TypeHierarchyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.type_hierarchy;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/type-hierarchy.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class TypeHierarchyTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/type_hierarchy/TypeHierarchyTest.java
+++ b/test/behaviour/resolution/tests/type_hierarchy/TypeHierarchyTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/type-hierarchy.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/type-hierarchy.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class TypeHierarchyTest {

--- a/test/behaviour/resolution/tests/value_predicate/BUILD
+++ b/test/behaviour/resolution/tests/value_predicate/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "ValuePredicateTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.value_predicate.ValuePredicateTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.value_predicate.ValuePredicateTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/value_predicate/BUILD
+++ b/test/behaviour/resolution/tests/value_predicate/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "ValuePredicateTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.value_predicate.ValuePredicateTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:value-predicate.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/value_predicate/ValuePredicateTest.java
+++ b/test/behaviour/resolution/tests/value_predicate/ValuePredicateTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.value_predicate;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/value-predicate.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class ValuePredicateTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/value_predicate/ValuePredicateTest.java
+++ b/test/behaviour/resolution/tests/value_predicate/ValuePredicateTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/value-predicate.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/value-predicate.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class ValuePredicateTest {

--- a/test/behaviour/resolution/tests/variable_roles/BUILD
+++ b/test/behaviour/resolution/tests/variable_roles/BUILD
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 Grakn Labs
+# Copyright (C) 2020 Grakn Labs
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -15,40 +15,33 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-package(default_visibility = ["//test/behaviour/graql/language/define:__subpackages__"])
-
+package(default_visibility = ["//test/behaviour:__subpackages__"])
 load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_library")
 
-host_compatible_java_library(
-    name = "steps",
+java_test(
+    name = "test",
     srcs = [
-        "GraqlSteps.java"
+        "VariableRolesTest.java",
     ],
+    test_class = "grakn.core.test.behaviour.resolution.reasoner.variable_roles.VariableRolesTest",
     deps = [
-        # Package dependencies
-        "//test/behaviour/exception",
-        "//test/behaviour/connection:steps",
-        "//common/test:util",
-
-        # External dependencies from Grakn Labs
-        "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
-        "@graknlabs_graql//java/query",
-        "@graknlabs_common//:common",
-
         # External dependencies from Maven
-        "@maven//:junit_junit",
-        "@maven//:io_cucumber_cucumber_java",
-    ],
-    native_libraries_deps = [
-        "//concept:concept",
+        "@maven//:io_cucumber_cucumber_junit",
     ],
     runtime_deps = [
-        "//test/behaviour/connection/database:steps",
-        "//test/behaviour/connection/transaction:steps",
+        "//test/behaviour/connection:steps",
+        "//test/behaviour/connection/session:steps",
+        "//test/behaviour/config:parameters",
+        "//test/behaviour/resolution:steps",
+    ],
+    data = [
+        "@graknlabs_behaviour//graql/reasoner:variable-roles.feature",
     ],
     visibility = ["//visibility:public"],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
 )
 
 checkstyle_test(

--- a/test/behaviour/resolution/tests/variable_roles/BUILD
+++ b/test/behaviour/resolution/tests/variable_roles/BUILD
@@ -23,7 +23,7 @@ java_test(
     srcs = [
         "VariableRolesTest.java",
     ],
-    test_class = "grakn.core.test.behaviour.resolution.reasoner.variable_roles.VariableRolesTest",
+    test_class = "grakn.core.test.behaviour.resolution.tests.variable_roles.VariableRolesTest",
     deps = [
         # External dependencies from Maven
         "@maven//:io_cucumber_cucumber_junit",

--- a/test/behaviour/resolution/tests/variable_roles/VariableRolesTest.java
+++ b/test/behaviour/resolution/tests/variable_roles/VariableRolesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2020 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.test.behaviour.resolution.tests.variable_roles;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        strict = true,
+        plugin = "pretty",
+        glue = "grakn.core.test.behaviour",
+        features = "external/graknlabs_verification/behaviour/graql/reasoner/variable-roles.feature",
+        tags = "not @ignore and not @ignore-grakn-core"
+)
+public class VariableRolesTest {
+    // ATTENTION:
+    // When you click RUN from within this class through Intellij IDE, it will fail.
+    // You can fix it by doing:
+    //
+    // 1) Go to 'Run'
+    // 2) Select 'Edit Configurations...'
+    // 3) Select 'Bazel test UndefineTest'
+    //
+    // 4) Ensure 'Target Expression' is set correctly:
+    //    a) Use '//<this>/<package>/<name>:test-core' to test against grakn-core
+    //    b) Use '//<this>/<package>/<name>:test-kgms' to test against grakn-kgms
+    //
+    // 5) Update 'Bazel Flags':
+    //    a) Remove the line that says: '--test_filter=grakn.core.*'
+    //    b) Use the following Bazel flags:
+    //       --cache_test_results=no : to make sure you're not using cache
+    //       --test_output=streamed : to make sure all output is printed
+    //       --subcommands : to print the low-level commands and execution paths
+    //       --sandbox_debug : to keep the sandbox not deleted after test runs
+    //       --spawn_strategy=standalone : if you're on Mac, tests need permission to access filesystem (to run Grakn)
+    //
+    // 6) Hit the RUN button by selecting the test from the dropdown menu on the top bar
+}

--- a/test/behaviour/resolution/tests/variable_roles/VariableRolesTest.java
+++ b/test/behaviour/resolution/tests/variable_roles/VariableRolesTest.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
         strict = true,
         plugin = "pretty",
         glue = "grakn.core.test.behaviour",
-        features = "external/graknlabs_verification/behaviour/graql/reasoner/variable-roles.feature",
+        features = "external/graknlabs_behaviour/graql/reasoner/variable-roles.feature",
         tags = "not @ignore and not @ignore-grakn-core"
 )
 public class VariableRolesTest {


### PR DESCRIPTION
## What is the goal of this PR?
Implement BDD reasoning (aka resolution) tests that were present, and enable tests only using the handwritten answer counts. A later PR will enable forward-chaining based answer comparison.

TODO: arithmetic-equality and rule-interaction BDDs

## What are the changes implemented in this PR?
