### PR TITLE
Revert to synchronous retrievables in reasoner

### DIFF
--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -32,7 +32,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = true;
+    public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -32,7 +32,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = false;
+    public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -299,7 +299,7 @@ public abstract class AnswerState {
                              boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(filteredConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.filter = filter;
-                this.hash = Objects.hash(resolver, conceptMap, filter, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, parent, filter);
             }
 
             static Filtered filter(Partial<?> parent, Set<Identifier.Variable.Retrievable> filter, Actor<? extends Resolver<?>> root,
@@ -333,6 +333,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Filtered{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", filter=" + filter +
                         '}';
@@ -344,6 +345,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Filtered filtered = (Filtered) o;
                 return Objects.equals(root(), filtered.root()) &&
+                        Objects.equals(resolver(), filtered.resolver()) &&
                         Objects.equals(conceptMap, filtered.conceptMap) &&
                         Objects.equals(parent, filtered.parent) &&
                         Objects.equals(filter, filtered.filter);
@@ -366,7 +368,7 @@ public abstract class AnswerState {
                            boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(mappedConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.mapping = mapping;
-                this.hash = Objects.hash(resolver, conceptMap, mapping, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, mapping, parent);
             }
 
             static Mapped map(Partial<?> parent, Mapping mapping, Actor<? extends Resolver<?>> root,
@@ -406,6 +408,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Mapped{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", mapping=" + mapping +
                         '}';
@@ -417,6 +420,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Mapped mapped = (Mapped) o;
                 return Objects.equals(root(), mapped.root()) &&
+                        Objects.equals(resolver(), mapped.resolver()) &&
                         Objects.equals(conceptMap, mapped.conceptMap) &&
                         Objects.equals(parent, mapped.parent) &&
                         Objects.equals(mapping, mapped.mapping);
@@ -441,7 +445,7 @@ public abstract class AnswerState {
                 super(unifiedConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.unifier = unifier;
                 this.instanceRequirements = instanceRequirements;
-                this.hash = Objects.hash(resolver, conceptMap, unifier, instanceRequirements, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, unifier, instanceRequirements, parent);
             }
 
             static Optional<Partial.Unified> unify(Partial<?> parent, Unifier unifier,
@@ -486,6 +490,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Unified{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", unifier=" + unifier +
                         ", instanceRequirements=" + instanceRequirements +
@@ -498,6 +503,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Unified unified = (Unified) o;
                 return Objects.equals(root(), unified.root()) &&
+                        Objects.equals(resolver(), unified.resolver()) &&
                         Objects.equals(conceptMap, unified.conceptMap) &&
                         Objects.equals(parent, unified.parent) &&
                         Objects.equals(unifier, unified.unifier) &&

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -25,7 +25,6 @@ import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Mapped;
 import grakn.core.reasoner.resolution.answer.AnswerState.Top;
 import grakn.core.traversal.common.Identifier;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -46,13 +45,13 @@ public class AnswerStateTest {
         mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
         mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
-        Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping), null);
         assertTrue(mapped.conceptMap().concepts().isEmpty());
 
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts));
         Map<Identifier.Variable.Retrievable, Concept> expected = new HashMap<>();
         expected.put(Identifier.Variable.name("a"), new MockConcept(0));
         expected.put(Identifier.Variable.name("b"), new MockConcept(1));
@@ -68,8 +67,8 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Top top = Top.initial(filter, false, null);
-        Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
-                .mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = identity(new ConceptMap(concepts), top,  null, null, false)
+                .mapToDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
@@ -78,7 +77,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts));
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
@@ -96,8 +95,8 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("c"), new MockConcept(2));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Top top = Top.initial(filter, false, null);
-        Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
-                .mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = identity(new ConceptMap(concepts), top, null, null, false)
+                .mapToDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
@@ -106,7 +105,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts));
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -99,7 +99,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
-        Partial<?> upstreamAnswer = fromDownstream.answer().asMapped().toUpstream(self());
+        Partial<?> upstreamAnswer = fromDownstream.answer().asMapped().toUpstream();
 
         if (!responseProducer.hasProduced(upstreamAnswer.conceptMap())) {
             responseProducer.recordProduced(upstreamAnswer.conceptMap());
@@ -167,7 +167,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(concludable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         ResponseProducer responseProducer = new ResponseProducer(upstreamAnswers, iteration);
         mayRegisterRules(fromUpstream, iterationState, responseProducer);
@@ -190,7 +190,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(concludable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(upstreamAnswers, newIteration);
         mayRegisterRules(fromUpstream, iterationState, responseProducerNewIter);
@@ -233,11 +233,11 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         // if we have, we do not allow rules to be registered as possible downstreams
         if (!recursionState.hasReceived(fromUpstream.partialAnswer().conceptMap())) {
             for (Map.Entry<Actor<ConclusionResolver>, Set<Unifier>> entry : applicableRules.entrySet()) {
-                Actor<ConclusionResolver> ruleActor = entry.getKey();
+                Actor<ConclusionResolver> conclusionResolver = entry.getKey();
                 for (Unifier unifier : entry.getValue()) {
-                    Optional<Unified> unified = fromUpstream.partialAnswer().unifyToDownstream(unifier);
+                    Optional<Unified> unified = fromUpstream.partialAnswer().unifyToDownstream(unifier, conclusionResolver);
                     if (unified.isPresent()) {
-                        Request toDownstream = Request.create(self(), ruleActor, unified.get());
+                        Request toDownstream = Request.create(self(), conclusionResolver, unified.get());
                         responseProducer.addDownstreamProducer(toDownstream);
                     }
                 }

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -103,7 +103,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         if (!materialisations.hasNext()) throw GraknException.of(ILLEGAL_STATE);
 
         ResourceIterator<AnswerState.Partial<?>> materialisedAnswers = materialisations
-                .map(concepts -> fromUpstream.partialAnswer().asUnified().aggregateToUpstream(concepts, self()))
+                .map(concepts -> fromUpstream.partialAnswer().asUnified().aggregateToUpstream(concepts))
                 .filter(Optional::isPresent)
                 .map(Optional::get);
         conclusionResponses.addResponses(materialisedAnswers);
@@ -191,7 +191,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
                                                                                                          answer)));
         } else {
             Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-            AnswerState.Partial.Filtered downstreamAnswer = fromUpstream.partialAnswer().filterToDownstream(named);
+            AnswerState.Partial.Filtered downstreamAnswer = fromUpstream.partialAnswer().filterToDownstream(named, ruleResolver);
             conclusionResponses.addDownstream(Request.create(self(), ruleResolver, downstreamAnswer));
         }
 
@@ -202,7 +202,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         Traversal traversal1 = boundTraversal(conclusion.conjunction().traversal(), answer);
         ResourceIterator<ConceptMap> traversal = traversalEngine.iterator(traversal1).map(conceptMgr::conceptMap);
         Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-        return traversal.map(ans -> fromUpstream.partialAnswer().asUnified().extend(ans).filterToDownstream(named));
+        return traversal.map(ans -> fromUpstream.partialAnswer().asUnified().extend(ans).filterToDownstream(named, ruleResolver));
     }
 
     @Override

--- a/reasoner/resolution/resolver/ConditionResolver.java
+++ b/reasoner/resolution/resolver/ConditionResolver.java
@@ -64,7 +64,7 @@ public class ConditionResolver extends ConjunctionResolver<ConditionResolver> {
 
     @Override
     protected Optional<AnswerState> toUpstreamAnswer(AnswerState.Partial<?> fromDownstream) {
-        return Optional.of(fromDownstream.asFiltered().toUpstream(self()));
+        return Optional.of(fromDownstream.asFiltered().toUpstream());
     }
 
     @Override

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -116,7 +116,7 @@ public class NegationResolver extends Resolver<NegationResolver> {
               the toplevel root with the negation iterations, which we cannot allow. So, we must use THIS resolver
               as a sort of new root! TODO: should NegationResolvers also implement a kind of Root interface??
         */
-        Filtered downstreamPartial = fromUpstream.partialAnswer().filterToDownstream(negated.retrieves());
+        Filtered downstreamPartial = fromUpstream.partialAnswer().filterToDownstream(negated.retrieves(), downstream);
         Request request = Request.create(self(), this.downstream, downstreamPartial);
         requestFromDownstream(request, fromUpstream, 0);
         negationResponse.setRequested();
@@ -156,7 +156,7 @@ public class NegationResolver extends Resolver<NegationResolver> {
     private Partial<?> upstreamAnswer(Request fromUpstream) {
         // TODO: decide if we want to use isMapped here? Can Mapped currently act as a filter?
         assert fromUpstream.partialAnswer().isMapped();
-        Partial<?> upstreamAnswer = fromUpstream.partialAnswer().asMapped().toUpstream(self());
+        Partial<?> upstreamAnswer = fromUpstream.partialAnswer().asMapped().toUpstream();
 
         if (fromUpstream.partialAnswer().recordExplanations()) {
             resolutionRecorder.tell(state -> state.record(fromUpstream.partialAnswer()));

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -87,7 +87,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
         return new ResponseProducer(upstreamAnswers, iteration);
     }
 
@@ -100,7 +100,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
         return responseProducerPrevious.newIteration(upstreamAnswers, newIteration);
     }
 

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -18,10 +18,9 @@
 package grakn.core.reasoner.resolution.resolver;
 
 import grakn.core.common.exception.GraknException;
+import grakn.core.common.iterator.ResourceIterator;
 import grakn.core.concept.ConceptManager;
-import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concurrent.actor.Actor;
-import grakn.core.concurrent.producer.Producer;
 import grakn.core.logic.resolvable.Retrievable;
 import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
@@ -35,29 +34,21 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
-import static grakn.core.common.exception.ErrorMessage.Internal.UNIMPLEMENTED;
-import static grakn.core.concurrent.common.Executors.asyncPool2;
 
 public class RetrievableResolver extends Resolver<RetrievableResolver> {
-
-    private static final int PREFETCH_SIZE = 32;
-    private static final int REFETCH_THRESHOLD = PREFETCH_SIZE / 4;
-
     private static final Logger LOG = LoggerFactory.getLogger(RetrievableResolver.class);
     private final Retrievable retrievable;
-    private final Map<Request, Responses> responses;
+    private final Map<Request, ResponseProducer> responseProducers;
 
     public RetrievableResolver(Actor<RetrievableResolver> self, Retrievable retrievable, ResolverRegistry registry,
-                               TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean resolutionTracing) {
+                               TraversalEngine traversalEngine, ConceptManager conceptMgr, boolean explanations) {
         super(self, RetrievableResolver.class.getSimpleName() + "(pattern: " + retrievable.pattern() + ")",
-              registry, traversalEngine, conceptMgr, resolutionTracing);
+              registry, traversalEngine, conceptMgr, explanations);
         this.retrievable = retrievable;
-        this.responses = new HashMap<>();
+        this.responseProducers = new HashMap<>();
     }
 
     @Override
@@ -65,13 +56,13 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         LOG.trace("{}: received Request: {}", name(), fromUpstream);
         if (isTerminated()) return;
 
-        Responses responses = mayUpdateAndGetResponses(fromUpstream, iteration);
-        if (iteration < responses.iteration()) {
-            // short circuit old iteration exhausted messages to upstream
+        ResponseProducer responseProducer = mayUpdateAndGetResponseProducer(fromUpstream, iteration);
+        if (iteration < responseProducer.iteration()) {
+            // short circuit old iteration failed messages to upstream
             failToUpstream(fromUpstream, iteration);
         } else {
-            assert iteration == responses.iteration();
-            responses.nextAnswer();
+            assert iteration == responseProducer.iteration();
+            tryAnswer(fromUpstream, responseProducer, iteration);
         }
     }
 
@@ -90,189 +81,58 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         throw GraknException.of(ILLEGAL_STATE);
     }
 
-    Responses createResponses(Request fromUpstream, int iteration) {
-        LOG.debug("{}: Creating a new Responses for request: {}", name(), fromUpstream);
-        assert fromUpstream.partialAnswer().isMapped();
-
-        Producer<ConceptMap> traversalAsync = traversalProducer(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap(), 2);
-        Producer<Partial<?>> upstreamAnswersAsync = traversalAsync
-                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
-
-        return new Responses(fromUpstream, upstreamAnswersAsync, iteration);
-    }
-
-    Responses reiterateResponses(Request fromUpstream, Responses responsesPrevious, int newIteration) {
-        assert newIteration > responsesPrevious.iteration();
-        LOG.debug("{}: Updating Responses for iteration '{}'", name(), newIteration);
-
-        assert newIteration > responsesPrevious.iteration();
-
-        assert fromUpstream.partialAnswer().isMapped();
-        Producer<ConceptMap> traversalAsync = traversalProducer(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap(), 2);
-        Producer<Partial<?>> upstreamAnswersAsync = traversalAsync
-                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
-
-        return new Responses(fromUpstream, upstreamAnswersAsync, newIteration);
-    }
-
-    /*
-    TODO clean up the following two when we remove the requirement for every resolver to have ResponseProducers
-     */
     @Override
     protected ResponseProducer responseProducerCreate(Request fromUpstream, int iteration) {
-        throw GraknException.of(UNIMPLEMENTED);
+        LOG.debug("{}: Creating a new ResponseProducer for request: {}", name(), fromUpstream);
+        assert fromUpstream.partialAnswer().isMapped();
+        ResourceIterator<Partial<?>> upstreamAnswers =
+                traversalIterator(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap())
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+        return new ResponseProducer(upstreamAnswers, iteration);
     }
 
     @Override
-    protected ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer responseProducer, int newIteration) {
-        throw GraknException.of(UNIMPLEMENTED);
+    protected ResponseProducer responseProducerReiterate(Request fromUpstream, ResponseProducer responseProducerPrevious, int newIteration) {
+        assert newIteration > responseProducerPrevious.iteration();
+        LOG.debug("{}: Updating ResponseProducer for iteration '{}'", name(), newIteration);
+
+        assert newIteration > responseProducerPrevious.iteration();
+        assert fromUpstream.partialAnswer().isMapped();
+        ResourceIterator<Partial<?>> upstreamAnswers =
+                traversalIterator(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap())
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+        return responseProducerPrevious.newIteration(upstreamAnswers, newIteration);
     }
 
-    private Responses mayUpdateAndGetResponses(Request fromUpstream, int iteration) {
-        if (!responses.containsKey(fromUpstream)) {
-            responses.put(fromUpstream, createResponses(fromUpstream, iteration));
+    private ResponseProducer mayUpdateAndGetResponseProducer(Request fromUpstream, int iteration) {
+        if (!responseProducers.containsKey(fromUpstream)) {
+            responseProducers.put(fromUpstream, responseProducerCreate(fromUpstream, iteration));
         } else {
-            Responses responses = this.responses.get(fromUpstream);
-            assert iteration <= responses.iteration() + 1;
+            ResponseProducer responseProducer = responseProducers.get(fromUpstream);
+            assert iteration <= responseProducer.iteration() + 1;
 
-            if (responses.iteration() + 1 == iteration) {
+            if (responseProducer.iteration() + 1 == iteration) {
                 // when the same request for the next iteration the first time, re-initialise required state
-                Responses responseProducerNextIter = reiterateResponses(fromUpstream, responses, iteration);
-                this.responses.put(fromUpstream, responseProducerNextIter);
+                ResponseProducer responseProducerNextIter = responseProducerReiterate(fromUpstream, responseProducer, iteration);
+                responseProducers.put(fromUpstream, responseProducerNextIter);
             }
         }
-        return responses.get(fromUpstream);
+        return responseProducers.get(fromUpstream);
     }
 
-    public void receiveTraversalAnswer(Partial<?> upstreamAnswer, Request fromUpstreamSource) {
-        if (isTerminated()) return;
-        Responses responses = this.responses.get(fromUpstreamSource);
-        responses.decrementProcessing();
-        if (responses.hasAwaitingRequest()) {
-            dispatchAnswer(upstreamAnswer, responses.popAwaitingRequest());
-            responses.mayFetch();
+    private void tryAnswer(Request fromUpstream, ResponseProducer responseProducer, int iteration) {
+        if (responseProducer.hasUpstreamAnswer()) {
+            Partial<?> upstreamAnswer = responseProducer.upstreamAnswers().next();
+            responseProducer.recordProduced(upstreamAnswer.conceptMap());
+            answerToUpstream(upstreamAnswer, fromUpstream, iteration);
         } else {
-            responses.addFetched(upstreamAnswer);
+            failToUpstream(fromUpstream, iteration);
         }
     }
 
-    public void receiveTraversalDone(Request fromUpstreamSource) {
-        if (isTerminated()) return;
-        Responses responses = this.responses.get(fromUpstreamSource);
-        responses.setTraversalDone();
-        if (!responses.hasFetched()) {
-            responses.finished();
-        }
-    }
-
-    private void dispatchAnswer(Partial<?> upstreamAnswer, Request fromUpstreamSource) {
-        answerToUpstream(upstreamAnswer, fromUpstreamSource, responses.get(fromUpstreamSource).iteration());
-    }
-
-    private void dispatchFail(Request fromUpstreamSource) {
-        Responses responses = this.responses.get(fromUpstreamSource);
-        failToUpstream(fromUpstreamSource, responses.iteration);
-    }
-
-    private class Responses {
-
-        private final Request request;
-        private final int iteration;
-        private final Producer<Partial<?>> traversalUpstreamAnswers;
-        private final List<Partial<?>> fetched;
-        private final List<Request> awaitingAnswers;
-        private int processing;
-        private boolean traversalDone;
-
-        public Responses(Request request, Producer<Partial<?>> traversalUpstreamAnswers, int iteration) {
-            this.request = request;
-            this.traversalUpstreamAnswers = traversalUpstreamAnswers;
-            this.iteration = iteration;
-            this.fetched = new LinkedList<>();
-            this.awaitingAnswers = new LinkedList<>();
-            this.processing = 0;
-            this.traversalDone = false;
-        }
-
-        public int iteration() {
-            return iteration;
-        }
-
-        public void setTraversalDone() {
-            this.traversalDone = true;
-            this.processing = 0;
-        }
-
-        public boolean hasAwaitingRequest() {
-            return !awaitingAnswers.isEmpty();
-        }
-
-        public Request popAwaitingRequest() {
-            return awaitingAnswers.remove(0);
-        }
-
-        public boolean hasFetched() {
-            return !fetched.isEmpty();
-        }
-
-        public void addFetched(Partial<?> upstreamAnswer) {
-            fetched.add(upstreamAnswer);
-        }
-
-        public void nextAnswer() {
-            if (traversalDone && fetched.isEmpty()) {
-                dispatchFail(request);
-            } else {
-                if (!fetched.isEmpty()) dispatchAnswer(fetched.remove(0), request);
-                else awaitingAnswers.add(request);
-                mayFetch();
-            }
-        }
-
-        private void mayFetch() {
-            // when buffered answers is mostly empty, trigger more processing
-            if (!traversalDone && fetched.size() + processing < REFETCH_THRESHOLD) {
-                int toFetch = PREFETCH_SIZE - fetched.size() - processing;
-                this.traversalUpstreamAnswers.produce(new Queue(request), toFetch, asyncPool2());
-                processing += toFetch;
-            }
-        }
-
-        public void decrementProcessing() {
-            processing--;
-        }
-
-        public void finished() {
-            while (hasAwaitingRequest()) {
-                dispatchFail(popAwaitingRequest());
-            }
-            assert traversalDone && awaitingAnswers.isEmpty() && fetched.isEmpty();
-        }
-
-        class Queue implements Producer.Queue<Partial<?>> {
-
-            private final Request sourceRequest;
-
-            Queue(Request sourceRequest) {
-                this.sourceRequest = sourceRequest;
-            }
-
-            @Override
-            public void put(Partial<?> upstreamAnswer) {
-                self().tell(resolver -> resolver.receiveTraversalAnswer(upstreamAnswer, sourceRequest));
-            }
-
-            @Override
-            public void done() {
-                self().tell(resolver -> resolver.receiveTraversalDone(sourceRequest));
-            }
-
-            @Override
-            public void done(Throwable e) {
-                self().tell(resolver -> exception(e));
-            }
-        }
-
+    @Override
+    protected void exception(Throwable e) {
+        LOG.error("Actor exception", e);
     }
 
 }

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -128,9 +128,10 @@ public interface Root {
 
             assert !plan.isEmpty();
             ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
+            ResolverRegistry.MappedResolver mappedResolver = downstreamResolvers.get(plan.get(0));
             Partial.Mapped downstream = fromUpstream.partialAnswer()
-                    .mapToDownstream(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping()));
-            Request toDownstream = Request.create(self(),downstreamResolvers.get(plan.get(0)).resolver(), downstream, 0);
+                    .mapToDownstream(Mapping.of(mappedResolver.mapping()), mappedResolver.resolver());
+            Request toDownstream = Request.create(self(), mappedResolver.resolver(), downstream, 0);
             responseProducerNewIter.addDownstreamProducer(toDownstream);
             return responseProducerNewIter;
         }
@@ -322,7 +323,7 @@ public interface Root {
             assert !downstreamResolvers.isEmpty();
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }
@@ -345,7 +346,7 @@ public interface Root {
             ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }


### PR DESCRIPTION
## What is the goal of this PR?
We revert to non-asynchronous producers in Retrievable until the CI stalling is fixed. We also refactor AnswerState to have more correct equality checks and a better flow when moving between states

## What are the changes implemented in this PR?
* Revert `RetrievableResolver` to not use asynchronous producers for traversals, and instead use standard iterators
* Fix `AnswerState` data flow when moving up and down states
* Equality functions and hashes are updated
