### PR TITLE
Transaction delete-update isolation checks are less aggressive

### DIFF
--- a/graph/DataGraph.java
+++ b/graph/DataGraph.java
@@ -29,6 +29,7 @@ import grakn.core.graph.common.KeyGenerator;
 import grakn.core.graph.common.StatisticsBytes;
 import grakn.core.graph.common.Storage;
 import grakn.core.graph.iid.EdgeIID;
+import grakn.core.graph.iid.IID;
 import grakn.core.graph.iid.PrefixIID;
 import grakn.core.graph.iid.VertexIID;
 import grakn.core.graph.vertex.AttributeVertex;
@@ -88,11 +89,13 @@ public class DataGraph implements Graph {
     private final ConcurrentMap<VertexIID.Type, ConcurrentSet<ThingVertex>> thingsByTypeIID;
     private final AttributesByIID attributesByIID;
     private final Statistics statistics;
+    private final boolean isReadOnly;
     private boolean isModified;
 
-    public DataGraph(Storage.Data storage, SchemaGraph schemaGraph) {
+    public DataGraph(Storage.Data storage, SchemaGraph schemaGraph, boolean isReadOnly) {
         this.storage = storage;
         this.schemaGraph = schemaGraph;
+        this.isReadOnly = isReadOnly;
         keyGenerator = new KeyGenerator.Data.Buffered();
         thingsByIID = new ConcurrentHashMap<>();
         thingsByTypeIID = new ConcurrentHashMap<>();
@@ -103,6 +106,11 @@ public class DataGraph implements Graph {
     @Override
     public Storage.Data storage() {
         return storage;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return isReadOnly;
     }
 
     public SchemaGraph schema() {
@@ -408,9 +416,10 @@ public class DataGraph implements Graph {
         } else delete(vertex.asAttribute());
     }
 
-    public void setModified() {
+    public void setModified(IID iid) {
         assert storage.isOpen();
         if (!isModified) isModified = true;
+        if (!isReadOnly) storage.setModified(iid.bytes());
     }
 
     public boolean isModified() {

--- a/graph/Graph.java
+++ b/graph/Graph.java
@@ -20,12 +20,15 @@
 package grakn.core.graph;
 
 import grakn.core.graph.common.Storage;
+import grakn.core.graph.iid.IID;
 
 public interface Graph {
 
     Storage storage();
 
-    void setModified();
+    boolean isReadOnly();
+
+    void setModified(IID iid);
 
     boolean isModified();
 

--- a/graph/SchemaGraph.java
+++ b/graph/SchemaGraph.java
@@ -25,6 +25,7 @@ import grakn.core.common.parameters.Label;
 import grakn.core.graph.common.Encoding;
 import grakn.core.graph.common.KeyGenerator;
 import grakn.core.graph.common.Storage;
+import grakn.core.graph.iid.IID;
 import grakn.core.graph.iid.IndexIID;
 import grakn.core.graph.iid.IndexIID.Type.Rule;
 import grakn.core.graph.iid.StructureIID;
@@ -129,16 +130,17 @@ public class SchemaGraph implements Graph {
         return storage;
     }
 
+    @Override
+    public boolean isReadOnly() {
+        return isReadOnly;
+    }
+
     public Rules rules() {
         return rules;
     }
 
     public SchemaGraph.Statistics stats() {
         return statistics;
-    }
-
-    public boolean isReadOnly() {
-        return isReadOnly;
     }
 
     public boolean isInitialised() throws GraknException {
@@ -345,8 +347,9 @@ public class SchemaGraph implements Graph {
         }
     }
 
-    public void setModified() {
+    public void setModified(IID iid) {
         if (!isModified) isModified = true;
+        if (!isReadOnly) storage.setModified(iid.bytes());
     }
 
     public boolean isModified() {

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -47,6 +47,8 @@ public interface Storage {
 
     void mergeUntracked(byte[] key, byte[] value);
 
+    void setModified(byte[] key);
+
     <G> FunctionalIterator<G> iterate(byte[] key, BiFunction<byte[], byte[], G> constructor);
 
     GraknException exception(ErrorMessage error);

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -33,6 +33,8 @@ public interface Storage {
 
     byte[] get(byte[] key);
 
+    byte[] getForUpdate(byte[] key);
+
     byte[] getLastKey(byte[] prefix);
 
     void delete(byte[] key);

--- a/graph/common/Storage.java
+++ b/graph/common/Storage.java
@@ -33,8 +33,6 @@ public interface Storage {
 
     byte[] get(byte[] key);
 
-    byte[] getForUpdate(byte[] key);
-
     byte[] getLastKey(byte[] prefix);
 
     void delete(byte[] key);

--- a/graph/structure/impl/RuleStructureImpl.java
+++ b/graph/structure/impl/RuleStructureImpl.java
@@ -94,7 +94,7 @@ public abstract class RuleStructureImpl implements RuleStructure {
     public void setModified() {
         if (!isModified) {
             isModified = true;
-            graph.setModified();
+            graph.setModified(iid);
         }
     }
 

--- a/graph/vertex/AttributeVertex.java
+++ b/graph/vertex/AttributeVertex.java
@@ -47,6 +47,8 @@ public interface AttributeVertex<VALUE> extends ThingVertex {
      */
     VALUE value();
 
+    boolean isPersisted();
+
     boolean isBoolean();
 
     boolean isLong();

--- a/graph/vertex/impl/AttributeVertexImpl.java
+++ b/graph/vertex/impl/AttributeVertexImpl.java
@@ -126,10 +126,12 @@ public abstract class AttributeVertexImpl<VALUE> extends ThingVertexImpl impleme
     }
 
     private void commitVertex() {
-        graph.storage().putUntracked(attributeIID.bytes());
-        graph.storage().putUntracked(EdgeIID.InwardsISA.of(type().iid(), iid).bytes());
-        graph.storage().putUntracked(index().bytes(), attributeIID.bytes());
-        // TODO: we should make use of attribute indexes to look up attributes by value (without type) quickly
+        if (graph.storage().getForUpdate(attributeIID.bytes()) == null) {
+            graph.storage().putUntracked(attributeIID.bytes());
+            graph.storage().putUntracked(EdgeIID.InwardsISA.of(type().iid(), iid).bytes());
+            graph.storage().putUntracked(index().bytes(), attributeIID.bytes());
+            // TODO: we should make use of attribute indexes to look up attributes by value (without type) quickly
+        }
     }
 
     @Override

--- a/graph/vertex/impl/ThingVertexImpl.java
+++ b/graph/vertex/impl/ThingVertexImpl.java
@@ -102,7 +102,7 @@ public abstract class ThingVertexImpl extends VertexImpl<VertexIID.Thing> implem
     public void setModified() {
         if (!isModified) {
             isModified = true;
-            graph.setModified();
+            graph.setModified(iid);
         }
     }
 

--- a/graph/vertex/impl/TypeVertexImpl.java
+++ b/graph/vertex/impl/TypeVertexImpl.java
@@ -97,7 +97,7 @@ public abstract class TypeVertexImpl extends VertexImpl<VertexIID.Type> implemen
     public void setModified() {
         if (!isModified) {
             isModified = true;
-            graph.setModified();
+            graph.setModified(iid);
         }
     }
 

--- a/rocks/RocksStorage.java
+++ b/rocks/RocksStorage.java
@@ -86,11 +86,6 @@ public abstract class RocksStorage implements Storage {
     }
 
     @Override
-    public byte[] getForUpdate(byte[] key) {
-        throw exception(ILLEGAL_OPERATION);
-    }
-
-    @Override
     public byte[] getLastKey(byte[] prefix) {
         throw exception(ILLEGAL_OPERATION);
     }
@@ -231,19 +226,6 @@ public abstract class RocksStorage implements Storage {
         }
 
         @Override
-        public byte[] getForUpdate(byte[] key) {
-            try {
-                deleteCloseSchemaWriteLock.readLock().lock();
-                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
-                return storageTransaction.getForUpdate(readOptions, key, false);
-            } catch (RocksDBException e) {
-                throw exception(e);
-            } finally {
-                deleteCloseSchemaWriteLock.readLock().unlock();
-            }
-        }
-
-        @Override
         public byte[] getLastKey(byte[] prefix) {
             assert isOpen();
             byte[] upperBound = Arrays.copyOf(prefix, prefix.length);
@@ -283,7 +265,15 @@ public abstract class RocksStorage implements Storage {
 
         @Override
         public void setModified(byte[] key) {
-            getForUpdate(key);
+            try {
+                deleteCloseSchemaWriteLock.readLock().lock();
+                if (!isOpen()) throw GraknException.of(RESOURCE_CLOSED);
+                storageTransaction.getForUpdate(readOptions, key, false);
+            } catch (RocksDBException e) {
+                throw exception(e);
+            } finally {
+                deleteCloseSchemaWriteLock.readLock().unlock();
+            }
         }
 
         @Override

--- a/rocks/RocksTransaction.java
+++ b/rocks/RocksTransaction.java
@@ -153,7 +153,7 @@ public abstract class RocksTransaction implements Grakn.Transaction {
             SchemaGraph schemaGraph = new SchemaGraph(schemaStorage, type().isRead());
 
             dataStorage = storageFactory.storageData(session.database(), this);
-            DataGraph dataGraph = new DataGraph(dataStorage, schemaGraph);
+            DataGraph dataGraph = new DataGraph(dataStorage, schemaGraph, type.isRead());
 
             graphMgr = new GraphManager(schemaGraph, dataGraph);
             initialise(graphMgr, new TraversalCache(), new LogicCache());
@@ -252,7 +252,7 @@ public abstract class RocksTransaction implements Grakn.Transaction {
 
             cache = session.database().cacheBorrow();
             dataStorage = storageFactory.storageData(session.database(), this);
-            DataGraph dataGraph = new DataGraph(dataStorage, cache.schemaGraph());
+            DataGraph dataGraph = new DataGraph(dataStorage, cache.schemaGraph(), type.isRead());
             graphMgr = new GraphManager(cache.schemaGraph(), dataGraph);
 
             initialise(graphMgr, cache.traversal(), cache.logic());

--- a/test/integration/BasicTest.java
+++ b/test/integration/BasicTest.java
@@ -826,4 +826,69 @@ public class BasicTest {
             tx.query().match(Graql.parseQuery("match $x sub thing;").asMatch());
         }
     }
+
+    @Test
+    public void test_write_and_update_isolation_guarantees() throws IOException {
+        Util.resetDirectory(dataDir);
+        reset_directory_and_create_attribute_types();
+
+        try (Grakn grakn = RocksGrakn.open(options)) {
+            try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.SCHEMA)) {
+                try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+                    txn.query().define(Graql.parseQuery("define person sub entity, owns name; name sub attribute, value string;"));
+                    txn.commit();
+                }
+            }
+            try (Grakn.Session session = grakn.session(database, Arguments.Session.Type.DATA)) {
+                try (Grakn.Transaction txn = session.transaction(Arguments.Transaction.Type.WRITE)) {
+                    txn.query().insert(Graql.parseQuery("insert $x isa person, has name \"Alice\";"));
+                    txn.query().insert(Graql.parseQuery("insert $x isa person, has name \"Bob\";"));
+                    txn.commit();
+                }
+
+                /* we expect to be able to concurrently insert and attribute and append an edge to the attribute safely */
+
+                Grakn.Transaction txn1 = session.transaction(Arguments.Transaction.Type.WRITE);
+                Grakn.Transaction txn2 = session.transaction(Arguments.Transaction.Type.WRITE);
+
+                txn1.query().insert(Graql.parseQuery("match $alice \"Alice\" isa name; insert $x isa person, has $alice;"));
+                txn2.query().insert(Graql.parseQuery("insert $x isa person, has name \"Alice\";"));
+
+                txn1.commit();
+                txn2.commit();
+
+                /* we expect that concurrently deleting and inserting an attribute throws */
+                boolean threw = false;
+                try {
+                    txn1 = session.transaction(Arguments.Transaction.Type.WRITE);
+                    txn2 = session.transaction(Arguments.Transaction.Type.WRITE);
+
+                    txn1.query().insert(Graql.parseQuery("match $alice \"Alice\" isa name; delete $alice;"));
+                    txn2.query().insert(Graql.parseQuery("insert $x isa person, has name \"Alice\";"));
+
+                    txn1.commit();
+                    txn2.commit();
+                } catch (Exception e) {
+                    threw = true;
+                }
+                assertTrue(threw);
+
+                /* we expect that deleting and appending an edge to an attribute throws */
+                threw = false;
+                try {
+                    txn1 = session.transaction(Arguments.Transaction.Type.WRITE);
+                    txn2 = session.transaction(Arguments.Transaction.Type.WRITE);
+
+                    txn1.query().insert(Graql.parseQuery("match $alice \"Alice\" isa name; delete $a;"));
+                    txn2.query().insert(Graql.parseQuery("match $alice \"Alice\" isa name; insert $x isa person, has $a;"));
+
+                    txn1.commit();
+                    txn2.commit();
+                } catch (Exception e) {
+                    threw = true;
+                }
+                assertTrue(threw);
+            }
+        }
+    }
 }

--- a/test/integration/BasicTest.java
+++ b/test/integration/BasicTest.java
@@ -846,10 +846,19 @@ public class BasicTest {
                     txn.commit();
                 }
 
-                /* we expect to be able to concurrently insert and attribute and append an edge to the attribute safely */
-
+                /* we expect to be able to concurrent insert the same attribute */
                 Grakn.Transaction txn1 = session.transaction(Arguments.Transaction.Type.WRITE);
                 Grakn.Transaction txn2 = session.transaction(Arguments.Transaction.Type.WRITE);
+
+                txn1.query().insert(Graql.parseQuery("insert $x isa person, has name \"Catherine\";"));
+                txn2.query().insert(Graql.parseQuery("insert $x isa person, has name \"Catherine\";"));
+
+                txn1.commit();
+                txn2.commit();
+                /* we expect to be able to concurrently insert and attribute and append an edge to the attribute safely */
+
+                txn1 = session.transaction(Arguments.Transaction.Type.WRITE);
+                txn2 = session.transaction(Arguments.Transaction.Type.WRITE);
 
                 txn1.query().insert(Graql.parseQuery("match $alice \"Alice\" isa name; insert $x isa person, has $alice;"));
                 txn2.query().insert(Graql.parseQuery("insert $x isa person, has name \"Alice\";"));


### PR DESCRIPTION
## What is the goal of this PR?

We extend the solution in `2c08a45de117bedde3d3a0ec3f4b6798326c6134` to prevent concurrent writes to the same attribute from throwing a BUSY exception from RocksDB, even when the attribute previously existed, massively improving the UX of concurrent insertions.

## What are the changes implemented in this PR?
* **we now protect attribute insertions using `putUntracked` with a `get`** --  to maintain isolation guarantees, if the attribute does exist, we perform a `getForUpdate` to make rocksDB track the attribute and throw conflicts if deleted. 
* When committing or setting `Attribute` vertices as modified, we only have rocksDB track the vertex if the attribute is persisted.