### PR TITLE
Update RocksDB to 6.15.2

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "d934c8eb83c4a86465e4c7289f20fb81bfbae02f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "569dc458eebdd2181ee5766754414157372e75a6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -145,9 +145,9 @@
 @maven//:org_objenesis_objenesis
 @maven//:org_objenesis_objenesis_2_5
 @maven//:org_rocksdb_rocksdbjni
-@maven//:org_rocksdb_rocksdbjni_6_11_4
+@maven//:org_rocksdb_rocksdbjni_6_15_2
 @maven//:org_rocksdb_rocksdbjni_dev
-@maven//:org_rocksdb_rocksdbjni_dev_6_11_4
+@maven//:org_rocksdb_rocksdbjni_dev_6_15_2
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_28
 @maven//:org_zeroturnaround_zt_exec


### PR DESCRIPTION
## What is the goal of this PR?

We have upgraded RocksDB from version 6.11.4 to 6.15.2.

## What are the changes implemented in this PR?

- Upgrade `@graknlabs_dependencies` to the new version which has RocksDB 6.15.2