### PR TITLE
RPC: Ensure ConceptMap always has an Explainables object

### DIFF
--- a/server/common/ResponseBuilder.java
+++ b/server/common/ResponseBuilder.java
@@ -855,6 +855,7 @@ public class ResponseBuilder {
                 ConceptProto.Concept conceptProto = ResponseBuilder.Concept.protoConcept(concept);
                 conceptMapProto.putMap(id.reference().name(), conceptProto);
             });
+            conceptMapProto.setExplainables(AnswerProto.Explainables.getDefaultInstance());
             return conceptMapProto.build();
         }
 


### PR DESCRIPTION
## What is the goal of this PR?

We've fixed a possible null pointer exception when running Explain queries from a client.

## What are the changes implemented in this PR?

The recent Reasoner rework (https://github.com/vaticle/typedb/pull/6497) introduced a new data structure named `ConclusionAnswer` which piggybacks on the `ConceptMap` RPC message structure, due to significant similarity between the two.

`ConceptMap` has an `explainables` field which is technically nullable, however it has never been null before; we have always initialised it to be an empty map, if the underlying `ConceptMap` has no `Explainables`. Given that a `ConclusionAnswer` never has Explainables by definition, this new RPC ConceptMap was initialised without an `Explainables` RPC object, violating the expectations of TypeDB Client.

(Technically, there is nothing in the protocol that says it can't be null, however because it had never been null in practice, the client code was never built to accommodate that - including all of its tests.)

Given that we are planning on reworking the entire model and possibly getting rid of `ConceptMap` in TypeDB 3.0, I am opting for the path that solves the problem in the easiest way for now, which is to simply ensure that the RPC ConceptMap's `explainables` property is always populated.