### PR TITLE
Fix traversal error that lead to a role being scoped twice in the same relation

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,5 +56,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "65fa364e971eab81bb9b4929a461d7238ca87b01", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "dfb1f8b0fd010c8308fe76e5478f4c2d0916aac6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -70,11 +70,18 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         this.filter = filter;
         this.edgeCount = procedure.edgesCount();
         this.iterators = new HashMap<>();
-        this.answer = new HashMap<>();
-        this.answer.put(procedure.startVertex().id(), start);
         this.scopes = new Scopes();
         this.seekStack = new SeekStack(edgeCount);
         this.state = State.INIT;
+        this.answer = new HashMap<>();
+
+        Identifier startId = procedure.startVertex().id();
+        this.answer.put(startId, start);
+        if (startId.isScoped()) {
+            Identifier.Variable scope = startId.asScoped().scope();
+            Scopes.Scoped scoped = scopes.getOrInitialise(scope);
+            scoped.push(start.asThing(), 0);
+        }
     }
 
     @Override
@@ -269,11 +276,6 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
                     return true;
                 }
             });
-        } else if (edge.from().id().isScoped()) {
-            Identifier.Variable scope = edge.from().id().asScoped().scope();
-            Scopes.Scoped scoped = scopes.getOrInitialise(scope);
-            scoped.push(fromVertex.asThing(), edge.order());
-            toIter = edge.branch(graphMgr, fromVertex, params);
         } else if (edge.isRolePlayer()) {
             Identifier.Variable scope = edge.asRolePlayer().scope();
             Scopes.Scoped scoped = scopes.getOrInitialise(scope);
@@ -306,10 +308,10 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         if (edge.to().id().isScoped()) {
             Identifier.Variable scope = edge.to().id().asScoped().scope();
             if (scopes.get(scope).orderVisited(pos)) scopes.get(scope).popLast();
-        } else if (edge.from().id().isScoped()) {
-            Identifier.Variable scope = edge.from().id().asScoped().scope();
-            assert scopes.get(scope).orderVisited(pos);
-            scopes.get(scope).popLast();
+//        } else if (edge.from().id().isScoped()) {
+//            Identifier.Variable scope = edge.from().id().asScoped().scope();
+//            assert scopes.get(scope).orderVisited(pos);
+//            scopes.get(scope).popLast();
         } else if (edge.isRolePlayer()) {
             Identifier.Variable scope = edge.asRolePlayer().scope();
             if (scopes.get(scope).orderVisited(pos)) scopes.get(scope).popLast();

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -308,10 +308,6 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         if (edge.to().id().isScoped()) {
             Identifier.Variable scope = edge.to().id().asScoped().scope();
             if (scopes.get(scope).orderVisited(pos)) scopes.get(scope).popLast();
-//        } else if (edge.from().id().isScoped()) {
-//            Identifier.Variable scope = edge.from().id().asScoped().scope();
-//            assert scopes.get(scope).orderVisited(pos);
-//            scopes.get(scope).popLast();
         } else if (edge.isRolePlayer()) {
             Identifier.Variable scope = edge.asRolePlayer().scope();
             if (scopes.get(scope).orderVisited(pos)) scopes.get(scope).popLast();


### PR DESCRIPTION
## What is the goal of this PR?
In the traversal engine, when scoping a role instance to a relation, we previously set the scope based on both the start and end of an edge. However, this can lead to scoping the same role twice (once from the previous edge's end, and once from the next edge's start), which throws an assertion error. We now only scope based on the end of an edge.

## What are the changes implemented in this PR?
* only set scope based on the `to` of an edge
* to make up for not setting the `from` of an edge, we catch the only case where this is required ahead of time: if the start vertex is scoped