### PR TITLE
Fix possible segfault when closing session

### DIFF
--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -181,9 +181,11 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public <G> ResourceIterator<G> iterate(byte[] key, BiFunction<byte[], byte[], G> constructor) {
-            assert isOpen();
+//            assert isOpen();
+            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
             RocksIterator<G> iterator = new RocksIterator<>(this, key, constructor);
             iterators.add(iterator);
+            if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED); //guard against close() race conditions
             return iterator.onFinalise(iterator::close);
         }
     }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -181,7 +181,7 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public <G> ResourceIterator<G> iterate(byte[] key, BiFunction<byte[], byte[], G> constructor) {
-//            assert isOpen();
+//            assert isOpen(); // TODO: verify why this was an assertion rather than an exception
             if (!isOpen()) throw GraknException.of(TRANSACTION_CLOSED);
             RocksIterator<G> iterator = new RocksIterator<>(this, key, constructor);
             iterators.add(iterator);


### PR DESCRIPTION
## What is the goal of this PR?

We fixed a possible segfault when closing a session while a db operation is running.

## What are the changes implemented in this PR?

- Verify that the Storage is open before attempting to iterate over the schema graph

## Additional information

See https://github.com/graknlabs/grakn/pull/6185 for the related fix to the data graph.
