### PR TITLE
Use hex representation to display IID string

### DIFF
--- a/concept/thing/impl/ThingImpl.java
+++ b/concept/thing/impl/ThingImpl.java
@@ -18,6 +18,7 @@
 
 package grakn.core.concept.thing.impl;
 
+import grakn.common.collection.Bytes;
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.ConceptImpl;
 import grakn.core.concept.thing.Attribute;
@@ -83,7 +84,7 @@ public abstract class ThingImpl extends ConceptImpl implements Thing {
 
     @Override
     public String getIIDForPrinting() {
-        return vertex.iid().toString();
+        return Bytes.bytesToHexString(vertex.iid().bytes());
     }
 
     @Override


### PR DESCRIPTION
## What is the goal of this PR?

The display IID string should be using hex representation, instead of internal string representation.

## What are the changes implemented in this PR?

- Use hex representation for `getIIDForPrinting`.
