### PR TITLE
Sessions no longer close when one of their transaction streams ends abruptly

### DIFF
--- a/server/rpc/TransactionStream.java
+++ b/server/rpc/TransactionStream.java
@@ -97,23 +97,11 @@ public class TransactionStream implements StreamObserver<Transaction.Req> {
         }
     }
 
-    /**
-     * This method is invoked when a client abruptly terminates a connection to
-     * the server. So, we want to make sure to also close and delete the current
-     * session and all the transactions associated to the same client.
-     *
-     * This might create issues if a session is used by other concurrent clients,
-     * the better approach would be to signal a closure intent to the session
-     * and the session should be able to detect whether it's been used by other
-     * connections, if not close it completely.
-     *
-     * TODO: improve by sending closure intent to the session
-     */
     @Override
     public void onError(Throwable error) {
         try {
             TransactionRPC t;
-            if ((t = transactionRPC.get()) != null) t.sessionRPC().closeWithError(error);
+            if ((t = transactionRPC.get()) != null) t.close();
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
         } finally {

--- a/server/rpc/TransactionStream.java
+++ b/server/rpc/TransactionStream.java
@@ -101,7 +101,7 @@ public class TransactionStream implements StreamObserver<Transaction.Req> {
     public void onError(Throwable error) {
         try {
             TransactionRPC t;
-            if ((t = transactionRPC.get()) != null) t.close();
+            if ((t = transactionRPC.get()) != null) t.closeWithError(error);
         } catch (Exception e) {
             LOG.error(e.getMessage(), e);
         } finally {


### PR DESCRIPTION
## What is the goal of this PR?

We had a safety measure where, if an RPC transaction stream was abruptly ended by the peer, the server would close its session. This was to prevent "zombie sessions" lingering on the server despite the client being gone. However, it causes issues when a session opens many transactions. If one of them ends abruptly, that may not mean the _whole_ client failed; perhaps just one thread on it. So we don't want the session to die.

Previously, this safeguard was the least bad option. But now we have session timeout, it is no longer serving any purpose. So we may safely remove it, allowing sessions to continue even if one of their transactions dies.

## What are the changes implemented in this PR?

Sessions no longer close when one of their transaction streams ends abruptly
