### PR TITLE
Prevent open iterators from crashing RocksDB when tx closes

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -115,9 +115,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: graknlabs-ubuntu-20.04
-#      filter:
-#        owner: graknlabs
-#        branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       # dependencies: [test-assembly-linux-targz] TODO: re-enable
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -115,9 +115,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: graknlabs-ubuntu-20.04
-      filter:
-        owner: graknlabs
-        branch: master
+#      filter:
+#        owner: graknlabs
+#        branch: master
       # dependencies: [test-assembly-linux-targz] TODO: re-enable
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -31,7 +31,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = false;
+    public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;
     public static final boolean DEFAULT_QUERY_READ_PREFETCH = true;

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -69,6 +69,12 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
         // additionally, it can cause deadlock within ResolverRegistry as different threads initialise actors
     }
 
+    @Override
+    protected void exception(Throwable e) {
+        LOG.error("Actor exception: {}", e.getMessage());
+        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
+    }
+
     public String name() {
         return name;
     }

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -178,12 +178,6 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         return responseProducerNewIter;
     }
 
-    @Override
-    protected void exception(Throwable e) {
-        LOG.error("Actor exception", e);
-        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-    }
-
     private void tryAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration) {
         if (responseProducer.hasUpstreamAnswer()) {
             Partial<?> upstreamAnswer = responseProducer.upstreamAnswers().next();

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -209,12 +209,6 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         return name() + ": then " + conclusion.rule().then();
     }
 
-    @Override
-    protected void exception(Throwable e) {
-        LOG.error("Actor exception", e);
-        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-    }
-
     private static class ConclusionResponses {
 
         private final List<ResourceIterator<AnswerState.Partial<?>>> materialisedAnswers;

--- a/reasoner/resolution/resolver/ConditionResolver.java
+++ b/reasoner/resolution/resolver/ConditionResolver.java
@@ -72,9 +72,4 @@ public class ConditionResolver extends ConjunctionResolver<ConditionResolver> {
         return name() + ": " + rule.when();
     }
 
-    @Override
-    protected void exception(Throwable e) {
-        LOG.error("Actor exception", e);
-        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-    }
 }

--- a/reasoner/resolution/resolver/ConjunctionResolver.java
+++ b/reasoner/resolution/resolver/ConjunctionResolver.java
@@ -293,10 +293,5 @@ public abstract class ConjunctionResolver<T extends ConjunctionResolver<T>> exte
             return Optional.of(fromDownstream.asFiltered().toUpstream(self()));
         }
 
-        @Override
-        protected void exception(Throwable e) {
-            LOG.error("Actor exception", e);
-            // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-        }
     }
 }

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -170,12 +170,6 @@ public class NegationResolver extends Resolver<NegationResolver> {
         throw GraknException.of(ILLEGAL_STATE);
     }
 
-    @Override
-    protected void exception(Throwable e) {
-        LOG.error("Actor exception", e);
-        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-    }
-
     private static class NegationResponse {
 
         List<Awaiting> awaiting;

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -173,11 +173,6 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         failToUpstream(fromUpstreamSource, responses.iteration);
     }
 
-    @Override
-    protected void exception(Throwable e) {
-        LOG.error("Actor exception", e);
-    }
-
     private class Responses {
 
         private final int iteration;

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -158,12 +158,6 @@ public interface Root {
             this.skipped++;
         }
 
-        @Override
-        protected void exception(Throwable e) {
-            LOG.error("Actor exception", e);
-            // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-        }
-
     }
 
     class Disjunction extends Resolver<Disjunction> implements Root {
@@ -327,12 +321,6 @@ public interface Root {
                 responseProducer.addDownstreamProducer(request);
             }
             return responseProducerNewIter;
-        }
-
-        @Override
-        protected void exception(Throwable e) {
-            LOG.error("Actor exception", e);
-            // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
         }
 
     }

--- a/rocks/RocksIterator.java
+++ b/rocks/RocksIterator.java
@@ -47,7 +47,6 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
         if (state != State.COMPLETED) {
             this.internalRocksIterator = storage.getInternalRocksIterator();
             this.internalRocksIterator.seek(prefix);
-            if (!internalRocksIterator.isValid()) System.out.println("INVALID ITERATOR");
             state = State.EMPTY;
             byte[] key;
             if (!internalRocksIterator.isValid() || !bytesHavePrefix(key = internalRocksIterator.key(), prefix)) {
@@ -62,7 +61,7 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
         }
     }
 
-    public synchronized final T peek() {
+    public final T peek() {
         if (!hasNext()) throw new NoSuchElementException();
         return next;
     }
@@ -75,7 +74,7 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
     }
 
     @Override
-    public synchronized final boolean hasNext() {
+    public final boolean hasNext() {
         switch (state) {
             case COMPLETED:
                 return false;

--- a/rocks/RocksIterator.java
+++ b/rocks/RocksIterator.java
@@ -65,18 +65,18 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
             case EMPTY:
                 return fetchAndCheck();
             case INIT:
-                return initialiseAndFetch();
+                return initialiseAndCheck();
             default: // This should never be reached
                 return false;
         }
     }
 
-    private synchronized boolean initialiseAndFetch() {
+    private synchronized boolean initialiseAndCheck() {
         if (state != State.COMPLETED) {
             this.internalRocksIterator = storage.getInternalRocksIterator();
             this.internalRocksIterator.seek(prefix);
             state = State.EMPTY;
-            return mayConstructNext();
+            return hasValidNext();
         } else {
             return false;
         }
@@ -85,13 +85,13 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
     private synchronized boolean fetchAndCheck() {
         if (state != State.COMPLETED) {
             internalRocksIterator.next();
-            return mayConstructNext();
+            return hasValidNext();
         } else {
             return false;
         }
     }
 
-    private synchronized boolean mayConstructNext() {
+    private synchronized boolean hasValidNext() {
         byte[] key;
         if (!internalRocksIterator.isValid() || !bytesHavePrefix(key = internalRocksIterator.key(), prefix)) {
             recycle();

--- a/rocks/RocksIterator.java
+++ b/rocks/RocksIterator.java
@@ -21,7 +21,6 @@ package grakn.core.rocks;
 import grakn.core.common.iterator.AbstractResourceIterator;
 
 import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
 import static grakn.core.common.collection.Bytes.bytesHavePrefix;
@@ -30,7 +29,6 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
 
     private final byte[] prefix;
     private final RocksStorage storage;
-    private final AtomicBoolean isOpen;
     private final BiFunction<byte[], byte[], T> constructor;
     private org.rocksdb.RocksIterator internalRocksIterator;
     private State state;
@@ -42,43 +40,42 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
         this.storage = storage;
         this.prefix = prefix;
         this.constructor = constructor;
-
-        isOpen = new AtomicBoolean(true);
         state = State.INIT;
     }
 
-    private void initalise() {
-        this.internalRocksIterator = storage.getInternalRocksIterator();
-        this.internalRocksIterator.seek(prefix);
-    }
-
-    private boolean fetchAndCheck() {
-        byte[] key;
-        if (!internalRocksIterator.isValid() || !bytesHavePrefix(key = internalRocksIterator.key(), prefix)) {
-            state = State.COMPLETED;
-            recycle();
-            return false;
-        }
-
-        next = constructor.apply(key, internalRocksIterator.value());
-        synchronized (this) {
-            if (state != State.COMPLETED) {
-                internalRocksIterator.next();
-                state = State.FETCHED;
-                return true;
-            } else{
+    private synchronized boolean initialise() {
+        if (state != State.COMPLETED) {
+            this.internalRocksIterator = storage.getInternalRocksIterator();
+            this.internalRocksIterator.seek(prefix);
+            if (!internalRocksIterator.isValid()) System.out.println("INVALID ITERATOR");
+            state = State.EMPTY;
+            byte[] key;
+            if (!internalRocksIterator.isValid() || !bytesHavePrefix(key = internalRocksIterator.key(), prefix)) {
+                recycle();
                 return false;
             }
+            next = constructor.apply(key, internalRocksIterator.value());
+            state = State.FETCHED;
+            return true;
+        } else {
+            return false;
         }
     }
 
-    public final T peek() {
+    public synchronized final T peek() {
         if (!hasNext()) throw new NoSuchElementException();
         return next;
     }
 
     @Override
-    public final boolean hasNext() {
+    public synchronized final T next() {
+        if (!hasNext()) throw new NoSuchElementException();
+        state = State.EMPTY;
+        return next;
+    }
+
+    @Override
+    public synchronized final boolean hasNext() {
         switch (state) {
             case COMPLETED:
                 return false;
@@ -87,18 +84,26 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
             case EMPTY:
                 return fetchAndCheck();
             case INIT:
-                initalise();
-                return fetchAndCheck();
+                return initialise();
             default: // This should never be reached
                 return false;
         }
     }
 
-    @Override
-    public final T next() {
-        if (!hasNext()) throw new NoSuchElementException();
-        state = State.EMPTY;
-        return next;
+    private synchronized boolean fetchAndCheck() {
+        if (state != State.COMPLETED) {
+            internalRocksIterator.next();
+            byte[] key;
+            if (!internalRocksIterator.isValid() || !bytesHavePrefix(key = internalRocksIterator.key(), prefix)) {
+                recycle();
+                return false;
+            }
+            next = constructor.apply(key, internalRocksIterator.value());
+            state = State.FETCHED;
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override
@@ -107,13 +112,11 @@ public final class RocksIterator<T> extends AbstractResourceIterator<T> implemen
     }
 
     @Override
-    public void close() {
-        if (isOpen.compareAndSet(true, false)) {
-            synchronized (this) {
-                if (state != State.INIT) storage.recycle(internalRocksIterator);
-                state = State.COMPLETED;
-                storage.remove(this);
-            }
+    public synchronized void close() {
+        if (state != State.COMPLETED) {
+            if (state != State.INIT) storage.recycle(internalRocksIterator);
+            state = State.COMPLETED;
+            storage.remove(this);
         }
     }
 }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -249,6 +249,7 @@ public abstract class RocksStorage implements Storage {
             if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
             RocksIterator<G> iterator = new RocksIterator<>(this, key, constructor);
             iterators.add(iterator);
+            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED); //guard against close() race conditions
             return iterator;
         }
 

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -102,8 +102,8 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             }
             return state == State.FETCHED;
         } catch (Throwable e) {
-            LOG.error("Parameters: " + params.toString());
-            LOG.error("GraphProcedure: " + procedure.toString());
+//            LOG.error("Parameters: " + params.toString());
+//            LOG.error("GraphProcedure: " + procedure.toString());
             throw e;
         }
     }

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -102,14 +102,15 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
                 throw GraknException.of(ILLEGAL_STATE);
             }
             return state == State.FETCHED;
-        } catch (GraknException e) { // note: catching runtime exception
-            if (e.code().isPresent() && e.code().get().equals(TRANSACTION_CLOSED.code())) {
-                LOG.debug("Transaction was closed during graph iteration");
-            }
-            throw e;
         } catch (Throwable e) {
-            LOG.error("Parameters: " + params.toString());
-            LOG.error("GraphProcedure: " + procedure.toString());
+            // note: catching runtime exception until we can gracefully interrupt running queries on tx close
+            if (e instanceof GraknException && ((GraknException) e).code().isPresent()
+                    && ((GraknException) e).code().get().equals(TRANSACTION_CLOSED.code())) {
+                LOG.debug("Transaction was closed during graph iteration");
+            } else {
+                LOG.error("Parameters: " + params.toString());
+                LOG.error("GraphProcedure: " + procedure.toString());
+            }
             throw e;
         }
     }

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
 public class GraphIterator extends AbstractResourceIterator<VertexMap> {
@@ -101,9 +102,14 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
                 throw GraknException.of(ILLEGAL_STATE);
             }
             return state == State.FETCHED;
+        } catch (GraknException e) { // note: catching runtime exception
+            if (e.code().isPresent() && e.code().get().equals(TRANSACTION_CLOSED.code())) {
+                LOG.debug("Transaction was closed during graph iteration");
+            }
+            throw e;
         } catch (Throwable e) {
-//            LOG.error("Parameters: " + params.toString());
-//            LOG.error("GraphProcedure: " + procedure.toString());
+            LOG.error("Parameters: " + params.toString());
+            LOG.error("GraphProcedure: " + procedure.toString());
             throw e;
         }
     }


### PR DESCRIPTION
## What is the goal of this PR?

It's currently possible to crash RocksDB by closing open iterators that a class is currently using. Guarding against this requires synchronisation between state changes in `RocksIterator`, and guarding between closing storage and opening new iterators in RocksStorage.

## What are the changes implemented in this PR?
* Guard state changes in RocksIterator with `synchronized` and remove need for `isOpen` atomic boolean
* Re-check that the storage is still open after obtaining an iterator, throwing an exception if not open anymore. This method means we don't need to use `synchronized` for this guard, which would be very expensive and contended.
* Lazily compute the next answer in `RocksIterator`, instead of right after consuming the last answer
* Because a transaction closing while iteration is till occuring is very common, we add a special case for the error logging in `GraphIterator` when it gets a `TRANSACTION_CLOSED` exception