### PR TITLE
Make CI green again

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -102,7 +102,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
+      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_GRAKN_USERNAME
         export DEPLOY_APT_PASSWORD=$REPO_GRAKN_PASSWORD
@@ -112,7 +112,7 @@ build:
       filter:
         owner: graknlabs
         branch: master
-      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour]
+      dependencies: [build, build-dependency, test-unit, test-integration, test-behaviour-connection, test-behaviour-concept, test-behaviour-match, test-behaviour-writable, test-behaviour-definable]
       command: |
         bazel test --config=rbe //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:


### PR DESCRIPTION
## What is the goal of this PR?

Fix `automation.yml` such that CI pipeline is operational again.

## What are the changes implemented in this PR?

Instead of depending on `test-behaviour` job which is no longer present, depend on all `test-behaviour-*` jobs that replaced it.