### PR TITLE
Introduce 'Grakn server already running' error and refactor exception handling

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -67,6 +67,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Server(15, "Iteration was requested for ID '%s', but this ID does not correspond to an existing query iterator.");
         public static final Server DUPLICATE_REQUEST =
                 new Server(16, "The request with ID '%s' is a duplicate.");
+        public static final Server ALREADY_RUNNING =
+                new Server(17, "Another instance of Grakn Core server is already running at this port: '%s'.");
 
         private static final String codePrefix = "SRV";
         private static final String messagePrefix = "Invalid Server Operation";


### PR DESCRIPTION
## What is the goal of this PR?

We improved the way we handle errors and introduced an error message for the case when the user tries to start Grakn Core server while another instance is already running on the same port.

## What are the changes implemented in this PR?

 - added `ALREADY_RUNNING` error message;
 - refactored error handling.

close https://github.com/graknlabs/grakn/issues/6022
