### PR TITLE
Prevent rare segfaults with storage read-write lock

### DIFF
--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -257,13 +257,23 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public GraknException exception(ErrorMessage errorMessage) {
-            transaction.close();
+            try {
+                readWriteLock.writeLock().lock();
+                transaction.close();
+            } finally {
+                readWriteLock.writeLock().unlock();
+            }
             return super.exception(errorMessage);
         }
 
         @Override
         public GraknException exception(Exception exception) {
-            transaction.close();
+            try {
+                readWriteLock.writeLock().lock();
+                transaction.close();
+            } finally {
+                readWriteLock.writeLock().unlock();
+            }
             return super.exception(exception);
         }
 
@@ -276,6 +286,16 @@ public abstract class RocksStorage implements Storage {
 
         public void rollback() throws RocksDBException {
             storageTransaction.rollback();
+        }
+
+        @Override
+        public void close() {
+            try {
+                readWriteLock.writeLock().lock();
+                super.close();
+            } finally {
+                readWriteLock.writeLock().unlock();
+            }
         }
     }
 

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -206,6 +206,7 @@ public abstract class RocksStorage implements Storage {
             if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             try {
                 readWriteLock.readLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 return storageTransaction.get(readOptions, key);
             } catch (RocksDBException e) {
                 throw exception(e);
@@ -241,6 +242,7 @@ public abstract class RocksStorage implements Storage {
             }
             try {
                 readWriteLock.writeLock().lock();
+                if (!isOpen() || !transaction.isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.delete(key);
             } catch (RocksDBException e) {
                 throw exception(e);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -205,12 +205,12 @@ public abstract class RocksStorage implements Storage {
         public byte[] get(byte[] key) {
             if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
             try {
-                if (!isReadOnly) readWriteLock.readLock().lock();
+                readWriteLock.readLock().lock();
                 return storageTransaction.get(readOptions, key);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                if (!isReadOnly) readWriteLock.readLock().unlock();
+                readWriteLock.readLock().unlock();
             }
         }
 
@@ -222,9 +222,12 @@ public abstract class RocksStorage implements Storage {
             assert upperBound[upperBound.length - 1] != Byte.MIN_VALUE;
 
             try (org.rocksdb.RocksIterator iterator = getInternalRocksIterator()) {
+                readWriteLock.readLock().lock();
                 iterator.seekForPrev(upperBound);
                 if (bytesHavePrefix(iterator.key(), prefix)) return iterator.key();
                 else return null;
+            } finally {
+                readWriteLock.readLock().unlock();
             }
         }
 

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -269,6 +269,7 @@ public abstract class RocksStorage implements Storage {
         @Override
         public GraknException exception(ErrorMessage errorMessage) {
             try {
+                // TODO i think this will deadlock on transaction.close() since it's not a reentrant lock
                 readWriteLock.writeLock().lock();
                 transaction.close();
             } finally {
@@ -280,6 +281,7 @@ public abstract class RocksStorage implements Storage {
         @Override
         public GraknException exception(Exception exception) {
             try {
+                // TODO i think this will deadlock on transaction.close() since it's not a reentrant lock
                 readWriteLock.writeLock().lock();
                 transaction.close();
             } finally {

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -57,7 +57,7 @@ public abstract class RocksStorage implements Storage {
 
     protected final ConcurrentSet<RocksIterator<?>> iterators;
     protected final Transaction storageTransaction;
-    protected final ReadWriteLock deleteOrCloseLock;
+    protected final ReadWriteLock deleteCloseSchemaWriteLock;
     protected final ReadOptions readOptions;
     protected final boolean isReadOnly;
 
@@ -76,7 +76,7 @@ public abstract class RocksStorage implements Storage {
         storageTransaction = rocksDB.beginTransaction(writeOptions, transactionOptions);
         snapshot = storageTransaction.getSnapshot();
         readOptions = new ReadOptions().setSnapshot(snapshot);
-        deleteOrCloseLock = new StampedLock().asReadWriteLock();
+        deleteCloseSchemaWriteLock = new StampedLock().asReadWriteLock();
         isOpen = new AtomicBoolean(true);
     }
 
@@ -155,7 +155,7 @@ public abstract class RocksStorage implements Storage {
     @Override
     public void close() {
         try {
-            deleteOrCloseLock.writeLock().lock();
+            deleteCloseSchemaWriteLock.writeLock().lock();
             if (isOpen.compareAndSet(true, false)) {
                 iterators.parallelStream().forEach(RocksIterator::close);
                 recycled.forEach(AbstractImmutableNativeReference::close);
@@ -166,7 +166,7 @@ public abstract class RocksStorage implements Storage {
                 writeOptions.close();
             }
         } finally {
-            deleteOrCloseLock.writeLock().unlock();
+            deleteCloseSchemaWriteLock.writeLock().unlock();
         }
     }
 
@@ -179,13 +179,13 @@ public abstract class RocksStorage implements Storage {
         @Override
         public byte[] get(byte[] key) {
             try {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 return storageTransaction.get(readOptions, key);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
 
@@ -210,13 +210,13 @@ public abstract class RocksStorage implements Storage {
         @Override
         public byte[] get(byte[] key) {
             try {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 return storageTransaction.get(readOptions, key);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
 
@@ -228,13 +228,13 @@ public abstract class RocksStorage implements Storage {
             assert upperBound[upperBound.length - 1] != Byte.MIN_VALUE;
 
             try (org.rocksdb.RocksIterator iterator = getInternalRocksIterator()) {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 iterator.seekForPrev(upperBound);
                 if (bytesHavePrefix(iterator.key(), prefix)) return iterator.key();
                 else return null;
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
 
@@ -246,7 +246,7 @@ public abstract class RocksStorage implements Storage {
                 else throw exception(ILLEGAL_STATE);
             }
             try {
-                deleteOrCloseLock.writeLock().lock();
+                deleteCloseSchemaWriteLock.writeLock().lock();
                 if (!isOpen() || (!transaction.isOpen() && transaction.isData())) {
                     throw GraknException.of(RESOURCE_CLOSED);
                 }
@@ -254,7 +254,7 @@ public abstract class RocksStorage implements Storage {
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.writeLock().unlock();
+                deleteCloseSchemaWriteLock.writeLock().unlock();
             }
         }
 
@@ -311,7 +311,7 @@ public abstract class RocksStorage implements Storage {
             boolean obtainedWriteLock = false;
             try {
                 if (transaction.isOpen()) {
-                    deleteOrCloseLock.readLock().lock();
+                    deleteCloseSchemaWriteLock.writeLock().lock();
                     obtainedWriteLock = true;
                 }
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
@@ -319,7 +319,7 @@ public abstract class RocksStorage implements Storage {
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                if (obtainedWriteLock) deleteOrCloseLock.readLock().unlock();
+                if (obtainedWriteLock) deleteCloseSchemaWriteLock.writeLock().unlock();
             }
         }
 
@@ -329,7 +329,7 @@ public abstract class RocksStorage implements Storage {
             boolean obtainedWriteLock = false;
             try {
                 if (transaction.isOpen()) {
-                    deleteOrCloseLock.readLock().lock();
+                    deleteCloseSchemaWriteLock.writeLock().lock();
                     obtainedWriteLock = true;
                 }
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
@@ -337,7 +337,7 @@ public abstract class RocksStorage implements Storage {
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                if (obtainedWriteLock) deleteOrCloseLock.readLock().unlock();
+                if (obtainedWriteLock) deleteCloseSchemaWriteLock.writeLock().unlock();
             }
         }
     }
@@ -361,13 +361,13 @@ public abstract class RocksStorage implements Storage {
         public void put(byte[] key, byte[] value) {
             assert isOpen() && !isReadOnly;
             try {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.put(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
 
@@ -375,13 +375,13 @@ public abstract class RocksStorage implements Storage {
         public void putUntracked(byte[] key, byte[] value) {
             assert isOpen() && !isReadOnly;
             try {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.putUntracked(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
 
@@ -389,13 +389,13 @@ public abstract class RocksStorage implements Storage {
         public void mergeUntracked(byte[] key, byte[] value) {
             assert isOpen() && !isReadOnly;
             try {
-                deleteOrCloseLock.readLock().lock();
+                deleteCloseSchemaWriteLock.readLock().lock();
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.mergeUntracked(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                deleteOrCloseLock.readLock().unlock();
+                deleteCloseSchemaWriteLock.readLock().unlock();
             }
         }
     }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -311,7 +311,7 @@ public abstract class RocksStorage implements Storage {
             boolean obtainedWriteLock = false;
             try {
                 if (transaction.isOpen()) {
-                    deleteOrCloseLock.writeLock().lock(); //note: schema puts always obtain write lock due to rule index
+                    deleteOrCloseLock.readLock().lock();
                     obtainedWriteLock = true;
                 }
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
@@ -319,7 +319,7 @@ public abstract class RocksStorage implements Storage {
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                if (obtainedWriteLock) deleteOrCloseLock.writeLock().unlock();
+                if (obtainedWriteLock) deleteOrCloseLock.readLock().unlock();
             }
         }
 
@@ -329,7 +329,7 @@ public abstract class RocksStorage implements Storage {
             boolean obtainedWriteLock = false;
             try {
                 if (transaction.isOpen()) {
-                    deleteOrCloseLock.writeLock().lock(); //note: schema puts always obtain write lock
+                    deleteOrCloseLock.readLock().lock();
                     obtainedWriteLock = true;
                 }
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
@@ -337,7 +337,7 @@ public abstract class RocksStorage implements Storage {
             } catch (RocksDBException e) {
                 throw exception(e);
             } finally {
-                if (obtainedWriteLock) deleteOrCloseLock.writeLock().unlock();
+                if (obtainedWriteLock) deleteOrCloseLock.readLock().unlock();
             }
         }
     }

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -311,7 +311,8 @@ public abstract class RocksStorage implements Storage {
         public void put(byte[] key, byte[] value) {
             assert isOpen() && !isReadOnly;
             try {
-                if (transaction.isOpen()) readWriteLock.writeLock().lock();
+                readWriteLock.writeLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.put(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
@@ -324,7 +325,8 @@ public abstract class RocksStorage implements Storage {
         public void putUntracked(byte[] key, byte[] value) {
             assert isOpen() && !isReadOnly;
             try {
-                if (transaction.isOpen()) readWriteLock.writeLock().lock();
+                readWriteLock.writeLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.putUntracked(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
@@ -354,6 +356,7 @@ public abstract class RocksStorage implements Storage {
             assert isOpen() && !isReadOnly;
             try {
                 readWriteLock.readLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.put(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
@@ -367,6 +370,7 @@ public abstract class RocksStorage implements Storage {
             assert isOpen() && !isReadOnly;
             try {
                 readWriteLock.readLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.putUntracked(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);
@@ -380,6 +384,7 @@ public abstract class RocksStorage implements Storage {
             assert isOpen() && !isReadOnly;
             try {
                 readWriteLock.readLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
                 storageTransaction.mergeUntracked(key, value);
             } catch (RocksDBException e) {
                 throw exception(e);

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -311,7 +311,7 @@ public abstract class RocksStorage implements Storage {
             boolean obtainedWriteLock = false;
             try {
                 if (transaction.isOpen()) {
-                    deleteOrCloseLock.writeLock().lock(); //note: schema puts always obtain write lock
+                    deleteOrCloseLock.writeLock().lock(); //note: schema puts always obtain write lock due to rule index
                     obtainedWriteLock = true;
                 }
                 if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);


### PR DESCRIPTION
## What is the goal of this PR?

To prevent segfaults that can occur when a transaction has asynchronous work calling `put()` or `get()` on storage, after another thread has called `close()` on storage. To prevent this, we insert a read-write lock that needs to be obtained before each storage operation. Benchmark simulations show this isn't a major performance bottleneck, but we should still move towards more efficient implementations if possible (starting with investigating the use of Optimistic locking for low-contention locks)


## What are the changes implemented in this PR?
* Add read-write lock to every storage object
* any data `get()` and `put()` must obtain the read lock to prevent race conditions with `close()`
* any data delete must obtain write lock to prevent race conditions with `close()` and `put()` and `get()`