### PR TITLE
Fix failing test-assembly jobs

### DIFF
--- a/.circleci/windows/dependencies.config
+++ b/.circleci/windows/dependencies.config
@@ -19,7 +19,7 @@
 -->
 
 <packages>
-    <package id="bazel" version="3.0.0"/>
+    <package id="bazel" version="4.0.0"/>
     <package id="python" version="3.7.4"/>
     <package id="openjdk11" version="11.0.9.11"/>
 </packages>

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -21,7 +21,7 @@ def graknlabs_dependencies():
     git_repository(
         name = "graknlabs_dependencies",
         remote = "https://github.com/graknlabs/dependencies",
-        commit = "5aca0eb4e727278182656952477f2266af551621", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
+        commit = "f820ac42b10c1708bfcd6cd6a67aa3c44c3d6263", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_dependencies
     )
 
 def graknlabs_common():


### PR DESCRIPTION
## What is the goal of this PR?

Upgrade Bazel in Windows and macOS jobs to ensure they are built and tested.

## What are the changes implemented in this PR?

* Bump `@graknlabs_dependencies` version to include graknlabs/dependencies#276
* Bump Bazel version in Windows job