### PR TITLE
Allow waiting for scheduled timed events during event loop shutdown

### DIFF
--- a/concurrent/actor/EventLoop.java
+++ b/concurrent/actor/EventLoop.java
@@ -52,7 +52,6 @@ public class EventLoop {
 
     public void schedule(Runnable job, Consumer<Throwable> errorHandler) {
         assert state != State.STOPPED : "unexpected state: " + state;
-
         jobs.offer(new Job(job, errorHandler));
     }
 
@@ -65,7 +64,12 @@ public class EventLoop {
         thread.join();
     }
 
-    public synchronized void stop() throws InterruptedException {
+    public synchronized void shutdown(long scheduledWaitTime) throws InterruptedException {
+        schedule(clock.get() + scheduledWaitTime, () -> state = State.STOPPED, DEFAULT_ERROR_HANDLER);
+        await();
+    }
+
+    public synchronized void shutdownNow() throws InterruptedException {
         schedule(() -> state = State.STOPPED, DEFAULT_ERROR_HANDLER);
         await();
     }

--- a/concurrent/actor/EventLoop.java
+++ b/concurrent/actor/EventLoop.java
@@ -60,10 +60,6 @@ public class EventLoop {
         return new Cancellable(deadline, job, errorHandler);
     }
 
-    public synchronized void await() throws InterruptedException {
-        thread.join();
-    }
-
     public synchronized void shutdown(long scheduledWaitTime) throws InterruptedException {
         schedule(clock.get() + scheduledWaitTime, () -> state = State.STOPPED, DEFAULT_ERROR_HANDLER);
         await();
@@ -72,6 +68,10 @@ public class EventLoop {
     public synchronized void shutdownNow() throws InterruptedException {
         schedule(() -> state = State.STOPPED, DEFAULT_ERROR_HANDLER);
         await();
+    }
+
+    private void await() throws InterruptedException {
+        thread.join();
     }
 
     public long time() {

--- a/concurrent/actor/EventLoopGroup.java
+++ b/concurrent/actor/EventLoopGroup.java
@@ -51,14 +51,20 @@ public class EventLoopGroup {
     }
 
     public synchronized void await() throws InterruptedException {
-        for (int i = 0; i < eventLoops.length; i++) {
-            eventLoops[i].await();
+        for (EventLoop eventLoop : eventLoops) {
+            eventLoop.await();
         }
     }
 
-    public synchronized void stop() throws InterruptedException {
-        for (int i = 0; i < eventLoops.length; i++) {
-            eventLoops[i].stop();
+    public synchronized void shutdown(long scheduledWaitTime) throws InterruptedException {
+        for (EventLoop eventLoop : eventLoops) {
+            eventLoop.shutdown(scheduledWaitTime);
+        }
+    }
+
+    public synchronized void shutdownNow() throws InterruptedException {
+        for (EventLoop eventLoop : eventLoops) {
+            eventLoop.shutdownNow();
         }
     }
 }

--- a/concurrent/actor/EventLoopGroup.java
+++ b/concurrent/actor/EventLoopGroup.java
@@ -50,12 +50,6 @@ public class EventLoopGroup {
         return eventLoop;
     }
 
-    public synchronized void await() throws InterruptedException {
-        for (EventLoop eventLoop : eventLoops) {
-            eventLoop.await();
-        }
-    }
-
     public synchronized void shutdown(long scheduledWaitTime) throws InterruptedException {
         for (EventLoop eventLoop : eventLoops) {
             eventLoop.shutdown(scheduledWaitTime);


### PR DESCRIPTION
## What is the goal of this PR?

Add the functionality to wait for scheduled timed events for a certain amount of time during event loop shutting down.

## What are the changes implemented in this PR?

- Add `shutdown` and `shutdownNow` methods in which `shutdown` allows waiting for the currently scheduled timed events to complete for a certain amount of time.