### PR TITLE
Speed up remote caching by minimizing downloads

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,4 +27,4 @@ build:rbe --bes_results_url=https://app.buildbuddy.io/invocation/
 build:rbe --tls_client_certificate=/opt/credentials/buildbuddy-cert.pem
 build:rbe --tls_client_key=/opt/credentials/buildbuddy-key.pem
 build:rbe --remote_timeout=3600
-
+build:rbe --remote_download_minimal


### PR DESCRIPTION
## What is the goal of this PR?

Speed up `build` phase of CI by instructing Bazel to minimize the amount of downloads it does.

## What are the changes implemented in this PR?

Add an option that instructs Bazel to conserve bandwidth