### PR TITLE
Propagate resolver exceptions to query

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -87,20 +87,20 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Internal(3, "Illegal internal operation! This method should not have been called.");
         public static final Internal ILLEGAL_ARGUMENT =
                 new Internal(4, "Illegal argument provided.");
-        public static final Internal UNRECOGNISED_VALUE =
-                new Internal(5, "Unrecognised encoding value!");
-        public static final Internal DIRTY_INITIALISATION =
-                new Internal(6, "Invalid Database Initialisation.");
-        public static final Internal GRAKN_CLOSED =
-                new Internal(7, "Attempted to open a session on a closed Grakn backend.");
-        public static final Internal OUT_OF_BOUNDS =
-                new Internal(8, "Resource out of bounds.");
-        public static final Internal UNEXPECTED_INTERRUPTION =
-                new Internal(9, "Unexpected thread interruption!");
-        public static final Internal UNEXPECTED_PLANNING_ERROR =
-                new Internal(10, "Unexpected error during traversal plan optimisation.");
         public static final Internal RESOURCE_CLOSED =
-                new Internal(11, "Attempted to utilise a closed resource.");
+                new Internal(5, "Attempted to utilise a closed resource.");
+        public static final Internal UNRECOGNISED_VALUE =
+                new Internal(6, "Unrecognised encoding value!");
+        public static final Internal DIRTY_INITIALISATION =
+                new Internal(7, "Invalid Database Initialisation.");
+        public static final Internal GRAKN_CLOSED =
+                new Internal(8, "Attempted to open a session on a closed Grakn backend.");
+        public static final Internal OUT_OF_BOUNDS =
+                new Internal(9, "Resource out of bounds.");
+        public static final Internal UNEXPECTED_INTERRUPTION =
+                new Internal(10, "Unexpected thread interruption!");
+        public static final Internal UNEXPECTED_PLANNING_ERROR =
+                new Internal(11, "Unexpected error during traversal plan optimisation.");
         public static final Internal UNIMPLEMENTED =
                 new Internal(12, "This functionality is not yet implemented.");
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -99,8 +99,10 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Internal(9, "Unexpected thread interruption!");
         public static final Internal UNEXPECTED_PLANNING_ERROR =
                 new Internal(10, "Unexpected error during traversal plan optimisation.");
+        public static final Internal RESOURCE_CLOSED =
+                new Internal(11, "Attempted to utilise a closed resource.");
         public static final Internal UNIMPLEMENTED =
-                new Internal(11, "This functionality is not yet implemented.");
+                new Internal(12, "This functionality is not yet implemented.");
 
         private static final String codePrefix = "INT";
         private static final String messagePrefix = "Invalid Internal State";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -510,12 +510,14 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Reasoner(1, "Reasoning cannot be enabled/disabled per query. Try using Transaction options instead.");
         public static final Reasoner REVERSE_UNIFICATION_MISSING_CONCEPT =
                 new Reasoner(2, "Reverse unification failed because a concept for identifier '%s' was not found in the provided map '%s'.");
+        public static final Reasoner RESOLUTION_TERMINATED =
+                new Reasoner(3, "Resolution is terminated.");
         public static final Reasoner REASONER_TRACING_CANNOT_BE_TOGGLED_PER_QUERY =
-                new Reasoner(3, "Reasoner tracing cannot be enabled/disabled per query. Try using Transaction options instead.");
+                new Reasoner(4, "Reasoner tracing cannot be enabled/disabled per query. Try using Transaction options instead.");
         public static final Reasoner REASONER_TRACING_HAS_NOT_BEEN_INITIALISED =
-                new Reasoner(4, "Attempted to get the resolution tracer before it has been initialised.");
+                new Reasoner(5, "Attempted to get the resolution tracer before it has been initialised.");
         public static final Reasoner REASONER_TRACING_CALL_TO_FINISH_BEFORE_START =
-                new Reasoner(5, "Reasoner tracing has been instructed to finish without being started. Start the tracer before any resolution takes place.");
+                new Reasoner(6, "Reasoner tracing has been instructed to finish without being started. Start the tracer before any resolution takes place.");
 
         private static final String codePrefix = "RSN";
         private static final String messagePrefix = "Reasoner Error";

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -18,10 +18,12 @@
 
 package grakn.core.reasoner.resolution;
 
+import grakn.core.common.exception.GraknCheckedException;
 import grakn.core.common.exception.GraknException;
 import grakn.core.concept.ConceptManager;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.concurrent.actor.EventLoopGroup;
+import grakn.core.concurrent.common.ConcurrentSet;
 import grakn.core.logic.LogicManager;
 import grakn.core.logic.Rule;
 import grakn.core.logic.resolvable.Concludable;
@@ -46,27 +48,36 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.exception.ErrorMessage.Reasoner.RESOLUTION_TERMINATED;
 
 public class ResolverRegistry {
 
     private final static Logger LOG = LoggerFactory.getLogger(ResolverRegistry.class);
 
     private final ConceptManager conceptMgr;
-    private final HashMap<Concludable, Actor<ConcludableResolver>> concludableActors;
     private final LogicManager logicMgr;
-    private final boolean resolutionTracing;
-    private final HashMap<Rule, Actor<ConditionResolver>> ruleConditions;
-    private final HashMap<Rule, Actor<ConclusionResolver>> ruleConclusions; // by Rule not Rule.Conclusion because well defined equality exists
+    private final Map<Concludable, Actor<ConcludableResolver>> concludableResolvers;
+    private final ConcurrentMap<Rule, Actor<ConditionResolver>> ruleConditions;
+    private final ConcurrentMap<Rule, Actor<ConclusionResolver>> ruleConclusions; // by Rule not Rule.Conclusion because well defined equality exists
+    private final Set<Actor<? extends Resolver<?>>> resolvers;
     private final Actor<ResolutionRecorder> resolutionRecorder;
     private final TraversalEngine traversalEngine;
-    private EventLoopGroup elg;
     private final Planner planner;
+    private EventLoopGroup elg;
+    private boolean explanations;
+    private final boolean resolutionTracing;
+    private AtomicBoolean terminated;
 
     public ResolverRegistry(EventLoopGroup elg, Actor<ResolutionRecorder> resolutionRecorder, TraversalEngine traversalEngine,
                             ConceptManager conceptMgr, LogicManager logicMgr, boolean resolutionTracing) {
@@ -75,57 +86,83 @@ public class ResolverRegistry {
         this.traversalEngine = traversalEngine;
         this.conceptMgr = conceptMgr;
         this.logicMgr = logicMgr;
+        this.concludableResolvers = new HashMap<>();
+        this.ruleConditions = new ConcurrentHashMap<>();
+        this.ruleConclusions = new ConcurrentHashMap<>();
+        this.resolvers = new ConcurrentSet<>();
+        this.planner = new Planner(conceptMgr, logicMgr);
+        this.terminated = new AtomicBoolean(false);
         this.resolutionTracing = resolutionTracing;
-        concludableActors = new HashMap<>();
-        ruleConditions = new HashMap<>();
-        ruleConclusions = new HashMap<>();
-        planner = new Planner(conceptMgr, logicMgr);
     }
 
-    public Actor<Root.Conjunction> rootConjunction(Conjunction conjunction, @Nullable Long offset,
-                                                   @Nullable Long limit, Consumer<Top> onAnswer,
-                                                   Consumer<Integer> onFail) {
+    public void terminateResolvers(Throwable cause) {
+        if (terminated.compareAndSet(false, true)) {
+            resolvers.forEach(actor -> {
+                actor.tell(r -> r.terminate(cause));
+            });
+        }
+    }
+
+    public Actor<Root.Conjunction> root(Conjunction conjunction, @Nullable Long offset,
+                                        @Nullable Long limit, Consumer<Top> onAnswer,
+                                        Consumer<Integer> onFail, Consumer<Throwable> onException) throws GraknCheckedException {
         LOG.debug("Creating Root.Conjunction for: '{}'", conjunction);
-        return Actor.create(
+        Actor<Root.Conjunction> resolver = Actor.create(
                 elg, self -> new Root.Conjunction(
-                        self, conjunction, offset, limit, onAnswer, onFail, resolutionRecorder, this,
+                        self, conjunction, offset, limit, onAnswer, onFail, onException, resolutionRecorder, this,
                         traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing));
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return resolver;
     }
 
-    public Actor<Root.Disjunction> rootDisjunction(Disjunction disjunction, @Nullable Long offset,
-                                                   @Nullable Long limit, Consumer<Top> onAnswer,
-                                                   Consumer<Integer> onExhausted) {
+    public Actor<Root.Disjunction> root(Disjunction disjunction, @Nullable Long offset,
+                                        @Nullable Long limit, Consumer<Top> onAnswer,
+                                        Consumer<Integer> onExhausted, Consumer<Throwable> onException) throws GraknCheckedException {
         LOG.debug("Creating Root.Disjunction for: '{}'", disjunction);
-        return Actor.create(
-                elg, self -> new Root.Disjunction(self, disjunction, offset, limit, onAnswer, onExhausted, resolutionRecorder,
-                                                  this, traversalEngine, conceptMgr, resolutionTracing)
+        Actor<Root.Disjunction> resolver = Actor.create(
+                elg, self -> new Root.Disjunction(self, disjunction, offset, limit, onAnswer, onExhausted, onException,
+                                                  resolutionRecorder, this, traversalEngine, conceptMgr, resolutionTracing)
         );
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return resolver;
     }
 
-    public MappedResolver negated(Negated negated, Conjunction upstream) {
+    public MappedResolver negated(Negated negated, Conjunction upstream) throws GraknCheckedException {
         LOG.debug("Creating Negation resolver for : {}", negated);
         Actor<NegationResolver> negatedResolver = Actor.create(
                 elg, self -> new NegationResolver(self, negated, this, traversalEngine, conceptMgr,
                                                   resolutionRecorder, resolutionTracing)
         );
+        resolvers.add(negatedResolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
         Map<Retrievable, Retrievable> filteredMapping = identityFiltered(upstream, negated);
         return MappedResolver.of(negatedResolver, filteredMapping);
     }
 
-    public Actor<ConditionResolver> registerCondition(Rule rule) {
+    public Actor<ConditionResolver> registerCondition(Rule rule) throws GraknCheckedException {
         LOG.debug("Register retrieval for rule condition actor: '{}'", rule);
-        return ruleConditions.computeIfAbsent(rule, (r) -> Actor.create(elg, self -> new ConditionResolver(
+        Actor<ConditionResolver> resolver = ruleConditions.computeIfAbsent(rule, (r) -> Actor.create(elg, self -> new ConditionResolver(
                 self, r, resolutionRecorder, this, traversalEngine, conceptMgr, logicMgr, planner,
                 resolutionTracing)));
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return resolver;
+
     }
 
-    public Actor<ConclusionResolver> registerConclusion(Rule.Conclusion conclusion) {
+    public Actor<ConclusionResolver> registerConclusion(Rule.Conclusion conclusion) throws GraknCheckedException {
         LOG.debug("Register retrieval for rule conclusion actor: '{}'", conclusion);
-        return ruleConclusions.computeIfAbsent(conclusion.rule(), (r) -> Actor.create(elg, self -> new ConclusionResolver(
+        Actor<ConclusionResolver> resolver = ruleConclusions.computeIfAbsent(conclusion.rule(), (r) -> Actor.create(elg, self -> new ConclusionResolver(
                 self, conclusion, this, resolutionRecorder, traversalEngine, conceptMgr, resolutionTracing)));
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return resolver;
+
     }
 
-    public MappedResolver registerResolvable(Resolvable<?> resolvable) {
+    public MappedResolver registerResolvable(Resolvable<?> resolvable) throws GraknCheckedException {
         if (resolvable.isRetrievable()) {
             return registerRetrievable(resolvable.asRetrievable());
         } else if (resolvable.isConcludable()) {
@@ -133,37 +170,44 @@ public class ResolverRegistry {
         } else throw GraknException.of(ILLEGAL_STATE);
     }
 
-    private MappedResolver registerRetrievable(grakn.core.logic.resolvable.Retrievable retrievable) {
+    private MappedResolver registerRetrievable(grakn.core.logic.resolvable.Retrievable retrievable) throws GraknCheckedException {
         LOG.debug("Register RetrievableResolver: '{}'", retrievable.pattern());
-        Actor<RetrievableResolver> retrievableActor = Actor.create(elg, self -> new RetrievableResolver(
+        Actor<RetrievableResolver> resolver = Actor.create(elg, self -> new RetrievableResolver(
                 self, retrievable, this, traversalEngine, conceptMgr, resolutionTracing));
-        return MappedResolver.of(retrievableActor, identity(retrievable));
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return MappedResolver.of(resolver, identity(retrievable));
     }
-    // note: must be thread safe. We could move to a ConcurrentHashMap if we create an alpha-equivalence wrapper
 
-    private synchronized MappedResolver registerConcludable(Concludable concludable) {
+    // note: must be thread safe. We could move to a ConcurrentHashMap if we create an alpha-equivalence wrapper
+    private synchronized MappedResolver registerConcludable(Concludable concludable) throws GraknCheckedException {
         LOG.debug("Register ConcludableResolver: '{}'", concludable.pattern());
-        for (Map.Entry<Concludable, Actor<ConcludableResolver>> c : concludableActors.entrySet()) {
+        for (Map.Entry<Concludable, Actor<ConcludableResolver>> c : concludableResolvers.entrySet()) {
             // TODO: This needs to be optimised from a linear search to use an alpha hash
             AlphaEquivalence alphaEquality = concludable.alphaEquals(c.getKey());
             if (alphaEquality.isValid()) {
                 return MappedResolver.of(c.getValue(), alphaEquality.asValid().idMapping());
             }
         }
-        Actor<ConcludableResolver> concludableActor = Actor.create(elg, self ->
+        Actor<ConcludableResolver> resolver = Actor.create(elg, self ->
                 new ConcludableResolver(self, concludable, resolutionRecorder, this, traversalEngine, conceptMgr,
                                         logicMgr, resolutionTracing));
-        concludableActors.put(concludable, concludableActor);
-        return MappedResolver.of(concludableActor, identity(concludable));
+        concludableResolvers.put(concludable, resolver);
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return MappedResolver.of(resolver, identity(concludable));
     }
 
-    public Actor<ConjunctionResolver.Nested> nested(Conjunction conjunction) {
+    public Actor<ConjunctionResolver.Nested> nested(Conjunction conjunction) throws GraknCheckedException {
         LOG.debug("Creating Conjunction resolver for : {}", conjunction);
-        return Actor.create(
+        Actor<ConjunctionResolver.Nested> resolver = Actor.create(
                 elg, self -> new ConjunctionResolver.Nested(
                         self, conjunction, resolutionRecorder, this, traversalEngine, conceptMgr, logicMgr, planner,
                         resolutionTracing)
         );
+        resolvers.add(resolver);
+        if (terminated.get()) throw GraknCheckedException.of(RESOLUTION_TERMINATED); // guard against races without synchronized
+        return resolver;
     }
 
     private Map<Retrievable, Retrievable> identity(Resolvable<Conjunction> conjunctionResolvable) {

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -46,7 +46,6 @@ import java.util.Optional;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
-import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 
 public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     private static final Logger LOG = LoggerFactory.getLogger(Resolver.class);
@@ -77,7 +76,7 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     protected void exception(Throwable e) {
         if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
             String code = ((GraknException) e).code().get();
-            if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())) {
+            if (code.equals(RESOURCE_CLOSED.code())) {
                 LOG.debug("Resolver interrupted by transaction close: {}", e.getMessage());
                 registry.terminateResolvers(e);
                 return;

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 
 public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
@@ -56,6 +57,7 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
     protected final TraversalEngine traversalEngine;
     protected final ConceptManager conceptMgr;
     private final boolean resolutionTracing;
+    private boolean terminated;
 
     protected Resolver(Actor<T> self, String name, ResolverRegistry registry, TraversalEngine traversalEngine,
                       ConceptManager conceptMgr, boolean resolutionTracing) {
@@ -65,6 +67,7 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
         this.traversalEngine = traversalEngine;
         this.conceptMgr = conceptMgr;
         this.resolutionTracing = resolutionTracing;
+        this.terminated = false;
         this.requestRouter = new HashMap<>();
         // Note: initialising downstream actors in constructor will create all actors ahead of time, so it is non-lazy
         // additionally, it can cause deadlock within ResolverRegistry as different threads initialise actors
@@ -72,16 +75,16 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
 
     @Override
     protected void exception(Throwable e) {
-        if (e instanceof GraknException) {
-            GraknException exception = (GraknException) e;
-            if (exception.code().isPresent() && exception.code().get().equals(TRANSACTION_CLOSED.code())) {
-                LOG.debug("Resolver interrupted by transaction close: {}", exception.getMessage());
+        if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
+            String code = ((GraknException) e).code().get();
+            if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())) {
+                LOG.debug("Resolver interrupted by transaction close: {}", e.getMessage());
+                registry.terminateResolvers(e);
                 return;
             }
         }
         LOG.error("Actor exception: {}", e.getMessage());
-        // TODO, once integrated into the larger flow of executing queries, kill the resolvers and report and exception to root
-        // TODO we should really be cooperatively killing resolvers, rather than forcibly from lower down
+        registry.terminateResolvers(e);
     }
 
     public String name() {
@@ -94,11 +97,18 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
 
     protected abstract void receiveFail(Response.Fail fromDownstream, int iteration);
 
+    public void terminate(Throwable cause) {
+        this.terminated = true;
+    }
+
+    public boolean isTerminated() { return terminated; }
+
     protected abstract void initialiseDownstreamResolvers();
 
     protected abstract ResponseProducer responseProducerCreate(Request fromUpstream, int iteration);
 
-    protected abstract ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer responseProducer, int newIteration);
+    protected abstract ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer
+            responseProducer, int newIteration);
 
     protected Request fromUpstream(Request toDownstream) {
         assert requestRouter.containsKey(toDownstream);

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -77,7 +77,7 @@ public abstract class Resolver<T extends Resolver<T>> extends Actor.State<T> {
         if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
             String code = ((GraknException) e).code().get();
             if (code.equals(RESOURCE_CLOSED.code())) {
-                LOG.debug("Resolver interrupted by transaction close: {}", e.getMessage());
+                LOG.debug("Resolver interrupted by resource close: {}", e.getMessage());
                 registry.terminateResolvers(e);
                 return;
             }

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -17,6 +17,7 @@
 
 package grakn.core.reasoner.resolution.resolver;
 
+import grakn.core.common.exception.GraknCheckedException;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.concept.Concept;
@@ -56,7 +57,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
 
     private final Actor<ResolutionRecorder> resolutionRecorder;
     private final Rule.Conclusion conclusion;
-    private final Map<Request, ConclusionResponses> conclusionResponsess;
+    private final Map<Request, ConclusionResponses> conclusionResponses;
     private boolean isInitialised;
     private Actor<ConditionResolver> ruleResolver;
 
@@ -67,15 +68,15 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
               registry, traversalEngine, conceptMgr, resolutionTracing);
         this.conclusion = conclusion;
         this.resolutionRecorder = resolutionRecorder;
-        this.conclusionResponsess = new HashMap<>();
+        this.conclusionResponses = new HashMap<>();
         this.isInitialised = false;
     }
 
     @Override
     public void receiveRequest(Request fromUpstream, int iteration) {
         LOG.trace("{}: received Request: {}", name(), fromUpstream);
-
         if (!isInitialised) initialiseDownstreamResolvers();
+        if (isTerminated()) return;
 
         ConclusionResponses conclusionResponses = getOrUpdateResponses(fromUpstream, iteration);
 
@@ -88,28 +89,14 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         }
     }
 
-    private void tryAnswer(Request fromUpstream, ConclusionResponses conclusionResponses, int iteration) {
-        // TODO try to use a downstream that is available, or a local iterator
-        // TODO to produce an upstream answer
-
-        Optional<AnswerState.Partial<?>> answer = conclusionResponses.nextResponse();
-        if (answer.isPresent()) {
-            conclusionResponses.recordProduced(answer.get().conceptMap());
-            answerToUpstream(answer.get(), fromUpstream, iteration);
-        } else if (conclusionResponses.hasDownstream()) {
-            requestFromDownstream(conclusionResponses.nextDownstream(), fromUpstream, iteration);
-        } else {
-            failToUpstream(fromUpstream, iteration);
-        }
-    }
-
     @Override
     protected void receiveAnswer(Response.Answer fromDownstream, int iteration) {
         LOG.trace("{}: received Answer: {}", name(), fromDownstream);
+        if (isTerminated()) return;
 
         Request toDownstream = fromDownstream.sourceRequest();
         Request fromUpstream = fromUpstream(toDownstream);
-        ConclusionResponses conclusionResponses = conclusionResponsess.get(fromUpstream);
+        ConclusionResponses conclusionResponses = this.conclusionResponses.get(fromUpstream);
 
         ResourceIterator<Map<Identifier.Variable, Concept>> materialisations = conclusion
                 .materialise(fromDownstream.answer().conceptMap(), traversalEngine, conceptMgr);
@@ -126,9 +113,11 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
         LOG.trace("{}: received Fail: {}", name(), fromDownstream);
+        if (isTerminated()) return;
+
         Request toDownstream = fromDownstream.sourceRequest();
         Request fromUpstream = fromUpstream(toDownstream);
-        ConclusionResponses conclusionResponses = conclusionResponsess.get(fromUpstream);
+        ConclusionResponses conclusionResponses = this.conclusionResponses.get(fromUpstream);
 
         if (iteration < conclusionResponses.iteration()) {
             // short circuit old iteration fail messages to upstream
@@ -141,27 +130,49 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
     }
 
     @Override
+    public void terminate(Throwable cause) {
+        super.terminate(cause);
+        conclusionResponses.clear();
+    }
+
+    @Override
     protected void initialiseDownstreamResolvers() {
         LOG.debug("{}: initialising downstream resolvers", name());
-        ruleResolver = registry.registerCondition(conclusion.rule());
-        isInitialised = true;
+        try {
+            ruleResolver = registry.registerCondition(conclusion.rule());
+            isInitialised = true;
+        } catch (GraknCheckedException e) {
+            terminate(e);
+        }
+    }
+
+    private void tryAnswer(Request fromUpstream, ConclusionResponses conclusionResponses, int iteration) {
+        Optional<AnswerState.Partial<?>> answer = conclusionResponses.nextResponse();
+        if (answer.isPresent()) {
+            conclusionResponses.recordProduced(answer.get().conceptMap());
+            answerToUpstream(answer.get(), fromUpstream, iteration);
+        } else if (conclusionResponses.hasDownstream()) {
+            requestFromDownstream(conclusionResponses.nextDownstream(), fromUpstream, iteration);
+        } else {
+            failToUpstream(fromUpstream, iteration);
+        }
     }
 
     private ConclusionResponses getOrUpdateResponses(Request fromUpstream, int iteration) {
-        if (!conclusionResponsess.containsKey(fromUpstream)) {
-            conclusionResponsess.put(fromUpstream, createConclusionResponses(fromUpstream, iteration));
+        if (!conclusionResponses.containsKey(fromUpstream)) {
+            conclusionResponses.put(fromUpstream, createConclusionResponses(fromUpstream, iteration));
         } else {
-            ConclusionResponses conclusionResponses = conclusionResponsess.get(fromUpstream);
+            ConclusionResponses conclusionResponses = this.conclusionResponses.get(fromUpstream);
             assert conclusionResponses.iteration() == iteration ||
                     conclusionResponses.iteration() + 1 == iteration;
 
             if (conclusionResponses.iteration() + 1 == iteration) {
                 // when the same request for the next iteration the first time, re-initialise required state
                 ConclusionResponses conclusionResponsesNextIter = createConclusionResponses(fromUpstream, iteration);
-                conclusionResponsess.put(fromUpstream, conclusionResponsesNextIter);
+                this.conclusionResponses.put(fromUpstream, conclusionResponsesNextIter);
             }
         }
-        return conclusionResponsess.get(fromUpstream);
+        return conclusionResponses.get(fromUpstream);
     }
 
     private ConclusionResponses createConclusionResponses(Request fromUpstream, int iteration) {

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -63,6 +63,8 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     @Override
     public void receiveRequest(Request fromUpstream, int iteration) {
         LOG.trace("{}: received Request: {}", name(), fromUpstream);
+        if (isTerminated()) return;
+
         Responses responses = mayUpdateAndGetResponses(fromUpstream, iteration);
         if (iteration < responses.iteration()) {
             // short circuit old iteration exhausted messages to upstream
@@ -143,6 +145,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     }
 
     public void receiveTraversalAnswer(Partial<?> upstreamAnswer, Request fromUpstreamSource) {
+        if (isTerminated()) return;
         Responses responses = this.responses.get(fromUpstreamSource);
         responses.decrementProcessing();
         if (responses.hasAwaitingRequest()) {
@@ -154,6 +157,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
     }
 
     public void receiveTraversalDone(Request fromUpstreamSource) {
+        if (isTerminated()) return;
         Responses responses = this.responses.get(fromUpstreamSource);
         responses.setTraversalDone();
         if (!responses.hasFetched()) {

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -46,7 +46,7 @@ import java.util.function.BiFunction;
 import static grakn.core.common.collection.Bytes.bytesHavePrefix;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_OPERATION;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
+import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_DATA_READ_VIOLATION;
 import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_SCHEMA_READ_VIOLATION;
 
@@ -201,7 +201,7 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public byte[] get(byte[] key) {
-            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
+            if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             try {
                 if (!isReadOnly) readWriteLock.readLock().lock();
                 return storageTransaction.get(readOptions, key);
@@ -228,7 +228,7 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public void delete(byte[] key) {
-            if (!isOpen() || !transaction.isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
+            if (!isOpen() || !transaction.isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             if (isReadOnly) {
                 if (transaction.isSchema()) throw exception(TRANSACTION_SCHEMA_READ_VIOLATION);
                 else if (transaction.isData()) throw exception(TRANSACTION_DATA_READ_VIOLATION);
@@ -246,10 +246,10 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public <G> ResourceIterator<G> iterate(byte[] key, BiFunction<byte[], byte[], G> constructor) {
-            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
+            if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             RocksIterator<G> iterator = new RocksIterator<>(this, key, constructor);
             iterators.add(iterator);
-            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED); //guard against close() race conditions
+            if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED); //guard against close() race conditions
             return iterator;
         }
 

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -132,7 +132,7 @@ public class ReasonerTest {
                 try {
                     List<ConceptMap> ans = txn.query().match(Graql.parseQuery("match $x isa is-still-good;").asMatch()).toList();
                 } catch (GraknException e) {
-                    assertEquals(e.code().get(), RESOLUTION_TERMINATED.code());
+                    assertEquals(((GraknException)e.getCause()).code().get(), RESOLUTION_TERMINATED.code());
                     return;
                 }
                 fail();

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -17,6 +17,7 @@
 
 package grakn.core.reasoner;
 
+import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.common.parameters.Options;
 import grakn.core.common.parameters.Options.Database;
@@ -41,8 +42,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static grakn.core.common.exception.ErrorMessage.Reasoner.RESOLUTION_TERMINATED;
 import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class ReasonerTest {
     private static final Path dataDir = Paths.get(System.getProperty("user.dir")).resolve("query-test");
@@ -95,6 +98,44 @@ public class ReasonerTest {
                     assertEquals("milk", a.get("x").asThing().getType().getLabel().scopedName());
                 });
                 assertEquals(2, ans.size());
+            }
+        }
+    }
+
+    @Test
+    public void test_exception_kills_query() {
+        try (RocksSession session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.WRITE)) {
+                ConceptManager conceptMgr = txn.concepts();
+                LogicManager logicMgr = txn.logic();
+
+                EntityType milk = conceptMgr.putEntityType("milk");
+                AttributeType ageInDays = conceptMgr.putAttributeType("age-in-days", AttributeType.ValueType.LONG);
+                AttributeType isStillGood = conceptMgr.putAttributeType("is-still-good", AttributeType.ValueType.BOOLEAN);
+                milk.setOwns(ageInDays);
+                milk.setOwns(isStillGood);
+                logicMgr.putRule(
+                        "old-milk-is-not-good",
+                        Graql.parsePattern("{ $x isa milk, has age-in-days >= 10; }").asConjunction(),
+                        Graql.parseVariable("$x has is-still-good false").asThing());
+                txn.commit();
+            }
+        }
+        try (RocksSession session = grakn.session(database, Arguments.Session.Type.DATA)) {
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.WRITE)) {
+                txn.query().insert(Graql.parseQuery("insert $x isa milk, has age-in-days 5;").asInsert());
+                txn.query().insert(Graql.parseQuery("insert $x isa milk, has age-in-days 10;").asInsert());
+                txn.commit();
+            }
+            try (RocksTransaction txn = singleThreadElgTransaction(session, Arguments.Transaction.Type.READ)) {
+                txn.reasoner().resolverRegistry().terminateResolvers(new RuntimeException());
+                try {
+                    List<ConceptMap> ans = txn.query().match(Graql.parseQuery("match $x isa is-still-good;").asMatch()).toList();
+                } catch (GraknException e) {
+                    assertEquals(e.code().get(), RESOLUTION_TERMINATED.code());
+                    return;
+                }
+                fail();
             }
         }
     }

--- a/test/integration/reasoner/ReiterationTest.java
+++ b/test/integration/reasoner/ReiterationTest.java
@@ -18,6 +18,7 @@
 package grakn.core.reasoner;
 
 import grakn.common.concurrent.NamedThreadFactory;
+import grakn.core.common.exception.GraknCheckedException;
 import grakn.core.common.parameters.Arguments;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.concurrent.actor.EventLoopGroup;
@@ -126,14 +127,14 @@ public class ReiterationTest {
                 boolean[] receivedInferredAnswer = {false};
 
                 ResolutionTracer.get().start();
-                Actor<Root.Conjunction> root = registry.rootConjunction(conjunction, null, null, answer -> {
+                Actor<Root.Conjunction> root = registry.root(conjunction, null, null, answer -> {
                     if (answer.requiresReiteration()) receivedInferredAnswer[0] = true;
                     responses.add(answer);
                 }, iterDone -> {
                     assert iteration[0] == iterDone;
                     doneInIteration[0]++;
                     failed.add(iterDone);
-                });
+                }, throwable -> fail());
 
                 Set<Top> answers = new HashSet<>();
                 // iteration 0
@@ -166,6 +167,9 @@ public class ReiterationTest {
                     }
                     ResolutionTracer.get().finish();
                 }
+            } catch (GraknCheckedException e) {
+                e.printStackTrace();
+                fail();
             }
         }
     }

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -106,8 +106,8 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
         } catch (Throwable e) {
             // note: catching runtime exception until we can gracefully interrupt running queries on tx close
             if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
-                String code = ((GraknException) e).code().get();
-                if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())) {
+                String code = ((GraknException)e).code().get();
+                if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())){
                     LOG.debug("Transaction was closed during graph iteration");
                 }
             } else {

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
@@ -104,9 +105,11 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             return state == State.FETCHED;
         } catch (Throwable e) {
             // note: catching runtime exception until we can gracefully interrupt running queries on tx close
-            if (e instanceof GraknException && ((GraknException) e).code().isPresent()
-                    && ((GraknException) e).code().get().equals(TRANSACTION_CLOSED.code())) {
-                LOG.debug("Transaction was closed during graph iteration");
+            if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
+                String code = ((GraknException) e).code().get();
+                if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())) {
+                    LOG.debug("Transaction was closed during graph iteration");
+                }
             } else {
                 LOG.error("Parameters: " + params.toString());
                 LOG.error("GraphProcedure: " + procedure.toString());

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -43,7 +43,6 @@ import java.util.TreeMap;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
-import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
 public class GraphIterator extends AbstractResourceIterator<VertexMap> {
@@ -107,9 +106,7 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             // note: catching runtime exception until we can gracefully interrupt running queries on tx close
             if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
                 String code = ((GraknException)e).code().get();
-                if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())){
-                    LOG.debug("Transaction was closed during graph iteration");
-                }
+                if (code.equals(RESOURCE_CLOSED.code())) LOG.debug("Transaction was closed during graph iteration");
             } else {
                 LOG.error("Parameters: " + params.toString());
                 LOG.error("GraphProcedure: " + procedure.toString());

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -104,9 +104,9 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             return state == State.FETCHED;
         } catch (Throwable e) {
             // note: catching runtime exception until we can gracefully interrupt running queries on tx close
-            if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
-                String code = ((GraknException)e).code().get();
-                if (code.equals(RESOURCE_CLOSED.code())) LOG.debug("Transaction was closed during graph iteration");
+            if (e instanceof GraknException && ((GraknException) e).code().isPresent() &&
+                    ((GraknException) e).code().get().equals(RESOURCE_CLOSED.code())) {
+                LOG.debug("Transaction was closed during graph iteration");
             } else {
                 LOG.error("Parameters: " + params.toString());
                 LOG.error("GraphProcedure: " + procedure.toString());


### PR DESCRIPTION
## What is the goal of this PR?
This PR connects exceptions thrown during reasoner resolution to the match query to report errors to the user. During resolution, it is possible a resolver generates or receives an exception in the event loop, which should lead to an error in the query being reported to the user, which must be asynchronously propagated through the resolvers back to the user's iterator.

## What are the changes implemented in this PR?
* Propagate exceptions from resolvers via the `ResolverRegistry` to all other resolvers
* Root resolvers pass exceptions back to the parent `ResponseProducer`, which passes it back to the `Queue` it produces into
* throw `RESOURCE_CLOSED` in iterators that are closed to not leak context about closed transactions specifically