### PR TITLE
Added tests for statistics counter

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -69,6 +69,7 @@ build:
         bazel test //test/integration/reasoner/... --test_output=streamed
         bazel test //test/integration/migrator/... --test_output=streamed
         bazel test //test/integration/logic/... --test_output=streamed
+        bazel test //test/integration/statistics/... --test_output=streamed
       # bazel test //test/integration/traversal/... --test_output=streamed
     test-behaviour-connection:
       image: graknlabs-ubuntu-20.04

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -569,6 +569,10 @@ public class DataGraph implements Graph {
             }
         }
 
+        public long hasEdgeCount(Label thing, Label attribute) {
+            return hasEdgeCount(schemaGraph.getType(thing), schemaGraph.getType(attribute));
+        }
+
         public long thingVertexSum(Set<Label> labels) {
             return thingVertexSum(labels.stream().map(schemaGraph::getType));
         }

--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -436,8 +436,8 @@ public class DataGraph implements Graph {
         iterate(thingsByIID.values()).filter(v -> v.status().equals(BUFFERED) && !v.isInferred()).forEachRemaining(
                 vertex -> {
                     VertexIID.Thing newIID = generate(storage.dataKeyGenerator(), vertex.type().iid(), vertex.type().properLabel());
-                    vertex.iid(newIID);
                     IIDMap.put(vertex.iid(), newIID);
+                    vertex.iid(newIID);
                 }
         ); // thingByIID no longer contains valid mapping from IID to TypeVertex
         thingsByIID.values().stream().filter(v -> !v.isInferred()).forEach(Vertex::commit);

--- a/test/integration/statistics/BUILD
+++ b/test/integration/statistics/BUILD
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2021 Grakn Labs
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@graknlabs_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
+load("@graknlabs_dependencies//builder/java:rules.bzl", "host_compatible_java_test")
+
+host_compatible_java_test(
+    name = "test-statistics",
+    srcs = ["StatisticsTest.java"],
+    test_class = "grakn.core.rocks.StatisticsTest",
+    native_libraries_deps = [
+        "//rocks:rocks",
+        "//:grakn",
+        "//concept:concept",
+    ],
+    deps = [
+        # Internal dependencies
+        "//test/integration/util:util",
+        "//common:common",
+
+        # External dependencies from Grakn Labs
+        "@graknlabs_graql//java/query:query",
+        "@graknlabs_graql//java:graql",
+    ],
+    resources = [
+        "//common/test:logback"
+    ],
+    resource_strip_prefix = "common/test",
+)
+
+checkstyle_test(
+    name = "checkstyle",
+    include = glob([
+        "*",
+    ]),
+    license_type = "agpl",
+)

--- a/test/integration/statistics/StatisticsTest.java
+++ b/test/integration/statistics/StatisticsTest.java
@@ -91,6 +91,7 @@ public class StatisticsTest {
                         long newAge = attribute.getValue() + 1;
                         Attribute.Long newAttribute = attribute.getType().asLong().put(newAge);
                         cm.get("x").asEntity().setHas(newAttribute);
+                        cm.get("x").asEntity().setHas(newAttribute);
                         ages.add(newAge);
                     });
                     tx.commit();

--- a/test/integration/statistics/StatisticsTest.java
+++ b/test/integration/statistics/StatisticsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+package grakn.core.rocks;
+
+import grakn.core.Grakn;
+import grakn.core.common.parameters.Arguments;
+import grakn.core.common.parameters.Label;
+import grakn.core.test.integration.util.Util;
+import graql.lang.Graql;
+import graql.lang.query.GraqlDefine;
+import graql.lang.query.GraqlInsert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class StatisticsTest {
+
+    private static Path directory = Paths.get(System.getProperty("user.dir")).resolve("statistics-test");
+    private static String database = "statistics-test";
+
+    @Test
+    public void test_statistics() throws IOException {
+        Util.resetDirectory(directory);
+        try (RocksGrakn grakn = RocksGrakn.open(directory)) {
+            grakn.databases().create(database);
+            try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
+                try (Grakn.Transaction tx = session.transaction(Arguments.Transaction.Type.WRITE)) {
+                    GraqlDefine query = Graql.parseQuery("" +
+                            "define " +
+                            "person sub entity, owns age; " +
+                            "age sub attribute, value long; " +
+                            "");
+                    tx.query().define(query);
+                    tx.commit();
+                }
+            }
+            int personCount = 1000;
+            Random random = new Random(0);
+            Set<Long> ages = new HashSet<>();
+            try (RocksSession session = grakn.session(database, Arguments.Session.Type.DATA)) {
+                try (RocksTransaction tx = session.transaction(Arguments.Transaction.Type.WRITE)) {
+                    for (int i = 0; i < personCount; i++) {
+                        long age = random.nextLong() % personCount;
+                        ages.add(age);
+                        GraqlInsert query = Graql.parseQuery("insert $x isa person, has age " + age + ";").asInsert();
+                        tx.query().insert(query);
+                    }
+                    tx.commit();
+                }
+            }
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            try (RocksSession session = grakn.session(database, Arguments.Session.Type.DATA)) {
+                try (RocksTransaction tx = session.transaction(Arguments.Transaction.Type.READ)) {
+                    assertEquals(tx.graphMgr.data().stats().thingVertexCount(Label.of("person")), personCount);
+                    assertEquals(tx.graphMgr.data().stats().thingVertexCount(Label.of("age")), ages.size());
+                    assertEquals(tx.graphMgr.data().stats().hasEdgeCount(Label.of("person"), Label.of("age")), personCount);
+                }
+            }
+        }
+    }
+}

--- a/test/integration/statistics/StatisticsTest.java
+++ b/test/integration/statistics/StatisticsTest.java
@@ -49,7 +49,7 @@ public class StatisticsTest {
         try (RocksGrakn grakn = RocksGrakn.open(directory)) {
             grakn.databases().create(database);
             setupSchema(grakn);
-            int personCount = 1;
+            int personCount = 1000;
             Set<Long> ages = new HashSet<>();
             Random random = new Random(0);
             insertPersonAndAges(grakn, personCount, ages, random);


### PR DESCRIPTION
## What is the goal of this PR?

Adding statistics test so that we don't regress on statistics counting.

## What are the changes implemented in this PR?

- Added an integration test for statistics which includes
     - Simple entity count
     - Attribute deduplication
     - Has edge deduplication
     - Has edge deletion
 - Fix a bug of generating wrong buffered iid maps.
 - Fix https://github.com/graknlabs/grakn/issues/5995