### PR TITLE
Fully remove rule indexes when undefining a rule

### DIFF
--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -586,16 +586,16 @@ public class SchemaGraph implements Graph {
                     Set<RuleStructure> rules = concludesVertex.get(type);
                     if (rules != null && rules.contains(rule)) {
                         concludesVertex.get(type).remove(rule);
-                        storage.delete(Rule.Key.concludedVertex(type.iid(), rule.iid()).bytes());
                     }
+                    storage.delete(Rule.Key.concludedVertex(type.iid(), rule.iid()).bytes());
                 }
 
                 private void deleteConcludesEdgeTo(RuleStructure rule, TypeVertex type) {
                     Set<RuleStructure> rules = concludesEdgeTo.get(type);
                     if (rules != null && rules.contains(rule)) {
                         rules.remove(rule);
-                        storage.delete(Rule.Key.concludedEdgeTo(type.iid(), rule.iid()).bytes());
                     }
+                    storage.delete(Rule.Key.concludedEdgeTo(type.iid(), rule.iid()).bytes());
                 }
 
                 private Set<RuleStructure> loadConcludesVertex(TypeVertex type) {

--- a/reasoner/Reasoner.java
+++ b/reasoner/Reasoner.java
@@ -95,7 +95,6 @@ public class Reasoner {
         for (Conjunction conj : disjunction.conjunctions()) {
             Set<Variable> vars = conj.variables();
             Set<Negation> negs = conj.negations();
-            if (iterate(vars).anyMatch(v -> v.resolvedTypes().isEmpty())) return true;
             if (iterate(vars).flatMap(v -> iterate(v.resolvedTypes())).distinct().anyMatch(this::hasRule)) return true;
             if (!negs.isEmpty() && iterate(negs).anyMatch(n -> mayReason(n.disjunction()))) return true;
         }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -230,7 +230,7 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public void delete(byte[] key) {
-            if (!isOpen() || !transaction.isOpen()) throw GraknException.of(RESOURCE_CLOSED);
+            if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             if (isReadOnly) {
                 if (transaction.isSchema()) throw exception(TRANSACTION_SCHEMA_READ_VIOLATION);
                 else if (transaction.isData()) throw exception(TRANSACTION_DATA_READ_VIOLATION);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -230,7 +230,7 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public void delete(byte[] key) {
-            if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
+            if (!isOpen() || (!transaction.isOpen() && transaction.isData())) throw GraknException.of(RESOURCE_CLOSED);
             if (isReadOnly) {
                 if (transaction.isSchema()) throw exception(TRANSACTION_SCHEMA_READ_VIOLATION);
                 else if (transaction.isData()) throw exception(TRANSACTION_DATA_READ_VIOLATION);

--- a/test/integration/QueryTest.java
+++ b/test/integration/QueryTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import static grakn.core.test.integration.util.Util.assertNotNulls;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -174,7 +175,6 @@ public class QueryTest {
                     query = Graql.parseQuery(queryString);
                     transaction.query().undefine(query);
 
-
                     transaction.commit();
                 }
 
@@ -202,6 +202,10 @@ public class QueryTest {
 
                     // check total count
                     assertEquals(15 - 5, tx.logic().rules().toList().size());
+
+                    // ensure that we can't trigger a rule
+
+                    List<ConceptMap> answers = tx.query().match(Graql.parseQuery("match $x isa repo-fork;").asMatch()).toList();
                 }
             }
         }

--- a/test/integration/QueryTest.java
+++ b/test/integration/QueryTest.java
@@ -203,8 +203,7 @@ public class QueryTest {
                     // check total count
                     assertEquals(15 - 5, tx.logic().rules().toList().size());
 
-                    // ensure that we can't trigger a rule
-
+                    // a query that used to trigger a rule should not cause an error
                     List<ConceptMap> answers = tx.query().match(Graql.parseQuery("match $x isa repo-fork;").asMatch()).toList();
                 }
             }


### PR DESCRIPTION
## What is the goal of this PR?

As outlined in #6228, undefining a rule and committing appears to not completely clear the rule indices, causing subsequent null pointer exceptions. This PR actually deletes persisted rule indexes when undefining rules.

## What are the changes implemented in this PR?
* Delete index keys from storage when undefining a rule
* On delete, only check if storage is open as opposed to ensuring that Transaction and storage are open (as the transaction is closed when the committing begins), causing deletes to throw a RESOURCE_CLOSED exception