### PR TITLE
At most a single relation is allowed on a thing variable

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -204,18 +204,20 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new Pattern(8, "The thing variable '%s' has multiple 'iid' constraints.");
         public static final Pattern MULTIPLE_THING_CONSTRAINT_ISA =
                 new Pattern(9, "The thing variable '%s' has multiple 'isa' constraints, '%s' and '%s'.");
+        public static final Pattern MULTIPLE_THING_CONSTRAINT_RELATION =
+                new Pattern(10, "The thing variable '%s' has multiple 'relation' constraints");
         public static final Pattern ILLEGAL_DERIVED_THING_CONSTRAINT_ISA =
-                new Pattern(10, "The thing variable '%s' has a derived 'isa' constraint, in a query that does not allow it.");
+                new Pattern(11, "The thing variable '%s' has a derived 'isa' constraint, in a query that does not allow it.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_SUB =
-                new Pattern(11, "The type variable '%s' has multiple 'sub' constraints.");
+                new Pattern(12, "The type variable '%s' has multiple 'sub' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_LABEL =
-                new Pattern(12, "The type variable '%s' has multiple 'label' constraints.");
+                new Pattern(13, "The type variable '%s' has multiple 'label' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_VALUE_TYPE =
-                new Pattern(13, "Tye type variable '%s' has multiple 'value' constraints.");
+                new Pattern(14, "Tye type variable '%s' has multiple 'value' constraints.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_REGEX =
-                new Pattern(14, "The type variable '%s' has multiple 'regex' constraints.");
+                new Pattern(15, "The type variable '%s' has multiple 'regex' constraints.");
         public static final Pattern UNSATISFIABLE_PATTERN =
-                new Pattern(15, "The pattern '%s' can never be satisfied the current schema, specifically due to '%s'.");
+                new Pattern(16, "The pattern '%s' can never be satisfied the current schema, specifically due to '%s'.");
 
         private static final String codePrefix = "QRY";
         private static final String messagePrefix = "Invalid Query Pattern";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -205,7 +205,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final Pattern MULTIPLE_THING_CONSTRAINT_ISA =
                 new Pattern(9, "The thing variable '%s' has multiple 'isa' constraints, '%s' and '%s'.");
         public static final Pattern MULTIPLE_THING_CONSTRAINT_RELATION =
-                new Pattern(10, "The thing variable '%s' has multiple 'relation' constraints");
+                new Pattern(10, "The relation variable '%s' has multiple 'relation' constraints");
         public static final Pattern ILLEGAL_DERIVED_THING_CONSTRAINT_ISA =
                 new Pattern(11, "The thing variable '%s' has a derived 'isa' constraint, in a query that does not allow it.");
         public static final Pattern MULTIPLE_TYPE_CONSTRAINT_SUB =

--- a/logic/resolvable/ConcludableTest.java
+++ b/logic/resolvable/ConcludableTest.java
@@ -165,16 +165,6 @@ public class ConcludableTest {
     }
 
     @Test
-    public void test_conjunction_multiple_relations_are_built() {
-        String conjunction = "{ $a($x); $a($y); }";
-        Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));
-        assertEquals(0, isaConcludablesCount(concludables));
-        assertEquals(0, hasConcludablesCount(concludables));
-        assertEquals(2, relationConcludablesCount(concludables));
-        assertEquals(0, attributeConcludablesCount(concludables));
-    }
-
-    @Test
     public void test_conjunction_isa_and_has_are_built() {
         String conjunction = "{ $p isa person, has name $n; $n \"Alice\"; }";
         Set<Concludable> concludables = Concludable.create(parseConjunction(conjunction));

--- a/logic/tool/TypeResolver.java
+++ b/logic/tool/TypeResolver.java
@@ -337,8 +337,8 @@ public class TypeResolver {
             var.isa().ifPresent(constraint -> registerIsa(resolver, constraint));
             var.is().forEach(constraint -> registerIsThing(resolver, constraint));
             var.has().forEach(constraint -> registerHas(resolver, constraint));
-            if (insertable) var.relation().forEach(constraint -> registerInsertableRelation(resolver, constraint));
-            else var.relation().forEach(constraint -> registerRelation(resolver, constraint));
+            if (insertable) var.relation().ifPresent(constraint -> registerInsertableRelation(resolver, constraint));
+            else var.relation().ifPresent(constraint -> registerRelation(resolver, constraint));
             var.iid().ifPresent(constraint -> registerIID(resolver, constraint));
             return resolver;
         }

--- a/pattern/equivalence/AlphaEquivalence.java
+++ b/pattern/equivalence/AlphaEquivalence.java
@@ -102,8 +102,7 @@ public abstract class AlphaEquivalence {
             for (Map.Entry<Variable, Variable> e : toMerge.entrySet()) {
                 Variable var = toMerge.get(e.getKey());
                 if (existing.containsKey(e.getKey())) {
-                    if (!var.equals(e.getValue()))
-                        return Optional.empty();
+                    if (!var.equals(e.getValue())) return Optional.empty();
                 } else {
                     existing.put(e.getKey(), var);
                 }
@@ -123,7 +122,7 @@ public abstract class AlphaEquivalence {
 
         @Override
         public <T extends AlphaEquivalent<T>> AlphaEquivalence validIfAlphaEqual(@Nullable T member1, @Nullable T member2) {
-            if (member1 == null && member2 == null) return Valid.create();
+            if (member1 == null && member2 == null) return this;
             if (member1 != null && member2 != null) return addOrInvalidate(member1.alphaEquals(member2));
             return AlphaEquivalence.invalid();
         }
@@ -233,8 +232,7 @@ public abstract class AlphaEquivalence {
 
         @Override
         public AlphaEquivalence alphaEquals(EquivalenceSet<T> that) { // TODO: Should be able to accept a set not an alpha set?
-            if (that.size() != size())
-                return AlphaEquivalence.invalid();
+            if (that.size() != size()) return AlphaEquivalence.invalid();
             try {
                 return containsAll(that);
             } catch (NullPointerException unused) {
@@ -252,24 +250,21 @@ public abstract class AlphaEquivalence {
 
         private AlphaEquivalence containsAll(EquivalenceSet<T> c) {
             AlphaEquivalence alphaMap = Valid.create();
-            for (T e : c.set())
-                alphaMap = alphaMap.addOrInvalidate(contains(e));
-            if (!alphaMap.isValid())
-                return alphaMap;
+            for (T e : c.set()) alphaMap = alphaMap.addOrInvalidate(contains(e));
+            if (!alphaMap.isValid()) return alphaMap;
             return alphaMap;
         }
 
         private AlphaEquivalence contains(T o) {
             Iterator<T> it = iterator();
             if (o == null) {
-                while (it.hasNext())
-                    if (it.next() == null)
-                        return Valid.create();
+                while (it.hasNext()) {
+                    if (it.next() == null) return Valid.create();
+                }
             } else {
                 while (it.hasNext()) {
                     AlphaEquivalence alphaMap = it.next().alphaEquals(o);
-                    if (alphaMap.isValid())
-                        return Valid.create(alphaMap.asValid().variableMapping());
+                    if (alphaMap.isValid()) return Valid.create(alphaMap.asValid().variableMapping());
                 }
             }
             return AlphaEquivalence.invalid();

--- a/pattern/equivalence/AlphaEquivalenceTest.java
+++ b/pattern/equivalence/AlphaEquivalenceTest.java
@@ -57,9 +57,9 @@ public class AlphaEquivalenceTest {
         Set<Variable> anonVariables = parseAnonymousThingVariables(graqlVariables);
         return anonVariables.stream()
                 .filter(Variable::isThing)
-                .filter(variable -> variable.asThing().relation().size() > 0)
+                .filter(variable -> variable.asThing().relation().isPresent())
                 .findFirst()
-                .get().asThing().relation().iterator().next().owner();
+                .get().asThing().relation().get().owner();
     }
 
     private Set<Variable> parseAnonymousThingVariables(String... graqlVariables) {

--- a/query/Deleter.java
+++ b/query/Deleter.java
@@ -116,7 +116,7 @@ public class Deleter {
                 validate(var);
                 Thing thing = matched.get(var.reference().asName()).asThing();
                 if (!var.has().isEmpty()) deleteHas(var, thing);
-                if (!var.relation().isEmpty()) deleteRelation(var, thing.asRelation());
+                if (var.relation().isPresent()) deleteRelation(var, thing.asRelation());
                 detached.put(var, thing);
             }
         }
@@ -124,7 +124,7 @@ public class Deleter {
         private void validate(ThingVariable var) {
             try (GrablTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "validate")) {
                 if (!var.reference().isName()) {
-                    ErrorMessage.ThingWrite msg = !var.relation().isEmpty()
+                    ErrorMessage.ThingWrite msg = var.relation().isPresent()
                             ? ILLEGAL_ANONYMOUS_RELATION_IN_DELETE
                             : ILLEGAL_ANONYMOUS_VARIABLE_IN_DELETE;
                     throw GraknException.of(msg, var);
@@ -149,8 +149,8 @@ public class Deleter {
 
         private void deleteRelation(ThingVariable var, Relation relation) {
             try (GrablTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "delete_relation")) {
-                if (var.relation().size() == 1) {
-                    var.relation().iterator().next().players().forEach(rolePlayer -> {
+                if (var.relation().isPresent()) {
+                    var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = matched.get(rolePlayer.player().reference().asName()).asThing();
                         RoleType roleType = getRoleType(relation, player, rolePlayer);
                         relation.removePlayer(roleType, player);

--- a/query/Inserter.java
+++ b/query/Inserter.java
@@ -188,7 +188,7 @@ public class Inserter {
                 assert thing != null;
 
                 inserted.put(id, thing);
-                if (!var.relation().isEmpty()) insertRolePlayers(thing.asRelation(), var);
+                if (var.relation().isPresent()) insertRolePlayers(thing.asRelation(), var);
                 if (!var.has().isEmpty()) insertHas(thing, var.has());
                 return thing;
             }
@@ -221,7 +221,7 @@ public class Inserter {
                 if (thingType.isEntityType()) {
                     return thingType.asEntityType().create();
                 } else if (thingType.isRelationType()) {
-                    if (!var.relation().isEmpty()) return thingType.asRelationType().create();
+                    if (var.relation().isPresent()) return thingType.asRelationType().create();
                     else throw GraknException.of(RELATION_CONSTRAINT_MISSING, var.reference());
                 } else if (thingType.isAttributeType()) {
                     return insertAttribute(thingType.asAttributeType(), var);
@@ -264,10 +264,10 @@ public class Inserter {
         }
 
         private void insertRolePlayers(Relation relation, ThingVariable var) {
-            assert !var.relation().isEmpty();
+            assert var.relation().isPresent();
             try (GrablTracingThreadStatic.ThreadTrace ignored = traceOnThread(TRACE_PREFIX + "extend_relation")) {
-                if (var.relation().size() == 1) {
-                    var.relation().iterator().next().players().forEach(rolePlayer -> {
+                if (var.relation().isPresent()) {
+                    var.relation().get().players().forEach(rolePlayer -> {
                         Thing player = insert(rolePlayer.player());
                         RoleType roleType = getRoleType(relation, player, rolePlayer);
                         relation.addPlayer(roleType, player);


### PR DESCRIPTION
## What is the goal of this PR?
We address the fact that a user can write semantically undefined multiple relation constraints on a single relation variable. In this PR we disallow writing multiple relation constraints on the same relation variable. 


## Semantic Explanation

When addressing a relation in a query, we constraint a variable with a relation constraint:

```
$r (role-a: $x);
```

This statements requires that the variable `r` identifies a relation with one role player `$x` playing the role `role-a`. However, if we add another, separate relation constraint:
```
$r (role-b: $y);
```
we now also constraint the relation `r` to be idenfied with a player `$y` playing a role `role-b`. Since we view relations as hyper-relations defined as a set of role players, it doesn't semantically make sense to try to define `$r` by two different sets of role players (or alternatively, it's identified by their intersection). The next-best semantically sound thing to execute would be to do the following:
```
$r (role-a: $x, role-b: $y);
```

If we wanted to query for other parts of the same relation, we should define a new relation variable and set its identity to be equivalent to the first:
```
$r1 (role-a: $x);
$r2 is $r1;
$r2 (role-b: $y);
```
This allows us to satisfy the semantic requirements of definition of relations, and explore other role players on the next relation variable `$r2`


## What are the changes implemented in this PR?
* Disallow writing multiple relation constraints on a relation variable
* `ThingVariable` now contains a single nullable `relationConstraint` instead of a possibly empty set
