### PR TITLE
Upgrade to latest @graknlabs_dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,15 +57,11 @@ com_github_grpc_grpc_deps()
 # Load //builder/python
 load("@graknlabs_dependencies//builder/python:deps.bzl", python_deps = "deps")
 python_deps()
-load("@rules_python//python:pip.bzl", "pip_repositories", "pip3_import")
-pip_repositories()
 
 # Load //tool/common
 load("@graknlabs_dependencies//tool/common:deps.bzl", "graknlabs_dependencies_ci_pip",
     graknlabs_dependencies_tool_maven_artifacts = "maven_artifacts")
 graknlabs_dependencies_ci_pip()
-load("@graknlabs_dependencies_ci_pip//:requirements.bzl", graknlabs_dependencies_pip_install = "pip_install")
-graknlabs_dependencies_pip_install()
 
 # Load //tool/checkstyle
 load("@graknlabs_dependencies//tool/checkstyle:deps.bzl", checkstyle_deps = "deps")

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "1fe947a6a7f78d6b0dbe14481cdd0d6929988e5e", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "d934c8eb83c4a86465e4c7289f20fb81bfbae02f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Latest version of `@graknlabs_dependencies` updates `rules-python` and therefore all repos that depend on it need to bring imports to an up-to-date state.

## What are the changes implemented in this PR?

Update `WORKSPACE` to match latest `@graknlabs_dependencies`