### PR TITLE
In gRPC, encode Request IDs as bytes, and move 'inferred' to Thing

### DIFF
--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -42,7 +42,7 @@ def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
         remote = "https://github.com/alexjpwalker/protocol",
-        commit = "d8ec1776bbd799e1e969138c458d670785d05c69", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        commit = "39122114004684f270d78fa7da0e500f4c575e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/graknlabs/protocol",
-        tag = "2.0.0", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/alexjpwalker/protocol",
+        commit = "d8ec1776bbd799e1e969138c458d670785d05c69", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -41,8 +41,8 @@ def graknlabs_graql():
 def graknlabs_protocol():
     git_repository(
         name = "graknlabs_protocol",
-        remote = "https://github.com/alexjpwalker/protocol",
-        commit = "39122114004684f270d78fa7da0e500f4c575e10", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
+        remote = "https://github.com/graknlabs/protocol",
+        commit = "8f5d97641c34486652dfc26c1d1f28ab0e677e9b", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_protocol
     )
 
 def graknlabs_grabl_tracing():

--- a/server/SessionService.java
+++ b/server/SessionService.java
@@ -17,7 +17,6 @@
 
 package grakn.core.server;
 
-import com.google.protobuf.ByteString;
 import grakn.common.collection.ConcurrentSet;
 import grakn.core.Grakn;
 import grakn.core.common.exception.GraknException;
@@ -31,8 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.StampedLock;
 
-import static com.google.protobuf.ByteString.copyFrom;
-import static grakn.core.common.collection.Bytes.uuidToBytes;
 import static grakn.core.common.exception.ErrorMessage.Session.SESSION_CLOSED;
 import static grakn.core.concurrent.executor.Executors.scheduled;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -89,10 +86,6 @@ public class SessionService implements AutoCloseable {
 
     public Options.Session options() {
         return options;
-    }
-
-    public ByteString UUIDAsByteString() {
-        return copyFrom(uuidToBytes(session.uuid()));
     }
 
     private void setIdleTimeout() {

--- a/server/common/RequestReader.java
+++ b/server/common/RequestReader.java
@@ -17,6 +17,7 @@
 
 package grakn.core.server.common;
 
+import com.google.protobuf.ByteString;
 import grabl.tracing.client.GrablTracingThreadStatic;
 import grakn.core.common.exception.GraknException;
 import grakn.core.common.parameters.Options;
@@ -27,7 +28,9 @@ import grakn.protocol.TransactionProto;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
+import static grakn.core.common.collection.Bytes.bytesToUUID;
 import static grakn.core.common.exception.ErrorMessage.Server.BAD_VALUE_TYPE;
 import static grakn.protocol.OptionsProto.Options.BatchSizeOptCase.BATCH_SIZE;
 import static grakn.protocol.OptionsProto.Options.ExplainOptCase.EXPLAIN;
@@ -39,6 +42,10 @@ import static grakn.protocol.OptionsProto.Options.SessionIdleTimeoutOptCase.SESS
 import static grakn.protocol.OptionsProto.Options.TraceInferenceOptCase.TRACE_INFERENCE;
 
 public class RequestReader {
+
+    public static UUID byteStringAsUUID(ByteString byteString) {
+        return bytesToUUID(byteString.toByteArray());
+    }
 
     public static <T extends Options<?, ?>> T applyDefaultOptions(T options, OptionsProto.Options request) {
         if (request.getInferOptCase().equals(INFER)) {

--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -320,7 +320,8 @@ public class ResponseBuilder {
         public static ConceptProto.Thing protoThing(grakn.core.concept.thing.Thing thing) {
             ConceptProto.Thing.Builder protoThing = ConceptProto.Thing.newBuilder()
                     .setIid(ByteString.copyFrom(thing.getIID()))
-                    .setType(protoType(thing.getType()));
+                    .setType(protoType(thing.getType()))
+                    .setInferred(thing.isInferred());
             if (thing.isAttribute()) protoThing.setValue(attributeValue(thing.asAttribute()));
             return protoThing.build();
         }
@@ -625,12 +626,6 @@ public class ResponseBuilder {
         public static TransactionProto.Transaction.Res getTypeRes(UUID reqID, ThingType thingType) {
             return thingRes(reqID, ConceptProto.Thing.Res.newBuilder().setThingGetTypeRes(
                     ConceptProto.Thing.GetType.Res.newBuilder().setThingType(protoType(thingType))
-            ));
-        }
-
-        public static TransactionProto.Transaction.Res isInferredRes(UUID reqID, boolean isInferred) {
-            return thingRes(reqID, ConceptProto.Thing.Res.newBuilder().setThingIsInferredRes(
-                    ConceptProto.Thing.IsInferred.Res.newBuilder().setInferred(isInferred)
             ));
         }
 

--- a/server/concept/ConceptService.java
+++ b/server/concept/ConceptService.java
@@ -27,8 +27,11 @@ import grakn.core.server.common.ResponseBuilder;
 import grakn.protocol.ConceptProto;
 import grakn.protocol.TransactionProto.Transaction;
 
+import java.util.UUID;
+
 import static grakn.core.common.exception.ErrorMessage.Server.BAD_VALUE_TYPE;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
+import static grakn.core.server.common.RequestReader.byteStringAsUUID;
 import static grakn.core.server.common.ResponseBuilder.ConceptManager.getThingRes;
 import static grakn.core.server.common.ResponseBuilder.ConceptManager.putAttributeTypeRes;
 import static grakn.core.server.common.ResponseBuilder.ConceptManager.putEntityTypeRes;
@@ -46,21 +49,22 @@ public class ConceptService {
 
     public void execute(Transaction.Req req) {
         ConceptProto.ConceptManager.Req conceptMgrReq = req.getConceptManagerReq();
+        UUID reqID = byteStringAsUUID(req.getReqId());
         switch (conceptMgrReq.getReqCase()) {
             case GET_THING_TYPE_REQ:
-                getThingType(conceptMgrReq.getGetThingTypeReq().getLabel(), req);
+                getThingType(conceptMgrReq.getGetThingTypeReq().getLabel(), reqID);
                 return;
             case GET_THING_REQ:
-                getThing(conceptMgrReq.getGetThingReq().getIid().toByteArray(), req);
+                getThing(conceptMgrReq.getGetThingReq().getIid().toByteArray(), reqID);
                 return;
             case PUT_ENTITY_TYPE_REQ:
-                putEntityType(conceptMgrReq.getPutEntityTypeReq().getLabel(), req);
+                putEntityType(conceptMgrReq.getPutEntityTypeReq().getLabel(), reqID);
                 return;
             case PUT_ATTRIBUTE_TYPE_REQ:
-                putAttributeType(conceptMgrReq.getPutAttributeTypeReq(), req);
+                putAttributeType(conceptMgrReq.getPutAttributeTypeReq(), reqID);
                 return;
             case PUT_RELATION_TYPE_REQ:
-                putRelationType(conceptMgrReq.getPutRelationTypeReq().getLabel(), req);
+                putRelationType(conceptMgrReq.getPutRelationTypeReq().getLabel(), reqID);
                 return;
             default:
             case REQ_NOT_SET:
@@ -68,20 +72,20 @@ public class ConceptService {
         }
     }
 
-    private void getThingType(String label, Transaction.Req req) {
-        transactionSvc.respond(ResponseBuilder.ConceptManager.getThingTypeRes(req.getReqId(), conceptMgr.getThingType(label)));
+    private void getThingType(String label, UUID reqID) {
+        transactionSvc.respond(ResponseBuilder.ConceptManager.getThingTypeRes(reqID, conceptMgr.getThingType(label)));
     }
 
-    private void getThing(byte[] iid, Transaction.Req req) {
-        transactionSvc.respond(getThingRes(req.getReqId(), conceptMgr.getThing(iid)));
+    private void getThing(byte[] iid, UUID reqID) {
+        transactionSvc.respond(getThingRes(reqID, conceptMgr.getThing(iid)));
     }
 
-    private void putEntityType(String label, Transaction.Req req) {
+    private void putEntityType(String label, UUID reqID) {
         EntityType entityType = conceptMgr.putEntityType(label);
-        transactionSvc.respond(putEntityTypeRes(req.getReqId(), entityType));
+        transactionSvc.respond(putEntityTypeRes(reqID, entityType));
     }
 
-    private void putAttributeType(ConceptProto.ConceptManager.PutAttributeType.Req attributeTypeReq, Transaction.Req req) {
+    private void putAttributeType(ConceptProto.ConceptManager.PutAttributeType.Req attributeTypeReq, UUID reqID) {
         ConceptProto.AttributeType.ValueType valueTypeProto = attributeTypeReq.getValueType();
         AttributeType.ValueType valueType;
         switch (valueTypeProto) {
@@ -106,12 +110,11 @@ public class ConceptService {
                 throw GraknException.of(BAD_VALUE_TYPE, valueTypeProto);
         }
         AttributeType attributeType = conceptMgr.putAttributeType(attributeTypeReq.getLabel(), valueType);
-        transactionSvc.respond(putAttributeTypeRes(req.getReqId(), attributeType));
+        transactionSvc.respond(putAttributeTypeRes(reqID, attributeType));
     }
 
-    private void putRelationType(String label, Transaction.Req req) {
+    private void putRelationType(String label, UUID reqID) {
         RelationType relationType = conceptMgr.putRelationType(label);
-        String reqID = req.getReqId();
         transactionSvc.respond(putRelationTypeRes(reqID, relationType));
     }
 

--- a/server/concept/ThingService.java
+++ b/server/concept/ThingService.java
@@ -53,7 +53,6 @@ import static grakn.core.server.common.ResponseBuilder.Thing.getHasResPart;
 import static grakn.core.server.common.ResponseBuilder.Thing.getPlayingResPart;
 import static grakn.core.server.common.ResponseBuilder.Thing.getRelationsResPart;
 import static grakn.core.server.common.ResponseBuilder.Thing.getTypeRes;
-import static grakn.core.server.common.ResponseBuilder.Thing.isInferredRes;
 import static grakn.core.server.common.ResponseBuilder.Thing.setHasRes;
 import static grakn.core.server.common.ResponseBuilder.Thing.unsetHasRes;
 
@@ -78,9 +77,6 @@ public class ThingService {
                 return;
             case THING_GET_TYPE_REQ:
                 getType(thing, reqID);
-                return;
-            case THING_IS_INFERRED_REQ:
-                isInferred(thing, reqID);
                 return;
             case THING_SET_HAS_REQ:
                 setHas(thing, thingReq.getThingSetHasReq().getAttribute(), reqID);
@@ -143,10 +139,6 @@ public class ThingService {
     private void delete(Thing thing, UUID reqID) {
         thing.delete();
         transactionSvc.respond(deleteRes(reqID));
-    }
-
-    private void isInferred(Thing thing, UUID reqID) {
-        transactionSvc.respond(isInferredRes(reqID, thing.isInferred()));
     }
 
     private void getType(Thing thing, UUID reqID) {

--- a/server/concept/ThingService.java
+++ b/server/concept/ThingService.java
@@ -35,11 +35,13 @@ import grakn.protocol.TransactionProto.Transaction;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static grakn.common.collection.Collections.pair;
 import static grakn.core.common.exception.ErrorMessage.Server.MISSING_CONCEPT;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
+import static grakn.core.server.common.RequestReader.byteStringAsUUID;
 import static grakn.core.server.common.ResponseBuilder.Thing.Attribute.getOwnersResPart;
 import static grakn.core.server.common.ResponseBuilder.Thing.Relation.addPlayerRes;
 import static grakn.core.server.common.ResponseBuilder.Thing.Relation.getPlayersByRoleTypeResPart;
@@ -69,48 +71,49 @@ public class ThingService {
         ConceptProto.Thing.Req thingReq = req.getThingReq();
         assert thingReq != null;
         Thing thing = notNull(conceptMgr.getThing(thingReq.getIid().toByteArray()));
+        UUID reqID = byteStringAsUUID(req.getReqId());
         switch (thingReq.getReqCase()) {
             case THING_DELETE_REQ:
-                delete(thing, req);
+                delete(thing, reqID);
                 return;
             case THING_GET_TYPE_REQ:
-                getType(thing, req);
+                getType(thing, reqID);
                 return;
             case THING_IS_INFERRED_REQ:
-                isInferred(thing, req);
+                isInferred(thing, reqID);
                 return;
             case THING_SET_HAS_REQ:
-                setHas(thing, thingReq.getThingSetHasReq().getAttribute(), req);
+                setHas(thing, thingReq.getThingSetHasReq().getAttribute(), reqID);
                 return;
             case THING_UNSET_HAS_REQ:
-                unsetHas(thing, thingReq.getThingUnsetHasReq().getAttribute(), req);
+                unsetHas(thing, thingReq.getThingUnsetHasReq().getAttribute(), reqID);
                 return;
             case THING_GET_HAS_REQ:
-                getHas(thing, thingReq.getThingGetHasReq(), req);
+                getHas(thing, thingReq.getThingGetHasReq(), reqID);
                 return;
             case THING_GET_RELATIONS_REQ:
-                getRelations(thing, thingReq.getThingGetRelationsReq().getRoleTypesList(), req);
+                getRelations(thing, thingReq.getThingGetRelationsReq().getRoleTypesList(), reqID);
                 return;
             case THING_GET_PLAYING_REQ:
-                getPlaying(thing, req);
+                getPlaying(thing, reqID);
                 return;
             case RELATION_ADD_PLAYER_REQ:
-                addPlayer(thing.asRelation(), thingReq.getRelationAddPlayerReq(), req);
+                addPlayer(thing.asRelation(), thingReq.getRelationAddPlayerReq(), reqID);
                 return;
             case RELATION_REMOVE_PLAYER_REQ:
-                removePlayer(thing.asRelation(), thingReq.getRelationRemovePlayerReq(), req);
+                removePlayer(thing.asRelation(), thingReq.getRelationRemovePlayerReq(), reqID);
                 return;
             case RELATION_GET_PLAYERS_REQ:
-                getPlayers(thing.asRelation(), thingReq.getRelationGetPlayersReq().getRoleTypesList(), req);
+                getPlayers(thing.asRelation(), thingReq.getRelationGetPlayersReq().getRoleTypesList(), reqID);
                 return;
             case RELATION_GET_PLAYERS_BY_ROLE_TYPE_REQ:
-                getPlayersByRoleType(thing.asRelation(), req);
+                getPlayersByRoleType(thing.asRelation(), reqID);
                 return;
             case RELATION_GET_RELATING_REQ:
-                getRelating(thing.asRelation(), req);
+                getRelating(thing.asRelation(), reqID);
                 break;
             case ATTRIBUTE_GET_OWNERS_REQ:
-                getOwners(thing.asAttribute(), thingReq.getAttributeGetOwnersReq(), req);
+                getOwners(thing.asAttribute(), thingReq.getAttributeGetOwnersReq(), reqID);
                 return;
             case REQ_NOT_SET:
             default:
@@ -137,58 +140,57 @@ public class ThingService {
         else return null;
     }
 
-    private void delete(Thing thing, Transaction.Req req) {
+    private void delete(Thing thing, UUID reqID) {
         thing.delete();
-        transactionSvc.respond(deleteRes(req.getReqId()));
+        transactionSvc.respond(deleteRes(reqID));
     }
 
-    private void isInferred(Thing thing, Transaction.Req req) {
-        String reqID = req.getReqId();
+    private void isInferred(Thing thing, UUID reqID) {
         transactionSvc.respond(isInferredRes(reqID, thing.isInferred()));
     }
 
-    private void getType(Thing thing, Transaction.Req req) {
-        transactionSvc.respond(getTypeRes(req.getReqId(), thing.getType()));
+    private void getType(Thing thing, UUID reqID) {
+        transactionSvc.respond(getTypeRes(reqID, thing.getType()));
     }
 
-    private void getHas(Thing thing, ConceptProto.Thing.GetHas.Req getHasRequest, Transaction.Req req) {
+    private void getHas(Thing thing, ConceptProto.Thing.GetHas.Req getHasRequest, UUID reqID) {
         List<ConceptProto.Type> types = getHasRequest.getAttributeTypesList();
         Stream<? extends Attribute> attributes = types.isEmpty()
                 ? thing.getHas(getHasRequest.getKeysOnly())
                 : thing.getHas(types.stream().map(t -> notNull(getThingType(t)).asAttributeType()).toArray(AttributeType[]::new));
-        transactionSvc.stream(attributes.iterator(), req.getReqId(), atts -> getHasResPart(req.getReqId(), atts));
+        transactionSvc.stream(attributes.iterator(), reqID, atts -> getHasResPart(reqID, atts));
     }
 
-    private void getRelations(Thing thing, List<ConceptProto.Type> protoRoleTypes, Transaction.Req req) {
+    private void getRelations(Thing thing, List<ConceptProto.Type> protoRoleTypes, UUID reqID) {
         RoleType[] roleTypes = protoRoleTypes.stream().map(type -> notNull(getRoleType(type))).toArray(RoleType[]::new);
         Stream<? extends Relation> concepts = thing.getRelations(roleTypes);
-        transactionSvc.stream(concepts.iterator(), req.getReqId(), rels -> getRelationsResPart(req.getReqId(), rels));
+        transactionSvc.stream(concepts.iterator(), reqID, rels -> getRelationsResPart(reqID, rels));
     }
 
-    private void getPlaying(Thing thing, Transaction.Req req) {
+    private void getPlaying(Thing thing, UUID reqID) {
         Stream<? extends RoleType> roleTypes = thing.getPlaying();
-        transactionSvc.stream(roleTypes.iterator(), req.getReqId(), rols -> getPlayingResPart(req.getReqId(), rols));
+        transactionSvc.stream(roleTypes.iterator(), reqID, rols -> getPlayingResPart(reqID, rols));
     }
 
-    private void setHas(Thing thing, ConceptProto.Thing protoAttribute, Transaction.Req req) {
+    private void setHas(Thing thing, ConceptProto.Thing protoAttribute, UUID reqID) {
         Attribute attribute = getThing(protoAttribute).asAttribute();
         thing.setHas(attribute);
-        transactionSvc.respond(setHasRes(req.getReqId()));
+        transactionSvc.respond(setHasRes(reqID));
     }
 
-    private void unsetHas(Thing thing, ConceptProto.Thing protoAttribute, Transaction.Req req) {
+    private void unsetHas(Thing thing, ConceptProto.Thing protoAttribute, UUID reqID) {
         Attribute attribute = getThing(protoAttribute).asAttribute();
         thing.unsetHas(attribute);
-        transactionSvc.respond(unsetHasRes(req.getReqId()));
+        transactionSvc.respond(unsetHasRes(reqID));
     }
 
-    private void getPlayers(Relation relation, List<ConceptProto.Type> protoRoleTypes, Transaction.Req req) {
+    private void getPlayers(Relation relation, List<ConceptProto.Type> protoRoleTypes, UUID reqID) {
         RoleType[] roleTypes = protoRoleTypes.stream().map(type -> notNull(getRoleType(type))).toArray(RoleType[]::new);
         Stream<? extends Thing> players = relation.getPlayers(roleTypes);
-        transactionSvc.stream(players.iterator(), req.getReqId(), things -> getPlayersResPart(req.getReqId(), things));
+        transactionSvc.stream(players.iterator(), reqID, things -> getPlayersResPart(reqID, things));
     }
 
-    private void getPlayersByRoleType(Relation relation, Transaction.Req req) {
+    private void getPlayersByRoleType(Relation relation, UUID reqID) {
         // TODO: this should be optimised to actually iterate over role players by role type lazily
         Map<? extends RoleType, ? extends List<? extends Thing>> playersByRole = relation.getPlayersByRoleType();
         Stream.Builder<Pair<RoleType, Thing>> responses = Stream.builder();
@@ -197,26 +199,26 @@ public class ThingService {
                 responses.add(pair(players.getKey(), player));
             }
         }
-        transactionSvc.stream(responses.build().iterator(), req.getReqId(),
-                              players -> getPlayersByRoleTypeResPart(req.getReqId(), players));
+        transactionSvc.stream(responses.build().iterator(), reqID,
+                              players -> getPlayersByRoleTypeResPart(reqID, players));
     }
 
-    private void getRelating(Relation relation, Transaction.Req req) {
-        transactionSvc.stream(relation.getRelating().iterator(), req.getReqId(),
-                              roleTypes -> getRelatingResPart(req.getReqId(), roleTypes));
+    private void getRelating(Relation relation, UUID reqID) {
+        transactionSvc.stream(relation.getRelating().iterator(), reqID,
+                              roleTypes -> getRelatingResPart(reqID, roleTypes));
     }
 
-    private void addPlayer(Relation relation, ConceptProto.Relation.AddPlayer.Req addPlayerReq, Transaction.Req req) {
+    private void addPlayer(Relation relation, ConceptProto.Relation.AddPlayer.Req addPlayerReq, UUID reqID) {
         relation.addPlayer(getRoleType(addPlayerReq.getRoleType()), getThing(addPlayerReq.getPlayer()).asThing());
-        transactionSvc.respond(addPlayerRes(req.getReqId()));
+        transactionSvc.respond(addPlayerRes(reqID));
     }
 
-    private void removePlayer(Relation relation, ConceptProto.Relation.RemovePlayer.Req removePlayerReq, Transaction.Req req) {
+    private void removePlayer(Relation relation, ConceptProto.Relation.RemovePlayer.Req removePlayerReq, UUID reqID) {
         relation.removePlayer(getRoleType(removePlayerReq.getRoleType()), getThing(removePlayerReq.getPlayer()).asThing());
-        transactionSvc.respond(removePlayerRes(req.getReqId()));
+        transactionSvc.respond(removePlayerRes(reqID));
     }
 
-    private void getOwners(Attribute attribute, ConceptProto.Attribute.GetOwners.Req getOwnersReq, Transaction.Req req) {
+    private void getOwners(Attribute attribute, ConceptProto.Attribute.GetOwners.Req getOwnersReq, UUID reqID) {
         Stream<? extends Thing> things;
         switch (getOwnersReq.getFilterCase()) {
             case THING_TYPE:
@@ -227,7 +229,7 @@ public class ThingService {
                 things = attribute.getOwners();
         }
 
-        transactionSvc.stream(things.iterator(), req.getReqId(), owners -> getOwnersResPart(req.getReqId(), owners));
+        transactionSvc.stream(things.iterator(), reqID, owners -> getOwnersResPart(reqID, owners));
     }
 
 }

--- a/server/concept/TypeService.java
+++ b/server/concept/TypeService.java
@@ -32,6 +32,7 @@ import grakn.protocol.TransactionProto.Transaction;
 
 import javax.annotation.Nullable;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static grakn.common.util.Objects.className;
@@ -40,6 +41,7 @@ import static grakn.core.common.exception.ErrorMessage.Server.MISSING_CONCEPT;
 import static grakn.core.common.exception.ErrorMessage.Server.MISSING_FIELD;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
 import static grakn.core.common.exception.ErrorMessage.TypeWrite.ILLEGAL_SUPERTYPE_ENCODING;
+import static grakn.core.server.common.RequestReader.byteStringAsUUID;
 import static grakn.core.server.common.RequestReader.valueType;
 import static grakn.core.server.common.ResponseBuilder.Type.AttributeType.getOwnersResPart;
 import static grakn.core.server.common.ResponseBuilder.Type.AttributeType.getRegexRes;
@@ -85,101 +87,102 @@ public class TypeService {
         this.conceptMgr = conceptMgr;
     }
 
-    public void execute(Transaction.Req request) {
-        ConceptProto.Type.Req typeReq = request.getTypeReq();
+    public void execute(Transaction.Req req) {
+        ConceptProto.Type.Req typeReq = req.getTypeReq();
         String label = typeReq.getLabel();
         String scope = typeReq.getScope();
         Type type = scope != null && !scope.isEmpty() ?
                 notNull(conceptMgr.getRelationType(scope)).getRelates(label) :
                 notNull(conceptMgr.getThingType(label));
+        UUID reqID = byteStringAsUUID(req.getReqId());
         switch (typeReq.getReqCase()) {
             case TYPE_DELETE_REQ:
-                delete(type, request);
+                delete(type, reqID);
                 return;
             case TYPE_SET_LABEL_REQ:
-                setLabel(type, typeReq.getTypeSetLabelReq().getLabel(), request);
+                setLabel(type, typeReq.getTypeSetLabelReq().getLabel(), reqID);
                 return;
             case TYPE_IS_ABSTRACT_REQ:
-                isAbstract(type, request);
+                isAbstract(type, reqID);
                 return;
             case TYPE_GET_SUPERTYPE_REQ:
-                getSupertype(type, request);
+                getSupertype(type, reqID);
                 return;
             case TYPE_SET_SUPERTYPE_REQ:
-                setSupertype(type, typeReq.getTypeSetSupertypeReq().getType(), request);
+                setSupertype(type, typeReq.getTypeSetSupertypeReq().getType(), reqID);
                 return;
             case TYPE_GET_SUPERTYPES_REQ:
-                getSupertypes(type, request);
+                getSupertypes(type, reqID);
                 return;
             case TYPE_GET_SUBTYPES_REQ:
-                getSubtypes(type, request);
+                getSubtypes(type, reqID);
                 return;
             case ROLE_TYPE_GET_RELATION_TYPES_REQ:
-                getRelationTypes(type.asRoleType(), request);
+                getRelationTypes(type.asRoleType(), reqID);
                 return;
             case ROLE_TYPE_GET_PLAYERS_REQ:
-                getPlayers(type.asRoleType(), request);
+                getPlayers(type.asRoleType(), reqID);
                 return;
             case THING_TYPE_SET_ABSTRACT_REQ:
-                setAbstract(type.asThingType(), request);
+                setAbstract(type.asThingType(), reqID);
                 return;
             case THING_TYPE_UNSET_ABSTRACT_REQ:
-                unsetAbstract(type.asThingType(), request);
+                unsetAbstract(type.asThingType(), reqID);
                 return;
             case THING_TYPE_SET_OWNS_REQ:
-                setOwns(type.asThingType(), typeReq.getThingTypeSetOwnsReq(), request);
+                setOwns(type.asThingType(), typeReq.getThingTypeSetOwnsReq(), reqID);
                 return;
             case THING_TYPE_SET_PLAYS_REQ:
-                setPlays(type.asThingType(), typeReq.getThingTypeSetPlaysReq(), request);
+                setPlays(type.asThingType(), typeReq.getThingTypeSetPlaysReq(), reqID);
                 return;
             case THING_TYPE_UNSET_OWNS_REQ:
-                unsetOwns(type.asThingType(), typeReq.getThingTypeUnsetOwnsReq().getAttributeType(), request);
+                unsetOwns(type.asThingType(), typeReq.getThingTypeUnsetOwnsReq().getAttributeType(), reqID);
                 return;
             case THING_TYPE_UNSET_PLAYS_REQ:
-                unsetPlays(type.asThingType(), typeReq.getThingTypeUnsetPlaysReq().getRole(), request);
+                unsetPlays(type.asThingType(), typeReq.getThingTypeUnsetPlaysReq().getRole(), reqID);
                 return;
             case THING_TYPE_GET_INSTANCES_REQ:
-                getInstances(type.asThingType(), request);
+                getInstances(type.asThingType(), reqID);
                 return;
             case THING_TYPE_GET_OWNS_REQ:
-                getOwns(type.asThingType(), typeReq, request);
+                getOwns(type.asThingType(), typeReq, reqID);
                 return;
             case THING_TYPE_GET_PLAYS_REQ:
-                getPlays(type.asThingType(), request);
+                getPlays(type.asThingType(), reqID);
                 return;
             case ENTITY_TYPE_CREATE_REQ:
-                create(type.asEntityType(), request);
+                create(type.asEntityType(), reqID);
                 return;
             case RELATION_TYPE_CREATE_REQ:
-                create(type.asRelationType(), request);
+                create(type.asRelationType(), reqID);
                 return;
             case RELATION_TYPE_GET_RELATES_FOR_ROLE_LABEL_REQ:
                 String roleLabel = typeReq.getRelationTypeGetRelatesForRoleLabelReq().getLabel();
-                getRelatesForRoleLabel(type.asRelationType(), roleLabel, request);
+                getRelatesForRoleLabel(type.asRelationType(), roleLabel, reqID);
                 return;
             case RELATION_TYPE_SET_RELATES_REQ:
-                setRelates(type.asRelationType(), typeReq.getRelationTypeSetRelatesReq(), request);
+                setRelates(type.asRelationType(), typeReq.getRelationTypeSetRelatesReq(), reqID);
                 return;
             case RELATION_TYPE_UNSET_RELATES_REQ:
-                unsetRelates(type.asRelationType(), typeReq.getRelationTypeUnsetRelatesReq(), request);
+                unsetRelates(type.asRelationType(), typeReq.getRelationTypeUnsetRelatesReq(), reqID);
                 return;
             case RELATION_TYPE_GET_RELATES_REQ:
-                getRelates(type.asRelationType(), request);
+                getRelates(type.asRelationType(), reqID);
                 return;
             case ATTRIBUTE_TYPE_PUT_REQ:
-                put(type.asAttributeType(), typeReq.getAttributeTypePutReq().getValue(), request);
+                put(type.asAttributeType(), typeReq.getAttributeTypePutReq().getValue(), reqID);
                 return;
             case ATTRIBUTE_TYPE_GET_REQ:
-                get(type.asAttributeType(), typeReq.getAttributeTypeGetReq().getValue(), request);
+                get(type.asAttributeType(), typeReq.getAttributeTypeGetReq().getValue(), reqID);
                 return;
             case ATTRIBUTE_TYPE_GET_REGEX_REQ:
-                getRegex(type.asAttributeType(), request);
+                getRegex(type.asAttributeType(), reqID);
                 return;
             case ATTRIBUTE_TYPE_SET_REGEX_REQ:
-                setRegex(type.asAttributeType(), typeReq.getAttributeTypeSetRegexReq().getRegex(), request);
+                setRegex(type.asAttributeType(), typeReq.getAttributeTypeSetRegexReq().getRegex(), reqID);
                 return;
             case ATTRIBUTE_TYPE_GET_OWNERS_REQ:
-                getOwners(type.asAttributeType(), typeReq.getAttributeTypeGetOwnersReq().getOnlyKey(), request);
+                getOwners(type.asAttributeType(), typeReq.getAttributeTypeGetOwnersReq().getOnlyKey(), reqID);
                 return;
             case REQ_NOT_SET:
             default:
@@ -202,30 +205,30 @@ public class TypeService {
         else return null;
     }
 
-    private void setLabel(Type type, String label, Transaction.Req request) {
+    private void setLabel(Type type, String label, UUID reqID) {
         type.setLabel(label);
-        transactionSvc.respond(setLabelRes(request.getReqId()));
+        transactionSvc.respond(setLabelRes(reqID));
     }
 
-    private void isAbstract(Type type, Transaction.Req request) {
-        transactionSvc.respond(isAbstractRes(request.getReqId(), type.isAbstract()));
+    private void isAbstract(Type type, UUID reqID) {
+        transactionSvc.respond(isAbstractRes(reqID, type.isAbstract()));
     }
 
-    private void setAbstract(ThingType thingType, Transaction.Req req) {
+    private void setAbstract(ThingType thingType, UUID reqID) {
         thingType.setAbstract();
-        transactionSvc.respond(setAbstractRes(req.getReqId()));
+        transactionSvc.respond(setAbstractRes(reqID));
     }
 
-    private void unsetAbstract(ThingType thingType, Transaction.Req req) {
+    private void unsetAbstract(ThingType thingType, UUID reqID) {
         thingType.unsetAbstract();
-        transactionSvc.respond(unsetAbstractRes(req.getReqId()));
+        transactionSvc.respond(unsetAbstractRes(reqID));
     }
 
-    private void getSupertype(Type type, Transaction.Req request) {
-        transactionSvc.respond(getSupertypeRes(request.getReqId(), type.getSupertype()));
+    private void getSupertype(Type type, UUID reqID) {
+        transactionSvc.respond(getSupertypeRes(reqID, type.getSupertype()));
     }
 
-    private void setSupertype(Type type, ConceptProto.Type supertype, Transaction.Req req) {
+    private void setSupertype(Type type, ConceptProto.Type supertype, UUID reqID) {
         Type sup = getThingType(supertype);
 
         if (type.isEntityType()) {
@@ -238,51 +241,51 @@ public class TypeService {
             throw GraknException.of(ILLEGAL_SUPERTYPE_ENCODING, className(type.getClass()));
         }
 
-        transactionSvc.respond(setSupertypeRes(req.getReqId()));
+        transactionSvc.respond(setSupertypeRes(reqID));
     }
 
-    private void getSupertypes(Type type, Transaction.Req req) {
-        transactionSvc.stream(type.getSupertypes().iterator(), req.getReqId(),
-                              types -> getSupertypesResPart(req.getReqId(), types));
+    private void getSupertypes(Type type, UUID reqID) {
+        transactionSvc.stream(type.getSupertypes().iterator(), reqID,
+                              types -> getSupertypesResPart(reqID, types));
     }
 
-    private void getSubtypes(Type type, Transaction.Req req) {
-        transactionSvc.stream(type.getSubtypes().iterator(), req.getReqId(),
-                              types -> getSubtypesResPart(req.getReqId(), types));
+    private void getSubtypes(Type type, UUID reqID) {
+        transactionSvc.stream(type.getSubtypes().iterator(), reqID,
+                              types -> getSubtypesResPart(reqID, types));
     }
 
-    private void getInstances(ThingType thingType, Transaction.Req req) {
-        transactionSvc.stream(thingType.getInstances().iterator(), req.getReqId(),
-                              things -> getInstancesResPart(req.getReqId(), things));
+    private void getInstances(ThingType thingType, UUID reqID) {
+        transactionSvc.stream(thingType.getInstances().iterator(), reqID,
+                              things -> getInstancesResPart(reqID, things));
     }
 
-    private void getOwns(ThingType thingType, ConceptProto.Type.Req typeReq, Transaction.Req req) {
+    private void getOwns(ThingType thingType, ConceptProto.Type.Req typeReq, UUID reqID) {
         if (typeReq.getThingTypeGetOwnsReq().getFilterCase() == VALUE_TYPE) {
             getOwns(thingType, valueType(typeReq.getThingTypeGetOwnsReq().getValueType()),
-                    typeReq.getThingTypeGetOwnsReq().getKeysOnly(), req);
+                    typeReq.getThingTypeGetOwnsReq().getKeysOnly(), reqID);
         } else {
-            getOwns(thingType, typeReq.getThingTypeGetOwnsReq().getKeysOnly(), req);
+            getOwns(thingType, typeReq.getThingTypeGetOwnsReq().getKeysOnly(), reqID);
         }
     }
 
-    private void getOwns(ThingType thingType, boolean keysOnly, Transaction.Req req) {
-        transactionSvc.stream(thingType.getOwns(keysOnly).iterator(), req.getReqId(),
-                              attributeTypes -> getOwnsResPart(req.getReqId(), attributeTypes));
+    private void getOwns(ThingType thingType, boolean keysOnly, UUID reqID) {
+        transactionSvc.stream(thingType.getOwns(keysOnly).iterator(), reqID,
+                              attributeTypes -> getOwnsResPart(reqID, attributeTypes));
     }
 
     private void getOwns(ThingType thingType, AttributeType.ValueType valueType,
-                         boolean keysOnly, Transaction.Req req) {
-        transactionSvc.stream(thingType.getOwns(valueType, keysOnly).iterator(), req.getReqId(),
-                              attributeTypes -> getOwnsResPart(req.getReqId(), attributeTypes));
+                         boolean keysOnly, UUID reqID) {
+        transactionSvc.stream(thingType.getOwns(valueType, keysOnly).iterator(), reqID,
+                              attributeTypes -> getOwnsResPart(reqID, attributeTypes));
     }
 
-    private void getPlays(ThingType thingType, Transaction.Req req) {
-        transactionSvc.stream(thingType.getPlays().iterator(), req.getReqId(),
-                              roleTypes -> getPlaysResPart(req.getReqId(), roleTypes));
+    private void getPlays(ThingType thingType, UUID reqID) {
+        transactionSvc.stream(thingType.getPlays().iterator(), reqID,
+                              roleTypes -> getPlaysResPart(reqID, roleTypes));
     }
 
     private void setOwns(ThingType thingType, ConceptProto.ThingType.SetOwns.Req setOwnsRequest,
-                         Transaction.Req req) {
+                         UUID reqID) {
         AttributeType attributeType = getThingType(setOwnsRequest.getAttributeType()).asAttributeType();
         boolean isKey = setOwnsRequest.getIsKey();
 
@@ -292,11 +295,11 @@ public class TypeService {
         } else {
             thingType.setOwns(attributeType, isKey);
         }
-        transactionSvc.respond(setOwnsRes(req.getReqId()));
+        transactionSvc.respond(setOwnsRes(reqID));
     }
 
     private void setPlays(ThingType thingType, ConceptProto.ThingType.SetPlays.Req setPlaysRequest,
-                          Transaction.Req req) {
+                          UUID reqID) {
         RoleType role = getRoleType(setPlaysRequest.getRole());
         if (setPlaysRequest.hasOverriddenRole()) {
             RoleType overriddenRole = getRoleType(setPlaysRequest.getOverriddenRole());
@@ -304,25 +307,25 @@ public class TypeService {
         } else {
             thingType.setPlays(role);
         }
-        transactionSvc.respond(setPlaysRes(req.getReqId()));
+        transactionSvc.respond(setPlaysRes(reqID));
     }
 
-    private void unsetOwns(ThingType thingType, ConceptProto.Type protoAttributeType, Transaction.Req req) {
+    private void unsetOwns(ThingType thingType, ConceptProto.Type protoAttributeType, UUID reqID) {
         thingType.unsetOwns(getThingType(protoAttributeType).asAttributeType());
-        transactionSvc.respond(unsetOwnsRes(req.getReqId()));
+        transactionSvc.respond(unsetOwnsRes(reqID));
     }
 
-    private void unsetPlays(ThingType thingType, ConceptProto.Type protoRoleType, Transaction.Req req) {
+    private void unsetPlays(ThingType thingType, ConceptProto.Type protoRoleType, UUID reqID) {
         thingType.unsetPlays(notNull(getRoleType(protoRoleType)));
-        transactionSvc.respond(unsetPlaysRes(req.getReqId()));
+        transactionSvc.respond(unsetPlaysRes(reqID));
     }
 
-    private void getOwners(AttributeType attributeType, boolean onlyKey, Transaction.Req req) {
-        transactionSvc.stream(attributeType.getOwners(onlyKey).iterator(), req.getReqId(),
-                              owners -> getOwnersResPart(req.getReqId(), owners));
+    private void getOwners(AttributeType attributeType, boolean onlyKey, UUID reqID) {
+        transactionSvc.stream(attributeType.getOwners(onlyKey).iterator(), reqID,
+                              owners -> getOwnersResPart(reqID, owners));
     }
 
-    private void put(AttributeType attributeType, ConceptProto.Attribute.Value protoValue, Transaction.Req req) {
+    private void put(AttributeType attributeType, ConceptProto.Attribute.Value protoValue, UUID reqID) {
         Attribute attribute;
         switch (protoValue.getValueCase()) {
             case STRING:
@@ -347,10 +350,10 @@ public class TypeService {
                 throw GraknException.of(BAD_VALUE_TYPE, protoValue.getValueCase());
         }
 
-        transactionSvc.respond(putRes(req.getReqId(), attribute));
+        transactionSvc.respond(putRes(reqID, attribute));
     }
 
-    private void get(AttributeType attributeType, ConceptProto.Attribute.Value protoValue, Transaction.Req req) {
+    private void get(AttributeType attributeType, ConceptProto.Attribute.Value protoValue, UUID reqID) {
         Attribute attribute;
         switch (protoValue.getValueCase()) {
             case STRING:
@@ -375,65 +378,65 @@ public class TypeService {
                 throw GraknException.of(BAD_VALUE_TYPE);
         }
 
-        transactionSvc.respond(getRes(req.getReqId(), attribute));
+        transactionSvc.respond(getRes(reqID, attribute));
     }
 
-    private void getRegex(AttributeType attributeType, Transaction.Req req) {
-        transactionSvc.respond(getRegexRes(req.getReqId(), attributeType.asString().getRegex()));
+    private void getRegex(AttributeType attributeType, UUID reqID) {
+        transactionSvc.respond(getRegexRes(reqID, attributeType.asString().getRegex()));
     }
 
-    private void setRegex(AttributeType attributeType, String regex, Transaction.Req req) {
+    private void setRegex(AttributeType attributeType, String regex, UUID reqID) {
         if (regex.isEmpty()) attributeType.asString().setRegex(null);
         else attributeType.asString().setRegex(Pattern.compile(regex));
-        transactionSvc.respond(setRegexRes(req.getReqId()));
+        transactionSvc.respond(setRegexRes(reqID));
     }
 
-    private void getRelates(RelationType relationType, Transaction.Req req) {
-        transactionSvc.stream(relationType.getRelates().iterator(), req.getReqId(),
-                              roleTypes -> getRelatesResPart(req.getReqId(), roleTypes));
+    private void getRelates(RelationType relationType, UUID reqID) {
+        transactionSvc.stream(relationType.getRelates().iterator(), reqID,
+                              roleTypes -> getRelatesResPart(reqID, roleTypes));
     }
 
-    private void getRelatesForRoleLabel(RelationType relationType, String roleLabel, Transaction.Req req) {
-        transactionSvc.respond(getRelatesForRoleLabelRes(req.getReqId(), relationType.getRelates(roleLabel)));
+    private void getRelatesForRoleLabel(RelationType relationType, String roleLabel, UUID reqID) {
+        transactionSvc.respond(getRelatesForRoleLabelRes(reqID, relationType.getRelates(roleLabel)));
     }
 
     private void setRelates(RelationType relationType, ConceptProto.RelationType.SetRelates.Req setRelatesReq,
-                            Transaction.Req req) {
+                            UUID reqID) {
         if (setRelatesReq.getOverriddenCase() == OVERRIDDEN_LABEL) {
             relationType.setRelates(setRelatesReq.getLabel(), setRelatesReq.getOverriddenLabel());
         } else {
             relationType.setRelates(setRelatesReq.getLabel());
         }
-        transactionSvc.respond(setRelatesRes(req.getReqId()));
+        transactionSvc.respond(setRelatesRes(reqID));
     }
 
     private void unsetRelates(RelationType relationType, ConceptProto.RelationType.UnsetRelates.Req unsetRelatesReq,
-                              Transaction.Req req) {
+                              UUID reqID) {
         relationType.unsetRelates(unsetRelatesReq.getLabel());
-        transactionSvc.respond(unsetRelatesRes(req.getReqId()));
+        transactionSvc.respond(unsetRelatesRes(reqID));
     }
 
-    private void getRelationTypes(RoleType roleType, Transaction.Req req) {
-        transactionSvc.stream(roleType.getRelationTypes().iterator(), req.getReqId(),
-                              relationTypes -> getRelationTypesResPart(req.getReqId(), relationTypes));
+    private void getRelationTypes(RoleType roleType, UUID reqID) {
+        transactionSvc.stream(roleType.getRelationTypes().iterator(), reqID,
+                              relationTypes -> getRelationTypesResPart(reqID, relationTypes));
     }
 
-    private void getPlayers(RoleType roleType, Transaction.Req req) {
-        transactionSvc.stream(roleType.getPlayers().iterator(), req.getReqId(),
-                              players -> getPlayersResPart(req.getReqId(), players));
+    private void getPlayers(RoleType roleType, UUID reqID) {
+        transactionSvc.stream(roleType.getPlayers().iterator(), reqID,
+                              players -> getPlayersResPart(reqID, players));
     }
 
-    private void create(EntityType entityType, Transaction.Req req) {
-        transactionSvc.respond(createRes(req.getReqId(), entityType.create()));
+    private void create(EntityType entityType, UUID reqID) {
+        transactionSvc.respond(createRes(reqID, entityType.create()));
     }
 
-    private void create(RelationType relationType, Transaction.Req req) {
-        transactionSvc.respond(createRes(req.getReqId(), relationType.create()));
+    private void create(RelationType relationType, UUID reqID) {
+        transactionSvc.respond(createRes(reqID, relationType.create()));
     }
 
-    private void delete(Type type, Transaction.Req request) {
+    private void delete(Type type, UUID reqID) {
         type.delete();
-        transactionSvc.respond(deleteRes(request.getReqId()));
+        transactionSvc.respond(deleteRes(reqID));
     }
 
 }

--- a/server/logic/RuleService.java
+++ b/server/logic/RuleService.java
@@ -26,8 +26,11 @@ import grakn.protocol.TransactionProto.Transaction;
 
 import javax.annotation.Nullable;
 
+import java.util.UUID;
+
 import static grakn.core.common.exception.ErrorMessage.Server.MISSING_CONCEPT;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
+import static grakn.core.server.common.RequestReader.byteStringAsUUID;
 import static grakn.core.server.common.ResponseBuilder.Logic.Rule.deleteRes;
 import static grakn.core.server.common.ResponseBuilder.Logic.Rule.setLabelRes;
 
@@ -41,15 +44,16 @@ public class RuleService {
         this.logicMgr = logicMgr;
     }
 
-    public void execute(Transaction.Req request) {
-        LogicProto.Rule.Req ruleReq = request.getRuleReq();
+    public void execute(Transaction.Req req) {
+        LogicProto.Rule.Req ruleReq = req.getRuleReq();
         Rule rule = notNull(logicMgr.getRule(ruleReq.getLabel()));
+        UUID reqID = byteStringAsUUID(req.getReqId());
         switch (ruleReq.getReqCase()) {
             case RULE_DELETE_REQ:
-                delete(rule, request);
+                delete(rule, reqID);
                 return;
             case RULE_SET_LABEL_REQ:
-                setLabel(rule, ruleReq.getRuleSetLabelReq().getLabel(), request);
+                setLabel(rule, ruleReq.getRuleSetLabelReq().getLabel(), reqID);
                 return;
             case REQ_NOT_SET:
             default:
@@ -57,14 +61,14 @@ public class RuleService {
         }
     }
 
-    private void setLabel(Rule rule, String label, Transaction.Req request) {
+    private void setLabel(Rule rule, String label, UUID reqID) {
         rule.setLabel(label);
-        transactionSvc.respond(setLabelRes(request.getReqId()));
+        transactionSvc.respond(setLabelRes(reqID));
     }
 
-    private void delete(Rule rule, Transaction.Req request) {
+    private void delete(Rule rule, UUID reqID) {
         rule.delete();
-        transactionSvc.respond(deleteRes(request.getReqId()));
+        transactionSvc.respond(deleteRes(reqID));
     }
 
     private static Rule notNull(@Nullable Rule rule) {

--- a/server/query/QueryService.java
+++ b/server/query/QueryService.java
@@ -38,10 +38,13 @@ import graql.lang.query.GraqlMatch;
 import graql.lang.query.GraqlUndefine;
 import graql.lang.query.GraqlUpdate;
 
+import java.util.UUID;
+
 import static grabl.tracing.client.GrablTracingThreadStatic.traceOnThread;
 import static grakn.core.common.exception.ErrorMessage.Server.UNKNOWN_REQUEST_TYPE;
 import static grakn.core.server.common.RequestReader.applyDefaultOptions;
 import static grakn.core.server.common.RequestReader.applyQueryOptions;
+import static grakn.core.server.common.RequestReader.byteStringAsUUID;
 import static grakn.core.server.common.ResponseBuilder.QueryManager.defineRes;
 import static grakn.core.server.common.ResponseBuilder.QueryManager.deleteRes;
 import static grakn.core.server.common.ResponseBuilder.QueryManager.explainResPart;
@@ -69,36 +72,37 @@ public class QueryService {
             Options.Query options = new Options.Query();
             applyDefaultOptions(options, queryReq.getOptions());
             applyQueryOptions(options, queryReq.getOptions());
+            UUID reqID = byteStringAsUUID(req.getReqId());
             switch (queryReq.getReqCase()) {
                 case DEFINE_REQ:
-                    this.define(queryReq.getDefineReq().getQuery(), options, req);
+                    this.define(queryReq.getDefineReq().getQuery(), options, reqID);
                     return;
                 case UNDEFINE_REQ:
-                    this.undefine(queryReq.getUndefineReq().getQuery(), options, req);
+                    this.undefine(queryReq.getUndefineReq().getQuery(), options, reqID);
                     return;
                 case MATCH_REQ:
-                    this.match(queryReq.getMatchReq().getQuery(), options, req);
+                    this.match(queryReq.getMatchReq().getQuery(), options, reqID);
                     return;
                 case MATCH_AGGREGATE_REQ:
-                    this.matchAggregate(queryReq.getMatchAggregateReq().getQuery(), options, req);
+                    this.matchAggregate(queryReq.getMatchAggregateReq().getQuery(), options, reqID);
                     return;
                 case MATCH_GROUP_REQ:
-                    this.matchGroup(queryReq.getMatchGroupReq().getQuery(), options, req);
+                    this.matchGroup(queryReq.getMatchGroupReq().getQuery(), options, reqID);
                     return;
                 case MATCH_GROUP_AGGREGATE_REQ:
-                    this.matchGroupAggregate(queryReq.getMatchGroupAggregateReq().getQuery(), options, req);
+                    this.matchGroupAggregate(queryReq.getMatchGroupAggregateReq().getQuery(), options, reqID);
                     return;
                 case INSERT_REQ:
-                    this.insert(queryReq.getInsertReq().getQuery(), options, req);
+                    this.insert(queryReq.getInsertReq().getQuery(), options, reqID);
                     return;
                 case DELETE_REQ:
-                    this.delete(queryReq.getDeleteReq().getQuery(), options, req);
+                    this.delete(queryReq.getDeleteReq().getQuery(), options, reqID);
                     return;
                 case UPDATE_REQ:
-                    this.update(queryReq.getUpdateReq().getQuery(), options, req);
+                    this.update(queryReq.getUpdateReq().getQuery(), options, reqID);
                     return;
                 case EXPLAIN_REQ:
-                    this.explain(queryReq.getExplainReq().getExplainableId(), req);
+                    this.explain(queryReq.getExplainReq().getExplainableId(), reqID);
                     return;
                 case REQ_NOT_SET:
                 default:
@@ -107,71 +111,71 @@ public class QueryService {
         }
     }
 
-    private void define(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void define(String queryStr, Options.Query options, UUID reqID) {
         GraqlDefine query = Graql.parseQuery(queryStr).asDefine();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         queryMgr.define(query, context);
-        transactionSvc.respond(defineRes(req.getReqId()));
+        transactionSvc.respond(defineRes(reqID));
     }
 
-    private void undefine(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void undefine(String queryStr, Options.Query options, UUID reqID) {
         GraqlUndefine query = Graql.parseQuery(queryStr).asUndefine();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         queryMgr.undefine(query, context);
-        transactionSvc.respond(undefineRes(req.getReqId()));
+        transactionSvc.respond(undefineRes(reqID));
     }
 
-    private void match(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void match(String queryStr, Options.Query options, UUID reqID) {
         GraqlMatch query = Graql.parseQuery(queryStr).asMatch();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         FunctionalIterator<ConceptMap> answers = queryMgr.match(query, context);
-        transactionSvc.stream(answers, req.getReqId(), context.options(), a -> matchResPart(req.getReqId(), a));
+        transactionSvc.stream(answers, reqID, context.options(), a -> matchResPart(reqID, a));
     }
 
-    private void matchAggregate(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void matchAggregate(String queryStr, Options.Query options, UUID reqID) {
         GraqlMatch.Aggregate query = Graql.parseQuery(queryStr).asMatchAggregate();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
-        transactionSvc.respond(matchAggregateRes(req.getReqId(), queryMgr.match(query, context)));
+        transactionSvc.respond(matchAggregateRes(reqID, queryMgr.match(query, context)));
     }
 
-    private void matchGroup(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void matchGroup(String queryStr, Options.Query options, UUID reqID) {
         GraqlMatch.Group query = Graql.parseQuery(queryStr).asMatchGroup();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         FunctionalIterator<ConceptMapGroup> answers = queryMgr.match(query, context);
-        transactionSvc.stream(answers, req.getReqId(), context.options(), a -> matchGroupResPart(req.getReqId(), a));
+        transactionSvc.stream(answers, reqID, context.options(), a -> matchGroupResPart(reqID, a));
     }
 
-    private void matchGroupAggregate(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void matchGroupAggregate(String queryStr, Options.Query options, UUID reqID) {
         GraqlMatch.Group.Aggregate query = Graql.parseQuery(queryStr).asMatchGroupAggregate();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         FunctionalIterator<NumericGroup> answers = queryMgr.match(query, context);
-        transactionSvc.stream(answers, req.getReqId(), context.options(), a -> matchGroupAggregateResPart(req.getReqId(), a));
+        transactionSvc.stream(answers, reqID, context.options(), a -> matchGroupAggregateResPart(reqID, a));
     }
 
-    private void insert(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void insert(String queryStr, Options.Query options, UUID reqID) {
         GraqlInsert query = Graql.parseQuery(queryStr).asInsert();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         FunctionalIterator<ConceptMap> answers = queryMgr.insert(query, context);
-        transactionSvc.stream(answers, req.getReqId(), context.options(), a -> insertResPart(req.getReqId(), a));
+        transactionSvc.stream(answers, reqID, context.options(), a -> insertResPart(reqID, a));
     }
 
-    private void delete(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void delete(String queryStr, Options.Query options, UUID reqID) {
         GraqlDelete query = Graql.parseQuery(queryStr).asDelete();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         queryMgr.delete(query, context);
-        transactionSvc.respond(deleteRes(req.getReqId()));
+        transactionSvc.respond(deleteRes(reqID));
     }
 
-    private void update(String queryStr, Options.Query options, TransactionProto.Transaction.Req req) {
+    private void update(String queryStr, Options.Query options, UUID reqID) {
         GraqlUpdate query = Graql.parseQuery(queryStr).asUpdate();
         Context.Query context = new Context.Query(transactionSvc.context(), options.query(query), query);
         FunctionalIterator<ConceptMap> answers = queryMgr.update(query, context);
-        transactionSvc.stream(answers, req.getReqId(), context.options(), a -> updateResPart(req.getReqId(), a));
+        transactionSvc.stream(answers, reqID, context.options(), a -> updateResPart(reqID, a));
     }
 
-    private void explain(long explainableId, TransactionProto.Transaction.Req req) {
+    private void explain(long explainableId, UUID reqID) {
         FunctionalIterator<Explanation> explanations = queryMgr.explain(explainableId);
-        transactionSvc.stream(explanations, req.getReqId(), a -> explainResPart(req.getReqId(), a));
+        transactionSvc.stream(explanations, reqID, a -> explainResPart(reqID, a));
     }
 
 }


### PR DESCRIPTION
## What is the goal of this PR?

Previously the ID of a transaction request was stored as a string, which is an inefficient representation of a UUID. We've changed it to bytes.

Also, we deleted `IsInferred` and added the `inferred` flag to `Thing`, allowing clients to check if a Thing is inferred without an additional network roundtrip.

## What are the changes implemented in this PR?

Store request IDs as bytes, not strings
Add `inferred` flag to `Thing` in protobuf
