### PR TITLE
Fix bugs that cause statistics counts to be inaccurate

### DIFF
--- a/graph/adjacency/impl/ThingAdjacencyImpl.java
+++ b/graph/adjacency/impl/ThingAdjacencyImpl.java
@@ -169,7 +169,7 @@ public abstract class ThingAdjacencyImpl implements ThingAdjacency {
     @Override
     public ThingEdgeImpl put(Encoding.Edge.Thing encoding, ThingVertex adjacent, boolean isInferred) {
         assert !encoding.isOptimisation();
-        if (encoding == Encoding.Edge.Thing.HAS && direction.isOut()) {
+        if (encoding == Encoding.Edge.Thing.HAS && direction.isOut() && !isInferred) {
             owner.graph().stats().hasEdgeCreated(owner.iid(), adjacent.iid().asAttribute());
         }
         ThingEdgeImpl edge = direction.isOut()

--- a/graph/edge/impl/ThingEdgeImpl.java
+++ b/graph/edge/impl/ThingEdgeImpl.java
@@ -157,7 +157,7 @@ public abstract class ThingEdgeImpl implements ThingEdge {
                     graph.storage().delete(outIID().bytes());
                     graph.storage().delete(inIID().bytes());
                 }
-                if (encoding == Encoding.Edge.Thing.HAS) {
+                if (encoding == Encoding.Edge.Thing.HAS && !isInferred) {
                     graph.stats().hasEdgeDeleted(from.iid(), to.iid().asAttribute());
                 }
             }
@@ -321,7 +321,7 @@ public abstract class ThingEdgeImpl implements ThingEdge {
                 to().ins().remove(this);
                 graph.storage().delete(this.outIID.bytes());
                 graph.storage().delete(this.inIID.bytes());
-                if (encoding == Encoding.Edge.Thing.HAS) {
+                if (encoding == Encoding.Edge.Thing.HAS && !isInferred) {
                     graph.stats().hasEdgeDeleted(fromIID, toIID.asAttribute());
                 }
             }


### PR DESCRIPTION
## What is the goal of this PR?

Fix bugs that cause statistics counts to be inaccurate.

## What are the changes implemented in this PR?

- Do not call `computeIfAbsent` recursively which causes recursive update exception.
- Only report statistics count change if has edges are not inferred.
- Commit count jobs for HAS edges using persisted IID instead of buffered IID.
