### PR TITLE
All conjunction resolvers deduplicate concept maps

### DIFF
--- a/reasoner/resolution/resolver/ConditionResolver.java
+++ b/reasoner/resolution/resolver/ConditionResolver.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Optional;
 
 // note: in the future, we may introduce query rewriting here
-public class ConditionResolver extends ConjunctionResolver<ConditionResolver, CompoundResolver.RequestState> {
+public class ConditionResolver extends ConjunctionResolver<ConditionResolver> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConditionResolver.class);
 
@@ -60,20 +60,15 @@ public class ConditionResolver extends ConjunctionResolver<ConditionResolver, Co
         return Optional.of(fromDownstream.asFiltered().toUpstream());
     }
 
+
     @Override
-    boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
-        answerToUpstream(upstreamAnswer, fromUpstream, iteration);
-        return true;
+    ConjunctionResolver.RequestState requestStateNew(int iteration) {
+        return new ConjunctionResolver.RequestState(iteration);
     }
 
     @Override
-    RequestState requestStateNew(int iteration) {
-        return new RequestState(iteration);
-    }
-
-    @Override
-    RequestState requestStateForIteration(RequestState requestStatePrior, int iteration) {
-        return new RequestState(iteration);
+    ConjunctionResolver.RequestState requestStateForIteration(ConjunctionResolver.RequestState requestStatePrior, int iteration) {
+        return new ConjunctionResolver.RequestState(iteration);
     }
 
     @Override

--- a/reasoner/resolution/resolver/ConjunctionResolver.java
+++ b/reasoner/resolution/resolver/ConjunctionResolver.java
@@ -21,6 +21,7 @@ package grakn.core.reasoner.resolution.resolver;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.iterator.Iterators;
 import grakn.core.concept.ConceptManager;
+import grakn.core.concept.answer.ConceptMap;
 import grakn.core.logic.LogicManager;
 import grakn.core.logic.resolvable.Concludable;
 import grakn.core.logic.resolvable.Negated;
@@ -51,10 +52,8 @@ import java.util.Set;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.iterator.Iterators.iterate;
 
-public abstract class ConjunctionResolver<
-        RESOLVER extends ConjunctionResolver<RESOLVER, REQ_STATE>,
-        REQ_STATE extends CompoundResolver.RequestState
-        > extends CompoundResolver<RESOLVER, REQ_STATE> {
+public abstract class ConjunctionResolver<RESOLVER extends ConjunctionResolver<RESOLVER>>
+        extends CompoundResolver<RESOLVER, ConjunctionResolver.RequestState> {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConjunctionResolver.class);
 
@@ -80,7 +79,7 @@ public abstract class ConjunctionResolver<
         this.downstreamResolvers = new HashMap<>();
     }
 
-    protected abstract void nextAnswer(Request fromUpstream, REQ_STATE requestState, int iteration);
+    protected abstract void nextAnswer(Request fromUpstream, RequestState requestState, int iteration);
 
     abstract Optional<AnswerState> toUpstreamAnswer(Partial<?> fromDownstream);
 
@@ -91,7 +90,7 @@ public abstract class ConjunctionResolver<
 
         Request toDownstream = fromDownstream.sourceRequest();
         Request fromUpstream = fromUpstream(toDownstream);
-        REQ_STATE requestState = requestStates.get(fromUpstream);
+        RequestState requestState = requestStates.get(fromUpstream);
 
         Plans.Plan plan = plans.get(fromUpstream.partialAnswer().conceptMap().concepts().keySet());
 
@@ -105,16 +104,29 @@ public abstract class ConjunctionResolver<
             boolean answerAccepted = upstreamAnswer.isPresent() && tryAcceptUpstreamAnswer(upstreamAnswer.get(), fromUpstream, iteration);
             if (!answerAccepted) nextAnswer(fromUpstream, requestState, iteration);
         } else {
-            int nextResolverIndex = fromDownstream.planIndex() + 1;
-            ResolverRegistry.ResolverView nextPlannedDownstream = downstreamResolvers.get(plan.get(nextResolverIndex));
-            Partial<?> downstream = forDownstreamResolver(nextPlannedDownstream, fromDownstream.answer());
-            Request downstreamRequest = Request.create(driver(), nextPlannedDownstream.resolver(), downstream, nextResolverIndex);
-            requestState.addDownstreamProducer(downstreamRequest);
-            requestFromDownstream(downstreamRequest, fromUpstream, iteration);
+            toNextChild(fromDownstream, iteration, fromUpstream, requestState, plan);
         }
     }
 
-    abstract boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration);
+    private boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
+        RequestState requestState = requestStates.get(fromUpstream);
+        if (!requestState.hasProduced(upstreamAnswer.conceptMap())) {
+            requestState.recordProduced(upstreamAnswer.conceptMap());
+            answerToUpstream(upstreamAnswer, fromUpstream, iteration);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private void toNextChild(Response.Answer fromDownstream, int iteration, Request fromUpstream, RequestState requestState, Plans.Plan plan) {
+        int nextResolverIndex = fromDownstream.planIndex() + 1;
+        ResolverRegistry.ResolverView nextPlannedDownstream = downstreamResolvers.get(plan.get(nextResolverIndex));
+        Partial<?> downstream = forDownstreamResolver(nextPlannedDownstream, fromDownstream.answer());
+        Request downstreamRequest = Request.create(driver(), nextPlannedDownstream.resolver(), downstream, nextResolverIndex);
+        requestState.addDownstreamProducer(downstreamRequest);
+        requestFromDownstream(downstreamRequest, fromUpstream, iteration);
+    }
 
     @Override
     protected void receiveFail(Response.Fail fromDownstream, int iteration) {
@@ -123,7 +135,7 @@ public abstract class ConjunctionResolver<
 
         Request toDownstream = fromDownstream.sourceRequest();
         Request fromUpstream = fromUpstream(toDownstream);
-        REQ_STATE requestState = this.requestStates.get(fromUpstream);
+        RequestState requestState = this.requestStates.get(fromUpstream);
 
         if (iteration < requestState.iteration()) {
             // short circuit old iteration failed messages to upstream
@@ -163,12 +175,12 @@ public abstract class ConjunctionResolver<
     }
 
     @Override
-    protected REQ_STATE requestStateCreate(Request fromUpstream, int iteration) {
+    protected RequestState requestStateCreate(Request fromUpstream, int iteration) {
         LOG.debug("{}: Creating a new RequestState for request: {}", name(), fromUpstream);
         Plans.Plan plan = plans.getOrCreate(fromUpstream.partialAnswer().conceptMap().concepts().keySet(), resolvables, negateds);
         assert !plan.isEmpty();
 
-        REQ_STATE requestState = requestStateNew(iteration);
+        RequestState requestState = requestStateNew(iteration);
         ResolverRegistry.ResolverView childResolver = downstreamResolvers.get(plan.get(0));
         Partial<?> downstream = forDownstreamResolver(childResolver, fromUpstream.partialAnswer());
         Request toDownstream = Request.create(driver(), childResolver.resolver(), downstream, 0);
@@ -177,14 +189,14 @@ public abstract class ConjunctionResolver<
     }
 
     @Override
-    protected REQ_STATE requestStateReiterate(Request fromUpstream, REQ_STATE requestStatePrior,
-                                              int newIteration) {
+    protected RequestState requestStateReiterate(Request fromUpstream, RequestState requestStatePrior,
+                                                 int newIteration) {
         assert newIteration > requestStatePrior.iteration();
         LOG.debug("{}: Updating RequestState for iteration '{}'", name(), newIteration);
         Plans.Plan plan = plans.getOrCreate(fromUpstream.partialAnswer().conceptMap().concepts().keySet(), resolvables, negateds);
 
         assert !plan.isEmpty();
-        REQ_STATE requestStateNextIteration = requestStateForIteration(requestStatePrior, newIteration);
+        RequestState requestStateNextIteration = requestStateForIteration(requestStatePrior, newIteration);
         ResolverRegistry.ResolverView childResolver = downstreamResolvers.get(plan.get(0));
         Partial<?> downstream = forDownstreamResolver(childResolver, fromUpstream.partialAnswer());
         Request toDownstream = Request.create(driver(), childResolver.resolver(), downstream, 0);
@@ -192,9 +204,9 @@ public abstract class ConjunctionResolver<
         return requestStateNextIteration;
     }
 
-    abstract REQ_STATE requestStateNew(int iteration);
+    abstract RequestState requestStateNew(int iteration);
 
-    abstract REQ_STATE requestStateForIteration(REQ_STATE requestStatePrior, int iteration);
+    abstract RequestState requestStateForIteration(RequestState requestStatePrior, int iteration);
 
     Partial<?> forDownstreamResolver(ResolverRegistry.ResolverView resolver, Partial<?> partialAnswer) {
         if (resolver.isMapped()) {
@@ -203,6 +215,33 @@ public abstract class ConjunctionResolver<
             return partialAnswer.filterToDownstream(resolver.asFiltered().filter(), resolver.resolver());
         } else {
             throw GraknException.of(ILLEGAL_STATE);
+        }
+    }
+
+
+    public static class RequestState extends CompoundResolver.RequestState {
+
+        private final Set<ConceptMap> produced;
+
+        public RequestState(int iteration) {
+            this(iteration, new HashSet<>());
+        }
+
+        public RequestState(int iteration, Set<ConceptMap> produced) {
+            super(iteration);
+            this.produced = produced;
+        }
+
+        public void recordProduced(ConceptMap conceptMap) {
+            produced.add(conceptMap);
+        }
+
+        public boolean hasProduced(ConceptMap conceptMap) {
+            return produced.contains(conceptMap);
+        }
+
+        public Set<ConceptMap> produced() {
+            return produced;
         }
     }
 
@@ -246,7 +285,7 @@ public abstract class ConjunctionResolver<
         }
     }
 
-    public static class Nested extends ConjunctionResolver<Nested, RequestState> {
+    public static class Nested extends ConjunctionResolver<Nested> {
 
         public Nested(Driver<Nested> driver, Conjunction conjunction, Driver<ResolutionRecorder> resolutionRecorder,
                       ResolverRegistry registry, TraversalEngine traversalEngine, ConceptManager conceptMgr,
@@ -256,7 +295,7 @@ public abstract class ConjunctionResolver<
         }
 
         @Override
-        protected void nextAnswer(Request fromUpstream, RequestState requestState, int iteration) {
+        protected void nextAnswer(Request fromUpstream, ConjunctionResolver.RequestState requestState, int iteration) {
             if (requestState.hasDownstreamProducer()) {
                 requestFromDownstream(requestState.nextDownstreamProducer(), fromUpstream, iteration);
             } else {
@@ -270,19 +309,13 @@ public abstract class ConjunctionResolver<
         }
 
         @Override
-        boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
-            answerToUpstream(upstreamAnswer, fromUpstream, iteration);
-            return true;
+        ConjunctionResolver.RequestState requestStateNew(int iteration) {
+            return new ConjunctionResolver.RequestState(iteration);
         }
 
         @Override
-        RequestState requestStateNew(int iteration) {
-            return new RequestState(iteration);
-        }
-
-        @Override
-        RequestState requestStateForIteration(RequestState requestStatePrior, int iteration) {
-            return new RequestState(iteration);
+        ConjunctionResolver.RequestState requestStateForIteration(ConjunctionResolver.RequestState requestStatePrior, int iteration) {
+            return new ConjunctionResolver.RequestState(iteration);
         }
     }
 }

--- a/reasoner/resolution/resolver/RootResolver.java
+++ b/reasoner/resolution/resolver/RootResolver.java
@@ -18,7 +18,6 @@
 package grakn.core.reasoner.resolution.resolver;
 
 import grakn.core.concept.ConceptManager;
-import grakn.core.concept.answer.ConceptMap;
 import grakn.core.logic.LogicManager;
 import grakn.core.reasoner.resolution.Planner;
 import grakn.core.reasoner.resolution.ResolutionRecorder;
@@ -31,10 +30,7 @@ import grakn.core.traversal.TraversalEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 
 public interface RootResolver {
@@ -43,7 +39,7 @@ public interface RootResolver {
 
     void submitFail(int iteration);
 
-    class Conjunction extends ConjunctionResolver<Conjunction, Conjunction.RequestState> implements RootResolver {
+    class Conjunction extends ConjunctionResolver<Conjunction> implements RootResolver {
 
         private static final Logger LOG = LoggerFactory.getLogger(Conjunction.class);
 
@@ -120,43 +116,7 @@ public interface RootResolver {
             return new RequestState(iteration, requestStatePrior.produced());
         }
 
-        @Override
-        boolean tryAcceptUpstreamAnswer(AnswerState upstreamAnswer, Request fromUpstream, int iteration) {
-            RequestState requestState = requestStates.get(fromUpstream);
-            if (!requestState.hasProduced(upstreamAnswer.conceptMap())) {
-                requestState.recordProduced(upstreamAnswer.conceptMap());
-                answerToUpstream(upstreamAnswer, fromUpstream, iteration);
-                return true;
-            } else {
-                return false;
-            }
-        }
 
-        static class RequestState extends CompoundResolver.RequestState {
-
-            private final Set<ConceptMap> produced;
-
-            public RequestState(int iteration) {
-                this(iteration, new HashSet<>());
-            }
-
-            public RequestState(int iteration, Set<ConceptMap> produced) {
-                super(iteration);
-                this.produced = produced;
-            }
-
-            public void recordProduced(ConceptMap conceptMap) {
-                produced.add(conceptMap);
-            }
-
-            public boolean hasProduced(ConceptMap conceptMap) {
-                return produced.contains(conceptMap);
-            }
-
-            public Set<ConceptMap> produced() {
-                return produced;
-            }
-        }
     }
 
     class Disjunction extends DisjunctionResolver<Disjunction> implements RootResolver {


### PR DESCRIPTION
## What is the goal of this PR?
As an optimisation we have accidentally removed, we re-introduce the ability for each Conjunction resolver to deduplicte answers. This should reduce work where (notably in Condition resolvers), more variables are present than in the upstream resolver (eg. compare conclusion resolvers to condition resolvers) - not filtering out duplicates produced by varying variables the upstream doesn't care about can lead to doing too much work.

## What are the changes implemented in this PR?
* All conjunction resolvers use the same `RequestState`, which is used to deduplicte answers