### PR TITLE
Make RocksDB (Debug) library the default

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -71,7 +71,7 @@ artifact_repackage(
 )
 
 assemble_deps_common = [
-    "//server:server-deps-dev",
+    "//server:server-deps-prod",
 #    "//server:server-deps-prod",
     ":console-artifact-jars",
 ]

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "8e39ba39d29e4bb8fc4b900f0131b7a77cc7eb00", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "09f3e6b591bd1456049d119d1c59f99154681e07", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():

--- a/dependencies/maven/artifacts.bzl
+++ b/dependencies/maven/artifacts.bzl
@@ -38,7 +38,8 @@ artifacts = [
     "io.netty:netty-all",
     "junit:junit",
     "org.rocksdb:rocksdbjni",
-    "org.rocksdb:rocksdbjni-dev",
+    "org.rocksdb:rocksdbjni-dev-mac",
+    "org.rocksdb:rocksdbjni-dev-linux",
     "org.slf4j:slf4j-api",
     "org.zeroturnaround:zt-exec"
 ]

--- a/dependencies/maven/artifacts.snapshot
+++ b/dependencies/maven/artifacts.snapshot
@@ -146,8 +146,10 @@
 @maven//:org_objenesis_objenesis_2_5
 @maven//:org_rocksdb_rocksdbjni
 @maven//:org_rocksdb_rocksdbjni_6_15_2
-@maven//:org_rocksdb_rocksdbjni_dev
-@maven//:org_rocksdb_rocksdbjni_dev_6_15_2
+@maven//:org_rocksdb_rocksdbjni_dev_linux
+@maven//:org_rocksdb_rocksdbjni_dev_linux_6_15_2
+@maven//:org_rocksdb_rocksdbjni_dev_mac
+@maven//:org_rocksdb_rocksdbjni_dev_mac_6_15_2
 @maven//:org_slf4j_slf4j_api
 @maven//:org_slf4j_slf4j_api_1_7_28
 @maven//:org_zeroturnaround_zt_exec

--- a/rocks/BUILD
+++ b/rocks/BUILD
@@ -58,7 +58,7 @@ native_java_libraries(
     linux_deps = [
         "@maven//:com_google_ortools_ortools_linux_x86_64",
         "@maven//:com_google_ortools_ortools_linux_x86_64_java",
-        "@maven//:org_rocksdb_rocksdbjni_dev_linux",
+        "@maven//:org_rocksdb_rocksdbjni",
     ],
     windows_deps = [
         "@maven//:com_google_ortools_ortools_win32_x86_64",

--- a/rocks/BUILD
+++ b/rocks/BUILD
@@ -40,8 +40,6 @@ native_java_libraries(
 
         # External dependencies from Maven
         "@maven//:com_google_code_findbugs_jsr305",
-        # "@maven//:org_rocksdb_rocksdbjni_dev", # Use this JAR for debugging RocksDB on Mac
-        "@maven//:org_rocksdb_rocksdbjni",
         "@maven//:org_slf4j_slf4j_api"
     ],
     native_libraries_deps = [
@@ -55,14 +53,17 @@ native_java_libraries(
     mac_deps = [
         "@maven//:com_google_ortools_ortools_darwin",
         "@maven//:com_google_ortools_ortools_darwin_java",
+        "@maven//:org_rocksdb_rocksdbjni_dev_mac",
     ],
     linux_deps = [
         "@maven//:com_google_ortools_ortools_linux_x86_64",
-        "@maven//:com_google_ortools_ortools_linux_x86_64_java"
+        "@maven//:com_google_ortools_ortools_linux_x86_64_java",
+        "@maven//:org_rocksdb_rocksdbjni_dev_linux",
     ],
     windows_deps = [
         "@maven//:com_google_ortools_ortools_win32_x86_64",
-        "@maven//:com_google_ortools_ortools_win32_x86_64_java"
+        "@maven//:com_google_ortools_ortools_win32_x86_64_java",
+        "@maven//:org_rocksdb_rocksdbjni",
     ],
     tags = ["maven_coordinates=io.grakn.core:grakn-rocks:{pom_version}"],
     visibility = [ "//visibility:public" ]

--- a/server/BUILD
+++ b/server/BUILD
@@ -133,11 +133,8 @@ java_deps(
     name = "server-deps-mac",
     target = ":server-bin-mac",
     java_deps_root = "server/lib/common/",
-#    java_deps_root_overrides = {
-#        "rocksdbjni-dev-*": "server/lib/dev/",
-#    },
     java_deps_root_overrides = {
-        "rocksdbjni-*": "server/lib/prod/",
+        "rocksdbjni-dev-*": "server/lib/dev/",
     },
     visibility = ["//:__pkg__"],
     maven_name = True,
@@ -147,11 +144,8 @@ java_deps(
     name = "server-deps-linux",
     target = ":server-bin-linux",
     java_deps_root = "server/lib/common/",
-#    java_deps_root_overrides = {
-#        "rocksdbjni-dev-*": "server/lib/dev/",
-#    },
     java_deps_root_overrides = {
-        "rocksdbjni-*": "server/lib/prod/",
+        "rocksdbjni-dev-*": "server/lib/dev/",
     },
     visibility = ["//:__pkg__"],
     maven_name = True,
@@ -161,37 +155,23 @@ java_deps(
     name = "server-deps-windows",
     target = ":server-bin-windows",
     java_deps_root = "server/lib/common/",
-#    java_deps_root_overrides = {
-#        "rocksdbjni-dev-*": "server/lib/dev/",
-#    },
     java_deps_root_overrides = {
-        "rocksdbjni-*": "server/lib/prod/",
+        "rocksdbjni-dev-*": "server/lib/dev/",
     },
     visibility = ["//:__pkg__"],
     maven_name = True,
 )
 
 java_deps(
-    name = "server-deps-dev",
-    target = "@maven//:org_rocksdb_rocksdbjni_dev",
-    java_deps_root = "server/lib/dev/",
+    name = "server-deps-prod",
+    target = "@maven//:org_rocksdb_rocksdbjni",
+    java_deps_root = "server/lib/prod/",
     visibility = ["//:__pkg__"],
     maven_name = True,
 )
 
-# TODO: Once we have a cross-platform rocksdbjni-dev build, make rocksdbjni-dev the default version that we use
-#       (by uncommenting server-deps-prod and deleting server-deps-dev)
-#java_deps(
-#    name = "server-deps-prod",
-#    target = "@maven//:org_rocksdb_rocksdbjni",
-#    java_deps_root = "server/lib/prod/",
-#    visibility = ["//:__pkg__"],
-#    maven_name = True,
-#)
-
 assemble_deps_common = [
-    ":server-deps-dev",
-#    ":server-deps-prod",
+    ":server-deps-prod",
 ]
 
 assemble_files = {
@@ -272,7 +252,7 @@ assemble_apt(
       "grakn-bin (=%{@graknlabs_common})"
     ],
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json",
-    archives = [":server-deps-dev", ":server-deps-linux"],
+    archives = [":server-deps-prod", ":server-deps-linux"],
     installation_dir = "/opt/grakn/core/",
     files = assemble_files,
     empty_dirs = [


### PR DESCRIPTION
## What is the goal of this PR?

We have made the `//rocks` package depends on RocksDB (Debug) library in order to increase debuggability during development.

However, there are two caveats:

1. In Bazel: RocksDB (Debug) is disabled for Linux until we fix the assertion tests, and for Windows until we deploy RocksDB (Debug) for Windows platform. Therefore, it is only active for Mac.
2. In the actual distribution, the `--debug` flag is active for Mac and Linux. For Windows, it will effectively be ignored until we deploy RocksDB (Debug) for the Windows platform. 

## What are the changes implemented in this PR?

- Make `//rocks` package depend on RocksDB (Debug)
- Make the actual distribution contain both RocksDB (Debug) which is placed under `server/lib/dev` and RocksDB (Prod) which is placed under `server/lib/prod`