### PR TITLE
Remove unused transaction schema factory reference

### DIFF
--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -70,14 +70,12 @@ public class RocksDatabase implements Grakn.Database {
     private Cache cache;
 
     private final Factory.Session sessionFactory;
-    private final Factory.TransactionSchema transactionSchemaFactory;
     protected final AtomicBoolean isOpen;
 
-    protected RocksDatabase(RocksGrakn grakn, String name, Factory.Session sessionFactory, Factory.TransactionSchema transactionSchemaFactory) {
+    protected RocksDatabase(RocksGrakn grakn, String name, Factory.Session sessionFactory) {
         this.grakn = grakn;
         this.name = name;
         this.sessionFactory = sessionFactory;
-        this.transactionSchemaFactory = transactionSchemaFactory;
         schemaKeyGenerator = new KeyGenerator.Schema.Persisted();
         dataKeyGenerator = new KeyGenerator.Data.Persisted();
         sessions = new ConcurrentHashMap<>();
@@ -94,21 +92,21 @@ public class RocksDatabase implements Grakn.Database {
         isOpen = new AtomicBoolean(true);
     }
 
-    static RocksDatabase createAndOpen(RocksGrakn grakn, String name, Factory.Session sessionFactory, Factory.TransactionSchema transactionSchemaFactory) {
+    static RocksDatabase createAndOpen(RocksGrakn grakn, String name, Factory.Session sessionFactory) {
         try {
             Files.createDirectory(grakn.directory().resolve(name));
         } catch (IOException e) {
             throw GraknException.of(e);
         }
 
-        RocksDatabase database = new RocksDatabase(grakn, name, sessionFactory, transactionSchemaFactory);
+        RocksDatabase database = new RocksDatabase(grakn, name, sessionFactory);
         database.initialise();
         database.statisticsBgCounterStart();
         return database;
     }
 
-    static RocksDatabase loadAndOpen(RocksGrakn grakn, String name, Factory.Session sessionFactory, Factory.TransactionSchema transactionSchemaFactory) {
-        RocksDatabase database = new RocksDatabase(grakn, name, sessionFactory, transactionSchemaFactory);
+    static RocksDatabase loadAndOpen(RocksGrakn grakn, String name, Factory.Session sessionFactory) {
+        RocksDatabase database = new RocksDatabase(grakn, name, sessionFactory);
         database.load();
         database.statisticsBgCounterStart();
         return database;

--- a/rocks/RocksFactory.java
+++ b/rocks/RocksFactory.java
@@ -48,12 +48,12 @@ public final class RocksFactory implements Factory {
             databaseFactory = new Database() {
                 @Override
                 public RocksDatabase databaseCreateAndOpen(RocksGrakn grakn, String name) {
-                    return RocksDatabase.createAndOpen(grakn, name, sessionFactory(), transactionSchemaFactory());
+                    return RocksDatabase.createAndOpen(grakn, name, sessionFactory());
                 }
 
                 @Override
                 public RocksDatabase databaseLoadAndOpen(RocksGrakn grakn, String name) {
-                    return RocksDatabase.loadAndOpen(grakn, name, sessionFactory(), transactionSchemaFactory());
+                    return RocksDatabase.loadAndOpen(grakn, name, sessionFactory());
                 }
             };
         }


### PR DESCRIPTION
## What is the goal of this PR?

We have removed an unused transaction schema factory reference in RocksDatabase.

It was originally added in order to allow for differentiating "transaction for schema initialisation" and "transaction for regular use". We've simplified the design since and the ability to construct "transaction for schema initialisation" and "transaction for regular use" has been moved into RocksSession.Schema. Therefore, this reference should be removed.

## What are the changes implemented in this PR?

- Remove an unused transaction schema factory reference