### PR TITLE
Remove offset and limit from reasoner

### DIFF
--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -189,4 +189,5 @@ public class Reasoner {
         newClone.bound(bounds.toMap(Type::getLabel, Thing::getIID));
         return newClone;
     }
+
 }

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -106,12 +106,11 @@ public class ResolverRegistry {
         }
     }
 
-    public Actor.Driver<RootResolver.Conjunction> root(Conjunction conjunction, @Nullable Long offset,
-                                                       @Nullable Long limit, Consumer<Top> onAnswer,
+    public Actor.Driver<RootResolver.Conjunction> root(Conjunction conjunction, Consumer<Top> onAnswer,
                                                        Consumer<Integer> onFail, Consumer<Throwable> onException) {
         LOG.debug("Creating Root.Conjunction for: '{}'", conjunction);
         Actor.Driver<RootResolver.Conjunction> resolver = Actor.driver(driver -> new RootResolver.Conjunction(
-                driver, conjunction, offset, limit, onAnswer, onFail, onException, resolutionRecorder, this,
+                driver, conjunction, onAnswer, onFail, onException, resolutionRecorder, this,
                 traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing
         ), elg);
         resolvers.add(resolver);
@@ -119,12 +118,11 @@ public class ResolverRegistry {
         return resolver;
     }
 
-    public Actor.Driver<RootResolver.Disjunction> root(Disjunction disjunction, @Nullable Long offset,
-                                                       @Nullable Long limit, Consumer<Top> onAnswer,
+    public Actor.Driver<RootResolver.Disjunction> root(Disjunction disjunction, Consumer<Top> onAnswer,
                                                        Consumer<Integer> onExhausted, Consumer<Throwable> onException) {
         LOG.debug("Creating Root.Disjunction for: '{}'", disjunction);
         Actor.Driver<RootResolver.Disjunction> resolver = Actor.driver(driver -> new RootResolver.Disjunction(
-                driver, disjunction, offset, limit, onAnswer, onExhausted, onException,
+                driver, disjunction, onAnswer, onExhausted, onException,
                 resolutionRecorder, this, traversalEngine, conceptMgr, resolutionTracing
         ), elg);
         resolvers.add(resolver);

--- a/reasoner/resolution/resolver/DisjunctionResolver.java
+++ b/reasoner/resolution/resolver/DisjunctionResolver.java
@@ -25,6 +25,7 @@ import grakn.core.reasoner.resolution.ResolutionRecorder;
 import grakn.core.reasoner.resolution.ResolverRegistry;
 import grakn.core.reasoner.resolution.answer.AnswerState;
 import grakn.core.reasoner.resolution.answer.AnswerState.Partial;
+import grakn.core.reasoner.resolution.answer.AnswerState.Partial.Filtered;
 import grakn.core.reasoner.resolution.framework.Request;
 import grakn.core.reasoner.resolution.framework.Response;
 import grakn.core.traversal.TraversalEngine;
@@ -39,7 +40,8 @@ import java.util.Set;
 
 import static grakn.core.common.iterator.Iterators.iterate;
 
-public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<RESOLVER>> extends CompoundResolver<RESOLVER, DisjunctionResolver.RequestState> {
+public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<RESOLVER>>
+        extends CompoundResolver<RESOLVER, DisjunctionResolver.RequestState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(Disjunction.class);
 
@@ -94,7 +96,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
         assert fromUpstream.partialAnswer().isFiltered() || fromUpstream.partialAnswer().isIdentity();
         RequestState requestState = new RequestState(iteration);
         for (Driver<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
-            AnswerState.Partial.Filtered downstream = fromUpstream.partialAnswer()
+            Filtered downstream = fromUpstream.partialAnswer()
                     .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
             Request request = Request.create(driver(), conjunctionResolver, downstream);
             requestState.addDownstreamProducer(request);
@@ -111,7 +113,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
 
         RequestState requestStateNextIteration = requestStateForIteration(requestStatePrior, newIteration);
         for (Driver<ConjunctionResolver.Nested> conjunctionResolver : downstreamResolvers) {
-            AnswerState.Partial.Filtered downstream = fromUpstream.partialAnswer()
+            Filtered downstream = fromUpstream.partialAnswer()
                     .filterToDownstream(conjunctionRetrievedIds(conjunctionResolver), conjunctionResolver);
             Request request = Request.create(driver(), conjunctionResolver, downstream);
             requestStateNextIteration.addDownstreamProducer(request);

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -48,6 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class ReasonerTest {
+
     private static final Path dataDir = Paths.get(System.getProperty("user.dir")).resolve("query-test");
     private static final Path logDir = dataDir.resolve("logs");
     private static final Database options = new Database().dataDir(dataDir).logsDir(logDir);

--- a/test/integration/reasoner/ReiterationTest.java
+++ b/test/integration/reasoner/ReiterationTest.java
@@ -127,7 +127,7 @@ public class ReiterationTest {
                 boolean[] receivedInferredAnswer = {false};
 
                 ResolutionTracer.get().start();
-                Actor.Driver<RootResolver.Conjunction> root = registry.root(conjunction, null, null, answer -> {
+                Actor.Driver<RootResolver.Conjunction> root = registry.root(conjunction, answer -> {
                     if (answer.requiresReiteration()) receivedInferredAnswer[0] = true;
                     responses.add(answer);
                 }, iterDone -> {

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -136,7 +136,7 @@ public class ResolutionTest {
                 LinkedBlockingQueue<Throwable> exceptions = new LinkedBlockingQueue<>();
                 Actor.Driver<RootResolver.Conjunction> root;
                 try {
-                    root = registry.root(conjunctionPattern, null, null, responses::add, iterDone -> doneReceived.incrementAndGet(), exceptions::add);
+                    root = registry.root(conjunctionPattern, responses::add, iterDone -> doneReceived.incrementAndGet(), exceptions::add);
                 } catch (GraknException e) {
                     fail();
                 }
@@ -474,7 +474,7 @@ public class ResolutionTest {
                         .filter(Identifier::isName).map(Identifier.Variable::asName).toSet();
                 Actor.Driver<RootResolver.Conjunction> root;
                 try {
-                    root = registry.root(conjunctionPattern, null, null, responses::add,
+                    root = registry.root(conjunctionPattern, responses::add,
                                          iterDone -> doneReceived.incrementAndGet(), (throwable) -> fail());
                 } catch (GraknException e) {
                     fail();
@@ -484,8 +484,8 @@ public class ResolutionTest {
                 for (int i = 0; i < answerCount; i++) {
                     Identity downstream = Top.initial(filter, false, root).toDownstream();
                     root.execute(actor ->
-                                      actor.receiveRequest(
-                                              Request.create(root, downstream), 0)
+                                         actor.receiveRequest(
+                                                 Request.create(root, downstream), 0)
                     );
                     Top answer = responses.take();
 
@@ -538,7 +538,7 @@ public class ResolutionTest {
         AtomicLong doneReceived = new AtomicLong(0L);
         Actor.Driver<RootResolver.Disjunction> root;
         try {
-            root = registry.root(disjunction, offset, limit, responses::add, iterDone -> doneReceived.incrementAndGet(), (throwable) -> fail());
+            root = registry.root(disjunction, responses::add, iterDone -> doneReceived.incrementAndGet(), (throwable) -> fail());
         } catch (GraknException e) {
             fail();
             return;
@@ -555,7 +555,7 @@ public class ResolutionTest {
                 .filter(Identifier::isName).map(Identifier.Variable::asName).toSet();
         Actor.Driver<RootResolver.Conjunction> root;
         try {
-            root = registry.root(conjunction, offset, limit, responses::add, iterDone -> doneReceived.incrementAndGet(), (throwable) -> fail());
+            root = registry.root(conjunction, responses::add, iterDone -> doneReceived.incrementAndGet(), (throwable) -> fail());
         } catch (GraknException e) {
             fail();
             return;

--- a/test/integration/reasoner/ResolutionTest.java
+++ b/test/integration/reasoner/ResolutionTest.java
@@ -44,7 +44,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -104,7 +103,7 @@ public class ResolutionTest {
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; $p1 has age $a; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 3L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 3L);
             }
         }
     }
@@ -151,33 +150,6 @@ public class ResolutionTest {
     }
 
     @Test
-    public void test_conjunction_no_rules_limited_offset() throws InterruptedException {
-        try (RocksSession session = schemaSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                transaction.query().define(Graql.parseQuery(
-                        "define person sub entity, owns age, plays twins:twin1, plays twins:twin2;" +
-                                "age sub attribute, value long;" +
-                                "twins sub relation, relates twin1, relates twin2;"));
-                transaction.commit();
-            }
-        }
-        try (RocksSession session = dataSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 24; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 24; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 24; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.commit();
-            }
-        }
-        try (RocksSession session = dataSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                Conjunction conjunctionPattern = parseConjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; $p1 has age $a; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, 1L, 1L, 1L);
-            }
-        }
-    }
-
-    @Test
     public void test_disjunction_no_rules() throws InterruptedException {
         try (RocksSession session = schemaSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
@@ -202,39 +174,7 @@ public class ResolutionTest {
                                                            Identifier.Variable.name("p1"),
                                                            Identifier.Variable.name("p2"));
                 Disjunction disjunction = parseDisjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; { $p1 has age 24; } or { $p1 has age 26; }; }");
-                createRootAndAssertResponses(transaction, disjunction, filter, null, null, 2L);
-            }
-        }
-    }
-
-    @Test
-    public void test_disjunction_no_rules_limit_offset() throws InterruptedException {
-        try (RocksSession session = schemaSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                transaction.query().define(Graql.parseQuery(
-                        "define person sub entity, owns age, plays twins:twin1, plays twins:twin2;" +
-                                "age sub attribute, value long;" +
-                                "twins sub relation, relates twin1, relates twin2;"));
-                transaction.commit();
-            }
-        }
-        try (RocksSession session = dataSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 24; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 25; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 26; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.query().insert(Graql.parseQuery("insert $p1 isa person, has age 27; $t(twin1: $p1, twin2: $p2) isa twins; $p2 isa person;"));
-                transaction.commit();
-            }
-        }
-        try (RocksSession session = dataSession()) {
-            try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
-                Set<Identifier.Variable.Name> filter = set(Identifier.Variable.name("t"),
-                                                           Identifier.Variable.name("p1"),
-                                                           Identifier.Variable.name("p2"));
-                Disjunction disjunction = parseDisjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; " +
-                        "{ $p1 has age 24; } or { $p1 has age 26; } or { $p1 has age 27;} ; }");
-                createRootAndAssertResponses(transaction, disjunction, filter, 1L, 1L, 1L);
+                createRootAndAssertResponses(transaction, disjunction, filter, 2L);
             }
         }
     }
@@ -262,7 +202,7 @@ public class ResolutionTest {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ $t(twin1: $p1, twin2: $p2) isa twins; " +
                         "$p1 has age $a; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 0L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 0L);
             }
         }
     }
@@ -299,7 +239,7 @@ public class ResolutionTest {
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ $p1 isa person, has age 42; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 6L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 6L);
             }
         }
     }
@@ -331,7 +271,7 @@ public class ResolutionTest {
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ $p isa person; not { { $p has age 24; } or { $p has age 42; }; }; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 1L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 1L);
             }
         }
     }
@@ -369,7 +309,7 @@ public class ResolutionTest {
 
                 String rootConjunction = "{ $e(employee: $x) isa employment; }";
                 Conjunction conjunctionPattern = parseConjunction(transaction, rootConjunction);
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 9L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 9L);
             }
         }
     }
@@ -408,7 +348,7 @@ public class ResolutionTest {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 String rootConjunction = "{ $a isa woman; $b isa man; $f(friend: $a, friend: $b) isa friendship; }";
                 Conjunction conjunctionPattern = parseConjunction(transaction, rootConjunction);
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 2L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 2L);
             }
         }
     }
@@ -450,7 +390,7 @@ public class ResolutionTest {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ $x isa man; " +
                         "(friend: $x, friend: $y) isa friendship; $y isa woman; (associated: $y, associated: $z) isa association; $z isa company; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 1L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 1L);
             }
         }
     }
@@ -487,7 +427,7 @@ public class ResolutionTest {
         try (RocksSession session = dataSession()) {
             try (RocksTransaction transaction = singleThreadElgTransaction(session)) {
                 Conjunction conjunctionPattern = parseConjunction(transaction, "{ (container:$l3, contained:$l4) isa containment; }");
-                createRootAndAssertResponses(transaction, conjunctionPattern, null, null, 6L);
+                createRootAndAssertResponses(transaction, conjunctionPattern, 6L);
             }
         }
     }
@@ -592,8 +532,7 @@ public class ResolutionTest {
     }
 
     private void createRootAndAssertResponses(RocksTransaction transaction, Disjunction disjunction,
-                                              Set<Identifier.Variable.Name> filter, @Nullable Long offset, @Nullable Long limit,
-                                              long answerCount) throws InterruptedException {
+                                              Set<Identifier.Variable.Name> filter, long answerCount) throws InterruptedException {
         ResolverRegistry registry = transaction.reasoner().resolverRegistry();
         LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
         AtomicLong doneReceived = new AtomicLong(0L);
@@ -607,8 +546,8 @@ public class ResolutionTest {
         assertResponses(root, filter, responses, doneReceived, answerCount);
     }
 
-    private void createRootAndAssertResponses(RocksTransaction transaction, Conjunction conjunction, @Nullable Long offset,
-                                              @Nullable Long limit, long answerCount) throws InterruptedException {
+    private void createRootAndAssertResponses(RocksTransaction transaction, Conjunction conjunction, long answerCount)
+            throws InterruptedException {
         ResolverRegistry registry = transaction.reasoner().resolverRegistry();
         LinkedBlockingQueue<Top> responses = new LinkedBlockingQueue<>();
         AtomicLong doneReceived = new AtomicLong(0L);


### PR DESCRIPTION
## What is the goal of this PR?
It's incorrect to apply offset and limit inside reasoner, as we cannot sort natively. To do this properly, we keep offset and limit only at the top level iterator, and the caller is responsible for making sure that reasoner is not going to "over-compute" when a limit is present.

## What are the changes implemented in this PR?
* Remove `offset` and `limit` from reasoner
* Clean up naming and imports in Resolvers