### PR TITLE
Reasoner resolvers handle old exhausted messages correctly

### DIFF
--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -69,25 +69,25 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     }
 
     private void requestFailed(int iteration) {
-        LOG.trace("New iteration {}", iteration);
-        assert this.iteration == iteration || this.iteration == iteration + 1;
+        LOG.trace("Failed to find answer to request in iteration: " + iteration);
 
-        if (iteration == this.iteration && mustReiterate()) {
-            nextIteration();
-            retry();
-        } else if (this.iteration == iteration) {
-            // fully terminated finding answers
-            if (!done) {
-                done = true;
-                queue.done();
+        if (!done && iteration == this.iteration && !mustReiterate()) {
+            // query is completely terminated
+            done = true;
+            queue.done();
+            return;
+        }
+
+        if (!done) {
+            if (iteration == this.iteration) {
+                prepareNextIteration();
             }
-        } else {
-            // straggler request failing from prior iteration
-            retry();
+            assert iteration < this.iteration;
+            retryInNewIteration();
         }
     }
 
-    private void nextIteration() {
+    private void prepareNextIteration() {
         iteration++;
         iterationInferredAnswer = false;
         resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY);
@@ -104,7 +104,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         return iterationInferredAnswer;
     }
 
-    private void retry() {
+    private void retryInNewIteration() {
         requestAnswer();
     }
 

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -49,6 +49,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
         this.resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY);
         this.queue = null;
         this.iteration = 0;
+        this.done = false;
     }
 
     @Override

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -139,6 +139,12 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
+        if (iteration < responseProducer.iteration()) {
+            // short circuit old iteration exhausted messages back out of the actor model
+            respondToUpstream(new Response.Exhausted(fromUpstream), iteration);
+            return;
+        }
+
         responseProducer.removeDownstreamProducer(fromDownstream.sourceRequest());
         tryAnswer(fromUpstream, responseProducer, iteration);
     }

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -140,7 +140,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
         if (iteration < responseProducer.iteration()) {
-            // short circuit old iteration exhausted messages back out of the actor model
+            // short circuit old iteration exhausted messages to upstream
             respondToUpstream(new Response.Exhausted(fromUpstream), iteration);
             return;
         }

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -60,7 +60,7 @@ public class RetrievableResolver extends ResolvableResolver<RetrievableResolver>
         LOG.trace("{}: received Request: {}", name(), fromUpstream);
         ResponseProducer responseProducer = mayUpdateAndGetResponseProducer(fromUpstream, iteration);
         if (iteration < responseProducer.iteration()) {
-            // short circuit if the request came from a prior iteration
+            // short circuit old iteration exhausted messages to upstream
             respondToUpstream(new Response.Exhausted(fromUpstream), iteration);
         } else {
             assert iteration == responseProducer.iteration();

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -150,7 +150,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
         if (iteration < responseProducer.iteration()) {
-            // short circuit old iteration exhausted messages back out of the actor model
+            // short circuit old iteration exhausted messages to upstream
             respondToUpstream(new Response.Exhausted(fromUpstream), iteration);
             return;
         }

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -149,6 +149,12 @@ public class RuleResolver extends Resolver<RuleResolver> {
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
+        if (iteration < responseProducer.iteration()) {
+            // short circuit old iteration exhausted messages back out of the actor model
+            respondToUpstream(new Response.Exhausted(fromUpstream), iteration);
+            return;
+        }
+
         responseProducer.removeDownstreamProducer(fromDownstream.sourceRequest());
         tryAnswer(fromUpstream, responseProducer, iteration);
     }


### PR DESCRIPTION
## What is the goal of this PR?
To prevent a class of bugs to do with reiteration (which are difficult to test), we make sure we don't let previous iterations' `Exhausted` event loop messages pollute more advanced iteration states. One visible consequence is when a reasoning query reports it is finished, and we close resources, we no longer see exceptions due to ongoing resolver work.

## What are the changes implemented in this PR?
* The ReasonerProducer only retries requests from previous iterations that failed in new iterations, if it hasn't already completely terminated
* Each resolver receiving an out of date response will immediately forward it upstream, and not allow it to affect new iteration state