### PR TITLE
Add test for cloned labeled variables throwing assertion

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,5 +56,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "f5277aaf442894f15d8185c577d3c8dec04fd6ad", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "35b8a1e4cf808c277457fb385cf0947a24c218b0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/logic/resolvable/RetrievableTest.java
+++ b/logic/resolvable/RetrievableTest.java
@@ -97,6 +97,17 @@ public class RetrievableTest {
     }
 
     @Test
+    public void test_shared_role_between_concludable_and_retrievable() {
+        Set<Concludable> concludables = Concludable.create(parse(
+                "{ $e(employee: $p, employer:$c) isa employment; $p isa person; $c isa company; }"));
+        Set<Retrievable> retrievables = Retrievable.extractFrom(parse(
+                "{ $e(employee: $p, employer:$c) isa employment; $r (employee: $p) isa employment; $p isa non-inferred-role-player; }"), concludables);
+        assertEquals(3, concludables.size());
+        assertEquals(set(parse("{ $r (employee: $p) isa employment; $p isa non-inferred-role-player; }")),
+                     retrievables.stream().map(Retrievable::pattern).collect(Collectors.toSet()));
+    }
+
+    @Test
     public void test_relation_is_in_retrievable() {
         Set<Concludable> concludables = Concludable.create(parse("{ $p isa person, has name $n; $n \"Alice\"; }"));
         Set<Retrievable> retrievables = Retrievable.extractFrom(parse(


### PR DESCRIPTION
## What is the goal of this PR?
Add test that illustrates cloning error with shared roles, which was patched in https://github.com/graknlabs/grakn/pull/6275 and the proper fixed is documented as a task in https://github.com/graknlabs/grakn/issues/6276

## What are the changes implemented in this PR?
* Add a test that throws during constraint cloning without the mitigation in #6275 