### PR TITLE
Bump Java version for macOS assembly test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ commands:
 jobs:
   test-assembly-mac-zip:
     macos:
-      xcode: "10.2.1"
+      xcode: "12.4.0"
     working_directory: ~/grakn
     steps:
       - install-bazel-mac


### PR DESCRIPTION
## What is the goal of this PR?

As Grakn Core server no longer boots up under Java 8, Java used in `test-assembly-mac-zip` needs to be upgraded.

## What are the changes implemented in this PR?

Bump macOS image used in tests to the latest one