### PR TITLE
Fix traversal backtracking when a relation edge iterator fails

### DIFF
--- a/traversal/iterator/GraphIterator.java
+++ b/traversal/iterator/GraphIterator.java
@@ -173,9 +173,8 @@ public class GraphIterator extends AbstractFunctionalIterator<VertexMap> {
         if (edge.onlyStartsFromRelation()) {
             assert edge.from().id().isVariable();
             seekStack.addSeeks(scopes.get(edge.from().id().asVariable()).edgeOrders());
-        } else {
-            seekStack.addSeeks(edge.from().dependedEdgeOrders());
         }
+        seekStack.addSeeks(edge.from().dependedEdgeOrders());
     }
 
     private void closureFailure(ProcedureEdge<?, ?> edge) {


### PR DESCRIPTION
## What is the goal of this PR?
When a branch fails in the traversal engine, we must backtrack. However, when we backtrack an edge that starts at a relation that fails to find a child, we include all of the role players that are scoped to the relation that we can seek back to, as an optimisation. However, we must also include the predecessors of the relation itself as possible backtrack candidates, otherwise we will miss other valid forward paths.

## What are the changes implemented in this PR?
* When backtracking an edge that starts at a relation, we include all the scoped roles AND the relation's predecessors as backtrack candidates in the `SeekStack`, which is what happens in the standard case when not backtracking through a relation