### PR TITLE
Throw exception correctly on transaction lock timeout

### DIFF
--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -151,7 +151,7 @@ public class RocksDatabase implements Grakn.Database {
                 lock = dataWriteSchemaLock().tryWriteLock(options.schemaLockAcquireTimeoutMillis(), TimeUnit.MILLISECONDS);
                 if (lock == 0) throw GraknException.of(SCHEMA_ACQUIRE_LOCK_TIMEOUT);
             } catch (InterruptedException e) {
-                throw GraknException.of(SCHEMA_ACQUIRE_LOCK_TIMEOUT);
+                throw GraknException.of(e);
             }
             session = sessionFactory.sessionSchema(this, options);
         } else if (type.isData()) {

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -149,6 +149,7 @@ public class RocksDatabase implements Grakn.Database {
         if (type.isSchema()) {
             try {
                 lock = dataWriteSchemaLock().tryWriteLock(options.schemaLockAcquireTimeoutMillis(), TimeUnit.MILLISECONDS);
+                if (lock == 0) throw GraknException.of(SCHEMA_ACQUIRE_LOCK_TIMEOUT);
             } catch (InterruptedException e) {
                 throw GraknException.of(SCHEMA_ACQUIRE_LOCK_TIMEOUT);
             }

--- a/rocks/RocksSession.java
+++ b/rocks/RocksSession.java
@@ -186,8 +186,8 @@ public abstract class RocksSession implements Grakn.Session {
                 int timeout = options.schemaLockAcquireTimeoutMillis();
                 lock = database().dataWriteSchemaLock().tryReadLock(timeout, TimeUnit.MILLISECONDS);
                 if (lock == 0) throw GraknException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
-            } catch (InterruptedException err) {
-                throw GraknException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
+            } catch (InterruptedException e) {
+                throw GraknException.of(e);
             }
             RocksTransaction.Data transaction = txDataFactory.transaction(this, type, options);
             transactions.put(transaction, lock);

--- a/rocks/RocksSession.java
+++ b/rocks/RocksSession.java
@@ -185,6 +185,7 @@ public abstract class RocksSession implements Grakn.Session {
             try {
                 int timeout = options.schemaLockAcquireTimeoutMillis();
                 lock = database().dataWriteSchemaLock().tryReadLock(timeout, TimeUnit.MILLISECONDS);
+                if (lock == 0) throw GraknException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
             } catch (InterruptedException err) {
                 throw GraknException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
             }


### PR DESCRIPTION
## What is the goal of this PR?

When a transaction fails to acquire a write lock, presently, it throws `ERROR: Error: 13 INTERNAL: null Please check server logs for the stack trace.` when a commit is attempted, which is incorrect. We made it instead throw  `ERROR: Error: 13 INTERNAL: [TXN13] Invalid Transaction Operation: Could not acquire lock for data transaction. A schema session may have been left open. Please check server logs for the stack trace.` immediately, which is much more informative.


## What are the changes implemented in this PR?

Check the return value from trying to acquire a lock and correctly throw an exception if the result is 0, meaning the attempt timed out.