### PR TITLE
Prevent losing disjunctions' conjunctions

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,5 +56,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "7a4c464e2af295bb2bd392d9cc61784ecbed137e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "71f72dce4e7b46488f0f1f5a6c457018b83660c5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -23,6 +23,7 @@ import grakn.core.pattern.variable.VariableRegistry;
 import graql.lang.pattern.Conjunctable;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
@@ -33,15 +34,15 @@ import static graql.lang.common.GraqlToken.Char.CURLY_OPEN;
 import static graql.lang.common.GraqlToken.Char.NEW_LINE;
 import static graql.lang.common.GraqlToken.Operator.OR;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Collectors.toList;
 
 public class Disjunction implements Pattern, Cloneable {
 
     private static final String TRACE_PREFIX = "disjunction.";
-    private final Set<Conjunction> conjunctions;
+    private final List<Conjunction> conjunctions;
     private final int hash;
 
-    public Disjunction(Set<Conjunction> conjunctions) {
+    public Disjunction(List<Conjunction> conjunctions) {
         this.conjunctions = conjunctions;
         this.hash = Objects.hash(conjunctions);
     }
@@ -57,17 +58,17 @@ public class Disjunction implements Pattern, Cloneable {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "create")) {
             return new Disjunction(graql.patterns().stream().map(
                     conjunction -> Conjunction.create(conjunction, bounds)
-            ).collect(toSet()));
+            ).collect(toList()));
         }
     }
 
-    public Set<Conjunction> conjunctions() {
+    public List<Conjunction> conjunctions() {
         return conjunctions;
     }
 
     @Override
     public Disjunction clone() {
-        return new Disjunction(iterate(conjunctions).map(Conjunction::clone).toSet());
+        return new Disjunction(iterate(conjunctions).map(Conjunction::clone).toList());
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?
We currently do an unintuitive equality check for Conjunctions, depending only on the identifier of the variables - regardles of constraints, which can lead to losing "equal" conjunctions. To prevent deduplicating conjunctions we create in a disjunction, we store them in a list rather than a set. This can be correctly implemented after is https://github.com/graknlabs/grakn/issues/6115 is complete.

## What are the changes implemented in this PR?
* Store conjunctions in a list, within a disjunction
* Bump `@graknlabs_behaviour`, which contains a test that fails for this case without this fix.