### PR TITLE
Add specialised error message for bad file path in importer

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -528,14 +528,16 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
     }
 
     public static class Migrator extends ErrorMessage {
+        public static final Migrator FILE_NOT_FOUND =
+                new Migrator(1, "The specified file path '%s' could not be found.");
         public static final Migrator FILE_NOT_READABLE =
-                new Migrator(1, "The specified file '%s' cannot be opened for read.");
+                new Migrator(2, "The specified file '%s' cannot be opened for read.");
         public static final Migrator FILE_NOT_WRITABLE =
-                new Migrator(2, "The specified file '%s' cannot be opened for write.");
+                new Migrator(3, "The specified file '%s' cannot be opened for write.");
         public static final Migrator TYPE_NOT_FOUND =
-                new Migrator(3, "The type '%s' (originally '%s') is not defined in the schema.");
+                new Migrator(4, "The type '%s' (originally '%s') is not defined in the schema.");
         public static final Migrator INVALID_DATA =
-                new Migrator(4, "The data being imported is invalid.");
+                new Migrator(5, "The data being imported is invalid.");
 
         private static final String codePrefix = "MIG";
         private static final String messagePrefix = "Migrator failure";

--- a/migrator/DataImporter.java
+++ b/migrator/DataImporter.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static grakn.core.common.exception.ErrorMessage.Migrator.FILE_NOT_FOUND;
 import static grakn.core.common.exception.ErrorMessage.Migrator.FILE_NOT_READABLE;
 import static grakn.core.common.exception.ErrorMessage.Migrator.INVALID_DATA;
 import static grakn.core.common.exception.ErrorMessage.Migrator.TYPE_NOT_FOUND;
@@ -77,6 +78,7 @@ public class DataImporter implements Migrator {
     private Grakn.Transaction tx;
 
     DataImporter(Grakn grakn, String database, Path filename, Map<String, String> remapLabels, String version) {
+        if (!Files.exists(filename)) throw GraknException.of(FILE_NOT_FOUND, filename);
         this.session = grakn.session(database, Arguments.Session.Type.DATA);
         this.filename = filename;
         this.remapLabels = remapLabels;


### PR DESCRIPTION
## What is the goal of this PR?
To address the cryptic importer error reported in #6165 we throw a specific error when the import file path is not found, rather than using the generic not readable exception.
 
## What are the changes implemented in this PR?
* throw specialised FILE_NOT_FOUND error message when importer is provided a data file that could not be found
