### PR TITLE
Fix test-assembly-windows-zip CI job

### DIFF
--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -32,3 +32,6 @@ C:\Python37\python.exe -m pip install wheel
 REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
 SETX BAZEL_PYTHON C:\Python37\python.exe
+
+REM temporary workaround around "AsAbsoluteWindowsPath failed: Unix-style paths are unsupported" error
+DEL .bazelrc

--- a/.circleci/windows/prepare.bat
+++ b/.circleci/windows/prepare.bat
@@ -33,5 +33,6 @@ REM permanently set variables for Bazel build
 SETX BAZEL_SH "C:\Program Files\Git\usr\bin\bash.exe"
 SETX BAZEL_PYTHON C:\Python37\python.exe
 
+REM TODO: https://github.com/graknlabs/grakn/issues/6200
 REM temporary workaround around "AsAbsoluteWindowsPath failed: Unix-style paths are unsupported" error
 DEL .bazelrc


### PR DESCRIPTION
## What is the goal of this PR?

Work around limitations of Bazel on Windows by removing `.bazelrc` file when building on this platform.

## What are the changes implemented in this PR?

Delete `.bazelrc` file before executing the job