### PR TITLE
Fix transaction conflict checking exception in statistics counter thread

### DIFF
--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -729,8 +729,7 @@ public class DataGraph implements Graph {
 
         public boolean processCountJobs() {
             ResourceIterator<CountJob> countJobs = storage.iterate(StatisticsBytes.countJobKey(), CountJob::of);
-            long processedCount = 0;
-            while (processedCount < COUNT_JOB_BATCH_SIZE && countJobs.hasNext()) {
+            for (long processed = 0; processed < COUNT_JOB_BATCH_SIZE && countJobs.hasNext(); processed++) {
                 CountJob countJob = countJobs.next();
                 if (countJob instanceof CountJob.Attribute) {
                     processAttributeCountJob(countJob);
@@ -740,7 +739,6 @@ public class DataGraph implements Graph {
                     assert false;
                 }
                 storage.delete(countJob.key());
-                processedCount++;
             }
             storage.mergeUntracked(snapshotKey(), longToBytes(1));
             return countJobs.hasNext();

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -370,7 +370,8 @@ public class RocksDatabase implements Grakn.Database {
         private void countFn() {
             do {
                 try (RocksTransaction.Data tx = session.transaction(WRITE)) {
-                    tx.graphMgr.data().stats().processCountJobs();
+                    boolean shouldRestart = tx.graphMgr.data().stats().processCountJobs();
+                    if (shouldRestart) countJobNotifications.release();
                     tx.commit();
                 } catch (GraknException e) {
                     if (e.code().isPresent() && e.code().get().equals(DATABASE_CLOSED.code())) {


### PR DESCRIPTION
## What is the goal of this PR?

Process statistics counting jobs in small batches so that it won't run too long and cause rocksDB unable to check transaction conflicts.

## What are the changes implemented in this PR?

- Process statistics counting jobs in small batches.