### PR TITLE
Make key generator of things generate correct key

### DIFF
--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -128,7 +128,7 @@ public class RocksDatabase implements Grakn.Database {
         try (RocksSession.Schema session = createAndOpenSession(SCHEMA, new Options.Session()).asSchema()) {
             try (RocksTransaction.Schema txn = session.initialisationTransaction()) {
                 schemaKeyGenerator.sync(txn.schemaStorage());
-                dataKeyGenerator.sync(txn.dataStorage());
+                dataKeyGenerator.sync(txn.schemaStorage(), txn.dataStorage());
             }
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

Fix a bug that caused the key generator for things generates the duplicate keys after the server restarts.

## What are the changes implemented in this PR?

- Use both schema and data storage to sync up persisted data key generator properly.