### PR TITLE
Event loop catches all errors

### DIFF
--- a/concurrent/actor/Actor.java
+++ b/concurrent/actor/Actor.java
@@ -87,7 +87,7 @@ public class Actor<STATE extends Actor.State<STATE>> {
     public static abstract class State<STATE extends State<STATE>> {
         private final Actor<STATE> self;
 
-        protected abstract void exception(Exception e);
+        protected abstract void exception(Throwable e);
 
         protected State(Actor<STATE> self) {
             this.self = self;

--- a/concurrent/actor/EventLoop.java
+++ b/concurrent/actor/EventLoop.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 
 public class EventLoop {
     private static final Logger LOG = LoggerFactory.getLogger(EventLoop.class);
-    private static final Consumer<Exception> DEFAULT_EXCEPTION_HANDLER = e -> LOG.error("An unexpected error has occurred.", e);
+    private static final Consumer<Throwable> DEFAULT_EXCEPTION_HANDLER = e -> LOG.error("An unexpected error has occurred.", e);
 
     private enum State {READY, RUNNING, STOPPED}
 
@@ -50,13 +50,13 @@ public class EventLoop {
         thread.start();
     }
 
-    public void schedule(Runnable job, Consumer<Exception> errorHandler) {
+    public void schedule(Runnable job, Consumer<Throwable> errorHandler) {
         assert state != State.STOPPED : "unexpected state: " + state;
 
         jobs.offer(new Job(job, errorHandler));
     }
 
-    public EventLoop.Cancellable schedule(long deadline, Runnable job, Consumer<Exception> errorHandler) {
+    public EventLoop.Cancellable schedule(long deadline, Runnable job, Consumer<Throwable> errorHandler) {
         assert state != State.STOPPED : "unexpected state: " + state;
         return new Cancellable(deadline, job, errorHandler);
     }
@@ -105,7 +105,7 @@ public class EventLoop {
     public class Cancellable {
         private ScheduledJobQueue.Scheduled scheduled;
 
-        public Cancellable(long scheduleMs, Runnable job, Consumer<Exception> errorHandler) {
+        public Cancellable(long scheduleMs, Runnable job, Consumer<Throwable> errorHandler) {
             scheduled = null;
             EventLoop.this.schedule(() -> scheduled = scheduledJobs.offer(scheduleMs, new Job(job, errorHandler)), errorHandler);
         }
@@ -117,9 +117,9 @@ public class EventLoop {
 
     private static class Job {
         private final Runnable job;
-        private final Consumer<Exception> errorHandler;
+        private final Consumer<Throwable> errorHandler;
 
-        public Job(Runnable job, Consumer<Exception> errorHandler) {
+        public Job(Runnable job, Consumer<Throwable> errorHandler) {
             this.job = job;
             this.errorHandler = errorHandler;
         }
@@ -127,7 +127,7 @@ public class EventLoop {
         public void run() {
             try {
                 job.run();
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 errorHandler.accept(e);
             }
         }

--- a/concurrent/actor/EventLoop.java
+++ b/concurrent/actor/EventLoop.java
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 
 public class EventLoop {
     private static final Logger LOG = LoggerFactory.getLogger(EventLoop.class);
-    private static final Consumer<Throwable> DEFAULT_EXCEPTION_HANDLER = e -> LOG.error("An unexpected error has occurred.", e);
+    private static final Consumer<Throwable> DEFAULT_ERROR_HANDLER = e -> LOG.error("An unexpected error has occurred.", e);
 
     private enum State {READY, RUNNING, STOPPED}
 
@@ -66,7 +66,7 @@ public class EventLoop {
     }
 
     public synchronized void stop() throws InterruptedException {
-        schedule(() -> state = State.STOPPED, DEFAULT_EXCEPTION_HANDLER);
+        schedule(() -> state = State.STOPPED, DEFAULT_ERROR_HANDLER);
         await();
     }
 
@@ -111,7 +111,7 @@ public class EventLoop {
         }
 
         public void cancel() {
-            EventLoop.this.schedule(() -> scheduled.cancel(), DEFAULT_EXCEPTION_HANDLER);
+            EventLoop.this.schedule(() -> scheduled.cancel(), DEFAULT_ERROR_HANDLER);
         }
     }
 

--- a/reasoner/resolution/ResolutionRecorder.java
+++ b/reasoner/resolution/ResolutionRecorder.java
@@ -45,7 +45,7 @@ public class ResolutionRecorder extends Actor.State<ResolutionRecorder> {
     }
 
     @Override
-    protected void exception(Exception e) {
+    protected void exception(Throwable e) {
         LOG.error("Actor exception", e);
     }
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -185,7 +185,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
     }
 
     @Override
-    protected void exception(Exception e) {
+    protected void exception(Throwable e) {
         LOG.error("Actor exception", e);
         // TODO, once integrated into the larger flow of executing queries, kill the actors and report and exception to root
     }

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -130,7 +130,7 @@ public class RetrievableResolver extends ResolvableResolver<RetrievableResolver>
     }
 
     @Override
-    protected void exception(Exception e) {
+    protected void exception(Throwable e) {
         LOG.error("Actor exception", e);
     }
 

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -205,7 +205,7 @@ public class RootResolver extends Resolver<RootResolver> {
     }
 
     @Override
-    protected void exception(Exception e) {
+    protected void exception(Throwable e) {
         LOG.error("Actor exception", e);
         // TODO, once integrated into the larger flow of executing queries, kill the actors and report and exception to root
     }

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -201,7 +201,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
     }
 
     @Override
-    protected void exception(Exception e) {
+    protected void exception(Throwable e) {
         LOG.error("Actor exception", e);
         // TODO, once integrated into the larger flow of executing queries, kill the actors and report and exception to root
     }


### PR DESCRIPTION
## What is the goal of this PR?
The event loop threads should not die when errors nor exceptions are thrown. This PR allows the event loop to catch any throwable, and propagate the error to the responsible actor.

## What are the changes implemented in this PR?
* error handlers associated with `Job`s in the event loop now consume `Throwable` instead of just `Exception`
* All subtypes of `Actor.State` must now implement `exception(Throwable e)` instead of `exception(Exception e)`