### PR TITLE
Do not acquire schema lock from data read transaction

### DIFF
--- a/rocks/RocksSession.java
+++ b/rocks/RocksSession.java
@@ -221,7 +221,10 @@ public abstract class RocksSession implements Grakn.Session {
         @Override
         void remove(RocksTransaction transaction) {
             long lock = transactions.remove(transaction);
-            if (transaction.type().isWrite()) database().schemaLock().unlockRead(lock);
+            if (transaction.type().isWrite()) {
+                assert lock != 0;
+                database().schemaLock().unlockRead(lock);
+            }
         }
     }
 }

--- a/rocks/RocksSession.java
+++ b/rocks/RocksSession.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.StampedLock;
 
 import static grakn.common.util.Objects.className;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_CAST;
+import static grakn.core.common.exception.ErrorMessage.Internal.UNEXPECTED_INTERRUPTION;
 import static grakn.core.common.exception.ErrorMessage.Session.SCHEMA_ACQUIRE_LOCK_TIMEOUT;
 import static grakn.core.common.exception.ErrorMessage.Session.SESSION_CLOSED;
 import static grakn.core.common.exception.ErrorMessage.Transaction.DATA_ACQUIRE_LOCK_TIMEOUT;
@@ -210,7 +211,7 @@ public abstract class RocksSession implements Grakn.Session {
                     lock = database().schemaLock().tryReadLock(timeout, MILLISECONDS);
                     if (lock == 0) throw GraknException.of(DATA_ACQUIRE_LOCK_TIMEOUT);
                 } catch (InterruptedException e) {
-                    throw GraknException.of(e);
+                    throw GraknException.of(UNEXPECTED_INTERRUPTION);
                 }
             }
             RocksTransaction.Data transaction = txDataFactory.transaction(this, type, options);


### PR DESCRIPTION
## What is the goal of this PR?

Currently, we erroneously acquired schema lock for a data read transaction, but only unlock for data write transaction. This causes sometimes schema lock is acquired and never unlocked, hence causing the database to unable to open transactions.

## What are the changes implemented in this PR?

- Acquire schema lock only when data transaction type is WRITE.
