### PR TITLE
Use isX, not 'instanceof' to check type encodings

### DIFF
--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -268,7 +268,7 @@ public class Unifier {
 
             private boolean predicatesSatisfied(Variable id, Concept concept) {
                 if (id.isRetrievable() && predicates.containsKey(id.asRetrievable())) {
-                    assert concept.isThing() && (concept.asThing() instanceof Attribute);
+                    assert concept.isAttribute();
                     return predicates.get(id.asRetrievable()).apply(concept.asAttribute());
                 } else {
                     return true;

--- a/migrator/Exporter.java
+++ b/migrator/Exporter.java
@@ -177,15 +177,15 @@ public class Exporter implements Migrator {
 
     private DataProto.ValueObject.Builder readValue(Attribute attribute) {
         DataProto.ValueObject.Builder valueObject = DataProto.ValueObject.newBuilder();
-        if (attribute instanceof Attribute.String) {
+        if (attribute.isString()) {
             valueObject.setString(attribute.asString().getValue());
-        } else if (attribute instanceof Attribute.Boolean) {
+        } else if (attribute.isBoolean()) {
             valueObject.setBoolean(attribute.asBoolean().getValue());
-        } else if (attribute instanceof Attribute.Long) {
+        } else if (attribute.isLong()) {
             valueObject.setLong(attribute.asLong().getValue());
-        } else if (attribute instanceof Attribute.Double) {
+        } else if (attribute.isDouble()) {
             valueObject.setDouble(attribute.asDouble().getValue());
-        } else if (attribute instanceof Attribute.DateTime) {
+        } else if (attribute.isDateTime()) {
             valueObject.setDatetime(attribute.asDateTime().getValue().atZone(ZoneId.of("Z")).toInstant().toEpochMilli());
         } else {
             throw GraknException.of(ILLEGAL_STATE);

--- a/migrator/SchemaExporter.java
+++ b/migrator/SchemaExporter.java
@@ -87,7 +87,7 @@ public class SchemaExporter {
                                      attributeType.getSupertype().getLabel().name()))
                 .append(COMMA_NEWLINE_INDENT)
                 .append(String.format("value %s", getValueTypeString(attributeType.getValueType())));
-        if (attributeType instanceof AttributeType.String) {
+        if (attributeType.isString()) {
             java.util.regex.Pattern regex = attributeType.asString().getRegex();
             if (regex != null) {
                 builder.append(COMMA_NEWLINE_INDENT)

--- a/query/Definer.java
+++ b/query/Definer.java
@@ -119,7 +119,7 @@ public class Definer {
                 throw GraknException.of(TYPE_NOT_FOUND, labelConstraint.label());
             }
 
-            if (variable.valueType().isPresent() && !(type instanceof AttributeType)) {
+            if (variable.valueType().isPresent() && !(type.isAttributeType())) {
                 throw GraknException.of(ATTRIBUTE_VALUE_TYPE_DEFINED_NOT_ON_ATTRIBUTE_TYPE, labelConstraint.label());
             }
 
@@ -184,13 +184,13 @@ public class Definer {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "define_sub")) {
             LabelConstraint labelConstraint = var.label().get();
             ThingType supertype = define(subConstraint.type()).asThingType();
-            if (supertype instanceof EntityType) {
+            if (supertype.isEntityType()) {
                 if (thingType == null) thingType = conceptMgr.putEntityType(labelConstraint.label());
                 thingType.asEntityType().setSupertype(supertype.asEntityType());
-            } else if (supertype instanceof RelationType) {
+            } else if (supertype.isRelationType()) {
                 if (thingType == null) thingType = conceptMgr.putRelationType(labelConstraint.label());
                 thingType.asRelationType().setSupertype(supertype.asRelationType());
-            } else if (supertype instanceof AttributeType) {
+            } else if (supertype.isAttributeType()) {
                 ValueType valueType;
                 if (var.valueType().isPresent()) valueType = ValueType.of(var.valueType().get().valueType());
                 else if (!supertype.isRoot()) valueType = supertype.asAttributeType().getValueType();

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -221,14 +221,14 @@ public class Inserter {
                 assert isaConstraint.type().label().isPresent();
                 ThingType thingType = getThingType(isaConstraint.type().label().get());
 
-                if (thingType instanceof EntityType) {
+                if (thingType.isEntityType()) {
                     return thingType.asEntityType().create();
-                } else if (thingType instanceof RelationType) {
+                } else if (thingType.isRelationType()) {
                     if (!var.relation().isEmpty()) return thingType.asRelationType().create();
                     else throw GraknException.of(RELATION_CONSTRAINT_MISSING, var.reference());
-                } else if (thingType instanceof AttributeType) {
+                } else if (thingType.isAttributeType()) {
                     return insertAttribute(thingType.asAttributeType(), var);
-                } else if (thingType instanceof ThingTypeImpl.Root) {
+                } else if (thingType.isThingType() && thingType.isRoot()) {
                     throw GraknException.of(ILLEGAL_ABSTRACT_WRITE, Thing.class.getSimpleName(), thingType.getLabel());
                 } else {
                     assert false;

--- a/query/Undefiner.java
+++ b/query/Undefiner.java
@@ -160,7 +160,7 @@ public class Undefiner {
 
     private void undefineSub(ThingType thingType, SubConstraint subConstraint) {
         try (ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "undefine_sub")) {
-            if (thingType instanceof RoleType) {
+            if (thingType.isRoleType()) {
                 throw GraknException.of(ROLE_DEFINED_OUTSIDE_OF_RELATION, thingType.getLabel());
             }
             ThingType supertype = getThingType(subConstraint.type().label().get());
@@ -169,7 +169,7 @@ public class Undefiner {
             } else if (thingType.getSupertypes().noneMatch(t -> t.equals(supertype))) {
                 throw GraknException.of(INVALID_UNDEFINE_SUB, thingType.getLabel(), supertype.getLabel());
             }
-            if (thingType instanceof RelationType) {
+            if (thingType.isRelationType()) {
                 variables.stream().filter(v -> v.label().isPresent() && v.label().get().scope().isPresent() &&
                         v.label().get().scope().get().equals(thingType.getLabel().name())).forEach(undefined::add);
             }

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -98,7 +98,7 @@ public class ResponseBuilder {
 
         public static ConceptProto.Concept concept(grakn.core.concept.Concept concept) {
             if (concept == null) return null;
-            if (concept instanceof Thing) {
+            if (concept.isThing()) {
                 return ConceptProto.Concept.newBuilder().setThing(thing(concept.asThing())).build();
             } else {
                 return ConceptProto.Concept.newBuilder().setType(type(concept.asType())).build();
@@ -124,15 +124,15 @@ public class ResponseBuilder {
         }
 
         private static ConceptProto.Type.Encoding getEncoding(Type type) {
-            if (type instanceof EntityType) {
+            if (type.isEntityType()) {
                 return ConceptProto.Type.Encoding.ENTITY_TYPE;
-            } else if (type instanceof RelationType) {
+            } else if (type.isRelationType()) {
                 return ConceptProto.Type.Encoding.RELATION_TYPE;
-            } else if (type instanceof AttributeType) {
+            } else if (type.isAttributeType()) {
                 return ConceptProto.Type.Encoding.ATTRIBUTE_TYPE;
-            } else if (type instanceof ThingType) {
+            } else if (type.isThingType()) {
                 return ConceptProto.Type.Encoding.THING_TYPE;
-            } else if (type instanceof RoleType) {
+            } else if (type.isRoleType()) {
                 return ConceptProto.Type.Encoding.ROLE_TYPE;
             } else {
                 throw GraknException.of(ILLEGAL_STATE);
@@ -142,15 +142,15 @@ public class ResponseBuilder {
         public static ConceptProto.Attribute.Value attributeValue(Attribute attribute) {
             ConceptProto.Attribute.Value.Builder builder = ConceptProto.Attribute.Value.newBuilder();
 
-            if (attribute instanceof Attribute.String) {
+            if (attribute.isString()) {
                 builder.setString(attribute.asString().getValue());
-            } else if (attribute instanceof Attribute.Long) {
+            } else if (attribute.isLong()) {
                 builder.setLong(attribute.asLong().getValue());
-            } else if (attribute instanceof Attribute.Boolean) {
+            } else if (attribute.isBoolean()) {
                 builder.setBoolean(attribute.asBoolean().getValue());
-            } else if (attribute instanceof Attribute.DateTime) {
+            } else if (attribute.isDateTime()) {
                 builder.setDateTime(attribute.asDateTime().getValue().toInstant(ZoneOffset.UTC).toEpochMilli());
-            } else if (attribute instanceof Attribute.Double) {
+            } else if (attribute.isDouble()) {
                 builder.setDouble(attribute.asDouble().getValue());
             } else {
                 throw GraknException.of(ErrorMessage.Server.BAD_VALUE_TYPE);
@@ -184,15 +184,15 @@ public class ResponseBuilder {
         }
 
         public static ConceptProto.AttributeType.ValueType valueType(AttributeType attributeType) {
-            if (attributeType instanceof AttributeType.String) {
+            if (attributeType.isString()) {
                 return ConceptProto.AttributeType.ValueType.STRING;
-            } else if (attributeType instanceof AttributeType.Boolean) {
+            } else if (attributeType.isBoolean()) {
                 return ConceptProto.AttributeType.ValueType.BOOLEAN;
-            } else if (attributeType instanceof AttributeType.Long) {
+            } else if (attributeType.isLong()) {
                 return ConceptProto.AttributeType.ValueType.LONG;
-            } else if (attributeType instanceof AttributeType.Double) {
+            } else if (attributeType.isDouble()) {
                 return ConceptProto.AttributeType.ValueType.DOUBLE;
-            } else if (attributeType instanceof AttributeType.DateTime) {
+            } else if (attributeType.isDateTime()) {
                 return ConceptProto.AttributeType.ValueType.DATETIME;
             } else if (attributeType.isRoot()) {
                 return ConceptProto.AttributeType.ValueType.OBJECT;

--- a/server/concept/TypeService.java
+++ b/server/concept/TypeService.java
@@ -218,11 +218,11 @@ public class TypeService {
     private void setSupertype(Type type, ConceptProto.Type supertype, Transaction.Req request) {
         Type sup = getThingType(supertype);
 
-        if (type instanceof EntityType) {
+        if (type.isEntityType()) {
             type.asEntityType().setSupertype(sup.asEntityType());
-        } else if (type instanceof RelationType) {
+        } else if (type.isRelationType()) {
             type.asRelationType().setSupertype(sup.asRelationType());
-        } else if (type instanceof AttributeType) {
+        } else if (type.isAttributeType()) {
             type.asAttributeType().setSupertype(sup.asAttributeType());
         } else {
             throw GraknException.of(ILLEGAL_SUPERTYPE_ENCODING, className(type.getClass()));

--- a/test/behaviour/graql/GraqlSteps.java
+++ b/test/behaviour/graql/GraqlSteps.java
@@ -550,7 +550,7 @@ public class GraqlSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (concept instanceof Type) {
+            if (concept.isType()) {
                 return label.equals(concept.asType().getLabel().toString());
             }
 
@@ -580,7 +580,7 @@ public class GraqlSteps {
         }
 
         public boolean check(Concept concept) {
-            if (!(concept instanceof Attribute)) {
+            if (!concept.isAttribute()) {
                 return false;
             }
 
@@ -621,7 +621,7 @@ public class GraqlSteps {
 
         @Override
         public boolean check(Concept concept) {
-            if (!(concept instanceof Thing)) { return false; }
+            if (!concept.isThing()) { return false; }
 
             Set<Attribute> keys = concept.asThing().getHas(true).collect(Collectors.toSet());
 


### PR DESCRIPTION
## What is the goal of this PR?

We refactored the codebase to ensure the `isX` methods of the subclasses of `Concept` are used consistently, not `instanceof`.

## What are the changes implemented in this PR?

Use isX, not 'instanceof' to check type encodings
