### PR TITLE
Fix grakn debug mode startup script on Linux

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -28,7 +28,7 @@ def graknlabs_common():
     git_repository(
         name = "graknlabs_common",
         remote = "https://github.com/graknlabs/common",
-        commit = "15a2a883a9375e7dddca00e4c6bd55efdd357469", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
+        commit = "f4a469c4cf5a33758777d95ed1af347d31b59d24", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_common
     )
 
 def graknlabs_graql():


### PR DESCRIPTION
## What is the goal of this PR?

Fix Grakn startup script so that it can run with debug flag on Linux, which will fall back to using the production version and gives you a warning.

## What are the changes implemented in this PR?

- Bump common, which fixes this issue. https://github.com/graknlabs/common/pull/85