### PR TITLE
Inject filters into reasoner resolvers

### DIFF
--- a/common/iterator/AbstractResourceIterator.java
+++ b/common/iterator/AbstractResourceIterator.java
@@ -189,6 +189,12 @@ public abstract class AbstractResourceIterator<T> implements ResourceIterator<T>
     }
 
     @Override
+    public void toSet(Set<T> set) {
+        this.forEachRemaining(set::add);
+        recycle();
+    }
+
+    @Override
     public LinkedHashSet<T> toLinkedSet() {
         LinkedHashSet<T> linkedSet = new LinkedHashSet<>();
         forEachRemaining(linkedSet::add);

--- a/common/iterator/ResourceIterator.java
+++ b/common/iterator/ResourceIterator.java
@@ -73,6 +73,8 @@ public interface ResourceIterator<T> extends Iterator<T> {
 
     Set<T> toSet();
 
+    void toSet(Set<T> set);
+
     LinkedHashSet<T> toLinkedSet();
 
     long count();

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class Conjunction implements Pattern, Cloneable {
         return negations;
     }
 
-    public Traversal traversal(List<Identifier.Variable.Name> filter) {
+    public Traversal traversal(Set<Identifier.Variable.Name> filter) {
         Traversal traversal = new Traversal();
         variableSet.forEach(variable -> variable.addTo(traversal));
         assert iterate(filter).allMatch(variableMap::containsKey);
@@ -142,7 +143,7 @@ public class Conjunction implements Pattern, Cloneable {
     }
 
     public Traversal traversal() {
-        return traversal(new ArrayList<>());
+        return traversal(new HashSet<>());
     }
 
     public void setSatisfiable(boolean isSatisfiable) {

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -25,8 +25,6 @@ import graql.lang.pattern.Conjunctable;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.iterator.Iterators.iterate;

--- a/pattern/Disjunction.java
+++ b/pattern/Disjunction.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.iterator.Iterators.iterate;

--- a/query/Matcher.java
+++ b/query/Matcher.java
@@ -70,7 +70,7 @@ public class Matcher {
     private final Reasoner reasoner;
     private final GraqlMatch query;
     private final Disjunction disjunction;
-    private final List<Identifier.Variable.Name> filter;
+    private final Set<Identifier.Variable.Name> filter;
     private final Context.Query context;
 
     public Matcher(Reasoner reasoner, GraqlMatch query) {
@@ -81,7 +81,7 @@ public class Matcher {
         this.reasoner = reasoner;
         this.query = query;
         this.disjunction = Disjunction.create(query.conjunction().normalise());
-        this.filter = iterate(query.filter()).map(v -> Identifier.Variable.of(v.reference().asName())).toList();
+        this.filter = iterate(query.filter()).map(v -> Identifier.Variable.of(v.reference().asName())).toSet();
         this.context = context;
         if (context != null) {
             if (query.sort().isPresent()) this.context.producer(EXHAUSTIVE); // TODO: remove this once sort is optimised

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -41,10 +41,8 @@ import grakn.core.traversal.common.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.util.Set;
 
-import static grakn.common.collection.Collections.list;
 import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Pattern.UNSATISFIABLE_CONJUNCTION;
 import static grakn.core.common.iterator.Iterators.iterate;

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -30,10 +30,8 @@ import graql.lang.pattern.variable.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.List;
 import java.util.Set;
 
 import static grakn.core.common.iterator.Iterators.iterate;
@@ -75,7 +73,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
 
     private void requestAnswered(ResolutionAnswer resolutionAnswer) {
         if (resolutionAnswer.isInferred()) iterationInferredAnswer = true;
-        queue.put(resolutionAnswer.derived().withInitial()); // withInitial includes filtering
+        queue.put(resolutionAnswer.derived().withInitialFiltered()); // withInitial includes filtering
     }
 
     private void requestExhausted(int iteration) {

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -25,28 +25,37 @@ import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.reasoner.resolution.framework.Request;
 import grakn.core.reasoner.resolution.framework.ResolutionAnswer;
 import grakn.core.reasoner.resolution.resolver.RootResolver;
+import grakn.core.traversal.common.Identifier;
+import graql.lang.pattern.variable.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.List;
+import java.util.Set;
+
+import static grakn.core.common.iterator.Iterators.iterate;
 import static grakn.core.reasoner.resolution.answer.AnswerState.DownstreamVars.Root;
 import static grakn.core.reasoner.resolution.framework.ResolutionAnswer.Derivation.EMPTY;
 
-@ThreadSafe // TODO: verify
+@ThreadSafe
 public class ReasonerProducer implements Producer<ConceptMap> {
     private static final Logger LOG = LoggerFactory.getLogger(ReasonerProducer.class);
 
     private final Actor<RootResolver> rootResolver;
+    private final Set<Reference.Name> filter;
     private Queue<ConceptMap> queue;
     private Request resolveRequest;
     private boolean iterationInferredAnswer;
     private boolean done;
     private int iteration;
 
-    public ReasonerProducer(Conjunction conjunction, ResolverRegistry resolverMgr) {
+    public ReasonerProducer(Conjunction conjunction, ResolverRegistry resolverMgr, Set<Identifier.Variable.Name> idFilter) {
         this.rootResolver = resolverMgr.createRoot(conjunction, this::requestAnswered, this::requestExhausted);
-        this.resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY);
+        this.filter = iterate(idFilter).map(Identifier.Variable.Name::reference).toSet();
+        this.resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY, filter);
         this.queue = null;
         this.iteration = 0;
         this.done = false;
@@ -64,9 +73,9 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     @Override
     public void recycle() {}
 
-    private void requestAnswered(ResolutionAnswer answer) {
-        if (answer.isInferred()) iterationInferredAnswer = true;
-        queue.put(answer.derived().withInitial());
+    private void requestAnswered(ResolutionAnswer resolutionAnswer) {
+        if (resolutionAnswer.isInferred()) iterationInferredAnswer = true;
+        queue.put(resolutionAnswer.derived().withInitial()); // withInitial includes filtering
     }
 
     private void requestExhausted(int iteration) {
@@ -91,7 +100,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     private void prepareNextIteration() {
         iteration++;
         iterationInferredAnswer = false;
-        resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY);
+        resolveRequest = Request.create(new Request.Path(rootResolver), Root.create(), EMPTY, filter);
     }
 
     private boolean mustReiterate() {

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -31,7 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
-
 import java.util.Set;
 
 import static grakn.core.common.iterator.Iterators.iterate;
@@ -73,7 +72,7 @@ public class ReasonerProducer implements Producer<ConceptMap> {
 
     private void requestAnswered(ResolutionAnswer resolutionAnswer) {
         if (resolutionAnswer.isInferred()) iterationInferredAnswer = true;
-        queue.put(resolutionAnswer.derived().withInitialFiltered()); // withInitial includes filtering
+        queue.put(resolutionAnswer.derived().withInitialFiltered());
     }
 
     private void requestExhausted(int iteration) {

--- a/reasoner/resolution/ResolutionRecorder.java
+++ b/reasoner/resolution/ResolutionRecorder.java
@@ -72,7 +72,7 @@ public class ResolutionRecorder extends Actor.State<ResolutionRecorder> {
 
         int actorIndex = actorIndices.computeIfAbsent(newAnswer.producer(), key -> actorIndices.size());
         LOG.debug("actor index for " + newAnswer.producer() + ": " + actorIndex);
-        AnswerIndex newAnswerIndex = new AnswerIndex(actorIndex, newAnswer.derived().withInitial());
+        AnswerIndex newAnswerIndex = new AnswerIndex(actorIndex, newAnswer.derived().withInitialFiltered());
         if (answers.containsKey(newAnswerIndex)) {
             ResolutionAnswer existingAnswer = answers.get(newAnswerIndex);
             ResolutionAnswer.Derivation existingDerivation = existingAnswer.derivation();

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -20,7 +20,6 @@ package grakn.core.reasoner.resolution;
 
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.ConceptManager;
-import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.concurrent.actor.EventLoopGroup;
 import grakn.core.logic.LogicManager;
@@ -44,7 +43,6 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -20,6 +20,7 @@ package grakn.core.reasoner.resolution;
 
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.ConceptManager;
+import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.concurrent.actor.EventLoopGroup;
 import grakn.core.logic.LogicManager;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -99,7 +99,7 @@ public abstract class AnswerState {
                 this.filter = filter;
             }
 
-            public ConceptMap withInitial() {
+            public ConceptMap withInitialFiltered() {
                 HashMap<Reference.Name, Concept> withInitial = new HashMap<>(conceptMap().concepts());
                 if (initial != null) {
                    withInitial.putAll(initial.conceptMap().concepts());

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -52,7 +52,7 @@ public class AnswerStateTest {
         expectedDerived.put(Reference.name("a"), new MockConcept(0));
         expectedDerived.put(Reference.name("b"), new MockConcept(1));
         assertEquals(new ConceptMap(expectedDerived), derived.conceptMap());
-        assertEquals(new ConceptMap(expectedDerived), derived.withInitial());
+        assertEquals(new ConceptMap(expectedDerived), derived.withInitialFiltered());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class AnswerStateTest {
         Map<Reference.Name, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Reference.name("a"), new MockConcept(0));
         expectedWithInitial.put(Reference.name("b"), new MockConcept(1));
-        assertEquals(new ConceptMap(expectedWithInitial), derived.withInitial());
+        assertEquals(new ConceptMap(expectedWithInitial), derived.withInitialFiltered());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class AnswerStateTest {
         expectedWithInitial.put(Reference.name("a"), new MockConcept(0));
         expectedWithInitial.put(Reference.name("b"), new MockConcept(1));
         expectedWithInitial.put(Reference.name("c"), new MockConcept(2));
-        assertEquals(new ConceptMap(expectedWithInitial), derived.withInitial());
+        assertEquals(new ConceptMap(expectedWithInitial), derived.withInitialFiltered());
     }
 
     public static class MockConcept extends ConceptImpl implements Concept {

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -105,12 +105,13 @@ public class Request {
         if (o == null || getClass() != o.getClass()) return false;
         Request request = (Request) o;
         return Objects.equals(path, request.path) &&
-                Objects.equals(partialAnswer, request.partialAnswer());
+                Objects.equals(partialAnswer, request.partialAnswer()) &&
+                Objects.equals(answerFilter, request.answerFilter);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, partialAnswer);
+        return Objects.hash(path, partialAnswer, answerFilter);
     }
 
     @Override

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -31,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 
 import static grakn.common.collection.Collections.list;
-import static grakn.common.collection.Collections.set;
 
 public class Request {
     private final Path path;

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -18,8 +18,8 @@
 
 package grakn.core.reasoner.resolution.framework;
 
-import grakn.core.concurrent.actor.Actor;
 import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concurrent.actor.Actor;
 import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.TraversalEngine;

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -103,7 +103,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
-        ConceptMap conceptMap = fromDownstream.answer().derived().withInitial();
+        ConceptMap conceptMap = fromDownstream.answer().derived().withInitialFiltered();
         if (!responseProducer.hasProduced(conceptMap)) {
             responseProducer.recordProduced(conceptMap);
 

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -116,7 +116,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
                 derivation = null;
             }
 
-            ResolutionAnswer answer = new ResolutionAnswer(fromUpstream.answerBounds().asMapped().mapToUpstream(conceptMap),
+            ResolutionAnswer answer = new ResolutionAnswer(fromUpstream.partialAnswer().asMapped().mapToUpstream(conceptMap),
                                                            concludable.toString(), derivation, self(), fromDownstream.answer().isInferred());
 
             respondToUpstream(Answer.create(fromUpstream, answer), iteration);
@@ -168,7 +168,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
         iterationStates.putIfAbsent(root, new IterationState(iteration));
         IterationState iterationState = iterationStates.get(root);
 
-        Traversal traversal = boundTraversal(concludable.conjunction().traversal(), request.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(concludable.conjunction().traversal(), request.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
 
         ResponseProducer responseProducer = new ResponseProducer(traversalProducer, iteration);
@@ -188,7 +188,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
             iterationState.nextIteration(newIteration);
         }
 
-        Traversal traversal = boundTraversal(concludable.conjunction().traversal(), request.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(concludable.conjunction().traversal(), request.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
 
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(traversalProducer, newIteration);
@@ -205,8 +205,8 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
     private void tryAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration) {
         while (responseProducer.hasTraversalProducer()) {
             ConceptMap conceptMap = responseProducer.traversalProducer().next();
-            assert fromUpstream.answerBounds().isMapped();
-            AnswerState.UpstreamVars.Derived derivedAnswer = fromUpstream.answerBounds().asMapped().mapToUpstream(conceptMap);
+            assert fromUpstream.partialAnswer().isMapped();
+            AnswerState.UpstreamVars.Derived derivedAnswer = fromUpstream.partialAnswer().asMapped().mapToUpstream(conceptMap);
             LOG.trace("{}: has found via traversal: {}", name(), conceptMap);
             if (!responseProducer.hasProduced(conceptMap)) {
                 responseProducer.recordProduced(conceptMap);
@@ -243,11 +243,11 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
     private void mayRegisterRules(Request request, IterationState iterationState, ResponseProducer responseProducer) {
         // loop termination: when receiving a new request, we check if we have seen it before from this root query
         // if we have, we do not allow rules to be registered as possible downstreams
-        if (!iterationState.hasReceived(request.answerBounds().conceptMap())) {
+        if (!iterationState.hasReceived(request.partialAnswer().conceptMap())) {
             for (Map.Entry<Actor<RuleResolver>, Set<Unifier>> entry : applicableRules.entrySet()) {
                 Actor<RuleResolver> ruleActor = entry.getKey();
                 for (Unifier unifier : entry.getValue()) {
-                    AnswerState.UpstreamVars.Initial initial = AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap());
+                    AnswerState.UpstreamVars.Initial initial = AnswerState.UpstreamVars.Initial.of(request.partialAnswer().conceptMap());
                     Optional<AnswerState.DownstreamVars.Unified> unified = initial.toDownstreamVars(unifier);
                     if (unified.isPresent()) {
                         Request toDownstream = Request.create(request.path().append(ruleActor), unified.get(),
@@ -256,7 +256,7 @@ public class ConcludableResolver extends ResolvableResolver<ConcludableResolver>
                     }
                 }
             }
-            iterationState.recordReceived(request.answerBounds().conceptMap());
+            iterationState.recordReceived(request.partialAnswer().conceptMap());
         }
     }
 

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -86,7 +86,7 @@ public class RetrievableResolver extends ResolvableResolver<RetrievableResolver>
     @Override
     protected ResponseProducer responseProducerCreate(Request fromUpstream, int iteration) {
         LOG.debug("{}: Creating a new ResponseProducer for request: {}", name(), fromUpstream);
-        Traversal traversal = boundTraversal(retrievable.conjunction().traversal(), fromUpstream.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(retrievable.conjunction().traversal(), fromUpstream.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         return new ResponseProducer(traversalProducer, iteration);
     }
@@ -97,7 +97,7 @@ public class RetrievableResolver extends ResolvableResolver<RetrievableResolver>
         LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
 
         assert newIteration > responseProducerPrevious.iteration();
-        Traversal traversal = boundTraversal(retrievable.conjunction().traversal(), fromUpstream.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(retrievable.conjunction().traversal(), fromUpstream.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         return responseProducerPrevious.newIteration(traversalProducer, newIteration);
     }
@@ -121,7 +121,7 @@ public class RetrievableResolver extends ResolvableResolver<RetrievableResolver>
     private void tryAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration) {
         while (responseProducer.hasTraversalProducer()) {
             ConceptMap conceptMap = responseProducer.traversalProducer().next();
-            AnswerState.UpstreamVars.Derived derivedAnswer = fromUpstream.answerBounds().asMapped().mapToUpstream(conceptMap);
+            AnswerState.UpstreamVars.Derived derivedAnswer = fromUpstream.partialAnswer().asMapped().mapToUpstream(conceptMap);
             LOG.trace("{}: has found via traversal: {}", name(), conceptMap);
             if (!responseProducer.hasProduced(conceptMap)) {
                 responseProducer.recordProduced(conceptMap);

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -52,7 +52,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import static grakn.common.collection.Collections.map;
-import static grakn.common.collection.Collections.set;
 import static grakn.core.common.iterator.Iterators.iterate;
 import static grakn.core.reasoner.resolution.answer.AnswerState.UpstreamVars;
 
@@ -190,7 +189,6 @@ public class RootResolver extends Resolver<RootResolver> {
     @Override
     protected ResponseProducer responseProducerCreate(Request request, int iteration) {
         LOG.debug("{}: Creating a new ResponseProducer for request: {}", name(), request);
-        assert request.partialAnswer().isRoot(); // We can ignore the empty ConceptMap of the incoming request
 
         ResourceIterator<ConceptMap> traversalProducer = traversalEngine.iterator(conjunction.traversal())
                 .map(conceptMgr::conceptMap);

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static grakn.common.collection.Collections.map;
 import static grakn.core.common.iterator.Iterators.iterate;
 
 public class RuleResolver extends Resolver<RuleResolver> {

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -117,13 +117,13 @@ public class RuleResolver extends Resolver<RuleResolver> {
             derivation = null;
         }
 
-        ConceptMap whenAnswer = fromDownstream.answer().derived().withInitial();
+        ConceptMap whenAnswer = fromDownstream.answer().derived().withInitialFiltered();
         if (fromDownstream.planIndex() == plan.size() - 1) {
             Map<Identifier, Concept> thenMaterialisation = rule.putConclusion(whenAnswer, traversalEngine, conceptMgr);
             assert fromUpstream.partialAnswer().isUnified();
             Optional<AnswerState.UpstreamVars.Derived> unifiedAnswer = fromUpstream.partialAnswer().asUnified().unifyToUpstream(thenMaterialisation);
-            if (unifiedAnswer.isPresent() && !responseProducer.hasProduced(unifiedAnswer.get().withInitial())) {
-                responseProducer.recordProduced(unifiedAnswer.get().withInitial());
+            if (unifiedAnswer.isPresent() && !responseProducer.hasProduced(unifiedAnswer.get().withInitialFiltered())) {
+                responseProducer.recordProduced(unifiedAnswer.get().withInitialFiltered());
                 // TODO revisit whether using `rule.when()` is the correct pattern to associate with the unified answer? Variables won't match
                 ResolutionAnswer answer = new ResolutionAnswer(unifiedAnswer.get(), rule.when().toString(), derivation, self(), true);
                 respondToUpstream(Answer.create(fromUpstream, answer), iteration);

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -120,8 +120,8 @@ public class RuleResolver extends Resolver<RuleResolver> {
         ConceptMap whenAnswer = fromDownstream.answer().derived().withInitial();
         if (fromDownstream.planIndex() == plan.size() - 1) {
             Map<Identifier, Concept> thenMaterialisation = rule.putConclusion(whenAnswer, traversalEngine, conceptMgr);
-            assert fromUpstream.answerBounds().isUnified();
-            Optional<AnswerState.UpstreamVars.Derived> unifiedAnswer = fromUpstream.answerBounds().asUnified().unifyToUpstream(thenMaterialisation);
+            assert fromUpstream.partialAnswer().isUnified();
+            Optional<AnswerState.UpstreamVars.Derived> unifiedAnswer = fromUpstream.partialAnswer().asUnified().unifyToUpstream(thenMaterialisation);
             if (unifiedAnswer.isPresent() && !responseProducer.hasProduced(unifiedAnswer.get().withInitial())) {
                 responseProducer.recordProduced(unifiedAnswer.get().withInitial());
                 // TODO revisit whether using `rule.when()` is the correct pattern to associate with the unified answer? Variables won't match
@@ -136,7 +136,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
             Request downstreamRequest = Request.create(fromUpstream.path().append(nextPlannedDownstream.resolver()),
                                                        AnswerState.UpstreamVars.Initial.of(whenAnswer).toDownstreamVars(
                                                                Mapping.of(nextPlannedDownstream.mapping())),
-                                                       derivation, planIndex);
+                                                       derivation, planIndex, null);
             responseProducer.addDownstreamProducer(downstreamRequest);
             requestFromDownstream(downstreamRequest, fromUpstream, iteration);
         }
@@ -179,14 +179,14 @@ public class RuleResolver extends Resolver<RuleResolver> {
 
     @Override
     protected ResponseProducer responseProducerCreate(Request request, int iteration) {
-        Traversal traversal = boundTraversal(rule.when().traversal(), request.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(rule.when().traversal(), request.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalIterator = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         ResponseProducer responseProducer = new ResponseProducer(traversalIterator, iteration);
         if (!plan.isEmpty()) {
             Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                                  AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
+                                                  AnswerState.UpstreamVars.Initial.of(request.partialAnswer().conceptMap())
                                                           .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                                  new ResolutionAnswer.Derivation(map()), 0);
+                                                  ResolutionAnswer.Derivation.EMPTY, 0, null);
             responseProducer.addDownstreamProducer(toDownstream);
         }
         return responseProducer;
@@ -197,14 +197,14 @@ public class RuleResolver extends Resolver<RuleResolver> {
         assert newIteration > responseProducerPrevious.iteration();
         LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
 
-        Traversal traversal = boundTraversal(rule.when().traversal(), request.answerBounds().conceptMap());
+        Traversal traversal = boundTraversal(rule.when().traversal(), request.partialAnswer().conceptMap());
         ResourceIterator<ConceptMap> traversalIterator = traversalEngine.iterator(traversal).map(conceptMgr::conceptMap);
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(traversalIterator, newIteration);
         if (!plan.isEmpty()) {
             Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
-                                                  AnswerState.UpstreamVars.Initial.of(request.answerBounds().conceptMap())
+                                                  AnswerState.UpstreamVars.Initial.of(request.partialAnswer().conceptMap())
                                                           .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                                  new ResolutionAnswer.Derivation(map()), 0);
+                                                  ResolutionAnswer.Derivation.EMPTY, 0, null);
             responseProducerNewIter.addDownstreamProducer(toDownstream);
         }
         return responseProducerNewIter;
@@ -223,8 +223,8 @@ public class RuleResolver extends Resolver<RuleResolver> {
             if (!responseProducer.hasProduced(conceptMap)) {
                 responseProducer.recordProduced(conceptMap);
                 Map<Identifier, Concept> thenMaterialisation = rule.putConclusion(conceptMap, traversalEngine, conceptMgr);
-                assert fromUpstream.answerBounds().isUnified();
-                Optional<AnswerState.UpstreamVars.Derived> derivedAnswer = fromUpstream.answerBounds().asUnified().unifyToUpstream(thenMaterialisation);
+                assert fromUpstream.partialAnswer().isUnified();
+                Optional<AnswerState.UpstreamVars.Derived> derivedAnswer = fromUpstream.partialAnswer().asUnified().unifyToUpstream(thenMaterialisation);
                 if (derivedAnswer.isPresent()) {
                     ResolutionAnswer answer = new ResolutionAnswer(derivedAnswer.get(), rule.when().toString(),
                                                                    ResolutionAnswer.Derivation.EMPTY, self(), true);

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -53,6 +53,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static grakn.common.collection.Collections.map;
 import static grakn.core.common.iterator.Iterators.iterate;
 
 public class RuleResolver extends Resolver<RuleResolver> {
@@ -185,7 +186,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
             Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
                                                   AnswerState.UpstreamVars.Initial.of(request.partialAnswer().conceptMap())
                                                           .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                                  ResolutionAnswer.Derivation.EMPTY, 0, null);
+                                                  new ResolutionAnswer.Derivation(map()), 0, null);
             responseProducer.addDownstreamProducer(toDownstream);
         }
         return responseProducer;
@@ -203,7 +204,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
             Request toDownstream = Request.create(request.path().append(downstreamResolvers.get(plan.get(0)).resolver()),
                                                   AnswerState.UpstreamVars.Initial.of(request.partialAnswer().conceptMap())
                                                           .toDownstreamVars(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping())),
-                                                  ResolutionAnswer.Derivation.EMPTY, 0, null);
+                                                  new ResolutionAnswer.Derivation(map()), 0, null);
             responseProducerNewIter.addDownstreamProducer(toDownstream);
         }
         return responseProducerNewIter;
@@ -226,7 +227,7 @@ public class RuleResolver extends Resolver<RuleResolver> {
                 Optional<AnswerState.UpstreamVars.Derived> derivedAnswer = fromUpstream.partialAnswer().asUnified().unifyToUpstream(thenMaterialisation);
                 if (derivedAnswer.isPresent()) {
                     ResolutionAnswer answer = new ResolutionAnswer(derivedAnswer.get(), rule.when().toString(),
-                                                                   ResolutionAnswer.Derivation.EMPTY, self(), true);
+                                                                   new ResolutionAnswer.Derivation(map()), self(), true);
                     respondToUpstream(Answer.create(fromUpstream, answer), iteration);
                     return;
                 }

--- a/test/integration/reasoner/BUILD
+++ b/test/integration/reasoner/BUILD
@@ -46,6 +46,7 @@ host_compatible_java_test(
 host_compatible_java_test(
     name = "test-resolution",
     srcs = ["ResolutionTest.java"],
+    test_class = "grakn.core.reasoner.ResolutionTest",
     native_libraries_deps = [
         "//concept:concept",
         "//logic:logic",
@@ -54,17 +55,19 @@ host_compatible_java_test(
         "//rocks:rocks",
         "//:grakn",
     ],
-    resource_strip_prefix = "common/test",
-    resources = [
-        "//common/test:logback",
-    ],
-    test_class = "grakn.core.reasoner.ResolutionTest",
     deps = [
         # Internal dependencies
         "//common:common",
         "//concurrent:concurrent",
         "//test/integration/util",
+
+        # External dependencies from Grakn Labs
+        "@graknlabs_graql//java/pattern:pattern",
         "@graknlabs_graql//java:graql",
+    ],
+    resource_strip_prefix = "common/test",
+    resources = [
+        "//common/test:logback",
     ],
 )
 

--- a/traversal/Traversal.java
+++ b/traversal/Traversal.java
@@ -41,7 +41,6 @@ import graql.lang.common.GraqlToken;
 import graql.lang.pattern.variable.Reference;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -76,26 +75,26 @@ public class Traversal {
 
     private final Parameters parameters;
     private final Structure structure;
-    private final List<Identifier.Variable.Name> filter;
+    private final Set<Identifier.Variable.Name> filter;
     private List<Planner> planners;
     private boolean modifiable;
 
     public Traversal() {
         structure = new Structure();
         parameters = new Parameters();
-        filter = new ArrayList<>();
+        filter = new HashSet<>();
         modifiable = true;
     }
 
     // TODO: We should not dynamically calculate properties like this, and then guard against 'modifiable'.
     //       We should introduce a "builder pattern" to Traversal, such that users of this library will build
     //       traversals with Traversal.Builder, and call .build() in the end to produce a final Object.
-    private List<Identifier.Variable.Name> filter() {
+    private Set<Identifier.Variable.Name> filter() {
         if (filter.isEmpty()) {
             modifiable = false;
             iterate(structure.vertices())
                     .map(TraversalVertex::id).filter(Identifier::isName)
-                    .map(id -> id.asVariable().asName()).toList(filter);
+                    .map(id -> id.asVariable().asName()).toSet(filter);
         }
         return filter;
     }

--- a/traversal/Traversal.java
+++ b/traversal/Traversal.java
@@ -290,7 +290,7 @@ public class Traversal {
         structure.predicateEdge(structure.thingVertex(att1), structure.thingVertex(att2), predicate);
     }
 
-    public void filter(List<Identifier.Variable.Name> filter) {
+    public void filter(Set<Identifier.Variable.Name> filter) {
         assert modifiable;
         this.filter.addAll(filter);
     }

--- a/traversal/TraversalEngine.java
+++ b/traversal/TraversalEngine.java
@@ -26,9 +26,9 @@ import grakn.core.traversal.common.Identifier;
 import grakn.core.traversal.common.VertexMap;
 import grakn.core.traversal.procedure.GraphProcedure;
 
-import java.util.List;
+import java.util.Set;
 
-import static grakn.common.collection.Collections.list;
+import static grakn.common.collection.Collections.set;
 
 public class TraversalEngine {
 
@@ -64,11 +64,11 @@ public class TraversalEngine {
     }
 
     public ResourceIterator<VertexMap> iterator(GraphProcedure procedure, Traversal.Parameters params) {
-        return iterator(procedure, params, list());
+        return iterator(procedure, params, set());
     }
 
     public ResourceIterator<VertexMap> iterator(GraphProcedure procedure, Traversal.Parameters params,
-                                                List<Identifier.Variable.Name> filter) {
+                                                Set<Identifier.Variable.Name> filter) {
         return procedure.iterator(graphMgr, params, filter);
     }
 }

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -52,7 +52,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     private final GraphManager graphMgr;
     private final GraphProcedure procedure;
     private final Traversal.Parameters params;
-    private final List<Identifier.Variable.Name> filter;
+    private final Set<Identifier.Variable.Name> filter;
     private final Map<Identifier, ResourceIterator<? extends Vertex<?, ?>>> iterators;
     private final Map<Identifier, Vertex<?, ?>> answer;
     private final Map<Identifier, ThingVertex> roles;
@@ -65,7 +65,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     enum State {INIT, EMPTY, FETCHED, COMPLETED}
 
     public GraphIterator(GraphManager graphMgr, Vertex<?, ?> start, GraphProcedure procedure,
-                         Traversal.Parameters params, List<Identifier.Variable.Name> filter) {
+                         Traversal.Parameters params, Set<Identifier.Variable.Name> filter) {
         assert procedure.edgesCount() > 0;
         this.graphMgr = graphMgr;
         this.procedure = procedure;

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -163,13 +163,13 @@ public class GraphProcedure implements Procedure {
         ).asType();
     }
 
-    private void assertWithinFilterBounds(List<Identifier.Variable.Name> filter) {
+    private void assertWithinFilterBounds(Set<Identifier.Variable.Name> filter) {
         assert iterate(vertices.keySet()).anyMatch(id -> id.isName() && filter.contains(id.asVariable().asName()));
     }
 
     @Override
     public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                        List<Identifier.Variable.Name> filter, int parallelisation) {
+                                        Set<Identifier.Variable.Name> filter, int parallelisation) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
         assertWithinFilterBounds(filter);
@@ -181,7 +181,7 @@ public class GraphProcedure implements Procedure {
 
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                                List<Identifier.Variable.Name> filter) {
+                                                Set<Identifier.Variable.Name> filter) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
         assertWithinFilterBounds(filter);

--- a/traversal/procedure/Procedure.java
+++ b/traversal/procedure/Procedure.java
@@ -25,13 +25,13 @@ import grakn.core.traversal.Traversal;
 import grakn.core.traversal.common.Identifier;
 import grakn.core.traversal.common.VertexMap;
 
-import java.util.List;
+import java.util.Set;
 
 public interface Procedure {
 
     Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                 List<Identifier.Variable.Name> filter, int parallelisation);
+                                 Set<Identifier.Variable.Name> filter, int parallelisation);
 
     ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                         List<Identifier.Variable.Name> filter);
+                                         Set<Identifier.Variable.Name> filter);
 }

--- a/traversal/procedure/VertexProcedure.java
+++ b/traversal/procedure/VertexProcedure.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import static grakn.common.collection.Collections.map;
 import static grakn.common.collection.Collections.pair;
@@ -90,7 +91,7 @@ public class VertexProcedure implements Procedure {
 
     @Override
     public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                        List<Identifier.Variable.Name> filter, int parallelisation) {
+                                        Set<Identifier.Variable.Name> filter, int parallelisation) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
         return Producers.producer(iterator(graphMgr, params, filter));
@@ -98,7 +99,7 @@ public class VertexProcedure implements Procedure {
 
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                                List<Identifier.Variable.Name> filter) {
+                                                Set<Identifier.Variable.Name> filter) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
         assert vertex.id().isName() && filter.contains(vertex.id().asVariable().asName());


### PR DESCRIPTION
## What is the goal of this PR?

To correctly deduplicate answers within a conjunction, we filter answers in the `Root` resolver before adding them to the deduplication set. We also convert filter to be `set` type, rather than `list` type.

## What are the changes implemented in this PR?
* Inject `filter` into `RootResolver` and add the filter to `AnswerState.DownstreamVars.Root.aggregateToUpstream(conceptMap, filter)`
* rename `answerBounds` to `partialAnswer` inside resolver messages
* change filter to be within a `set`