### PR TITLE
Parallel configuration is available in all options 

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -130,9 +130,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: graknlabs-ubuntu-20.04
-      filter:
-        owner: graknlabs
-        branch: master
+#      filter:
+#        owner: graknlabs
+#        branch: master
       # dependencies: [test-assembly-linux-targz] TODO: re-enable
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -130,9 +130,9 @@ build:
         bazel test //test/assembly:docker --test_output=streamed
     deploy-artifact-snapshot:
       image: graknlabs-ubuntu-20.04
-#      filter:
-#        owner: graknlabs
-#        branch: master
+      filter:
+        owner: graknlabs
+        branch: master
       # dependencies: [test-assembly-linux-targz] TODO: re-enable
       command: |
         export DEPLOY_ARTIFACT_USERNAME=$REPO_GRAKN_USERNAME

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -45,6 +45,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     private Boolean traceInference = null;
     private Boolean explain = null;
     private Integer batchSize = null;
+    private Boolean parallel = null;
     private Integer sessionIdlTimeoutMillis = null;
     private Integer schemaLockAcquireTimeoutMillis = null;
     private Boolean readAnyReplica = null;
@@ -102,6 +103,16 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public SELF responseBatchSize(int batchSize) {
         this.batchSize = batchSize;
+        return getThis();
+    }
+
+    public boolean parallel() {
+        if (parallel != null) return parallel;
+        return DEFAULT_PARALLEL;
+    }
+
+    public SELF parallel(boolean parallel) {
+        this.parallel = parallel;
         return getThis();
     }
 
@@ -201,7 +212,6 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public static class Query extends Options<Transaction, Query> {
 
-        private Boolean parallel = null;
         private GraqlQuery query = null;
 
         @Override
@@ -239,14 +249,5 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
             return this;
         }
 
-        public boolean parallel() {
-            if (parallel != null) return parallel;
-            return DEFAULT_PARALLEL;
-        }
-
-        public Query parallel(boolean parallel) {
-            this.parallel = parallel;
-            return this;
-        }
     }
 }

--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -108,7 +108,8 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
 
     public boolean parallel() {
         if (parallel != null) return parallel;
-        return DEFAULT_PARALLEL;
+        else if (parent != null) return parent.parallel();
+        else return DEFAULT_PARALLEL;
     }
 
     public SELF parallel(boolean parallel) {

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "fae0daeb8dbc0b966e6e32e9b4bef7be6a6f4064", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "6845c810abae756d3de1845aede67c13c6902919", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "6845c810abae756d3de1845aede67c13c6902919", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "195cedd57551936d42c28b258c820263fcc1b563", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0-alpha-10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "fae0daeb8dbc0b966e6e32e9b4bef7be6a6f4064", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -41,11 +41,11 @@ public class RequestReader {
         if (request.getExplainOptCase().equals(EXPLAIN)) {
             options.explain(request.getExplain());
         }
-        if (request.getBatchSizeOptCase().equals(BATCH_SIZE)) {
-            options.responseBatchSize(request.getBatchSize());
-        }
         if (request.getParallelOptCase().equals(PARALLEL)) {
             options.parallel(request.getParallel());
+        }
+        if (request.getBatchSizeOptCase().equals(BATCH_SIZE)) {
+            options.responseBatchSize(request.getBatchSize());
         }
         if (request.getSessionIdleTimeoutOptCase().equals(SESSION_IDLE_TIMEOUT_MILLIS)) {
             options.sessionIdleTimeoutMillis(request.getSessionIdleTimeoutMillis());

--- a/server/rpc/common/RequestReader.java
+++ b/server/rpc/common/RequestReader.java
@@ -23,6 +23,7 @@ import grakn.protocol.OptionsProto;
 import static grakn.protocol.OptionsProto.Options.BatchSizeOptCase.BATCH_SIZE;
 import static grakn.protocol.OptionsProto.Options.ExplainOptCase.EXPLAIN;
 import static grakn.protocol.OptionsProto.Options.InferOptCase.INFER;
+import static grakn.protocol.OptionsProto.Options.ParallelOptCase.PARALLEL;
 import static grakn.protocol.OptionsProto.Options.PrefetchOptCase.PREFETCH;
 import static grakn.protocol.OptionsProto.Options.SchemaLockAcquireTimeoutOptCase.SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS;
 import static grakn.protocol.OptionsProto.Options.SessionIdleTimeoutOptCase.SESSION_IDLE_TIMEOUT_MILLIS;
@@ -42,6 +43,9 @@ public class RequestReader {
         }
         if (request.getBatchSizeOptCase().equals(BATCH_SIZE)) {
             options.responseBatchSize(request.getBatchSize());
+        }
+        if (request.getParallelOptCase().equals(PARALLEL)) {
+            options.parallel(request.getParallel());
         }
         if (request.getSessionIdleTimeoutOptCase().equals(SESSION_IDLE_TIMEOUT_MILLIS)) {
             options.sessionIdleTimeoutMillis(request.getSessionIdleTimeoutMillis());


### PR DESCRIPTION
## What is the goal of this PR?
To enable setting parallel execution above solely the query level, we push the `parallel` option from `Options.Query` up to the parent class `Options`, making it available in all types of Options.

## What are the changes implemented in this PR?
* Push `parallel()` and `isParallel()` to abstract parent class `Options` from `Options.Query`
