### PR TITLE
Fix materialisation from rule traversal answers

### DIFF
--- a/reasoner/resolution/framework/ResponseProducer.java
+++ b/reasoner/resolution/framework/ResponseProducer.java
@@ -23,13 +23,14 @@ import grakn.core.concept.answer.ConceptMap;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 public class ResponseProducer {
     private final Set<ConceptMap> produced;
     private final Iterator<ConceptMap> traversalProducer;
-    private final List<Request> downstreamProducer;
+    private final LinkedHashSet<Request> downstreamProducer;
     private final int iteration;
     private Iterator<Request> downstreamProducerSelector;
 
@@ -41,7 +42,7 @@ public class ResponseProducer {
         this.traversalProducer = traversalProducer;
         this.iteration = iteration;
         this.produced = produced;
-        downstreamProducer = new ArrayList<>();
+        downstreamProducer = new LinkedHashSet<>();
         downstreamProducerSelector = downstreamProducer.iterator();
     }
 

--- a/test/behaviour/resolution/ResolutionSteps.java
+++ b/test/behaviour/resolution/ResolutionSteps.java
@@ -88,7 +88,8 @@ public class ResolutionSteps {
         Grakn.Transaction tx = reasonedDbTxn();
         oldAnswers = tx.query().match(queryToTest).toSet();
         for (int i = 0; i < executionCount - 1; i++) {
-            try (Grakn.Transaction transaction = reasonedSession().transaction(Arguments.Transaction.Type.READ)) {
+            try (Grakn.Transaction transaction = reasonedSession().transaction(Arguments.Transaction.Type.READ,
+                                                                               new Options.Transaction().infer(true))) {
                 Set<ConceptMap> answers = transaction.query().match(queryToTest).toSet();
                 assertEquals(oldAnswers, answers);
             }


### PR DESCRIPTION
## What is the goal of this PR?

Rules that perform traversals to find answers, should also materialise them as the `then` of the rule, and pass the result upstream. This PR fixes the previous incorrect behaviour

## What are the changes implemented in this PR?
* Materialise `then` symmetrically between receiving an answer, and producing an answer with a local traversal