### PR TITLE
Remove avoidable toString costs

### DIFF
--- a/logic/resolvable/Resolvable.java
+++ b/logic/resolvable/Resolvable.java
@@ -64,11 +64,4 @@ public abstract class Resolvable<T extends Pattern> {
     public Negated asNegated() {
         throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Negated.class));
     }
-
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "{" +
-                "pattern=" + pattern +
-                '}';
-    }
 }

--- a/reasoner/resolution/framework/Request.java
+++ b/reasoner/resolution/framework/Request.java
@@ -39,6 +39,8 @@ public class Request {
     private final ResolutionAnswer.Derivation partialDerivation;
     private final int planIndex;
 
+    private final int hash;
+
     private Request(Path path,
                     AnswerState.DownstreamVars startingConcept,
                     ResolutionAnswer.Derivation partialDerivation,
@@ -47,6 +49,7 @@ public class Request {
         this.partialAnswer = startingConcept;
         this.partialDerivation = partialDerivation;
         this.planIndex = planIndex;
+        this.hash = Objects.hash(path, partialAnswer);
     }
 
     public static Request create(Path path,
@@ -98,7 +101,7 @@ public class Request {
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, partialAnswer);
+        return hash;
     }
 
     @Override

--- a/traversal/planner/GraphPlanner.java
+++ b/traversal/planner/GraphPlanner.java
@@ -277,7 +277,7 @@ public class GraphPlanner implements Planner {
                 setInitialValues();
             }
         }
-        LOG.trace(solver.exportModelAsLpFormat());
+        if (LOG.isTraceEnabled()) LOG.trace(solver.exportModelAsLpFormat());
     }
 
     void updateCostNext(double costPrevious, double costNext) {

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -171,8 +171,10 @@ public class GraphProcedure implements Procedure {
     @Override
     public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
                                         Set<Identifier.Variable.Name> filter, int parallelisation) {
-        LOG.debug(params.toString());
-        LOG.debug(this.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(params.toString());
+            LOG.debug(this.toString());
+        }
         assertWithinFilterBounds(filter);
         ConcurrentSet<VertexMap> produced = new ConcurrentSet<>();
         ResourceIterator<ResourceIterator<VertexMap>> iterators = startVertex().iterator(graphMgr, params)
@@ -183,8 +185,10 @@ public class GraphProcedure implements Procedure {
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
                                                 Set<Identifier.Variable.Name> filter) {
-        LOG.debug(params.toString());
-        LOG.debug(this.toString());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(params.toString());
+            LOG.debug(this.toString());
+        }
         assertWithinFilterBounds(filter);
         return startVertex().iterator(graphMgr, params).flatMap(
                 sv -> new GraphIterator(graphMgr, sv, this, params, filter)


### PR DESCRIPTION
## What is the goal of this PR?

To improve performance, we only perform costly `toString()` operations when the appropriate log level is set.

## What are the changes implemented in this PR?
* Wrap several places in `if (LOG.isXXXEnabled()) { }` where logging was expensive
* Cache the hash code of resolution requests
* delete unncessary toString of `Resolvable`