### PR TITLE
Include console jars in assembled distribution

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -70,14 +70,9 @@ artifact_repackage(
     files_to_keep = ["console"],
 )
 
-assemble_deps_common = [
-    "//server:server-deps-prod",
-    ":console-artifact-jars",
-]
-
 assemble_targz(
     name = "assemble-linux-targz",
-    targets = assemble_deps_common + ["//server:server-deps-linux", "@graknlabs_common//binary:assemble-bash-targz"],
+    targets = ["//server:server-deps-linux", ":console-artifact-jars", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-linux",
@@ -85,7 +80,7 @@ assemble_targz(
 
 assemble_zip(
     name = "assemble-mac-zip",
-    targets = assemble_deps_common + ["//server:server-deps-mac", "@graknlabs_common//binary:assemble-bash-targz"],
+    targets = ["//server:server-deps-mac", "//server:server-deps-prod", ":console-artifact-jars", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-mac",
@@ -93,7 +88,7 @@ assemble_zip(
 
 assemble_zip(
     name = "assemble-windows-zip",
-    targets = assemble_deps_common + ["//server:server-deps-windows", "@graknlabs_common//binary:assemble-bat-targz"],
+    targets = ["//server:server-deps-windows", ":console-artifact-jars", "@graknlabs_common//binary:assemble-bat-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-windows",

--- a/BUILD
+++ b/BUILD
@@ -77,7 +77,7 @@ assemble_deps_common = [
 
 assemble_targz(
     name = "assemble-linux-targz",
-    targets = ["//server:server-deps-linux", "@graknlabs_common//binary:assemble-bash-targz"],
+    targets = assemble_deps_common + ["//server:server-deps-linux", "@graknlabs_common//binary:assemble-bash-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-linux",
@@ -93,7 +93,7 @@ assemble_zip(
 
 assemble_zip(
     name = "assemble-windows-zip",
-    targets = ["//server:server-deps-windows", "@graknlabs_common//binary:assemble-bat-targz"],
+    targets = assemble_deps_common + ["//server:server-deps-windows", "@graknlabs_common//binary:assemble-bat-targz"],
     additional_files = assemble_files,
     permissions = permissions,
     output_filename = "grakn-core-all-windows",


### PR DESCRIPTION
## What is the goal of this PR?

Fix the assembly distribution that causes assembled distribution doesn't have console in it.

## What are the changes implemented in this PR?

- Include console jars that were mistakenly removed by  https://github.com/graknlabs/grakn/commit/468d57a2ed141f64f491e6547bd7472966cfe5b9