### PR TITLE
Implement rule negation validation to prevent contradictions

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -95,6 +95,7 @@ build:
       command: |
         bazel test //test/behaviour/graql/language/define/... --test_output=streamed
         bazel test //test/behaviour/graql/language/undefine/... --test_output=streamed
+        bazel test //test/behaviour/graql/language/rule_validation/... --test_output=streamed
     test-behaviour-reasoner:
       image: graknlabs-ubuntu-20.04
       command: |
@@ -105,11 +106,11 @@ build:
         bazel test //test/behaviour/resolution/tests/type_hierarchy:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/value_predicate:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/resolution_test_framework:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
       # bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
       # bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
-      # bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
-      # bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
-      # bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
     test-assembly-linux-targz:
       image: graknlabs-ubuntu-20.04
       filter:

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -482,20 +482,18 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     public static class RuleWrite extends ErrorMessage {
         public static final RuleWrite INVALID_UNDEFINE_RULE_BODY =
                 new RuleWrite(1, "The rule body of '%s' ('when' or 'then') cannot be undefined. The rule must be undefined entirely by referring to its label.");
-        public static final RuleWrite RULES_IN_NEGATED_CYCLE_NOT_STRATIFIABLE =
-                new RuleWrite(2, "The rules '%s' causes inference cycles with negations");
-        public static final RuleWrite INVALID_NEGATION =
-                new RuleWrite(3, "The rule '%s' contains a negation, which is currently unsupported"); // TODO: relax this to specific shapes of negations later
+        public static final RuleWrite CONTRADICTORY_RULE_CYCLE =
+                new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
         public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
-                new RuleWrite(4, "The rule '%'s contains a negation containing a disjunction, which is currently unsupported");
+                new RuleWrite(3, "The rule '%'s contains a negation containing a disjunction, which is currently unsupported");
         public static final RuleWrite RULE_CAN_IMPLY_UNINSERTABLE_RESULTS =
-                new RuleWrite(5, "The rule '%s' when can imply the type combination '%s', which cannot be inserted into the rule's then.");
+                new RuleWrite(4, "The rule '%s' when can imply the type combination '%s', which cannot be inserted into the rule's then.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(6, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
-                new RuleWrite(7, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
+                new RuleWrite(6, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite MAX_RULE_REACHED =
-                new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
+                new RuleWrite(7, "The maximum number of rules has been reached: '%s'");
 
         private static final String codePrefix = "RUW";
         private static final String messagePrefix = "Invalid Rule Write";

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -309,7 +309,7 @@ public class SchemaGraph implements Graph {
         } finally {
             singleLabelLocks.get(scopedLabel).writeLock().unlock();
             multiLabelLock.readLock().unlock();
-            rules().conclusions().isOutdated(true);
+            rules().conclusions().outdated(true);
         }
     }
 
@@ -533,7 +533,7 @@ public class SchemaGraph implements Graph {
                 return outdated;
             }
 
-            public void isOutdated(boolean isOutdated) {
+            public void outdated(boolean isOutdated) {
                 this.outdated = isOutdated;
             }
 

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -18,17 +18,37 @@
 
 package grakn.core.logic;
 
+import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.FunctionalIterator;
 import grakn.core.common.parameters.Label;
 import grakn.core.concept.ConceptManager;
 import grakn.core.graph.GraphManager;
-import grakn.core.graph.common.Encoding;
 import grakn.core.graph.structure.RuleStructure;
 import grakn.core.logic.tool.TypeResolver;
 import grakn.core.traversal.TraversalEngine;
 import graql.lang.pattern.Conjunction;
 import graql.lang.pattern.Pattern;
 import graql.lang.pattern.variable.ThingVariable;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static grakn.common.collection.Collections.set;
+import static grakn.core.common.exception.ErrorMessage.RuleWrite.CONTRADICTORY_RULE_CYCLE;
+import static grakn.core.common.iterator.Iterators.iterate;
+import static grakn.core.common.iterator.Iterators.link;
+import static graql.lang.common.GraqlToken.Char.CURLY_CLOSE;
+import static graql.lang.common.GraqlToken.Char.CURLY_OPEN;
+import static graql.lang.common.GraqlToken.Char.NEW_LINE;
+import static graql.lang.common.GraqlToken.Char.SEMICOLON;
+import static graql.lang.common.GraqlToken.Char.SPACE;
 
 public class LogicManager {
 
@@ -51,7 +71,7 @@ public class LogicManager {
             structure.delete();
             logicCache.rule().invalidate(label);
         }
-        return logicCache.rule().get(label, l -> Rule.of(graphMgr, conceptMgr, this, label, when, then));
+        return logicCache.rule().get(label, l -> Rule.of(graphMgr, this, label, when, then));
     }
 
     public Rule getRule(String label) {
@@ -66,10 +86,6 @@ public class LogicManager {
         return graphMgr.schema().rules().all().map(this::fromStructure);
     }
 
-    public FunctionalIterator<Rule> rulesWithNegations() {
-        return rules().filter(rule -> !rule.when().negations().isEmpty());
-    }
-
     public FunctionalIterator<Rule> rulesConcluding(Label type) {
         return graphMgr.schema().rules().conclusions().concludesVertex(graphMgr.schema().getType(type)).map(this::fromStructure);
     }
@@ -78,6 +94,9 @@ public class LogicManager {
         return graphMgr.schema().rules().conclusions().concludesEdgeTo(graphMgr.schema().getType(attributeType)).map(this::fromStructure);
     }
 
+    private FunctionalIterator<Rule> rulesWithNegations() {
+        return rules().filter(rule -> !rule.when().negations().isEmpty());
+    }
 
     /**
      * On commit we must clear the rule cache and revalidate rules - this will force re-running type resolution
@@ -94,21 +113,95 @@ public class LogicManager {
         // re-index if rules are valid and satisfiable
         if (graphMgr.schema().rules().conclusions().isOutdated()) {
             graphMgr.schema().rules().all().forEachRemaining(s -> fromStructure(s).reindex());
+            graphMgr.schema().rules().conclusions().outdated(false);
         }
 
         // using the new index, validate new rules are stratifiable (eg. do not cause cycles through a negation)
-        graphMgr.schema().rules().buffered().filter(structure -> structure.status().equals(Encoding.Status.BUFFERED))
-                .forEachRemaining(structure -> getRule(structure.label()).validateCycles(conceptMgr, this));
+        validateCycles(conceptMgr, this);
     }
+
+
+    private void validateCycles(ConceptManager conceptMgr, LogicManager logicMgr) {
+        Set<Rule> negationRulesTriggeringRules = logicMgr.rulesWithNegations()
+                .filter(rule -> !rule.condition().negatedConcludablesTriggeringRules(conceptMgr, logicMgr).isEmpty())
+                .toSet();
+
+        for (Rule negationRule : negationRulesTriggeringRules) {
+            Map<Rule, RuleDependency> visitedRecursiveRules = new HashMap<>();
+            visitedRecursiveRules.put(negationRule, RuleDependency.of(negationRule, null));
+            List<RuleDependency> frontier = new LinkedList<>(recursiveRules(negationRule, conceptMgr, logicMgr));
+            RuleDependency visiting;
+            while (!frontier.isEmpty()) {
+                visiting = frontier.remove(0);
+                if (visitedRecursiveRules.containsKey(visiting.rule)) {
+                    List<Rule> cycle = buildCycle(visiting, visitedRecursiveRules);
+                    String readableCycle = cycle.stream().map(Rule::getLabel).collect(Collectors.joining(" -> \n"));
+                    throw GraknException.of(CONTRADICTORY_RULE_CYCLE, "\n" + readableCycle);
+                } else {
+                    visitedRecursiveRules.put(visiting.rule, visiting);
+                    Set<RuleDependency> recursive = recursiveRules(visiting.rule, conceptMgr, logicMgr);
+                    recursive.removeAll(visitedRecursiveRules.values());
+                    frontier.addAll(recursive);
+                }
+            }
+        }
+    }
+
+    private List<Rule> buildCycle(RuleDependency dependency, Map<Rule, RuleDependency> visitedRecursiveRules) {
+        List<Rule> cycle = new LinkedList<>();
+        cycle.add(dependency.rule);
+        Rule triggeringRule = dependency.triggeringRule;
+        while (!cycle.contains(triggeringRule)) {
+            cycle.add(triggeringRule);
+            triggeringRule = visitedRecursiveRules.get(triggeringRule).triggeringRule;
+        }
+        cycle.add(triggeringRule);
+        return cycle;
+    }
+
+    private Set<RuleDependency> recursiveRules(Rule rule, ConceptManager conceptMgr, LogicManager logicMgr) {
+        return link(iterate(rule.condition().concludablesTriggeringRules(conceptMgr, logicMgr)),
+                    iterate(rule.condition().negatedConcludablesTriggeringRules(conceptMgr, logicMgr)))
+                .flatMap(concludable -> concludable.getApplicableRules(conceptMgr, logicMgr))
+                .map(recursiveRule -> RuleDependency.of(recursiveRule, rule)).toSet();
+    }
+
+    private static class RuleDependency {
+        final Rule rule;
+        final Rule triggeringRule;
+
+        private RuleDependency(Rule rule, @Nullable Rule triggeredFrom) {
+            this.rule = rule;
+            this.triggeringRule = triggeredFrom;
+        }
+
+        public static RuleDependency of(Rule rule, Rule triggeredFrom) {
+            return new RuleDependency(rule, triggeredFrom);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            final RuleDependency that = (RuleDependency) o;
+            return Objects.equals(rule, that.rule) && Objects.equals(triggeringRule, that.triggeringRule);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(rule, triggeringRule);
+        }
+    }
+
+    private Rule fromStructure(RuleStructure ruleStructure) {
+        return logicCache.rule().get(ruleStructure.label(), l -> Rule.of(this, ruleStructure));
+    }
+
 
     public TypeResolver typeResolver() {
         return typeResolver;
     }
 
     GraphManager graph() { return graphMgr; }
-
-    private Rule fromStructure(RuleStructure ruleStructure) {
-        return logicCache.rule().get(ruleStructure.label(), l -> Rule.of(this, ruleStructure));
-    }
 
 }

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -33,11 +33,13 @@ import graql.lang.pattern.variable.ThingVariable;
 public class LogicManager {
 
     private final GraphManager graphMgr;
+    private final ConceptManager conceptMgr;
     private final TypeResolver typeResolver;
     private LogicCache logicCache;
 
     public LogicManager(GraphManager graphMgr, ConceptManager conceptMgr, TraversalEngine traversalEng, LogicCache logicCache) {
         this.graphMgr = graphMgr;
+        this.conceptMgr = conceptMgr;
         this.logicCache = logicCache;
         this.typeResolver = new TypeResolver(conceptMgr, traversalEng, logicCache);
     }
@@ -49,7 +51,7 @@ public class LogicManager {
             structure.delete();
             logicCache.rule().invalidate(label);
         }
-        return logicCache.rule().get(label, l -> Rule.of(graphMgr, this, label, when, then));
+        return logicCache.rule().get(label, l -> Rule.of(graphMgr, conceptMgr, this, label, when, then));
     }
 
     public Rule getRule(String label) {
@@ -96,7 +98,7 @@ public class LogicManager {
 
         // using the new index, validate new rules are stratifiable (eg. do not cause cycles through a negation)
         graphMgr.schema().rules().buffered().filter(structure -> structure.status().equals(Encoding.Status.BUFFERED))
-                .forEachRemaining(structure -> getRule(structure.label()).validateCycles(logicMgr));
+                .forEachRemaining(structure -> getRule(structure.label()).validateCycles(conceptMgr, this));
     }
 
     public TypeResolver typeResolver() {

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -64,6 +64,10 @@ public class LogicManager {
         return graphMgr.schema().rules().all().map(this::fromStructure);
     }
 
+    public FunctionalIterator<Rule> rulesWithNegations() {
+        return rules().filter(rule -> !rule.when().negations().isEmpty());
+    }
+
     public FunctionalIterator<Rule> rulesConcluding(Label type) {
         return graphMgr.schema().rules().conclusions().concludesVertex(graphMgr.schema().getType(type)).map(this::fromStructure);
     }
@@ -92,7 +96,7 @@ public class LogicManager {
 
         // using the new index, validate new rules are stratifiable (eg. do not cause cycles through a negation)
         graphMgr.schema().rules().buffered().filter(structure -> structure.status().equals(Encoding.Status.BUFFERED))
-                .forEachRemaining(structure -> getRule(structure.label()).validateCycles());
+                .forEachRemaining(structure -> getRule(structure.label()).validateCycles(logicMgr));
     }
 
     public TypeResolver typeResolver() {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -271,7 +271,6 @@ public class Rule {
                 if (negatedConcludablesTriggeringRules == null) {
                     negatedConcludablesTriggeringRules = concludables(rule.when().negations())
                             .filter(c -> c.getApplicableRules(conceptMgr, logicMgr).hasNext()).toSet();
-                    ;
                 }
             }
             return negatedConcludablesTriggeringRules;

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -106,11 +106,14 @@ public abstract class Concludable extends Resolvable<Conjunction> {
     }
 
     public FunctionalIterator<Rule> getApplicableRules(ConceptManager conceptMgr, LogicManager logicMgr) {
-        synchronized (this) {
-            if (applicableRules == null) applicableRules = applicableRules(conceptMgr, logicMgr);
+        if (applicableRules == null) {
+            synchronized (this) {
+                if (applicableRules == null) applicableRules = applicableRules(conceptMgr, logicMgr);
+            }
         }
         // This gives a deterministic ordering to the applicable rules, which is important for testing.
-        return Iterators.iterate(applicableRules.keySet().stream().sorted(Comparator.comparing(Rule::getLabel)).collect(Collectors.toList()));
+        return Iterators.iterate(applicableRules.keySet().stream().sorted(Comparator.comparing(Rule::getLabel))
+                                         .collect(Collectors.toList()));
     }
 
     abstract Map<Rule, Set<Unifier>> applicableRules(ConceptManager conceptMgr, LogicManager logicMgr);

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -51,6 +51,7 @@ import grakn.core.pattern.variable.Variable;
 import grakn.core.traversal.Traversal;
 import grakn.core.traversal.TraversalEngine;
 import grakn.core.traversal.common.Identifier;
+import grakn.core.traversal.common.VertexMap;
 import graql.lang.common.GraqlArg.ValueType;
 import graql.lang.pattern.variable.Reference;
 
@@ -92,7 +93,7 @@ public class TypeResolver {
             Map<Identifier.Variable.Name, Label> mapping = new HashMap<>();
             vertexMap.forEach((id, vertex) -> {
                 assert vertex.isType();
-                traversalBuilder.getVariable(id).map(Variable::id).filter(Identifier::isName)
+                traversalBuilder.getOriginalVariable(id).map(Variable::id).filter(Identifier::isName)
                         .ifPresent(originalRef -> mapping.put(originalRef.asName(), vertex.asType().properLabel()));
             });
             return mapping;
@@ -147,7 +148,7 @@ public class TypeResolver {
         Map<Identifier.Variable.Retrievable, Set<Label>> resolvedLabels = executeResolverTraversals(traversalBuilder);
         if (resolvedLabels.isEmpty()) conjunction.setCoherent(false);
         else {
-            resolvedLabels.forEach((id, labels) -> traversalBuilder.getVariable(id).ifPresent(variable -> {
+            resolvedLabels.forEach((id, labels) -> traversalBuilder.getOriginalVariable(id).ifPresent(variable -> {
                 assert variable.resolvedTypes().isEmpty() || variable.resolvedTypes().containsAll(labels);
                 variable.setResolvedTypes(labels);
             }));
@@ -187,12 +188,12 @@ public class TypeResolver {
                     result -> {
                         // TODO: This filter should not be needed if we enforce traversal only to return non-abstract
                         assert iterate(result.map().values()).allMatch(Vertex::isType);
-                        if (iterate(result.map().values()).noneMatch(typeVertex -> typeVertex.asType().isAbstract())) {
+                        if (!containsAbstractThing(result, traversalBuilder)) {
                             result.forEach((id, vertex) -> {
-                                mapping.putIfAbsent(id, new HashSet<>());
-                                if (!traversalBuilder.getVariable(id).isPresent()) return;
-                                if (traversalBuilder.getVariable(id).get().isThing()) {
-                                    mapping.get(id).add(vertex.asType().properLabel());
+                                Optional<Variable> originalVar = traversalBuilder.getOriginalVariable(id);
+                                if (originalVar.isPresent()) {
+                                    Set<Label> labels = mapping.computeIfAbsent(id, (i) -> new HashSet<>());
+                                    labels.add(vertex.asType().properLabel());
                                 }
                             });
                         }
@@ -202,14 +203,25 @@ public class TypeResolver {
         });
     }
 
+    private boolean containsAbstractThing(VertexMap resolvedTypes, TraversalBuilder traversalBuilder) {
+        for (Map.Entry<Identifier.Variable.Retrievable, Vertex<?, ?>> entry : resolvedTypes.map().entrySet()) {
+            Identifier.Variable.Retrievable id = entry.getKey();
+            Optional<Variable> variable = traversalBuilder.getOriginalVariable(id);
+            if (entry.getValue().asType().isAbstract() && variable.isPresent() && variable.get().isThing()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static class TraversalBuilder {
 
         private static final Identifier.Variable ROOT_ATTRIBUTE_ID = Identifier.Variable.of(Reference.label(ATTRIBUTE.toString()));
         private static final Label ROOT_ATTRIBUTE_LABEL = Label.of(ATTRIBUTE.toString());
         private static final Label ROOT_THING_LABEL = Label.of(THING.toString());
-        private final Map<Identifier.Variable, Variable> resolvers;
         private final Map<Identifier.Variable, Set<ValueType>> resolverValueTypes;
         private final Map<Identifier.Variable, TypeVariable> originalToResolver;
+        private final Map<Identifier.Variable, Variable> resolverToOriginal;
         private final ConceptManager conceptMgr;
         private final Conjunction conjunction;
         private final Traversal traversal;
@@ -222,7 +234,7 @@ public class TypeResolver {
             this.conceptMgr = conceptMgr;
             this.conjunction = conjunction;
             this.traversal = initialTraversal;
-            this.resolvers = new HashMap<>();
+            this.resolverToOriginal = new HashMap<>();
             this.originalToResolver = new HashMap<>();
             this.resolverValueTypes = new HashMap<>();
             this.sysVarCounter = initialAnonymousVarCounter;
@@ -232,7 +244,7 @@ public class TypeResolver {
         }
 
         public Set<Identifier.Variable.Retrievable> retrievedResolvers() {
-            return iterate(resolvers.keySet()).filter(Identifier::isRetrievable).map(Identifier.Variable::asRetrievable).toSet();
+            return iterate(resolverToOriginal.keySet()).filter(Identifier::isRetrievable).map(Identifier.Variable::asRetrievable).toSet();
         }
 
         public int sysVarCounter() {
@@ -243,8 +255,8 @@ public class TypeResolver {
             return traversal;
         }
 
-        Optional<Variable> getVariable(Identifier.Variable id) {
-            return Optional.ofNullable(resolvers.get(id));
+        Optional<Variable> getOriginalVariable(Identifier.Variable id) {
+            return Optional.ofNullable(resolverToOriginal.get(id));
         }
 
         private void register(Variable variable) {
@@ -263,7 +275,7 @@ public class TypeResolver {
                 resolver = var;
             }
             originalToResolver.put(var.id(), resolver);
-            resolvers.putIfAbsent(resolver.id(), var);
+            resolverToOriginal.putIfAbsent(resolver.id(), var);
             if (!var.resolvedTypes().isEmpty()) traversal.labels(resolver.id(), var.resolvedTypes());
 
             for (TypeConstraint constraint : var.constraints()) {
@@ -318,7 +330,7 @@ public class TypeResolver {
 
             TypeVariable resolver = new TypeVariable(var.id());
             originalToResolver.put(var.id(), resolver);
-            resolvers.putIfAbsent(resolver.id(), var);
+            resolverToOriginal.putIfAbsent(resolver.id(), var);
             resolverValueTypes.putIfAbsent(resolver.id(), set());
 
             // Note: order is important! convertValue assumes that any other Variable encountered from that edge will
@@ -404,8 +416,8 @@ public class TypeResolver {
         }
 
         private void registerSubAttribute(Variable resolver) {
-            assert resolvers.get(resolver.id()).isThing();
-            Optional<IsaConstraint> isa = resolvers.get(resolver.id()).asThing().isa();
+            assert resolverToOriginal.get(resolver.id()).isThing();
+            Optional<IsaConstraint> isa = resolverToOriginal.get(resolver.id()).asThing().isa();
             if (!isa.isPresent()) {
                 registerRootAttribute();
                 traversal.sub(resolver.id(), ROOT_ATTRIBUTE_ID, true);

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -145,7 +145,7 @@ public class TypeResolver {
         Traversal resolverTraversal = new Traversal();
         TraversalBuilder traversalBuilder = builder(resolverTraversal, conjunction, scopingConjunctions, insertable);
         resolverTraversal.filter(traversalBuilder.retrievedResolvers());
-        Map<Identifier.Variable.Retrievable, Set<Label>> resolvedLabels = executeResolverTraversals(traversalBuilder);
+        Map<Identifier.Variable.Retrievable, Set<Label>> resolvedLabels = executeTypeResolvers(traversalBuilder);
         if (resolvedLabels.isEmpty()) conjunction.setCoherent(false);
         else {
             resolvedLabels.forEach((id, labels) -> traversalBuilder.getOriginalVariable(id).ifPresent(variable -> {
@@ -181,7 +181,7 @@ public class TypeResolver {
         return currentBuilder;
     }
 
-    private Map<Identifier.Variable.Retrievable, Set<Label>> executeResolverTraversals(TraversalBuilder traversalBuilder) {
+    private Map<Identifier.Variable.Retrievable, Set<Label>> executeTypeResolvers(TraversalBuilder traversalBuilder) {
         return logicCache.resolver().get(traversalBuilder.traversal(), traversal -> {
             Map<Identifier.Variable.Retrievable, Set<Label>> mapping = new HashMap<>();
             traversalEng.iterator(traversal, true)

--- a/reasoner/resolution/ResolverRegistry.java
+++ b/reasoner/resolution/ResolverRegistry.java
@@ -147,10 +147,10 @@ public class ResolverRegistry {
                 .collect(Collectors.toSet());
     }
 
-    public Actor.Driver<ConditionResolver> registerCondition(Rule rule) {
-        LOG.debug("Register retrieval for rule condition actor: '{}'", rule);
-        Actor.Driver<ConditionResolver> resolver = ruleConditions.computeIfAbsent(rule, (r) -> Actor.driver(
-                driver -> new ConditionResolver(driver, r, resolutionRecorder, this, traversalEngine,
+    public Actor.Driver<ConditionResolver> registerCondition(Rule.Condition ruleCondition) {
+        LOG.debug("Register retrieval for rule condition actor: '{}'", ruleCondition);
+        Actor.Driver<ConditionResolver> resolver = ruleConditions.computeIfAbsent(ruleCondition.rule(), (r) -> Actor.driver(
+                driver -> new ConditionResolver(driver, ruleCondition, resolutionRecorder, this, traversalEngine,
                                                 conceptMgr, logicMgr, planner, resolutionTracing), executorService
         ));
         resolvers.add(resolver);

--- a/reasoner/resolution/resolver/ConclusionResolver.java
+++ b/reasoner/resolution/resolver/ConclusionResolver.java
@@ -135,7 +135,7 @@ public class ConclusionResolver extends Resolver<ConclusionResolver> {
     protected void initialiseDownstreamResolvers() {
         LOG.debug("{}: initialising downstream resolvers", name());
         try {
-            ruleResolver = registry.registerCondition(conclusion.rule());
+            ruleResolver = registry.registerCondition(conclusion.rule().condition());
             isInitialised = true;
         } catch (GraknException e) {
             terminate(e);

--- a/reasoner/resolution/resolver/ConditionResolver.java
+++ b/reasoner/resolution/resolver/ConditionResolver.java
@@ -20,6 +20,8 @@ package grakn.core.reasoner.resolution.resolver;
 import grakn.core.concept.ConceptManager;
 import grakn.core.logic.LogicManager;
 import grakn.core.logic.Rule;
+import grakn.core.logic.resolvable.Concludable;
+import grakn.core.pattern.Conjunction;
 import grakn.core.reasoner.resolution.Planner;
 import grakn.core.reasoner.resolution.ResolutionRecorder;
 import grakn.core.reasoner.resolution.ResolverRegistry;
@@ -30,20 +32,33 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
+import java.util.Set;
+
+import static grakn.core.common.iterator.Iterators.iterate;
 
 // note: in the future, we may introduce query rewriting here
 public class ConditionResolver extends ConjunctionResolver<ConditionResolver, CompoundResolver.RequestState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConditionResolver.class);
 
-    private final Rule rule;
+    private final Rule.Condition condition;
 
-    public ConditionResolver(Driver<ConditionResolver> driver, Rule rule, Driver<ResolutionRecorder> resolutionRecorder,
+    public ConditionResolver(Driver<ConditionResolver> driver, Rule.Condition condition, Driver<ResolutionRecorder> resolutionRecorder,
                              ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
                              LogicManager logicMgr, Planner planner, boolean resolutionTracing) {
-        super(driver, ConditionResolver.class.getCanonicalName() + "(rule:" + rule.getLabel() + ")", rule.when(),
+        super(driver, ConditionResolver.class.getCanonicalName() + "(rule:" + condition.rule().getLabel() + ")",
               resolutionRecorder, registry, traversalEngine, conceptMgr, logicMgr, planner, resolutionTracing);
-        this.rule = rule;
+        this.condition = condition;
+    }
+
+    @Override
+    public Conjunction conjunction() {
+        return condition.rule().when();
+    }
+
+    @Override
+    Set<Concludable> concludablesTriggeringRules() {
+        return condition.concludablesTriggeringRules(conceptMgr, logicMgr);
     }
 
     @Override
@@ -78,7 +93,7 @@ public class ConditionResolver extends ConjunctionResolver<ConditionResolver, Co
 
     @Override
     public String toString() {
-        return name() + ": " + rule.when();
+        return name() + ": " + condition.rule().when();
     }
 
 }

--- a/reasoner/resolution/resolver/DisjunctionResolver.java
+++ b/reasoner/resolution/resolver/DisjunctionResolver.java
@@ -125,7 +125,7 @@ public abstract class DisjunctionResolver<RESOLVER extends DisjunctionResolver<R
 
     protected Set<Identifier.Variable.Retrievable> conjunctionRetrievedIds(Driver<ConjunctionResolver.Nested> conjunctionResolver) {
         // TODO use a map from resolvable to resolvers, then we don't have to reach into the state and use the conjunction
-        return iterate(conjunctionResolver.actor().conjunction.variables()).filter(v -> v.id().isRetrievable())
+        return iterate(conjunctionResolver.actor().conjunction().variables()).filter(v -> v.id().isRetrievable())
                 .map(v -> v.id().asRetrievable()).toSet();
     }
 

--- a/test/behaviour/debug/debug.feature
+++ b/test/behaviour/debug/debug.feature
@@ -17,91 +17,10 @@
 
 Feature: Debugging Space
 
-  Background: Set up databases for resolution testing
+  Background:
     Given connection has been opened
+    Given connection delete all databases
     Given connection does not have any database
-    Given connection create database: reasoned
-    Given connection create database: materialised
-    Given connection open schema sessions for databases:
-      | reasoned     |
-      | materialised |
-    Given for each session, open transactions of type: write
-    Given for each session, graql define
-      """
-      define
 
-      person sub entity,
-        owns name,
-        plays friendship:friend,
-        plays employment:employee;
-
-      company sub entity,
-        owns name,
-        plays employment:employer;
-
-      place sub entity,
-        owns name,
-        plays location-hierarchy:subordinate,
-        plays location-hierarchy:superior;
-
-      friendship sub relation,
-        relates friend;
-
-      employment sub relation,
-        relates employee,
-        relates employer;
-
-      location-hierarchy sub relation,
-        relates subordinate,
-        relates superior;
-
-      name sub attribute, value string;
-      """
-    Given for each session, transaction commits
-    # each scenario specialises the schema further
-    Given for each session, open transactions of type: write
-
-
-  Scenario: a rule can infer a relation based on ownership of any instance of a specific attribute type
-    Given for each session, graql define
-      """
-      define
-      year sub attribute, value long, plays employment:favourite-year;
-      employment relates favourite-year;
-      rule kronenbourg-employs-anyone-with-a-name: when {
-        $x isa company, has name "Kronenbourg";
-        $p isa person, has name $n;
-        $y 1664 isa year;
-      } then {
-        (employee: $p, employer: $x, favourite-year: $y) isa employment;
-      };
-      """
-    Given for each session, transaction commits
-    Given connection close all sessions
-    Given connection open data sessions for databases:
-      | reasoned     |
-      | materialised |
-    Given for each session, open transactions of type: write
-    Given for each session, graql insert
-      """
-      insert
-      $x isa company, has name "Kronenbourg";
-      $p isa person, has name "Ronald";
-      $p2 isa person, has name "Prasanth";
-      $y 1664 isa year;
-      """
-    Given for each session, transaction commits
-    Given for each session, open transactions of type: write
-    Then materialised database is completed
-    Given for each session, transaction commits
-    Given for each session, open transactions of type: read
-    Then for graql query
-      """
-      match
-        $x 1664 isa year;
-        ($x, employee: $p, employer: $y) isa employment;
-      """
-    Then all answers are correct in reasoned database
-    Then answer size in reasoned database is: 2
-    Then materialised and reasoned databases are the same size
-
+  # Paste any scenarios below for debugging.
+  # Do not commit any changes to this file.

--- a/test/behaviour/debug/debug.feature
+++ b/test/behaviour/debug/debug.feature
@@ -17,10 +17,91 @@
 
 Feature: Debugging Space
 
-  Background:
+  Background: Set up databases for resolution testing
     Given connection has been opened
-    Given connection delete all databases
     Given connection does not have any database
+    Given connection create database: reasoned
+    Given connection create database: materialised
+    Given connection open schema sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given for each session, open transactions of type: write
+    Given for each session, graql define
+      """
+      define
 
-  # Paste any scenarios below for debugging.
-  # Do not commit any changes to this file.
+      person sub entity,
+        owns name,
+        plays friendship:friend,
+        plays employment:employee;
+
+      company sub entity,
+        owns name,
+        plays employment:employer;
+
+      place sub entity,
+        owns name,
+        plays location-hierarchy:subordinate,
+        plays location-hierarchy:superior;
+
+      friendship sub relation,
+        relates friend;
+
+      employment sub relation,
+        relates employee,
+        relates employer;
+
+      location-hierarchy sub relation,
+        relates subordinate,
+        relates superior;
+
+      name sub attribute, value string;
+      """
+    Given for each session, transaction commits
+    # each scenario specialises the schema further
+    Given for each session, open transactions of type: write
+
+
+  Scenario: a rule can infer a relation based on ownership of any instance of a specific attribute type
+    Given for each session, graql define
+      """
+      define
+      year sub attribute, value long, plays employment:favourite-year;
+      employment relates favourite-year;
+      rule kronenbourg-employs-anyone-with-a-name: when {
+        $x isa company, has name "Kronenbourg";
+        $p isa person, has name $n;
+        $y 1664 isa year;
+      } then {
+        (employee: $p, employer: $x, favourite-year: $y) isa employment;
+      };
+      """
+    Given for each session, transaction commits
+    Given connection close all sessions
+    Given connection open data sessions for databases:
+      | reasoned     |
+      | materialised |
+    Given for each session, open transactions of type: write
+    Given for each session, graql insert
+      """
+      insert
+      $x isa company, has name "Kronenbourg";
+      $p isa person, has name "Ronald";
+      $p2 isa person, has name "Prasanth";
+      $y 1664 isa year;
+      """
+    Given for each session, transaction commits
+    Given for each session, open transactions of type: write
+    Then materialised database is completed
+    Given for each session, transaction commits
+    Given for each session, open transactions of type: read
+    Then for graql query
+      """
+      match
+        $x 1664 isa year;
+        ($x, employee: $p, employer: $y) isa employment;
+      """
+    Then all answers are correct in reasoned database
+    Then answer size in reasoned database is: 2
+    Then materialised and reasoned databases are the same size
+

--- a/test/integration/BasicTest.java
+++ b/test/integration/BasicTest.java
@@ -818,12 +818,12 @@ public class BasicTest {
                         tx.close();
                         session.close();
                     }).start();
-                    tx.query().match(Graql.parseQuery("match $x isa thing;").asMatch());
+                    tx.query().match(Graql.parseQuery("match $x sub thing;").asMatch());
                 }).start();
             }
             Grakn.Session session = grakn.session(database, Arguments.Session.Type.DATA);
             Grakn.Transaction tx = session.transaction(Arguments.Transaction.Type.WRITE);
-            tx.query().match(Graql.parseQuery("match $x isa thing;").asMatch());
+            tx.query().match(Graql.parseQuery("match $x sub thing;").asMatch());
         }
     }
 }


### PR DESCRIPTION
## What is the goal of this PR?
To properly support negation in rules, we must validate that rules cannot contradict themselves and reach a stable final solution, we require that rules containing negations do not recurse through the negation - this is called stratified negation.
This PR implements the commit time cycle detection required to ban cyclical rules through negations.

## What are the changes implemented in this PR?
* At commit time, we reindex rules if required, then validate there are no cycles through rules with negation
* we remove the restriction that rules cannot have negations
* we enable a set of reasoning BDD files that require negations: `negation`, `recursion`, `schema-queries`
* introduce `Rule.Condition`, which caches concludables and their applicable rules to avoid recomputing them many times
* `ConditionResolver` uses the new `Rule.Condition`
* fix a bug in type resolution to do with including abstract types
