### PR TITLE
Fix rule satisfiability validation

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -490,10 +490,12 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new RuleWrite(4, "The rule '%'s contains a negation containing a disjunction, which is currently unsupported");
         public static final RuleWrite RULE_CAN_IMPLY_UNINSERTABLE_RESULTS =
                 new RuleWrite(5, "The rule '%s' when can imply the type combination '%s', which cannot be inserted into the rule's then.");
-        public static final RuleWrite RULE_CANNOT_BE_SATISFIED =
-                new RuleWrite(6, "The rule '%s' can never satisfy a type for the variable '%s' that can be inserted.");
+        public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
+                new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
+        public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
+                new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite MAX_RULE_REACHED =
-                new RuleWrite(7, "The maximum number of rules has been reached: '%s'");
+                new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
 
         private static final String codePrefix = "RUW";
         private static final String messagePrefix = "Invalid Rule Write";

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -198,17 +198,11 @@ public class Rule {
     private void pruneThenResolvedTypes() {
         // TODO: name is inconsistent with elsewhere
         then.variables().stream().filter(variable -> variable.id().isName())
-                .forEach(thenVar ->
-                                 when.variables().stream()
-                                         .filter(whenVar -> whenVar.id().equals(thenVar.id()))
-                                         .filter(whenVar -> !(whenVar.isSatisfiable() && whenVar.resolvedTypes().isEmpty()))
-                                         .findFirst().ifPresent(whenVar -> {
-                                     if (thenVar.resolvedTypes().isEmpty() && thenVar.isSatisfiable()) {
-                                         thenVar.addResolvedTypes(whenVar.resolvedTypes());
-                                     } else thenVar.retainResolvedTypes(whenVar.resolvedTypes());
-                                     if (thenVar.resolvedTypes().isEmpty()) then.setCoherent(false);
-                                 })
-                );
+                .forEach(thenVar -> {
+                    Variable whenVar = when.variable(thenVar.id());
+                    thenVar.retainResolvedTypes(whenVar.resolvedTypes());
+                    if (thenVar.resolvedTypes().isEmpty()) then.setCoherent(false);
+                });
     }
 
     private Conjunction whenPattern(graql.lang.pattern.Conjunction<? extends Pattern> conjunction, LogicManager logicMgr) {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -196,7 +196,6 @@ public class Rule {
      * Remove type hints in the `then` pattern that are not valid in the `when` pattern
      */
     private void pruneThenResolvedTypes() {
-        // TODO: name is inconsistent with elsewhere
         then.variables().stream().filter(variable -> variable.id().isName())
                 .forEach(thenVar -> {
                     Variable whenVar = when.variable(thenVar.id());

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -788,6 +788,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         private final Set<Concludable> concludables = new HashSet<>();
 
         Extractor(Conjunction conjunction) {
+            assert conjunction.isCoherent();
             Set<Constraint> constraints = conjunction.variables().stream().flatMap(variable -> variable.constraints().stream())
                     .collect(toSet());
             constraints.stream().filter(Constraint::isThing).map(Constraint::asThing).filter(ThingConstraint::isRelation)

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -417,8 +417,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             assert generating().isPresent();
             Variable generatedRelation = generating().get();
             Set<Label> relationTypes = generatedRelation.resolvedTypes();
-            // may never be empty as its always known to be at least a relation
-            assert generatedRelation.isSatisfiable();
+            assert !relationTypes.isEmpty();
 
             Map<Rule, Set<Unifier>> applicableRules = new HashMap<>();
             relationTypes.forEach(type -> logicMgr.rulesConcluding(type)
@@ -557,8 +556,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             assert generating().isPresent();
             Variable generatedAttribute = generating().get();
             Set<Label> attributeTypes = generatedAttribute.resolvedTypes();
-            // may never be empty as its always known to be at least an attribute
-            assert generatedAttribute.isSatisfiable();
+            assert !generatedAttribute.resolvedTypes().isEmpty();
 
             Map<Rule, Set<Unifier>> applicableRules = new HashMap<>();
             attributeTypes.forEach(type -> logicMgr.rulesConcludingHas(type)
@@ -664,24 +662,15 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             assert generating().isPresent();
             Variable generated = generating().get();
             Set<Label> types = generated.resolvedTypes();
-            assert generated.isSatisfiable();
+            assert !types.isEmpty();
 
             Map<Rule, Set<Unifier>> applicableRules = new HashMap<>();
-            if (types.isEmpty()) {
-                logicMgr.rules()
-                        .forEachRemaining(rule -> unify(rule.conclusion(), conceptMgr)
-                                .forEachRemaining(unifier -> {
-                                    applicableRules.putIfAbsent(rule, new HashSet<>());
-                                    applicableRules.get(rule).add(unifier);
-                                }));
-            } else {
-                types.forEach(type -> logicMgr.rulesConcluding(type)
-                        .forEachRemaining(rule -> unify(rule.conclusion(), conceptMgr)
-                                .forEachRemaining(unifier -> {
-                                    applicableRules.putIfAbsent(rule, new HashSet<>());
-                                    applicableRules.get(rule).add(unifier);
-                                })));
-            }
+            types.forEach(type -> logicMgr.rulesConcluding(type)
+                    .forEachRemaining(rule -> unify(rule.conclusion(), conceptMgr)
+                            .forEachRemaining(unifier -> {
+                                applicableRules.putIfAbsent(rule, new HashSet<>());
+                                applicableRules.get(rule).add(unifier);
+                            })));
 
             return applicableRules;
         }
@@ -772,8 +761,7 @@ public abstract class Concludable extends Resolvable<Conjunction> {
             assert generating().isPresent();
             Variable generatedAttr = generating().get();
             Set<Label> attributeTypes = generatedAttr.resolvedTypes();
-            // may never be empty as its always known to be at least an attribute
-            assert generatedAttr.isSatisfiable();
+            assert !attributeTypes.isEmpty();
 
             Map<Rule, Set<Unifier>> applicableRules = new HashMap<>();
             attributeTypes.forEach(type -> logicMgr.rulesConcluding(type)

--- a/pattern/Conjunction.java
+++ b/pattern/Conjunction.java
@@ -123,7 +123,6 @@ public class Conjunction implements Pattern, Cloneable {
                 else if (var.isType()) {
                     Optional<LabelConstraint> existingLabel = var.asType().label();
                     if (existingLabel.isPresent() && !existingLabel.get().properLabel().equals(boundVar.first())) {
-                        var.setSatisfiable(false);
                         this.setCoherent(false);
                     } else if (!existingLabel.isPresent()) {
                         var.asType().label(boundVar.first());
@@ -132,7 +131,6 @@ public class Conjunction implements Pattern, Cloneable {
                 } else if (var.isThing()) {
                     Optional<IIDConstraint> existingIID = var.asThing().iid();
                     if (existingIID.isPresent() && !Arrays.equals(existingIID.get().iid(), (boundVar.second()))) {
-                        var.setSatisfiable(false);
                         this.setCoherent(false);
                     } else {
                         var.asThing().iid(boundVar.second());

--- a/pattern/variable/Variable.java
+++ b/pattern/variable/Variable.java
@@ -37,14 +37,12 @@ public abstract class Variable implements Pattern {
 
     private final Set<Label> resolvedTypes;
     private final int hash;
-    private boolean isSatisfiable;
     final Identifier.Variable identifier;
 
     Variable(Identifier.Variable identifier) {
         this.identifier = identifier;
         this.hash = Objects.hash(identifier);
         this.resolvedTypes = new HashSet<>();
-        this.isSatisfiable = true;
     }
 
     public abstract Set<? extends Constraint> constraints();
@@ -81,10 +79,6 @@ public abstract class Variable implements Pattern {
         resolvedTypes.add(label);
     }
 
-    public void clearResolvedTypes() {
-        resolvedTypes.clear();
-    }
-
     public void addResolvedTypes(Set<Label> labels) {
         resolvedTypes.addAll(labels);
     }
@@ -100,10 +94,6 @@ public abstract class Variable implements Pattern {
 
     public Set<Label> resolvedTypes() {
         return resolvedTypes;
-    }
-
-    public boolean isSatisfiable() {
-        return isSatisfiable;
     }
 
     @Override

--- a/pattern/variable/Variable.java
+++ b/pattern/variable/Variable.java
@@ -106,10 +106,6 @@ public abstract class Variable implements Pattern {
         return isSatisfiable;
     }
 
-    public void setSatisfiable(boolean isSatisfiable) {
-        this.isSatisfiable = isSatisfiable;
-    }
-
     @Override
     public String toString() {
         return reference().toString();

--- a/test/integration/logic/BUILD
+++ b/test/integration/logic/BUILD
@@ -44,6 +44,7 @@ host_compatible_java_test(
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",
         "@graknlabs_graql//java:graql",
+        "@graknlabs_graql//java/pattern:pattern",
     ],
 )
 

--- a/test/integration/logic/RuleTest.java
+++ b/test/integration/logic/RuleTest.java
@@ -661,11 +661,11 @@ public class RuleTest {
                     person.setOwns(name);
 
                     ThingVariable<?> then = Graql.parseVariable("$x has name 'fido'").asThing();
-                    assertThrowsWithMessage(() -> txn.logic().putRule(
+                    assertThrowsGraknException(() -> txn.logic().putRule(
                             "dogs-are-named-fido",
                             Graql.parsePattern("{$x isa dog;}").asConjunction(),
                             then
-                    ), GraknException.of(RULE_THEN_CANNOT_BE_SATISFIED, "dogs-are-named-fido", then).getMessage());
+                    ), RULE_THEN_CANNOT_BE_SATISFIED.code());
                 }
             }
         }

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -1058,7 +1058,7 @@ public class TypeResolverTest {
 
         assertEquals(expectedLabels, resolvedTypeMap(conjunction).get("$_relation:partner"));
 
-        typeResolver.resolveVariables(conjunction, list(), false);
+        typeResolver.resolveVariables(conjunction, false);
         Set<String> expectedResolvedTypes = set("partnership:partner");
 
         assertEquals(expectedResolvedTypes, resolvedTypeMap(disjunction.conjunctions().get(0)).get("$_relation:partner"));

--- a/test/integration/logic/TypeResolverTest.java
+++ b/test/integration/logic/TypeResolverTest.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static grakn.common.collection.Collections.list;
 import static grakn.common.collection.Collections.set;
 import static grakn.core.common.test.Util.assertThrows;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -1057,7 +1058,7 @@ public class TypeResolverTest {
 
         assertEquals(expectedLabels, resolvedTypeMap(conjunction).get("$_relation:partner"));
 
-        typeResolver.resolveVariables(conjunction, false);
+        typeResolver.resolveVariables(conjunction, list(), false);
         Set<String> expectedResolvedTypes = set("partnership:partner");
 
         assertEquals(expectedResolvedTypes, resolvedTypeMap(disjunction.conjunctions().get(0)).get("$_relation:partner"));

--- a/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
+++ b/test/integration/logic/resolvable/UnifyRelationConcludableTest.java
@@ -104,6 +104,8 @@ public class UnifyRelationConcludableTest {
                                                        "part-time-employment sub employment," +
                                                        "    relates part-time-employee as employee," +
                                                        "    relates restriction;" +
+                                                       "restricted-entity sub entity, " +
+                                                       "    plays part-time-employment:restriction;" +
                                                        "friendship sub relation," +
                                                        "    relates friend;" +
                                                        "name sub attribute, value string, abstract;" +

--- a/test/integration/reasoner/resolution/PlannerTest.java
+++ b/test/integration/reasoner/resolution/PlannerTest.java
@@ -22,7 +22,6 @@ import grakn.core.common.parameters.Options.Database;
 import grakn.core.concept.ConceptManager;
 import grakn.core.concept.type.AttributeType;
 import grakn.core.concept.type.EntityType;
-import grakn.core.concept.type.RelationType;
 import grakn.core.logic.LogicManager;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Resolvable;
@@ -65,6 +64,12 @@ public class PlannerTest {
         grakn = RocksGrakn.open(options);
         grakn.databases().create(database);
         initialise(Arguments.Session.Type.SCHEMA, Arguments.Transaction.Type.WRITE);
+        rocksTransaction.query().define(Graql.parseQuery("define person sub entity, plays friendship:friend, owns name; " +
+                                                                 "friendship sub relation, relates friend;" +
+                                                                 "name sub attribute, value string;"));
+        rocksTransaction.commit();
+        session.close();
+        initialise(Arguments.Session.Type.SCHEMA, Arguments.Transaction.Type.WRITE);
     }
 
     private void initialise(Arguments.Session.Type schema, Arguments.Transaction.Type write) {
@@ -81,18 +86,8 @@ public class PlannerTest {
         grakn.close();
     }
 
-    private void defineBasicSchema() {
-        rocksTransaction.query().define(Graql.parseQuery("define person sub entity, plays friendship:friend, owns name; " +
-                                                                 "friendship sub relation, relates friend;" +
-                                                                 "name sub attribute, value string;"));
-        rocksTransaction.commit();
-        session.close();
-        initialise(Arguments.Session.Type.SCHEMA, Arguments.Transaction.Type.WRITE);
-    }
-
     @Test
     public void test_planner_retrievable_dependent_upon_concludable() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $a has $b; }", logicMgr)).iterator().next();
         Retrievable retrievable = new Retrievable(resolvedConjunction("{ $c($b); }", logicMgr));
 
@@ -103,7 +98,6 @@ public class PlannerTest {
 
     @Test
     public void test_planner_prioritises_retrievable_without_dependencies() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $p has name $n; }", logicMgr)).iterator().next();
         Retrievable retrievable = new Retrievable(resolvedConjunction("{ $p isa person; }", logicMgr));
 
@@ -115,15 +109,20 @@ public class PlannerTest {
 
     @Test
     public void test_planner_prioritises_largest_retrievable_without_dependencies() {
-        EntityType person = conceptMgr.putEntityType("person");
-        person.setOwns(conceptMgr.putAttributeType("first-name", AttributeType.ValueType.STRING));
-        person.setOwns(conceptMgr.putAttributeType("surname", AttributeType.ValueType.STRING));
-        person.setOwns(conceptMgr.putAttributeType("age", AttributeType.ValueType.STRING));
-        EntityType company = conceptMgr.putEntityType("company");
-        company.setOwns(conceptMgr.putAttributeType("name", AttributeType.ValueType.STRING));
+        rocksTransaction.query().undefine(Graql.parseQuery("undefine person owns name;"));
+        rocksTransaction.query().define(Graql.parseQuery("define company sub entity, owns company-name;" +
+                                                                 "name sub attribute, value string, abstract;" +
+                                                                 "first-name sub name;" +
+                                                                 "surname sub name;" +
+                                                                 "company-name sub name;" +
+                                                                 "age sub attribute, value long;" +
+                                                                 "person owns first-name, owns surname;"));
+        rocksTransaction.commit();
+        session.close();
+        initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
 
         Retrievable retrievable = new Retrievable(resolvedConjunction("{ $p isa person, has age $a, has first-name $fn, has " +
-                                                                "surname $sn; }", logicMgr));
+                                                                              "surname $sn; }", logicMgr));
         Concludable concludable = Concludable.create(resolvedConjunction("{ ($p, $c); }", logicMgr)).iterator().next();
         Retrievable retrievable2 = new Retrievable(resolvedConjunction("{ $c isa company, has name $cn; }", logicMgr));
 
@@ -135,15 +134,20 @@ public class PlannerTest {
 
     @Test
     public void test_planner_prioritises_largest_named_variables_retrievable_without_dependencies() {
-        EntityType person = conceptMgr.putEntityType("person");
-        person.setOwns(conceptMgr.putAttributeType("first-name", AttributeType.ValueType.STRING));
-        person.setOwns(conceptMgr.putAttributeType("surname", AttributeType.ValueType.STRING));
-        person.setOwns(conceptMgr.putAttributeType("age", AttributeType.ValueType.STRING));
-        EntityType company = conceptMgr.putEntityType("company");
-        company.setOwns(conceptMgr.putAttributeType("name", AttributeType.ValueType.STRING));
+        rocksTransaction.query().undefine(Graql.parseQuery("undefine person owns name;"));
+        rocksTransaction.query().define(Graql.parseQuery("define company sub entity, owns company-name;" +
+                                                                 "name sub attribute, value string, abstract;" +
+                                                                 "first-name sub name;" +
+                                                                 "surname sub name;" +
+                                                                 "company-name sub name;" +
+                                                                 "age sub attribute, value long;" +
+                                                                 "person owns first-name, owns surname, owns age;"));
+        rocksTransaction.commit();
+        session.close();
+        initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
 
         Retrievable retrievable = new Retrievable(resolvedConjunction("{ $p isa person, has age 30, has first-name " +
-                                                                "\"Alice\", has surname \"Bachelor\"; }", logicMgr));
+                                                                              "\"Alice\", has surname \"Bachelor\"; }", logicMgr));
         Concludable concludable = Concludable.create(resolvedConjunction("{ ($p, $c); }", logicMgr)).iterator().next();
         Retrievable retrievable2 = new Retrievable(resolvedConjunction("{ $c isa company, has name $cn; }", logicMgr));
 
@@ -155,7 +159,6 @@ public class PlannerTest {
 
     @Test
     public void test_planner_starts_at_independent_concludable() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $r($a, $b); }", logicMgr)).iterator().next();
         Concludable concludable2 = Concludable.create(resolvedConjunction("{ $r has $c; }", logicMgr)).iterator().next();
 
@@ -167,6 +170,13 @@ public class PlannerTest {
 
     @Test
     public void test_planner_multiple_dependencies() {
+        rocksTransaction.query().define(Graql.parseQuery("define employment sub relation, relates employee, relates employer;" +
+                                                                 "person plays employment:employee;" +
+                                                                 "company sub entity, plays employment:employer, owns name;"));
+        rocksTransaction.commit();
+        session.close();
+        initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);
+
         EntityType person = conceptMgr.putEntityType("person");
         AttributeType name = conceptMgr.putAttributeType("name", AttributeType.ValueType.STRING);
         person.setOwns(name);
@@ -187,7 +197,6 @@ public class PlannerTest {
 
     @Test
     public void test_planner_two_circular_has_dependencies() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $a has $b; }", logicMgr)).iterator().next();
         Concludable concludable2 = Concludable.create(resolvedConjunction("{ $b has $a; }", logicMgr)).iterator().next();
 
@@ -200,7 +209,6 @@ public class PlannerTest {
 
     @Test
     public void test_planner_two_circular_relates_dependencies() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $a($b); }", logicMgr)).iterator().next();
         Concludable concludable2 = Concludable.create(resolvedConjunction("{ $b($a); }", logicMgr)).iterator().next();
 
@@ -213,7 +221,6 @@ public class PlannerTest {
 
     @Test
     public void test_planner_disconnected_conjunction() {
-        defineBasicSchema();
         Concludable concludable = Concludable.create(resolvedConjunction("{ $a($b); }", logicMgr)).iterator().next();
         Concludable concludable2 = Concludable.create(resolvedConjunction("{ $c($d); }", logicMgr)).iterator().next();
 
@@ -226,19 +233,15 @@ public class PlannerTest {
 
     @Test
     public void test_planner_prioritises_concludable_with_least_applicable_rules() {
-        EntityType person = conceptMgr.putEntityType("person");
-        RelationType friendship = conceptMgr.putRelationType("friendship");
-        friendship.setRelates("friend");
-        RelationType marriage = conceptMgr.putRelationType("marriage");
-        marriage.setRelates("spouse");
-        person.setPlays(friendship.getRelates("friend"));
-        person.setPlays(marriage.getRelates("spouse"));
-        AttributeType name = conceptMgr.putAttributeType("name", AttributeType.ValueType.STRING);
-        person.setOwns(name);
-        logicMgr.putRule(
-                "marriage-is-friendship",
-                Graql.parsePattern("{$x isa person; $y isa person; (spouse: $x, spouse: $y) isa marriage; }").asConjunction(),
-                Graql.parseVariable("(friend: $x, friend: $y) isa friendship").asThing());
+        rocksTransaction.query().define(Graql.parseQuery("define  " +
+                                                                 "marriage sub relation, relates spouse;" +
+                                                                 "person plays marriage:spouse, owns age;" +
+                                                                 "age sub attribute, value long;" +
+                                                                 "rule marriage-is-friendship: when {" +
+                                                                 "$x isa person; $y isa person; (spouse: $x, spouse: $y) isa marriage; " +
+                                                                 "} then {" +
+                                                                 "(friend: $x, friend: $y) isa friendship;" +
+                                                                 "};"));
         rocksTransaction.commit();
         session.close();
         initialise(Arguments.Session.Type.DATA, Arguments.Transaction.Type.READ);


### PR DESCRIPTION
## What is the goal of this PR?
We previously checked that a rule is coherent/satisfiability by checking each variable in the `when` and the `then`. However, we no longer set the satisfiability of a variable at all, instead setting only `isCoherent` at the conjunction. This PR updates Rule validation to reflect this change and removes `isSatisfiable` from `Variable`

Fixes #6227 

## What are the changes implemented in this PR?
* Fix rule validation
* Add a new test case to test `when` validation, extending the current `then` validation
* Remove `isSatisfiable` getters and setters from `Variable`