### PR TITLE
Update planner cost model for joins to reflect seeks being implemented

### DIFF
--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -29,6 +29,7 @@ pub(super) mod constraint;
 pub(super) mod variable;
 
 pub(super) const OPEN_ITERATOR_RELATIVE_COST: f64 = 5.0;
+pub(super) const SEEK_ITERATOR_RELATIVE_COST: f64 = 5.0;
 pub(super) const ADVANCE_ITERATOR_RELATIVE_COST: f64 = 1.0;
 
 const _REGEX_EXPECTED_CHECKS_PER_MATCH: f64 = 2.0;
@@ -191,9 +192,10 @@ impl Cost {
     }
 
     pub(crate) fn join(self, other: Self, join_size: f64) -> Self {
+        let io_ratio = f64::max(self.io_ratio * other.io_ratio / join_size, Cost::MIN_IO_RATIO); // Probability of join = 1 / total_join_size
         Self {
-            cost: std::cmp::min(self.cost, other.cost), // We seek at most twice the size of the smaller iterator.
-            io_ratio: f64::max(self.io_ratio * other.io_ratio / join_size, Cost::MIN_IO_RATIO), // Probability of join = 1 / total_join_size
+            cost: (2.0 + io_ratio) * SEEK_ITERATOR_RELATIVE_COST, // We expect to seek once per intersection on average
+            io_ratio,
         }
     }
 


### PR DESCRIPTION
## Product change and motivation
Updates the cost for a join between iterators to reflect seeks being introduced (#7367). The sum of the iterator sizes was accurate when we had to scan through the iterator. With seeks, we can skip impossible values. The number of seeks is on the order of the size of the smaller iterator.

