### PR TITLE
Fix crashing race condition after write query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4182,7 +4182,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?tag=3.0.0#111f1a9ed8aac3360c0b5d16e68c1ecebe823137"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.1.0#91fa29cd81c56752b6a71a4a6850a78f89f7521c"
 dependencies = [
  "prost",
  "tonic",
@@ -4223,7 +4223,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?tag=3.1.0-rc0#992eba46dce28afabacbef3621a79c9dffd5cf10"
+source = "git+https://github.com/typedb/typeql?tag=3.1.0#339951690948d6612dd07ea77e80461b98c58cd5"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -25,13 +25,12 @@ use ir::{
         },
         nested_pattern::NestedPattern,
         variable_category::VariableCategory,
-        Vertex,
+        Scope, Vertex,
     },
     pipeline::{block::BlockContext, VariableRegistry},
 };
 use itertools::{chain, Itertools};
 use tracing::{event, Level};
-use ir::pattern::Scope;
 
 use crate::{
     annotation::{
@@ -129,7 +128,8 @@ fn make_builder<'a>(
                         .conjunctions()
                         .iter()
                         .map(|branch| {
-                            let branch_shared_variables = branch.referenced_variables()
+                            let branch_shared_variables = branch
+                                .referenced_variables()
                                 .filter(|var| block_context.is_variable_available(conjunction.scope_id(), *var))
                                 .collect();
                             make_builder(

--- a/executor/instruction/mod.rs
+++ b/executor/instruction/mod.rs
@@ -4,12 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{
-    collections::HashMap,
-    fmt,
-    marker::PhantomData,
-    ops::Bound,
-};
+use std::{collections::HashMap, fmt, marker::PhantomData, ops::Bound};
 
 use ::iterator::minmax_or;
 use answer::{variable_value::VariableValue, Thing, Type};


### PR DESCRIPTION
## Release notes: product changes

Resolve issue where a large write query (~100k keys) would sometimes cause the server to crash at the end.

## Motivation

## Implementation

Each write query expects exclusive ownership over the snapshot. We ensure that by checking and, if necessary, interrupting outgoing answer streams that read from the snapshot before handing the snapshot over to the write query executor.

This check created a race condition when the stream has ended, but the reference to the snapshot is not yet released. This PR adds an explicit check for the end of the worker task.

Resolves #7427. 