### PR TITLE
Explanations rpc

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -109,8 +109,8 @@ build:
         bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
-      # bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
-      # bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
+        bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
     test-assembly-linux-targz:
       image: graknlabs-ubuntu-20.04
       filter:

--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -109,7 +109,7 @@ build:
         bazel test //test/behaviour/resolution/tests/negation:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/recursion:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/schema_queries:test --test_output=streamed
-        bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
+        # bazel test //test/behaviour/resolution/tests/variable_roles:test --test_output=streamed
         bazel test //test/behaviour/resolution/tests/concept_inequality:test --test_output=streamed
     test-assembly-linux-targz:
       image: graknlabs-ubuntu-20.04

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -132,7 +132,7 @@ public class ConceptMap implements Answer {
     }
 
     public ConceptMap withExplainableConcept(Retrievable id, Conjunction conjunction) {
-        assert concepts.get(id).isRelation() && concepts.get(id).isAttribute();
+        assert concepts.get(id).isRelation() || concepts.get(id).isAttribute();
         if (concepts.get(id).isRelation()) {
             HashMap<Retrievable, Explainable> clone = new HashMap<>(explainables.explainableRelations);
             clone.put(id, Explainable.unidentified(conjunction));
@@ -219,7 +219,7 @@ public class ConceptMap implements Answer {
             relations.putAll(explainables.explainableRelations);
             attributes.putAll(explainables.explainableAttributes);
             ownerships.putAll(explainables.explainableOwnerships);
-            return new Explainables(explainableRelations, explainableAttributes, ownerships);
+            return new Explainables(relations, attributes, ownerships);
         }
 
         @Override

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -185,23 +185,23 @@ public class ConceptMap implements Answer {
             this.concepts = concepts;
         }
 
-        public FunctionalIterator<Explainable> explainables() {
+        public FunctionalIterator<Explainable> iterator() {
             return link(iterate(explainableConcepts.values()), iterate(explainableOwnerships.values()));
         }
 
-        public Map<Retrievable, Explainable> explainableRelations() {
+        public Map<Retrievable, Explainable> relations() {
             return explainableConcepts.entrySet().stream()
                     .filter((entry) -> concepts.get(entry.getKey()).isRelation())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
-        public Map<Retrievable, Explainable> explainableAttributes() {
+        public Map<Retrievable, Explainable> attributes() {
             return explainableConcepts.entrySet().stream()
                     .filter((entry) -> concepts.get(entry.getKey()).isAttribute())
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
 
-        public Map<Pair<Retrievable, Retrievable>, Explainable> explainableOwnerships() {
+        public Map<Pair<Retrievable, Retrievable>, Explainable> ownerships() {
             return explainableOwnerships;
         }
 

--- a/concept/answer/ConceptMap.java
+++ b/concept/answer/ConceptMap.java
@@ -136,13 +136,15 @@ public class ConceptMap implements Answer {
         if (concepts.get(id).isRelation()) {
             HashMap<Retrievable, Explainable> clone = new HashMap<>(explainables.explainableRelations);
             clone.put(id, Explainable.unidentified(conjunction));
-            return new ConceptMap(concepts,
+            return new ConceptMap(
+                    concepts,
                     new Explainables(unmodifiableMap(clone), explainables.explainableRelations, explainables.explainableOwnerships)
             );
         } else {
             HashMap<Retrievable, Explainable> clone = new HashMap<>(explainables.explainableAttributes);
             clone.put(id, Explainable.unidentified(conjunction));
-            return new ConceptMap(concepts,
+            return new ConceptMap(
+                    concepts,
                     new Explainables(explainables.explainableRelations, unmodifiableMap(clone), explainables.explainableOwnerships)
             );
         }
@@ -151,7 +153,8 @@ public class ConceptMap implements Answer {
     public ConceptMap withExplainableAttrOwnership(Retrievable owner, Retrievable attribute, Conjunction conjunction) {
         Map<Pair<Retrievable, Retrievable>, Explainable> explainableAttributeOwnershipsClone = new HashMap<>(explainables.explainableOwnerships);
         explainableAttributeOwnershipsClone.put(new Pair<>(owner, attribute), Explainable.unidentified(conjunction));
-        return new ConceptMap(concepts,
+        return new ConceptMap(
+                concepts,
                 new Explainables(explainables.explainableRelations, explainables.explainableAttributes, unmodifiableMap(explainableAttributeOwnershipsClone))
         );
     }

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -35,14 +35,14 @@ def graknlabs_graql():
     git_repository(
         name = "graknlabs_graql",
         remote = "https://github.com/graknlabs/graql",
-        commit = "754b56a8a850d209785b9eb663a4331b9a8a16d6", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
+        commit = "be64cd9d253b56526715b3dd0435716d26a34f87", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_graql
     )
 
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "db450964d23303ab73a04c781db0dd0ef53fa869", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "1343b1d48086bfa25b6b8374e1de3e4ac648ebe5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "38d442fdb2f1a5f2f9707c3ee5625fe09efc3a97", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        commit = "71b277adb6b2ad249da4d1f5e2ae9079b0d70a48", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/flyingsilverfin/protocol",
+        commit = "a28df3375981d7f096bbd9cb7df6d1605b7a1a8f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "db450964d23303ab73a04c781db0dd0ef53fa869", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "d0bdb8772ba93df126a23f9e10f690e586bb2e87", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/flyingsilverfin/protocol",
-        commit = "a28df3375981d7f096bbd9cb7df6d1605b7a1a8f", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "1343b1d48086bfa25b6b8374e1de3e4ac648ebe5", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/reasoner/BUILD
+++ b/reasoner/BUILD
@@ -23,6 +23,7 @@ package(default_visibility = [
     "//query:__subpackages__",
     "//reasoner:__subpackages__",
     "//rocks:__pkg__",
+    "//server:__pkg__",
     "//test/integration/reasoner:__pkg__",
 ])
 

--- a/reasoner/ExplainablesManager.java
+++ b/reasoner/ExplainablesManager.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static grakn.core.concept.answer.ConceptMap.Explainables.Explainable.NOT_IDENTIFIED;
+import static grakn.core.concept.answer.ConceptMap.Explainable.NOT_IDENTIFIED;
 
 public class ExplainablesManager {
 

--- a/reasoner/ExplainablesManager.java
+++ b/reasoner/ExplainablesManager.java
@@ -39,7 +39,7 @@ public class ExplainablesManager {
     }
 
     public void setAndRecordExplainables(ConceptMap explainableMap) {
-        explainableMap.explainables().explainables().forEachRemaining(explainable -> {
+        explainableMap.explainables().iterator().forEachRemaining(explainable -> {
             long nextId = this.nextId.getAndIncrement();
             explainable.setId(nextId);
             conjunctions.put(nextId, explainable.conjunction());

--- a/reasoner/resolution/answer/AnswerStateImpl.java
+++ b/reasoner/resolution/answer/AnswerStateImpl.java
@@ -76,7 +76,7 @@ public abstract class AnswerStateImpl implements AnswerState {
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>(extension.concepts());
         // add the initial concept map second, to make sure we override and retain all of these
         concepts.putAll(conceptMap().concepts());
-        return new ConceptMap(concepts, conceptMap().explainables().merge(extension.explainables(), concepts));
+        return new ConceptMap(concepts, conceptMap().explainables().merge(extension.explainables()));
     }
 
     public static abstract class TopImpl extends AnswerStateImpl implements Top {

--- a/reasoner/resolution/answer/AnswerStateImpl.java
+++ b/reasoner/resolution/answer/AnswerStateImpl.java
@@ -76,7 +76,7 @@ public abstract class AnswerStateImpl implements AnswerState {
         Map<Identifier.Variable.Retrievable, Concept> concepts = new HashMap<>(extension.concepts());
         // add the initial concept map second, to make sure we override and retain all of these
         concepts.putAll(conceptMap().concepts());
-        return new ConceptMap(concepts, conceptMap().explainables().merge(extension.explainables()));
+        return new ConceptMap(concepts, conceptMap().explainables().merge(extension.explainables(), concepts));
     }
 
     public static abstract class TopImpl extends AnswerStateImpl implements Top {

--- a/reasoner/resolution/answer/Mapping.java
+++ b/reasoner/resolution/answer/Mapping.java
@@ -50,7 +50,7 @@ public class Mapping {
                 transformed.put(mapped, concept);
             }
         }
-        return new ConceptMap(transformed); // we ignore explainables because they can't be mapped here
+        return new ConceptMap(transformed);
     }
 
     public ConceptMap unTransform(ConceptMap conceptMap) {

--- a/reasoner/resolution/answer/Mapping.java
+++ b/reasoner/resolution/answer/Mapping.java
@@ -50,7 +50,7 @@ public class Mapping {
                 transformed.put(mapped, concept);
             }
         }
-        return new ConceptMap(transformed, conceptMap.explainables());
+        return new ConceptMap(transformed); // we ignore explainables because they can't be mapped here
     }
 
     public ConceptMap unTransform(ConceptMap conceptMap) {

--- a/server/BUILD
+++ b/server/BUILD
@@ -77,6 +77,7 @@ native_java_libraries(
         "//logic:logic",
         "//query:query",
         "//rocks:rocks",
+        "//reasoner:reasoner",
         "//migrator:migrator",
     ],
     runtime_deps = [

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -763,10 +763,8 @@ public class ResponseBuilder {
             AnswerProto.ConceptMap.Builder conceptMapProto = AnswerProto.ConceptMap.newBuilder();
             // TODO: needs testing
             answer.concepts().forEach((id, concept) -> {
-                if (id.isName()) {
-                    ConceptProto.Concept conceptProto = ResponseBuilder.Concept.protoConcept(concept);
-                    conceptMapProto.putMap(id.asVariable().asName().reference().name(), conceptProto);
-                }
+                ConceptProto.Concept conceptProto = ResponseBuilder.Concept.protoConcept(concept);
+                conceptMapProto.putMap(id.name(), conceptProto);
             });
             conceptMapProto.setExplainables(explainables(answer.explainables()));
             return conceptMapProto.build();
@@ -775,15 +773,15 @@ public class ResponseBuilder {
         private static AnswerProto.Explainables explainables(ConceptMap.Explainables explainables) {
             AnswerProto.Explainables.Builder builder = AnswerProto.Explainables.newBuilder();
             explainables.relations().forEach(
-                    (var, explainable) -> builder.putExplainableRelations(var.toString(), explainable(explainable))
+                    (var, explainable) -> builder.putExplainableRelations(var.name(), explainable(explainable))
             );
             explainables.attributes().forEach(
-                    (var, explainable) -> builder.putExplainableAttributes(var.toString(), explainable(explainable))
+                    (var, explainable) -> builder.putExplainableAttributes(var.name(), explainable(explainable))
             );
             explainables.ownerships().forEach((ownership, explainable) -> {
                         AnswerProto.ExplainableOwnership.Builder ownershipBuilder = AnswerProto.ExplainableOwnership.newBuilder();
-                        ownershipBuilder.setOwner(ownership.first().toString());
-                        ownershipBuilder.setAttribute(ownership.second().toString());
+                        ownershipBuilder.setOwner(ownership.first().name());
+                        ownershipBuilder.setAttribute(ownership.second().name());
                         ownershipBuilder.setExplainable(explainable(explainable));
                         builder.addExplainableOwnerships(ownershipBuilder.build());
                     }

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -782,7 +782,7 @@ public class ResponseBuilder {
             );
             Map<String, Map<String, ConceptMap.Explainable>> ownedExtracted = new HashMap<>();
             explainables.ownerships().forEach((ownership, explainable) -> {
-                Map<String, ConceptMap.Explainable> owned = ownedExtracted.computeIfAbsent(ownership.first().name(), new HashMap<>());
+                Map<String, ConceptMap.Explainable> owned = ownedExtracted.computeIfAbsent(ownership.first().name(), (val) -> new HashMap<String, ConceptMap.Explainable>());
                 owned.put(ownership.second().name(), explainable);
             });
             ownedExtracted.forEach((owner, owned) -> {

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -774,13 +774,13 @@ public class ResponseBuilder {
 
         private static AnswerProto.Explainables explainables(ConceptMap.Explainables explainables) {
             AnswerProto.Explainables.Builder builder = AnswerProto.Explainables.newBuilder();
-            explainables.explainableRelations().forEach(
+            explainables.relations().forEach(
                     (var, explainable) -> builder.putExplainableRelations(var.toString(), explainable(explainable))
             );
-            explainables.explainableAttributes().forEach(
-                    (var, explainable) -> builder.putExplainableRelations(var.toString(), explainable(explainable))
+            explainables.attributes().forEach(
+                    (var, explainable) -> builder.putExplainableAttributes(var.toString(), explainable(explainable))
             );
-            explainables.explainableOwnerships().forEach((ownership, explainable) -> {
+            explainables.ownerships().forEach((ownership, explainable) -> {
                         AnswerProto.ExplainableOwnership.Builder ownershipBuilder = AnswerProto.ExplainableOwnership.newBuilder();
                         ownershipBuilder.setOwner(ownership.first().toString());
                         ownershipBuilder.setAttribute(ownership.second().toString());

--- a/server/logic/RuleService.java
+++ b/server/logic/RuleService.java
@@ -28,8 +28,8 @@ import javax.annotation.Nullable;
 
 import static grakn.core.common.exception.ErrorMessage.Server.MISSING_CONCEPT;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
-import static grakn.core.server.common.ResponseBuilder.Rule.deleteRes;
-import static grakn.core.server.common.ResponseBuilder.Rule.setLabelRes;
+import static grakn.core.server.common.ResponseBuilder.Logic.Rule.deleteRes;
+import static grakn.core.server.common.ResponseBuilder.Logic.Rule.setLabelRes;
 
 public class RuleService {
 

--- a/server/query/QueryService.java
+++ b/server/query/QueryService.java
@@ -99,6 +99,7 @@ public class QueryService {
                     return;
                 case EXPLAIN_REQ:
                     this.explain(queryReq.getExplainReq().getExplainableId(), req);
+                    return;
                 case REQ_NOT_SET:
                 default:
                     throw GraknException.of(UNKNOWN_REQUEST_TYPE);

--- a/test/integration/reasoner/ExplanationTest.java
+++ b/test/integration/reasoner/ExplanationTest.java
@@ -392,10 +392,10 @@ public class ExplanationTest {
 
                 Map<Pair<ConceptMap, ConceptMap.Explainable>, List<Explanation>> allExplanations = new HashMap<>();
                 for (ConceptMap explainableMap : explainableMaps) {
-                    List<ConceptMap.Explainable> explainables = explainableMap.explainables().explainables().toList();
+                    List<ConceptMap.Explainable> explainables = explainableMap.explainables().iterator().toList();
                     assertEquals(1, explainables.size());
-                    List<Explanation> explanations = txn.query().explain(explainables.iterator().next().id()).toList();
-                    allExplanations.put(new Pair<>(explainableMap, explainables.iterator().next()), explanations);
+                    List<Explanation> explanations = txn.query().explain(explainables.get(0).id()).toList();
+                    allExplanations.put(new Pair<>(explainableMap, explainables.get(0)), explanations);
                 }
 
                 int oneExplanation = 0;
@@ -480,7 +480,7 @@ public class ExplanationTest {
                 assertEquals(3, explanation.conclusionAnswer().concepts().size());
 
                 ConceptMap marriageIsFriendshipAnswer = explanation.conditionAnswer();
-                assertEquals(1, marriageIsFriendshipAnswer.explainables().explainables().count());
+                assertEquals(1, marriageIsFriendshipAnswer.explainables().iterator().count());
                 assertSingleExplainableExplanations(marriageIsFriendshipAnswer, 1, 1, 1, txn);
             }
         }
@@ -488,7 +488,7 @@ public class ExplanationTest {
 
     private List<Explanation> assertSingleExplainableExplanations(ConceptMap ans, int anonymousConcepts, int explainablesCount,
                                                                   int explanationsCount, RocksTransaction txn) {
-        List<ConceptMap.Explainable> explainables = ans.explainables().explainables().toList();
+        List<ConceptMap.Explainable> explainables = ans.explainables().iterator().toList();
         assertEquals(anonymousConcepts, iterate(ans.concepts().keySet()).filter(Identifier::isAnonymous).count());
         assertEquals(explainablesCount, explainables.size());
         ConceptMap.Explainable explainable = explainables.iterator().next();

--- a/test/integration/reasoner/ExplanationTest.java
+++ b/test/integration/reasoner/ExplanationTest.java
@@ -50,7 +50,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static grakn.core.common.iterator.Iterators.iterate;
-import static grakn.core.concept.answer.ConceptMap.Explainables.Explainable.NOT_IDENTIFIED;
+import static grakn.core.concept.answer.ConceptMap.Explainable.NOT_IDENTIFIED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -390,9 +390,9 @@ public class ExplanationTest {
                 List<ConceptMap> explainableMaps = iterate(ans).filter(answer -> !answer.explainables().isEmpty()).toList();
                 assertEquals(6, explainableMaps.size());
 
-                Map<Pair<ConceptMap, ConceptMap.Explainables.Explainable>, List<Explanation>> allExplanations = new HashMap<>();
+                Map<Pair<ConceptMap, ConceptMap.Explainable>, List<Explanation>> allExplanations = new HashMap<>();
                 for (ConceptMap explainableMap : explainableMaps) {
-                    List<ConceptMap.Explainables.Explainable> explainables = explainableMap.explainables().explainables().toList();
+                    List<ConceptMap.Explainable> explainables = explainableMap.explainables().explainables().toList();
                     assertEquals(1, explainables.size());
                     List<Explanation> explanations = txn.query().explain(explainables.iterator().next().id()).toList();
                     allExplanations.put(new Pair<>(explainableMap, explainables.iterator().next()), explanations);
@@ -401,7 +401,7 @@ public class ExplanationTest {
                 int oneExplanation = 0;
                 int twoExplanations = 0;
                 int threeExplanations = 0;
-                for (Map.Entry<Pair<ConceptMap, ConceptMap.Explainables.Explainable>, List<Explanation>> entry : allExplanations.entrySet()) {
+                for (Map.Entry<Pair<ConceptMap, ConceptMap.Explainable>, List<Explanation>> entry : allExplanations.entrySet()) {
                     List<Explanation> explanations = entry.getValue();
                     if (explanations.size() == 1) oneExplanation++;
                     else if (explanations.size() == 2) twoExplanations++;
@@ -488,10 +488,10 @@ public class ExplanationTest {
 
     private List<Explanation> assertSingleExplainableExplanations(ConceptMap ans, int anonymousConcepts, int explainablesCount,
                                                                   int explanationsCount, RocksTransaction txn) {
-        List<ConceptMap.Explainables.Explainable> explainables = ans.explainables().explainables().toList();
+        List<ConceptMap.Explainable> explainables = ans.explainables().explainables().toList();
         assertEquals(anonymousConcepts, iterate(ans.concepts().keySet()).filter(Identifier::isAnonymous).count());
         assertEquals(explainablesCount, explainables.size());
-        ConceptMap.Explainables.Explainable explainable = explainables.iterator().next();
+        ConceptMap.Explainable explainable = explainables.iterator().next();
         assertNotEquals(NOT_IDENTIFIED, explainable.id());
         List<Explanation> explanations = txn.query().explain(explainable.id()).toList();
         assertEquals(explanationsCount, explanations.size());

--- a/test/integration/reasoner/resolution/ResolutionTest.java
+++ b/test/integration/reasoner/resolution/ResolutionTest.java
@@ -494,7 +494,7 @@ public class ResolutionTest {
             Match.Finished answer = responses.poll(1000, TimeUnit.MILLISECONDS);// polling prevents the test hanging
             if (answer != null) {
                 answersFound += 1;
-                if (answer.conceptMap().explainables().explainables().count() > 0) {
+                if (answer.conceptMap().explainables().iterator().count() > 0) {
                     explainableAnswersFound++;
                 }
             }

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -19,7 +19,6 @@
 package grakn.core.traversal.common;
 
 import grakn.core.common.exception.GraknException;
-import graql.lang.common.GraqlToken;
 import graql.lang.pattern.variable.Reference;
 
 import javax.annotation.Nullable;
@@ -246,7 +245,7 @@ public abstract class Identifier {
             }
 
             public String name() {
-                return "_" + id; //TODO this shouldn't be hardcoded here...?
+                return reference().name() + id;
             }
 
             @Override

--- a/traversal/common/Identifier.java
+++ b/traversal/common/Identifier.java
@@ -19,6 +19,7 @@
 package grakn.core.traversal.common;
 
 import grakn.core.common.exception.GraknException;
+import graql.lang.common.GraqlToken;
 import graql.lang.pattern.variable.Reference;
 
 import javax.annotation.Nullable;
@@ -111,8 +112,8 @@ public abstract class Identifier {
     public abstract static class Variable extends Identifier {
 
         final Reference reference;
-        private final Integer id;
         private final int hash;
+        protected final Integer id;
 
         private Variable(Reference reference, @Nullable Integer id) {
             this.reference = reference;
@@ -196,11 +197,13 @@ public abstract class Identifier {
             return hash;
         }
 
-        public static class Retrievable extends Variable {
+        public static abstract class Retrievable extends Variable {
 
             public Retrievable(Reference reference, Integer id) {
                 super(reference, id);
             }
+
+            public abstract String name();
 
             @Override
             public boolean isRetrievable() {
@@ -220,6 +223,11 @@ public abstract class Identifier {
             }
 
             @Override
+            public String name() {
+                return reference.asName().name();
+            }
+
+            @Override
             public Reference.Name reference() {
                 return reference.asName();
             }
@@ -235,6 +243,10 @@ public abstract class Identifier {
 
             private Anonymous(Reference.Anonymous reference, int id) {
                 super(reference, id);
+            }
+
+            public String name() {
+                return "_" + id; //TODO this shouldn't be hardcoded here...?
             }
 
             @Override


### PR DESCRIPTION
## What is the goal of this PR?
To make Explanations and the explain() functionality available to our clients, we implement the protocol extended in https://github.com/graknlabs/protocol/pull/131, which creates new RPC endpoints for `QueryManager.explain()` and extended serialisation of `ConceptMap`.

## What are the changes implemented in this PR?
* Add RPC endpoint for `QueryManager.explain()`
* Extend `ConceptMap` serialisation to serialise `explainableRelations`, `explainableAttributes`, and `explainableOwnerships`