### PR TITLE
Disable reasoner/inference by default

### DIFF
--- a/common/parameters/Options.java
+++ b/common/parameters/Options.java
@@ -32,7 +32,7 @@ public abstract class Options<PARENT extends Options<?, ?>, SELF extends Options
     public static final int DEFAULT_RESPONSE_BATCH_SIZE = 50;
     public static final int DEFAULT_SESSION_IDLE_TIMEOUT_MILLIS = 10_000;
     public static final int DEFAULT_SCHEMA_LOCK_ACQUIRE_TIMEOUT_MILLIS = 10_000;
-    public static final boolean DEFAULT_INFER = true;
+    public static final boolean DEFAULT_INFER = false;
     public static final boolean DEFAULT_TRACE_INFERENCE = false;
     public static final boolean DEFAULT_EXPLAIN = false;
     public static final boolean DEFAULT_PARALLEL = true;

--- a/test/behaviour/connection/transaction/TransactionSteps.java
+++ b/test/behaviour/connection/transaction/TransactionSteps.java
@@ -60,7 +60,7 @@ public class TransactionSteps {
         for (Grakn.Session session : sessions) {
             List<Grakn.Transaction> transactions = new ArrayList<>();
             for (Arguments.Transaction.Type type : types) {
-                Grakn.Transaction transaction = session.transaction(type, (new Options.Transaction()));
+                Grakn.Transaction transaction = session.transaction(type, (new Options.Transaction()).infer(true));
                 transactions.add(transaction);
             }
             sessionsToTransactions.put(session, transactions);

--- a/test/integration/reasoner/ExplanationTest.java
+++ b/test/integration/reasoner/ExplanationTest.java
@@ -66,11 +66,11 @@ public class ExplanationTest {
     private static RocksGrakn grakn;
 
     private RocksTransaction singleThreadElgTransaction(RocksSession session, Arguments.Transaction.Type transactionType) {
-        return singleThreadElgTransaction(session, transactionType, new Options.Transaction());
+        return singleThreadElgTransaction(session, transactionType, new Options.Transaction().infer(true));
     }
 
     private RocksTransaction singleThreadElgTransaction(RocksSession session, Arguments.Transaction.Type transactionType, Options.Transaction options) {
-        RocksTransaction transaction = session.transaction(transactionType, options);
+        RocksTransaction transaction = session.transaction(transactionType, options.infer(true));
         ActorExecutorGroup service = new ActorExecutorGroup(1, new NamedThreadFactory("grakn-core-actor"));
         transaction.reasoner().resolverRegistry().setExecutorService(service);
         return transaction;

--- a/test/integration/reasoner/resolution/ReiterationTest.java
+++ b/test/integration/reasoner/resolution/ReiterationTest.java
@@ -20,6 +20,7 @@ package grakn.core.reasoner.resolution;
 import grakn.common.concurrent.NamedThreadFactory;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Arguments;
+import grakn.core.common.parameters.Options;
 import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concurrent.actor.Actor;
 import grakn.core.concurrent.actor.ActorExecutorGroup;
@@ -191,7 +192,7 @@ public class ReiterationTest {
     }
 
     private RocksTransaction singleThreadElgTransaction(RocksSession session) {
-        RocksTransaction transaction = session.transaction(Arguments.Transaction.Type.WRITE);
+        RocksTransaction transaction = session.transaction(Arguments.Transaction.Type.WRITE, new Options.Transaction().infer(true));
         ActorExecutorGroup service = new ActorExecutorGroup(1, new NamedThreadFactory("grakn-core-actor"));
         transaction.reasoner().resolverRegistry().setExecutorService(service);
         return transaction;


### PR DESCRIPTION
## What is the goal of this PR?
Until we're completely satisfied with reasoner's performance, including in edge cases, we will disable reasoning by default. It can be disable as a Transaction-level option, `infer`.

## What are the changes implemented in this PR?
* Disable reasoning by default