### PR TITLE
Remove pyenv usage

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -137,9 +137,9 @@ build:
         bazel run --define version=$(git rev-parse HEAD) //:deploy-windows-zip -- snapshot
     deploy-apt-snapshot:
       image: vaticle-ubuntu-22.04
-#      filter:
-#        owner: vaticle
-#        branch: [master, development]
+      filter:
+        owner: vaticle
+        branch: [master, development]
       dependencies: [test-assembly-linux-targz]
       command: |
         export DEPLOY_APT_USERNAME=$REPO_VATICLE_USERNAME


### PR DESCRIPTION
## What is the goal of this PR?

We've removed another use of pyenv from our apt-deployment job in Factory. This was missed in:
- https://github.com/vaticle/typedb/pull/6676

## What are the changes implemented in this PR?

We've removed a useage of pyenv.
