### PR TITLE
In-use iterators that are closed can throw a closed message

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -99,8 +99,10 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Internal(9, "Unexpected thread interruption!");
         public static final Internal UNEXPECTED_PLANNING_ERROR =
                 new Internal(10, "Unexpected error during traversal plan optimisation.");
+        public static final Internal RESOURCE_CLOSED =
+                new Internal(11, "Attempted to utilise a closed resource.");
         public static final Internal UNIMPLEMENTED =
-                new Internal(11, "This functionality is not yet implemented.");
+                new Internal(12, "This functionality is not yet implemented.");
 
         private static final String codePrefix = "INT";
         private static final String messagePrefix = "Invalid Internal State";

--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
+import static grakn.core.common.exception.ErrorMessage.Internal.RESOURCE_CLOSED;
 import static grakn.core.common.exception.ErrorMessage.Transaction.TRANSACTION_CLOSED;
 import static java.util.stream.Collectors.toMap;
 
@@ -104,9 +105,11 @@ public class GraphIterator extends AbstractResourceIterator<VertexMap> {
             return state == State.FETCHED;
         } catch (Throwable e) {
             // note: catching runtime exception until we can gracefully interrupt running queries on tx close
-            if (e instanceof GraknException && ((GraknException) e).code().isPresent()
-                    && ((GraknException) e).code().get().equals(TRANSACTION_CLOSED.code())) {
-                LOG.debug("Transaction was closed during graph iteration");
+            if (e instanceof GraknException && ((GraknException) e).code().isPresent()) {
+                String code = ((GraknException) e).code().get();
+                if (code.equals(TRANSACTION_CLOSED.code()) || code.equals(RESOURCE_CLOSED.code())) {
+                    LOG.debug("Transaction was closed during graph iteration");
+                }
             } else {
                 LOG.error("Parameters: " + params.toString());
                 LOG.error("GraphProcedure: " + procedure.toString());


### PR DESCRIPTION
## What is the goal of this PR?
When dealing with race conditions between using and closing RocksIterators, we can end up in a state where the user of an iterator calls `hasNext()` and get a `true` back, but by the time they call `next()` the iterator is closed. To avoid throwing a `NoSuchElementException`, we introduce a `Resource closed` exception

## What are the changes implemented in this PR?
* `RocksIterator` throws a new message`RESOURCE_CLOSED` when it is closed but a user calls `next()` on it 