### PR TITLE
Traversals and reasoner return concepts for anonymous variables too

### DIFF
--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -39,7 +39,7 @@ import grakn.core.graph.iid.VertexIID;
 import grakn.core.graph.vertex.ThingVertex;
 import grakn.core.graph.vertex.TypeVertex;
 import grakn.core.graph.vertex.Vertex;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import grakn.core.traversal.common.VertexMap;
 
 import java.util.ArrayList;
@@ -73,7 +73,7 @@ public final class ConceptManager {
     }
 
     public ConceptMap conceptMap(VertexMap vertexMap) {
-        Map<Retrieved, Concept> map = new HashMap<>();
+        Map<Retrievable, Concept> map = new HashMap<>();
         vertexMap.forEach((id, vertex) -> {
             if (vertex.isThing()) map.put(id, ThingImpl.of(vertex.asThing()));
             else if (vertex.isType()) map.put(id, TypeImpl.of(graphMgr, vertex.asType()));

--- a/concept/ConceptManager.java
+++ b/concept/ConceptManager.java
@@ -39,8 +39,8 @@ import grakn.core.graph.iid.VertexIID;
 import grakn.core.graph.vertex.ThingVertex;
 import grakn.core.graph.vertex.TypeVertex;
 import grakn.core.graph.vertex.Vertex;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import grakn.core.traversal.common.VertexMap;
-import graql.lang.pattern.variable.Reference;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,11 +73,10 @@ public final class ConceptManager {
     }
 
     public ConceptMap conceptMap(VertexMap vertexMap) {
-        Map<Reference.Name, Concept> map = new HashMap<>();
-        vertexMap.forEach((reference, vertex) -> {
-            if (!reference.isName()) throw exception(GraknException.of(ILLEGAL_STATE));
-            if (vertex.isThing()) map.put(reference.asName(), ThingImpl.of(vertex.asThing()));
-            else if (vertex.isType()) map.put(reference.asName(), TypeImpl.of(graphMgr, vertex.asType()));
+        Map<Retrieved, Concept> map = new HashMap<>();
+        vertexMap.forEach((id, vertex) -> {
+            if (vertex.isThing()) map.put(id, ThingImpl.of(vertex.asThing()));
+            else if (vertex.isType()) map.put(id, TypeImpl.of(graphMgr, vertex.asType()));
             else throw exception(GraknException.of(ILLEGAL_STATE));
         });
         return new ConceptMap(map);

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -25,6 +25,8 @@ import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.concept.Concept;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Type;
+import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import graql.lang.pattern.variable.Reference;
 import graql.lang.pattern.variable.UnboundVariable;
 
@@ -42,19 +44,19 @@ import static grakn.core.common.iterator.Iterators.iterate;
 
 public class ConceptMap implements Answer {
 
-    private final Map<Reference.Name, ? extends Concept> concepts;
+    private final Map<Retrieved, ? extends Concept> concepts;
     private final int hash;
 
     public ConceptMap() {
         this(new HashMap<>());
     }
 
-    public ConceptMap(Map<Reference.Name, ? extends Concept> concepts) {
+    public ConceptMap(Map<Retrieved, ? extends Concept> concepts) {
         this.concepts = concepts;
         this.hash = Objects.hash(this.concepts);
     }
 
-    public ResourceIterator<Pair<Reference.Name, Concept>> iterator() {
+    public ResourceIterator<Pair<Retrieved, Concept>> iterator() {
         return iterate(concepts.entrySet()).map(e -> pair(e.getKey(), e.getValue()));
     }
 
@@ -63,7 +65,11 @@ public class ConceptMap implements Answer {
     }
 
     public boolean contains(Reference.Name variable) {
-        return concepts.containsKey(variable);
+        return concepts.containsKey(Identifier.Variable.of(variable));
+    }
+
+    public boolean contains(Retrieved id) {
+        return concepts.containsKey(id);
     }
 
     public Concept get(String variable) {
@@ -76,23 +82,27 @@ public class ConceptMap implements Answer {
     }
 
     public Concept get(Reference.Name variable) {
-        return concepts.get(variable);
+        return concepts.get(Identifier.Variable.of(variable));
     }
 
-    public Map<Reference.Name, ? extends Concept> concepts() { return concepts; }
+    public Concept get(Retrieved id) {
+        return concepts.get(id);
+    }
 
-    public ConceptMap filter(Set<Reference.Name> vars) {
-        Map<Reference.Name, ? extends Concept> filtered = concepts.entrySet().stream()
+    public Map<Retrieved, ? extends Concept> concepts() { return concepts; }
+
+    public ConceptMap filter(Set<? extends Retrieved> vars) {
+        Map<Retrieved, ? extends Concept> filtered = concepts.entrySet().stream()
                 .filter(e -> vars.contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         return new ConceptMap(filtered);
     }
 
-    public void forEach(BiConsumer<Reference.Name, Concept> consumer) {
+    public void forEach(BiConsumer<Retrieved, Concept> consumer) {
         concepts.forEach(consumer);
     }
 
-    public <T, U> Map<Reference.Name, Either<T, U>> toMap(Function<Type, T> typeFn, Function<Thing, U> thingFn) {
+    public <T, U> Map<Retrieved, Either<T, U>> toMap(Function<Type, T> typeFn, Function<Thing, U> thingFn) {
         return toMap(concept -> {
             if (concept.isType()) return Either.first(typeFn.apply(concept.asType()));
             else if (concept.isThing()) return Either.second(thingFn.apply(concept.asThing()));
@@ -100,8 +110,8 @@ public class ConceptMap implements Answer {
         });
     }
 
-    public <T> Map<Reference.Name, T> toMap(Function<Concept, T> conceptFn) {
-        Map<Reference.Name, T> map = new HashMap<>();
+    public <T> Map<Retrieved, T> toMap(Function<Concept, T> conceptFn) {
+        Map<Retrieved, T> map = new HashMap<>();
         iterate(concepts.entrySet()).forEachRemaining(e -> map.put(e.getKey(), conceptFn.apply(e.getValue())));
         return map;
     }

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -26,7 +26,7 @@ import grakn.core.concept.Concept;
 import grakn.core.concept.thing.Thing;
 import grakn.core.concept.type.Type;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import graql.lang.pattern.variable.Reference;
 import graql.lang.pattern.variable.UnboundVariable;
 
@@ -44,19 +44,19 @@ import static grakn.core.common.iterator.Iterators.iterate;
 
 public class ConceptMap implements Answer {
 
-    private final Map<Retrieved, ? extends Concept> concepts;
+    private final Map<Retrievable, ? extends Concept> concepts;
     private final int hash;
 
     public ConceptMap() {
         this(new HashMap<>());
     }
 
-    public ConceptMap(Map<Retrieved, ? extends Concept> concepts) {
+    public ConceptMap(Map<Retrievable, ? extends Concept> concepts) {
         this.concepts = concepts;
         this.hash = Objects.hash(this.concepts);
     }
 
-    public ResourceIterator<Pair<Retrieved, Concept>> iterator() {
+    public ResourceIterator<Pair<Retrievable, Concept>> iterator() {
         return iterate(concepts.entrySet()).map(e -> pair(e.getKey(), e.getValue()));
     }
 
@@ -68,7 +68,7 @@ public class ConceptMap implements Answer {
         return concepts.containsKey(Identifier.Variable.of(variable));
     }
 
-    public boolean contains(Retrieved id) {
+    public boolean contains(Retrievable id) {
         return concepts.containsKey(id);
     }
 
@@ -85,24 +85,24 @@ public class ConceptMap implements Answer {
         return concepts.get(Identifier.Variable.of(variable));
     }
 
-    public Concept get(Retrieved id) {
+    public Concept get(Retrievable id) {
         return concepts.get(id);
     }
 
-    public Map<Retrieved, ? extends Concept> concepts() { return concepts; }
+    public Map<Retrievable, ? extends Concept> concepts() { return concepts; }
 
-    public ConceptMap filter(Set<? extends Retrieved> vars) {
-        Map<Retrieved, ? extends Concept> filtered = concepts.entrySet().stream()
+    public ConceptMap filter(Set<? extends Retrievable> vars) {
+        Map<Retrievable, ? extends Concept> filtered = concepts.entrySet().stream()
                 .filter(e -> vars.contains(e.getKey()))
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         return new ConceptMap(filtered);
     }
 
-    public void forEach(BiConsumer<Retrieved, Concept> consumer) {
+    public void forEach(BiConsumer<Retrievable, Concept> consumer) {
         concepts.forEach(consumer);
     }
 
-    public <T, U> Map<Retrieved, Either<T, U>> toMap(Function<Type, T> typeFn, Function<Thing, U> thingFn) {
+    public <T, U> Map<Retrievable, Either<T, U>> toMap(Function<Type, T> typeFn, Function<Thing, U> thingFn) {
         return toMap(concept -> {
             if (concept.isType()) return Either.first(typeFn.apply(concept.asType()));
             else if (concept.isThing()) return Either.second(thingFn.apply(concept.asThing()));
@@ -110,8 +110,8 @@ public class ConceptMap implements Answer {
         });
     }
 
-    public <T> Map<Retrieved, T> toMap(Function<Concept, T> conceptFn) {
-        Map<Retrieved, T> map = new HashMap<>();
+    public <T> Map<Retrievable, T> toMap(Function<Concept, T> conceptFn) {
+        Map<Retrievable, T> map = new HashMap<>();
         iterate(concepts.entrySet()).forEachRemaining(e -> map.put(e.getKey(), conceptFn.apply(e.getValue())));
         return map;
     }

--- a/logic/LogicCache.java
+++ b/logic/LogicCache.java
@@ -21,6 +21,7 @@ package grakn.core.logic;
 import grakn.core.common.cache.CommonCache;
 import grakn.core.common.parameters.Label;
 import grakn.core.traversal.Traversal;
+import grakn.core.traversal.common.Identifier;
 import graql.lang.pattern.variable.Reference;
 
 import java.util.Map;
@@ -28,7 +29,7 @@ import java.util.Set;
 
 public class LogicCache {
 
-    private CommonCache<Traversal, Map<Reference, Set<Label>>> typeResolverCache;
+    private CommonCache<Traversal, Map<Identifier.Variable, Set<Label>>> typeResolverCache;
     private CommonCache<String, Rule> ruleCache;
 
     public LogicCache() {
@@ -41,7 +42,7 @@ public class LogicCache {
         this.typeResolverCache = new CommonCache<>(size, timeOutMinutes);
     }
 
-    public CommonCache<Traversal, Map<Reference, Set<Label>>> resolver() { return typeResolverCache; }
+    public CommonCache<Traversal, Map<Identifier.Variable, Set<Label>>> resolver() { return typeResolverCache; }
 
     CommonCache<String, Rule> rule() { return ruleCache; }
 }

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -549,7 +549,7 @@ public class Rule {
                 @Override
                 public ResourceIterator<Map<Identifier.Variable, Concept>> materialise(ConceptMap whenConcepts, TraversalEngine traversalEng,
                                                                                        ConceptManager conceptMgr) {
-                    Identifier.Variable.Retrieved ownerId = has().owner().id();
+                    Identifier.Variable.Retrievable ownerId = has().owner().id();
                     assert whenConcepts.contains(ownerId) && whenConcepts.get(ownerId).isThing();
                     Map<Identifier.Variable, Concept> thenConcepts = new HashMap<>();
                     Thing owner = whenConcepts.get(ownerId.reference().asName()).asThing();
@@ -667,7 +667,7 @@ public class Rule {
                 @Override
                 public ResourceIterator<Map<Identifier.Variable, Concept>> materialise(ConceptMap whenConcepts, TraversalEngine traversalEng,
                                                                                        ConceptManager conceptMgr) {
-                    Identifier.Variable.Retrieved ownerId = has().owner().id();
+                    Identifier.Variable.Retrievable ownerId = has().owner().id();
                     assert whenConcepts.contains(ownerId) && whenConcepts.get(ownerId).isThing();
                     Thing owner = whenConcepts.get(ownerId).asThing();
                     Map<Identifier.Variable, Concept> thenConcepts = new HashMap<>();

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -41,7 +41,7 @@ import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.pattern.variable.TypeVariable;
 import grakn.core.pattern.variable.Variable;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import grakn.core.traversal.predicate.Predicate;
 import graql.lang.common.GraqlToken;
 import graql.lang.pattern.variable.Reference;
@@ -72,18 +72,18 @@ import static java.util.stream.Collectors.toSet;
 public abstract class Concludable extends Resolvable<Conjunction> {
 
     private Map<Rule, Set<Unifier>> applicableRules;
-    Set<Retrieved> retrievedIds;
+    Set<Retrievable> retrievableIds;
 
     private Concludable(Conjunction conjunction) {
         super(conjunction);
         this.applicableRules = null;
-        this.retrievedIds = iterate(pattern().identifiers()).filter(Identifier::isRetrieved)
-                .map(Identifier.Variable::asRetrieved).toSet();
+        this.retrievableIds = iterate(pattern().identifiers()).filter(Identifier::isRetrievable)
+                .map(Identifier.Variable::asRetrievable).toSet();
     }
 
     @Override
-    public Set<Retrieved> retrieves() {
-        return retrievedIds;
+    public Set<Retrievable> retrieves() {
+        return retrievableIds;
     }
 
     public boolean isConcludable() {
@@ -261,7 +261,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
     }
 
     protected void addConstantValueRequirements(Unifier.Builder unifierBuilder, Set<ValueConstraint<?>> values,
-                                                Identifier.Variable.Retrieved id, Identifier.Variable.Retrieved unifiedId) {
+                                                Retrievable id, Retrievable unifiedId) {
         for (ValueConstraint<?> value : equalsConstantConstraints(values)) {
             unifierBuilder.requirements().predicates(id, valueEqualsFunction(value));
             unifierBuilder.unifiedRequirements().predicates(unifiedId, valueEqualsFunction(value));
@@ -345,7 +345,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                         unifierBuilder.unifiedRequirements().isaExplicit(relationConclusion.relation().owner().id(), allowedTypes);
                         unifierBuilder.requirements().isaExplicit(relation().owner().id(), allowedTypes);
                     } else {
-                        unifierBuilder.add(concludableRelationType.id().asRetrieved(), conclusionRelationType.id());
+                        unifierBuilder.add(concludableRelationType.id().asRetrievable(), conclusionRelationType.id());
                     }
                 } else return Iterators.empty();
             }
@@ -394,7 +394,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                         unifierBuilder.unifiedRequirements().roleTypes(thenRoleType.id(), allowedTypes);
                         unifierBuilder.requirements().roleTypes(conjRoleType.id(), allowedTypes);
                     } else {
-                        unifierBuilder.add(conjRoleType.id().asRetrieved(), thenRoleType.id());
+                        unifierBuilder.add(conjRoleType.id().asRetrievable(), thenRoleType.id());
                     }
                 }
             }));
@@ -635,7 +635,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
                     unifierBuilder.unifiedRequirements().isaExplicit(isaConclusion.isa().owner().id(), subtypeLabels(type.resolvedTypes(), conceptMgr)
                             .collect(toSet()));
                 } else {
-                    unifierBuilder.add(type.id().asRetrieved(), isaConclusion.isa().type().id());
+                    unifierBuilder.add(type.id().asRetrievable(), isaConclusion.isa().type().id());
                 }
                 addConstantValueRequirements(unifierBuilder, values, isa().owner().id(), isaConclusion.isa().owner().id());
             } else return Iterators.empty();

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -263,8 +263,8 @@ public abstract class Concludable extends Resolvable<Conjunction> {
     protected void addConstantValueRequirements(Unifier.Builder unifierBuilder, Set<ValueConstraint<?>> values,
                                                 Retrievable id, Retrievable unifiedId) {
         for (ValueConstraint<?> value : equalsConstantConstraints(values)) {
-            unifierBuilder.requirements().predicates(id, valueEqualsFunction(value));
             unifierBuilder.unifiedRequirements().predicates(unifiedId, valueEqualsFunction(value));
+            unifierBuilder.requirements().predicates(id, valueEqualsFunction(value));
         }
     }
 
@@ -632,8 +632,9 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             if (unificationSatisfiable(type, isaConclusion.isa().type(), conceptMgr)) {
                 if (type.reference().isLabel()) {
                     // form: $r isa friendship -> require type subs(friendship) for anonymous type variable
-                    unifierBuilder.unifiedRequirements().isaExplicit(isaConclusion.isa().owner().id(), subtypeLabels(type.resolvedTypes(), conceptMgr)
-                            .collect(toSet()));
+                    Set<Label> subtypes = subtypeLabels(type.resolvedTypes(), conceptMgr).collect(toSet());
+                    unifierBuilder.unifiedRequirements().isaExplicit(isaConclusion.isa().owner().id(), subtypes);
+                    unifierBuilder.requirements().isaExplicit(isa().owner().id(), subtypes);
                 } else {
                     unifierBuilder.add(type.id().asRetrievable(), isaConclusion.isa().type().id());
                 }

--- a/logic/resolvable/Negated.java
+++ b/logic/resolvable/Negated.java
@@ -21,7 +21,7 @@ import grakn.core.pattern.Disjunction;
 import grakn.core.pattern.Negation;
 import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -32,13 +32,13 @@ import static grakn.core.common.iterator.Iterators.iterate;
 public class Negated extends Resolvable<Disjunction> {
 
     // note: we always guarantee unique anonymous IDs within one query
-    private final Set<Retrieved> identifiers;
+    private final Set<Retrievable> identifiers;
 
     public Negated(Negation negation) {
         super(negation.disjunction());
         this.identifiers = new HashSet<>();
-        pattern().conjunctions().forEach(c -> iterate(c.identifiers()).filter(Identifier::isRetrieved)
-                .forEachRemaining(id -> identifiers.add(id.asRetrieved())));
+        pattern().conjunctions().forEach(c -> iterate(c.identifiers()).filter(Identifier::isRetrievable)
+                .forEachRemaining(id -> identifiers.add(id.asRetrievable())));
     }
 
     @Override
@@ -47,7 +47,7 @@ public class Negated extends Resolvable<Disjunction> {
     }
 
     @Override
-    public Set<Retrieved> retrieves() {
+    public Set<Retrievable> retrieves() {
         return this.identifiers;
     }
 

--- a/logic/resolvable/Negated.java
+++ b/logic/resolvable/Negated.java
@@ -19,8 +19,9 @@ package grakn.core.logic.resolvable;
 
 import grakn.core.pattern.Disjunction;
 import grakn.core.pattern.Negation;
-import grakn.core.pattern.variable.Variable;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.pattern.variable.ThingVariable;
+import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -30,23 +31,24 @@ import static grakn.core.common.iterator.Iterators.iterate;
 
 public class Negated extends Resolvable<Disjunction> {
 
-    private final Set<Reference.Name> variableNames;
+    // note: we always guarantee unique anonymous IDs within one query
+    private final Set<Retrieved> identifiers;
 
     public Negated(Negation negation) {
         super(negation.disjunction());
-        this.variableNames = new HashSet<>();
-        pattern().conjunctions().forEach(c -> iterate(c.variables()).filter(v -> v.reference().isName())
-                .map(v -> v.reference().asName()).forEachRemaining(variableNames::add));
+        this.identifiers = new HashSet<>();
+        pattern().conjunctions().forEach(c -> iterate(c.identifiers()).filter(Identifier::isRetrieved)
+                .forEachRemaining(id -> identifiers.add(id.asRetrieved())));
     }
 
     @Override
-    public Optional<Variable> generating() {
+    public Optional<ThingVariable> generating() {
         return Optional.empty();
     }
 
     @Override
-    public Set<Reference.Name> variableNames() {
-        return variableNames;
+    public Set<Retrieved> retrieves() {
+        return this.identifiers;
     }
 
     @Override

--- a/logic/resolvable/Resolvable.java
+++ b/logic/resolvable/Resolvable.java
@@ -20,8 +20,7 @@ package grakn.core.logic.resolvable;
 import grakn.core.common.exception.GraknException;
 import grakn.core.pattern.Pattern;
 import grakn.core.pattern.variable.ThingVariable;
-import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.Optional;
 import java.util.Set;
@@ -41,7 +40,7 @@ public abstract class Resolvable<T extends Pattern> {
 
     public abstract Optional<ThingVariable> generating();
 
-    public abstract Set<Retrieved> retrieves();
+    public abstract Set<Retrievable> retrieves();
 
     public boolean isRetrievable() {
         return false;
@@ -55,8 +54,8 @@ public abstract class Resolvable<T extends Pattern> {
         return false;
     }
 
-    public Retrievable asRetrievable() {
-        throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Retrievable.class));
+    public grakn.core.logic.resolvable.Retrievable asRetrievable() {
+        throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(grakn.core.logic.resolvable.Retrievable.class));
     }
 
     public Concludable asConcludable() {

--- a/logic/resolvable/Resolvable.java
+++ b/logic/resolvable/Resolvable.java
@@ -19,8 +19,9 @@ package grakn.core.logic.resolvable;
 
 import grakn.core.common.exception.GraknException;
 import grakn.core.pattern.Pattern;
-import grakn.core.pattern.variable.Variable;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.pattern.variable.ThingVariable;
+import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.Optional;
 import java.util.Set;
@@ -38,9 +39,9 @@ public abstract class Resolvable<T extends Pattern> {
         return pattern;
     }
 
-    public abstract Optional<Variable> generating();
+    public abstract Optional<ThingVariable> generating();
 
-    public abstract Set<Reference.Name> variableNames();
+    public abstract Set<Retrieved> retrieves();
 
     public boolean isRetrievable() {
         return false;

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -25,7 +25,6 @@ import grakn.core.pattern.constraint.type.TypeConstraint;
 import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.pattern.variable.Variable;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -36,16 +35,16 @@ import static grakn.core.common.iterator.Iterators.iterate;
 
 public class Retrievable extends Resolvable<Conjunction> {
 
-    private final Set<Retrieved> retrievedIds;
+    private final Set<Identifier.Variable.Retrievable> retrievableIds;
 
     public Retrievable(Conjunction conjunction) {
         super(conjunction);
-        this.retrievedIds = iterate(pattern().identifiers()).filter(Identifier::isRetrieved)
-                .map(Identifier.Variable::asRetrieved).toSet();
+        this.retrievableIds = iterate(pattern().identifiers()).filter(Identifier::isRetrievable)
+                .map(Identifier.Variable::asRetrievable).toSet();
     }
 
     public static Set<Retrievable> extractFrom(Conjunction conjunction, Set<Concludable> toExclude) {
-        return Retrievable.Extractor.of(conjunction, toExclude).extract();
+        return grakn.core.logic.resolvable.Retrievable.Extractor.of(conjunction, toExclude).extract();
     }
 
     @Override
@@ -54,8 +53,8 @@ public class Retrievable extends Resolvable<Conjunction> {
     }
 
     @Override
-    public Set<Retrieved> retrieves() {
-        return retrievedIds;
+    public Set<Identifier.Variable.Retrievable> retrieves() {
+        return retrievableIds;
     }
 
     @Override
@@ -86,7 +85,7 @@ public class Retrievable extends Resolvable<Conjunction> {
 
         public Set<Retrievable> extract() {
             concludables.forEach(concludable -> extractedConstraints.addAll(concludable.concludableConstraints()));
-            iterate(conjunction.variables()).filter(var -> var.id().isRetrieved()).forEachRemaining(var -> {
+            iterate(conjunction.variables()).filter(var -> var.id().isRetrievable()).forEachRemaining(var -> {
                 if (!extractedVariables.contains(var)) {
                     SubgraphRegistry subgraph = new SubgraphRegistry();
                     subgraph.registerVariable(var);

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -22,8 +22,10 @@ import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.constraint.Constraint;
 import grakn.core.pattern.constraint.thing.ThingConstraint;
 import grakn.core.pattern.constraint.type.TypeConstraint;
+import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.pattern.variable.Variable;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -34,12 +36,12 @@ import static grakn.core.common.iterator.Iterators.iterate;
 
 public class Retrievable extends Resolvable<Conjunction> {
 
-    private final Set<Reference.Name> variableNames;
+    private final Set<Retrieved> retrievedIds;
 
     public Retrievable(Conjunction conjunction) {
         super(conjunction);
-        this.variableNames = iterate(pattern().variables()).filter(v -> v.reference().isName())
-                .map(v -> v.reference().asName()).toSet();
+        this.retrievedIds = iterate(pattern().identifiers()).filter(Identifier::isRetrieved)
+                .map(Identifier.Variable::asRetrieved).toSet();
     }
 
     public static Set<Retrievable> extractFrom(Conjunction conjunction, Set<Concludable> toExclude) {
@@ -47,13 +49,13 @@ public class Retrievable extends Resolvable<Conjunction> {
     }
 
     @Override
-    public Optional<Variable> generating() {
+    public Optional<ThingVariable> generating() {
         return Optional.empty();
     }
 
     @Override
-    public Set<Reference.Name> variableNames() {
-        return variableNames;
+    public Set<Retrieved> retrieves() {
+        return retrievedIds;
     }
 
     @Override
@@ -84,7 +86,7 @@ public class Retrievable extends Resolvable<Conjunction> {
 
         public Set<Retrievable> extract() {
             concludables.forEach(concludable -> extractedConstraints.addAll(concludable.concludableConstraints()));
-            iterate(conjunction.variables()).filter(var -> var.id().reference().isName()).forEachRemaining(var -> {
+            iterate(conjunction.variables()).filter(var -> var.id().isRetrieved()).forEachRemaining(var -> {
                 if (!extractedVariables.contains(var)) {
                     SubgraphRegistry subgraph = new SubgraphRegistry();
                     subgraph.registerVariable(var);

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -68,7 +68,7 @@ public class Unifier {
                         unifiedRequirements.isaExplicit(unifiedId.asRetrieved(), requirements.isaExplicit().get(id));
                     }
                     if (requirements.predicates.containsKey(id)) {
-                        unifiedRequirements.predicates(unifiedId.asRetrieved(), unifiedRequirements.predicates().get(id));
+                        unifiedRequirements.predicates(unifiedId.asRetrieved(), requirements.predicates().get(id));
                     }
                 }
             });
@@ -92,7 +92,7 @@ public class Unifier {
     public Optional<Pair<ConceptMap, Requirements.Instance>> unify(ConceptMap conceptMap) {
         Map<Retrieved, Concept> unifiedMap = new HashMap<>();
 
-        if (unifiedRequirements.contradicts(conceptMap)) {
+        if (requirements.contradicts(conceptMap)) {
             return Optional.empty();
         }
 
@@ -119,7 +119,7 @@ public class Unifier {
      */
     public Optional<ConceptMap> unUnify(Map<Variable, Concept> concepts, Requirements.Instance instanceRequirements) {
 
-        if (!constraintRequirements().exactlySatisfiedBy(concepts)) return Optional.empty();
+        if (!unifiedRequirements.exactlySatisfiedBy(concepts)) return Optional.empty();
 
         Map<Variable.Retrieved, Concept> reversedConcepts = new HashMap<>();
         for (Map.Entry<Variable, Set<Variable.Retrieved>> entry : reverseUnifier.entrySet()) {
@@ -143,7 +143,7 @@ public class Unifier {
         return unifier;
     }
 
-    Requirements.Constraint constraintRequirements() {
+    public Requirements.Constraint requirements() {
         return requirements;
     }
 
@@ -163,6 +163,7 @@ public class Unifier {
                 "unifier=" + unifierString(unifier) +
                 ", reverseUnifier=" + unifierString(reverseUnifier) +
                 ", requirements=" + requirements +
+                ", unifiedRequirements=" + unifiedRequirements +
                 '}';
     }
 

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -45,8 +45,8 @@ public class Unifier {
 
     private final Map<Variable.Retrieved, Set<Variable>> unifier;
     private final Map<Variable, Set<Variable.Retrieved>> reverseUnifier;
-    private final Requirements.Constraint unifiedRequirements;
     private final Requirements.Constraint requirements;
+    private final Requirements.Constraint unifiedRequirements;
 
     private Unifier(Map<Variable.Retrieved, Set<Variable>> unifier, Requirements.Constraint requirements,
                     Requirements.Constraint unifiedRequirements) {
@@ -71,22 +71,18 @@ public class Unifier {
      */
     public Optional<Pair<ConceptMap, Requirements.Instance>> unify(ConceptMap conceptMap) {
         Map<Retrieved, Concept> unifiedMap = new HashMap<>();
-
-        if (requirements.contradicts(conceptMap)) {
-            return Optional.empty();
-        }
+        if (requirements.contradicts(conceptMap)) return Optional.empty();
 
         for (Map.Entry<Variable.Retrieved, Set<Variable>> entry : unifier.entrySet()) {
             Variable.Retrieved toUnify = entry.getKey();
             Concept concept = conceptMap.get(toUnify.asRetrieved());
-            if (concept != null) {
-                for (Variable unified : entry.getValue()) {
-                    if (unified.isRetrieved()) {
-                        if (!unifiedMap.containsKey(unified.asRetrieved())) {
-                            unifiedMap.put(unified.asRetrieved(), concept);
-                        }
-                        if (!unifiedMap.get(unified.asRetrieved()).equals(concept)) return Optional.empty();
+            if (concept == null) continue;
+            for (Variable unified : entry.getValue()) {
+                if (unified.isRetrieved()) {
+                    if (!unifiedMap.containsKey(unified.asRetrieved())) {
+                        unifiedMap.put(unified.asRetrieved(), concept);
                     }
+                    if (!unifiedMap.get(unified.asRetrieved()).equals(concept)) return Optional.empty();
                 }
             }
         }
@@ -121,10 +117,6 @@ public class Unifier {
 
     public Map<Variable.Retrieved, Set<Variable>> mapping() {
         return unifier;
-    }
-
-    public Requirements.Constraint unifiedRequirements() {
-        return unifiedRequirements;
     }
 
     public Requirements.Constraint requirements() {
@@ -195,7 +187,6 @@ public class Unifier {
             return new Builder(unifierCopy, requirementsCopy, unifiedRequirementsCopy);
         }
     }
-
 
     public static abstract class Requirements {
 

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -24,7 +24,7 @@ import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.thing.Attribute;
 import grakn.core.concept.type.ThingType;
-import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable;
 import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.Collections;
@@ -42,11 +42,11 @@ import static grakn.core.common.exception.ErrorMessage.Reasoner.REVERSE_UNIFICAT
 
 public class Unifier {
 
-    private final Map<Identifier.Variable, Set<Identifier.Variable>> unifier;
-    private final Map<Identifier.Variable, Set<Identifier.Variable>> unUnifier;
+    private final Map<Variable.Retrieved, Set<Variable>> unifier;
+    private final Map<Variable, Set<Variable.Retrieved>> unUnifier;
     private final Requirements.Constraint requirements;
 
-    private Unifier(Map<Identifier.Variable, Set<Identifier.Variable>> unifier, Requirements.Constraint requirements) {
+    private Unifier(Map<Variable.Retrieved, Set<Variable>> unifier, Requirements.Constraint requirements) {
         this.unifier = Collections.unmodifiableMap(unifier);
         this.requirements = requirements;
         this.unUnifier = reverse(this.unifier);
@@ -65,23 +65,21 @@ public class Unifier {
 
     the latter will never be valid as it is a contradiction, the former empty map is the result of the unifier's filtering
      */
-
     public Optional<Pair<ConceptMap, Requirements.Instance>> unify(ConceptMap conceptMap) {
         Map<Retrieved, Concept> unifiedMap = new HashMap<>();
 
-        for (Map.Entry<Identifier.Variable, Set<Identifier.Variable>> entry : unifier.entrySet()) {
-            Identifier.Variable toUnify = entry.getKey();
-            if (toUnify.isRetrieved()) {
-                Concept concept = conceptMap.get(toUnify.asRetrieved());
-                if (concept != null) {
-                    Set<Identifier.Variable> unifieds = entry.getValue();
-                    for (Identifier.Variable unified : unifieds) {
-                        if (unified.isRetrieved()) {
-                            if (!unifiedMap.containsKey(unified.asRetrieved())) {
-                                unifiedMap.put(unified.asRetrieved(), concept);
-                            }
-                            if (!unifiedMap.get(unified.asRetrieved()).equals(concept)) return Optional.empty();
+        // TODO we should also make sure the requirements are satisfied here!
+
+        for (Map.Entry<Variable.Retrieved, Set<Variable>> entry : unifier.entrySet()) {
+            Variable.Retrieved toUnify = entry.getKey();
+            Concept concept = conceptMap.get(toUnify.asRetrieved());
+            if (concept != null) {
+                for (Variable unified : entry.getValue()) {
+                    if (unified.isRetrieved()) {
+                        if (!unifiedMap.containsKey(unified.asRetrieved())) {
+                            unifiedMap.put(unified.asRetrieved(), concept);
                         }
+                        if (!unifiedMap.get(unified.asRetrieved()).equals(concept)) return Optional.empty();
                     }
                 }
             }
@@ -93,42 +91,44 @@ public class Unifier {
      * Un-unify a map of concepts, with given identifiers. These must include anonymous and labelled concepts,
      * as they may be mapped to from a named variable, and may have requirements that need to be met.
      */
-    public Optional<ConceptMap> unUnify(Map<Identifier.Variable, Concept> concepts, Requirements.Instance instanceRequirements) {
-        Map<Identifier.Variable, Concept> reversedConcepts = new HashMap<>();
-        for (Map.Entry<Identifier.Variable, Set<Identifier.Variable>> entry : unUnifier.entrySet()) {
-            Identifier.Variable toReverse = entry.getKey();
-            Set<Identifier.Variable> reversed = entry.getValue();
+    public Optional<ConceptMap> unUnify(Map<Variable, Concept> concepts, Requirements.Instance instanceRequirements) {
+
+        if (!constraintRequirements().satisfiedBy(concepts)) return Optional.empty();
+
+        Map<Variable.Retrieved, Concept> reversedConcepts = new HashMap<>();
+        for (Map.Entry<Variable, Set<Variable.Retrieved>> entry : unUnifier.entrySet()) {
+            Variable toReverse = entry.getKey();
+            Set<Variable.Retrieved> reversed = entry.getValue();
             if (!concepts.containsKey(toReverse)) {
                 throw GraknException.of(REVERSE_UNIFICATION_MISSING_CONCEPT, toReverse, concepts);
             }
             Concept concept = concepts.get(toReverse);
-            for (Identifier.Variable r : reversed) {
+            for (Variable.Retrieved r : reversed) {
                 if (!reversedConcepts.containsKey(r)) reversedConcepts.put(r, concept);
                 if (!reversedConcepts.get(r).equals(concept)) return Optional.empty();
             }
         }
 
-        if (instanceRequirements.satisfiedBy(reversedConcepts) && constraintRequirements().satisfiedBy(reversedConcepts)) {
-            return Optional.of(toConceptMap(reversedConcepts));
-        } else {
-            return Optional.empty();
-        }
+        if (instanceRequirements.satisfiedBy(reversedConcepts)) return Optional.of(new ConceptMap(reversedConcepts));
+        else return Optional.empty();
     }
 
-    private ConceptMap toConceptMap(Map<Identifier.Variable, Concept> concepts) {
-        Map<Retrieved, Concept> retrievedConcepts = new HashMap<>();
-        concepts.forEach((id, concept) -> {
-            if (id.isRetrieved()) retrievedConcepts.put(id.asRetrieved(), concept);
-        });
-        return new ConceptMap(retrievedConcepts);
-    }
-
-    public Map<Identifier.Variable, Set<Identifier.Variable>> mapping() {
+    public Map<Variable.Retrieved, Set<Variable>> mapping() {
         return unifier;
     }
 
     Requirements.Constraint constraintRequirements() {
         return requirements;
+    }
+
+    private Map<Variable, Set<Variable.Retrieved>> reverse(Map<Variable.Retrieved, Set<Variable>> unifier) {
+        Map<Variable, Set<Variable.Retrieved>> reverse = new HashMap<>();
+        unifier.forEach((unify, unifieds) -> {
+            for (Variable unified : unifieds) {
+                reverse.computeIfAbsent(unified, (u) -> new HashSet<>()).add(unify);
+            }
+        });
+        return reverse;
     }
 
     @Override
@@ -140,35 +140,25 @@ public class Unifier {
                 '}';
     }
 
-    private String unifierString(Map<Identifier.Variable, ? extends Set<Identifier.Variable>> unifier) {
+    private String unifierString(Map<? extends Variable, ? extends Set<? extends Variable>> unifier) {
         return "{" + unifier.entrySet().stream().map(e -> e.getKey() + "->" + e.getValue()).collect(Collectors.joining(",")) + "}";
-    }
-
-    private Map<Identifier.Variable, Set<Identifier.Variable>> reverse(Map<Identifier.Variable, Set<Identifier.Variable>> unifier) {
-        Map<Identifier.Variable, Set<Identifier.Variable>> reverse = new HashMap<>();
-        unifier.forEach((unify, unifieds) -> {
-            for (Identifier.Variable unified : unifieds) {
-                reverse.computeIfAbsent(unified, (u) -> new HashSet<>()).add(unify);
-            }
-        });
-        return reverse;
     }
 
     public static class Builder {
 
-        Map<Identifier.Variable, Set<Identifier.Variable>> unifier;
+        Map<Variable.Retrieved, Set<Variable>> unifier;
         Requirements.Constraint requirements;
 
         public Builder() {
             this(new HashMap<>(), new Requirements.Constraint());
         }
 
-        private Builder(Map<Identifier.Variable, Set<Identifier.Variable>> unifier, Requirements.Constraint requirements) {
+        private Builder(Map<Variable.Retrieved, Set<Variable>> unifier, Requirements.Constraint requirements) {
             this.unifier = unifier;
             this.requirements = requirements;
         }
 
-        public void add(Identifier.Variable source, Identifier.Variable target) {
+        public void add(Variable.Retrieved source, Variable target) {
             unifier.computeIfAbsent(source, (s) -> new HashSet<>()).add(target);
         }
 
@@ -180,31 +170,32 @@ public class Unifier {
             return new Unifier(unifier, requirements);
         }
 
-        public Builder duplicate() {
-            Map<Identifier.Variable, Set<Identifier.Variable>> unifierCopy = new HashMap<>();
+        public Builder clone() {
+            Map<Variable.Retrieved, Set<Variable>> unifierCopy = new HashMap<>();
             unifier.forEach(((identifier, unifieds) -> unifierCopy.put(identifier, set(unifieds))));
             Requirements.Constraint requirementsCopy = requirements.duplicate();
             return new Builder(unifierCopy, requirementsCopy);
         }
     }
 
-    /*
-    Record requirements that may be used to fail a unification
 
-    Allowed requirements we may impose:
-    1. a type variable may be required to within a set of allowed types
-    2. a thing variable may be required to be an explicit instance of a set of allowed types
-    3. a thing variable may have to satisfy a specific predicate (ie when it's an attribute)
-
-    Note that in the future we may treat these (and variable equality constraints encoded in unifier)
-     as constraints we can use to rewrite queries that are unified with. This would be more efficient,
-     but query rewriting was designed _out_ of our architecture, and will have to be carefully re-added.
-     */
     public static abstract class Requirements {
 
+        /*
+        Record constraint-based requirements that may be used to fail a unification
+
+        Allowed requirements we may impose:
+        1. a type variable may be required to within a set of allowed types
+        2. a thing variable may be required to be an explicit instance of a set of allowed types
+        3. a thing variable may have to satisfy a specific predicate (ie when it's an attribute)
+
+        Note that in the future we may treat these (and variable equality constraints encoded in unifier)
+         as constraints we can use to rewrite queries that are unified with. This would be more efficient,
+         but query rewriting was designed _out_ of our architecture, and will have to be carefully re-added.
+         */
         public static class Constraint {
 
-            private final Map<Identifier.Variable, Set<Label>> types;
+            private final Map<Variable, Set<Label>> roleTypes;
             private final Map<Retrieved, Set<Label>> isaExplicit;
             private final Map<Retrieved, Function<Attribute, Boolean>> predicates;
 
@@ -212,34 +203,34 @@ public class Unifier {
                 this(new HashMap<>(), new HashMap<>(), new HashMap<>());
             }
 
-            public Constraint(Map<Identifier.Variable, Set<Label>> types, Map<Retrieved, Set<Label>> isaExplicit,
+            public Constraint(Map<Variable, Set<Label>> roleTypes, Map<Retrieved, Set<Label>> isaExplicit,
                               Map<Retrieved, Function<Attribute, Boolean>> predicates) {
-                this.types = types;
+                this.roleTypes = roleTypes;
                 this.isaExplicit = isaExplicit;
                 this.predicates = predicates;
             }
 
-            public boolean satisfiedBy(Map<Identifier.Variable, Concept> concepts) {
-                for (Map.Entry<Identifier.Variable, Concept> identifiedConcept : concepts.entrySet()) {
-                    Identifier.Variable id = identifiedConcept.getKey();
+            public boolean satisfiedBy(Map<Variable, Concept> concepts) {
+                for (Map.Entry<Variable, Concept> identifiedConcept : concepts.entrySet()) {
+                    Variable id = identifiedConcept.getKey();
                     Concept concept = identifiedConcept.getValue();
-                    if (!(typesSatisfied(id, concept) && isaXSatisfied(id, concept) && predicatesSatisfied(id, concept))) {
+                    if (!(typesSatisfied(id, concept) && isaExplicitSatisfied(id, concept) && predicatesSatisfied(id, concept))) {
                         return false;
                     }
                 }
                 return true;
             }
 
-            private boolean typesSatisfied(Identifier.Variable id, Concept concept) {
-                if (types.containsKey(id)) {
+            private boolean typesSatisfied(Variable id, Concept concept) {
+                if (roleTypes.containsKey(id)) {
                     assert concept.isType();
-                    return types.get(id).contains(concept.asType().getLabel());
+                    return roleTypes.get(id).contains(concept.asType().getLabel());
                 } else {
                     return true;
                 }
             }
 
-            private boolean isaXSatisfied(Identifier.Variable id, Concept concept) {
+            private boolean isaExplicitSatisfied(Variable id, Concept concept) {
                 if (id.isRetrieved() && isaExplicit.containsKey(id.asRetrieved())) {
                     assert concept.isThing();
                     ThingType type = concept.asThing().getType();
@@ -249,7 +240,7 @@ public class Unifier {
                 }
             }
 
-            private boolean predicatesSatisfied(Identifier.Variable id, Concept concept) {
+            private boolean predicatesSatisfied(Variable id, Concept concept) {
                 if (id.isRetrieved() && predicates.containsKey(id.asRetrieved())) {
                     assert concept.isThing() && (concept.asThing() instanceof Attribute);
                     return predicates.get(id.asRetrieved()).apply(concept.asAttribute());
@@ -258,9 +249,9 @@ public class Unifier {
                 }
             }
 
-            public void types(Identifier.Variable identifier, Set<Label> labels) {
-                assert !types.containsKey(identifier) || types.get(identifier).equals(labels);
-                types.put(identifier, set(labels));
+            public void roleTypes(Variable identifier, Set<Label> labels) {
+                assert !roleTypes.containsKey(identifier) || roleTypes.get(identifier).equals(labels);
+                roleTypes.put(identifier, set(labels));
             }
 
             public void isaExplicit(Retrieved identifier, Set<Label> labels) {
@@ -273,17 +264,17 @@ public class Unifier {
                 predicates.put(identifier, predicateFn);
             }
 
-            public Map<Identifier.Variable, Set<Label>> types() { return types; }
+            public Map<Variable, Set<Label>> roleTypes() { return roleTypes; }
 
             public Map<Retrieved, Set<Label>> isaExplicit() { return isaExplicit; }
 
             public Map<Retrieved, Function<Attribute, Boolean>> predicates() { return predicates; }
 
             private Constraint duplicate() {
-                Map<Identifier.Variable, Set<Label>> typesCopy = new HashMap<>();
+                Map<Variable, Set<Label>> typesCopy = new HashMap<>();
                 Map<Retrieved, Set<Label>> isaExplicitCopy = new HashMap<>();
                 Map<Retrieved, Function<Attribute, Boolean>> predicatesCopy = new HashMap<>();
-                types.forEach(((identifier, labels) -> typesCopy.put(identifier, set(labels))));
+                roleTypes.forEach(((identifier, labels) -> typesCopy.put(identifier, set(labels))));
                 isaExplicit.forEach(((identifier, labels) -> isaExplicitCopy.put(identifier, set(labels))));
                 predicates.forEach((predicatesCopy::put));
                 return new Constraint(typesCopy, isaExplicitCopy, predicatesCopy);
@@ -300,21 +291,19 @@ public class Unifier {
                 this.hash = Objects.hash(requireCompatible);
             }
 
-            public boolean satisfiedBy(Map<Identifier.Variable, Concept> toTest) {
-                for (Map.Entry<Identifier.Variable, ? extends Concept> entry : toTest.entrySet()) {
-                    if (entry.getKey().isRetrieved()) {
-                        Retrieved id = entry.getKey().asRetrieved();
-                        Concept compatible = requireCompatible.get(id);
-                        if (compatible != null) {
-                            Concept testConcept = entry.getValue();
-                            // things must be exactly equal
-                            if ((compatible.isThing() && !compatible.equals(testConcept)) ||
-                                    // if the required concept is a type, the test concept must also be a type
-                                    (compatible.isType() && !testConcept.isType()) ||
-                                    // types must be compatible (testConcept must be a subtype of required concept)
-                                    (compatible.isType() && testConcept.asType().getSupertypes().noneMatch(t -> t.equals(compatible)))) {
-                                return false;
-                            }
+            public boolean satisfiedBy(Map<Variable.Retrieved, Concept> toTest) {
+                for (Map.Entry<Variable.Retrieved, ? extends Concept> entry : toTest.entrySet()) {
+                    Retrieved id = entry.getKey().asRetrieved();
+                    Concept compatible = requireCompatible.get(id);
+                    if (compatible != null) {
+                        Concept testConcept = entry.getValue();
+                        // things must be exactly equal
+                        if ((compatible.isThing() && !compatible.equals(testConcept)) ||
+                                // if the required concept is a type, the test concept must also be a type
+                                (compatible.isType() && !testConcept.isType()) ||
+                                // types must be compatible (testConcept must be a subtype of required concept)
+                                (compatible.isType() && testConcept.asType().getSupertypes().noneMatch(t -> t.equals(compatible)))) {
+                            return false;
                         }
                     }
                 }

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -80,14 +80,16 @@ public class TypeResolver {
         this.logicCache = logicCache;
     }
 
-    public ResourceIterator<Map<Reference.Name, Label>> combinations(Conjunction conjunction, boolean insertable) {
-        TraversalBuilder traversalBuilder = new TraversalBuilder(conjunction, conceptMgr, new Traversal(), 0, insertable);
+    public ResourceIterator<Map<Identifier.Variable.Name, Label>> namedCombinations(Conjunction conjunction, boolean insertable) {
+        Traversal resolverTraversal = new Traversal();
+        TraversalBuilder traversalBuilder = new TraversalBuilder(conjunction, conceptMgr, resolverTraversal, 0, insertable);
+        resolverTraversal.filter(traversalBuilder.retrievedResolvers());
         return traversalEng.iterator(traversalBuilder.traversal()).map(vertexMap -> {
-            Map<Reference.Name, Label> mapping = new HashMap<>();
-            vertexMap.forEach((ref, vertex) -> {
+            Map<Identifier.Variable.Name, Label> mapping = new HashMap<>();
+            vertexMap.forEach((id, vertex) -> {
                 assert vertex.isType();
-                traversalBuilder.getVariable(ref).map(Variable::reference).filter(Reference::isName)
-                        .map(Reference::asName).ifPresent(originalRef -> mapping.put(originalRef, vertex.asType().properLabel()));
+                traversalBuilder.getVariable(id).map(Variable::id).filter(Identifier::isName)
+                        .ifPresent(originalRef -> mapping.put(originalRef.asName(), vertex.asType().properLabel()));
             });
             return mapping;
         });
@@ -122,8 +124,8 @@ public class TypeResolver {
         resolveLabels(conjunction);
         Traversal resolverTraversal = new Traversal();
         TraversalBuilder traversalBuilder = builder(resolverTraversal, conjunction, scopingConjunctions, insertable);
-        resolverTraversal.filter(traversalBuilder.namedResolverIds());
-        Map<Reference, Set<Label>> resolvedLabels = executeResolverTraversals(traversalBuilder);
+        resolverTraversal.filter(traversalBuilder.retrievedResolvers());
+        Map<Identifier.Variable, Set<Label>> resolvedLabels = executeResolverTraversals(traversalBuilder);
         if (resolvedLabels.isEmpty()) {
             conjunction.setSatisfiable(false);
             return;
@@ -132,8 +134,8 @@ public class TypeResolver {
         long numOfTypes = traversalEng.graph().schema().stats().thingTypeCount();
         long numOfConcreteTypes = traversalEng.graph().schema().stats().concreteThingTypeCount();
 
-        resolvedLabels.forEach((ref, labels) -> {
-            traversalBuilder.getVariable(ref)
+        resolvedLabels.forEach((id, labels) -> {
+            traversalBuilder.getVariable(id)
                     .filter(var -> (var.isType() && labels.size() < numOfTypes) || (var.isThing() && labels.size() < numOfConcreteTypes))
                     .ifPresent(variable -> {
                         assert variable.resolvedTypes().isEmpty() || variable.resolvedTypes().containsAll(labels);
@@ -164,17 +166,17 @@ public class TypeResolver {
         return currentBuilder;
     }
 
-    private Map<Reference, Set<Label>> executeResolverTraversals(TraversalBuilder traversalBuilder) {
+    private Map<Identifier.Variable, Set<Label>> executeResolverTraversals(TraversalBuilder traversalBuilder) {
         return logicCache.resolver().get(traversalBuilder.traversal(), traversal -> {
-            Map<Reference, Set<Label>> mapping = new HashMap<>();
+            Map<Identifier.Variable, Set<Label>> mapping = new HashMap<>();
             traversalEng.iterator(traversal, true).forEachRemaining(
-                    result -> result.forEach((ref, vertex) -> {
-                        mapping.putIfAbsent(ref, new HashSet<>());
+                    result -> result.forEach((id, vertex) -> {
+                        mapping.putIfAbsent(id, new HashSet<>());
                         assert vertex.isType();
                         // TODO: This filter should not be needed if we enforce traversal only to return non-abstract
-                        if (!traversalBuilder.getVariable(ref).isPresent()) return;
-                        if (!(vertex.asType().isAbstract() && traversalBuilder.getVariable(ref).get().isThing()))
-                            mapping.get(ref).add(vertex.asType().properLabel());
+                        if (!traversalBuilder.getVariable(id).isPresent()) return;
+                        if (!(vertex.asType().isAbstract() && traversalBuilder.getVariable(id).get().isThing()))
+                            mapping.get(id).add(vertex.asType().properLabel());
                     })
             );
             return mapping;
@@ -186,9 +188,9 @@ public class TypeResolver {
         private static final Identifier.Variable ROOT_ATTRIBUTE_ID = Identifier.Variable.of(Reference.label(ATTRIBUTE.toString()));
         private static final Label ROOT_ATTRIBUTE_LABEL = Label.of(ATTRIBUTE.toString());
         private static final Label ROOT_THING_LABEL = Label.of(THING.toString());
-        private final Map<Reference, Variable> variableRegister;
-        private final Map<Identifier, TypeVariable> resolverRegister;
-        private final Map<Identifier, Set<ValueType>> valueTypeRegister;
+        private final Map<Identifier.Variable, Variable> resolvers;
+        private final Map<Identifier.Variable, Set<ValueType>> resolverValueTypes;
+        private final Map<Identifier.Variable, TypeVariable> originalToResolver;
         private final ConceptManager conceptMgr;
         private final Traversal traversal;
         private final boolean insertable;
@@ -199,17 +201,17 @@ public class TypeResolver {
                          int initialAnonymousVarCounter, boolean insertable) {
             this.conceptMgr = conceptMgr;
             this.traversal = initialTraversal;
-            this.variableRegister = new HashMap<>();
-            this.resolverRegister = new HashMap<>();
-            this.valueTypeRegister = new HashMap<>();
+            this.resolvers = new HashMap<>();
+            this.originalToResolver = new HashMap<>();
+            this.resolverValueTypes = new HashMap<>();
             this.sysVarCounter = initialAnonymousVarCounter;
             this.insertable = insertable;
             this.hasRootAttribute = false;
             conjunction.variables().forEach(this::register);
         }
 
-        public Set<Identifier.Variable.Name> namedResolverIds() {
-            return iterate(resolverRegister.values()).filter(v -> v.id().isName()).map(v -> v.id().asName()).toSet();
+        public Set<Identifier.Variable.Retrieved> retrievedResolvers() {
+            return iterate(resolvers.keySet()).filter(Identifier::isRetrieved).map(Identifier.Variable::asRetrieved).toSet();
         }
 
         public int sysVarCounter() {
@@ -220,9 +222,8 @@ public class TypeResolver {
             return traversal;
         }
 
-        Optional<Variable> getVariable(Reference reference) {
-            if (!variableRegister.containsKey(reference)) return Optional.empty();
-            return Optional.of(variableRegister.get(reference));
+        Optional<Variable> getVariable(Identifier.Variable id) {
+            return Optional.ofNullable(resolvers.get(id));
         }
 
         private void register(Variable variable) {
@@ -232,16 +233,16 @@ public class TypeResolver {
         }
 
         private TypeVariable register(TypeVariable var) {
-            if (resolverRegister.containsKey(var.id())) return resolverRegister.get(var.id());
+            if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
             TypeVariable resolver;
             if (var.label().isPresent() && var.label().get().scope().isPresent()) {
-                resolver = new TypeVariable(newSystemId());
+                resolver = new TypeVariable(var.id());
                 traversal.labels(resolver.id(), var.resolvedTypes());
             } else {
                 resolver = var;
             }
-            resolverRegister.put(var.id(), resolver);
-            variableRegister.putIfAbsent(resolver.reference(), var);
+            originalToResolver.put(var.id(), resolver);
+            resolvers.putIfAbsent(resolver.id(), var);
             if (!var.resolvedTypes().isEmpty()) traversal.labels(resolver.id(), var.resolvedTypes());
 
             for (TypeConstraint constraint : var.constraints()) {
@@ -292,12 +293,12 @@ public class TypeResolver {
         }
 
         private TypeVariable register(ThingVariable var) {
-            if (resolverRegister.containsKey(var.id())) return resolverRegister.get(var.id());
+            if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
 
-            TypeVariable resolver = new TypeVariable(var.reference().isAnonymous() ? newSystemId() : var.id());
-            resolverRegister.put(var.id(), resolver);
-            variableRegister.putIfAbsent(resolver.reference(), var);
-            valueTypeRegister.putIfAbsent(resolver.id(), set());
+            TypeVariable resolver = new TypeVariable(var.id());
+            originalToResolver.put(var.id(), resolver);
+            resolvers.putIfAbsent(resolver.id(), var);
+            resolverValueTypes.putIfAbsent(resolver.id(), set());
 
             // Note: order is important! convertValue assumes that any other Variable encountered from that edge will
             // have resolved its valueType, so we execute convertValue first.
@@ -363,26 +364,26 @@ public class TypeResolver {
             Set<ValueType> valueTypes;
             if (constraint.isVariable()) {
                 TypeVariable comparableVar = register(constraint.asVariable().value());
-                assert valueTypeRegister.containsKey(comparableVar.id()); //This will fail without careful ordering.
+                assert resolverValueTypes.containsKey(comparableVar.id()); //This will fail without careful ordering.
                 registerSubAttribute(comparableVar);
-                valueTypes = valueTypeRegister.get(comparableVar.id());
+                valueTypes = resolverValueTypes.get(comparableVar.id());
             } else {
                 valueTypes = iterate(Encoding.ValueType.of(constraint.value().getClass()).comparables())
                         .map(Encoding.ValueType::graqlValueType).toSet();
             }
 
-            if (valueTypeRegister.get(resolver.id()).isEmpty()) {
+            if (resolverValueTypes.get(resolver.id()).isEmpty()) {
                 valueTypes.forEach(valueType -> traversal.valueType(resolver.id(), valueType));
-                valueTypeRegister.put(resolver.id(), valueTypes);
-            } else if (!valueTypeRegister.get(resolver.id()).containsAll(valueTypes)) {
+                resolverValueTypes.put(resolver.id(), valueTypes);
+            } else if (!resolverValueTypes.get(resolver.id()).containsAll(valueTypes)) {
                 throw GraknException.of(UNSATISFIABLE_CONJUNCTION, constraint);
             }
             registerSubAttribute(resolver);
         }
 
         private void registerSubAttribute(Variable resolver) {
-            assert variableRegister.get(resolver.reference()).isThing();
-            Optional<IsaConstraint> isa = variableRegister.get(resolver.reference()).asThing().isa();
+            assert resolvers.get(resolver.id()).isThing();
+            Optional<IsaConstraint> isa = resolvers.get(resolver.id()).asThing().isa();
             if (!isa.isPresent()) {
                 registerRootAttribute();
                 traversal.sub(resolver.id(), ROOT_ATTRIBUTE_ID, true);
@@ -402,6 +403,7 @@ public class TypeResolver {
                 hasRootAttribute = true;
             }
         }
+
 
         private Identifier.Variable newSystemId() {
             return Identifier.Variable.of(SystemReference.of(sysVarCounter++));

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -210,8 +210,8 @@ public class TypeResolver {
             conjunction.variables().forEach(this::register);
         }
 
-        public Set<Identifier.Variable.Retrieved> retrievedResolvers() {
-            return iterate(resolvers.keySet()).filter(Identifier::isRetrieved).map(Identifier.Variable::asRetrieved).toSet();
+        public Set<Identifier.Variable.Retrievable> retrievedResolvers() {
+            return iterate(resolvers.keySet()).filter(Identifier::isRetrievable).map(Identifier.Variable::asRetrievable).toSet();
         }
 
         public int sysVarCounter() {

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -236,7 +236,7 @@ public class TypeResolver {
             if (originalToResolver.containsKey(var.id())) return originalToResolver.get(var.id());
             TypeVariable resolver;
             if (var.label().isPresent() && var.label().get().scope().isPresent()) {
-                resolver = new TypeVariable(var.id());
+                resolver = new TypeVariable(newSystemId());
                 traversal.labels(resolver.id(), var.resolvedTypes());
             } else {
                 resolver = var;

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -32,7 +32,7 @@ import grakn.core.pattern.variable.VariableCloner;
 import grakn.core.pattern.variable.VariableRegistry;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import graql.lang.pattern.Conjunctable;
 import graql.lang.pattern.variable.BoundVariable;
 
@@ -115,10 +115,10 @@ public class Conjunction implements Pattern, Cloneable {
         }
     }
 
-    public void bound(Map<Retrieved, Either<Label, byte[]>> bounds) {
+    public void bound(Map<Retrievable, Either<Label, byte[]>> bounds) {
         variableSet.forEach(var -> {
-            if (var.id().isRetrieved() && bounds.containsKey(var.id().asRetrieved())) {
-                Either<Label, byte[]> boundVar = bounds.get(var.id().asRetrieved());
+            if (var.id().isRetrievable() && bounds.containsKey(var.id().asRetrievable())) {
+                Either<Label, byte[]> boundVar = bounds.get(var.id().asRetrievable());
                 if (var.isType() != boundVar.isFirst()) throw GraknException.of(CONTRADICTORY_BOUND_VARIABLE, var);
                 else if (var.isType()) {
                     Optional<LabelConstraint> existingLabel = var.asType().label();
@@ -159,7 +159,7 @@ public class Conjunction implements Pattern, Cloneable {
         return negations;
     }
 
-    public Traversal traversal(Set<? extends Retrieved> filter) {
+    public Traversal traversal(Set<? extends Retrievable> filter) {
         Traversal traversal = new Traversal();
         variableSet.forEach(variable -> variable.addTo(traversal));
         assert iterate(filter).allMatch(variableMap::containsKey);

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -32,9 +32,9 @@ import grakn.core.pattern.variable.VariableCloner;
 import grakn.core.pattern.variable.VariableRegistry;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import graql.lang.pattern.Conjunctable;
 import graql.lang.pattern.variable.BoundVariable;
-import graql.lang.pattern.variable.Reference;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -49,7 +49,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.common.collection.Collections.set;
@@ -116,10 +115,10 @@ public class Conjunction implements Pattern, Cloneable {
         }
     }
 
-    public void bound(Map<Reference.Name, Either<Label, byte[]>> bounds) {
+    public void bound(Map<Retrieved, Either<Label, byte[]>> bounds) {
         variableSet.forEach(var -> {
-            if (var.id().isName() && bounds.containsKey(var.id().reference().asName())) {
-                Either<Label, byte[]> boundVar = bounds.get(var.id().reference().asName());
+            if (var.id().isRetrieved() && bounds.containsKey(var.id().asRetrieved())) {
+                Either<Label, byte[]> boundVar = bounds.get(var.id().asRetrieved());
                 if (var.isType() != boundVar.isFirst()) throw GraknException.of(CONTRADICTORY_BOUND_VARIABLE, var);
                 else if (var.isType()) {
                     Optional<LabelConstraint> existingLabel = var.asType().label();
@@ -152,11 +151,15 @@ public class Conjunction implements Pattern, Cloneable {
         return variableSet;
     }
 
+    public Set<Identifier.Variable> identifiers() {
+        return variableMap.keySet();
+    }
+
     public Set<Negation> negations() {
         return negations;
     }
 
-    public Traversal traversal(Set<Identifier.Variable.Name> filter) {
+    public Traversal traversal(Set<? extends Retrieved> filter) {
         Traversal traversal = new Traversal();
         variableSet.forEach(variable -> variable.addTo(traversal));
         assert iterate(filter).allMatch(variableMap::containsKey);
@@ -178,13 +181,6 @@ public class Conjunction implements Pattern, Cloneable {
 
     public boolean isBounded() {
         return isBounded;
-    }
-
-    private boolean printable(Variable variable) {
-        if (variable.reference().isName() || !variable.reference().isLabel()) return !variable.constraints().isEmpty();
-        if (variable.isThing()) return !variable.asThing().relation().isEmpty() && !variable.asThing().has().isEmpty();
-        if (variable.isType() && variable.reference().isLabel()) return variable.constraints().size() > 1;
-        throw GraknException.of(ILLEGAL_STATE);
     }
 
     @Override

--- a/pattern/equivalence/AlphaEquivalence.java
+++ b/pattern/equivalence/AlphaEquivalence.java
@@ -18,9 +18,7 @@
 package grakn.core.pattern.equivalence;
 
 import grakn.core.pattern.variable.Variable;
-import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import javax.annotation.Nullable;
 import java.util.AbstractMap;
@@ -154,18 +152,18 @@ public abstract class AlphaEquivalence {
             return this;
         }
 
-        public Map<Retrieved, Retrieved> idMapping() {
+        public Map<Retrievable, Retrievable> idMapping() {
             return variableMapping().entrySet().stream()
                     .map(e -> new AbstractMap.SimpleEntry<>(
                             e.getKey().id(),
                             e.getValue().id()))
                     .filter(e -> {
-                        assert e.getKey().isRetrieved() == e.getValue().isRetrieved();
-                        return e.getKey().isRetrieved();
+                        assert e.getKey().isRetrievable() == e.getValue().isRetrievable();
+                        return e.getKey().isRetrievable();
                     })
                     .collect(Collectors.toMap(
-                            e -> e.getKey().asRetrieved(),
-                            e -> e.getValue().asRetrieved()
+                            e -> e.getKey().asRetrievable(),
+                            e -> e.getValue().asRetrievable()
                     ));
         }
 

--- a/pattern/equivalence/AlphaEquivalence.java
+++ b/pattern/equivalence/AlphaEquivalence.java
@@ -18,6 +18,8 @@
 package grakn.core.pattern.equivalence;
 
 import grakn.core.pattern.variable.Variable;
+import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import graql.lang.pattern.variable.Reference;
 
 import javax.annotation.Nullable;
@@ -152,18 +154,18 @@ public abstract class AlphaEquivalence {
             return this;
         }
 
-        public Map<Reference.Name, Reference.Name> namedVariableMapping() {
+        public Map<Retrieved, Retrieved> idMapping() {
             return variableMapping().entrySet().stream()
                     .map(e -> new AbstractMap.SimpleEntry<>(
-                            e.getKey().id().reference(),
-                            e.getValue().id().reference()))
-                    .filter(e -> e.getKey().isName() && e.getValue().isName())
-                    .map(e -> new AbstractMap.SimpleEntry<>(
-                            e.getKey().asName(),
-                            e.getValue().asName()))
+                            e.getKey().id(),
+                            e.getValue().id()))
+                    .filter(e -> {
+                        assert e.getKey().isRetrieved() == e.getValue().isRetrieved();
+                        return e.getKey().isRetrieved();
+                    })
                     .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            Map.Entry::getValue
+                            e -> e.getKey().asRetrieved(),
+                            e -> e.getValue().asRetrieved()
                     ));
         }
 

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -97,8 +97,7 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
 
     @Override
     public Identifier.Variable.Retrievable id() {
-        // TODO this is ugly
-        return super.id().asRetrievable();
+        return identifier.asRetrievable();
     }
 
     @Override

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -96,9 +96,9 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
     }
 
     @Override
-    public Identifier.Variable.Retrieved id() {
+    public Identifier.Variable.Retrievable id() {
         // TODO this is ugly
-        return super.id().asRetrieved();
+        return super.id().asRetrievable();
     }
 
     @Override

--- a/pattern/variable/ThingVariable.java
+++ b/pattern/variable/ThingVariable.java
@@ -96,6 +96,12 @@ public class ThingVariable extends Variable implements AlphaEquivalent<ThingVari
     }
 
     @Override
+    public Identifier.Variable.Retrieved id() {
+        // TODO this is ugly
+        return super.id().asRetrieved();
+    }
+
+    @Override
     public void addTo(Traversal traversal) {
         // TODO: create vertex properties first, then the vertex itself, then edges
         //       that way, we can make properties to be 'final' objects that are

--- a/pattern/variable/TypeVariable.java
+++ b/pattern/variable/TypeVariable.java
@@ -80,6 +80,11 @@ public class TypeVariable extends Variable implements AlphaEquivalent<TypeVariab
         return new TypeVariable(identifier);
     }
 
+    @Override
+    public Identifier.Variable id() {
+        return identifier;
+    }
+
     Variable constrainConcept(List<ConceptConstraint> constraints, VariableRegistry registry) {
         constraints.forEach(constraint -> this.constrain(TypeConstraint.of(this, constraint, registry)));
         return this;

--- a/pattern/variable/Variable.java
+++ b/pattern/variable/Variable.java
@@ -35,10 +35,10 @@ import static grakn.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 
 public abstract class Variable implements Pattern {
 
-    private final Identifier.Variable identifier;
     private final Set<Label> resolvedTypes;
     private final int hash;
     private boolean isSatisfiable;
+    final Identifier.Variable identifier;
 
     Variable(Identifier.Variable identifier) {
         this.identifier = identifier;
@@ -53,9 +53,7 @@ public abstract class Variable implements Pattern {
 
     public abstract void constraining(Constraint constraint);
 
-    public Identifier.Variable id() {
-        return identifier;
-    }
+    public abstract Identifier.Variable id();
 
     public Reference reference() {
         return identifier.reference();

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -41,7 +41,7 @@ import grakn.core.pattern.variable.ThingVariable;
 import grakn.core.pattern.variable.VariableRegistry;
 import grakn.core.reasoner.Reasoner;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import graql.lang.pattern.variable.UnboundVariable;
 import graql.lang.query.GraqlInsert;
 import graql.lang.query.GraqlMatch;
@@ -145,7 +145,7 @@ public class Inserter {
         private final ConceptManager conceptMgr;
         private final ConceptMap matched;
         private final Set<ThingVariable> variables;
-        private final Map<Retrieved, Thing> inserted;
+        private final Map<Retrievable, Thing> inserted;
 
         Operation(ConceptManager conceptMgr, ConceptMap matched, Set<ThingVariable> variables) {
             this.conceptMgr = conceptMgr;
@@ -172,9 +172,9 @@ public class Inserter {
 
         private Thing insert(ThingVariable var) {
             try (GrablTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "insert")) {
-                assert var.id().isRetrieved(); // thing variables are always retrieved
+                assert var.id().isRetrievable(); // thing variables are always retrieved
                 Thing thing;
-                Retrieved id = var.id();
+                Retrievable id = var.id();
 
                 if (id.isName() && (thing = inserted.get(id)) != null) return thing;
                 else if (matchedContains(var) && var.constraints().isEmpty()) return matchedGet(var);

--- a/reasoner/BUILD
+++ b/reasoner/BUILD
@@ -73,12 +73,14 @@ host_compatible_java_test(
         "//concept:concept",
         "//pattern:pattern",
         "//reasoner:reasoner",
+        "//traversal:traversal",
     ],
     deps = [
         # Internal dependencies
         "//common",
 
         # External dependencies from Grakn Labs
+        "@graknlabs_common//:common",
         "@graknlabs_graql//java/pattern",
     ],
 )

--- a/reasoner/BUILD
+++ b/reasoner/BUILD
@@ -81,7 +81,6 @@ host_compatible_java_test(
 
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",
-        "@graknlabs_graql//java/pattern",
     ],
 )
 

--- a/reasoner/ReasonerProducer.java
+++ b/reasoner/ReasonerProducer.java
@@ -27,6 +27,7 @@ import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Identity;
 import grakn.core.reasoner.resolution.answer.AnswerState.Top;
 import grakn.core.reasoner.resolution.framework.Request;
 import grakn.core.reasoner.resolution.framework.Resolver;
+import grakn.core.traversal.common.Identifier;
 import graql.lang.pattern.variable.Reference;
 import graql.lang.pattern.variable.UnboundVariable;
 import graql.lang.query.GraqlMatch;
@@ -84,8 +85,8 @@ public class ReasonerProducer implements Producer<ConceptMap> {
     @Override
     public void recycle() {}
 
-    private Set<Reference.Name> filter(List<UnboundVariable> filter) {
-        return iterate(filter).map(v -> v.reference().asName()).toSet();
+    private Set<Identifier.Variable.Name> filter(List<UnboundVariable> filter) {
+        return iterate(filter).map(v -> Identifier.Variable.of(v.reference().asName())).toSet();
     }
 
 

--- a/reasoner/resolution/Planner.java
+++ b/reasoner/resolution/Planner.java
@@ -22,9 +22,8 @@ import grakn.core.concept.ConceptManager;
 import grakn.core.logic.LogicManager;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Resolvable;
-import grakn.core.logic.resolvable.Retrievable;
 import grakn.core.pattern.variable.ThingVariable;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,17 +49,17 @@ public class Planner {
         this.logicMgr = logicMgr;
     }
 
-    public List<Resolvable<?>> plan(Set<Resolvable<?>> resolvables, Set<Retrieved> bound) {
+    public List<Resolvable<?>> plan(Set<Resolvable<?>> resolvables, Set<Retrievable> bound) {
         return new Plan(resolvables, bound).plan;
     }
 
     class Plan {
         private final List<Resolvable<?>> plan;
-        private final Map<Resolvable<?>, Set<Retrieved>> dependencies;
-        private final Set<Retrieved> answered;
+        private final Map<Resolvable<?>, Set<Retrievable>> dependencies;
+        private final Set<Retrievable> answered;
         private final Set<Resolvable<?>> remaining;
 
-        Plan(Set<Resolvable<?>> resolvables, Set<Retrieved> boundVars) {
+        Plan(Set<Resolvable<?>> resolvables, Set<Retrievable> boundVars) {
             assert resolvables.size() > 0;
             this.plan = new ArrayList<>();
             this.answered = new HashSet<>(boundVars);
@@ -80,7 +79,7 @@ public class Planner {
         private void computePlan() {
             while (remaining.size() != 0) {
                 Optional<Concludable> concludable;
-                Optional<Retrievable> retrievable;
+                Optional<grakn.core.logic.resolvable.Retrievable> retrievable;
 
                 // Retrievable where:
                 // all of it's dependencies are already satisfied,
@@ -167,14 +166,14 @@ public class Planner {
         /**
          * Determine the resolvables that are dependent upon the generation of each variable
          */
-        private Map<Resolvable<?>, Set<Retrieved>> dependencies(Set<Resolvable<?>> resolvables) {
-            Map<Resolvable<?>, Set<Retrieved>> deps = new HashMap<>();
-            Set<Retrieved> generated = iterate(resolvables).map(Resolvable::generating).filter(Optional::isPresent)
+        private Map<Resolvable<?>, Set<Retrievable>> dependencies(Set<Resolvable<?>> resolvables) {
+            Map<Resolvable<?>, Set<Retrievable>> deps = new HashMap<>();
+            Set<Retrievable> generated = iterate(resolvables).map(Resolvable::generating).filter(Optional::isPresent)
                     .map(Optional::get).map(ThingVariable::id).toSet();
             for (Resolvable<?> resolvable : resolvables) {
                 Optional<ThingVariable> generating = resolvable.generating();
                 deps.putIfAbsent(resolvable, new HashSet<>());
-                for (Retrieved v : resolvable.retrieves()) {
+                for (Retrievable v : resolvable.retrieves()) {
                     if (generated.contains(v) && !(generating.isPresent() && generating.get().id().equals(v))) {
                         // TODO: Should this rule the Resolvable<?> out if generates it's own dependency?
                         deps.get(resolvable).add(v);

--- a/reasoner/resolution/Planner.java
+++ b/reasoner/resolution/Planner.java
@@ -23,7 +23,8 @@ import grakn.core.logic.LogicManager;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Resolvable;
 import grakn.core.logic.resolvable.Retrievable;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.pattern.variable.ThingVariable;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,20 +50,20 @@ public class Planner {
         this.logicMgr = logicMgr;
     }
 
-    public List<Resolvable<?>> plan(Set<Resolvable<?>> resolvables, Set<Reference.Name> bound) {
+    public List<Resolvable<?>> plan(Set<Resolvable<?>> resolvables, Set<Retrieved> bound) {
         return new Plan(resolvables, bound).plan;
     }
 
     class Plan {
         private final List<Resolvable<?>> plan;
-        private final Map<Resolvable<?>, Set<Reference.Name>> dependencies;
-        private final Set<Reference.Name> varsAnswered;
+        private final Map<Resolvable<?>, Set<Retrieved>> dependencies;
+        private final Set<Retrieved> answered;
         private final Set<Resolvable<?>> remaining;
 
-        Plan(Set<Resolvable<?>> resolvables, Set<Reference.Name> boundVars) {
+        Plan(Set<Resolvable<?>> resolvables, Set<Retrieved> boundVars) {
             assert resolvables.size() > 0;
             this.plan = new ArrayList<>();
-            this.varsAnswered = new HashSet<>(boundVars);
+            this.answered = new HashSet<>(boundVars);
             this.dependencies = dependencies(resolvables);
             this.remaining = new HashSet<>(resolvables);
             computePlan();
@@ -72,7 +73,7 @@ public class Planner {
 
         private void add(Resolvable<?> resolvable) {
             plan.add(resolvable);
-            varsAnswered.addAll(resolvable.variableNames());
+            iterate(resolvable.retrieves()).forEachRemaining(answered::add);
             remaining.remove(resolvable);
         }
 
@@ -140,11 +141,11 @@ public class Planner {
         }
 
         private Stream<Resolvable<?>> dependenciesSatisfied(Stream<Resolvable<?>> resolvableStream) {
-            return resolvableStream.filter(c -> varsAnswered.containsAll(dependencies.get(c)));
+            return resolvableStream.filter(c -> answered.containsAll(dependencies.get(c)));
         }
 
         private Stream<Resolvable<?>> hasAnsweredVar(Stream<Resolvable<?>> resolvableStream) {
-            return resolvableStream.filter(r -> !Collections.disjoint(r.variableNames(), varsAnswered));
+            return resolvableStream.filter(r -> !Collections.disjoint(r.retrieves(), answered));
         }
 
         private Optional<Concludable> fewestRules(Stream<Resolvable<?>> resolvableStream) {
@@ -154,28 +155,27 @@ public class Planner {
         }
 
         private Optional<Resolvable<?>> mostAnsweredVars(Stream<Resolvable<?>> resolvables) {
-            return resolvables.max(Comparator.comparingInt(r -> iterate(r.variableNames())
-                            .filter(varsAnswered::contains).toSet().size()));
+            return resolvables.max(Comparator.comparingInt(r -> iterate(r.retrieves())
+                            .filter(answered::contains).toSet().size()));
         }
 
         private Optional<Resolvable<?>> mostUnansweredVars(Stream<Resolvable<?>> resolvableStream) {
-            return resolvableStream.max(Comparator.comparingInt(r -> iterate(r.variableNames())
-                    .filter(var -> !varsAnswered.contains(var)).toSet().size()));
+            return resolvableStream.max(Comparator.comparingInt(r -> iterate(r.retrieves())
+                    .filter(id -> !answered.contains(id)).toSet().size()));
         }
 
         /**
          * Determine the resolvables that are dependent upon the generation of each variable
          */
-        private Map<Resolvable<?>, Set<Reference.Name>> dependencies(Set<Resolvable<?>> resolvables) {
-            Map<Resolvable<?>, Set<Reference.Name>> deps = new HashMap<>();
-            Set<Reference.Name> generatedVars = iterate(resolvables).map(Resolvable::generating).filter(Optional::isPresent)
-                    .map(Optional::get).filter(v -> v.reference().isName()).map(v -> v.reference().asName()).toSet();
+        private Map<Resolvable<?>, Set<Retrieved>> dependencies(Set<Resolvable<?>> resolvables) {
+            Map<Resolvable<?>, Set<Retrieved>> deps = new HashMap<>();
+            Set<Retrieved> generated = iterate(resolvables).map(Resolvable::generating).filter(Optional::isPresent)
+                    .map(Optional::get).map(ThingVariable::id).toSet();
             for (Resolvable<?> resolvable : resolvables) {
-                Optional<Reference.Name> generating = resolvable.generating().filter(v -> v.reference().isName())
-                        .map(v -> v.reference().asName());
-                for (Reference.Name v : resolvable.variableNames()) {
-                    deps.putIfAbsent(resolvable, new HashSet<>());
-                    if (generatedVars.contains(v) && !(generating.isPresent() && generating.get().equals(v))) {
+                Optional<ThingVariable> generating = resolvable.generating();
+                deps.putIfAbsent(resolvable, new HashSet<>());
+                for (Retrieved v : resolvable.retrieves()) {
+                    if (generated.contains(v) && !(generating.isPresent() && generating.get().id().equals(v))) {
                         // TODO: Should this rule the Resolvable<?> out if generates it's own dependency?
                         deps.get(resolvable).add(v);
                     }

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -27,7 +27,6 @@ import grakn.core.logic.Rule;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Negated;
 import grakn.core.logic.resolvable.Resolvable;
-import grakn.core.logic.resolvable.Retrievable;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Disjunction;
 import grakn.core.pattern.equivalence.AlphaEquivalence;
@@ -40,7 +39,7 @@ import grakn.core.reasoner.resolution.resolver.RetrievableResolver;
 import grakn.core.reasoner.resolution.resolver.Root;
 import grakn.core.reasoner.resolution.resolver.RuleResolver;
 import grakn.core.traversal.TraversalEngine;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,7 +114,7 @@ public class ResolverRegistry {
         );
     }
 
-    private MappedResolver registerRetrievable(Retrievable retrievable) {
+    private MappedResolver registerRetrievable(grakn.core.logic.resolvable.Retrievable retrievable) {
         LOG.debug("Register RetrievableResolver: '{}'", retrievable.pattern());
         Actor<RetrievableResolver> retrievableActor = Actor.create(elg, self -> new RetrievableResolver(
                 self, retrievable, this, traversalEngine, conceptMgr, explanations));
@@ -153,19 +152,19 @@ public class ResolverRegistry {
         Actor<NegationResolver> negatedResolver = Actor.create(
                 elg, self -> new NegationResolver(self, negated, this, traversalEngine, resolutionRecorder, explanations)
         );
-        Map<Retrieved, Retrieved> filteredMapping = identityFiltered(upstream, negated);
+        Map<Retrievable, Retrievable> filteredMapping = identityFiltered(upstream, negated);
         return MappedResolver.of(negatedResolver, filteredMapping);
     }
 
-    private Map<Retrieved, Retrieved> identity(Resolvable<Conjunction> conjunctionResolvable) {
+    private Map<Retrievable, Retrievable> identity(Resolvable<Conjunction> conjunctionResolvable) {
         return conjunctionResolvable.retrieves().stream()
                 .collect(Collectors.toMap(Function.identity(), Function.identity()));
     }
 
-    private Map<Retrieved, Retrieved> identityFiltered(Conjunction upstream, Negated negated) {
+    private Map<Retrievable, Retrievable> identityFiltered(Conjunction upstream, Negated negated) {
         return upstream.variables().stream()
-                .filter(var -> var.id().isRetrieved() && negated.retrieves().contains(var.id().asRetrieved()))
-                .map(var -> var.id().asRetrieved())
+                .filter(var -> var.id().isRetrievable() && negated.retrieves().contains(var.id().asRetrievable()))
+                .map(var -> var.id().asRetrievable())
                 .collect(Collectors.toMap(Function.identity(), Function.identity()));
     }
 
@@ -177,18 +176,18 @@ public class ResolverRegistry {
 
     public static class MappedResolver {
         private final Actor<? extends Resolver<?>> resolver;
-        private final Map<Retrieved, Retrieved> mapping;
+        private final Map<Retrievable, Retrievable> mapping;
 
-        private MappedResolver(Actor<? extends Resolver<?>> resolver, Map<Retrieved, Retrieved> mapping) {
+        private MappedResolver(Actor<? extends Resolver<?>> resolver, Map<Retrievable, Retrievable> mapping) {
             this.resolver = resolver;
             this.mapping = mapping;
         }
 
-        public static MappedResolver of(Actor<? extends Resolver<?>> resolver, Map<Retrieved, Retrieved> mapping) {
+        public static MappedResolver of(Actor<? extends Resolver<?>> resolver, Map<Retrievable, Retrievable> mapping) {
             return new MappedResolver(resolver, mapping);
         }
 
-        public Map<Retrieved, Retrieved> mapping() {
+        public Map<Retrievable, Retrievable> mapping() {
             return mapping;
         }
 

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -26,7 +26,6 @@ import grakn.core.logic.resolvable.Unifier;
 import grakn.core.logic.resolvable.Unifier.Requirements.Instance;
 import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.traversal.common.Identifier;
-import graql.lang.pattern.variable.Reference;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -100,21 +99,21 @@ public abstract class AnswerState {
 
     public static class Top extends AnswerState {
 
-        private final Set<Reference.Name> filter;
+        private final Set<Identifier.Variable.Name> getFilter;
         private final int hash;
 
-        Top(ConceptMap conceptMap, @Nullable Set<Reference.Name> filter,
+        Top(ConceptMap conceptMap, @Nullable Set<Identifier.Variable.Name> getFilter,
             Actor<? extends Resolver<?>> root, boolean recordExplanations, boolean requiresReiteration,
             @Nullable Derivation derivation) {
             super(conceptMap, root, root, requiresReiteration, derivation, recordExplanations);
-            this.filter = filter;
-            this.hash = Objects.hash(root, conceptMap, filter);
+            this.getFilter = getFilter;
+            this.hash = Objects.hash(root, conceptMap, getFilter);
         }
 
-        public static Top initial(Set<Reference.Name> filter, boolean recordExplanations,
+        public static Top initial(Set<Identifier.Variable.Name> getFilter, boolean recordExplanations,
                                   Actor<? extends Resolver<?>> root) {
             Derivation derivation = recordExplanations ? Derivation.EMPTY : null;
-            return new Top(new ConceptMap(), filter, root, recordExplanations, false, derivation);
+            return new Top(new ConceptMap(), getFilter, root, recordExplanations, false, derivation);
         }
 
         public Partial.Identity toDownstream() {
@@ -122,7 +121,7 @@ public abstract class AnswerState {
         }
 
         Top with(ConceptMap conceptMap, boolean requiresReiteration, @Nullable Derivation derivation) {
-            return new Top(conceptMap, filter, root(), recordExplanations(), requiresReiteration, derivation);
+            return new Top(conceptMap, getFilter, root(), recordExplanations(), requiresReiteration, derivation);
         }
 
         @Override
@@ -130,13 +129,13 @@ public abstract class AnswerState {
             return "AnswerState.Top{" +
                     "root=" + root() +
                     ", conceptMap=" + conceptMap() +
-                    ", filter=" + filter +
+                    ", filter=" + getFilter +
                     '}';
         }
 
         @Override
         public ConceptMap conceptMap() {
-            return conceptMap.filter(filter);
+            return conceptMap.filter(getFilter);
         }
 
         public boolean isTop() { return true; }
@@ -152,7 +151,7 @@ public abstract class AnswerState {
             Top top = (Top) o;
             return Objects.equals(root(), top.root()) &&
                     Objects.equals(conceptMap, top.conceptMap) &&
-                    Objects.equals(filter, top.filter);
+                    Objects.equals(getFilter, top.getFilter);
         }
 
         @Override
@@ -205,7 +204,8 @@ public abstract class AnswerState {
             throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Partial.Unified.class));
         }
 
-        public Partial.Filtered filterToDownstream(Set<Reference.Name> filter) {
+
+        public Partial.Filtered filterToDownstream(Set<Identifier.Variable.Retrieved> filter) {
             return Filtered.filter(this, filter, root(), recordExplanations());
         }
 
@@ -225,13 +225,13 @@ public abstract class AnswerState {
         abstract Partial<?> with(ConceptMap conceptMap, Actor<? extends Resolver<?>> resolver,
                                  boolean requiresReiteration, @Nullable Derivation derivation);
 
-        protected ConceptMap mergedWithParent(Map<Reference.Name, ? extends Concept> unmerged) {
+        protected ConceptMap mergedWithParent(ConceptMap unmerged) {
             /*
             We MUST retain initial concepts, and add derived answers afterward. It's possible, and correct,
             that the derived answers overlap but are different: for example, when a subtype is found
             by the derived answer, but the initial already uses the supertype.
              */
-            Map<Reference.Name, Concept> withInitial = new HashMap<>(unmerged);
+            Map<Identifier.Variable.Retrieved, Concept> withInitial = new HashMap<>(unmerged.concepts());
             if (parent() != null) {
                 // add the initial concept map second, to make sure we override and retain all of these
                 withInitial.putAll(parent().conceptMap().concepts());
@@ -290,10 +290,10 @@ public abstract class AnswerState {
 
         public static class Filtered extends Partial<Partial<?>> {
 
-            private final Set<Reference.Name> filter;
+            private final Set<Identifier.Variable.Retrieved> filter;
             private final int hash;
 
-            private Filtered(ConceptMap filteredConceptMap, Partial<?> parent, Set<Reference.Name> filter,
+            private Filtered(ConceptMap filteredConceptMap, Partial<?> parent, Set<Identifier.Variable.Retrieved> filter,
                              Actor<? extends Resolver<?>> resolver, Actor<? extends Resolver<?>> root,
                              boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(filteredConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
@@ -301,7 +301,7 @@ public abstract class AnswerState {
                 this.hash = Objects.hash(resolver, conceptMap, filter, parent);
             }
 
-            static Filtered filter(Partial<?> parent, Set<Reference.Name> filter, Actor<? extends Resolver<?>> root,
+            static Filtered filter(Partial<?> parent, Set<Identifier.Variable.Retrieved> filter, Actor<? extends Resolver<?>> root,
                                    boolean recordExplanations) {
                 Derivation derivation = recordExplanations ? new AnswerState.Derivation(new HashMap<>()) : null;
                 return new Filtered(parent.conceptMap().filter(filter), parent, filter, null, root, false,
@@ -310,7 +310,7 @@ public abstract class AnswerState {
 
             public Partial<?> toUpstream(Actor<? extends Resolver<?>> resolver) {
                 if (conceptMap().concepts().isEmpty()) throw GraknException.of(ILLEGAL_STATE);
-                return parent().with(mergedWithParent(conceptMap().filter(filter).concepts()), resolver,
+                return parent().with(mergedWithParent(conceptMap().filter(filter)), resolver,
                                      requiresReiteration || parent().requiresReiteration(),
                                                  extendedParentDerivation(resolver).orElse(null));
             }
@@ -352,6 +352,7 @@ public abstract class AnswerState {
             public int hashCode() {
                 return hash;
             }
+
         }
 
         public static class Mapped extends Partial<Partial<?>> {
@@ -362,8 +363,7 @@ public abstract class AnswerState {
             private Mapped(ConceptMap mappedConceptMap, Partial<?> parent, Mapping mapping,
                            Actor<? extends Resolver<?>> resolver, Actor<? extends Resolver<?>> root,
                            boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
-                super(mappedConceptMap, parent, resolver, root, requiresReiteration, derivation,
-                      recordExplanations);
+                super(mappedConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.mapping = mapping;
                 this.hash = Objects.hash(resolver, conceptMap, mapping, parent);
             }
@@ -377,13 +377,13 @@ public abstract class AnswerState {
             }
 
             public Partial<?> aggregateToUpstream(ConceptMap additionalConcepts, Actor<? extends Resolver<?>> resolver) {
-                return parent().with(mergedWithParent(mapping.unTransform(additionalConcepts).concepts()), resolver,
+                return parent().with(mergedWithParent(mapping.unTransform(additionalConcepts)), resolver,
                                      requiresReiteration || parent().requiresReiteration(),
                                      extendedParentDerivation(resolver).orElse(null));
             }
 
             public Partial<?> toUpstream(Actor<? extends Resolver<?>> resolver) {
-                return parent().with(mergedWithParent(mapping.unTransform(this.conceptMap()).concepts()),resolver,
+                return parent().with(mergedWithParent(mapping.unTransform(this.conceptMap())),resolver,
                                      requiresReiteration || parent().requiresReiteration(),
                                      extendedParentDerivation(resolver).orElse(null));
             }
@@ -453,11 +453,10 @@ public abstract class AnswerState {
 
             }
 
-            public Optional<Partial<?>> aggregateToUpstream(Map<Identifier, Concept> identifiedConcepts,
-                                                            Actor<? extends Resolver<?>> resolver) {
-                Optional<ConceptMap> unUnified = unifier.unUnify(identifiedConcepts, instanceRequirements);
+            public Optional<Partial<?>> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts, Actor<? extends Resolver<?>> resolver) {
+                Optional<ConceptMap> unUnified = unifier.unUnify(concepts, instanceRequirements);
                 return unUnified.map(ans -> parent().with(
-                        mergedWithParent(new ConceptMap(ans.concepts()).concepts()), resolver, true,
+                        mergedWithParent(new ConceptMap(ans.concepts())), resolver, true,
                         extendedParentDerivation(resolver).orElse(null)));
             }
 

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -205,7 +205,7 @@ public abstract class AnswerState {
         }
 
 
-        public Partial.Filtered filterToDownstream(Set<Identifier.Variable.Retrieved> filter) {
+        public Partial.Filtered filterToDownstream(Set<Identifier.Variable.Retrievable> filter) {
             return Filtered.filter(this, filter, root(), recordExplanations());
         }
 
@@ -231,7 +231,7 @@ public abstract class AnswerState {
             that the derived answers overlap but are different: for example, when a subtype is found
             by the derived answer, but the initial already uses the supertype.
              */
-            Map<Identifier.Variable.Retrieved, Concept> withInitial = new HashMap<>(unmerged.concepts());
+            Map<Identifier.Variable.Retrievable, Concept> withInitial = new HashMap<>(unmerged.concepts());
             if (parent() != null) {
                 // add the initial concept map second, to make sure we override and retain all of these
                 withInitial.putAll(parent().conceptMap().concepts());
@@ -290,10 +290,10 @@ public abstract class AnswerState {
 
         public static class Filtered extends Partial<Partial<?>> {
 
-            private final Set<Identifier.Variable.Retrieved> filter;
+            private final Set<Identifier.Variable.Retrievable> filter;
             private final int hash;
 
-            private Filtered(ConceptMap filteredConceptMap, Partial<?> parent, Set<Identifier.Variable.Retrieved> filter,
+            private Filtered(ConceptMap filteredConceptMap, Partial<?> parent, Set<Identifier.Variable.Retrievable> filter,
                              Actor<? extends Resolver<?>> resolver, Actor<? extends Resolver<?>> root,
                              boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(filteredConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
@@ -301,7 +301,7 @@ public abstract class AnswerState {
                 this.hash = Objects.hash(resolver, conceptMap, filter, parent);
             }
 
-            static Filtered filter(Partial<?> parent, Set<Identifier.Variable.Retrieved> filter, Actor<? extends Resolver<?>> root,
+            static Filtered filter(Partial<?> parent, Set<Identifier.Variable.Retrievable> filter, Actor<? extends Resolver<?>> root,
                                    boolean recordExplanations) {
                 Derivation derivation = recordExplanations ? new AnswerState.Derivation(new HashMap<>()) : null;
                 return new Filtered(parent.conceptMap().filter(filter), parent, filter, null, root, false,

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -41,18 +41,18 @@ public class AnswerStateTest {
 
     @Test
     public void test_initial_empty_mapped_to_downstream_and_back() {
-        Map<Identifier.Variable.Retrieved, Identifier.Variable.Retrieved> mapping = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Identifier.Variable.Retrievable> mapping = new HashMap<>();
         mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
         mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping));
         assertTrue(mapped.conceptMap().concepts().isEmpty());
 
-        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts), null);
-        Map<Identifier.Variable.Retrieved, Concept> expected = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> expected = new HashMap<>();
         expected.put(Identifier.Variable.name("a"), new MockConcept(0));
         expected.put(Identifier.Variable.name("b"), new MockConcept(1));
         assertEquals(new ConceptMap(expected), partial.conceptMap());
@@ -63,23 +63,23 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Name, Identifier.Variable.Name>  mapping = new HashMap<>();
         mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
         mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
-        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Top top = Top.initial(filter, false, null);
         Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
                 .mapToDownstream(Mapping.of(mapping));
 
-        Map<Identifier.Variable.Retrieved, Concept> expectedMapped = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
         assertEquals(new ConceptMap(expectedMapped), mapped.conceptMap());
 
-        Map<Identifier.Variable.Retrieved, Concept> downstreamConcepts = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
 
-        Map<Identifier.Variable.Retrieved, Concept> expectedWithInitial = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
         expectedWithInitial.put(Identifier.Variable.name("b"), new MockConcept(1));
         assertEquals(new ConceptMap(expectedWithInitial), partial.conceptMap());
@@ -90,7 +90,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Name, Identifier.Variable.Name>  mapping = new HashMap<>();
         mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
         mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
-        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("c"), new MockConcept(2));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
@@ -98,16 +98,16 @@ public class AnswerStateTest {
         Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
                 .mapToDownstream(Mapping.of(mapping));
 
-        Map<Identifier.Variable.Retrieved, Concept> expectedMapped = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
         assertEquals(new ConceptMap(expectedMapped), mapped.conceptMap());
 
-        Map<Identifier.Variable.Retrieved, Concept> downstreamConcepts = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
 
-        Map<Identifier.Variable.Retrieved, Concept> expectedWithInitial = new HashMap<>();
+        Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
         expectedWithInitial.put(Identifier.Variable.name("b"), new MockConcept(1));
         expectedWithInitial.put(Identifier.Variable.name("c"), new MockConcept(2));

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -24,13 +24,15 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Mapped;
 import grakn.core.reasoner.resolution.answer.AnswerState.Top;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
+import static grakn.common.collection.Collections.set;
 import static grakn.core.reasoner.resolution.answer.AnswerState.Partial.Identity.identity;
 import static junit.framework.TestCase.assertEquals;
 import static junit.framework.TestCase.assertTrue;
@@ -39,73 +41,76 @@ public class AnswerStateTest {
 
     @Test
     public void test_initial_empty_mapped_to_downstream_and_back() {
-        Map<Reference.Name, Reference.Name> mapping = new HashMap<>();
-        mapping.put(Reference.name("a"), Reference.name("x"));
-        mapping.put(Reference.name("b"), Reference.name("y"));
-        Mapped mapped = Top.initial(mapping.keySet(), false, null).toDownstream().mapToDownstream(Mapping.of(mapping));
+        Map<Identifier.Variable.Retrieved, Identifier.Variable.Retrieved> mapping = new HashMap<>();
+        mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
+        mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
+        Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
+        Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping));
         assertTrue(mapped.conceptMap().concepts().isEmpty());
 
-        Map<Reference.Name, Concept> concepts = new HashMap<>();
-        concepts.put(Reference.name("x"), new MockConcept(0));
-        concepts.put(Reference.name("y"), new MockConcept(1));
+        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
+        concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts), null);
-        Map<Reference.Name, Concept> expected = new HashMap<>();
-        expected.put(Reference.name("a"), new MockConcept(0));
-        expected.put(Reference.name("b"), new MockConcept(1));
+        Map<Identifier.Variable.Retrieved, Concept> expected = new HashMap<>();
+        expected.put(Identifier.Variable.name("a"), new MockConcept(0));
+        expected.put(Identifier.Variable.name("b"), new MockConcept(1));
         assertEquals(new ConceptMap(expected), partial.conceptMap());
     }
 
     @Test
     public void test_initial_partially_mapped_to_downstream_and_back() {
-        Map<Reference.Name, Reference.Name>  mapping = new HashMap<>();
-        mapping.put(Reference.name("a"), Reference.name("x"));
-        mapping.put(Reference.name("b"), Reference.name("y"));
-        Map<Reference.Name, Concept> concepts = new HashMap<>();
-        concepts.put(Reference.name("a"), new MockConcept(0));
-        Top top = Top.initial(concepts.keySet(), false, null);
+        Map<Identifier.Variable.Name, Identifier.Variable.Name>  mapping = new HashMap<>();
+        mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
+        mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
+        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
+        Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
+        Top top = Top.initial(filter, false, null);
         Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
                 .mapToDownstream(Mapping.of(mapping));
 
-        Map<Reference.Name, Concept> expectedMapped = new HashMap<>();
-        expectedMapped.put(Reference.name("x"), new MockConcept(0));
+        Map<Identifier.Variable.Retrieved, Concept> expectedMapped = new HashMap<>();
+        expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
         assertEquals(new ConceptMap(expectedMapped), mapped.conceptMap());
 
-        Map<Reference.Name, Concept> downstreamConcepts = new HashMap<>();
-        downstreamConcepts.put(Reference.name("x"), new MockConcept(0));
-        downstreamConcepts.put(Reference.name("y"), new MockConcept(1));
+        Map<Identifier.Variable.Retrieved, Concept> downstreamConcepts = new HashMap<>();
+        downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
+        downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
 
-        Map<Reference.Name, Concept> expectedWithInitial = new HashMap<>();
-        expectedWithInitial.put(Reference.name("a"), new MockConcept(0));
-        expectedWithInitial.put(Reference.name("b"), new MockConcept(1));
+        Map<Identifier.Variable.Retrieved, Concept> expectedWithInitial = new HashMap<>();
+        expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
+        expectedWithInitial.put(Identifier.Variable.name("b"), new MockConcept(1));
         assertEquals(new ConceptMap(expectedWithInitial), partial.conceptMap());
     }
 
     @Test
     public void test_initial_with_unmapped_elements() {
-        Map<Reference.Name, Reference.Name>  mapping = new HashMap<>();
-        mapping.put(Reference.name("a"), Reference.name("x"));
-        mapping.put(Reference.name("b"), Reference.name("y"));
-        Map<Reference.Name, Concept> concepts = new HashMap<>();
-        concepts.put(Reference.name("a"), new MockConcept(0));
-        concepts.put(Reference.name("c"), new MockConcept(2));
-        Top top = Top.initial(concepts.keySet(), false, null);
+        Map<Identifier.Variable.Name, Identifier.Variable.Name>  mapping = new HashMap<>();
+        mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
+        mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
+        Map<Identifier.Variable.Retrieved, Concept> concepts = new HashMap<>();
+        concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
+        concepts.put(Identifier.Variable.name("c"), new MockConcept(2));
+        Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
+        Top top = Top.initial(filter, false, null);
         Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
                 .mapToDownstream(Mapping.of(mapping));
 
-        Map<Reference.Name, Concept> expectedMapped = new HashMap<>();
-        expectedMapped.put(Reference.name("x"), new MockConcept(0));
+        Map<Identifier.Variable.Retrieved, Concept> expectedMapped = new HashMap<>();
+        expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
         assertEquals(new ConceptMap(expectedMapped), mapped.conceptMap());
 
-        Map<Reference.Name, Concept> downstreamConcepts = new HashMap<>();
-        downstreamConcepts.put(Reference.name("x"), new MockConcept(0));
-        downstreamConcepts.put(Reference.name("y"), new MockConcept(1));
+        Map<Identifier.Variable.Retrieved, Concept> downstreamConcepts = new HashMap<>();
+        downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
+        downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
         Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
 
-        Map<Reference.Name, Concept> expectedWithInitial = new HashMap<>();
-        expectedWithInitial.put(Reference.name("a"), new MockConcept(0));
-        expectedWithInitial.put(Reference.name("b"), new MockConcept(1));
-        expectedWithInitial.put(Reference.name("c"), new MockConcept(2));
+        Map<Identifier.Variable.Retrieved, Concept> expectedWithInitial = new HashMap<>();
+        expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
+        expectedWithInitial.put(Identifier.Variable.name("b"), new MockConcept(1));
+        expectedWithInitial.put(Identifier.Variable.name("c"), new MockConcept(2));
         assertEquals(new ConceptMap(expectedWithInitial), partial.conceptMap());
     }
 

--- a/reasoner/resolution/answer/Mapping.java
+++ b/reasoner/resolution/answer/Mapping.java
@@ -19,7 +19,7 @@ package grakn.core.reasoner.resolution.answer;
 
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,23 +28,23 @@ import java.util.stream.Collectors;
 
 public class Mapping {
 
-    private final Map<Retrieved, Retrieved> mapping;
-    private final Map<Retrieved, Retrieved> reverseMapping;
+    private final Map<Retrievable, Retrievable> mapping;
+    private final Map<Retrievable, Retrievable> reverseMapping;
 
-    Mapping(Map<? extends Retrieved, ? extends Retrieved> mapping) {
+    Mapping(Map<? extends Retrievable, ? extends Retrievable> mapping) {
         this.mapping = new HashMap<>(mapping);
         this.reverseMapping = mapping.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
     }
 
-    public static Mapping of(Map<? extends Retrieved, ? extends Retrieved> variableMap) {
+    public static Mapping of(Map<? extends Retrievable, ? extends Retrievable> variableMap) {
         return new Mapping(variableMap);
     }
 
     public ConceptMap transform(ConceptMap conceptMap) {
-        Map<Retrieved, Concept> transformed = new HashMap<>();
-        for (Map.Entry<Retrieved, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
-            Retrieved id = entry.getKey();
-            Retrieved mapped = mapping.get(id);
+        Map<Retrievable, Concept> transformed = new HashMap<>();
+        for (Map.Entry<Retrievable, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
+            Retrievable id = entry.getKey();
+            Retrievable mapped = mapping.get(id);
             if (mapped != null) {
                 Concept concept = entry.getValue();
                 transformed.put(mapped, concept);
@@ -55,9 +55,9 @@ public class Mapping {
 
     public ConceptMap unTransform(ConceptMap conceptMap) {
         assert reverseMapping.size() == conceptMap.concepts().size();
-        Map<Retrieved, Concept> transformed = new HashMap<>();
-        for (Map.Entry<Retrieved, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
-            Retrieved id = entry.getKey();
+        Map<Retrievable, Concept> transformed = new HashMap<>();
+        for (Map.Entry<Retrievable, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
+            Retrievable id = entry.getKey();
             assert reverseMapping.containsKey(id);
             Concept concept = entry.getValue();
             transformed.put(reverseMapping.get(id), concept);

--- a/reasoner/resolution/answer/Mapping.java
+++ b/reasoner/resolution/answer/Mapping.java
@@ -19,7 +19,7 @@ package grakn.core.reasoner.resolution.answer;
 
 import grakn.core.concept.Concept;
 import grakn.core.concept.answer.ConceptMap;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,16 +28,41 @@ import java.util.stream.Collectors;
 
 public class Mapping {
 
-    private final Map<Reference.Name, Reference.Name> mapping;
-    private final Map<Reference.Name, Reference.Name> reverseMapping;
+    private final Map<Retrieved, Retrieved> mapping;
+    private final Map<Retrieved, Retrieved> reverseMapping;
 
-    Mapping(Map<Reference.Name, Reference.Name> mapping) {
-        this.mapping = mapping;
+    Mapping(Map<? extends Retrieved, ? extends Retrieved> mapping) {
+        this.mapping = new HashMap<>(mapping);
         this.reverseMapping = mapping.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
     }
 
-    public static Mapping of(Map<Reference.Name, Reference.Name> variableMap) {
+    public static Mapping of(Map<? extends Retrieved, ? extends Retrieved> variableMap) {
         return new Mapping(variableMap);
+    }
+
+    public ConceptMap transform(ConceptMap conceptMap) {
+        Map<Retrieved, Concept> transformed = new HashMap<>();
+        for (Map.Entry<Retrieved, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
+            Retrieved id = entry.getKey();
+            Retrieved mapped = mapping.get(id);
+            if (mapped != null) {
+                Concept concept = entry.getValue();
+                transformed.put(mapped, concept);
+            }
+        }
+        return new ConceptMap(transformed);
+    }
+
+    public ConceptMap unTransform(ConceptMap conceptMap) {
+        assert reverseMapping.size() == conceptMap.concepts().size();
+        Map<Retrieved, Concept> transformed = new HashMap<>();
+        for (Map.Entry<Retrieved, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
+            Retrieved id = entry.getKey();
+            assert reverseMapping.containsKey(id);
+            Concept concept = entry.getValue();
+            transformed.put(reverseMapping.get(id), concept);
+        }
+        return new ConceptMap(transformed);
     }
 
     @Override
@@ -59,30 +84,6 @@ public class Mapping {
         return "Mapping{" +
                 "mapping=" + mapping +
                 '}';
-    }
-
-    public ConceptMap transform(ConceptMap conceptMap) {
-        Map<Reference.Name, Concept> transformed = new HashMap<>();
-        for (Map.Entry<Reference.Name, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
-            Reference.Name ref = entry.getKey();
-            if (mapping.containsKey(ref)) {
-                Concept concept = entry.getValue();
-                transformed.put(mapping.get(ref), concept);
-            }
-        }
-        return new ConceptMap(transformed);
-    }
-
-    public ConceptMap unTransform(ConceptMap conceptMap) {
-        assert reverseMapping.size() == conceptMap.concepts().size();
-        Map<Reference.Name, Concept> transformed = new HashMap<>();
-        for (Map.Entry<Reference.Name, ? extends Concept> entry : conceptMap.concepts().entrySet()) {
-            Reference.Name ref = entry.getKey();
-            assert reverseMapping.containsKey(ref);
-            Concept concept = entry.getValue();
-            transformed.put(reverseMapping.get(ref), concept);
-        }
-        return new ConceptMap(transformed);
     }
 
 }

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -32,8 +32,7 @@ import grakn.core.reasoner.resolution.answer.AnswerState;
 import grakn.core.reasoner.resolution.framework.Response.Answer;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.TraversalEngine;
-import grakn.core.traversal.common.Identifier;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +71,7 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
 
     public abstract void receiveRequest(Request fromUpstream, int iteration);
 
-    protected abstract void receiveAnswer(Answer fromDownstream, int iteration);
+    protected abstract void receiveAnswer(Response.Answer fromDownstream, int iteration);
 
     protected abstract void receiveExhausted(Response.Fail fromDownstream, int iteration);
 
@@ -116,23 +115,21 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     }
 
     private Optional<ConceptMap> compatibleBounds(Conjunction conjunction, ConceptMap bounds) {
-        Map<Reference.Name, Concept> newBounds = new HashMap<>();
-        for (Map.Entry<Reference.Name, ? extends Concept> entry : bounds.concepts().entrySet()) {
-            Reference.Name ref = entry.getKey();
+        Map<Retrieved, Concept> newBounds = new HashMap<>();
+        for (Map.Entry<Retrieved, ? extends Concept> entry : bounds.concepts().entrySet()) {
+            Retrieved id = entry.getKey();
             Concept bound = entry.getValue();
-            Variable conjVariable = Iterators.iterate(conjunction.variables()).filter(var -> var.reference().equals(ref)).firstOrNull();
+            Variable conjVariable = conjunction.variable(id);
             assert conjVariable != null;
             if (conjVariable.isThing()) {
-                if (!conjVariable.asThing().iid().isPresent()) newBounds.put(ref, bound);
-                else {
-                    if (!Arrays.equals(conjVariable.asThing().iid().get().iid(), bound.asThing().getIID()))
-                        return Optional.empty();
+                if (!conjVariable.asThing().iid().isPresent()) newBounds.put(id, bound);
+                else if (!Arrays.equals(conjVariable.asThing().iid().get().iid(), bound.asThing().getIID())) {
+                    return Optional.empty();
                 }
             } else if (conjVariable.isType()) {
-                if (!conjVariable.asType().label().isPresent()) newBounds.put(ref, bound);
-                else {
-                    if (!conjVariable.asType().label().get().properLabel().equals(bound.asType().getLabel()))
-                        return Optional.empty();
+                if (!conjVariable.asType().label().isPresent()) newBounds.put(id, bound);
+                else if (!conjVariable.asType().label().get().properLabel().equals(bound.asType().getLabel())) {
+                    return Optional.empty();
                 }
             } else {
                 throw GraknException.of(ILLEGAL_STATE);
@@ -142,12 +139,12 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     }
 
     protected Traversal boundTraversal(Traversal traversal, ConceptMap bounds) {
-        bounds.concepts().forEach((ref, concept) -> {
-            Identifier.Variable.Name id = Identifier.Variable.of(ref);
-            if (concept.isThing()) traversal.iid(id, concept.asThing().getIID());
+        bounds.concepts().forEach((id, concept) -> {
+            assert id.isVariable();
+            if (concept.isThing()) traversal.iid(id.asVariable(), concept.asThing().getIID());
             else {
-                traversal.clearLabels(id);
-                traversal.labels(id, concept.asType().getLabel());
+                traversal.clearLabels(id.asVariable());
+                traversal.labels(id.asVariable(), concept.asType().getLabel());
             }
         });
         return traversal;

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -32,7 +32,7 @@ import grakn.core.reasoner.resolution.answer.AnswerState;
 import grakn.core.reasoner.resolution.framework.Response.Answer;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.TraversalEngine;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,9 +115,9 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     }
 
     private Optional<ConceptMap> compatibleBounds(Conjunction conjunction, ConceptMap bounds) {
-        Map<Retrieved, Concept> newBounds = new HashMap<>();
-        for (Map.Entry<Retrieved, ? extends Concept> entry : bounds.concepts().entrySet()) {
-            Retrieved id = entry.getKey();
+        Map<Retrievable, Concept> newBounds = new HashMap<>();
+        for (Map.Entry<Retrievable, ? extends Concept> entry : bounds.concepts().entrySet()) {
+            Retrievable id = entry.getKey();
             Concept bound = entry.getValue();
             Variable conjVariable = conjunction.variable(id);
             assert conjVariable != null;

--- a/reasoner/resolution/framework/ResponseProducer.java
+++ b/reasoner/resolution/framework/ResponseProducer.java
@@ -91,9 +91,16 @@ public class ResponseProducer {
 
     /**
      * Prepare a response producer for the another iteration from this one
-     * Notably maintains the set of produced answers for deduplication
      */
     public ResponseProducer newIteration(ResourceIterator<Partial<?>> upstreamAnswers, int iteration) {
         return new ResponseProducer(upstreamAnswers, iteration, new HashSet<>());
+    }
+
+    /**
+     * Prepare a response producer for the another iteration from this one
+     * Notably maintains the set of produced answers for deduplication
+     */
+    public ResponseProducer newIterationRetainDedup(ResourceIterator<Partial<?>> upstreamAnswers, int iteration) {
+        return new ResponseProducer(upstreamAnswers, iteration, this.produced);
     }
 }

--- a/reasoner/resolution/resolver/ConjunctionResolver.java
+++ b/reasoner/resolution/resolver/ConjunctionResolver.java
@@ -40,7 +40,7 @@ import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.reasoner.resolution.framework.Response;
 import grakn.core.reasoner.resolution.framework.ResponseProducer;
 import grakn.core.traversal.TraversalEngine;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -233,12 +233,12 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
         return responseProducerNewIter;
     }
 
-    private class Plans {
+    class Plans {
 
-        Map<Set<Reference.Name>, Plan> plans;
+        Map<Set<Retrieved>, Plan> plans;
         public Plans() { this.plans = new HashMap<>(); }
 
-        public Plan getOrCreate(Set<Reference.Name> boundVars, Set<Resolvable<?>> resolvable, Set<Negated> negations) {
+        public Plan getOrCreate(Set<Retrieved> boundVars, Set<Resolvable<?>> resolvable, Set<Negated> negations) {
             return plans.computeIfAbsent(boundVars, (bound) -> {
                 List<Resolvable<?>> plan = planner.plan(resolvable, bound);
                 plan.addAll(negations);
@@ -246,7 +246,7 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
             });
         }
 
-        public Plan get(Set<Reference.Name> boundVars) {
+        public Plan get(Set<Retrieved> boundVars) {
             assert plans.containsKey(boundVars);
             return plans.get(boundVars);
         }

--- a/reasoner/resolution/resolver/ConjunctionResolver.java
+++ b/reasoner/resolution/resolver/ConjunctionResolver.java
@@ -25,7 +25,6 @@ import grakn.core.logic.LogicManager;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Negated;
 import grakn.core.logic.resolvable.Resolvable;
-import grakn.core.logic.resolvable.Retrievable;
 import grakn.core.pattern.Conjunction;
 import grakn.core.pattern.Negation;
 import grakn.core.reasoner.resolution.Planner;
@@ -40,7 +39,7 @@ import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.reasoner.resolution.framework.Response;
 import grakn.core.reasoner.resolution.framework.ResponseProducer;
 import grakn.core.traversal.TraversalEngine;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -174,7 +173,7 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
         LOG.debug("{}: initialising downstream actors", name());
         Set<Concludable> concludables = Iterators.iterate(Concludable.create(conjunction))
                 .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
-        Set<Retrievable> retrievables = Retrievable.extractFrom(conjunction, concludables);
+        Set<grakn.core.logic.resolvable.Retrievable> retrievables = grakn.core.logic.resolvable.Retrievable.extractFrom(conjunction, concludables);
         resolvables.addAll(concludables);
         resolvables.addAll(retrievables);
         iterate(resolvables).forEachRemaining(resolvable -> downstreamResolvers.put(resolvable,
@@ -235,10 +234,10 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
 
     class Plans {
 
-        Map<Set<Retrieved>, Plan> plans;
+        Map<Set<Retrievable>, Plan> plans;
         public Plans() { this.plans = new HashMap<>(); }
 
-        public Plan getOrCreate(Set<Retrieved> boundVars, Set<Resolvable<?>> resolvable, Set<Negated> negations) {
+        public Plan getOrCreate(Set<Retrievable> boundVars, Set<Resolvable<?>> resolvable, Set<Negated> negations) {
             return plans.computeIfAbsent(boundVars, (bound) -> {
                 List<Resolvable<?>> plan = planner.plan(resolvable, bound);
                 plan.addAll(negations);
@@ -246,7 +245,7 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
             });
         }
 
-        public Plan get(Set<Retrieved> boundVars) {
+        public Plan get(Set<Retrievable> boundVars) {
             assert plans.containsKey(boundVars);
             return plans.get(boundVars);
         }

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -115,8 +115,8 @@ public class NegationResolver extends Resolver<NegationResolver> {
               the toplevel root with the negation iterations, which we cannot allow. So, we must use THIS resolver
               as a sort of new root! TODO: should NegationResolvers also implement a kind of Root interface??
         */
-        Filtered downstream = fromUpstream.partialAnswer().filterToDownstream(negated.variableNames());
-        Request request = Request.create(self(), this.downstream, downstream);
+        Filtered downstreamPartial = fromUpstream.partialAnswer().filterToDownstream(negated.retrieves());
+        Request request = Request.create(self(), this.downstream, downstreamPartial);
         requestFromDownstream(request, fromUpstream, 0);
         negationResponse.setRequested();
     }

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -29,12 +29,13 @@ import grakn.core.reasoner.resolution.answer.AnswerState;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Filtered;
 import grakn.core.reasoner.resolution.answer.AnswerState.Top;
+import grakn.core.reasoner.resolution.answer.Mapping;
 import grakn.core.reasoner.resolution.framework.Request;
 import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.reasoner.resolution.framework.Response;
 import grakn.core.reasoner.resolution.framework.ResponseProducer;
 import grakn.core.traversal.TraversalEngine;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -101,6 +102,29 @@ public interface Root {
             } else {
                 submitFail(iteration);
             }
+        }
+
+        /*
+        NOTE special behaviour: don't clear the deduplication set, in the root
+         */
+        @Override
+        protected ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer responseProducerPrevious,
+                                                             int newIteration) {
+            assert newIteration > responseProducerPrevious.iteration();
+            LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
+
+//        ResourceIterator<AnswerState.Partial> upstreamAnswers = toUpstreamAnswers(
+//                fromUpstream, compatibleBoundAnswers(conceptMgr, conjunction, fromUpstream.partialAnswer().conceptMap()));
+
+            Plans.Plan plan = plans.getOrCreate(fromUpstream.partialAnswer().conceptMap().concepts().keySet(), resolvables, negateds);
+
+            assert !plan.isEmpty();
+            ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
+            Partial.Mapped downstream = fromUpstream.partialAnswer()
+                    .mapToDownstream(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping()));
+            Request toDownstream = Request.create(self(),downstreamResolvers.get(plan.get(0)).resolver(), downstream, 0);
+            responseProducerNewIter.addDownstreamProducer(toDownstream);
+            return responseProducerNewIter;
         }
 
         protected void failToUpstream(Request fromUpstream, int iteration) {
@@ -231,7 +255,7 @@ public interface Root {
             Request toDownstream = fromDownstream.sourceRequest();
             Request fromUpstream = fromUpstream(toDownstream);
 
-            Top answer = fromUpstream.partialAnswer().asIdentity().toTop();
+            Top answer = fromDownstream.answer().asIdentity().toTop();
             ConceptMap filteredMap = answer.conceptMap();
             if (!responseProducer.hasProduced(filteredMap)) {
                 responseProducer.recordProduced(filteredMap);
@@ -278,16 +302,17 @@ public interface Root {
             assert !downstreamResolvers.isEmpty();
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionFilter(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }
             return responseProducer;
         }
 
-        private Set<Reference.Name> conjunctionFilter(Actor<ConjunctionResolver.Nested> conjunctionResolver) {
-            return iterate(conjunctionResolver.state.conjunction.variables()).filter(v -> v.reference().isName())
-                    .map(v -> v.reference().asName()).toSet();
+        private Set<Identifier.Variable.Retrieved> conjunctionRetrievedIds(Actor<ConjunctionResolver.Nested> conjunctionResolver) {
+            // TODO use a map from resolvable to resolvers, then we don't have to reach into the state and use the conjunction
+            return iterate(conjunctionResolver.state.conjunction.variables()).filter(v -> v.id().isRetrieved())
+                    .map(v -> v.id().asRetrieved()).toSet();
         }
 
         @Override
@@ -297,10 +322,10 @@ public interface Root {
             LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
 
             assert newIteration > responseProducerPrevious.iteration();
-            ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(Iterators.empty(), newIteration);
+            ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionFilter(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -113,9 +113,6 @@ public interface Root {
             assert newIteration > responseProducerPrevious.iteration();
             LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
 
-//        ResourceIterator<AnswerState.Partial> upstreamAnswers = toUpstreamAnswers(
-//                fromUpstream, compatibleBoundAnswers(conceptMgr, conjunction, fromUpstream.partialAnswer().conceptMap()));
-
             Plans.Plan plan = plans.getOrCreate(fromUpstream.partialAnswer().conceptMap().concepts().keySet(), resolvables, negateds);
 
             assert !plan.isEmpty();

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -306,10 +306,10 @@ public interface Root {
             return responseProducer;
         }
 
-        private Set<Identifier.Variable.Retrieved> conjunctionRetrievedIds(Actor<ConjunctionResolver.Nested> conjunctionResolver) {
+        private Set<Identifier.Variable.Retrievable> conjunctionRetrievedIds(Actor<ConjunctionResolver.Nested> conjunctionResolver) {
             // TODO use a map from resolvable to resolvers, then we don't have to reach into the state and use the conjunction
-            return iterate(conjunctionResolver.state.conjunction.variables()).filter(v -> v.id().isRetrieved())
-                    .map(v -> v.id().asRetrieved()).toSet();
+            return iterate(conjunctionResolver.state.conjunction.variables()).filter(v -> v.id().isRetrievable())
+                    .map(v -> v.id().asRetrievable()).toSet();
         }
 
         @Override

--- a/reasoner/resolution/resolver/RuleResolver.java
+++ b/reasoner/resolution/resolver/RuleResolver.java
@@ -81,7 +81,7 @@ public class RuleResolver extends ConjunctionResolver<RuleResolver> {
     }
 
     private ResourceIterator<Partial<?>> materialisations(Partial<?> whenAnswer) {
-        ResourceIterator<Map<Identifier, Concept>> materialisations = rule.conclusion()
+        ResourceIterator<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion()
                 .materialise(whenAnswer.conceptMap(), traversalEngine, conceptMgr);
         if (!materialisations.hasNext()) throw GraknException.of(ILLEGAL_STATE);
 

--- a/server/rpc/common/ResponseBuilder.java
+++ b/server/rpc/common/ResponseBuilder.java
@@ -265,9 +265,11 @@ public class ResponseBuilder {
         public static AnswerProto.ConceptMap conceptMap(ConceptMap answer) {
             AnswerProto.ConceptMap.Builder conceptMapProto = AnswerProto.ConceptMap.newBuilder();
             // TODO: needs testing
-            answer.concepts().forEach((ref, concept) -> {
-                ConceptProto.Concept conceptProto = ResponseBuilder.Concept.concept(concept);
-                conceptMapProto.putMap(ref.name(), conceptProto);
+            answer.concepts().forEach((id, concept) -> {
+                if (id.isName()) {
+                    ConceptProto.Concept conceptProto = ResponseBuilder.Concept.concept(concept);
+                    conceptMapProto.putMap(id.asVariable().asName().reference().name(), conceptProto);
+                }
             });
 
             // TODO

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -44,7 +44,6 @@ host_compatible_java_test(
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",
         "@graknlabs_graql//java:graql",
-        "@graknlabs_graql//java/pattern",
     ],
 )
 

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -79,7 +79,7 @@ host_compatible_java_test(
 
 host_compatible_java_test(
     name = "test-unification-relation-concludable",
-    srcs = ["resolvable/UnifyRelationConcludableTest.java"],
+    srcs = ["resolvable/UnifyRelationConcludableTest.java", "resolvable/Util.java"],
     native_libraries_deps = [
         "//rocks:rocks",
         "//:grakn",
@@ -102,7 +102,7 @@ host_compatible_java_test(
 
 host_compatible_java_test(
     name = "test-unification-has-concludable",
-    srcs = ["resolvable/UnifyHasConcludableTest.java"],
+    srcs = ["resolvable/UnifyHasConcludableTest.java", "resolvable/Util.java"],
     native_libraries_deps = [
         "//rocks:rocks",
         "//:grakn",
@@ -125,7 +125,7 @@ host_compatible_java_test(
 
 host_compatible_java_test(
     name = "test-unification-isa-concludable",
-    srcs = ["resolvable/UnifyIsaConcludableTest.java"],
+    srcs = ["resolvable/UnifyIsaConcludableTest.java", "resolvable/Util.java"],
     native_libraries_deps = [
         "//rocks:rocks",
         "//:grakn",
@@ -152,7 +152,7 @@ host_compatible_java_test(
 
 host_compatible_java_test(
     name = "test-unification-attribute-concludable",
-    srcs = ["resolvable/UnifyAttributeConcludableTest.java"],
+    srcs = ["resolvable/UnifyAttributeConcludableTest.java", "resolvable/Util.java"],
     native_libraries_deps = [
         "//rocks:rocks",
         "//:grakn",

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -40,7 +40,6 @@ import grakn.core.rocks.RocksTransaction;
 import grakn.core.test.integration.util.Util;
 import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
-import graql.lang.pattern.variable.Reference;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -107,10 +106,10 @@ public class RuleTest {
                     assertEquals(2, people.size());
 
                     Rule rule = txn.logic().getRule("marriage-is-friendship");
-                    ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), people.get(0)),
-                                                               pair(Reference.name("y"), people.get(1))));
+                    ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), people.get(0)),
+                                                               pair(Identifier.Variable.name("y"), people.get(1))));
 
-                    List<Map<Identifier, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
+                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
                     assertEquals(1, materialisations.size());
                     assertEquals(5, materialisations.get(0).size());
 
@@ -163,10 +162,10 @@ public class RuleTest {
                     assertEquals(2, people.size());
 
                     Rule rule = txn.logic().getRule("marriage-is-friendship");
-                    ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), people.get(0)),
-                                                               pair(Reference.name("y"), people.get(1))));
+                    ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), people.get(0)),
+                                                               pair(Identifier.Variable.name("y"), people.get(1))));
 
-                    List<Map<Identifier, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
+                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
                     assertEquals(1, materialisations.size());
                     assertEquals(5, materialisations.get(0).size());
                     friendshipInstances = friendship.getInstances().collect(Collectors.toList());
@@ -211,9 +210,9 @@ public class RuleTest {
                     Attribute.Long ageInDays10 = ageInDays.asLong().put(10L);
 
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
-                    ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), milkInst),
-                                                               pair(Reference.name("a"), ageInDays10)));
-                    List<Map<Identifier, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
+                    ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), milkInst),
+                                                               pair(Identifier.Variable.name("a"), ageInDays10)));
+                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
                     assertEquals(1, materialisations.size());
                     assertEquals(2, materialisations.get(0).size());
 
@@ -258,8 +257,8 @@ public class RuleTest {
                     milkInst.setHas(ageInDays.asLong().put(20L));
 
                     Rule rule = txn.logic().getRule("old-milk-is-not-good");
-                    ConceptMap whenAnswer = new ConceptMap(map(pair(Reference.name("x"), milkInst)));
-                    List<Map<Identifier, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
+                    ConceptMap whenAnswer = new ConceptMap(map(pair(Identifier.Variable.name("x"), milkInst)));
+                    List<Map<Identifier.Variable, Concept>> materialisations = rule.conclusion().materialise(whenAnswer, txn.traversal(), conceptMgr).toList();
                     assertEquals(1, materialisations.size());
                     assertEquals(3, materialisations.get(0).size());
 

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -55,6 +55,9 @@ import java.util.stream.Collectors;
 import static grakn.common.collection.Collections.map;
 import static grakn.common.collection.Collections.pair;
 import static grakn.common.collection.Collections.set;
+import static grakn.core.logic.resolvable.Util.createRule;
+import static grakn.core.logic.resolvable.Util.getStringMapping;
+import static grakn.core.logic.resolvable.Util.resolvedConjunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -112,37 +115,19 @@ public class UnifyAttributeConcludableTest {
     @After
     public void tearDownTransaction() { rocksTransaction.close(); }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
-                                                                e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
-        );
-    }
-
     private Thing instanceOf(String stringAttributeLabel, String stringValue) {
         AttributeType type = conceptMgr.getAttributeType(stringAttributeLabel);
         assert type != null;
         return type.asString().put(stringValue);
     }
 
-    private Conjunction resolvedConjunction(String query) {
-        Conjunction conjunction = Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
-        logicMgr.typeResolver().resolve(conjunction);
-        return conjunction;
-    }
-
-    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                     Graql.parseVariable(thenThingPattern).asThing());
-        return rule;
-    }
-
     @Test
     public void literal_predicates_unify_and_filter_answers() {
         String conjunction = "{ $a = 'john'; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Attribute queryConcludable = concludables.iterator().next().asAttribute();
 
-        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -154,9 +139,13 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(1, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(1, unifier.requirements().predicates().size());
+
+        // test forward unification can reject an invalid partial answer
+        ConceptMap unUnified = new ConceptMap(map(pair(Identifier.Variable.name("a"), instanceOf("first-name", "bob"))));
+        assertFalse(unifier.unify(unUnified).isPresent());
 
         // test filter allows a valid answer
        Map<Identifier.Variable, Concept> concepts = map(
@@ -177,14 +166,14 @@ public class UnifyAttributeConcludableTest {
     @Test
     public void variable_predicates_unify_value_conclusions() {
         String conjunction = "{ $x > $y; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         assertEquals(2, concludables.size());
         Concludable.Attribute queryConcludable = concludables.iterator().next().asAttribute();
         // Get the name of the attribute variable from whichever concludable is chosen
         String var = Iterators.iterate(concludables).map(Concludable::pattern).flatMap(
                 c -> Iterators.iterate(c.variables())).filter(Variable::isThing).map(v -> v.reference().syntax()).first().get();
 
-        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -196,11 +185,11 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
 
-        Rule rule2 = createRule("isa-rule-2", "{ " + var + " isa person; }", "(employee: " + var + ") isa employment");
+        Rule rule2 = createRule("isa-rule-2", "{ " + var + " isa person; }", "(employee: " + var + ") isa employment", logicMgr);
 
         unifiers = queryConcludable.unify(rule2.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -154,7 +154,7 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(1, unifier.constraintRequirements().predicates().size());
 
@@ -196,7 +196,7 @@ public class UnifyAttributeConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 

--- a/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyAttributeConcludableTest.java
@@ -112,7 +112,7 @@ public class UnifyAttributeConcludableTest {
     @After
     public void tearDownTransaction() { rocksTransaction.close(); }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
+    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
         return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
                                                                 e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
         );
@@ -159,17 +159,17 @@ public class UnifyAttributeConcludableTest {
         assertEquals(1, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+       Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "abe"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
     }

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -174,7 +174,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
         assertEquals(1, unifier.constraintRequirements().predicates().size());
@@ -224,7 +224,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
         assertEquals(1, unifier.constraintRequirements().predicates().size());
@@ -290,7 +290,7 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.get().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -323,7 +323,7 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.get().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -347,7 +347,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
@@ -389,7 +389,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
@@ -431,7 +431,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -488,7 +488,7 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(set(Label.of("self-owning-attribute")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().predicates().size());

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -58,6 +58,9 @@ import static grakn.common.collection.Collections.map;
 import static grakn.common.collection.Collections.pair;
 import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.logic.resolvable.Util.createRule;
+import static grakn.core.logic.resolvable.Util.getStringMapping;
+import static grakn.core.logic.resolvable.Util.resolvedConjunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -118,12 +121,6 @@ public class UnifyHasConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
-                                                                e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
-        );
-    }
-
     private Thing instanceOf(String label) {
         ThingType type = conceptMgr.getThingType(label);
         assert type != null;
@@ -142,26 +139,15 @@ public class UnifyHasConcludableTest {
         return type.asString().put(stringValue);
     }
 
-    private Conjunction resolvedConjunction(String query) {
-        Conjunction conjunction = Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
-        logicMgr.typeResolver().resolve(conjunction);
-        return conjunction;
-    }
-
-    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        return logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                Graql.parseVariable(thenThingPattern).asThing());
-    }
-
     //TODO: create more tests when type inference is working to test unifier pruning
 
     @Test
     public void has_attribute_exact_unifies_rule_has_exact() {
         String conjunction = "{ $y has name 'john'; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name 'john'");
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name 'john'", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -174,10 +160,14 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
-        assertEquals(1, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(1, unifier.requirements().predicates().size());
+
+        // test forward unification can reject an invalid partial answer
+        ConceptMap partialAnswer = new ConceptMap(map(pair(Identifier.Variable.anon(0), instanceOf("age"))));
+        assertFalse(unifier.unify(partialAnswer).isPresent());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -186,7 +176,7 @@ public class UnifyHasConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        assertEquals(2, unified.get().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -208,10 +198,10 @@ public class UnifyHasConcludableTest {
     @Test
     public void has_attribute_exact_unifies_rule_has_variable() {
         String conjunction = "{ $y has name 'john'; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -224,10 +214,10 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
-        assertEquals(1, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(1, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -236,7 +226,7 @@ public class UnifyHasConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        assertEquals(2, unified.get().concepts().size());
 
         // filter out invalid type
         concepts = map(
@@ -265,10 +255,10 @@ public class UnifyHasConcludableTest {
     @Test
     public void has_attribute_variable_unifies_rule_has_exact() {
         String conjunction = "{ $y has $a; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -290,18 +280,18 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.get().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void has_attribute_variable_unifies_rule_has_variable() {
         String conjunction = "{ $y has $b; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -323,18 +313,18 @@ public class UnifyHasConcludableTest {
         assertEquals(2, unified.get().concepts().size());
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void has_attribute_typed_variable_unifies_rule_has_exact() {
         String conjunction = "{ $y has name $b; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("has-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -347,10 +337,14 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
+        assertEquals(0, unifier.requirements().predicates().size());
+
+        // test forward unification can reject an invalid partial answer
+        ConceptMap partialAnswer = new ConceptMap(map(pair(Identifier.Variable.name("b"), instanceOf("age"))));
+        assertFalse(unifier.unify(partialAnswer).isPresent());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -373,10 +367,10 @@ public class UnifyHasConcludableTest {
     @Test
     public void has_attribute_typed_variable_unifies_rule_has_variable() {
         String conjunction = "{ $y has name $b; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a");
+        Rule rule = createRule("has-rule", "{ $x isa person; $a isa first-name; }", "$x has $a", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -389,10 +383,10 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -415,10 +409,10 @@ public class UnifyHasConcludableTest {
     @Test
     public void has_many_to_one_unifier() {
         String conjunction = "{ $x has attribute $y; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
+        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -431,18 +425,18 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void has_one_to_many_unifier() {
         String conjunction = "{ $b has attribute $b; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $x isa self-owning-attribute; }", "$x has self-owning-attribute 5");
+        Rule rule = createRule("has-rule", "{ $x isa self-owning-attribute; }", "$x has self-owning-attribute 5", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -473,10 +467,10 @@ public class UnifyHasConcludableTest {
     @Test
     public void has_all_equivalent_vars_unifier() {
         String conjunction = "{ $b has self-owning-attribute $b; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Has queryConcludable = concludables.iterator().next().asHas();
 
-        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a");
+        Rule rule = createRule("has-rule", "{ $a isa self-owning-attribute; }", "$a has $a", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -488,9 +482,9 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(1, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(set(Label.of("self-owning-attribute")), unifier.constraintRequirements().isaExplicit().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("self-owning-attribute")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("b")));
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 }

--- a/test/integration/logic/resolvable/UnifyHasConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyHasConcludableTest.java
@@ -118,7 +118,7 @@ public class UnifyHasConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
+    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
         return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
                                                                 e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
         );
@@ -180,28 +180,28 @@ public class UnifyHasConcludableTest {
         assertEquals(1, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
         // filter out invalid value
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "bob"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -230,28 +230,28 @@ public class UnifyHasConcludableTest {
         assertEquals(1, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("last-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
         // filter out invalid value
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("first-name", "bob"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -281,11 +281,11 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test unifier allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
 
@@ -314,11 +314,11 @@ public class UnifyHasConcludableTest {
         assertEquals(expected, result);
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("last-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
 
@@ -353,20 +353,20 @@ public class UnifyHasConcludableTest {
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -395,20 +395,20 @@ public class UnifyHasConcludableTest {
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("first-name", "john"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.name("a"), instanceOf("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -453,20 +453,20 @@ public class UnifyHasConcludableTest {
         }};
         assertEquals(expected, result);
         // test requirements of one-to-many using valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("self-owning-attribute")),
                 pair(Identifier.Variable.anon(0), instanceOf("self-owning-attribute"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // test requirements of one-to-many using invalid answer
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("person")),
                 pair(Identifier.Variable.anon(0), instanceOf("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -117,7 +117,7 @@ public class UnifyIsaConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
+    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
         return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
                                                                 e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
         );
@@ -282,20 +282,20 @@ public class UnifyIsaConcludableTest {
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("first-name", "john")),
                 pair(Identifier.Variable.label("first-name"), conceptMgr.getThingType("first-name"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("age")),
                 pair(Identifier.Variable.label("first-name"), conceptMgr.getThingType("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -324,20 +324,20 @@ public class UnifyIsaConcludableTest {
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("employment")),
                 pair(Identifier.Variable.label("employment"), conceptMgr.getThingType("employment"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("age")),
                 pair(Identifier.Variable.label("employment"), conceptMgr.getThingType("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -368,20 +368,20 @@ public class UnifyIsaConcludableTest {
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("employment")),
                 pair(Identifier.Variable.name("rel-type"), conceptMgr.getThingType("employment"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out invalid type
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), instanceOf("age")),
                 pair(Identifier.Variable.name("rel-type"), conceptMgr.getThingType("age"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -443,35 +443,35 @@ public class UnifyIsaConcludableTest {
         assertEquals(3, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier, Set<Label>> typesRequirements = unifier.constraintRequirements().types();
+        Map<Identifier.Variable, Set<Label>> typesRequirements = unifier.constraintRequirements().types();
         assertEquals(1, typesRequirements.size());
         assertEquals(set(Label.of("first-name")), typesRequirements.values().iterator().next());
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "johnny"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
 
         // filter out using >
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "abe"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
         // filter out using <
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "zack"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
         // filter out using contains
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "carol"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
 
     }

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -58,6 +58,9 @@ import static grakn.common.collection.Collections.map;
 import static grakn.common.collection.Collections.pair;
 import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.logic.resolvable.Util.createRule;
+import static grakn.core.logic.resolvable.Util.getStringMapping;
+import static grakn.core.logic.resolvable.Util.resolvedConjunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -117,12 +120,6 @@ public class UnifyIsaConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
-        return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
-                                                                e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
-        );
-    }
-
     private Thing instanceOf(String label) {
         ThingType type = conceptMgr.getThingType(label);
         assert type != null;
@@ -141,26 +138,14 @@ public class UnifyIsaConcludableTest {
         return type.asString().put(stringValue);
     }
 
-    private Conjunction resolvedConjunction(String query) {
-        Conjunction conjunction = Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
-        logicMgr.typeResolver().resolve(conjunction);
-        return conjunction;
-    }
-
-    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                     Graql.parseVariable(thenThingPattern).asThing());
-        return rule;
-    }
-
     @Test
     public void isa_variable_unifies_rule_has_exact() {
         String conjunction = "{ $a isa $t; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule", "{ $x isa person; }",
-                               "$x has first-name \"john\"");
+                               "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -173,19 +158,19 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void isa_variable_unifies_rule_relation_exact() {
         String conjunction = "{ $a isa $t; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule", "{ $x isa person; }",
-                               "(employee: $x) isa employment");
+                               "(employee: $x) isa employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -198,20 +183,20 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void isa_variable_unifies_relation_variable_type() {
         String conjunction = "{ $a isa $t; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule",
                                "{ $x isa person; $role-type type employment:employee; $rel-type relates $role-type; }",
-                               "($role-type: $x) isa $rel-type");
+                               "($role-type: $x) isa $rel-type", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -224,9 +209,9 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     /*
@@ -235,20 +220,20 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_variable_with_type_prunes_irrelevant_rules() {
         String conjunction = "{ $a isa $t; $t type company; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
-        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
 
-        Rule rule2 = createRule("isa-rule-2", "{ $x isa person; }", "(employee: $x) isa employment");
+        Rule rule2 = createRule("isa-rule-2", "{ $x isa person; }", "(employee: $x) isa employment", logicMgr);
         unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
 
         Rule rule3 = createRule("isa-rule-3",
                                 "{ $x isa person; $role-type type employment:employee; $rel-type relates $role-type; }",
-                                "($role-type: $x) isa $rel-type");
+                                "($role-type: $x) isa $rel-type", logicMgr);
         unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
 
         assertEquals(0, unifiers.size());
@@ -258,11 +243,11 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_exact_unifies_rule_has_exact() {
         String conjunction = "{ $a isa name; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule", "{ $x isa person; }",
-                               "$x has first-name \"john\"");
+                               "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -270,16 +255,15 @@ public class UnifyIsaConcludableTest {
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$a", set("$_0"));
-            put("$_name", set("$_first-name"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")),
-                     unifier.constraintRequirements().roleTypes().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().isaExplicit().values().iterator().next());
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -302,10 +286,10 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_exact_unifies_rule_relation_exact() {
         String conjunction = "{ $a isa relation; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
-        Rule rule = createRule("isa-rule", "{ $x isa person; }", "(employee: $x) isa employment");
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "(employee: $x) isa employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -313,15 +297,14 @@ public class UnifyIsaConcludableTest {
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         HashMap<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$a", set("$_0"));
-            put("$_relation", set("$_employment"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().roleTypes().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -344,12 +327,12 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_exact_unifies_rule_relation_variable() {
         String conjunction = "{ $a isa relation; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule",
                                "{ $x isa person; $role-type type employment:employee; $rel-type relates $role-type; }",
-                               "($role-type: $x) isa $rel-type");
+                               "($role-type: $x) isa $rel-type", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -357,15 +340,14 @@ public class UnifyIsaConcludableTest {
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         HashMap<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$a", set("$_0"));
-            put("$_relation", set("$rel-type"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().roleTypes().values().iterator().next());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Map<Identifier.Variable, Concept> concepts = map(
@@ -388,23 +370,23 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_concrete_prunes_irrelevant_rules() {
         String conjunction = "{ $a isa age; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
         Rule rule = createRule("isa-rule", "{ $x isa person; }",
-                               "$x has first-name \"john\"");
+                               "$x has first-name \"john\"", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
 
         Rule rule2 = createRule("isa-rule-2", "{ $x isa person; }",
-                                "(employee: $x) isa employment");
+                                "(employee: $x) isa employment", logicMgr);
         unifiers = queryConcludable.unify(rule2.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
 
         Rule rule3 = createRule("isa-rule-3",
                                 "{ $x isa person; $role-type type employment:employee; $rel-type relates $role-type; }",
-                                "($role-type: $x) isa $rel-type");
+                                "($role-type: $x) isa $rel-type", logicMgr);
         unifiers = queryConcludable.unify(rule3.conclusion(), conceptMgr).toList();
         assertEquals(0, unifiers.size());
     }
@@ -428,24 +410,22 @@ public class UnifyIsaConcludableTest {
     @Test
     public void isa_predicates_can_filter_answers() {
         String conjunction = "{ $a isa first-name; $a > 'b'; $a < 'y'; $a contains 'j'; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Isa queryConcludable = concludables.iterator().next().asIsa();
 
-        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"");
+        Rule rule = createRule("isa-rule", "{ $x isa person; }", "$x has first-name \"john\"", logicMgr);
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
 
         Unifier unifier = unifiers.get(0);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(3, unifier.constraintRequirements().predicates().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(3, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier.Variable, Set<Label>> typesRequirements = unifier.constraintRequirements().roleTypes();
-        assertEquals(1, typesRequirements.size());
-        assertEquals(set(Label.of("first-name")), typesRequirements.values().iterator().next());
+        assertEquals(set(Label.of("first-name")), unifier.requirements().isaExplicit().get(Identifier.Variable.name("a")));
         Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.name("x"), instanceOf("first-name", "johnny"))
         );

--- a/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyIsaConcludableTest.java
@@ -173,7 +173,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -198,7 +198,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -224,7 +224,7 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -275,9 +275,9 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("name"), Label.of("first-name"), Label.of("last-name")),
-                     unifier.constraintRequirements().types().values().iterator().next());
+                     unifier.constraintRequirements().roleTypes().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -318,8 +318,8 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().types().values().iterator().next());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().roleTypes().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -362,8 +362,8 @@ public class UnifyIsaConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
-        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().types().values().iterator().next());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(set(Label.of("relation"), Label.of("employment")), unifier.constraintRequirements().roleTypes().values().iterator().next());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -438,12 +438,12 @@ public class UnifyIsaConcludableTest {
         Unifier unifier = unifiers.get(0);
 
         // test requirements
-        assertEquals(0, unifier.constraintRequirements().types().size());
+        assertEquals(0, unifier.constraintRequirements().roleTypes().size());
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(3, unifier.constraintRequirements().predicates().size());
 
         // test filter allows a valid answer
-        Map<Identifier.Variable, Set<Label>> typesRequirements = unifier.constraintRequirements().types();
+        Map<Identifier.Variable, Set<Label>> typesRequirements = unifier.constraintRequirements().roleTypes();
         assertEquals(1, typesRequirements.size());
         assertEquals(set(Label.of("first-name")), typesRequirements.values().iterator().next());
         Map<Identifier.Variable, Concept> concepts = map(

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -180,6 +180,11 @@ public class UnifyRelationConcludableTest {
                      unifier.requirements().isaExplicit().get(Identifier.Variable.name("r")));
         assertEquals(0, unifier.requirements().predicates().size());
 
+        // test forward unification can reject an invalid partial answer
+        ConceptMap unUnified = new ConceptMap(map(pair(Identifier.Variable.name("r"), instanceOf("friendship")),
+                                                  pair(Identifier.Variable.name("y"), instanceOf("person"))));
+        assertFalse(unifier.unify(unUnified).isPresent());
+
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
         Thing person = instanceOf("person");
@@ -307,9 +312,10 @@ public class UnifyRelationConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        assertEquals(3, unified.get().concepts().size());
         assertEquals(employment.getType().getRelates("employee"), unified.get().get("role"));
         assertEquals(person, unified.get().get("y"));
+        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
 
         // filter out invalid types
         Relation friendship = instanceOf("friendship").asRelation();
@@ -531,8 +537,9 @@ public class UnifyRelationConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(1, unified.get().concepts().size());
+        assertEquals(2, unified.get().concepts().size());
         assertEquals(person, unified.get().get("p"));
+        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
 
         // filter out answers with differing role players that must be the same
         employment = instanceOf("employment").asRelation();

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -130,7 +130,7 @@ public class UnifyRelationConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier, Set<Identifier>> map) {
+    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
         Map<String, Set<String>> mapping = new HashMap<>();
         map.forEach((id, mapped) -> {
             HashSet<String> stringified = new HashSet<>();
@@ -206,13 +206,13 @@ public class UnifyRelationConcludableTest {
         Relation employment = instanceOf("employment").asRelation();
         Thing person = instanceOf("person");
         addRolePlayer(employment, "employee", person);
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
         assertEquals(employment, unified.get().get("r"));
@@ -222,13 +222,13 @@ public class UnifyRelationConcludableTest {
         Relation friendship = instanceOf("friendship").asRelation();
         person = instanceOf("person");
         addRolePlayer(friendship, "friend", person);
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), friendship),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), friendship.getType()),
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -263,13 +263,13 @@ public class UnifyRelationConcludableTest {
         Relation employment = instanceOf("employment").asRelation();
         Thing person = instanceOf("person");
         addRolePlayer(employment, "employee", person);
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
         assertEquals(employment.getType(), unified.get().get("rel"));
@@ -279,13 +279,13 @@ public class UnifyRelationConcludableTest {
         Relation friendship = instanceOf("friendship").asRelation();
         person = instanceOf("person");
         addRolePlayer(friendship, "friend", person);
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), friendship),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), friendship.getType()),
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -320,13 +320,13 @@ public class UnifyRelationConcludableTest {
         Relation employment = instanceOf("employment").asRelation();
         Thing person = instanceOf("person");
         addRolePlayer(employment, "employee", person);
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), employment.getType()),
                 pair(Identifier.Variable.label("employment:employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
         assertEquals(employment.getType().getRelates("employee"), unified.get().get("role"));
@@ -336,13 +336,13 @@ public class UnifyRelationConcludableTest {
         Relation friendship = instanceOf("friendship").asRelation();
         person = instanceOf("person");
         addRolePlayer(friendship, "friend", person);
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), friendship),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.label("employment"), friendship.getType()),
                 pair(Identifier.Variable.label("employment:employee"), friendship.getType().getRelates("friend"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -551,14 +551,14 @@ public class UnifyRelationConcludableTest {
         Thing person = instanceOf("person");
         addRolePlayer(employment, "employee", person);
         addRolePlayer(employment, "employee", person);
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.name("y"), person),
                 pair(Identifier.Variable.name("employment"), employment.getType()),
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(1, unified.get().concepts().size());
         assertEquals(person, unified.get().get("p"));
@@ -569,14 +569,14 @@ public class UnifyRelationConcludableTest {
         Thing differentPerson = instanceOf("person");
         addRolePlayer(employment, "employee", person);
         addRolePlayer(employment, "employee", differentPerson);
-        identifiedConcepts = map(
+        concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.name("y"), differentPerson),
                 pair(Identifier.Variable.name("employment"), employment.getType()),
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
-        unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertFalse(unified.isPresent());
     }
 
@@ -759,13 +759,13 @@ public class UnifyRelationConcludableTest {
         Thing person = instanceOf("person");
         addRolePlayer(employment, "employee", person);
         addRolePlayer(employment, "employee", person);
-        Map<Identifier, Concept> identifiedConcepts = map(
+        Map<Identifier.Variable, Concept> concepts = map(
                 pair(Identifier.Variable.anon(0), employment),
                 pair(Identifier.Variable.name("x"), person),
                 pair(Identifier.Variable.name("employment"), employment.getType()),
                 pair(Identifier.Variable.name("employee"), employment.getType().getRelates("employee"))
         );
-        Optional<ConceptMap> unified = unifier.unUnify(identifiedConcepts, new Unifier.Requirements.Instance(map()));
+        Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
         assertEquals(2, unified.get().concepts().size());
         assertEquals(person, unified.get().get("p"));

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -194,11 +194,11 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().types().size());
+        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment:employee")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -253,9 +253,9 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("relation:employee")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -310,9 +310,9 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -366,9 +366,9 @@ public class UnifyRelationConcludableTest {
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().types().size());
+        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("relation:employee")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
     }
@@ -538,11 +538,11 @@ public class UnifyRelationConcludableTest {
         Unifier unifier = unifiers.get(0);
 
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().types().size());
+        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment:employee")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 
@@ -746,11 +746,11 @@ public class UnifyRelationConcludableTest {
 
         Unifier unifier = unifiers.get(0);
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().types().size());
+        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
         assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().types().get(Identifier.Variable.label("employment:employee")));
+                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
         assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
         assertEquals(0, unifier.constraintRequirements().predicates().size());
 

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -63,6 +63,9 @@ import static grakn.common.collection.Collections.map;
 import static grakn.common.collection.Collections.pair;
 import static grakn.common.collection.Collections.set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.logic.resolvable.Util.createRule;
+import static grakn.core.logic.resolvable.Util.getStringMapping;
+import static grakn.core.logic.resolvable.Util.resolvedConjunction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -130,16 +133,6 @@ public class UnifyRelationConcludableTest {
         rocksTransaction.close();
     }
 
-    private Map<String, Set<String>> getStringMapping(Map<Identifier.Variable, Set<Identifier.Variable>> map) {
-        Map<String, Set<String>> mapping = new HashMap<>();
-        map.forEach((id, mapped) -> {
-            HashSet<String> stringified = new HashSet<>();
-            mapped.forEach(m -> stringified.add(m.toString()));
-            mapping.put(id.toString(), stringified);
-        });
-        return mapping;
-    }
-
     private Thing instanceOf(String label) {
         ThingType type = conceptMgr.getThingType(label);
         assert type != null : "Cannot find type " + label;
@@ -159,27 +152,14 @@ public class UnifyRelationConcludableTest {
         relation.addPlayer(roleType, player);
     }
 
-
-    private Conjunction resolvedConjunction(String query) {
-        Conjunction conjunction = Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
-        logicMgr.typeResolver().resolve(conjunction);
-        return conjunction;
-    }
-
-    private Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern) {
-        Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
-                                     Graql.parseVariable(thenThingPattern).asThing());
-        return rule;
-    }
-
     @Test
     public void relation_and_player_unifies_rule_relation_exact() {
         String conjunction = "{ $r (employee: $y) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("people-are-employed", "{ $x isa person; }",
-                               " (employee: $x) isa employment ");
+                               " (employee: $x) isa employment ", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -188,19 +168,17 @@ public class UnifyRelationConcludableTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$y", set("$x"));
             put("$r", set("$_0"));
-            put("$_employment:employee", set("$_employment:employee"));
-            put("$_employment", set("$_employment"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
+        assertEquals(1, unifier.requirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
+                     unifier.requirements().isaExplicit().get(Identifier.Variable.name("r")));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
@@ -235,11 +213,11 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_type_and_player_unifies_rule_relation_exact() {
         String conjunction = "{ (employee: $y) isa $rel; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("people-are-employed", "{ $x isa person; }",
-                               " (employee: $x) isa employment ");
+                               " (employee: $x) isa employment ", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -248,16 +226,16 @@ public class UnifyRelationConcludableTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$y", set("$x"));
             put("$rel", set("$_employment"));
-            put("$_relation:employee", set("$_employment:employee"));
+            put("$_0", set("$_0"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
@@ -271,9 +249,10 @@ public class UnifyRelationConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        assertEquals(3, unified.get().concepts().size());
         assertEquals(employment.getType(), unified.get().get("rel"));
         assertEquals(person, unified.get().get("y"));
+        assertEquals(employment, unified.get().get(Identifier.Variable.anon(0)));
 
         // filter out invalid types
         Relation friendship = instanceOf("friendship").asRelation();
@@ -292,11 +271,11 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_role_unifies_rule_relation_exact() {
         String conjunction = "{ ($role: $y) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("people-are-employed", "{ $x isa person; }",
-                               " (employee: $x) isa employment ");
+                               " (employee: $x) isa employment ", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -305,16 +284,16 @@ public class UnifyRelationConcludableTest {
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$y", set("$x"));
             put("$role", set("$_employment:employee"));
-            put("$_employment", set("$_employment"));
+            put("$_0", set("$_0"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(0, unifier.requirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().isaExplicit().size());
         assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
@@ -349,11 +328,11 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_without_isa_unifies_rule_relation() {
         String conjunction = "{ (employee: $y); }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("people-are-employed", "{ $x isa person; }",
-                               " (employee: $x) isa employment ");
+                               " (employee: $x) isa employment ", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         assertEquals(1, unifiers.size());
@@ -361,27 +340,27 @@ public class UnifyRelationConcludableTest {
         Map<String, Set<String>> result = getStringMapping(unifier.mapping());
         Map<String, Set<String>> expected = new HashMap<String, Set<String>>() {{
             put("$y", set("$x"));
-            put("$_relation:employee", set("$_employment:employee"));
+            put("$_0", set("$_0"));
         }};
         assertEquals(expected, result);
 
         // test requirements
-        assertEquals(1, unifier.constraintRequirements().roleTypes().size());
+        assertEquals(1, unifier.requirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().roleTypes().get(Identifier.Variable.label("relation:employee")));
+        assertEquals(0, unifier.requirements().isaExplicit().size());
+        assertEquals(0, unifier.requirements().predicates().size());
     }
 
     @Test
     public void relation_variables_one_to_many_unifiers() {
         String conjunction = "{ ($role: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("three-people-are-employed",
                                "{ $x isa person; $y isa person; $z isa person; }",
-                               "(employee: $x, employee: $y, employee: $z) isa employment");
+                               "(employee: $x, employee: $y, employee: $z) isa employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -390,17 +369,17 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$role", set("$_employment:employee"));
-                    put("$_employment", set("$_employment"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$role", set("$_employment:employee"));
-                    put("$_employment", set("$_employment"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$z"));
                     put("$role", set("$_employment:employee"));
-                    put("$_employment", set("$_employment"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -409,12 +388,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_variable_multiple_identical_unifiers() {
         String conjunction = "{ (employee: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("the-same-person-is-employed-twice",
                                "{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }",
-                               "($employee: $x, $employee: $x) isa $employment");
+                               "($employee: $x, $employee: $x) isa $employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -422,8 +401,7 @@ public class UnifyRelationConcludableTest {
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
-                    put("$_employment:employee", set("$employee"));
-                    put("$_employment", set("$employment"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -432,12 +410,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void unify_relation_many_to_many() {
         String conjunction = "{ (employee: $p, employee: $q) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("three-people-are-employed",
                                "{ $x isa person; $y isa person; $z isa person; }",
-                               "(employee: $x, employee: $y, employee: $z) isa employment");
+                               "(employee: $x, employee: $y, employee: $z) isa employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -446,38 +424,32 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$y"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$z"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$q", set("$z"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$z"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$z"));
                     put("$q", set("$y"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -486,13 +458,13 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_player_role_unifies_rule_relation_repeated_variable_role() {
         String conjunction = "{ ($role: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed",
                                "{ $x isa person; $y isa person; $employment type employment; " +
                                        "$employee type employment:employee; $employer type employment:employer; }",
-                               "($employee: $x, $employee: $y) isa $employment");
+                               "($employee: $x, $employee: $y) isa $employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -501,12 +473,12 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$role", set("$employee"));
-                    put("$_employment", set("$employment"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$role", set("$employee"));
-                    put("$_employment", set("$employment"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -515,13 +487,13 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_duplicate_players_unifies_rule_relation_distinct_players() {
         String conjunction = "{ (employee: $p, employee: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed",
                                "{ $x isa person; $y isa person; $employment type employment; " +
                                        "$employee type employment:employee; }",
-                               "($employee: $x, $employee: $y) isa $employment");
+                               "($employee: $x, $employee: $y) isa $employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
@@ -529,8 +501,7 @@ public class UnifyRelationConcludableTest {
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x", "$y"));
-                    put("$_employment", set("$employment"));
-                    put("$_employment:employee", set("$employee"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -538,13 +509,13 @@ public class UnifyRelationConcludableTest {
         Unifier unifier = unifiers.get(0);
 
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
+        assertEquals(1, unifier.requirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
+                     unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
@@ -583,12 +554,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_unifies_many_to_many_rule_relation_players() {
         String conjunction = "{ (employee: $p, employer: $p, employee: $q) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
                                "{ $x isa person; $y isa person; }",
-                               "(employee: $x, employer: $x, employee: $y) isa employment");
+                               "(employee: $x, employer: $x, employee: $y) isa employment", logicMgr);
 
         List<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         List<Map<String, Set<String>>> result = Iterators.iterate(unifier).map(u -> getStringMapping(u.mapping())).toList();
@@ -597,16 +568,12 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$y"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
-                    put("$_employment:employer", set("$_employment:employer"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x", "$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
-                    put("$_employment:employee", set("$_employment:employee"));
-                    put("$_employment:employer", set("$_employment:employer"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -615,12 +582,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_variable_role_unifies_many_to_many_rule_relation_roles() {
         String conjunction = "{ ($role1: $p, $role1: $q, $role2: $q) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
                                "{ $x isa person; $y isa person; }",
-                               "(employee: $x, employer: $x, employee: $y) isa employment");
+                               "(employee: $x, employer: $x, employee: $y) isa employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -629,30 +596,30 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$x", "$y"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee"));
                     put("$role2", set("$_employment:employer"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$x", "$y"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee", "$_employment:employer"));
                     put("$role2", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee", "$_employment:employer"));
                     put("$role2", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee"));
                     put("$role2", set("$_employment:employer"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -662,12 +629,12 @@ public class UnifyRelationConcludableTest {
     public void relation_variable_role_unifies_many_to_many_rule_relation_roles_2() {
         String conjunction = "{ ($role1: $p, $role2: $q, $role1: $p) isa employment; }";
 
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed-one-is-also-the-employer",
                                "{ $x isa person; $y isa person; }",
-                               "(employee: $x, employer: $x, employee: $y) isa employment");
+                               "(employee: $x, employer: $x, employee: $y) isa employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -676,23 +643,23 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x", "$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee"));
                     put("$role2", set("$_employment:employer"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x", "$y"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee", "$_employment:employer"));
                     put("$role2", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }},
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$y"));
-                    put("$_employment", set("$_employment"));
                     put("$role1", set("$_employment:employee", "$_employment:employer"));
                     put("$role2", set("$_employment:employee"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -701,12 +668,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_duplicate_roles_unifies_rule_relation_distinct_roles() {
         String conjunction = "{ (employee: $p, employee: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("two-people-are-employed",
                                "{ $x isa person; $y isa person; $employment type employment; $employee type employment:employee; }",
-                               "($employee: $x, $employee: $y) isa $employment");
+                               "($employee: $x, $employee: $y) isa $employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -714,8 +681,7 @@ public class UnifyRelationConcludableTest {
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x", "$y"));
-                    put("$_employment:employee", set("$employee"));
-                    put("$_employment", set("$employment"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -724,12 +690,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_distinct_roles_unifies_rule_relation_duplicate_roles() {
         String conjunction = "{ (employee: $p, employee: $q) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("a-person-is-employed-twice",
                                "{ $x isa person; $employment type employment; $employee type employment:employee; }",
-                               "($employee: $x, $employee: $x) isa $employment");
+                               "($employee: $x, $employee: $x) isa $employment", logicMgr);
 
         List<Unifier> unifiers = queryConcludable.unify(rule.conclusion(), conceptMgr).toList();
         Set<Map<String, Set<String>>> result = Iterators.iterate(unifiers).map(u -> getStringMapping(u.mapping())).toSet();
@@ -738,21 +704,20 @@ public class UnifyRelationConcludableTest {
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
                     put("$q", set("$x"));
-                    put("$_employment", set("$employment"));
-                    put("$_employment:employee", set("$employee"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
 
         Unifier unifier = unifiers.get(0);
         // test requirements
-        assertEquals(2, unifier.constraintRequirements().roleTypes().size());
-        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment")));
+        assertEquals(1, unifier.requirements().roleTypes().size());
         assertEquals(set(Label.of("employee", "employment"), Label.of("part-time-employee", "part-time-employment")),
-                     unifier.constraintRequirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
-        assertEquals(0, unifier.constraintRequirements().isaExplicit().size());
-        assertEquals(0, unifier.constraintRequirements().predicates().size());
+                     unifier.requirements().roleTypes().get(Identifier.Variable.label("employment:employee")));
+        assertEquals(1, unifier.requirements().isaExplicit().size());
+        assertEquals(set(Label.of("employment"), Label.of("part-time-employment")),
+                     unifier.requirements().isaExplicit().get(Identifier.Variable.anon(0)));
+        assertEquals(0, unifier.requirements().predicates().size());
 
         // test filter allows a valid answer
         Relation employment = instanceOf("employment").asRelation();
@@ -767,7 +732,7 @@ public class UnifyRelationConcludableTest {
         );
         Optional<ConceptMap> unified = unifier.unUnify(concepts, new Unifier.Requirements.Instance(map()));
         assertTrue(unified.isPresent());
-        assertEquals(2, unified.get().concepts().size());
+        assertEquals(3, unified.get().concepts().size());
         assertEquals(person, unified.get().get("p"));
         assertEquals(person, unified.get().get("q"));
     }
@@ -775,12 +740,12 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_duplicate_roles_unifies_rule_relation_duplicate_roles() {
         String conjunction = "{ (employee: $p, employee: $p) isa employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("a-person-is-employed-twice",
                                "{ $x isa person; $employment type employment; $employee type employment:employee; }",
-                               "($employee: $x, $employee: $x) isa $employment");
+                               "($employee: $x, $employee: $x) isa $employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();
@@ -788,8 +753,7 @@ public class UnifyRelationConcludableTest {
         Set<Map<String, Set<String>>> expected = set(
                 new HashMap<String, Set<String>>() {{
                     put("$p", set("$x"));
-                    put("$_employment", set("$employment"));
-                    put("$_employment:employee", set("$employee"));
+                    put("$_0", set("$_0"));
                 }}
         );
         assertEquals(expected, result);
@@ -798,13 +762,13 @@ public class UnifyRelationConcludableTest {
     @Test
     public void relation_more_players_than_rule_relation_fails_unify() {
         String conjunction = "{ (part-time-employee: $r, employer: $p, restriction: $q) isa part-time-employment; }";
-        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction));
+        Set<Concludable> concludables = Concludable.create(resolvedConjunction(conjunction, logicMgr));
         Concludable.Relation queryConcludable = concludables.iterator().next().asRelation();
 
         Rule rule = createRule("one-employee-one-employer",
                                "{ $x isa person; $y isa company; " +
                                        "$employee type employment:employee; $employer type employment:employer; }",
-                               "($employee: $x, $employer: $y) isa employment");
+                               "($employee: $x, $employer: $y) isa employment", logicMgr);
 
         ResourceIterator<Unifier> unifier = queryConcludable.unify(rule.conclusion(), conceptMgr);
         Set<Map<String, Set<String>>> result = unifier.map(u -> getStringMapping(u.mapping())).toSet();

--- a/test/integration/logic/resolvable/Util.java
+++ b/test/integration/logic/resolvable/Util.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+
+package grakn.core.logic.resolvable;
+
+import grakn.core.logic.LogicManager;
+import grakn.core.logic.Rule;
+import grakn.core.pattern.Conjunction;
+import grakn.core.pattern.Disjunction;
+import grakn.core.traversal.common.Identifier;
+import graql.lang.Graql;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class Util {
+
+
+    public static Conjunction resolvedConjunction(String query, LogicManager logicMgr) {
+        Conjunction conjunction = Disjunction.create(Graql.parsePattern(query).asConjunction().normalise()).conjunctions().iterator().next();
+        logicMgr.typeResolver().resolve(conjunction);
+        return conjunction;
+    }
+
+
+    public static Rule createRule(String label, String whenConjunctionPattern, String thenThingPattern, LogicManager logicMgr) {
+        Rule rule = logicMgr.putRule(label, Graql.parsePattern(whenConjunctionPattern).asConjunction(),
+                                     Graql.parseVariable(thenThingPattern).asThing());
+        return rule;
+    }
+
+    public static Map<String, Set<String>> getStringMapping(Map<Identifier.Variable.Retrieved, Set<Identifier.Variable>> map) {
+        return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
+                                                                e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
+        );
+    }
+
+}

--- a/test/integration/logic/resolvable/Util.java
+++ b/test/integration/logic/resolvable/Util.java
@@ -46,7 +46,7 @@ public class Util {
         return rule;
     }
 
-    public static Map<String, Set<String>> getStringMapping(Map<Identifier.Variable.Retrieved, Set<Identifier.Variable>> map) {
+    public static Map<String, Set<String>> getStringMapping(Map<Identifier.Variable.Retrievable, Set<Identifier.Variable>> map) {
         return map.entrySet().stream().collect(Collectors.toMap(v -> v.getKey().toString(),
                                                                 e -> e.getValue().stream().map(Identifier::toString).collect(Collectors.toSet()))
         );

--- a/test/integration/reasoner/BUILD
+++ b/test/integration/reasoner/BUILD
@@ -63,7 +63,6 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Grakn Labs
-        "@graknlabs_graql//java/pattern:pattern",
         "@graknlabs_graql//java:graql",
         "@graknlabs_common//:common",
     ],
@@ -97,7 +96,6 @@ host_compatible_java_test(
         "//test/integration/util",
 
         # External dependencies from Grakn Labs
-        "@graknlabs_graql//java/pattern",
         "@graknlabs_graql//java:graql",
         "@graknlabs_common//:common",
     ],

--- a/test/integration/reasoner/BUILD
+++ b/test/integration/reasoner/BUILD
@@ -53,6 +53,7 @@ host_compatible_java_test(
         "//pattern:pattern",
         "//reasoner:reasoner",
         "//rocks:rocks",
+        "//traversal:traversal",
         "//:grakn",
     ],
     deps = [
@@ -81,6 +82,7 @@ host_compatible_java_test(
         "//pattern:pattern",
         "//reasoner:reasoner",
         "//rocks:rocks",
+        "//traversal:traversal",
         "//:grakn",
     ],
     resource_strip_prefix = "common/test",

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -98,7 +98,6 @@ public class ReasonerTest {
         }
     }
 
-    @Ignore
     @Test
     public void test_has_explicit_rule() {
         try (RocksSession session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
@@ -139,7 +138,6 @@ public class ReasonerTest {
         }
     }
 
-    @Ignore
     @Test
     public void test_relation_rule() {
         try (RocksSession session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {

--- a/test/integration/reasoner/ReiterationTest.java
+++ b/test/integration/reasoner/ReiterationTest.java
@@ -33,8 +33,8 @@ import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
 import grakn.core.rocks.RocksTransaction;
 import grakn.core.test.integration.util.Util;
+import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
-import graql.lang.pattern.variable.Reference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,8 +111,8 @@ public class ReiterationTest {
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunction = parseConjunction(transaction, "{ $y isa Y; }");
-                Set<Reference.Name> filter = iterate(conjunction.variables()).map(Variable::reference).filter(Reference::isName)
-                        .map(Reference::asName).toSet();
+                Set<Identifier.Variable.Name> filter = iterate(conjunction.variables()).map(Variable::id).filter(Identifier::isName)
+                        .map(Identifier.Variable::asName).toSet();
                 ResolverRegistry registry = transaction.reasoner().resolverRegistry();
                 LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
                 LinkedBlockingQueue<Integer> exhausted = new LinkedBlockingQueue<>();
@@ -157,7 +157,7 @@ public class ReiterationTest {
         }
     }
 
-    private void sendRootRequest(Actor<Root.Conjunction> root, Set<Reference.Name> filter, int iteration) {
+    private void sendRootRequest(Actor<Root.Conjunction> root, Set<Identifier.Variable.Name> filter, int iteration) {
         Identity downstream = Top.initial(filter, false, root).toDownstream();
         root.tell(actor -> actor.receiveRequest(
                 Request.create(root, downstream), iteration)

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -126,7 +126,6 @@ public class ResolutionTest {
         }
     }
 
-    @Ignore
     @Test
     public void test_disjunction_no_rules() throws InterruptedException {
         try (RocksSession session = schemaSession()) {
@@ -157,7 +156,6 @@ public class ResolutionTest {
         }
     }
 
-    @Ignore
     @Test
     public void test_disjunction_no_rules_limit_offset() throws InterruptedException {
         try (RocksSession session = schemaSession()) {

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -32,8 +32,8 @@ import grakn.core.rocks.RocksGrakn;
 import grakn.core.rocks.RocksSession;
 import grakn.core.rocks.RocksTransaction;
 import grakn.core.test.integration.util.Util;
+import grakn.core.traversal.common.Identifier;
 import graql.lang.Graql;
-import graql.lang.pattern.variable.Reference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -148,9 +148,9 @@ public class ResolutionTest {
         }
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                Set<Reference.Name> filter = set(Reference.name("t"),
-                                                 Reference.name("p1"),
-                                                 Reference.name("p2"));
+                Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("t"),
+                                                           Identifier.Variable.name("p1"),
+                                                           Identifier.Variable.name("p2"));
                 Disjunction disjunction = parseDisjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; { $p1 has age 24; } or { $p1 has age 26; }; }");
                 createRootAndAssertResponses(transaction, disjunction, filter, null, null, 2L);
             }
@@ -180,9 +180,9 @@ public class ResolutionTest {
         }
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                Set<Reference.Name> filter = set(Reference.name("t"),
-                                                 Reference.name("p1"),
-                                                 Reference.name("p2"));
+                Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("t"),
+                                                           Identifier.Variable.name("p1"),
+                                                           Identifier.Variable.name("p2"));
                 Disjunction disjunction = parseDisjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; " +
                         "{ $p1 has age 24; } or { $p1 has age 26; } or { $p1 has age 27;} ; }");
                 createRootAndAssertResponses(transaction, disjunction, filter, 1L, 1L, 1L);
@@ -449,11 +449,11 @@ public class ResolutionTest {
                 ResolverRegistry registry = transaction.reasoner().resolverRegistry();
                 LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
                 AtomicLong doneReceived = new AtomicLong(0L);
-                Set<Reference.Name> filter = iterate(conjunctionPattern.variables()).map(Variable::reference)
-                        .filter(Reference::isName).map(Reference::asName).toSet();
+                Set<Identifier.Variable.Name> filter = iterate(conjunctionPattern.variables()).map(Variable::id)
+                        .filter(Identifier::isName).map(Identifier.Variable::asName).toSet();
                 Actor<grakn.core.reasoner.resolution.resolver.Root.Conjunction> root =
                         registry.rootConjunction(conjunctionPattern, null, null, responses::add,
-                                                                        iterDone -> doneReceived.incrementAndGet());
+                                                 iterDone -> doneReceived.incrementAndGet());
 
                 for (int i = 0; i < answerCount; i++) {
                     Identity downstream = Top.initial(filter, false, root).toDownstream();
@@ -497,7 +497,7 @@ public class ResolutionTest {
     }
 
     private void createRootAndAssertResponses(RocksTransaction transaction, Disjunction disjunction,
-                                              Set<Reference.Name> filter, @Nullable Long offset, @Nullable Long limit,
+                                              Set<Identifier.Variable.Name> filter, @Nullable Long offset, @Nullable Long limit,
                                               long answerCount) throws InterruptedException {
         ResolverRegistry registry = transaction.reasoner().resolverRegistry();
         LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
@@ -512,14 +512,14 @@ public class ResolutionTest {
         ResolverRegistry registry = transaction.reasoner().resolverRegistry();
         LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
         AtomicLong doneReceived = new AtomicLong(0L);
-        Set<Reference.Name> filter = iterate(conjunction.variables()).map(Variable::reference).filter(Reference::isName)
-                .map(Reference::asName).toSet();
+        Set<Identifier.Variable.Name> filter = iterate(conjunction.variables()).map(Variable::id)
+                .filter(Identifier::isName).map(Identifier.Variable::asName).toSet();
         Actor<grakn.core.reasoner.resolution.resolver.Root.Conjunction> root =
                 registry.rootConjunction(conjunction, offset, limit, responses::add, iterDone -> doneReceived.incrementAndGet());
         assertResponses(root, filter, responses, doneReceived, answerCount);
     }
 
-    private void assertResponses(Actor<? extends Resolver<?>> root, Set<Reference.Name> filter, LinkedBlockingQueue<Top> responses,
+    private void assertResponses(Actor<? extends Resolver<?>> root, Set<Identifier.Variable.Name> filter, LinkedBlockingQueue<Top> responses,
                                  AtomicLong doneReceived, long answerCount)
             throws InterruptedException {
         long startTime = System.currentTimeMillis();

--- a/traversal/Traversal.java
+++ b/traversal/Traversal.java
@@ -29,15 +29,14 @@ import grakn.core.graph.common.Encoding;
 import grakn.core.graph.iid.VertexIID;
 import grakn.core.graph.vertex.Vertex;
 import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import grakn.core.traversal.common.VertexMap;
-import grakn.core.traversal.graph.TraversalVertex;
 import grakn.core.traversal.planner.Planner;
 import grakn.core.traversal.predicate.Predicate;
 import grakn.core.traversal.predicate.PredicateArgument;
 import grakn.core.traversal.structure.Structure;
 import graql.lang.common.GraqlArg;
 import graql.lang.common.GraqlToken;
-import graql.lang.pattern.variable.Reference;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -76,7 +75,7 @@ public class Traversal {
 
     private final Parameters parameters;
     private final Structure structure;
-    private final Set<Identifier.Variable.Name> filter;
+    private final Set<Retrieved> filter;
     private List<Planner> planners;
     private boolean modifiable;
 
@@ -90,19 +89,18 @@ public class Traversal {
     // TODO: We should not dynamically calculate properties like this, and then guard against 'modifiable'.
     //       We should introduce a "builder pattern" to Traversal, such that users of this library will build
     //       traversals with Traversal.Builder, and call .build() in the end to produce a final Object.
-    private Set<Identifier.Variable.Name> filter() {
+    private Set<Retrieved> filter() {
         if (filter.isEmpty()) {
             modifiable = false;
-            iterate(structure.vertices())
-                    .map(TraversalVertex::id).filter(Identifier::isName)
-                    .map(id -> id.asVariable().asName()).toSet(filter);
+            iterate(structure.vertices()).filter(v -> v.id().isRetrieved()).map(v -> v.id().asVariable().asRetrieved())
+                    .toSet(filter);
         }
         return filter;
     }
 
     void initialise(TraversalCache cache) {
         planners = iterate(structure.asGraphs()).filter(p -> iterate(p.vertices()).anyMatch(
-                v -> v.id().isName() && filter().contains(v.id().asVariable().asName())
+                v -> v.id().isRetrieved() && filter().contains(v.id().asVariable().asRetrieved())
         )).map(s -> cache.get(s, Planner::create)).toList();
     }
 
@@ -116,7 +114,7 @@ public class Traversal {
                 planner.tryOptimise(graphMgr, extraPlanningTime);
                 return planner.procedure().iterator(graphMgr, parameters, filter());
             }).collect(toList())).map(partialAnswers -> {
-                Map<Reference, Vertex<?, ?>> combinedAnswers = new HashMap<>();
+                Map<Retrieved, Vertex<?, ?>> combinedAnswers = new HashMap<>();
                 partialAnswers.forEach(p -> combinedAnswers.putAll(p.map()));
                 return VertexMap.of(combinedAnswers);
             });
@@ -134,7 +132,7 @@ public class Traversal {
                 planner.tryOptimise(graphMgr, extraPlanningTime);
                 return planner.procedure().producer(graphMgr, parameters, filter(), parallelisation);
             }).map(producer -> produce(producer, mode, asyncPool2())).collect(toList())).map(partialAnswers -> {
-                Map<Reference, Vertex<?, ?>> combinedAnswers = new HashMap<>();
+                Map<Retrieved, Vertex<?, ?>> combinedAnswers = new HashMap<>();
                 partialAnswers.forEach(p -> combinedAnswers.putAll(p.map()));
                 return VertexMap.of(combinedAnswers);
             }));
@@ -296,8 +294,8 @@ public class Traversal {
         structure.predicateEdge(structure.thingVertex(att1), structure.thingVertex(att2), predicate);
     }
 
-    public void filter(Set<Identifier.Variable.Name> filter) {
-        assert modifiable;
+    public void filter(Set<? extends Retrieved> filter) {
+        assert modifiable && iterate(filter).noneMatch(Identifier::isLabel);
         this.filter.addAll(filter);
     }
 

--- a/traversal/TraversalEngine.java
+++ b/traversal/TraversalEngine.java
@@ -68,7 +68,7 @@ public class TraversalEngine {
     }
 
     public ResourceIterator<VertexMap> iterator(GraphProcedure procedure, Traversal.Parameters params,
-                                                Set<Identifier.Variable.Name> filter) {
+                                                Set<Identifier.Variable.Retrieved> filter) {
         return procedure.iterator(graphMgr, params, filter);
     }
 }

--- a/traversal/TraversalEngine.java
+++ b/traversal/TraversalEngine.java
@@ -68,7 +68,7 @@ public class TraversalEngine {
     }
 
     public ResourceIterator<VertexMap> iterator(GraphProcedure procedure, Traversal.Parameters params,
-                                                Set<Identifier.Variable.Retrieved> filter) {
+                                                Set<Identifier.Variable.Retrievable> filter) {
         return procedure.iterator(graphMgr, params, filter);
     }
 }

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -33,11 +33,13 @@ public abstract class Identifier {
 
     public boolean isVariable() { return false; }
 
+    public boolean isRetrieved() { return false; }
+
     public boolean isName() { return false; }
 
-    public boolean isLabel() { return false; }
-
     public boolean isAnonymous() { return false; }
+
+    public boolean isLabel() { return false; }
 
     public Scoped asScoped() {
         throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Scoped.class));
@@ -118,7 +120,7 @@ public abstract class Identifier {
             this.hash = Objects.hash(Variable.class, this.reference, this.id);
         }
 
-        public static Referable of(Reference.Referable reference) {
+        public static Variable of(Reference.Referable reference) {
             if (reference.isLabel()) return of(reference.asLabel());
             else if (reference.isName()) return of(reference.asName());
             else assert false;
@@ -137,11 +139,11 @@ public abstract class Identifier {
             return new Anonymous(reference, id);
         }
 
-        public static Referable name(String name) {
-            return Variable.of(Reference.name(name));
+        public static Name name(String name) {
+            return of(Reference.name(name));
         }
 
-        public static Referable label(String label) {
+        public static Label label(String label) {
             return Variable.of(Reference.label(label));
         }
 
@@ -159,16 +161,20 @@ public abstract class Identifier {
         @Override
         public Variable asVariable() { return this; }
 
+        public Variable.Retrieved asRetrieved() {
+            throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Retrieved.class));
+        }
+
         public Variable.Name asName() {
             throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Name.class));
         }
 
-        public Variable.Label asLabel() {
-            throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Label.class));
-        }
-
         public Variable.Anonymous asAnonymous() {
             throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Anonymous.class));
+        }
+
+        public Variable.Label asLabel() {
+            throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Label.class));
         }
 
         @Override
@@ -190,22 +196,27 @@ public abstract class Identifier {
             return hash;
         }
 
-        public static class Referable extends Variable {
+        public static class Retrieved extends Variable {
 
-            Referable(Reference reference) {
-                super(reference, null);
+            public Retrieved(Reference reference, Integer id) {
+                super(reference, id);
             }
 
             @Override
-            public Reference.Referable reference() {
-                return reference.asReferable();
+            public boolean isRetrieved() {
+                return true;
+            }
+
+            @Override
+            public Retrieved asRetrieved() {
+                return this;
             }
         }
 
-        public static class Name extends Referable {
+        public static class Name extends Retrieved {
 
             private Name(Reference.Name reference) {
-                super(reference);
+                super(reference, null);
             }
 
             @Override
@@ -220,25 +231,7 @@ public abstract class Identifier {
             public Variable.Name asName() { return this; }
         }
 
-        public static class Label extends Referable {
-
-            private Label(Reference.Label reference) {
-                super(reference);
-            }
-
-            @Override
-            public Reference.Label reference() {
-                return reference.asLabel();
-            }
-
-            @Override
-            public boolean isLabel() { return true; }
-
-            @Override
-            public Variable.Label asLabel() { return this; }
-        }
-
-        public static class Anonymous extends Variable {
+        public static class Anonymous extends Retrieved {
 
             private Anonymous(Reference.Anonymous reference, int id) {
                 super(reference, id);
@@ -254,6 +247,24 @@ public abstract class Identifier {
 
             @Override
             public Variable.Anonymous asAnonymous() { return this; }
+        }
+
+        public static class Label extends Variable {
+
+            private Label(Reference.Label reference) {
+                super(reference, null);
+            }
+
+            @Override
+            public Reference.Label reference() {
+                return reference.asLabel();
+            }
+
+            @Override
+            public boolean isLabel() { return true; }
+
+            @Override
+            public Variable.Label asLabel() { return this; }
         }
     }
 }

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -33,7 +33,7 @@ public abstract class Identifier {
 
     public boolean isVariable() { return false; }
 
-    public boolean isRetrieved() { return false; }
+    public boolean isRetrievable() { return false; }
 
     public boolean isName() { return false; }
 
@@ -161,8 +161,8 @@ public abstract class Identifier {
         @Override
         public Variable asVariable() { return this; }
 
-        public Variable.Retrieved asRetrieved() {
-            throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Variable.Retrieved.class));
+        public Retrievable asRetrievable() {
+            throw GraknException.of(ILLEGAL_CAST, className(this.getClass()), className(Retrievable.class));
         }
 
         public Variable.Name asName() {
@@ -196,24 +196,24 @@ public abstract class Identifier {
             return hash;
         }
 
-        public static class Retrieved extends Variable {
+        public static class Retrievable extends Variable {
 
-            public Retrieved(Reference reference, Integer id) {
+            public Retrievable(Reference reference, Integer id) {
                 super(reference, id);
             }
 
             @Override
-            public boolean isRetrieved() {
+            public boolean isRetrievable() {
                 return true;
             }
 
             @Override
-            public Retrieved asRetrieved() {
+            public Retrievable asRetrievable() {
                 return this;
             }
         }
 
-        public static class Name extends Retrieved {
+        public static class Name extends Retrievable {
 
             private Name(Reference.Name reference) {
                 super(reference, null);
@@ -231,7 +231,7 @@ public abstract class Identifier {
             public Variable.Name asName() { return this; }
         }
 
-        public static class Anonymous extends Retrieved {
+        public static class Anonymous extends Retrievable {
 
             private Anonymous(Reference.Anonymous reference, int id) {
                 super(reference, id);

--- a/traversal/common/VertexMap.java
+++ b/traversal/common/VertexMap.java
@@ -19,7 +19,7 @@
 package grakn.core.traversal.common;
 
 import grakn.core.graph.vertex.Vertex;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 
 import java.util.Map;
 import java.util.Objects;
@@ -29,31 +29,31 @@ import static java.util.Collections.unmodifiableMap;
 
 public class VertexMap {
 
-    private final Map<Retrieved, Vertex<?, ?>> map;
+    private final Map<Retrievable, Vertex<?, ?>> map;
     private final int hash;
 
-    public VertexMap(Map<Retrieved, Vertex<?, ?>> map) {
+    public VertexMap(Map<Retrievable, Vertex<?, ?>> map) {
         this.map = unmodifiableMap(map);
         this.hash = Objects.hash(this.map);
     }
 
-    public static VertexMap of(Map<Retrieved, Vertex<?, ?>> map) {
+    public static VertexMap of(Map<Retrievable, Vertex<?, ?>> map) {
         return new VertexMap(map);
     }
 
-    public Map<Retrieved, Vertex<?, ?>> map() {
+    public Map<Retrievable, Vertex<?, ?>> map() {
         return map;
     }
 
-    public Vertex<?, ?> get(Retrieved id) {
+    public Vertex<?, ?> get(Retrievable id) {
         return map.get(id);
     }
 
-    public boolean containsKey(Retrieved id) {
+    public boolean containsKey(Retrievable id) {
         return map.containsKey(id);
     }
 
-    public void forEach(BiConsumer<Retrieved, Vertex<?, ?>> action) {
+    public void forEach(BiConsumer<Retrievable, Vertex<?, ?>> action) {
         map.forEach(action);
     }
 

--- a/traversal/common/VertexMap.java
+++ b/traversal/common/VertexMap.java
@@ -19,7 +19,7 @@
 package grakn.core.traversal.common;
 
 import grakn.core.graph.vertex.Vertex;
-import graql.lang.pattern.variable.Reference;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 
 import java.util.Map;
 import java.util.Objects;
@@ -29,31 +29,31 @@ import static java.util.Collections.unmodifiableMap;
 
 public class VertexMap {
 
-    private final Map<Reference, Vertex<?, ?>> map;
+    private final Map<Retrieved, Vertex<?, ?>> map;
     private final int hash;
 
-    public VertexMap(Map<Reference, Vertex<?, ?>> map) {
+    public VertexMap(Map<Retrieved, Vertex<?, ?>> map) {
         this.map = unmodifiableMap(map);
         this.hash = Objects.hash(this.map);
     }
 
-    public static VertexMap of(Map<Reference, Vertex<?, ?>> map) {
+    public static VertexMap of(Map<Retrieved, Vertex<?, ?>> map) {
         return new VertexMap(map);
     }
 
-    public Map<Reference, Vertex<?, ?>> map() {
+    public Map<Retrieved, Vertex<?, ?>> map() {
         return map;
     }
 
-    public Vertex<?, ?> get(Reference reference) {
-        return map.get(reference);
+    public Vertex<?, ?> get(Retrieved id) {
+        return map.get(id);
     }
 
-    public boolean containsKey(Reference reference) {
-        return map.containsKey(reference);
+    public boolean containsKey(Retrieved id) {
+        return map.containsKey(id);
     }
 
-    public void forEach(BiConsumer<Reference, Vertex<?, ?>> action) {
+    public void forEach(BiConsumer<Retrieved, Vertex<?, ?>> action) {
         map.forEach(action);
     }
 

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -26,7 +26,7 @@ import grakn.core.graph.vertex.ThingVertex;
 import grakn.core.graph.vertex.Vertex;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.common.Identifier;
-import grakn.core.traversal.common.Identifier.Variable.Retrieved;
+import grakn.core.traversal.common.Identifier.Variable.Retrievable;
 import grakn.core.traversal.common.VertexMap;
 import grakn.core.traversal.procedure.GraphProcedure;
 import grakn.core.traversal.procedure.ProcedureEdge;
@@ -51,7 +51,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     private final GraphManager graphMgr;
     private final GraphProcedure procedure;
     private final Traversal.Parameters params;
-    private final Set<Retrieved> filter;
+    private final Set<Retrievable> filter;
     private final Map<Identifier, ResourceIterator<? extends Vertex<?, ?>>> iterators;
     private final Map<Identifier, Vertex<?, ?>> answer;
     private final Scopes scopes;
@@ -63,7 +63,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     enum State {INIT, EMPTY, FETCHED, COMPLETED}
 
     public GraphIterator(GraphManager graphMgr, Vertex<?, ?> start, GraphProcedure procedure,
-                         Traversal.Parameters params, Set<Retrieved> filter) {
+                         Traversal.Parameters params, Set<Retrievable> filter) {
         assert procedure.edgesCount() > 0;
         this.graphMgr = graphMgr;
         this.procedure = procedure;
@@ -325,8 +325,8 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     private VertexMap toVertexMap(Map<Identifier, Vertex<?, ?>> answer) {
         return VertexMap.of(
                 answer.entrySet().stream()
-                        .filter(e -> e.getKey().isRetrieved() && filter.contains(e.getKey().asVariable().asRetrieved()))
-                        .collect(toMap(e -> e.getKey().asVariable().asRetrieved(), Map.Entry::getValue))
+                        .filter(e -> e.getKey().isRetrievable() && filter.contains(e.getKey().asVariable().asRetrievable()))
+                        .collect(toMap(e -> e.getKey().asVariable().asRetrievable(), Map.Entry::getValue))
         );
     }
 

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -26,6 +26,7 @@ import grakn.core.graph.vertex.ThingVertex;
 import grakn.core.graph.vertex.Vertex;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.Identifier.Variable.Retrieved;
 import grakn.core.traversal.common.VertexMap;
 import grakn.core.traversal.procedure.GraphProcedure;
 import grakn.core.traversal.procedure.ProcedureEdge;
@@ -50,7 +51,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     private final GraphManager graphMgr;
     private final GraphProcedure procedure;
     private final Traversal.Parameters params;
-    private final Set<Identifier.Variable.Name> filter;
+    private final Set<Retrieved> filter;
     private final Map<Identifier, ResourceIterator<? extends Vertex<?, ?>>> iterators;
     private final Map<Identifier, Vertex<?, ?>> answer;
     private final Scopes scopes;
@@ -62,7 +63,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     enum State {INIT, EMPTY, FETCHED, COMPLETED}
 
     public GraphIterator(GraphManager graphMgr, Vertex<?, ?> start, GraphProcedure procedure,
-                         Traversal.Parameters params, Set<Identifier.Variable.Name> filter) {
+                         Traversal.Parameters params, Set<Retrieved> filter) {
         assert procedure.edgesCount() > 0;
         this.graphMgr = graphMgr;
         this.procedure = procedure;
@@ -318,14 +319,14 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
     public VertexMap next() {
         if (!hasNext()) throw new NoSuchElementException();
         state = State.EMPTY;
-        return toReferenceMap(answer);
+        return toVertexMap(answer);
     }
 
-    private VertexMap toReferenceMap(Map<Identifier, Vertex<?, ?>> answer) {
+    private VertexMap toVertexMap(Map<Identifier, Vertex<?, ?>> answer) {
         return VertexMap.of(
                 answer.entrySet().stream()
-                        .filter(e -> e.getKey().isName() && filter.contains(e.getKey().asVariable().asName()))
-                        .collect(toMap(k -> k.getKey().asVariable().reference(), Map.Entry::getValue))
+                        .filter(e -> e.getKey().isRetrieved() && filter.contains(e.getKey().asVariable().asRetrieved()))
+                        .collect(toMap(e -> e.getKey().asVariable().asRetrieved(), Map.Entry::getValue))
         );
     }
 

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -164,13 +164,13 @@ public class GraphProcedure implements Procedure {
         ).asType();
     }
 
-    private void assertWithinFilterBounds(Set<Identifier.Variable.Name> filter) {
-        assert iterate(vertices.keySet()).anyMatch(id -> id.isName() && filter.contains(id.asVariable().asName()));
+    private void assertWithinFilterBounds(Set<Identifier.Variable.Retrieved> filter) {
+        assert iterate(vertices.keySet()).anyMatch(filter::contains);
     }
 
     @Override
-    public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                        Set<Identifier.Variable.Name> filter, int parallelisation) {
+    public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params, Set<Identifier.Variable.Retrieved> filter,
+                                        int parallelisation) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(params.toString());
             LOG.debug(this.toString());
@@ -184,7 +184,7 @@ public class GraphProcedure implements Procedure {
 
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                                Set<Identifier.Variable.Name> filter) {
+                                                Set<Identifier.Variable.Retrieved> filter) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(params.toString());
             LOG.debug(this.toString());

--- a/traversal/procedure/GraphProcedure.java
+++ b/traversal/procedure/GraphProcedure.java
@@ -164,12 +164,12 @@ public class GraphProcedure implements Procedure {
         ).asType();
     }
 
-    private void assertWithinFilterBounds(Set<Identifier.Variable.Retrieved> filter) {
+    private void assertWithinFilterBounds(Set<Identifier.Variable.Retrievable> filter) {
         assert iterate(vertices.keySet()).anyMatch(filter::contains);
     }
 
     @Override
-    public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params, Set<Identifier.Variable.Retrieved> filter,
+    public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params, Set<Identifier.Variable.Retrievable> filter,
                                         int parallelisation) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(params.toString());
@@ -184,7 +184,7 @@ public class GraphProcedure implements Procedure {
 
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                                Set<Identifier.Variable.Retrieved> filter) {
+                                                Set<Identifier.Variable.Retrievable> filter) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(params.toString());
             LOG.debug(this.toString());

--- a/traversal/procedure/Procedure.java
+++ b/traversal/procedure/Procedure.java
@@ -30,8 +30,8 @@ import java.util.Set;
 public interface Procedure {
 
     Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                 Set<Identifier.Variable.Retrieved> filter, int parallelisation);
+                                 Set<Identifier.Variable.Retrievable> filter, int parallelisation);
 
     ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                         Set<Identifier.Variable.Retrieved> filter);
+                                         Set<Identifier.Variable.Retrievable> filter);
 }

--- a/traversal/procedure/Procedure.java
+++ b/traversal/procedure/Procedure.java
@@ -30,8 +30,8 @@ import java.util.Set;
 public interface Procedure {
 
     Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                 Set<Identifier.Variable.Name> filter, int parallelisation);
+                                 Set<Identifier.Variable.Retrieved> filter, int parallelisation);
 
     ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                         Set<Identifier.Variable.Name> filter);
+                                         Set<Identifier.Variable.Retrieved> filter);
 }

--- a/traversal/procedure/VertexProcedure.java
+++ b/traversal/procedure/VertexProcedure.java
@@ -31,9 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static grakn.common.collection.Collections.map;
@@ -91,7 +89,7 @@ public class VertexProcedure implements Procedure {
 
     @Override
     public Producer<VertexMap> producer(GraphManager graphMgr, Traversal.Parameters params,
-                                        Set<Identifier.Variable.Retrieved> filter, int parallelisation) {
+                                        Set<Identifier.Variable.Retrievable> filter, int parallelisation) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
         return async(iterator(graphMgr, params, filter));
@@ -99,16 +97,16 @@ public class VertexProcedure implements Procedure {
 
     @Override
     public ResourceIterator<VertexMap> iterator(GraphManager graphMgr, Traversal.Parameters params,
-                                                Set<Identifier.Variable.Retrieved> filter) {
+                                                Set<Identifier.Variable.Retrievable> filter) {
         LOG.debug(params.toString());
         LOG.debug(this.toString());
-        assert vertex.id().isRetrieved() && filter.contains(vertex.id().asVariable().asRetrieved());
+        assert vertex.id().isRetrievable() && filter.contains(vertex.id().asVariable().asRetrievable());
         ResourceIterator<? extends Vertex<?, ?>> iterator = vertex.iterator(graphMgr, params);
         for (ProcedureEdge<?, ?> e : vertex.outs()) {
             iterator = iterator.filter(v -> e.isClosure(graphMgr, v, v, params));
         }
 
-        return iterator.map(v -> VertexMap.of(map(pair(vertex.id().asVariable().asRetrieved(), v)))).distinct();
+        return iterator.map(v -> VertexMap.of(map(pair(vertex.id().asVariable().asRetrievable(), v)))).distinct();
     }
 
 }

--- a/traversal/structure/Structure.java
+++ b/traversal/structure/Structure.java
@@ -119,8 +119,7 @@ public class Structure {
             while (!verticesToVisit.isEmpty()) {
                 Structure newStructure = new Structure();
                 splitGraph(verticesToVisit.iterator().next(), newStructure, verticesToVisit, edgesToVisit);
-                if (newStructure.vertices().size() > 1 ||
-                        newStructure.vertices().iterator().next().id().isName()) {
+                if (newStructure.vertices().size() > 1 || newStructure.vertices().iterator().next().id().isRetrieved()) {
                     structures.add(newStructure);
                 }
             }

--- a/traversal/structure/Structure.java
+++ b/traversal/structure/Structure.java
@@ -119,7 +119,7 @@ public class Structure {
             while (!verticesToVisit.isEmpty()) {
                 Structure newStructure = new Structure();
                 splitGraph(verticesToVisit.iterator().next(), newStructure, verticesToVisit, edgesToVisit);
-                if (newStructure.vertices().size() > 1 || newStructure.vertices().iterator().next().id().isRetrieved()) {
+                if (newStructure.vertices().size() > 1 || newStructure.vertices().iterator().next().id().isRetrievable()) {
                     structures.add(newStructure);
                 }
             }


### PR DESCRIPTION
## What is the goal of this PR?
To enable reasoner to bind concepts to anonymous variables in conjunctions, we make a sweeping change that traversal engine and reasoner both return anonymous variables as well. Consequently, in Grakn now ConceptMaps contain `Identifer` rather than `References`, and can identify anonymous variables.

## What are the changes implemented in this PR?
* Traversal and reasoner can bind to and return anonymous variable answers
* Create a new type `Identifier.Variable.Retrievable` which is extended by `Identifier.Variable.Named` and `Identifier.Variable.Anonymous`
* Propagate usage of `Retrievable` to unifications, mappings, concept maps, vertex maps as tightly as possible
* As a new optimisation, we check `Unifier.Requirements.Constraint` _forwards_ when unifiying a previous partial answer as well as backward when we find the complete answer. This required building unified and non-unified requirements up together to deal with non-retrieved identifiers' requirements nicely
* Rename the `type` requirement in Unifier.Requirements to `roleType`, which is the only place it should be used. Labeled types for `isa friendship` or `has name $x` become part of the `isaExplicit` requirements now
* fix bug with infinitely reiteration - `Root` resolvers do not clear their deduplication sets when reiterating
* unignore some tests and fix unification tests