### PR TITLE
Run reasoning exclusively when rules are present

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -498,8 +498,10 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     }
 
     public static class Reasoner extends ErrorMessage {
+        public static final Reasoner REASONING_CANNOT_BE_TOGGLED_PER_QUERY =
+                new Reasoner(1, "Reasoning enabled/disabled cannot be set per query. Try using Transaction options instead");
         public static final Reasoner REVERSE_UNIFICATION_MISSING_CONCEPT =
-                new Reasoner(1, "Reverse unification failed because a concept for identifier '%s' was not found in the provided map '%s'");
+                new Reasoner(2, "Reverse unification failed because a concept for identifier '%s' was not found in the provided map '%s'");
 
         private static final String codePrefix = "RSN";
         private static final String messagePrefix = "Reasoner Error";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -499,7 +499,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
 
     public static class Reasoner extends ErrorMessage {
         public static final Reasoner REASONING_CANNOT_BE_TOGGLED_PER_QUERY =
-                new Reasoner(1, "Reasoning enabled/disabled cannot be set per query. Try using Transaction options instead");
+                new Reasoner(1, "Reasoning cannot be enabled/disabled per query. Try using Transaction options instead");
         public static final Reasoner REVERSE_UNIFICATION_MISSING_CONCEPT =
                 new Reasoner(2, "Reverse unification failed because a concept for identifier '%s' was not found in the provided map '%s'");
 

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -21,6 +21,7 @@ import grakn.core.common.exception.GraknException;
 import graql.lang.query.GraqlQuery;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_ARGUMENT;
+import static grakn.core.common.exception.ErrorMessage.Reasoner.REASONING_CANNOT_BE_TOGGLED_PER_QUERY;
 
 public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options<?, ?>> {
 
@@ -156,6 +157,11 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
             } else {
                 return DEFAULT_QUERY_READ_PREFETCH;
             }
+        }
+
+        @Override
+        public Query infer(boolean infer) {
+            throw GraknException.of(REASONING_CANNOT_BE_TOGGLED_PER_QUERY);
         }
 
         public Query prefetch(boolean prefetch) {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -71,7 +71,6 @@ public class Rule {
     private final Conjunction when;
     private final Conjunction then;
     private final Conclusion conclusion;
-    private final Set<Concludable> requiredWhenConcludables;
 
     private Rule(LogicManager logicMgr, RuleStructure structure) {
         this.structure = structure;
@@ -79,7 +78,6 @@ public class Rule {
         this.then = thenPattern(structure.then(), logicMgr);
         pruneThenResolvedTypes();
         this.conclusion = Conclusion.create(this.then);
-        this.requiredWhenConcludables = Concludable.create(this.when);
     }
 
     private Rule(GraphManager graphMgr, LogicManager logicMgr, String label,
@@ -90,7 +88,6 @@ public class Rule {
         validateSatisfiable();
         pruneThenResolvedTypes();
         this.conclusion = Conclusion.create(this.then);
-        this.requiredWhenConcludables = Concludable.create(this.when);
         validateInsertable();
         validateCycles();
         this.conclusion.index(this);
@@ -103,10 +100,6 @@ public class Rule {
     public static Rule of(GraphManager graphMgr, LogicManager logicMgr, String label,
                           graql.lang.pattern.Conjunction<? extends Pattern> when, ThingVariable<?> then) {
         return new Rule(graphMgr, logicMgr, label, when, then);
-    }
-
-    public Set<Concludable> whenConcludables() {
-        return requiredWhenConcludables;
     }
 
     public Conclusion conclusion() {

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -24,6 +24,7 @@ import grakn.core.pattern.constraint.thing.RelationConstraint;
 import graql.lang.Graql;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Set;
 
 import static grakn.common.collection.Collections.list;
@@ -64,6 +65,26 @@ public class ConcludableTest {
     }
 
     @Test
+    public void rule_concludables_built_correctly_from_rule_concerning_has_isa_value() throws IOException {
+        String conjunction = "{ $x isa milk, has age-in-days >= 10; }";
+        Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(1, hasConcludablesCount(concludables));
+        assertEquals(0, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
+    }
+
+    @Test
+    public void rule_concludables_built_correctly_from_rule_concerning_has() throws IOException {
+        String conjunction = "{ $x isa milk; $a 10 isa age-in-days; }";
+        Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(2, isaConcludablesCount(concludables));
+        assertEquals(0, hasConcludablesCount(concludables));
+        assertEquals(0, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
+    }
+
+    @Test
     public void test_conjunction_only_has_is_built() {
         String conjunction = "{ $a has $b; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
@@ -82,6 +103,7 @@ public class ConcludableTest {
         assertEquals(0, relationConcludablesCount(concludables));
         assertEquals(0, attributeConcludablesCount(concludables));
     }
+
 
     @Test
     public void test_conjunction_only_relation_is_built() {
@@ -239,6 +261,10 @@ public class ConcludableTest {
         String conjunction = "{ $diag(patient-role-type: $per) isa $diagnosis; $diagnosis type diagnosis-type;" +
                 "$per isa $person; $person type person-type; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(0, hasConcludablesCount(concludables));
+        assertEquals(1, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
         RelationConstraint relationConstraint = concludables.stream().filter(Concludable::isRelation).findFirst().get()
                 .asRelation().relation();
         IsaConstraint relationIsaConstraint = relationConstraint.owner().isa().get();
@@ -251,6 +277,10 @@ public class ConcludableTest {
     public void test_conjunction_concludables_contain_type_labels_with_anonymous_type_variable() {
         String conjunction = "{ $diag(patient-role-type: $per) isa diagnosis; $per isa person; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(0, hasConcludablesCount(concludables));
+        assertEquals(1, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
         RelationConstraint relationConstraint = concludables.stream().filter(Concludable::isRelation).findFirst()
                 .get().asRelation().relation();
         IsaConstraint relationIsaConstraint = relationConstraint.owner().isa().get();
@@ -263,6 +293,10 @@ public class ConcludableTest {
     public void test_conjunction_concludables_contain_type_labels_with_anonymous_type_and_relation_variable() {
         String conjunction = "{ (patient-role-type: $per) isa diagnosis; $per isa person; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(0, hasConcludablesCount(concludables));
+        assertEquals(1, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
         RelationConstraint relationConstraint = concludables.stream().filter(Concludable::isRelation).findFirst().get()
                 .asRelation().relation();
         IsaConstraint relationIsaConstraint = relationConstraint.owner().isa().get();
@@ -276,6 +310,10 @@ public class ConcludableTest {
         String conjunction = "{ (patient-role-type: $per) isa diagnosis; (patient-role-type: $p2) isa diagnosis; " +
                 "$per isa person; $per has age 50; $per has age 70; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(2, hasConcludablesCount(concludables));
+        assertEquals(2, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
         concludables.stream().filter(Concludable::isRelation).map(Concludable::asRelation).forEach(relationConcludable -> {
             assertTrue(relationConcludable.relation().owner().isa().isPresent());
         });
@@ -284,4 +322,5 @@ public class ConcludableTest {
             assertTrue(hasConcludable.has().attribute().isa().isPresent());
         });
     }
+
 }

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -24,7 +24,6 @@ import grakn.core.pattern.constraint.thing.RelationConstraint;
 import graql.lang.Graql;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Set;
 
 import static grakn.common.collection.Collections.list;
@@ -65,17 +64,7 @@ public class ConcludableTest {
     }
 
     @Test
-    public void rule_concludables_built_correctly_from_rule_concerning_has_isa_value() throws IOException {
-        String conjunction = "{ $x isa milk, has age-in-days >= 10; }";
-        Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
-        assertEquals(1, isaConcludablesCount(concludables));
-        assertEquals(1, hasConcludablesCount(concludables));
-        assertEquals(0, relationConcludablesCount(concludables));
-        assertEquals(0, attributeConcludablesCount(concludables));
-    }
-
-    @Test
-    public void rule_concludables_built_correctly_from_rule_concerning_has() throws IOException {
+    public void test_conjunction_isa_value_constrained_is_built() {
         String conjunction = "{ $x isa milk; $a 10 isa age-in-days; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
         assertEquals(2, isaConcludablesCount(concludables));
@@ -104,6 +93,15 @@ public class ConcludableTest {
         assertEquals(0, attributeConcludablesCount(concludables));
     }
 
+    @Test
+    public void test_conjunction_isa_has_value_constrained_is_built() {
+        String conjunction = "{ $x isa milk, has age-in-days >= 10; }";
+        Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
+        assertEquals(1, isaConcludablesCount(concludables));
+        assertEquals(1, hasConcludablesCount(concludables));
+        assertEquals(0, relationConcludablesCount(concludables));
+        assertEquals(0, attributeConcludablesCount(concludables));
+    }
 
     @Test
     public void test_conjunction_only_relation_is_built() {
@@ -322,5 +320,4 @@ public class ConcludableTest {
             assertTrue(hasConcludable.has().attribute().isa().isPresent());
         });
     }
-
 }

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -133,7 +133,7 @@ public class Reasoner {
         ResourceIterator<ConceptMap> answers;
         Conjunction conj = logicMgr.typeResolver().resolve(conjunction);
         if (conj.isSatisfiable()) {
-            if (!isInfer(context)) answers = produce(resolve(conj), context.producer());
+            if (isInfer(context)) answers = produce(resolve(conj), context.producer());
             else answers = traversalEng.iterator(conjunction.traversal(filter)).map(conceptMgr::conceptMap);
         } else if (!filter.isEmpty() && iterate(filter).anyMatch(id -> conj.variable(id).isThing()) ||
                 iterate(conjunction.variables()).anyMatch(Variable::isThing)) {

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -209,11 +209,13 @@ public class RootResolver extends Resolver<RootResolver> {
         ResourceIterator<ConceptMap> traversalIterator = traversalEngine.iterator(conjunction.traversal())
                 .map(conceptMgr::conceptMap);
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(traversalIterator, newIteration);
-        Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                              UpstreamVars.Initial.of(request.answerBounds().conceptMap()).
-                                                      toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                              new ResolutionAnswer.Derivation(map()), 0);
-        responseProducerNewIter.addDownstreamProducer(toDownstream);
+        if (!plan.isEmpty()) {
+            Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
+                                                  UpstreamVars.Initial.of(request.answerBounds().conceptMap()).
+                                                          toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
+                                                  new ResolutionAnswer.Derivation(map()), 0);
+            responseProducerNewIter.addDownstreamProducer(toDownstream);
+        }
         return responseProducerNewIter;
     }
 

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -167,9 +167,10 @@ public class RootResolver extends Resolver<RootResolver> {
 
     @Override
     protected void initialiseDownstreamActors() {
-        if (!concludables.isEmpty()) {
-            Set<Concludable> concludables = Iterators.iterate(Concludable.create(conjunction))
-                    .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
+        LOG.debug("{}: initialising downstream actors", name());
+        Set<Concludable> concludables = Iterators.iterate(Concludable.create(conjunction))
+                .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
+        if (concludables.size() > 0) {
             Set<Retrievable> retrievables = Retrievable.extractFrom(conjunction, concludables);
             Set<Resolvable> resolvables = new HashSet<>();
             resolvables.addAll(concludables);

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -69,7 +69,6 @@ public class RootResolver extends Resolver<RootResolver> {
     private final Actor<ResolutionRecorder> resolutionRecorder;
     private final Consumer<ResolutionAnswer> onAnswer;
     private final Consumer<Integer> onExhausted;
-    private final Set<Concludable> concludables;
     private final List<Resolvable> plan;
     private boolean isInitialised;
     private ResponseProducer responseProducer;
@@ -87,8 +86,6 @@ public class RootResolver extends Resolver<RootResolver> {
         this.logicMgr = logicMgr;
         this.planner = planner;
         this.isInitialised = false;
-        this.concludables = Iterators.iterate(Concludable.create(conjunction))
-                .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
         this.plan = new ArrayList<>();
         this.downstreamResolvers = new HashMap<>();
     }
@@ -171,6 +168,8 @@ public class RootResolver extends Resolver<RootResolver> {
     @Override
     protected void initialiseDownstreamActors() {
         if (!concludables.isEmpty()) {
+            Set<Concludable> concludables = Iterators.iterate(Concludable.create(conjunction))
+                    .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
             Set<Retrievable> retrievables = Retrievable.extractFrom(conjunction, concludables);
             Set<Resolvable> resolvables = new HashSet<>();
             resolvables.addAll(concludables);

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -190,12 +190,13 @@ public class RootResolver extends Resolver<RootResolver> {
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(conjunction.traversal())
                 .map(conceptMgr::conceptMap);
         ResponseProducer responseProducer = new ResponseProducer(traversalProducer, iteration);
-        Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                              UpstreamVars.Initial.of(request.answerBounds().conceptMap())
-                                                      .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                              new ResolutionAnswer.Derivation(map()), 0);
-        responseProducer.addDownstreamProducer(toDownstream);
-
+        if (!plan.isEmpty()) {
+            Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
+                                                  UpstreamVars.Initial.of(request.answerBounds().conceptMap())
+                                                          .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
+                                                  new ResolutionAnswer.Derivation(map()), 0);
+            responseProducer.addDownstreamProducer(toDownstream);
+        }
         return responseProducer;
     }
 

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -182,12 +182,13 @@ public class RuleResolver extends Resolver<RuleResolver> {
         Traversal traversal = boundTraversal(rule.when().traversal(), request.answerBounds().conceptMap());
         ResourceIterator<ConceptMap> traversalIterator = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         ResponseProducer responseProducer = new ResponseProducer(traversalIterator, iteration);
-        Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                              AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
-                                                      .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                              new ResolutionAnswer.Derivation(map()), 0);
-        responseProducer.addDownstreamProducer(toDownstream);
-
+        if (!plan.isEmpty()) {
+            Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
+                                                  AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
+                                                          .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
+                                                  new ResolutionAnswer.Derivation(map()), 0);
+            responseProducer.addDownstreamProducer(toDownstream);
+        }
         return responseProducer;
     }
 
@@ -199,11 +200,13 @@ public class RuleResolver extends Resolver<RuleResolver> {
         Traversal traversal = boundTraversal(rule.when().traversal(), request.answerBounds().conceptMap());
         ResourceIterator<ConceptMap> traversalIterator = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(traversalIterator, newIteration);
-        Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                              AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
-                                                      .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                              new ResolutionAnswer.Derivation(map()), 0);
-        responseProducerNewIter.addDownstreamProducer(toDownstream);
+        if (!plan.isEmpty()) {
+            Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
+                                                  AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
+                                                          .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
+                                                  new ResolutionAnswer.Derivation(map()), 0);
+            responseProducerNewIter.addDownstreamProducer(toDownstream);
+        }
         return responseProducerNewIter;
     }
 

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -162,8 +162,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
     @Override
     protected void initialiseDownstreamActors() {
         LOG.debug("{}: initialising downstream actors", name());
-
-        Set<Concludable> concludablesWithApplicableRules = Iterators.iterate(rule.whenConcludables())
+        Set<Concludable> concludablesWithApplicableRules = Iterators.iterate(Concludable.create(rule.when()))
                 .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
         Set<Retrievable> retrievables = Retrievable.extractFrom(rule.when(), concludablesWithApplicableRules);
         Set<Resolvable> resolvables = new HashSet<>();

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -162,17 +162,19 @@ public class RuleResolver extends Resolver<RuleResolver> {
     @Override
     protected void initialiseDownstreamActors() {
         LOG.debug("{}: initialising downstream actors", name());
-        Set<Concludable> concludablesWithApplicableRules = Iterators.iterate(Concludable.create(rule.when()))
+        Set<Concludable> concludables = Iterators.iterate(Concludable.create(rule.when()))
                 .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
-        Set<Retrievable> retrievables = Retrievable.extractFrom(rule.when(), concludablesWithApplicableRules);
-        Set<Resolvable> resolvables = new HashSet<>();
-        resolvables.addAll(concludablesWithApplicableRules);
-        resolvables.addAll(retrievables);
+        if (concludables.size() > 0) {
+            Set<Retrievable> retrievables = Retrievable.extractFrom(rule.when(), concludables);
+            Set<Resolvable> resolvables = new HashSet<>();
+            resolvables.addAll(concludables);
+            resolvables.addAll(retrievables);
 
-        plan = planner.plan(resolvables);
-        iterate(plan).forEachRemaining(resolvable -> {
-            downstreamResolvers.put(resolvable, registry.registerResolvable(resolvable));
-        });
+            plan = planner.plan(resolvables);
+            iterate(plan).forEachRemaining(resolvable -> {
+                downstreamResolvers.put(resolvable, registry.registerResolvable(resolvable));
+            });
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?
To avoid having to deduplicate answers from traversal engine and reasoner, we choose to either only execute a query in the traversal engine, or only in reasoner. The switch for this is whether there are any rules present. Further, the root reasoning resolver only creates child resolvers if any rules are applicable to the query it contains.

## What are the changes implemented in this PR?
* Either return a producer from the traversal, or a producer from reasoner when executing a query, depending on whether there are any rules present
* `RootResolver` only creates child resolvers if there are any applicable rules to any of the built concludables
* Throw an exception when trying to set inference on/off per-query (must be at transaction level, because we materialise answers in the graph. If the user runs a reasoning query, then disables reasoner, they will still see inferred answers! This is unexpected UX.)
* Rules no longer contain concludables directly, however, `RuleResolver` builds concludables for the rule's `when` conjunction lazily
* Migrate some `RuleTest` tests to `ConcludableTest`