### PR TITLE
Reduce Enum memory overhead by hardcoding lookups

### DIFF
--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -18,6 +18,7 @@
 
 package grakn.core.graph.common;
 
+import grakn.common.collection.Pair;
 import grakn.core.common.collection.Bytes;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Label;
@@ -166,6 +167,26 @@ public class Encoding {
         VERTEX_ROLE(180, PrefixType.THING),
         STRUCTURE_RULE(190, PrefixType.RULE);
 
+        private static Prefix[] keyIndex = indexedBytes(
+                pair(INDEX_TYPE.key, INDEX_TYPE),
+                pair(INDEX_RULE.key, INDEX_RULE),
+                pair(INDEX_ATTRIBUTE.key, INDEX_ATTRIBUTE),
+                pair(STATISTICS_THINGS.key, STATISTICS_THINGS),
+                pair(STATISTICS_COUNT_JOB.key, STATISTICS_COUNT_JOB),
+                pair(STATISTICS_COUNTED.key, STATISTICS_COUNTED),
+                pair(STATISTICS_SNAPSHOT.key, STATISTICS_SNAPSHOT),
+                pair(VERTEX_THING_TYPE.key, VERTEX_THING_TYPE),
+                pair(VERTEX_ENTITY_TYPE.key, VERTEX_ENTITY_TYPE),
+                pair(VERTEX_ATTRIBUTE_TYPE.key, VERTEX_ATTRIBUTE_TYPE),
+                pair(VERTEX_RELATION_TYPE.key, VERTEX_RELATION_TYPE),
+                pair(VERTEX_ROLE_TYPE.key, VERTEX_ROLE_TYPE),
+                pair(VERTEX_ENTITY.key, VERTEX_ENTITY),
+                pair(VERTEX_ATTRIBUTE.key, VERTEX_ATTRIBUTE),
+                pair(VERTEX_RELATION.key, VERTEX_RELATION),
+                pair(VERTEX_ROLE.key, VERTEX_ROLE),
+                pair(STRUCTURE_RULE.key, STRUCTURE_RULE)
+        );
+
 
         private final byte key;
         private final PrefixType type;
@@ -178,24 +199,9 @@ public class Encoding {
         }
 
         public static Prefix of(byte key) {
-            if (key == INDEX_TYPE.key) return INDEX_TYPE;
-            else if (key == INDEX_RULE.key) return INDEX_RULE;
-            else if (key == INDEX_ATTRIBUTE.key) return INDEX_ATTRIBUTE;
-            else if (key == STATISTICS_THINGS.key) return STATISTICS_THINGS;
-            else if (key == STATISTICS_COUNT_JOB.key) return STATISTICS_COUNT_JOB;
-            else if (key == STATISTICS_COUNTED.key) return STATISTICS_COUNTED;
-            else if (key == STATISTICS_SNAPSHOT.key) return STATISTICS_SNAPSHOT;
-            else if (key == VERTEX_THING_TYPE.key) return VERTEX_THING_TYPE;
-            else if (key == VERTEX_ENTITY_TYPE.key) return VERTEX_ENTITY_TYPE;
-            else if (key == VERTEX_ATTRIBUTE_TYPE.key) return VERTEX_ATTRIBUTE_TYPE;
-            else if (key == VERTEX_RELATION_TYPE.key) return VERTEX_RELATION_TYPE;
-            else if (key == VERTEX_ROLE_TYPE.key) return VERTEX_ROLE_TYPE;
-            else if (key == VERTEX_ENTITY.key) return VERTEX_ENTITY;
-            else if (key == VERTEX_ATTRIBUTE.key) return VERTEX_ATTRIBUTE;
-            else if (key == VERTEX_RELATION.key) return VERTEX_RELATION;
-            else if (key == VERTEX_ROLE.key) return VERTEX_ROLE;
-            else if (key == STRUCTURE_RULE.key) return STRUCTURE_RULE;
-            else throw GraknException.of(UNRECOGNISED_VALUE);
+            Prefix prefix = keyIndex[key];
+            if (prefix == null) throw GraknException.of(UNRECOGNISED_VALUE);
+            else return prefix;
         }
 
         public byte key() {
@@ -265,6 +271,38 @@ public class Encoding {
         EDGE_RELATING_IN(-72),
         EDGE_ROLEPLAYER_OUT(73, true),
         EDGE_ROLEPLAYER_IN(-73, true);
+
+        private static Infix[] keyIndex = indexedBytes(
+                pair(PROPERTY_LABEL.key, PROPERTY_LABEL),
+                pair(PROPERTY_SCOPE.key, PROPERTY_SCOPE),
+                pair(PROPERTY_ABSTRACT.key, PROPERTY_ABSTRACT),
+                pair(PROPERTY_VALUE_TYPE.key, PROPERTY_VALUE_TYPE),
+                pair(PROPERTY_REGEX.key, PROPERTY_REGEX),
+                pair(PROPERTY_WHEN.key, PROPERTY_WHEN),
+                pair(PROPERTY_THEN.key, PROPERTY_THEN),
+                pair(PROPERTY_VALUE.key, PROPERTY_VALUE),
+                pair(PROPERTY_VALUE_REF.key, PROPERTY_VALUE_REF),
+                pair(EDGE_ISA_IN.key, EDGE_ISA_IN),
+                pair(EDGE_SUB_OUT.key, EDGE_SUB_OUT),
+                pair(EDGE_SUB_IN.key, EDGE_SUB_IN),
+                pair(EDGE_OWNS_OUT.key, EDGE_OWNS_OUT),
+                pair(EDGE_OWNS_IN.key, EDGE_OWNS_IN),
+                pair(EDGE_OWNS_KEY_OUT.key, EDGE_OWNS_KEY_OUT),
+                pair(EDGE_OWNS_KEY_IN.key, EDGE_OWNS_KEY_IN),
+                pair(EDGE_PLAYS_OUT.key, EDGE_PLAYS_OUT),
+                pair(EDGE_PLAYS_IN.key, EDGE_PLAYS_IN),
+                pair(EDGE_RELATES_OUT.key, EDGE_RELATES_OUT),
+                pair(EDGE_RELATES_IN.key, EDGE_RELATES_IN),
+                pair(EDGE_HAS_OUT.key, EDGE_HAS_OUT),
+                pair(EDGE_HAS_IN.key, EDGE_HAS_IN),
+                pair(EDGE_PLAYING_OUT.key, EDGE_PLAYING_OUT),
+                pair(EDGE_PLAYING_IN.key, EDGE_PLAYING_IN),
+                pair(EDGE_RELATING_OUT.key, EDGE_RELATING_OUT),
+                pair(EDGE_RELATING_IN.key, EDGE_RELATING_IN),
+                pair(EDGE_ROLEPLAYER_OUT.key, EDGE_ROLEPLAYER_OUT),
+                pair(EDGE_ROLEPLAYER_IN.key, EDGE_ROLEPLAYER_IN)
+        );
+
         private final byte key;
         private final boolean isOptimisation;
         private final byte[] bytes;
@@ -280,35 +318,9 @@ public class Encoding {
         }
 
         public static Infix of(byte key) {
-            if (key == PROPERTY_LABEL.key) return PROPERTY_LABEL;
-            else if (key == PROPERTY_SCOPE.key) return PROPERTY_SCOPE;
-            else if (key == PROPERTY_ABSTRACT.key) return PROPERTY_ABSTRACT;
-            else if (key == PROPERTY_VALUE_TYPE.key) return PROPERTY_VALUE_TYPE;
-            else if (key == PROPERTY_REGEX.key) return PROPERTY_REGEX;
-            else if (key == PROPERTY_WHEN.key) return PROPERTY_WHEN;
-            else if (key == PROPERTY_THEN.key) return PROPERTY_THEN;
-            else if (key == PROPERTY_VALUE.key) return PROPERTY_VALUE;
-            else if (key == PROPERTY_VALUE_REF.key) return PROPERTY_VALUE_REF;
-            else if (key == EDGE_ISA_IN.key) return EDGE_ISA_IN; // EDGE_ISA_OUT does not exist by design
-            else if (key == EDGE_SUB_OUT.key) return EDGE_SUB_OUT;
-            else if (key == EDGE_SUB_IN.key) return EDGE_SUB_IN;
-            else if (key == EDGE_OWNS_OUT.key) return EDGE_OWNS_OUT;
-            else if (key == EDGE_OWNS_IN.key) return EDGE_OWNS_IN;
-            else if (key == EDGE_OWNS_KEY_OUT.key) return EDGE_OWNS_KEY_OUT;
-            else if (key == EDGE_OWNS_KEY_IN.key) return EDGE_OWNS_KEY_IN;
-            else if (key == EDGE_PLAYS_OUT.key) return EDGE_PLAYS_OUT;
-            else if (key == EDGE_PLAYS_IN.key) return EDGE_PLAYS_IN;
-            else if (key == EDGE_RELATES_OUT.key) return EDGE_RELATES_OUT;
-            else if (key == EDGE_RELATES_IN.key) return EDGE_RELATES_IN;
-            else if (key == EDGE_HAS_OUT.key) return EDGE_HAS_OUT;
-            else if (key == EDGE_HAS_IN.key) return EDGE_HAS_IN;
-            else if (key == EDGE_PLAYING_OUT.key) return EDGE_PLAYING_OUT;
-            else if (key == EDGE_PLAYING_IN.key) return EDGE_PLAYING_IN;
-            else if (key == EDGE_RELATING_OUT.key) return EDGE_RELATING_OUT;
-            else if (key == EDGE_RELATING_IN.key) return EDGE_RELATING_IN;
-            else if (key == EDGE_ROLEPLAYER_OUT.key) return EDGE_ROLEPLAYER_OUT;
-            else if (key == EDGE_ROLEPLAYER_IN.key) return EDGE_ROLEPLAYER_IN;
-            else throw GraknException.of(UNRECOGNISED_VALUE);
+            Infix infix = keyIndex[key];
+            if (infix == null) throw GraknException.of(UNRECOGNISED_VALUE);
+            else return infix;
         }
 
         public byte key() {
@@ -364,6 +376,15 @@ public class Encoding {
         public static final int STRING_MAX_SIZE = Bytes.SHORT_UNSIGNED_MAX_VALUE;
         public static final double DOUBLE_PRECISION = 0.0000000000000001;
 
+        private static ValueType[] keyIndex = indexedBytes(
+                pair(OBJECT.key, OBJECT),
+                pair(BOOLEAN.key, BOOLEAN),
+                pair(LONG.key, LONG),
+                pair(DOUBLE.key, DOUBLE),
+                pair(STRING.key, STRING),
+                pair(DATETIME.key, DATETIME)
+        );
+
         private static final Map<ValueType, Set<ValueType>> ASSIGNABLES = map(
                 pair(OBJECT, set(OBJECT)),
                 pair(BOOLEAN, set(BOOLEAN)),
@@ -400,13 +421,9 @@ public class Encoding {
         }
 
         public static ValueType of(byte value) {
-            if (value == OBJECT.key) return OBJECT;
-            else if (value == BOOLEAN.key) return BOOLEAN;
-            else if (value == LONG.key) return LONG;
-            else if (value == DOUBLE.key) return DOUBLE;
-            else if (value == STRING.key) return STRING;
-            else if (value == DATETIME.key) return DATETIME;
-            else throw GraknException.of(UNRECOGNISED_VALUE);
+            ValueType valueType = keyIndex[value];
+            if (valueType == null) throw GraknException.of(UNRECOGNISED_VALUE);
+            else return valueType;
         }
 
         public static ValueType of(Class<?> valueClass) {
@@ -496,6 +513,14 @@ public class Encoding {
             RELATION_TYPE(Prefix.VERTEX_RELATION_TYPE, Root.RELATION, Thing.RELATION),
             ROLE_TYPE(Prefix.VERTEX_ROLE_TYPE, Root.ROLE, Thing.ROLE);
 
+            private static Type[] prefixIndex = indexedBytes(
+                    pair(THING_TYPE.prefix.key, THING_TYPE),
+                    pair(ENTITY_TYPE.prefix.key, ENTITY_TYPE),
+                    pair(ATTRIBUTE_TYPE.prefix.key, ATTRIBUTE_TYPE),
+                    pair(RELATION_TYPE.prefix.key, RELATION_TYPE),
+                    pair(ROLE_TYPE.prefix.key, ROLE_TYPE)
+            );
+
             private final Prefix prefix;
             private final Root root;
             private final Thing instance;
@@ -507,12 +532,9 @@ public class Encoding {
             }
 
             public static Type of(byte prefix) {
-                if (prefix == THING_TYPE.prefix.key) return THING_TYPE;
-                else if (prefix == ENTITY_TYPE.prefix.key) return ENTITY_TYPE;
-                else if (prefix == ATTRIBUTE_TYPE.prefix.key) return ATTRIBUTE_TYPE;
-                else if (prefix == RELATION_TYPE.prefix.key) return RELATION_TYPE;
-                else if (prefix == ROLE_TYPE.prefix.key) return ROLE_TYPE;
-                else throw GraknException.of(UNRECOGNISED_VALUE);
+                Type type = prefixIndex[prefix];
+                if (type == null) throw GraknException.of(UNRECOGNISED_VALUE);
+                else return type;
             }
 
             public static Type of(Thing thing) {
@@ -588,6 +610,13 @@ public class Encoding {
             RELATION(Prefix.VERTEX_RELATION),
             ROLE(Prefix.VERTEX_ROLE);
 
+            private static Thing[] prefixIndex = indexedBytes(
+                    pair(ENTITY.prefix.key, ENTITY),
+                    pair(ATTRIBUTE.prefix.key, ATTRIBUTE),
+                    pair(RELATION.prefix.key, RELATION),
+                    pair(ROLE.prefix.key, ROLE)
+            );
+
             private final Prefix prefix;
 
             Thing(Prefix prefix) {
@@ -595,11 +624,9 @@ public class Encoding {
             }
 
             public static Thing of(byte prefix) {
-                if (prefix == ENTITY.prefix.key) return ENTITY;
-                else if (prefix == ATTRIBUTE.prefix.key) return ATTRIBUTE;
-                else if (prefix == RELATION.prefix.key) return RELATION;
-                else if (prefix == ROLE.prefix.key) return ROLE;
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                Thing thing = prefixIndex[prefix];
+                if (thing == null) throw GraknException.of(UNRECOGNISED_VALUE);
+                else return thing;
             }
 
             @Override
@@ -739,11 +766,17 @@ public class Encoding {
             }
 
             public static Thing of(byte infix) {
-                if ((HAS.out != null && HAS.out.key == infix) || (HAS.in != null && HAS.in.key == infix)) return HAS;
-                else if ((PLAYING.out != null && PLAYING.out.key == infix) || (PLAYING.in != null && PLAYING.in.key == infix)) return PLAYING;
-                else if ((RELATING.out != null && RELATING.out.key == infix) || (RELATING.in != null && RELATING.in.key == infix)) return RELATING;
-                else if ((ROLEPLAYER.out != null && ROLEPLAYER.out.key == infix) || (ROLEPLAYER.in != null && ROLEPLAYER.in.key == infix)) return ROLEPLAYER;
-                else throw GraknException.of(UNRECOGNISED_VALUE);
+                if ((HAS.out != null && HAS.out.key == infix) || (HAS.in != null && HAS.in.key == infix)) {
+                    return HAS;
+                } else if ((PLAYING.out != null && PLAYING.out.key == infix) || (PLAYING.in != null && PLAYING.in.key == infix)) {
+                    return PLAYING;
+                } else if ((RELATING.out != null && RELATING.out.key == infix) || (RELATING.in != null && RELATING.in.key == infix)) {
+                    return RELATING;
+                } else if ((ROLEPLAYER.out != null && ROLEPLAYER.out.key == infix) || (ROLEPLAYER.in != null && ROLEPLAYER.in.key == infix)) {
+                    return ROLEPLAYER;
+                } else {
+                    throw GraknException.of(UNRECOGNISED_VALUE);
+                }
             }
 
             @Override
@@ -922,5 +955,13 @@ public class Encoding {
                 return bytes;
             }
         }
+    }
+
+    private static <T> T[] indexedBytes(Pair<Byte, T>... byteIndices) {
+        Object[] array = new Object[255];
+        for (Pair<Byte, T> index : byteIndices) {
+            array[index.first()] = index.second();
+        }
+        return (T[]) array;
     }
 }

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -178,10 +178,24 @@ public class Encoding {
         }
 
         public static Prefix of(byte key) {
-            for (Prefix i : Prefix.values()) {
-                if (i.key == key) return i;
-            }
-            throw GraknException.of(UNRECOGNISED_VALUE);
+            if (key == INDEX_TYPE.key) return INDEX_TYPE;
+            else if (key == INDEX_RULE.key) return INDEX_RULE;
+            else if (key == INDEX_ATTRIBUTE.key) return INDEX_ATTRIBUTE;
+            else if (key == STATISTICS_THINGS.key) return STATISTICS_THINGS;
+            else if (key == STATISTICS_COUNT_JOB.key) return STATISTICS_COUNT_JOB;
+            else if (key == STATISTICS_COUNTED.key) return STATISTICS_COUNTED;
+            else if (key == STATISTICS_SNAPSHOT.key) return STATISTICS_SNAPSHOT;
+            else if (key == VERTEX_THING_TYPE.key) return VERTEX_THING_TYPE;
+            else if (key == VERTEX_ENTITY_TYPE.key) return VERTEX_ENTITY_TYPE;
+            else if (key == VERTEX_ATTRIBUTE_TYPE.key) return VERTEX_ATTRIBUTE_TYPE;
+            else if (key == VERTEX_RELATION_TYPE.key) return VERTEX_RELATION_TYPE;
+            else if (key == VERTEX_ROLE_TYPE.key) return VERTEX_ROLE_TYPE;
+            else if (key == VERTEX_ENTITY.key) return VERTEX_ENTITY;
+            else if (key == VERTEX_ATTRIBUTE.key) return VERTEX_ATTRIBUTE;
+            else if (key == VERTEX_RELATION.key) return VERTEX_RELATION;
+            else if (key == VERTEX_ROLE.key) return VERTEX_ROLE;
+            else if (key == STRUCTURE_RULE.key) return STRUCTURE_RULE;
+            else throw GraknException.of(UNRECOGNISED_VALUE);
         }
 
         public byte key() {
@@ -266,10 +280,35 @@ public class Encoding {
         }
 
         public static Infix of(byte key) {
-            for (Infix i : Infix.values()) {
-                if (i.key == key) return i;
-            }
-            throw GraknException.of(UNRECOGNISED_VALUE);
+            if (key == PROPERTY_LABEL.key) return PROPERTY_LABEL;
+            else if (key == PROPERTY_SCOPE.key) return PROPERTY_SCOPE;
+            else if (key == PROPERTY_ABSTRACT.key) return PROPERTY_ABSTRACT;
+            else if (key == PROPERTY_VALUE_TYPE.key) return PROPERTY_VALUE_TYPE;
+            else if (key == PROPERTY_REGEX.key) return PROPERTY_REGEX;
+            else if (key == PROPERTY_WHEN.key) return PROPERTY_WHEN;
+            else if (key == PROPERTY_THEN.key) return PROPERTY_THEN;
+            else if (key == PROPERTY_VALUE.key) return PROPERTY_VALUE;
+            else if (key == PROPERTY_VALUE_REF.key) return PROPERTY_VALUE_REF;
+            else if (key == EDGE_ISA_IN.key) return EDGE_ISA_IN; // EDGE_ISA_OUT does not exist by design
+            else if (key == EDGE_SUB_OUT.key) return EDGE_SUB_OUT;
+            else if (key == EDGE_SUB_IN.key) return EDGE_SUB_IN;
+            else if (key == EDGE_OWNS_OUT.key) return EDGE_OWNS_OUT;
+            else if (key == EDGE_OWNS_IN.key) return EDGE_OWNS_IN;
+            else if (key == EDGE_OWNS_KEY_OUT.key) return EDGE_OWNS_KEY_OUT;
+            else if (key == EDGE_OWNS_KEY_IN.key) return EDGE_OWNS_KEY_IN;
+            else if (key == EDGE_PLAYS_OUT.key) return EDGE_PLAYS_OUT;
+            else if (key == EDGE_PLAYS_IN.key) return EDGE_PLAYS_IN;
+            else if (key == EDGE_RELATES_OUT.key) return EDGE_RELATES_OUT;
+            else if (key == EDGE_RELATES_IN.key) return EDGE_RELATES_IN;
+            else if (key == EDGE_HAS_OUT.key) return EDGE_HAS_OUT;
+            else if (key == EDGE_HAS_IN.key) return EDGE_HAS_IN;
+            else if (key == EDGE_PLAYING_OUT.key) return EDGE_PLAYING_OUT;
+            else if (key == EDGE_PLAYING_IN.key) return EDGE_PLAYING_IN;
+            else if (key == EDGE_RELATING_OUT.key) return EDGE_RELATING_OUT;
+            else if (key == EDGE_RELATING_IN.key) return EDGE_RELATING_IN;
+            else if (key == EDGE_ROLEPLAYER_OUT.key) return EDGE_ROLEPLAYER_OUT;
+            else if (key == EDGE_ROLEPLAYER_IN.key) return EDGE_ROLEPLAYER_IN;
+            else throw GraknException.of(UNRECOGNISED_VALUE);
         }
 
         public byte key() {
@@ -361,24 +400,33 @@ public class Encoding {
         }
 
         public static ValueType of(byte value) {
-            for (ValueType vt : ValueType.values()) {
-                if (vt.key == value) return vt;
-            }
-            throw GraknException.of(UNRECOGNISED_VALUE);
+            if (value == OBJECT.key) return OBJECT;
+            else if (value == BOOLEAN.key) return BOOLEAN;
+            else if (value == LONG.key) return LONG;
+            else if (value == DOUBLE.key) return DOUBLE;
+            else if (value == STRING.key) return STRING;
+            else if (value == DATETIME.key) return DATETIME;
+            else throw GraknException.of(UNRECOGNISED_VALUE);
         }
 
         public static ValueType of(Class<?> valueClass) {
-            for (ValueType vt : ValueType.values()) {
-                if (vt.valueClass == valueClass) return vt;
-            }
-            throw GraknException.of(UNRECOGNISED_VALUE);
+            if (valueClass == OBJECT.valueClass) return OBJECT;
+            else if (valueClass == BOOLEAN.valueClass) return BOOLEAN;
+            else if (valueClass == LONG.valueClass) return LONG;
+            else if (valueClass == DOUBLE.valueClass) return DOUBLE;
+            else if (valueClass == STRING.valueClass) return STRING;
+            else if (valueClass == DATETIME.valueClass) return DATETIME;
+            else throw GraknException.of(UNRECOGNISED_VALUE);
         }
 
         public static ValueType of(GraqlArg.ValueType graqlValueType) {
-            for (ValueType vt : ValueType.values()) {
-                if (vt.graqlValueType == graqlValueType) return vt;
-            }
-            throw GraknException.of(UNRECOGNISED_VALUE);
+            if (graqlValueType == OBJECT.graqlValueType) return OBJECT;
+            else if (graqlValueType == BOOLEAN.graqlValueType) return BOOLEAN;
+            else if (graqlValueType == LONG.graqlValueType) return LONG;
+            else if (graqlValueType == DOUBLE.graqlValueType) return DOUBLE;
+            else if (graqlValueType == STRING.graqlValueType) return STRING;
+            else if (graqlValueType == DATETIME.graqlValueType) return DATETIME;
+            else throw GraknException.of(UNRECOGNISED_VALUE);
         }
 
         public byte[] bytes() {
@@ -459,17 +507,21 @@ public class Encoding {
             }
 
             public static Type of(byte prefix) {
-                for (Type t : Type.values()) {
-                    if (t.prefix.key == prefix) return t;
-                }
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                if (prefix == THING_TYPE.prefix.key) return THING_TYPE;
+                else if (prefix == ENTITY_TYPE.prefix.key) return ENTITY_TYPE;
+                else if (prefix == ATTRIBUTE_TYPE.prefix.key) return ATTRIBUTE_TYPE;
+                else if (prefix == RELATION_TYPE.prefix.key) return RELATION_TYPE;
+                else if (prefix == ROLE_TYPE.prefix.key) return ROLE_TYPE;
+                else throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
             public static Type of(Thing thing) {
-                for (Type t : Type.values()) {
-                    if (Objects.equals(t.instance, thing)) return t;
-                }
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                if (Objects.equals(thing, THING_TYPE.instance)) return THING_TYPE;
+                else if (Objects.equals(thing, ENTITY_TYPE.instance)) return ENTITY_TYPE;
+                else if (Objects.equals(thing, ATTRIBUTE_TYPE.instance)) return ATTRIBUTE_TYPE;
+                else if (Objects.equals(thing, RELATION_TYPE.instance)) return RELATION_TYPE;
+                else if (Objects.equals(thing, ROLE_TYPE.instance)) return ROLE_TYPE;
+                else throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
             /**
@@ -543,9 +595,10 @@ public class Encoding {
             }
 
             public static Thing of(byte prefix) {
-                for (Thing t : Thing.values()) {
-                    if (t.prefix.key == prefix) return t;
-                }
+                if (prefix == ENTITY.prefix.key) return ENTITY;
+                else if (prefix == ATTRIBUTE.prefix.key) return ATTRIBUTE;
+                else if (prefix == RELATION.prefix.key) return RELATION;
+                else if (prefix == ROLE.prefix.key) return ROLE;
                 throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
@@ -628,12 +681,12 @@ public class Encoding {
             }
 
             public static Type of(byte infix) {
-                for (Type t : Type.values()) {
-                    if (t.out.key == infix || t.in.key == infix) {
-                        return t;
-                    }
-                }
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                if (infix == SUB.in.key || infix == SUB.out.key) return SUB;
+                else if (infix == OWNS.in.key || infix == OWNS.out.key) return OWNS;
+                else if (infix == OWNS_KEY.in.key || infix == OWNS_KEY.out.key) return OWNS_KEY;
+                else if (infix == PLAYS.in.key || infix == PLAYS.out.key) return PLAYS;
+                else if (infix == RELATES.in.key || infix == RELATES.out.key) return RELATES;
+                else throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
             @Override
@@ -686,12 +739,11 @@ public class Encoding {
             }
 
             public static Thing of(byte infix) {
-                for (Thing t : Thing.values()) {
-                    if ((t.out != null && t.out.key == infix) || (t.in != null && t.in.key == infix)) {
-                        return t;
-                    }
-                }
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                if ((HAS.out != null && HAS.out.key == infix) || (HAS.in != null && HAS.in.key == infix)) return HAS;
+                else if ((PLAYING.out != null && PLAYING.out.key == infix) || (PLAYING.in != null && PLAYING.in.key == infix)) return PLAYING;
+                else if ((RELATING.out != null && RELATING.out.key == infix) || (RELATING.in != null && RELATING.in.key == infix)) return RELATING;
+                else if ((ROLEPLAYER.out != null && ROLEPLAYER.out.key == infix) || (ROLEPLAYER.in != null && ROLEPLAYER.in.key == infix)) return ROLEPLAYER;
+                else throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
             @Override
@@ -767,12 +819,10 @@ public class Encoding {
             }
 
             public static Infix of(byte[] key) {
-                if (key.length == 1) {
-                    for (Infix i : Infix.values()) {
-                        if (i.key == key[0]) return i;
-                    }
-                }
-                throw GraknException.of(UNRECOGNISED_VALUE);
+                if (key[0] == CONTAINED_TYPE.key) return CONTAINED_TYPE;
+                else if (key[0] == CONCLUDED_VERTEX.key) return CONCLUDED_VERTEX;
+                else if (key[0] == CONCLUDED_EDGE_TO.key) return CONCLUDED_EDGE_TO;
+                else throw GraknException.of(UNRECOGNISED_VALUE);
             }
 
             public byte[] bytes() { return bytes; }
@@ -798,9 +848,9 @@ public class Encoding {
 
             public static JobType of(byte[] key) {
                 if (key.length == 1) {
-                    for (JobType i : JobType.values()) {
-                        if (i.key == key[0]) return i;
-                    }
+                    if (key[0] == ATTRIBUTE_VERTEX.key) return ATTRIBUTE_VERTEX;
+                    else if (key[0] == HAS_EDGE.key) return HAS_EDGE;
+                    else throw GraknException.of(UNRECOGNISED_VALUE);
                 }
                 throw GraknException.of(UNRECOGNISED_VALUE);
             }
@@ -831,9 +881,9 @@ public class Encoding {
 
             public static JobOperation of(byte[] key) {
                 if (key.length == 1) {
-                    for (JobOperation i : JobOperation.values()) {
-                        if (i.key == key[0]) return i;
-                    }
+                    if (key[0] == CREATED.key) return CREATED;
+                    else if (key[0] == DELETED.key) return DELETED;
+                    else throw GraknException.of(UNRECOGNISED_VALUE);
                 }
                 throw GraknException.of(UNRECOGNISED_VALUE);
             }

--- a/graph/common/Encoding.java
+++ b/graph/common/Encoding.java
@@ -28,6 +28,9 @@ import javax.annotation.Nullable;
 import java.nio.charset.Charset;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -167,7 +170,7 @@ public class Encoding {
         VERTEX_ROLE(180, PrefixType.THING),
         STRUCTURE_RULE(190, PrefixType.RULE);
 
-        private static Prefix[] keyIndex = indexedBytes(
+        private static List<Prefix> keyIndex = indexedBytes(
                 pair(INDEX_TYPE.key, INDEX_TYPE),
                 pair(INDEX_RULE.key, INDEX_RULE),
                 pair(INDEX_ATTRIBUTE.key, INDEX_ATTRIBUTE),
@@ -199,7 +202,7 @@ public class Encoding {
         }
 
         public static Prefix of(byte key) {
-            Prefix prefix = keyIndex[key];
+            Prefix prefix = keyIndex.get(key + 128);
             if (prefix == null) throw GraknException.of(UNRECOGNISED_VALUE);
             else return prefix;
         }
@@ -272,7 +275,7 @@ public class Encoding {
         EDGE_ROLEPLAYER_OUT(73, true),
         EDGE_ROLEPLAYER_IN(-73, true);
 
-        private static Infix[] keyIndex = indexedBytes(
+        private static List<Infix> keyIndex = indexedBytes(
                 pair(PROPERTY_LABEL.key, PROPERTY_LABEL),
                 pair(PROPERTY_SCOPE.key, PROPERTY_SCOPE),
                 pair(PROPERTY_ABSTRACT.key, PROPERTY_ABSTRACT),
@@ -318,7 +321,7 @@ public class Encoding {
         }
 
         public static Infix of(byte key) {
-            Infix infix = keyIndex[key];
+            Infix infix = keyIndex.get(key); // already unsigned??
             if (infix == null) throw GraknException.of(UNRECOGNISED_VALUE);
             else return infix;
         }
@@ -376,7 +379,7 @@ public class Encoding {
         public static final int STRING_MAX_SIZE = Bytes.SHORT_UNSIGNED_MAX_VALUE;
         public static final double DOUBLE_PRECISION = 0.0000000000000001;
 
-        private static ValueType[] keyIndex = indexedBytes(
+        private static List<ValueType> keyIndex = indexedBytes(
                 pair(OBJECT.key, OBJECT),
                 pair(BOOLEAN.key, BOOLEAN),
                 pair(LONG.key, LONG),
@@ -421,7 +424,7 @@ public class Encoding {
         }
 
         public static ValueType of(byte value) {
-            ValueType valueType = keyIndex[value];
+            ValueType valueType = keyIndex.get(value + 128);
             if (valueType == null) throw GraknException.of(UNRECOGNISED_VALUE);
             else return valueType;
         }
@@ -513,7 +516,7 @@ public class Encoding {
             RELATION_TYPE(Prefix.VERTEX_RELATION_TYPE, Root.RELATION, Thing.RELATION),
             ROLE_TYPE(Prefix.VERTEX_ROLE_TYPE, Root.ROLE, Thing.ROLE);
 
-            private static Type[] prefixIndex = indexedBytes(
+            private static List<Type> prefixIndex = indexedBytes(
                     pair(THING_TYPE.prefix.key, THING_TYPE),
                     pair(ENTITY_TYPE.prefix.key, ENTITY_TYPE),
                     pair(ATTRIBUTE_TYPE.prefix.key, ATTRIBUTE_TYPE),
@@ -532,7 +535,7 @@ public class Encoding {
             }
 
             public static Type of(byte prefix) {
-                Type type = prefixIndex[prefix];
+                Type type = prefixIndex.get(prefix + 128);
                 if (type == null) throw GraknException.of(UNRECOGNISED_VALUE);
                 else return type;
             }
@@ -610,7 +613,7 @@ public class Encoding {
             RELATION(Prefix.VERTEX_RELATION),
             ROLE(Prefix.VERTEX_ROLE);
 
-            private static Thing[] prefixIndex = indexedBytes(
+            private static List<Thing> prefixIndex = indexedBytes(
                     pair(ENTITY.prefix.key, ENTITY),
                     pair(ATTRIBUTE.prefix.key, ATTRIBUTE),
                     pair(RELATION.prefix.key, RELATION),
@@ -624,7 +627,7 @@ public class Encoding {
             }
 
             public static Thing of(byte prefix) {
-                Thing thing = prefixIndex[prefix];
+                Thing thing = prefixIndex.get(prefix + 128);
                 if (thing == null) throw GraknException.of(UNRECOGNISED_VALUE);
                 else return thing;
             }
@@ -634,7 +637,6 @@ public class Encoding {
                 return prefix;
             }
         }
-
     }
 
     public interface Edge {
@@ -957,11 +959,12 @@ public class Encoding {
         }
     }
 
-    private static <T> T[] indexedBytes(Pair<Byte, T>... byteIndices) {
-        Object[] array = new Object[255];
+    private static <T> List<T> indexedBytes(Pair<Byte, T>... byteIndices) {
+        List<T> indexList = new ArrayList<>(Collections.nCopies(255, (T) null));
         for (Pair<Byte, T> index : byteIndices) {
-            array[index.first()] = index.second();
+            indexList.set(index.first() + 128, index.second());
         }
-        return (T[]) array;
+        return indexList;
     }
+
 }


### PR DESCRIPTION
## What is the goal of this PR?
Calling `Enum.values()` allocates a new byte array for each call. This leads to high memory overheads when converting bytes to our `Encoding` objects. To mitigate this, we create static indexing lists based on the byte value of a key, where possible, and elsewhere fall back to if-elseif blocks.

## What are the changes implemented in this PR?
* create static indexing list to look up bytes by index of their values where possible
* replace some calls in `Encoding` to `Enum.values()` with hard-coded if-else blocks when more sophisticated checks are required