### PR TITLE
Validate labels when creating Types

### DIFF
--- a/concept/BUILD
+++ b/concept/BUILD
@@ -45,6 +45,7 @@ native_java_libraries(
         "@graknlabs_common//:common",
         "@graknlabs_graql//java/common:common",
         "@graknlabs_graql//java/pattern:pattern",
+        "@graknlabs_graql//java:graql",
 
         # External Maven Dependencies
         "@maven//:com_google_code_findbugs_jsr305",

--- a/concept/type/impl/TypeImpl.java
+++ b/concept/type/impl/TypeImpl.java
@@ -28,6 +28,7 @@ import grakn.core.graph.common.Encoding;
 import grakn.core.graph.structure.RuleStructure;
 import grakn.core.graph.vertex.ThingVertex;
 import grakn.core.graph.vertex.TypeVertex;
+import graql.lang.Graql;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
@@ -60,6 +61,7 @@ public abstract class TypeImpl extends ConceptImpl implements Type {
     }
 
     TypeImpl(GraphManager graphMgr, String label, Encoding.Vertex.Type encoding, String scope) {
+        label = Graql.parseLabel(label);
         this.graphMgr = graphMgr;
         this.vertex = graphMgr.schema().create(encoding, label, scope);
         TypeVertex superTypeVertex = graphMgr.schema().getType(encoding.root().label(), encoding.root().scope());

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,7 +35,7 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/alexjpwalker/graql",
-        commit = "04acc14b63e3c100f0e5c774216e62dbeeacffe1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "39fe77403d0ed3015e5fb48adc8035aace075f71", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,8 +34,8 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/alexjpwalker/graql",
-        commit = "39fe77403d0ed3015e5fb48adc8035aace075f71", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        remote = "https://github.com/graknlabs/graql",
+        commit = "f7509cb39823af107679a241051fee78b793a620", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -34,8 +34,8 @@ def graknlabs_common():
 def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
-        remote = "https://github.com/graknlabs/graql",
-        tag = "2.0.0-alpha-9", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        remote = "https://github.com/alexjpwalker/graql",
+        commit = "04acc14b63e3c100f0e5c774216e62dbeeacffe1", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():


### PR DESCRIPTION
## What is the goal of this PR?

Previously it was possible to define Types with labels such as `1abc` and even the empty string by using Concept API, even though these labels are illegal in Graql. Now, we validate our type labels at the Concept API level, whenever attempting to create a new Type.

## What are the changes implemented in this PR?

Validate type labels when creating Types
