### PR TITLE
Make state module public

### DIFF
--- a/server/lib.rs
+++ b/server/lib.rs
@@ -32,7 +32,7 @@ pub mod authentication;
 pub mod error;
 pub mod parameters;
 pub mod service;
-pub(crate) mod state;
+pub mod state;
 
 #[derive(Default)]
 pub struct ServerBuilder {


### PR DESCRIPTION
## Product change and motivation

Make the `state` module public so that it can be extended by TypeDB Cluster.

## Implementation

Update the module visibility modifier from `pub(crate)` to `pub`