### PR TITLE
Fix concurrency bug causing null pointer exception while iterating edges

### DIFF
--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -141,8 +141,8 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
 
         edges.compute(infixIID, (iid, edgesByOutIID) -> {
             if (edgesByOutIID == null) edgesByOutIID = new ConcurrentHashMap<>();
-            if (edgesByOutIID.containsKey(edge.outIID())) {
-                ThingEdge thingEdge = edgesByOutIID.get(edge.outIID());
+            ThingEdge thingEdge = edgesByOutIID.get(edge.outIID());
+            if (thingEdge != null) {
                 if (thingEdge.isInferred() && !edge.isInferred()) thingEdge.isInferred(false);
             } else {
                 edgesByOutIID.put(edge.outIID(), edge);

--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -95,7 +95,7 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
             iids = newIIDs;
         }
 
-        return iterate(iids).flatMap(iid -> iterate(edges.get(iid).values()));
+        return iterate(iids).flatMap(iid -> iterate(edges.get(iid) != null ? edges.get(iid).values().iterator() : emptyIterator()));
     }
 
     @Override
@@ -139,13 +139,16 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
             );
         }
 
-        Map<EdgeIID.Thing, ThingEdge> edgesByOutIID = edges.computeIfAbsent(infixIID, iid -> new ConcurrentHashMap<>());
-        if (edgesByOutIID.containsKey(edge.outIID())) {
-            ThingEdge thingEdge = edgesByOutIID.get(edge.outIID());
-            if (thingEdge.isInferred() && !edge.isInferred()) thingEdge.isInferred(false);
-        } else {
-            edgesByOutIID.put(edge.outIID(), edge);
-        }
+        edges.compute(infixIID, (iid, edgesByOutIID) -> {
+            if (edgesByOutIID == null) edgesByOutIID = new ConcurrentHashMap<>();
+            if (edgesByOutIID.containsKey(edge.outIID())) {
+                ThingEdge thingEdge = edgesByOutIID.get(edge.outIID());
+                if (thingEdge.isInferred() && !edge.isInferred()) thingEdge.isInferred(false);
+            } else {
+                edgesByOutIID.put(edge.outIID(), edge);
+            }
+            return edgesByOutIID;
+        });
 
         if (isModified) owner.setModified();
         if (isReflexive) {

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -44,6 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
@@ -261,6 +262,11 @@ public class GraphProcedure implements Procedure {
         public ProcedureVertex.Type setLabel(ProcedureVertex.Type type, String label, String scope) {
             type.props().labels(Label.of(label, scope));
             return type;
+        }
+
+        public ProcedureVertex.Thing setTypes(ProcedureVertex.Thing thing, Set<String> types) {
+            thing.props().types(types.stream().map(x -> Label.of(x)).collect(Collectors.toSet()));
+            return thing;
         }
 
         public ProcedureVertex.Thing setPredicate(ProcedureVertex.Thing thing, Predicate.Value.String predicate) {


### PR DESCRIPTION
## What is the goal of this PR?

Fix concurrency bug causing null pointer exception while iterating edges.

## What are the changes implemented in this PR?

- Added a null check so that we don't falsely assume edges already exist while it's still being loaded. In case of the edges are null, returning an empty iterator is safe since it will be merged together with persisted edges that contain every edge.
- Fix edges map not updated atomically. 
- Fix https://github.com/graknlabs/grakn/issues/6118