### PR TITLE
Retrievables connected only by type are separate retrievables

### DIFF
--- a/logic/BUILD
+++ b/logic/BUILD
@@ -88,6 +88,7 @@ host_compatible_java_test(
     test_class = "grakn.core.logic.resolvable.RetrievableTest",
     deps = [
         # Internal dependencies
+        "//common",
 
         # External dependencies from Grakn Labs
         "@graknlabs_common//:common",

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -141,8 +141,8 @@ public class Retrievable extends Resolvable<Conjunction> {
             }
 
             private void registerLabeled(Variable variable) {
-                variable.constraints().forEach(this::registerConstraint);
-                variable.constraining().forEach(this::registerConstraint);
+                assert variable.id().isLabel() && variable.asType().label().isPresent();
+                registeredConstraints.add(variable.asType().label().get());
             }
 
             private void registerConstraint(Constraint constraint) {

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -86,7 +86,9 @@ public class Retrievable extends Resolvable<Conjunction> {
         public Set<Retrievable> extract() {
             concludables.forEach(concludable ->
                                          iterate(concludable.concludableConstraints())
-                                                 .filter(constraint -> !(constraint.isType() && constraint.asType().isLabel() && constraint.asType().owner().id().isLabel())
+                                                 .filter(constraint ->
+                                                                 !(constraint.isType() && constraint.asType().isLabel()
+                                                                         && constraint.asType().owner().id().isLabel())
                                                  ).forEachRemaining(extractedConstraints::add)
             );
             iterate(conjunction.variables()).filter(var -> var.id().isRetrievable()).forEachRemaining(var -> {
@@ -96,7 +98,8 @@ public class Retrievable extends Resolvable<Conjunction> {
                     subgraphs.add(subgraph);
                     extractedVariables.addAll(subgraph.registeredVariables());
                     iterate(subgraph.registeredConstraints).filter(constraint ->
-                                                                           !(constraint.isType() && constraint.asType().isLabel() && constraint.asType().owner().id().isLabel())
+                                                                           !(constraint.isType() && constraint.asType().isLabel()
+                                                                                   && constraint.asType().owner().id().isLabel())
                     ).forEachRemaining(extractedConstraints::add);
                 }
             });
@@ -126,14 +129,20 @@ public class Retrievable extends Resolvable<Conjunction> {
             private void registerVariable(Variable variable) {
                 if (!registeredVariables.contains(variable)) {
                     registeredVariables.add(variable);
-                    if (!variable.id().isLabel()) {
-                        variable.constraints().forEach(this::registerConstraint);
-                        variable.constraining().forEach(this::registerConstraint);
-                    } else {
-                        assert variable.asType().label().isPresent();
-                        registeredConstraints.add(variable.asType().label().get());
-                    }
+                    if (variable.id().isRetrievable()) registerRetrievable(variable);
+                    else registerLabeled(variable);
                 }
+            }
+
+            private void registerRetrievable(Variable variable) {
+                assert variable.id().isRetrievable();
+                variable.constraints().forEach(this::registerConstraint);
+                variable.constraining().forEach(this::registerConstraint);
+            }
+
+            private void registerLabeled(Variable variable) {
+                variable.constraints().forEach(this::registerConstraint);
+                variable.constraining().forEach(this::registerConstraint);
             }
 
             private void registerConstraint(Constraint constraint) {

--- a/logic/resolvable/Retrievable.java
+++ b/logic/resolvable/Retrievable.java
@@ -126,8 +126,13 @@ public class Retrievable extends Resolvable<Conjunction> {
             private void registerVariable(Variable variable) {
                 if (!registeredVariables.contains(variable)) {
                     registeredVariables.add(variable);
-                    variable.constraints().forEach(this::registerConstraint);
-                    variable.constraining().forEach(this::registerConstraint);
+                    if (!variable.id().isLabel()) {
+                        variable.constraints().forEach(this::registerConstraint);
+                        variable.constraining().forEach(this::registerConstraint);
+                    } else {
+                        assert variable.asType().label().isPresent();
+                        registeredConstraints.add(variable.asType().label().get());
+                    }
                 }
             }
 

--- a/logic/resolvable/RetrievableTest.java
+++ b/logic/resolvable/RetrievableTest.java
@@ -149,16 +149,10 @@ public class RetrievableTest {
     }
 
     @Test
-    public void test_retrievables_split_by_concludables_are_separated() {
-        Set<Concludable> concludables = Concludable.create(parse("{ $r1 (sharedWith: $user, sharedObj: $parent_pt) isa shareitRelation; " +
-                                                                         "$r2 (sharedWith: $user, sharedObj: $pt) isa shareitRelation; }"));
-        Set<Retrievable> retrievables = Retrievable.extractFrom(parse("{ $user isa user, has objID \"3816c3cfaa8f460d93623561f0948456\";" +
-                                                                              "        $pt isa priority_theme;" +
-                                                                              "        $parent_pt isa priority_theme, has objID $parent_objID;" +
-                                                                              "        $r1 (sharedWith: $user, sharedObj: $parent_pt) isa shareitRelation;" +
-                                                                              "        $r2 (sharedWith: $user, sharedObj: $pt) isa shareitRelation; }"), concludables);
-        assertEquals(2, concludables.size());
-        assertEquals(3, retrievables.size());
+    public void test_retrievables_split_by_labelled_type_are_separated() {
+        Set<Retrievable> retrievables = Retrievable.extractFrom(parse("{ $r1 (sharedWith: $user1, sharedObj: $obj1) isa shareitRelation;" +
+                                                                      "  $r2 (sharedWith: $user2, sharedObj: $obj2) isa shareitRelation; }"), set());
+        assertEquals(2, retrievables.size());
     }
 
     @Test

--- a/logic/resolvable/RetrievableTest.java
+++ b/logic/resolvable/RetrievableTest.java
@@ -150,8 +150,10 @@ public class RetrievableTest {
 
     @Test
     public void test_retrievables_split_by_labelled_type_are_separated() {
-        Set<Retrievable> retrievables = Retrievable.extractFrom(parse("{ $r1 (sharedWith: $user1, sharedObj: $obj1) isa shareitRelation;" +
-                                                                      "  $r2 (sharedWith: $user2, sharedObj: $obj2) isa shareitRelation; }"), set());
+        Set<Retrievable> retrievables = Retrievable.extractFrom(
+                parse("{ $r1 (employer: $c1, employee: $p1) isa employment; $r2 (employer: $c2, employee: $p2) isa employment; }"),
+                set()
+        );
         assertEquals(2, retrievables.size());
     }
 


### PR DESCRIPTION
## What is the goal of this PR?
We fix an error in the splitting of Retrievables out of conjunctions for resolution: the retrievables were considered "connected" even if they only have a labeled type variable in common. Not treating these separately means we are forced to consider all combinations of (essentially) disconnected named variables, which can explode in number.

This will probably be refactored when  #6276 is implemented.

## What are the changes implemented in this PR?
* While splitting retrievables out of conjunctions, if we encounter a labeled variable we may only add the label of the variable, and may not recursively explore any further constraints
* add test for a concludable splitting retrievables into subgraphs connected only by type variable
* replace `Stream` usage with `FunctionalIterator` in `RetrievableTest`