### PR TITLE
Reasoner handles nested disjunctions inside negations

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -514,6 +514,8 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Reasoner(4, "Attempted to get the resolution tracer before it has been initialised.");
         public static final Reasoner REASONER_TRACING_CALL_TO_FINISH_BEFORE_START =
                 new Reasoner(5, "Reasoner tracing has been instructed to finish without being started. Start the tracer before any resolution takes place.");
+        public static final Reasoner REASONER_TRACING_CALL_TO_WRITE_BEFORE_START =
+                new Reasoner(6, "Reasoner tracing has been instructed to write without being started. Start the tracer before any resolution takes place.");
 
         private static final String codePrefix = "RSN";
         private static final String messagePrefix = "Reasoner Error";

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -191,13 +191,16 @@ public class Conjunction implements Pattern, Cloneable {
 
     @Override
     public String toString() {
+        String negationsToString = negations.isEmpty() ? "" : negations.stream().map(Object::toString).collect(
+                Collectors.joining("" + SEMICOLON + SPACE, "", "" + SEMICOLON + SPACE));
         return variableSet.stream()
                 .map(variable -> variable.constraints().stream().map(Object::toString)
                         .collect(Collectors.joining("" + SEMICOLON + SPACE)))
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.joining("; " + NEW_LINE,
-                         "" + CURLY_OPEN + SPACE,
-                         "" + SEMICOLON + SPACE + CURLY_CLOSE));
+                                            "" + CURLY_OPEN + SPACE,
+                                            "" + SEMICOLON + SPACE + negationsToString + CURLY_CLOSE));
+
     }
 
     @Override

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -34,6 +34,7 @@ import grakn.core.reasoner.resolution.answer.AnswerState.Top;
 import grakn.core.reasoner.resolution.framework.Resolver;
 import grakn.core.reasoner.resolution.resolver.ConcludableResolver;
 import grakn.core.reasoner.resolution.resolver.ConjunctionResolver;
+import grakn.core.reasoner.resolution.resolver.DisjunctionResolver;
 import grakn.core.reasoner.resolution.resolver.NegationResolver;
 import grakn.core.reasoner.resolution.resolver.RetrievableResolver;
 import grakn.core.reasoner.resolution.resolver.Root;
@@ -163,6 +164,14 @@ public class ResolverRegistry {
                 elg, self -> new ConjunctionResolver.Nested(
                         self, conjunction, resolutionRecorder, this, traversalEngine, conceptMgr, logicMgr, planner,
                         resolutionTracing)
+        );
+    }
+
+    public Actor<DisjunctionResolver.Nested> nested(Disjunction disjunction) {
+        LOG.debug("Creating Disjunction resolver for : {}", disjunction);
+        return Actor.create(
+                elg, self -> new DisjunctionResolver.Nested(
+                        self, disjunction, resolutionRecorder, this, traversalEngine, conceptMgr, resolutionTracing)
         );
     }
 

--- a/reasoner/resolution/framework/ResolutionTracer.java
+++ b/reasoner/resolution/framework/ResolutionTracer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Reasoner.REASONER_TRACING_CALL_TO_FINISH_BEFORE_START;
+import static grakn.core.common.exception.ErrorMessage.Reasoner.REASONER_TRACING_CALL_TO_WRITE_BEFORE_START;
 import static grakn.core.common.exception.ErrorMessage.Reasoner.REASONER_TRACING_HAS_NOT_BEEN_INITIALISED;
 
 public final class ResolutionTracer {
@@ -115,10 +116,10 @@ public final class ResolutionTracer {
 
     private void startFile() {
         write(String.format(
-                "digraph %s {\n" +
+                "digraph request_%d {\n" +
                         "node [fontsize=12 fontname=arial width=0.5 shape=box style=filled]\n" +
                         "edge [fontsize=10 fontname=arial width=0.5]",
-                filename()));
+                rootRequestNumber));
     }
 
     private String filename() {
@@ -130,7 +131,7 @@ public final class ResolutionTracer {
     }
 
     private void write(String toWrite) {
-        assert writer != null;
+        if (writer == null) throw GraknException.of(REASONER_TRACING_CALL_TO_WRITE_BEFORE_START);
         writer.println(toWrite);
     }
 

--- a/reasoner/resolution/resolver/DisjunctionResolver.java
+++ b/reasoner/resolution/resolver/DisjunctionResolver.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2021 Grakn Labs
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package grakn.core.reasoner.resolution.resolver;
+
+import grakn.core.common.exception.GraknException;
+import grakn.core.common.iterator.Iterators;
+import grakn.core.concept.ConceptManager;
+import grakn.core.concept.answer.ConceptMap;
+import grakn.core.concurrent.actor.Actor;
+import grakn.core.pattern.Disjunction;
+import grakn.core.reasoner.resolution.ResolutionRecorder;
+import grakn.core.reasoner.resolution.ResolverRegistry;
+import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
+import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Filtered;
+import grakn.core.reasoner.resolution.framework.Request;
+import grakn.core.reasoner.resolution.framework.Resolver;
+import grakn.core.reasoner.resolution.framework.Response;
+import grakn.core.reasoner.resolution.framework.ResponseProducer;
+import grakn.core.traversal.TraversalEngine;
+import grakn.core.traversal.common.Identifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.iterator.Iterators.iterate;
+
+public abstract class DisjunctionResolver<T extends DisjunctionResolver<T>> extends Resolver<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Disjunction.class);
+    protected final Actor<ResolutionRecorder> resolutionRecorder;
+    protected final List<Actor<ConjunctionResolver.Nested>> downstreamResolvers;
+    private final grakn.core.pattern.Disjunction disjunction;
+    protected long skipped;
+    protected long answered;
+    protected boolean isInitialised;
+    final Map<Request, ResponseProducer> responseProducers;
+
+    public DisjunctionResolver(Actor<T> self, String name, grakn.core.pattern.Disjunction disjunction,
+                               Actor<ResolutionRecorder> resolutionRecorder, ResolverRegistry registry,
+                               TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean explanations) {
+        super(self, name, registry, traversalEngine, conceptMgr, explanations);
+        this.disjunction = disjunction;
+        this.resolutionRecorder = resolutionRecorder;
+        this.isInitialised = false;
+        this.downstreamResolvers = new ArrayList<>();
+        this.responseProducers = new HashMap<>();
+    }
+
+    protected abstract void nextAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration);
+
+    protected boolean mustOffset() { return false; }
+
+    protected void offsetOccurred() {}
+
+    @Override
+    public void receiveRequest(Request fromUpstream, int iteration) {
+        LOG.trace("{}: received Request: {}", name(), fromUpstream);
+
+        if (!isInitialised) initialiseDownstreamResolvers();
+
+        ResponseProducer responseProducer = mayUpdateAndGetResponseProducer(fromUpstream, iteration);
+        if (iteration < responseProducer.iteration()) {
+            // short circuit if the request came from a prior iteration
+            failToUpstream(fromUpstream, iteration);
+        } else {
+            assert iteration == responseProducer.iteration();
+            nextAnswer(fromUpstream, responseProducer, iteration);
+        }
+    }
+
+    @Override
+    protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
+        LOG.trace("{}: received answer: {}", name(), fromDownstream);
+
+        Request toDownstream = fromDownstream.sourceRequest();
+        Request fromUpstream = fromUpstream(toDownstream);
+        ResponseProducer responseProducer = responseProducers.get(fromUpstream);
+
+        Partial<?> answer = fromDownstream.answer();
+        ConceptMap filteredMap = answer.conceptMap();
+        if (!responseProducer.hasProduced(filteredMap)) {
+            responseProducer.recordProduced(filteredMap);
+            if (mustOffset()) {
+                offsetOccurred();
+                nextAnswer(fromUpstream, responseProducer, iteration);
+                return;
+            }
+            answerToUpstream(answer, fromUpstream, iteration);
+        } else {
+            nextAnswer(fromUpstream, responseProducer, iteration);
+        }
+    }
+
+    @Override
+    protected void receiveFail(Response.Fail fromDownstream, int iteration) {
+        LOG.trace("{}: received Exhausted, with iter {}: {}", name(), iteration, fromDownstream);
+        Request toDownstream = fromDownstream.sourceRequest();
+        Request fromUpstream = fromUpstream(toDownstream);
+        ResponseProducer responseProducer = responseProducers.get(fromUpstream);
+
+        if (iteration < responseProducer.iteration()) {
+            // short circuit old iteration failed messages back out of the actor model
+            failToUpstream(fromUpstream, iteration);
+            return;
+        }
+        responseProducer.removeDownstreamProducer(fromDownstream.sourceRequest());
+        nextAnswer(fromUpstream, responseProducer, iteration);
+    }
+
+    @Override
+    protected void initialiseDownstreamResolvers() {
+        LOG.debug("{}: initialising downstream resolvers", name());
+        for (grakn.core.pattern.Conjunction conjunction : disjunction.conjunctions()) {
+            downstreamResolvers.add(registry.nested(conjunction));
+        }
+        isInitialised = true;
+    }
+
+    private ResponseProducer mayUpdateAndGetResponseProducer(Request fromUpstream, int iteration) {
+        if (!responseProducers.containsKey(fromUpstream)) {
+            responseProducers.put(fromUpstream, responseProducerCreate(fromUpstream, iteration));
+        } else {
+            ResponseProducer responseProducer = responseProducers.get(fromUpstream);
+            assert responseProducer.iteration() == iteration ||
+                    responseProducer.iteration() + 1 == iteration;
+
+            if (responseProducer.iteration() + 1 == iteration) {
+                // when the same request for the next iteration the first time, re-initialise required state
+                ResponseProducer responseProducerNextIter = responseProducerReiterate(fromUpstream, responseProducer, iteration);
+                responseProducers.put(fromUpstream, responseProducerNextIter);
+            }
+        }
+        return responseProducers.get(fromUpstream);
+    }
+
+    @Override
+    protected ResponseProducer responseProducerCreate(Request fromUpstream, int iteration) {
+        LOG.debug("{}: Creating a new ResponseProducer for request: {}", name(), fromUpstream);
+        assert fromUpstream.partialAnswer().isFiltered() || fromUpstream.partialAnswer().isIdentity();
+        ResponseProducer responseProducer = new ResponseProducer(Iterators.empty(), iteration);
+        assert !downstreamResolvers.isEmpty();
+        for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
+            Filtered downstream = fromUpstream.partialAnswer()
+                    .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+            Request request = Request.create(self(), conjunctionResolver, downstream);
+            responseProducer.addDownstreamProducer(request);
+        }
+        return responseProducer;
+    }
+
+    @Override
+    protected ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer responseProducerPrevious,
+                                                         int newIteration) {
+        assert newIteration > responseProducerPrevious.iteration();
+        LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
+
+        assert newIteration > responseProducerPrevious.iteration();
+
+        ResponseProducer responseProducerNewIter = responseProducerNewIteration(responseProducerPrevious, newIteration);
+        for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
+            Filtered downstream = fromUpstream.partialAnswer()
+                    .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+            Request request = Request.create(self(), conjunctionResolver, downstream);
+            responseProducerNewIter.addDownstreamProducer(request);
+        }
+        return responseProducerNewIter;
+    }
+
+    abstract ResponseProducer responseProducerNewIteration(ResponseProducer responseProducerPrevious, int newIteration);
+
+    protected Set<Identifier.Variable.Retrievable> conjunctionRetrievedIds(Actor<ConjunctionResolver.Nested> conjunctionResolver) {
+        // TODO use a map from resolvable to resolvers, then we don't have to reach into the state and use the conjunction
+        return iterate(conjunctionResolver.state.conjunction.variables()).filter(v -> v.id().isRetrievable())
+                .map(v -> v.id().asRetrievable()).toSet();
+    }
+
+    public static class Nested extends DisjunctionResolver<Nested> {
+
+        public Nested(Actor<Nested> self, grakn.core.pattern.Disjunction disjunction,
+                      Actor<ResolutionRecorder> resolutionRecorder, ResolverRegistry registry,
+                      TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean explanations) {
+            super(self, Nested.class.getSimpleName() + "(pattern: " + disjunction + ")", disjunction,
+                  resolutionRecorder, registry, traversalEngine, conceptMgr, explanations);
+        }
+
+        @Override
+        protected void nextAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration) {
+            if (responseProducer.hasUpstreamAnswer()) {
+                throw GraknException.of(ILLEGAL_STATE);
+            } else {
+                if (responseProducer.hasDownstreamProducer()) {
+                    requestFromDownstream(responseProducer.nextDownstreamProducer(), fromUpstream, iteration);
+                } else {
+                    failToUpstream(fromUpstream, iteration);
+                }
+            }
+        }
+
+        @Override
+        protected ResponseProducer responseProducerNewIteration(ResponseProducer responseProducerPrevious, int newIteration) {
+            return responseProducerPrevious.newIteration(Iterators.empty(), newIteration);
+        }
+
+    }
+}

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -24,6 +24,7 @@ import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.logic.resolvable.Negated;
 import grakn.core.pattern.Conjunction;
+import grakn.core.pattern.Disjunction;
 import grakn.core.reasoner.resolution.ResolutionRecorder;
 import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
@@ -69,12 +70,11 @@ public class NegationResolver extends Resolver<NegationResolver> {
     protected void initialiseDownstreamResolvers() {
         LOG.debug("{}: initialising downstream resolvers", name());
 
-        List<Conjunction> disjunction = negated.pattern().conjunctions();
-        if (disjunction.size() == 1) {
-            downstream = registry.nested(disjunction.get(0));
+        Disjunction disjunction = negated.pattern();
+        if (disjunction.conjunctions().size() == 1) {
+            downstream = registry.nested(disjunction.conjunctions().get(0));
         } else {
-            // negations with complex disjunctions not yet working
-            throw GraknException.of(UNIMPLEMENTED);
+            downstream = registry.nested(disjunction);
         }
         isInitialised = true;
     }


### PR DESCRIPTION
## What is the goal of this PR?

We make it possible for reasoner to process disjunctions that are nested inside negations.

## What are the changes implemented in this PR?

- Create a parent class `DisjunctionResolver` from which `Nested` and `Root` disjunction resolvers inherit.
- Fix the `toString` method for conjunction to include its negations.
