### PR TITLE
Fix APT distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -150,7 +150,7 @@ assemble_apt(
     depends = [
         "openjdk-11-jre",
         "grakn-core-server (=%{version})",
-        "grakn-console (=%{:console-artifact-jars})",
+        "grakn-console (=%{@graknlabs_console_artifact_linux})",
     ],
     workspace_refs = "@graknlabs_grakn_core_workspace_refs//:refs.json",
 )


### PR DESCRIPTION
## What is the goal of this PR?

Fix `grakn-core-all` APT package by providing correct version of `grakn-console` dependency

## What are the changes implemented in this PR?

Use `@graknlabs_console_artifact_linux` key from `workspace_refs.json` to get `grakn-console` version