### PR TITLE
Refactor toString() methods for grakn patterns

### DIFF
--- a/pattern/BUILD
+++ b/pattern/BUILD
@@ -78,6 +78,23 @@ host_compatible_java_test(
     ],
 )
 
+host_compatible_java_test(
+    name = "test-conjunction",
+    srcs = [
+        "ConjunctionTest.java",
+    ],
+    test_class = "grakn.core.pattern.ConjunctionTest",
+    native_libraries_deps = [
+        "//pattern:pattern",
+    ],
+    deps = [
+        # External dependencies from Grakn Labs
+        "@graknlabs_common//:common",
+        "@graknlabs_graql//java/pattern",
+        "@graknlabs_graql//java:graql",
+    ],
+)
+
 checkstyle_test(
     name = "checkstyle",
     include = glob(["*", "*/*", "*/*/*"]),

--- a/pattern/BUILD
+++ b/pattern/BUILD
@@ -90,7 +90,6 @@ host_compatible_java_test(
     deps = [
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",
-        "@graknlabs_graql//java/pattern",
         "@graknlabs_graql//java:graql",
     ],
 )

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -52,6 +52,8 @@ import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.UNBOUNDED_NEGATION;
 import static grakn.core.common.exception.ErrorMessage.ThingRead.CONTRADICTORY_BOUND_VARIABLE;
 import static grakn.core.common.iterator.Iterators.iterate;
+import static graql.lang.common.GraqlToken.Char.CURLY_CLOSE;
+import static graql.lang.common.GraqlToken.Char.CURLY_OPEN;
 import static graql.lang.common.GraqlToken.Char.SEMICOLON;
 import static graql.lang.common.GraqlToken.Char.SPACE;
 import static java.util.Collections.unmodifiableMap;
@@ -173,7 +175,9 @@ public class Conjunction implements Pattern, Cloneable {
     @Override
     public String toString() {
         return variableSet.stream().flatMap(variable -> variable.constraints().stream()).map(Object::toString)
-                .collect(Collectors.joining("" + SEMICOLON + SPACE));
+                .collect(Collectors.joining("" + SEMICOLON + SPACE,
+                                            "" + CURLY_OPEN + SPACE,
+                                            "" + SPACE + CURLY_CLOSE));
     }
 
     @Override

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -170,13 +170,6 @@ public class Conjunction implements Pattern, Cloneable {
                                iterate(this.negations).map(Negation::clone).toSet());
     }
 
-//    @Override
-//    public String toString() {
-//        return Stream.concat(variableSet.stream().filter(this::printable), negations.stream()).map(Pattern::toString)
-//                .collect(Collectors.joining("" + SEMICOLON + NEW_LINE, "", "" + SEMICOLON));
-//    }
-
-
     @Override
     public String toString() {
         return variableSet.stream().flatMap(variable -> variable.constraints().stream()).map(Object::toString)

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -177,7 +177,7 @@ public class Conjunction implements Pattern, Cloneable {
         return variableSet.stream().flatMap(variable -> variable.constraints().stream()).map(Object::toString)
                 .collect(Collectors.joining("" + SEMICOLON + SPACE,
                                             "" + CURLY_OPEN + SPACE,
-                                            "" + SPACE + CURLY_CLOSE));
+                                            "" + SEMICOLON + SPACE + CURLY_CLOSE));
     }
 
     @Override

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -45,7 +45,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.common.collection.Collections.set;
@@ -53,8 +52,8 @@ import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.UNBOUNDED_NEGATION;
 import static grakn.core.common.exception.ErrorMessage.ThingRead.CONTRADICTORY_BOUND_VARIABLE;
 import static grakn.core.common.iterator.Iterators.iterate;
-import static graql.lang.common.GraqlToken.Char.NEW_LINE;
 import static graql.lang.common.GraqlToken.Char.SEMICOLON;
+import static graql.lang.common.GraqlToken.Char.SPACE;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.stream.Collectors.toSet;
@@ -171,10 +170,17 @@ public class Conjunction implements Pattern, Cloneable {
                                iterate(this.negations).map(Negation::clone).toSet());
     }
 
+//    @Override
+//    public String toString() {
+//        return Stream.concat(variableSet.stream().filter(this::printable), negations.stream()).map(Pattern::toString)
+//                .collect(Collectors.joining("" + SEMICOLON + NEW_LINE, "", "" + SEMICOLON));
+//    }
+
+
     @Override
     public String toString() {
-        return Stream.concat(variableSet.stream().filter(this::printable), negations.stream()).map(Pattern::toString)
-                .collect(Collectors.joining("" + SEMICOLON + NEW_LINE, "", "" + SEMICOLON));
+        return variableSet.stream().flatMap(variable -> variable.constraints().stream()).map(Object::toString)
+                .collect(Collectors.joining("" + SEMICOLON + SPACE));
     }
 
     @Override

--- a/pattern/ConjunctionTest.java
+++ b/pattern/ConjunctionTest.java
@@ -44,18 +44,19 @@ public class ConjunctionTest {
 
     @Test
     public void test_conjunction_with_entity_attribute_and_relation() {
-        Conjunction conjunction = parse("{ $p isa person, has $n; $n \"Alice\" isa name; $e(employee: $p) isa employment; }");
+        Conjunction conjunction = parse(
+                "{ $p isa person, has $n; $n \"Alice\" isa name; $e(employee: $p) isa employment; }");
 
         Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
-        Set<String> expectedVariableStrings = Stream.of(
-                "$p", "$_person", "$n", "$_name", "$e", "$_employment", "$_employment:employee").collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = set(
+                "$p", "$_person", "$n", "$_name", "$e", "$_employment", "$_employment:employee");
         assertEquals(expectedVariableStrings, variableStrings);
 
-        Set<String> expectedConstraintStrings = Stream.of(
-                "$p isa $_person", "$_person type person", "$p has $n", "$n isa $_name", "$_name type name",
-                "$n = \"Alice\"", "$e($_employment:employee:$p)", "$e isa $_employment", "$_employment type employment",
-                "$_employment:employee type employment:employee")
-                .collect(Collectors.toSet());
+        Set<String> expectedConstraintStrings = set("$p isa $_person", "$_person type person", "$p has $n",
+                                                    "$n isa $_name", "$_name type name", "$n = \"Alice\"",
+                                                    "$e($_employment:employee:$p)", "$e isa $_employment",
+                                                    "$_employment type employment",
+                                                    "$_employment:employee type employment:employee");
         assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
     }
 
@@ -67,9 +68,8 @@ public class ConjunctionTest {
         Set<String> expectedVariableStrings = Stream.of("$n", "$p", "$_name", "$_person").collect(Collectors.toSet());
         assertEquals(expectedVariableStrings, variableStrings);
 
-        Set<String> expectedConstraintStrings = Stream.of(
-                "$p isa $_person", "$_person type person", "$p has $n", "$n isa $_name", "$_name type name")
-                .collect(Collectors.toSet());
+        Set<String> expectedConstraintStrings = set("$p isa $_person", "$_person type person", "$p has $n",
+                                                    "$n isa $_name", "$_name type name");
         assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
     }
 
@@ -78,13 +78,24 @@ public class ConjunctionTest {
         Conjunction conjunction = parse("{ $p sub person, plays $r; $e sub employment, relates $r; }");
 
         Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
-        Set<String> expectedVariableStrings = Stream.of("$p", "$_person", "$r", "$e", "$_employment")
-                .collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = set("$p", "$_person", "$r", "$e", "$_employment");
         assertEquals(expectedVariableStrings, variableStrings);
 
-        Set<String> expectedConstraintStrings = Stream.of(
+        Set<String> expectedConstraintStrings = set(
                 "$p sub $_person", "$_person type person", "$p plays $r", "$e sub $_employment",
-                "$_employment type employment", "$e relates $r").collect(Collectors.toSet());
+                "$_employment type employment", "$e relates $r");
+        assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
+    }
+
+    @Test
+    public void test_conjunction_with_iids() {
+        Conjunction conjunction = parse("{ $x iid 0x12345678; $y iid 0x87654321; }");
+
+        Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = set("$x", "$y");
+        assertEquals(expectedVariableStrings, variableStrings);
+
+        Set<String> expectedConstraintStrings = set("$x iid 0x12345678", "$y iid 0x87654321");
         assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
     }
 }

--- a/pattern/ConjunctionTest.java
+++ b/pattern/ConjunctionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.pattern;
+
+import grakn.core.pattern.variable.Variable;
+import graql.lang.Graql;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static grakn.common.collection.Collections.set;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+public class ConjunctionTest {
+
+    private Conjunction parse(String query) {
+        return Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
+    }
+
+    private Set<String> conjunctionStringToStatementStrings(String conjunctionString) {
+        assertTrue(conjunctionString.startsWith("{ "));
+        assertTrue(conjunctionString.endsWith(" }"));
+        return set(Arrays.asList(conjunctionString.substring(2, conjunctionString.length() - 1).split("; ")));
+    }
+
+    @Test
+    public void test_conjunction_with_entity_attribute_and_relation() {
+        Conjunction conjunction = parse("{ $p isa person, has $n; $n \"Alice\" isa name; $e(employee: $p) isa employment; }");
+
+        Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = Stream.of(
+                "$p", "$_person", "$n", "$_name", "$e", "$_employment", "$_employment:employee").collect(Collectors.toSet());
+        assertEquals(expectedVariableStrings, variableStrings);
+
+        Set<String> expectedConstraintStrings = Stream.of(
+                "$p isa $_person", "$_person type person", "$p has $n", "$n isa $_name", "$_name type name",
+                "$n = \"Alice\"", "$e($_employment:employee:$p)", "$e isa $_employment", "$_employment type employment",
+                "$_employment:employee type employment:employee")
+                .collect(Collectors.toSet());
+        assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
+    }
+
+    @Test
+    public void test_conjunction_with_attribute_syntactic_sugar() {
+        Conjunction conjunction = parse("{ $p isa person, has name $n; }");
+
+        Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = Stream.of("$n", "$p", "$_name", "$_person").collect(Collectors.toSet());
+        assertEquals(expectedVariableStrings, variableStrings);
+
+        Set<String> expectedConstraintStrings = Stream.of(
+                "$p isa $_person", "$_person type person", "$p has $n", "$n isa $_name", "$_name type name")
+                .collect(Collectors.toSet());
+        assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
+    }
+
+    @Test
+    public void test_schema_conjunction() {
+        Conjunction conjunction = parse("{ $p sub person, plays $r; $e sub employment, relates $r; }");
+
+        Set<String> variableStrings = conjunction.variables().stream().map(Variable::toString).collect(Collectors.toSet());
+        Set<String> expectedVariableStrings = Stream.of("$p", "$_person", "$r", "$e", "$_employment")
+                .collect(Collectors.toSet());
+        assertEquals(expectedVariableStrings, variableStrings);
+
+        Set<String> expectedConstraintStrings = Stream.of(
+                "$p sub $_person", "$_person type person", "$p plays $r", "$e sub $_employment",
+                "$_employment type employment", "$e relates $r").collect(Collectors.toSet());
+        assertEquals(expectedConstraintStrings, conjunctionStringToStatementStrings(conjunction.toString()));
+    }
+}

--- a/pattern/constraint/thing/HasConstraint.java
+++ b/pattern/constraint/thing/HasConstraint.java
@@ -86,24 +86,6 @@ public class HasConstraint extends ThingConstraint implements AlphaEquivalent<Ha
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        syntax.append(HAS).append(SPACE);
-//
-//        if (attribute.reference().isName()) {
-//            syntax.append(attribute.reference().toString());
-//        } else {
-//            if (attribute.isa().isPresent() && attribute.isa().get().type().label().isPresent()) {
-//                syntax.append(attribute.isa().get().type().label().get().label());
-//            }
-//            syntax.append(SPACE);
-//            attribute.value().forEach(value -> syntax.append(value.toString()));
-//        }
-//
-//        return syntax.toString();
-//    }
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + HAS + SPACE + attribute.toString();

--- a/pattern/constraint/thing/HasConstraint.java
+++ b/pattern/constraint/thing/HasConstraint.java
@@ -86,22 +86,27 @@ public class HasConstraint extends ThingConstraint implements AlphaEquivalent<Ha
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        syntax.append(HAS).append(SPACE);
+//
+//        if (attribute.reference().isName()) {
+//            syntax.append(attribute.reference().toString());
+//        } else {
+//            if (attribute.isa().isPresent() && attribute.isa().get().type().label().isPresent()) {
+//                syntax.append(attribute.isa().get().type().label().get().label());
+//            }
+//            syntax.append(SPACE);
+//            attribute.value().forEach(value -> syntax.append(value.toString()));
+//        }
+//
+//        return syntax.toString();
+//    }
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        syntax.append(HAS).append(SPACE);
-
-        if (attribute.reference().isName()) {
-            syntax.append(attribute.reference().toString());
-        } else {
-            if (attribute.isa().isPresent() && attribute.isa().get().type().label().isPresent()) {
-                syntax.append(attribute.isa().get().type().label().get().label());
-            }
-            syntax.append(SPACE);
-            attribute.value().forEach(value -> syntax.append(value.toString()));
-        }
-
-        return syntax.toString();
+        return owner.toString() + SPACE + HAS + SPACE + attribute.toString();
     }
 
     @Override

--- a/pattern/constraint/thing/IIDConstraint.java
+++ b/pattern/constraint/thing/IIDConstraint.java
@@ -81,12 +81,17 @@ public class IIDConstraint extends ThingConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        syntax.append(IID).append(SPACE);
+//        syntax.append(Bytes.bytesToHexString(iid));
+//        return syntax.toString();
+//    }
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        syntax.append(IID).append(SPACE);
-        syntax.append(Bytes.bytesToHexString(iid));
-        return syntax.toString();
+        return owner.toString() + SPACE + IID + SPACE + Bytes.bytesToHexString(iid);
     }
 
     @Override

--- a/pattern/constraint/thing/IIDConstraint.java
+++ b/pattern/constraint/thing/IIDConstraint.java
@@ -81,14 +81,6 @@ public class IIDConstraint extends ThingConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        syntax.append(IID).append(SPACE);
-//        syntax.append(Bytes.bytesToHexString(iid));
-//        return syntax.toString();
-//    }
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + IID + SPACE + Bytes.bytesToHexString(iid);

--- a/pattern/constraint/thing/IsConstraint.java
+++ b/pattern/constraint/thing/IsConstraint.java
@@ -83,12 +83,6 @@ public class IsConstraint extends ThingConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + IS + SPACE + variable.reference().toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + IS + SPACE + variable.toString();

--- a/pattern/constraint/thing/IsConstraint.java
+++ b/pattern/constraint/thing/IsConstraint.java
@@ -83,9 +83,15 @@ public class IsConstraint extends ThingConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + IS + SPACE + variable.reference().toString();
+//    }
+
+
     @Override
     public String toString() {
-        return "" + IS + SPACE + variable.reference().toString();
+        return owner.toString() + SPACE + IS + SPACE + variable.toString();
     }
 
     @Override

--- a/pattern/constraint/thing/IsaConstraint.java
+++ b/pattern/constraint/thing/IsaConstraint.java
@@ -100,9 +100,15 @@ public class IsaConstraint extends ThingConstraint implements AlphaEquivalent<Is
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + (isExplicit ? ISAX : ISA) + SPACE + type.referenceSyntax();
+//    }
+
+
     @Override
     public String toString() {
-        return "" + (isExplicit ? ISAX : ISA) + SPACE + type.referenceSyntax();
+        return owner.toString() + (isExplicit ? ISAX : ISA) + SPACE + type.toString();
     }
 
     @Override

--- a/pattern/constraint/thing/IsaConstraint.java
+++ b/pattern/constraint/thing/IsaConstraint.java
@@ -100,15 +100,9 @@ public class IsaConstraint extends ThingConstraint implements AlphaEquivalent<Is
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + (isExplicit ? ISAX : ISA) + SPACE + type.referenceSyntax();
-//    }
-
-
     @Override
     public String toString() {
-        return owner.toString() + (isExplicit ? ISAX : ISA) + SPACE + type.toString();
+        return owner.toString() + SPACE + (isExplicit ? ISAX : ISA) + SPACE + type.toString();
     }
 
     @Override

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -40,8 +40,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static grakn.core.common.iterator.Iterators.iterate;
+import static graql.lang.common.GraqlToken.Char.COLON;
+import static graql.lang.common.GraqlToken.Char.COMMA;
 import static graql.lang.common.GraqlToken.Char.PARAN_CLOSE;
 import static graql.lang.common.GraqlToken.Char.PARAN_OPEN;
+import static graql.lang.common.GraqlToken.Char.SPACE;
 
 public class RelationConstraint extends ThingConstraint implements AlphaEquivalent<RelationConstraint> {
 
@@ -209,9 +212,15 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             return hash;
         }
 
+//        @Override
+//        public String toString() {
+//            return (roleType == null ? "" : roleType.referenceSyntax() + ":") + player.reference().toString();
+//        }
+
+
         @Override
         public String toString() {
-            return (roleType == null ? "" : roleType.referenceSyntax() + ":") + player.reference().toString();
+            return "" + (roleType().isPresent() ? "" : roleType.toString() + COLON + SPACE) + player.toString();
         }
 
         @Override
@@ -228,9 +237,17 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
         }
     }
 
+//    @Override
+//    public String toString() {
+//        return rolePlayers.stream().map(RolePlayer::toString)
+//                .collect(Collectors.joining(", ", PARAN_OPEN.toString(), PARAN_CLOSE.toString()));
+//    }
+
+
     @Override
     public String toString() {
-        return rolePlayers.stream().map(RolePlayer::toString)
-                .collect(Collectors.joining(", ", PARAN_OPEN.toString(), PARAN_CLOSE.toString()));
+        return owner.toString() + SPACE + PARAN_OPEN
+                + rolePlayers.stream().map(RolePlayer::toString).collect(Collectors.joining("" + COMMA + SPACE))
+                + PARAN_CLOSE;
     }
 }

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -212,15 +212,9 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             return hash;
         }
 
-//        @Override
-//        public String toString() {
-//            return (roleType == null ? "" : roleType.referenceSyntax() + ":") + player.reference().toString();
-//        }
-
-
         @Override
         public String toString() {
-            return "" + (roleType().isPresent() ? "" : roleType.toString() + COLON + SPACE) + player.toString();
+            return (roleType().isPresent() ? roleType.toString() + COLON + SPACE : "") + player.toString();
         }
 
         @Override
@@ -236,13 +230,6 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
             return new RelationConstraint.RolePlayer(roleTypeClone, playerClone, repetition);
         }
     }
-
-//    @Override
-//    public String toString() {
-//        return rolePlayers.stream().map(RolePlayer::toString)
-//                .collect(Collectors.joining(", ", PARAN_OPEN.toString(), PARAN_CLOSE.toString()));
-//    }
-
 
     @Override
     public String toString() {

--- a/pattern/constraint/thing/RelationConstraint.java
+++ b/pattern/constraint/thing/RelationConstraint.java
@@ -214,7 +214,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
         @Override
         public String toString() {
-            return (roleType().isPresent() ? roleType.toString() + COLON + SPACE : "") + player.toString();
+            return (roleType != null ? roleType.toString() + COLON : "") + player.toString();
         }
 
         @Override
@@ -233,7 +233,7 @@ public class RelationConstraint extends ThingConstraint implements AlphaEquivale
 
     @Override
     public String toString() {
-        return owner.toString() + SPACE + PARAN_OPEN
+        return owner.toString() + PARAN_OPEN
                 + rolePlayers.stream().map(RolePlayer::toString).collect(Collectors.joining("" + COMMA + SPACE))
                 + PARAN_CLOSE;
     }

--- a/pattern/constraint/thing/ValueConstraint.java
+++ b/pattern/constraint/thing/ValueConstraint.java
@@ -176,9 +176,15 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         return hash;
     }
 
+//    @Override
+//    public java.lang.String toString() {
+//        return predicate.toString() + SPACE + value.toString();
+//    }
+
+
     @Override
     public java.lang.String toString() {
-        return predicate.toString() + SPACE + value.toString();
+        return owner.toString() + SPACE + predicate.toString() + SPACE + value.toString();
     }
 
     public AlphaEquivalence alphaEquals(ValueConstraint<?> that) {
@@ -315,9 +321,15 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
             traversal.predicate(owner.id(), predicate, value);
         }
 
+//        @Override
+//        public java.lang.String toString() {
+//            return predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
+//        }
+
+
         @Override
         public java.lang.String toString() {
-            return predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
+            return owner.toString() + predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
         }
 
         @Override

--- a/pattern/constraint/thing/ValueConstraint.java
+++ b/pattern/constraint/thing/ValueConstraint.java
@@ -176,12 +176,6 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
         return hash;
     }
 
-//    @Override
-//    public java.lang.String toString() {
-//        return predicate.toString() + SPACE + value.toString();
-//    }
-
-
     @Override
     public java.lang.String toString() {
         return owner.toString() + SPACE + predicate.toString() + SPACE + value.toString();
@@ -321,15 +315,9 @@ public abstract class ValueConstraint<T> extends ThingConstraint implements Alph
             traversal.predicate(owner.id(), predicate, value);
         }
 
-//        @Override
-//        public java.lang.String toString() {
-//            return predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
-//        }
-
-
         @Override
         public java.lang.String toString() {
-            return owner.toString() + predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
+            return owner.toString() + SPACE + predicate.toString() + SPACE + QUOTE_DOUBLE + value + QUOTE_DOUBLE;
         }
 
         @Override

--- a/pattern/constraint/type/AbstractConstraint.java
+++ b/pattern/constraint/type/AbstractConstraint.java
@@ -70,10 +70,6 @@ public class AbstractConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() { return ABSTRACT.toString(); }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + ABSTRACT;

--- a/pattern/constraint/type/AbstractConstraint.java
+++ b/pattern/constraint/type/AbstractConstraint.java
@@ -25,6 +25,7 @@ import grakn.core.traversal.Traversal;
 import java.util.Objects;
 
 import static grakn.common.collection.Collections.set;
+import static graql.lang.common.GraqlToken.Char.SPACE;
 import static graql.lang.common.GraqlToken.Constraint.ABSTRACT;
 
 public class AbstractConstraint extends TypeConstraint {
@@ -69,8 +70,14 @@ public class AbstractConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() { return ABSTRACT.toString(); }
+
+
     @Override
-    public String toString() { return ABSTRACT.toString(); }
+    public String toString() {
+        return owner.toString() + SPACE + ABSTRACT;
+    }
 
     @Override
     public AbstractConstraint clone(Conjunction.Cloner cloner) {

--- a/pattern/constraint/type/IsConstraint.java
+++ b/pattern/constraint/type/IsConstraint.java
@@ -83,9 +83,14 @@ public class IsConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + IS + SPACE + variable.referenceSyntax();
+//    }
+
     @Override
     public String toString() {
-        return "" + IS + SPACE + variable.referenceSyntax();
+        return owner.toString() + SPACE + IS + SPACE + variable.toString();
     }
 
     @Override

--- a/pattern/constraint/type/IsConstraint.java
+++ b/pattern/constraint/type/IsConstraint.java
@@ -83,11 +83,6 @@ public class IsConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + IS + SPACE + variable.referenceSyntax();
-//    }
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + IS + SPACE + variable.toString();

--- a/pattern/constraint/type/LabelConstraint.java
+++ b/pattern/constraint/type/LabelConstraint.java
@@ -96,10 +96,6 @@ public class LabelConstraint extends TypeConstraint implements AlphaEquivalent<L
         return hash;
     }
 
-//    @Override
-//    public String toString() { return "" + TYPE + SPACE + scopedLabel(); }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + TYPE + SPACE + scopedLabel();

--- a/pattern/constraint/type/LabelConstraint.java
+++ b/pattern/constraint/type/LabelConstraint.java
@@ -96,8 +96,14 @@ public class LabelConstraint extends TypeConstraint implements AlphaEquivalent<L
         return hash;
     }
 
+//    @Override
+//    public String toString() { return "" + TYPE + SPACE + scopedLabel(); }
+
+
     @Override
-    public String toString() { return "" + TYPE + SPACE + scopedLabel(); }
+    public String toString() {
+        return owner.toString() + SPACE + TYPE + SPACE + scopedLabel();
+    }
 
     @Override
     public AlphaEquivalence alphaEquals(LabelConstraint that) {

--- a/pattern/constraint/type/OwnsConstraint.java
+++ b/pattern/constraint/type/OwnsConstraint.java
@@ -34,7 +34,6 @@ import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.OVERRIDDEN_TYPES_IN_TRAVERSAL;
 import static graql.lang.common.GraqlToken.Char.SPACE;
 import static graql.lang.common.GraqlToken.Constraint.AS;
-import static graql.lang.common.GraqlToken.Constraint.IS_KEY;
 import static graql.lang.common.GraqlToken.Constraint.OWNS;
 
 public class OwnsConstraint extends TypeConstraint {
@@ -113,16 +112,23 @@ public class OwnsConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        syntax.append(OWNS).append(SPACE).append(attributeType.referenceSyntax());
+//        if (overriddenAttributeType != null) {
+//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenAttributeType.referenceSyntax());
+//        }
+//        if (isKey) syntax.append(SPACE).append(IS_KEY);
+//
+//        return syntax.toString();
+//    }
+
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        syntax.append(OWNS).append(SPACE).append(attributeType.referenceSyntax());
-        if (overriddenAttributeType != null) {
-            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenAttributeType.referenceSyntax());
-        }
-        if (isKey) syntax.append(SPACE).append(IS_KEY);
-
-        return syntax.toString();
+        return owner.toString() + SPACE + OWNS + SPACE + attributeType.toString()
+                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenAttributeType.toString() : "");
     }
 
     @Override

--- a/pattern/constraint/type/OwnsConstraint.java
+++ b/pattern/constraint/type/OwnsConstraint.java
@@ -116,7 +116,7 @@ public class OwnsConstraint extends TypeConstraint {
     @Override
     public String toString() {
         return owner.toString() + SPACE + OWNS + SPACE + attributeType.toString()
-                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenAttributeType.toString() : "")
+                + (overriddenAttributeType != null ? "" + SPACE + AS + SPACE + overriddenAttributeType.toString() : "")
                 + (isKey ? "" + SPACE + IS_KEY : "");
     }
 

--- a/pattern/constraint/type/OwnsConstraint.java
+++ b/pattern/constraint/type/OwnsConstraint.java
@@ -34,6 +34,7 @@ import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.OVERRIDDEN_TYPES_IN_TRAVERSAL;
 import static graql.lang.common.GraqlToken.Char.SPACE;
 import static graql.lang.common.GraqlToken.Constraint.AS;
+import static graql.lang.common.GraqlToken.Constraint.IS_KEY;
 import static graql.lang.common.GraqlToken.Constraint.OWNS;
 
 public class OwnsConstraint extends TypeConstraint {
@@ -112,23 +113,11 @@ public class OwnsConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        syntax.append(OWNS).append(SPACE).append(attributeType.referenceSyntax());
-//        if (overriddenAttributeType != null) {
-//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenAttributeType.referenceSyntax());
-//        }
-//        if (isKey) syntax.append(SPACE).append(IS_KEY);
-//
-//        return syntax.toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + OWNS + SPACE + attributeType.toString()
-                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenAttributeType.toString() : "");
+                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenAttributeType.toString() : "")
+                + (isKey ? "" + SPACE + IS_KEY : "");
     }
 
     @Override

--- a/pattern/constraint/type/PlaysConstraint.java
+++ b/pattern/constraint/type/PlaysConstraint.java
@@ -117,15 +117,24 @@ public class PlaysConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        syntax.append(PLAYS).append(SPACE);
+//        if (relationType != null) syntax.append(relationType.referenceSyntax()).append(COLON);
+//        if (roleType != null) syntax.append(roleType.referenceSyntax());
+//        if (overriddenRoleType != null)
+//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
+//        return syntax.toString();
+//    }
+
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        syntax.append(PLAYS).append(SPACE);
-        if (relationType != null) syntax.append(relationType.referenceSyntax()).append(COLON);
-        if (roleType != null) syntax.append(roleType.referenceSyntax());
-        if (overriddenRoleType != null)
-            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
-        return syntax.toString();
+        return owner.toString() + SPACE + PLAYS
+                + (relation().isPresent() ? "" + SPACE + relationType + COLON : "")
+                + SPACE + roleType.toString()
+                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
     }
 
     @Override

--- a/pattern/constraint/type/PlaysConstraint.java
+++ b/pattern/constraint/type/PlaysConstraint.java
@@ -119,9 +119,9 @@ public class PlaysConstraint extends TypeConstraint {
 
     @Override
     public String toString() {
-        return owner.toString() + SPACE + PLAYS
-                + (relation().isPresent() ? "" + SPACE + relationType + COLON : "") + SPACE + roleType.toString()
-                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
+        return owner.toString() + SPACE + PLAYS + SPACE
+                + (relationType != null ? "" + relationType + COLON : "") + roleType.toString()
+                + (overriddenRoleType != null ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
     }
 
     @Override

--- a/pattern/constraint/type/PlaysConstraint.java
+++ b/pattern/constraint/type/PlaysConstraint.java
@@ -117,23 +117,10 @@ public class PlaysConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        syntax.append(PLAYS).append(SPACE);
-//        if (relationType != null) syntax.append(relationType.referenceSyntax()).append(COLON);
-//        if (roleType != null) syntax.append(roleType.referenceSyntax());
-//        if (overriddenRoleType != null)
-//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
-//        return syntax.toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + PLAYS
-                + (relation().isPresent() ? "" + SPACE + relationType + COLON : "")
-                + SPACE + roleType.toString()
+                + (relation().isPresent() ? "" + SPACE + relationType + COLON : "") + SPACE + roleType.toString()
                 + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
     }
 

--- a/pattern/constraint/type/RegexConstraint.java
+++ b/pattern/constraint/type/RegexConstraint.java
@@ -79,12 +79,6 @@ public class RegexConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + LIKE + SPACE + regex.toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + LIKE + SPACE + regex.toString();

--- a/pattern/constraint/type/RegexConstraint.java
+++ b/pattern/constraint/type/RegexConstraint.java
@@ -79,9 +79,15 @@ public class RegexConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + LIKE + SPACE + regex.toString();
+//    }
+
+
     @Override
     public String toString() {
-        return "" + LIKE + SPACE + regex.toString();
+        return owner.toString() + SPACE + LIKE + SPACE + regex.toString();
     }
 
     @Override

--- a/pattern/constraint/type/RelatesConstraint.java
+++ b/pattern/constraint/type/RelatesConstraint.java
@@ -108,16 +108,6 @@ public class RelatesConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        syntax.append(RELATES).append(SPACE).append(roleType.referenceSyntax());
-//        if (overriddenRoleType != null)
-//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
-//        return syntax.toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + RELATES + SPACE + roleType.toString()

--- a/pattern/constraint/type/RelatesConstraint.java
+++ b/pattern/constraint/type/RelatesConstraint.java
@@ -108,13 +108,20 @@ public class RelatesConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        syntax.append(RELATES).append(SPACE).append(roleType.referenceSyntax());
+//        if (overriddenRoleType != null)
+//            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
+//        return syntax.toString();
+//    }
+
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        syntax.append(RELATES).append(SPACE).append(roleType.referenceSyntax());
-        if (overriddenRoleType != null)
-            syntax.append(SPACE).append(AS).append(SPACE).append(overriddenRoleType.referenceSyntax());
-        return syntax.toString();
+        return owner.toString() + SPACE + RELATES + SPACE + roleType.toString()
+                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
     }
 
     @Override

--- a/pattern/constraint/type/RelatesConstraint.java
+++ b/pattern/constraint/type/RelatesConstraint.java
@@ -111,7 +111,7 @@ public class RelatesConstraint extends TypeConstraint {
     @Override
     public String toString() {
         return owner.toString() + SPACE + RELATES + SPACE + roleType.toString()
-                + (overridden().isPresent() ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
+                + (overriddenRoleType != null ? "" + SPACE + AS + SPACE + overriddenRoleType.toString() : "");
     }
 
     @Override

--- a/pattern/constraint/type/SubConstraint.java
+++ b/pattern/constraint/type/SubConstraint.java
@@ -99,9 +99,14 @@ public class SubConstraint extends TypeConstraint {
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + (isExplicit ? SUBX : SUB) + SPACE + type.referenceSyntax();
+//    }
+
     @Override
     public String toString() {
-        return "" + (isExplicit ? SUBX : SUB) + SPACE + type.referenceSyntax();
+        return owner.toString() + SPACE + (isExplicit ? SUBX : SUB) + SPACE + type.toString();
     }
 
     @Override

--- a/pattern/constraint/type/SubConstraint.java
+++ b/pattern/constraint/type/SubConstraint.java
@@ -99,11 +99,6 @@ public class SubConstraint extends TypeConstraint {
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + (isExplicit ? SUBX : SUB) + SPACE + type.referenceSyntax();
-//    }
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + (isExplicit ? SUBX : SUB) + SPACE + type.toString();

--- a/pattern/constraint/type/ValueTypeConstraint.java
+++ b/pattern/constraint/type/ValueTypeConstraint.java
@@ -83,9 +83,15 @@ public class ValueTypeConstraint extends TypeConstraint implements AlphaEquivale
         return hash;
     }
 
+//    @Override
+//    public String toString() {
+//        return "" + VALUE_TYPE + SPACE + valueType.toString();
+//    }
+
+
     @Override
     public String toString() {
-        return "" + VALUE_TYPE + SPACE + valueType.toString();
+        return owner.toString() + SPACE + VALUE_TYPE + SPACE + valueType.toString();
     }
 
     @Override

--- a/pattern/constraint/type/ValueTypeConstraint.java
+++ b/pattern/constraint/type/ValueTypeConstraint.java
@@ -83,12 +83,6 @@ public class ValueTypeConstraint extends TypeConstraint implements AlphaEquivale
         return hash;
     }
 
-//    @Override
-//    public String toString() {
-//        return "" + VALUE_TYPE + SPACE + valueType.toString();
-//    }
-
-
     @Override
     public String toString() {
         return owner.toString() + SPACE + VALUE_TYPE + SPACE + valueType.toString();

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -34,23 +34,16 @@ import grakn.core.traversal.common.Identifier;
 import graql.lang.common.GraqlToken;
 
 import java.time.LocalDateTime;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.ILLEGAL_DERIVED_THING_CONSTRAINT_ISA;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_IID;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_THING_CONSTRAINT_ISA;
-import static graql.lang.common.GraqlToken.Char.COMMA;
-import static graql.lang.common.GraqlToken.Char.SPACE;
 
 public class ThingVariable extends Variable implements AlphaEquivalent<ThingVariable> {
 
@@ -246,21 +239,21 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         return this;
     }
 
-    @Override
-    public String toString() {
-
-        StringBuilder head = new StringBuilder();
-        StringBuilder tail = new StringBuilder();
-
-        if (reference().isName()) head.append(reference());
-        tail.append(Stream.of(relationConstraints, isaConstraint == null ? new HashSet<IsaConstraint>() : set(isaConstraint),
-                              hasConstraints, valueConstraints, isConstraints)
-                            .flatMap(Collection::stream).filter(Objects::nonNull).map(ThingConstraint::toString)
-                            .collect(Collectors.joining("" + COMMA + SPACE)));
-        if (iidConstraint != null) tail.append(COMMA).append(SPACE).append(iidConstraint);
-        if (head.length() > 0 && tail.length() > 0) head.append(SPACE);
-        return head.append(tail.toString()).toString();
-    }
+//    @Override
+//    public String toString() {
+//
+//        StringBuilder head = new StringBuilder();
+//        StringBuilder tail = new StringBuilder();
+//
+//        if (reference().isName()) head.append(reference());
+//        tail.append(Stream.of(relationConstraints, isaConstraint == null ? new HashSet<IsaConstraint>() : set(isaConstraint),
+//                              hasConstraints, valueConstraints, isConstraints)
+//                              .flatMap(Collection::stream).filter(Objects::nonNull).map(ThingConstraint::toString)
+//                              .collect(Collectors.joining("" + COMMA + SPACE)));
+//        if (iidConstraint != null) tail.append(COMMA).append(SPACE).append(iidConstraint);
+//        if (head.length() > 0 && tail.length() > 0) head.append(SPACE);
+//        return head.append(tail.toString()).toString();
+//    }
 
     @Override
     public AlphaEquivalence alphaEquals(ThingVariable that) {

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -239,22 +239,6 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
         return this;
     }
 
-//    @Override
-//    public String toString() {
-//
-//        StringBuilder head = new StringBuilder();
-//        StringBuilder tail = new StringBuilder();
-//
-//        if (reference().isName()) head.append(reference());
-//        tail.append(Stream.of(relationConstraints, isaConstraint == null ? new HashSet<IsaConstraint>() : set(isaConstraint),
-//                              hasConstraints, valueConstraints, isConstraints)
-//                              .flatMap(Collection::stream).filter(Objects::nonNull).map(ThingConstraint::toString)
-//                              .collect(Collectors.joining("" + COMMA + SPACE)));
-//        if (iidConstraint != null) tail.append(COMMA).append(SPACE).append(iidConstraint);
-//        if (head.length() > 0 && tail.length() > 0) head.append(SPACE);
-//        return head.append(tail.toString()).toString();
-//    }
-
     @Override
     public AlphaEquivalence alphaEquals(ThingVariable that) {
         return AlphaEquivalence.valid()

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -41,21 +41,15 @@ import graql.lang.pattern.constraint.ConceptConstraint;
 import javax.annotation.Nullable;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_LABEL;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_REGEX;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_SUB;
 import static grakn.core.common.exception.ErrorMessage.Pattern.MULTIPLE_TYPE_CONSTRAINT_VALUE_TYPE;
-import static graql.lang.common.GraqlToken.Char.COMMA;
-import static graql.lang.common.GraqlToken.Char.SPACE;
 
 public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariable> {
 
@@ -254,23 +248,34 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 
+//    @Override
+//    public String toString() {
+//        StringBuilder syntax = new StringBuilder();
+//        if (!reference().isLabel()) {
+//            syntax.append(reference());
+//            if (labelConstraint != null) syntax.append(SPACE).append(labelConstraint.toString());
+//        } else {
+//            syntax.append(labelConstraint.label());
+//        }
+//
+//        if (constraints.size() > 1 || labelConstraint == null) syntax.append(SPACE);
+//        Stream<Set<? extends TypeConstraint>> conStream =
+//                Stream.of(set(subConstraint), set(abstractConstraint), ownsConstraints, relatesConstraints,
+//                          playsConstraints, set(valueTypeConstraint), set(regexConstraint), isConstraints);
+//        syntax.append(conStream.flatMap(Set::stream).filter(Objects::nonNull).map(TypeConstraint::toString)
+//                              .collect(Collectors.joining("" + COMMA + SPACE)));
+//        return syntax.toString();
+//    }
+
+
     @Override
     public String toString() {
-        StringBuilder syntax = new StringBuilder();
-        if (!reference().isLabel()) {
-            syntax.append(reference());
-            if (labelConstraint != null) syntax.append(SPACE).append(labelConstraint.toString());
+        if (reference().isLabel()) {
+            assert label().isPresent();
+            return "" + label().get().toString();
         } else {
-            syntax.append(labelConstraint.label());
+            return super.toString();
         }
-
-        if (constraints.size() > 1 || labelConstraint == null) syntax.append(SPACE);
-        Stream<Set<? extends TypeConstraint>> conStream =
-                Stream.of(set(subConstraint), set(abstractConstraint), ownsConstraints, relatesConstraints,
-                          playsConstraints, set(valueTypeConstraint), set(regexConstraint), isConstraints);
-        syntax.append(conStream.flatMap(Set::stream).filter(Objects::nonNull).map(TypeConstraint::toString)
-                              .collect(Collectors.joining("" + COMMA + SPACE)));
-        return syntax.toString();
     }
 
     public String referenceSyntax() {

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -248,26 +248,6 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         constraints().forEach(constraint -> constraint.addTo(traversal));
     }
 
-//    @Override
-//    public String toString() {
-//        StringBuilder syntax = new StringBuilder();
-//        if (!reference().isLabel()) {
-//            syntax.append(reference());
-//            if (labelConstraint != null) syntax.append(SPACE).append(labelConstraint.toString());
-//        } else {
-//            syntax.append(labelConstraint.label());
-//        }
-//
-//        if (constraints.size() > 1 || labelConstraint == null) syntax.append(SPACE);
-//        Stream<Set<? extends TypeConstraint>> conStream =
-//                Stream.of(set(subConstraint), set(abstractConstraint), ownsConstraints, relatesConstraints,
-//                          playsConstraints, set(valueTypeConstraint), set(regexConstraint), isConstraints);
-//        syntax.append(conStream.flatMap(Set::stream).filter(Objects::nonNull).map(TypeConstraint::toString)
-//                              .collect(Collectors.joining("" + COMMA + SPACE)));
-//        return syntax.toString();
-//    }
-
-
     @Override
     public String toString() {
         if (reference().isLabel()) {
@@ -276,12 +256,6 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         } else {
             return super.toString();
         }
-    }
-
-    public String referenceSyntax() {
-        if (reference().isLabel()) return labelConstraint.label();
-        else if (reference().isName() || reference().isAnonymous()) return reference().toString();
-        else throw new RuntimeException("Unhandled reference type.");
     }
 
     @Override

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -252,7 +252,7 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
     public String toString() {
         if (reference().isLabel()) {
             assert label().isPresent();
-            return "" + label().get().toString();
+            return "" + label().get().scopedLabel();
         } else {
             return super.toString();
         }

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -249,16 +249,6 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
     }
 
     @Override
-    public String toString() {
-        if (reference().isLabel()) {
-            assert label().isPresent();
-            return "" + label().get().scopedLabel();
-        } else {
-            return super.toString();
-        }
-    }
-
-    @Override
     public AlphaEquivalence alphaEquals(TypeVariable that) {
         return AlphaEquivalence.valid()
                 .validIf(id().isName() == that.id().isName())

--- a/pattern/variable/Variable.java
+++ b/pattern/variable/Variable.java
@@ -113,6 +113,11 @@ public abstract class Variable implements Pattern {
     }
 
     @Override
+    public String toString() {
+        return reference().toString();
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -42,8 +42,8 @@ import graql.lang.query.GraqlDefine;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
+import java.util.Optional;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_SCOPE_IS_NOT_RELATION_TYPE;
@@ -53,9 +53,9 @@ import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE_TYPE_MODIFIED;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.CYCLIC_TYPE_HIERARCHY;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.INVALID_DEFINE_SUB;
-import static grakn.core.common.exception.ErrorMessage.TypeWrite.OVERRIDDEN_NOT_SUPERTYPE;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.ROLE_DEFINED_OUTSIDE_OF_RELATION;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.TYPE_CONSTRAINT_UNACCEPTED;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.OVERRIDDEN_NOT_SUPERTYPE;
 import static graql.lang.common.GraqlToken.Constraint.IS;
 
 public class Definer {

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -42,8 +42,8 @@ import graql.lang.query.GraqlDefine;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Optional;
+import java.util.Set;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.exception.ErrorMessage.TypeRead.ROLE_TYPE_SCOPE_IS_NOT_RELATION_TYPE;
@@ -53,9 +53,9 @@ import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.ATTRIBUTE_VALUE_TYPE_MODIFIED;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.CYCLIC_TYPE_HIERARCHY;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.INVALID_DEFINE_SUB;
+import static grakn.core.common.exception.ErrorMessage.TypeWrite.OVERRIDDEN_NOT_SUPERTYPE;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.ROLE_DEFINED_OUTSIDE_OF_RELATION;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.TYPE_CONSTRAINT_UNACCEPTED;
-import static grakn.core.common.exception.ErrorMessage.TypeWrite.OVERRIDDEN_NOT_SUPERTYPE;
 import static graql.lang.common.GraqlToken.Constraint.IS;
 
 public class Definer {


### PR DESCRIPTION
## What is the goal of this PR?

To make `toString()` method on variables, constraints and conjunctions more intuitive, as outlined in issue [#6057](https://github.com/graknlabs/grakn/issues/6057).  This will also make the method more useful for debugging.

## What are the changes implemented in this PR?

* `Variable` displays the variable name, eg `$x`, `$_1`.
* `Constraint` shows the owner variable, followed by the constraint over the constrained/constraining variables. For example `$x sub $y`, `$_1 isa name`.
* `Conjunction` shows a concatenation of the conjunction's constraints, book-ended with curly brackets and delimited with semi-colons.
