### PR TITLE
Allow key generator serialisation to support cluster key synchronisation

### DIFF
--- a/common/collection/Bytes.java
+++ b/common/collection/Bytes.java
@@ -134,10 +134,23 @@ public class Bytes {
     }
 
     public static long bytesToLong(byte[] bytes) {
-        ByteBuffer buf = ByteBuffer.allocate(Long.SIZE / Byte.SIZE).order(ByteOrder.nativeOrder());
+        ByteBuffer buf = ByteBuffer.allocate(LONG_SIZE).order(ByteOrder.nativeOrder());
         buf.put(bytes);
         buf.flip();
         return buf.getLong();
+    }
+
+    public static byte[] intToBytes(int num) {
+        ByteBuffer buf = ByteBuffer.allocate(INTEGER_SIZE).order(ByteOrder.nativeOrder());
+        buf.putInt(num);
+        return buf.array();
+    }
+
+    public static int bytesToInt(byte[] bytes) {
+        ByteBuffer buf = ByteBuffer.allocate(INTEGER_SIZE).order(ByteOrder.nativeOrder());
+        buf.put(bytes);
+        buf.flip();
+        return buf.getInt();
     }
 
     /**

--- a/graph/iid/VertexIID.java
+++ b/graph/iid/VertexIID.java
@@ -86,7 +86,7 @@ public abstract class VertexIID extends IID {
             return new Type(bytes);
         }
 
-        static VertexIID.Type extract(byte[] bytes, int from) {
+        public static VertexIID.Type extract(byte[] bytes, int from) {
             return new Type(copyOfRange(bytes, from, from + LENGTH));
         }
 

--- a/rocks/RocksDatabase.java
+++ b/rocks/RocksDatabase.java
@@ -68,8 +68,8 @@ public class RocksDatabase implements Grakn.Database {
     protected final String name;
     protected StatisticsBackgroundCounter statisticsBackgroundCounter;
     protected RocksSession.Data statisticsBackgroundCounterSession;
-    private final KeyGenerator.Schema.Persisted schemaKeyGenerator;
-    private final KeyGenerator.Data.Persisted dataKeyGenerator;
+    protected final KeyGenerator.Schema.Persisted schemaKeyGenerator;
+    protected final KeyGenerator.Data.Persisted dataKeyGenerator;
     private final StampedLock schemaLock;
     private final RocksGrakn grakn;
     private final AtomicInteger schemaLockWriteRequests;


### PR DESCRIPTION
## What is the goal of this PR?

Allow key generator serialisation so that key generator values can be put into cluster's log entries to support cluster key synchronisation on leader election.

## What are the changes implemented in this PR?

- Allow key generator serialisation.