### PR TITLE
Correct traversal backtracking through relation scopes

### DIFF
--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -163,12 +163,13 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             if (edge.onlyStartsFromRelation()) {
                 seekStack.addSeeks(iterate(scopedEdgeOrders.get(edge.from().id().asVariable())).toSet());
                 seekStack.addSeeks(edge.to().dependedEdgeOrders());
-            }
-            if (edge.onlyEndsAtRelation()) {
+            } else if (edge.onlyEndsAtRelation()) {
                 seekStack.addSeeks(edge.from().dependedEdgeOrders());
                 seekStack.addSeeks(iterate(scopedEdgeOrders.get(edge.to().id().asVariable())).toSet());
+            } else {
+                seekStack.addSeeks(edge.to().dependedEdgeOrders());
+                seekStack.addSeeks(edge.from().dependedEdgeOrders());
             }
-
             return false;
         }
     }

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -32,6 +32,7 @@ import grakn.core.traversal.procedure.ProcedureEdge;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -251,7 +252,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     private boolean isClosure(ProcedureEdge<?, ?> edge, Vertex<?, ?> fromVertex, Vertex<?, ?> toVertex) {
         if (edge.isRolePlayer()) {
             Set<ThingVertex> withinScope = scopedRoles.computeIfAbsent(edge.asRolePlayer().scope(), id -> new HashSet<>());
-            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(edge.asRolePlayer().scope(), id -> new PriorityQueue<>());
+            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(edge.asRolePlayer().scope(), id -> new PriorityQueue<>(Comparator.reverseOrder()));
             boolean closed = edge.asRolePlayer().isClosure(graphMgr, fromVertex, toVertex, params, withinScope);
             if (closed) {
                 assert !scopedEdgeOrder.contains(edge.order());
@@ -268,7 +269,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         if (edge.to().id().isScoped()) {
             Identifier.Variable scope = edge.to().id().asScoped().scope();
             Set<ThingVertex> withinScope = scopedRoles.computeIfAbsent(scope, id -> new HashSet<>());
-            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(scope, id -> new PriorityQueue<>());
+            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(scope, id -> new PriorityQueue<>(Comparator.reverseOrder()));
             toIter = edge.branch(graphMgr, fromVertex, params).filter(role -> {
                 if (withinScope.contains(role.asThing())) return false;
                 else {
@@ -283,7 +284,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         } else if (edge.isRolePlayer()) {
             Identifier.Variable scope = edge.asRolePlayer().scope();
             Set<ThingVertex> withinScope = scopedRoles.computeIfAbsent(scope, id -> new HashSet<>());
-            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(scope, id -> new PriorityQueue<>());
+            PriorityQueue<Integer> scopedEdgeOrder = scopedEdgeOrders.computeIfAbsent(scope, id -> new PriorityQueue<>(Comparator.reverseOrder()));
             toIter = edge.asRolePlayer().branchEdge(graphMgr, fromVertex, params).filter(e -> {
                 if (withinScope.contains(e.optimised().get())) return false;
                 else {

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -164,12 +164,11 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     }
 
     private void closureFailure(ProcedureEdge<?, ?> edge) {
+        assert edge.from().id().isVariable();
         if (edge.onlyStartsFromRelation()) {
-            assert edge.from().id().isVariable();
             seekStack.addSeeks(scopes.get(edge.from().id().asVariable()).edgeOrders());
             seekStack.addSeeks(edge.to().dependedEdgeOrders());
         } else if (edge.onlyEndsAtRelation()) {
-            assert edge.from().id().isVariable();
             seekStack.addSeeks(edge.from().dependedEdgeOrders());
             seekStack.addSeeks(scopes.get(edge.to().id().asVariable()).edgeOrders());
         } else {

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -126,12 +126,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
                     else {
                         backTrackCleanUp(pos);
                         answer.remove(toID);
-                        if (edge.onlyStartsFromRelation()) {
-                            assert fromId.isVariable();
-                            seekStack.addSeeks(scopes.get(fromId.asVariable()).edgeOrders());
-                        } else {
-                            seekStack.addSeeks(edge.from().dependedEdgeOrders());
-                        }
+                        branchFailure(edge);
                         return false;
                     }
                 } else {
@@ -143,12 +138,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             }
             return true;
         } else {
-            if (edge.onlyStartsFromRelation()) {
-                assert fromId.isVariable();
-                seekStack.addSeeks(scopes.get(fromId.asVariable()).edgeOrders());
-            } else {
-                seekStack.addSeeks(edge.from().dependedEdgeOrders());
-            }
+            branchFailure(edge);
             return false;
         }
     }
@@ -159,19 +149,32 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             if (pos == edgeCount) return true;
             else return computeFirst(pos + 1);
         } else {
-            if (edge.onlyStartsFromRelation()) {
-                assert edge.from().id().isVariable();
-                seekStack.addSeeks(scopes.get(edge.from().id().asVariable()).edgeOrders());
-                seekStack.addSeeks(edge.to().dependedEdgeOrders());
-            } else if (edge.onlyEndsAtRelation()) {
-                assert edge.from().id().isVariable();
-                seekStack.addSeeks(edge.from().dependedEdgeOrders());
-                seekStack.addSeeks(scopes.get(edge.to().id().asVariable()).edgeOrders());
-            } else {
-                seekStack.addSeeks(edge.to().dependedEdgeOrders());
-                seekStack.addSeeks(edge.from().dependedEdgeOrders());
-            }
+            closureFailure(edge);
             return false;
+        }
+    }
+
+    private void branchFailure(ProcedureEdge<?, ?> edge) {
+        if (edge.onlyStartsFromRelation()) {
+            assert edge.from().id().isVariable();
+            seekStack.addSeeks(scopes.get(edge.from().id().asVariable()).edgeOrders());
+        } else {
+            seekStack.addSeeks(edge.from().dependedEdgeOrders());
+        }
+    }
+
+    private void closureFailure(ProcedureEdge<?, ?> edge) {
+        if (edge.onlyStartsFromRelation()) {
+            assert edge.from().id().isVariable();
+            seekStack.addSeeks(scopes.get(edge.from().id().asVariable()).edgeOrders());
+            seekStack.addSeeks(edge.to().dependedEdgeOrders());
+        } else if (edge.onlyEndsAtRelation()) {
+            assert edge.from().id().isVariable();
+            seekStack.addSeeks(edge.from().dependedEdgeOrders());
+            seekStack.addSeeks(scopes.get(edge.to().id().asVariable()).edgeOrders());
+        } else {
+            seekStack.addSeeks(edge.to().dependedEdgeOrders());
+            seekStack.addSeeks(edge.from().dependedEdgeOrders());
         }
     }
 

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -121,6 +121,8 @@ public abstract class ProcedureEdge<
 
     public boolean onlyStartsFromRelation() { return false; }
 
+    public boolean onlyEndsAtRelation() { return false; }
+
     public boolean onlyStartsFromAttributeType() { return false; }
 
     public boolean onlyStartsFromRelationType() { return false; }
@@ -935,6 +937,11 @@ public abstract class ProcedureEdge<
                                              Traversal.Parameters params) {
                         return fromVertex.asThing().ins().edge(RELATING, toVertex.asThing()) != null;
                     }
+
+                    @Override
+                    public boolean onlyEndsAtRelation() {
+                        return true;
+                    }
                 }
             }
 
@@ -1115,6 +1122,11 @@ public abstract class ProcedureEdge<
                                     e -> e.from().equals(rel) && !withinScope.contains(e.optimised().get())
                             );
                         }
+                    }
+
+                    @Override
+                    public boolean onlyEndsAtRelation() {
+                        return true;
                     }
                 }
             }

--- a/traversal/procedure/ProcedureEdge.java
+++ b/traversal/procedure/ProcedureEdge.java
@@ -1062,14 +1062,14 @@ public abstract class ProcedureEdge<
                         if (!roleTypes.isEmpty()) {
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> rel.outs().edge(ROLEPLAYER, rt.iid(), player.iid().prefix(), player.iid().type()).get()
-                                            .filter(e -> e.to().equals(player) && !scoped.isRoleVisited(e.optimised().get())))
+                                            .filter(e -> e.to().equals(player) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {
                             validEdge = rel.outs().edge(ROLEPLAYER).get().filter(
-                                    e -> e.to().equals(player) && !scoped.isRoleVisited(e.optimised().get())
+                                    e -> e.to().equals(player) && !scoped.contains(e.optimised().get())
                             ).first();
                         }
-                        validEdge.ifPresent(e -> scoped.roleVisited(e.optimised().get(), order()));
+                        validEdge.ifPresent(e -> scoped.record(e.optimised().get(), order()));
                         return validEdge.isPresent();
                     }
                 }
@@ -1123,14 +1123,14 @@ public abstract class ProcedureEdge<
                         if (!roleTypes.isEmpty()) {
                             validEdge = iterate(resolvedRoleTypes(graphMgr.schema())).flatMap(
                                     rt -> player.ins().edge(ROLEPLAYER, rt.iid(), rel.iid().prefix(), rel.iid().type()).get()
-                                            .filter(e -> e.from().equals(rel) && !scoped.isRoleVisited(e.optimised().get())))
+                                            .filter(e -> e.from().equals(rel) && !scoped.contains(e.optimised().get())))
                                     .first();
                         } else {
                             validEdge = player.ins().edge(ROLEPLAYER).get().filter(
-                                    e -> e.from().equals(rel) && !scoped.isRoleVisited(e.optimised().get())
+                                    e -> e.from().equals(rel) && !scoped.contains(e.optimised().get())
                             ).first();
                         }
-                        validEdge.ifPresent(e -> scoped.roleVisited(e.optimised().get(), order()));
+                        validEdge.ifPresent(e -> scoped.record(e.optimised().get(), order()));
                         return validEdge.isPresent();
                     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We encountered a query plans where answers go missing, when doing optimised backtracking from a scoped role back to the relation that scopes the role instance or role player edge. This PR corrects backtracking optimisations to avoid missing anwers that are valid.

## What are the changes implemented in this PR?
* Implement a priority queue associated with each relation that can be a scoper of role instances
* when backtracking from a scoped role, we only backtrack to the last role `branch` edge, rather than the edge that generates the relation itself. This means we "free" up roles to be re-visited by later iterators, rather than missing them completely