### PR TITLE
Resolution answer state equality depends on applicable resolver

### DIFF
--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -32,7 +32,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = true;
+    public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -32,7 +32,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = false;
+    public static final boolean DEFAULT_INFER = true;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -299,7 +299,7 @@ public abstract class AnswerState {
                              boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(filteredConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.filter = filter;
-                this.hash = Objects.hash(resolver, conceptMap, filter, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, parent, filter);
             }
 
             static Filtered filter(Partial<?> parent, Set<Identifier.Variable.Retrievable> filter, Actor<? extends Resolver<?>> root,
@@ -333,6 +333,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Filtered{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", filter=" + filter +
                         '}';
@@ -344,6 +345,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Filtered filtered = (Filtered) o;
                 return Objects.equals(root(), filtered.root()) &&
+                        Objects.equals(resolver(), filtered.resolver()) &&
                         Objects.equals(conceptMap, filtered.conceptMap) &&
                         Objects.equals(parent, filtered.parent) &&
                         Objects.equals(filter, filtered.filter);
@@ -366,7 +368,7 @@ public abstract class AnswerState {
                            boolean requiresReiteration, @Nullable Derivation derivation, boolean recordExplanations) {
                 super(mappedConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.mapping = mapping;
-                this.hash = Objects.hash(resolver, conceptMap, mapping, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, mapping, parent);
             }
 
             static Mapped map(Partial<?> parent, Mapping mapping, Actor<? extends Resolver<?>> root,
@@ -406,6 +408,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Mapped{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", mapping=" + mapping +
                         '}';
@@ -417,6 +420,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Mapped mapped = (Mapped) o;
                 return Objects.equals(root(), mapped.root()) &&
+                        Objects.equals(resolver(), mapped.resolver()) &&
                         Objects.equals(conceptMap, mapped.conceptMap) &&
                         Objects.equals(parent, mapped.parent) &&
                         Objects.equals(mapping, mapped.mapping);
@@ -441,7 +445,7 @@ public abstract class AnswerState {
                 super(unifiedConceptMap, parent, resolver, root, requiresReiteration, derivation, recordExplanations);
                 this.unifier = unifier;
                 this.instanceRequirements = instanceRequirements;
-                this.hash = Objects.hash(resolver, conceptMap, unifier, instanceRequirements, parent);
+                this.hash = Objects.hash(root, resolver, conceptMap, unifier, instanceRequirements, parent);
             }
 
             static Optional<Partial.Unified> unify(Partial<?> parent, Unifier unifier,
@@ -486,6 +490,7 @@ public abstract class AnswerState {
             public String toString() {
                 return "AnswerState.Partial.Unified{" +
                         "root=" + root() +
+                        "resolver=" + resolver() +
                         ", conceptMap=" + conceptMap() +
                         ", unifier=" + unifier +
                         ", instanceRequirements=" + instanceRequirements +
@@ -498,6 +503,7 @@ public abstract class AnswerState {
                 if (o == null || getClass() != o.getClass()) return false;
                 Unified unified = (Unified) o;
                 return Objects.equals(root(), unified.root()) &&
+                        Objects.equals(resolver(), unified.resolver()) &&
                         Objects.equals(conceptMap, unified.conceptMap) &&
                         Objects.equals(parent, unified.parent) &&
                         Objects.equals(unifier, unified.unifier) &&

--- a/reasoner/resolution/answer/AnswerStateTest.java
+++ b/reasoner/resolution/answer/AnswerStateTest.java
@@ -25,7 +25,6 @@ import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Mapped;
 import grakn.core.reasoner.resolution.answer.AnswerState.Top;
 import grakn.core.traversal.common.Identifier;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -46,13 +45,13 @@ public class AnswerStateTest {
         mapping.put(Identifier.Variable.name("a"), Identifier.Variable.name("x"));
         mapping.put(Identifier.Variable.name("b"), Identifier.Variable.name("y"));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
-        Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = Top.initial(filter, false, null).toDownstream().mapToDownstream(Mapping.of(mapping), null);
         assertTrue(mapped.conceptMap().concepts().isEmpty());
 
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>();
         concepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         concepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(concepts));
         Map<Identifier.Variable.Retrievable, Concept> expected = new HashMap<>();
         expected.put(Identifier.Variable.name("a"), new MockConcept(0));
         expected.put(Identifier.Variable.name("b"), new MockConcept(1));
@@ -68,8 +67,8 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("a"), new MockConcept(0));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Top top = Top.initial(filter, false, null);
-        Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
-                .mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = identity(new ConceptMap(concepts), top,  null, null, false)
+                .mapToDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
@@ -78,7 +77,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts));
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));
@@ -96,8 +95,8 @@ public class AnswerStateTest {
         concepts.put(Identifier.Variable.name("c"), new MockConcept(2));
         Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("a"), Identifier.Variable.name("b"));
         Top top = Top.initial(filter, false, null);
-        Mapped mapped = identity(new ConceptMap(concepts), top,  null, false)
-                .mapToDownstream(Mapping.of(mapping));
+        Mapped mapped = identity(new ConceptMap(concepts), top, null, null, false)
+                .mapToDownstream(Mapping.of(mapping), null);
 
         Map<Identifier.Variable.Retrievable, Concept> expectedMapped = new HashMap<>();
         expectedMapped.put(Identifier.Variable.name("x"), new MockConcept(0));
@@ -106,7 +105,7 @@ public class AnswerStateTest {
         Map<Identifier.Variable.Retrievable, Concept> downstreamConcepts = new HashMap<>();
         downstreamConcepts.put(Identifier.Variable.name("x"), new MockConcept(0));
         downstreamConcepts.put(Identifier.Variable.name("y"), new MockConcept(1));
-        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts), null);
+        Partial<?> partial = mapped.aggregateToUpstream(new ConceptMap(downstreamConcepts));
 
         Map<Identifier.Variable.Retrievable, Concept> expectedWithInitial = new HashMap<>();
         expectedWithInitial.put(Identifier.Variable.name("a"), new MockConcept(0));

--- a/reasoner/resolution/resolver/ConcludableResolver.java
+++ b/reasoner/resolution/resolver/ConcludableResolver.java
@@ -99,7 +99,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         Request fromUpstream = fromUpstream(toDownstream);
         ResponseProducer responseProducer = responseProducers.get(fromUpstream);
 
-        Partial<?> upstreamAnswer = fromDownstream.answer().asMapped().toUpstream(self());
+        Partial<?> upstreamAnswer = fromDownstream.answer().asMapped().toUpstream();
 
         if (!responseProducer.hasProduced(upstreamAnswer.conceptMap())) {
             responseProducer.recordProduced(upstreamAnswer.conceptMap());
@@ -167,7 +167,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(concludable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         ResponseProducer responseProducer = new ResponseProducer(upstreamAnswers, iteration);
         mayRegisterRules(fromUpstream, iterationState, responseProducer);
@@ -190,7 +190,7 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         ResourceIterator<Partial<?>> upstreamAnswers =
                 traversalIterator(concludable.pattern(), fromUpstream.partialAnswer().conceptMap())
-                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                        .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         ResponseProducer responseProducerNewIter = responseProducerPrevious.newIteration(upstreamAnswers, newIteration);
         mayRegisterRules(fromUpstream, iterationState, responseProducerNewIter);
@@ -233,11 +233,11 @@ public class ConcludableResolver extends Resolver<ConcludableResolver> {
         // if we have, we do not allow rules to be registered as possible downstreams
         if (!recursionState.hasReceived(fromUpstream.partialAnswer().conceptMap())) {
             for (Map.Entry<Actor<ConclusionResolver>, Set<Unifier>> entry : applicableRules.entrySet()) {
-                Actor<ConclusionResolver> ruleActor = entry.getKey();
+                Actor<ConclusionResolver> conclusionResolver = entry.getKey();
                 for (Unifier unifier : entry.getValue()) {
-                    Optional<Unified> unified = fromUpstream.partialAnswer().unifyToDownstream(unifier);
+                    Optional<Unified> unified = fromUpstream.partialAnswer().unifyToDownstream(unifier, conclusionResolver);
                     if (unified.isPresent()) {
-                        Request toDownstream = Request.create(self(), ruleActor, unified.get());
+                        Request toDownstream = Request.create(self(), conclusionResolver, unified.get());
                         responseProducer.addDownstreamProducer(toDownstream);
                     }
                 }

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -103,7 +103,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         if (!materialisations.hasNext()) throw GraknException.of(ILLEGAL_STATE);
 
         ResourceIterator<AnswerState.Partial<?>> materialisedAnswers = materialisations
-                .map(concepts -> fromUpstream.partialAnswer().asUnified().aggregateToUpstream(concepts, self()))
+                .map(concepts -> fromUpstream.partialAnswer().asUnified().aggregateToUpstream(concepts))
                 .filter(Optional::isPresent)
                 .map(Optional::get);
         conclusionResponses.addResponses(materialisedAnswers);
@@ -191,7 +191,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
                                                                                                          answer)));
         } else {
             Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-            AnswerState.Partial.Filtered downstreamAnswer = fromUpstream.partialAnswer().filterToDownstream(named);
+            AnswerState.Partial.Filtered downstreamAnswer = fromUpstream.partialAnswer().filterToDownstream(named, ruleResolver);
             conclusionResponses.addDownstream(Request.create(self(), ruleResolver, downstreamAnswer));
         }
 
@@ -202,7 +202,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
         Traversal traversal1 = boundTraversal(conclusion.conjunction().traversal(), answer);
         ResourceIterator<ConceptMap> traversal = traversalEngine.iterator(traversal1).map(conceptMgr::conceptMap);
         Set<Identifier.Variable.Retrievable> named = iterate(conclusion.retrievableIds()).filter(Identifier::isName).toSet();
-        return traversal.map(ans -> fromUpstream.partialAnswer().asUnified().extend(ans).filterToDownstream(named));
+        return traversal.map(ans -> fromUpstream.partialAnswer().asUnified().extend(ans).filterToDownstream(named, ruleResolver));
     }
 
     @Override

--- a/reasoner/resolution/resolver/ConditionResolver.java
+++ b/reasoner/resolution/resolver/ConditionResolver.java
@@ -64,7 +64,7 @@ public class ConditionResolver extends ConjunctionResolver<ConditionResolver> {
 
     @Override
     protected Optional<AnswerState> toUpstreamAnswer(AnswerState.Partial<?> fromDownstream) {
-        return Optional.of(fromDownstream.asFiltered().toUpstream(self()));
+        return Optional.of(fromDownstream.asFiltered().toUpstream());
     }
 
     @Override

--- a/reasoner/resolution/resolver/NegationResolver.java
+++ b/reasoner/resolution/resolver/NegationResolver.java
@@ -116,7 +116,7 @@ public class NegationResolver extends Resolver<NegationResolver> {
               the toplevel root with the negation iterations, which we cannot allow. So, we must use THIS resolver
               as a sort of new root! TODO: should NegationResolvers also implement a kind of Root interface??
         */
-        Filtered downstreamPartial = fromUpstream.partialAnswer().filterToDownstream(negated.retrieves());
+        Filtered downstreamPartial = fromUpstream.partialAnswer().filterToDownstream(negated.retrieves(), downstream);
         Request request = Request.create(self(), this.downstream, downstreamPartial);
         requestFromDownstream(request, fromUpstream, 0);
         negationResponse.setRequested();
@@ -156,7 +156,7 @@ public class NegationResolver extends Resolver<NegationResolver> {
     private Partial<?> upstreamAnswer(Request fromUpstream) {
         // TODO: decide if we want to use isMapped here? Can Mapped currently act as a filter?
         assert fromUpstream.partialAnswer().isMapped();
-        Partial<?> upstreamAnswer = fromUpstream.partialAnswer().asMapped().toUpstream(self());
+        Partial<?> upstreamAnswer = fromUpstream.partialAnswer().asMapped().toUpstream();
 
         if (fromUpstream.partialAnswer().recordExplanations()) {
             resolutionRecorder.tell(state -> state.record(fromUpstream.partialAnswer()));

--- a/reasoner/resolution/resolver/RetrievableResolver.java
+++ b/reasoner/resolution/resolver/RetrievableResolver.java
@@ -96,7 +96,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
 
         Producer<ConceptMap> traversalAsync = traversalProducer(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap(), 2);
         Producer<Partial<?>> upstreamAnswersAsync = traversalAsync
-                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         return new Responses(fromUpstream, upstreamAnswersAsync, iteration);
     }
@@ -110,7 +110,7 @@ public class RetrievableResolver extends Resolver<RetrievableResolver> {
         assert fromUpstream.partialAnswer().isMapped();
         Producer<ConceptMap> traversalAsync = traversalProducer(retrievable.pattern(), fromUpstream.partialAnswer().conceptMap(), 2);
         Producer<Partial<?>> upstreamAnswersAsync = traversalAsync
-                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap, self()));
+                .map(conceptMap -> fromUpstream.partialAnswer().asMapped().aggregateToUpstream(conceptMap));
 
         return new Responses(fromUpstream, upstreamAnswersAsync, newIteration);
     }

--- a/reasoner/resolution/resolver/Root.java
+++ b/reasoner/resolution/resolver/Root.java
@@ -128,9 +128,10 @@ public interface Root {
 
             assert !plan.isEmpty();
             ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
+            ResolverRegistry.MappedResolver mappedResolver = downstreamResolvers.get(plan.get(0));
             Partial.Mapped downstream = fromUpstream.partialAnswer()
-                    .mapToDownstream(Mapping.of(downstreamResolvers.get(plan.get(0)).mapping()));
-            Request toDownstream = Request.create(self(),downstreamResolvers.get(plan.get(0)).resolver(), downstream, 0);
+                    .mapToDownstream(Mapping.of(mappedResolver.mapping()), mappedResolver.resolver());
+            Request toDownstream = Request.create(self(), mappedResolver.resolver(), downstream, 0);
             responseProducerNewIter.addDownstreamProducer(toDownstream);
             return responseProducerNewIter;
         }
@@ -322,7 +323,7 @@ public interface Root {
             assert !downstreamResolvers.isEmpty();
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }
@@ -345,7 +346,7 @@ public interface Root {
             ResponseProducer responseProducerNewIter = responseProducerPrevious.newIterationRetainDedup(Iterators.empty(), newIteration);
             for (Actor<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
                 Filtered downstream = fromUpstream.partialAnswer().asIdentity()
-                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver));
+                        .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
                 Request request = Request.create(self(), conjunctionResolver, downstream);
                 responseProducer.addDownstreamProducer(request);
             }


### PR DESCRIPTION
## What is the goal of this PR?
To ensure that equality functions in `AnswerState` can distinguish between two answers that come from content-identical paths but with different resolvers (eg. two resolvers that produce the same answer, but have different queries or resolver instances), we update the equality functions to include the correct resolver that extends any answer state.

## What are the changes implemented in this PR?
* Update AnswerState equality functions
* Inject resolver that will receive an answer state, into the answer state
* The parent answer state that is being extended using `.with()` is responsible for updating derivations and concepts maps, instead of the child performing the operation and passing it in.