### PR TITLE
Optimised key ownership validation at commit time

### DIFF
--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -207,7 +207,8 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     @Override
     public void validate() {
-        if (getHas(true).map(Attribute::getType).count() < getType().getOwns(true).count()) {
+        long requiredKeys = getType().getOwns(true).count();
+        if (requiredKeys > 0 && getHas(true).map(Attribute::getType).count() < requiredKeys) {
             Set<AttributeType> missing = getType().getOwns(true).collect(toSet());
             missing.removeAll(getHas(true).map(Attribute::getType).collect(toSet()));
             throw exception(GraknException.of(THING_KEY_MISSING, getType().getLabel(), printTypeSet(missing)));


### PR DESCRIPTION
## What is the goal of this PR?
We make key validation much cheaper, when no keys can be present. In our previous implementation of concept validation, we checked whether required key attributes are owned - however in practice we accidentally scanned ALL attributes owned if _no_ attributes are owned as keys! This PR changes the implementation to only check for keys if there are key-attributes.

## What are the changes implemented in this PR?
* Only scan owned attributes by keyed type, if the attribute is required to own any keys.