### PR TITLE
Validate rule value type compatibility and fix attribute materialisation 

### DIFF
--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -487,15 +487,15 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
         public static final RuleWrite CONTRADICTORY_RULE_CYCLE =
                 new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
         public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
-                new RuleWrite(3, "The rule '%'s contains a negation containing a disjunction, which is currently unsupported");
-        public static final RuleWrite RULE_CAN_IMPLY_UNINSERTABLE_CONCLUSION =
-                new RuleWrite(4, "The rule '%s' when can imply the type combination '%s', which cannot be inserted into the rule's then.");
+                new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
+        public static final RuleWrite RULE_CAN_HAVE_UNINSERTABLE_CONCLUSION =
+                new RuleWrite(4, "The rule '%s''s conclusion may insert types '%s', which is not allowed in the current schema.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(6, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
-        public static final RuleWrite RULE_THEN_INVALID_VALUE_CONVERSION =
-                new RuleWrite(7, "The rule '%s' has a then clause with an invalid conversion from '%s' to '%s'.");
+        public static final RuleWrite RULE_THEN_INVALID_VALUE_ASSIGNMENT =
+                new RuleWrite(7, "The rule '%s' has a then clause with an invalid assignment of '%s' into a '%s'.");
         public static final RuleWrite MAX_RULE_REACHED =
                 new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
 

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -488,14 +488,16 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
         public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
                 new RuleWrite(3, "The rule '%'s contains a negation containing a disjunction, which is currently unsupported");
-        public static final RuleWrite RULE_CAN_IMPLY_UNINSERTABLE_RESULTS =
+        public static final RuleWrite RULE_CAN_IMPLY_UNINSERTABLE_CONCLUSION =
                 new RuleWrite(4, "The rule '%s' when can imply the type combination '%s', which cannot be inserted into the rule's then.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");
         public static final RuleWrite RULE_THEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(6, "The rule '%s' has a then clause '%s' that can never be satisfied in the current schema.");
+        public static final RuleWrite RULE_THEN_INVALID_VALUE_CONVERSION =
+                new RuleWrite(7, "The rule '%s' has a then clause with an invalid conversion from '%s' to '%s'.");
         public static final RuleWrite MAX_RULE_REACHED =
-                new RuleWrite(7, "The maximum number of rules has been reached: '%s'");
+                new RuleWrite(8, "The maximum number of rules has been reached: '%s'");
 
         private static final String codePrefix = "RUW";
         private static final String messagePrefix = "Invalid Rule Write";

--- a/common/exception/ErrorMessage.java
+++ b/common/exception/ErrorMessage.java
@@ -488,7 +488,7 @@ public abstract class ErrorMessage extends grakn.common.exception.ErrorMessage {
                 new RuleWrite(2, "A cycle containing negation(s) that can cause inference contradictions has been detected in rules: %s");
         public static final RuleWrite INVALID_NEGATION_CONTAINS_DISJUNCTION =
                 new RuleWrite(3, "The rule '%s' contains a negation containing a disjunction, which is currently unsupported");
-        public static final RuleWrite RULE_CAN_HAVE_UNINSERTABLE_CONCLUSION =
+        public static final RuleWrite RULE_CAN_HAVE_INVALID_CONCLUSION =
                 new RuleWrite(4, "The rule '%s''s conclusion may insert types '%s', which is not allowed in the current schema.");
         public static final RuleWrite RULE_WHEN_CANNOT_BE_SATISFIED =
                 new RuleWrite(5, "The rule '%s' has a when clause '%s' that can never be satisfied in the current schema.");

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -19,6 +19,7 @@
 package grakn.core.concept.type;
 
 import grakn.core.common.iterator.FunctionalIterator;
+import grakn.core.concept.answer.ConceptMap;
 import grakn.core.concept.thing.Attribute;
 import grakn.core.graph.common.Encoding;
 import graql.lang.common.GraqlArg;
@@ -127,6 +128,11 @@ public interface AttributeType extends ThingType {
         public Set<ValueType> comparables() {
             return iterate(encoding.comparables()).map(ValueType::of).toSet();
         }
+
+        public Set<ValueType> assignableInto() {
+            return iterate(encoding.assignables()).map(ValueType::of).toSet();
+        }
+
     }
 
     interface Boolean extends AttributeType {

--- a/concept/type/AttributeType.java
+++ b/concept/type/AttributeType.java
@@ -129,7 +129,7 @@ public interface AttributeType extends ThingType {
             return iterate(encoding.comparables()).map(ValueType::of).toSet();
         }
 
-        public Set<ValueType> assignableInto() {
+        public Set<ValueType> assignables() {
             return iterate(encoding.assignables()).map(ValueType::of).toSet();
         }
 

--- a/dependencies/graknlabs/repositories.bzl
+++ b/dependencies/graknlabs/repositories.bzl
@@ -56,5 +56,5 @@ def graknlabs_behaviour():
     git_repository(
         name = "graknlabs_behaviour",
         remote = "https://github.com/graknlabs/behaviour",
-        commit = "e9590e85755d1b3ea7b78f5f5245f24bf653b742", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
+        commit = "04a87f66ede6b8bb08478dc07e80d806f0a2ca76", # sync-marker: do not remove this comment, this is used for sync-dependencies by @graknlabs_behaviour
     )

--- a/logic/LogicManager.java
+++ b/logic/LogicManager.java
@@ -76,7 +76,7 @@ public class LogicManager {
             structure.delete();
             logicCache.rule().invalidate(label);
         }
-        return logicCache.rule().get(label, l -> Rule.of(graphMgr, this, label, when, then));
+        return logicCache.rule().get(label, l -> Rule.of(label, when, then, graphMgr, conceptMgr, this));
     }
 
     public Rule getRule(String label) {
@@ -112,8 +112,8 @@ public class LogicManager {
     public void revalidateAndReindexRules() {
         logicCache.rule().clear();
 
-        // validate all rules are valid and satisfiable
-        rules().forEachRemaining(Rule::validateSatisfiable);
+        // re-validate all rules are valid
+        rules().forEachRemaining(rule -> rule.validate(this, conceptMgr));
 
         // re-index if rules are valid and satisfiable
         if (graphMgr.schema().rules().conclusions().isOutdated()) {

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -65,7 +65,7 @@ import static grakn.common.util.Objects.className;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
-import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_CAN_HAVE_UNINSERTABLE_CONCLUSION;
+import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_CAN_HAVE_INVALID_CONCLUSION;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_ASSIGNMENT;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
@@ -400,7 +400,7 @@ public class Rule {
 
             whenCombinations.forEachRemaining(nameLabelMap -> {
                 if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
-                    throw GraknException.of(RULE_CAN_HAVE_UNINSERTABLE_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
+                    throw GraknException.of(RULE_CAN_HAVE_INVALID_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
             });
         }
 
@@ -668,7 +668,7 @@ public class Rule {
                     assert attributeType != null;
                     AttributeType.ValueType attrTypeValueType = attributeType.getValueType();
                     ValueConstraint<?> value = has().attribute().value().iterator().next();
-                    if (!AttributeType.ValueType.of(value.value().getClass()).assignableInto().contains(attrTypeValueType)) {
+                    if (!AttributeType.ValueType.of(value.value().getClass()).assignables().contains(attrTypeValueType)) {
                         throw GraknException.of(RULE_THEN_INVALID_VALUE_ASSIGNMENT, rule().getLabel(),
                                                 value.value().getClass().getSimpleName(),
                                                 attributeType.getValueType().getValueClass().getSimpleName());

--- a/logic/Rule.java
+++ b/logic/Rule.java
@@ -65,8 +65,9 @@ import static grakn.common.util.Objects.className;
 import static grakn.core.common.exception.ErrorMessage.Internal.ILLEGAL_STATE;
 import static grakn.core.common.exception.ErrorMessage.Pattern.INVALID_CASTING;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.INVALID_NEGATION_CONTAINS_DISJUNCTION;
-import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_CAN_IMPLY_UNINSERTABLE_RESULTS;
+import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_CAN_IMPLY_UNINSERTABLE_CONCLUSION;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_CANNOT_BE_SATISFIED;
+import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_THEN_INVALID_VALUE_CONVERSION;
 import static grakn.core.common.exception.ErrorMessage.RuleWrite.RULE_WHEN_CANNOT_BE_SATISFIED;
 import static grakn.core.common.iterator.Iterators.iterate;
 import static graql.lang.common.GraqlToken.Char.COLON;
@@ -91,7 +92,7 @@ public class Rule {
     private final Conclusion conclusion;
     private final Condition condition;
 
-    private Rule(LogicManager logicMgr, RuleStructure structure) {
+    private Rule(RuleStructure structure, LogicManager logicMgr) {
         this.structure = structure;
         this.then = thenPattern(structure.then(), logicMgr);
         this.when = whenPattern(structure.when(), structure.then(), logicMgr);
@@ -100,26 +101,17 @@ public class Rule {
         this.condition = Condition.create(this);
     }
 
-    private Rule(GraphManager graphMgr, LogicManager logicMgr, String label,
-                 graql.lang.pattern.Conjunction<? extends Pattern> when, graql.lang.pattern.variable.ThingVariable<?> then) {
-        this.structure = graphMgr.schema().rules().create(label, when, then);
-        this.then = thenPattern(structure.then(), logicMgr);
-        this.when = whenPattern(structure.when(), structure.then(), logicMgr);
-        pruneThenResolvedTypes();
-        validateSatisfiable();
-        validateInsertable(logicMgr);
-        this.conclusion = Conclusion.create(this);
-        this.conclusion.index();
-        this.condition = Condition.create(this);
-    }
-
     public static Rule of(LogicManager logicMgr, RuleStructure structure) {
-        return new Rule(logicMgr, structure);
+        return new Rule(structure, logicMgr);
     }
 
-    public static Rule of(GraphManager graphMgr, LogicManager logicMgr, String label,
-                          graql.lang.pattern.Conjunction<? extends Pattern> when, graql.lang.pattern.variable.ThingVariable<?> then) {
-        return new Rule(graphMgr, logicMgr, label, when, then);
+    public static Rule of(String label, graql.lang.pattern.Conjunction<? extends Pattern> when, graql.lang.pattern.variable.ThingVariable<?> then,
+                          GraphManager graphMgr, ConceptManager conceptMgr, LogicManager logicMgr) {
+        RuleStructure structure = graphMgr.schema().rules().create(label, when, then);
+        Rule rule = new Rule(structure, logicMgr);
+        rule.conclusion().index();
+        rule.validate(logicMgr, conceptMgr);
+        return rule;
     }
 
     public Conclusion conclusion() {
@@ -177,20 +169,16 @@ public class Rule {
         return structure.hashCode(); // does not need caching
     }
 
-    public void validateSatisfiable() {
+    public void validate(LogicManager logicMgr, ConceptManager conceptMgr) {
+        validateSatisfiable();
+        this.conclusion.validate(logicMgr, conceptMgr);
+    }
+
+    private void validateSatisfiable() {
         if (!when.isCoherent()) throw GraknException.of(RULE_WHEN_CANNOT_BE_SATISFIED, structure.label(), when);
         if (!then.isCoherent()) throw GraknException.of(RULE_THEN_CANNOT_BE_SATISFIED, structure.label(), then);
     }
 
-    public void validateInsertable(LogicManager logicMgr) {
-        FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeResolver().namedCombinations(when, false);
-        Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeResolver().namedCombinations(then, true).toSet();
-
-        whenCombinations.forEachRemaining(nameLabelMap -> {
-            if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
-                throw GraknException.of(RULE_CAN_IMPLY_UNINSERTABLE_RESULTS, structure.label(), nameLabelMap.toString());
-        });
-    }
 
     /**
      * Remove type hints in the `then` pattern that are not valid in the `when` pattern
@@ -318,11 +306,11 @@ public class Rule {
         }
 
         public static Conclusion create(Rule rule) {
-            Optional<Relation> r = Relation.of(rule.then(), rule);
+            Optional<Relation> r = Relation.of(rule);
             if ((r).isPresent()) return r.get();
-            Optional<Has.Explicit> e = Has.Explicit.of(rule.then(), rule);
+            Optional<Has.Explicit> e = Has.Explicit.of(rule);
             if (e.isPresent()) return e.get();
-            Optional<Has.Variable> v = Has.Variable.of(rule.then(), rule);
+            Optional<Has.Variable> v = Has.Variable.of(rule);
             if (v.isPresent()) return v.get();
             throw GraknException.of(ILLEGAL_STATE);
         }
@@ -402,6 +390,20 @@ public class Rule {
             throw GraknException.of(INVALID_CASTING, className(this.getClass()), className(Has.Explicit.class));
         }
 
+        public void validate(LogicManager logicMgr, ConceptManager conceptMgr) {
+            validateInsertable(logicMgr);
+        }
+
+        private void validateInsertable(LogicManager logicMgr) {
+            FunctionalIterator<Map<Identifier.Variable.Name, Label>> whenCombinations = logicMgr.typeResolver().namedCombinations(rule.when, false);
+            Set<Map<Identifier.Variable.Name, Label>> allowedThenCombinations = logicMgr.typeResolver().namedCombinations(rule.then, true).toSet();
+
+            whenCombinations.forEachRemaining(nameLabelMap -> {
+                if (allowedThenCombinations.stream().noneMatch(thenMap -> nameLabelMap.entrySet().containsAll(thenMap.entrySet())))
+                    throw GraknException.of(RULE_CAN_IMPLY_UNINSERTABLE_CONCLUSION, rule.structure.label(), nameLabelMap.toString());
+            });
+        }
+
         public interface Isa {
             IsaConstraint isa();
         }
@@ -439,8 +441,8 @@ public class Rule {
                 this.isa = isa;
             }
 
-            public static Optional<Relation> of(Conjunction conjunction, Rule rule) {
-                return iterate(conjunction.variables()).filter(Variable::isThing).map(Variable::asThing)
+            public static Optional<Relation> of(Rule rule) {
+                return iterate(rule.then().variables()).filter(Variable::isThing).map(Variable::asThing)
                         .flatMap(variable -> iterate(variable.constraints())
                                 .filter(ThingConstraint::isRelation)
                                 .map(constraint -> {
@@ -639,8 +641,8 @@ public class Rule {
                     this.value = value;
                 }
 
-                public static Optional<Explicit> of(Conjunction conjunction, Rule rule) {
-                    return iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
+                public static Optional<Explicit> of(Rule rule) {
+                    return iterate(rule.then().variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
                             .flatMap(variable -> iterate(variable.constraints()).filter(ThingConstraint::isHas)
                                     .filter(constraint -> constraint.asHas().attribute().id().reference().isAnonymous())
@@ -655,19 +657,48 @@ public class Rule {
                 }
 
                 @Override
+                public void validate(LogicManager logicMgr, ConceptManager conceptMgr) {
+                    super.validate(logicMgr, conceptMgr);
+                    validateCompatibleValues(conceptMgr);
+                }
+
+                private void validateCompatibleValues(ConceptManager conceptMgr) {
+                    Label attributeTypeLabel = isa().type().label().get().properLabel();
+                    AttributeType attributeType = conceptMgr.getAttributeType(attributeTypeLabel.name());
+                    assert attributeType != null;
+                    ValueConstraint<?> value = has().attribute().value().iterator().next();
+                    try {
+                        if (attributeType.isDateTime()) value.asDateTime();
+                        else if (attributeType.isBoolean()) value.asBoolean();
+                        else if (attributeType.isDouble()) value.asDouble();
+                        else if (attributeType.isLong()) value.asLong();
+                        else if (attributeType.isString()) value.asString();
+                        else throw GraknException.of(ILLEGAL_STATE);
+                    } catch (GraknException e) {
+                        if (e.code().isPresent() && e.code().get().equals(INVALID_CASTING.code())) {
+                            throw GraknException.of(RULE_THEN_INVALID_VALUE_CONVERSION, rule().getLabel(),
+                                                    value.value().getClass().getSimpleName(),
+                                                    attributeType.getValueType().getValueClass().getSimpleName());
+                        } else {
+                            throw e;
+                        }
+                    }
+                }
+
+                @Override
                 public FunctionalIterator<Map<Identifier.Variable, Concept>> materialise(ConceptMap whenConcepts, TraversalEngine traversalEng,
                                                                                          ConceptManager conceptMgr) {
                     Identifier.Variable.Retrievable ownerId = has().owner().id();
                     assert whenConcepts.contains(ownerId) && whenConcepts.get(ownerId).isThing();
                     Map<Identifier.Variable, Concept> thenConcepts = new HashMap<>();
                     Thing owner = whenConcepts.get(ownerId.reference().asName()).asThing();
-                    Attribute attribute = getOrCreateAttribute(conceptMgr);
+                    Attribute attribute = putAttribute(conceptMgr);
                     owner.setHas(attribute, true);
                     TypeVariable declaredType = has().attribute().isa().get().type();
-                    Identifier.Variable declaredTypeIdentifier = declaredType.id();
+                    Identifier.Variable declaredTypeId = declaredType.id();
                     AttributeType attrType = conceptMgr.getAttributeType(declaredType.label().get().properLabel().name());
                     assert attrType.equals(attribute.getType());
-                    thenConcepts.put(declaredTypeIdentifier, attrType);
+                    thenConcepts.put(declaredTypeId, attrType);
                     thenConcepts.put(has().attribute().id(), attribute);
                     thenConcepts.put(has().owner().id(), owner);
                     return Iterators.single(thenConcepts);
@@ -738,22 +769,20 @@ public class Rule {
                     return value;
                 }
 
-
-                private Attribute getOrCreateAttribute(ConceptManager conceptMgr) {
+                private Attribute putAttribute(ConceptManager conceptMgr) {
                     assert has().attribute().isa().isPresent()
                             && has().attribute().isa().get().type().label().isPresent()
                             && has().attribute().value().size() == 1
                             && has().attribute().value().iterator().next().isValueIdentity();
-                    Label attributeTypeLabel = has().attribute().isa().get().type().label().get().properLabel();
-                    AttributeType attributeType = conceptMgr.getAttributeType(attributeTypeLabel.name());
-                    assert attributeType != null;
+                    Label attributeTypeLabel = isa().type().label().get().properLabel();
+                    AttributeType attrType = conceptMgr.getAttributeType(attributeTypeLabel.name());
+                    assert attrType != null;
                     ValueConstraint<?> value = has().attribute().value().iterator().next();
-                    if (value.isBoolean()) return attributeType.asBoolean().put(value.asBoolean().value(), true);
-                    else if (value.isDateTime())
-                        return attributeType.asDateTime().put(value.asDateTime().value(), true);
-                    else if (value.isDouble()) return attributeType.asDouble().put(value.asDouble().value(), true);
-                    else if (value.isLong()) return attributeType.asLong().put(value.asLong().value(), true);
-                    else if (value.isString()) return attributeType.asString().put(value.asString().value(), true);
+                    if (attrType.isDateTime()) return attrType.asDateTime().put(value.asDateTime().value(), true);
+                    else if (attrType.isBoolean()) return attrType.asBoolean().put(value.asBoolean().value(), true);
+                    else if (attrType.isDouble()) return attrType.asDouble().put(value.asDouble().value(), true);
+                    else if (attrType.isLong()) return attrType.asLong().put(value.asLong().value(), true);
+                    else if (attrType.isString()) return attrType.asString().put(value.asString().value(), true);
                     else throw GraknException.of(ILLEGAL_STATE);
                 }
 
@@ -765,8 +794,8 @@ public class Rule {
                     super(hasConstraint, rule);
                 }
 
-                public static Optional<Variable> of(Conjunction conjunction, Rule rule) {
-                    return iterate(conjunction.variables()).filter(grakn.core.pattern.variable.Variable::isThing)
+                public static Optional<Variable> of(Rule rule) {
+                    return iterate(rule.then().variables()).filter(grakn.core.pattern.variable.Variable::isThing)
                             .map(grakn.core.pattern.variable.Variable::asThing)
                             .flatMap(variable -> iterate(variable.constraints()).filter(ThingConstraint::isHas)
                                     .filter(constraint -> constraint.asHas().attribute().id().isName())

--- a/logic/resolvable/Concludable.java
+++ b/logic/resolvable/Concludable.java
@@ -337,10 +337,9 @@ public abstract class Concludable extends Resolvable<Conjunction> {
         }
 
         public FunctionalIterator<Unifier> unify(Rule.Conclusion.Relation relationConclusion, ConceptManager conceptMgr) {
-            if (this.relation().players().size() > relationConclusion.relation().players().size())
-                return Iterators.empty();
-            Unifier.Builder unifierBuilder = Unifier.builder();
+            if (relation().players().size() > relationConclusion.relation().players().size()) return Iterators.empty();
 
+            Unifier.Builder unifierBuilder = Unifier.builder();
             if (unificationSatisfiable(relation().owner(), relationConclusion.relation().owner())) {
                 unifierBuilder.add(relation().owner().id(), relationConclusion.relation().owner().id());
             } else return Iterators.empty();

--- a/logic/resolvable/Unifier.java
+++ b/logic/resolvable/Unifier.java
@@ -193,7 +193,7 @@ public class Unifier {
         Record constraint-based requirements that may be used to fail a unification
 
         Allowed requirements we may impose:
-        1. a type variable may be required to within a set of allowed types
+        1. a role type variable may be required to within a set of allowed role types
         2. a thing variable may be required to be an explicit instance of a set of allowed types
         3. a thing variable may have to satisfy a specific predicate (ie when it's an attribute)
 
@@ -235,16 +235,14 @@ public class Unifier {
             }
 
             public boolean contradicts(ConceptMap conceptMap) {
-                boolean satisfies = true;
                 for (Map.Entry<Retrievable, ? extends Concept> identifiedConcept : conceptMap.concepts().entrySet()) {
                     Retrievable id = identifiedConcept.getKey();
                     Concept concept = identifiedConcept.getValue();
                     if (!(typesSatisfied(id, concept) && isaExplicitSatisfied(id, concept) && predicatesSatisfied(id, concept))) {
-                        satisfies = false;
-                        break;
+                        return true;
                     }
                 }
-                return !satisfies;
+                return false;
             }
 
             private boolean typesSatisfied(Variable id, Concept concept) {

--- a/reasoner/resolution/framework/Resolver.java
+++ b/reasoner/resolution/framework/Resolver.java
@@ -81,7 +81,7 @@ public abstract class Resolver<RESOLVER extends Resolver<RESOLVER>> extends Acto
                 return;
             }
         }
-        LOG.error("Actor exception: {}", e.getMessage());
+        LOG.error("Actor exception", e);
         registry.terminateResolvers(e);
     }
 


### PR DESCRIPTION
## What is the goal of this PR?

We fix a bug in which rules attempted to do an invalid value conversion, causing an exception. We also refactor rule validation to include a validation step to make sure attributes to be inserted are of the right type.

For example, the following now throws a meaningful error message about converting a Double to a Long:
```
define rule bad-double-as-long: when {
  $x isa person;
} then {
  $x has long-age 2.5;
}
``` 

## What are the changes implemented in this PR?
* Implement correct value conversion when materialising inferences
* Add a validation step to validate that Explicit Has conclusions are able to insert the written attribute value as the provided type
* Refactor rule constructor to keep only 1 constructor
* bump `graknlabs_behaviour` containing new rule validation tests

