### PR TITLE
Rule materialisation lookups should use relation type

### DIFF
--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -187,12 +187,6 @@ public class Rule {
         });
     }
 
-    @Override
-    public String toString() {
-        return "" + RULE + SPACE + getLabel() + COLON + NEW_LINE + WHEN + SPACE + CURLY_OPEN + NEW_LINE + when + NEW_LINE +
-                CURLY_CLOSE + SPACE + THEN + SPACE + CURLY_OPEN + NEW_LINE + then + NEW_LINE + CURLY_CLOSE + SEMICOLON;
-    }
-
     void validateCycles() {
         // TODO: implement this when we have negation
         // TODO: detect negated cycles in the rule graph
@@ -254,6 +248,12 @@ public class Rule {
     public void reindex() {
         conclusion().unindex();
         conclusion().index();
+    }
+
+    @Override
+    public String toString() {
+        return "" + RULE + SPACE + getLabel() + COLON + NEW_LINE + WHEN + SPACE + CURLY_OPEN + NEW_LINE + when + NEW_LINE +
+                CURLY_CLOSE + SPACE + THEN + SPACE + CURLY_OPEN + NEW_LINE + then + NEW_LINE + CURLY_CLOSE + SEMICOLON;
     }
 
     public static abstract class Conclusion {
@@ -486,7 +486,7 @@ public class Rule {
                                                                                         TraversalEngine traversalEng, ConceptManager conceptMgr) {
                 Traversal traversal = new Traversal();
                 Identifier.Variable.Retrievable relationId = relation().owner().id();
-                traversal.isa(relationId, Identifier.Variable.label(relationType.getLabel().name()), false);
+                traversal.types(relationId, set(relationType.getLabel()));
                 Set<Identifier.Variable> playersWithIds = new HashSet<>();
                 players.forEach(rp -> {
                     // note: NON-transitive role player types - we require an exact role being played

--- a/reasoner/resolution/answer/AnswerState.java
+++ b/reasoner/resolution/answer/AnswerState.java
@@ -466,7 +466,7 @@ public abstract class AnswerState {
 
             public Optional<Partial<?>> aggregateToUpstream(Map<Identifier.Variable, Concept> concepts) {
                 Optional<ConceptMap> unUnified = unifier.unUnify(concepts, instanceRequirements);
-                return unUnified.map(ans -> parent().with(new ConceptMap(ans.concepts()), true, resolvedBy(), this));
+                return unUnified.map(ans -> parent().with(ans, true, resolvedBy(), this));
             }
 
             @Override

--- a/reasoner/resolution/framework/ResolutionTracer.java
+++ b/reasoner/resolution/framework/ResolutionTracer.java
@@ -139,11 +139,11 @@ public final class ResolutionTracer {
         if (path.get() == null) throw GraknException.of(REASONER_TRACING_CALL_TO_FINISH_BEFORE_START);
         endFile();
         try {
-            LOG.trace("Resolution traces written to {}", path.get().toAbsolutePath());
+            LOG.debug("Resolution traces written to {}", path.get().toAbsolutePath());
             writer.close();
         } catch (Exception e) {
             e.printStackTrace();
-            LOG.trace("Resolution tracing failed to write to file");
+            LOG.debug("Resolution tracing failed to write to file");
         }
         rootRequestNumber += 1;
         path.set(null);

--- a/test/integration/reasoner/ReasonerTest.java
+++ b/test/integration/reasoner/ReasonerTest.java
@@ -132,7 +132,7 @@ public class ReasonerTest {
                 try {
                     List<ConceptMap> ans = txn.query().match(Graql.parseQuery("match $x isa is-still-good;").asMatch()).toList();
                 } catch (GraknException e) {
-                    assertEquals(((GraknException) e.getCause()).code().get(), RESOLUTION_TERMINATED.code());
+                    assertEquals(e.code().get(), RESOLUTION_TERMINATED.code());
                     return;
                 }
                 fail();


### PR DESCRIPTION
## What is the goal of this PR?
We incorrectly fail to use the relation type when performing a traversal to lookup whether the rule conclusion is already satisfied with a given set of concepts. This PR includes the relation type correctly in the lookup, fixing several reasoning BDD scenarios (notably, recursion tests).

## What are the changes implemented in this PR?
* Rule materialisations lookup with the correct (always known) relation type.
* log the location of the resolution tracing log files in DEBUG mode
* avoid creating an extra unnecessary concept map in AnswerState
* Fix a reasoning test that tried to check a exception cause rather than the exception itself