### PR TITLE
Refactor planner to track join variable in cost metadata

### DIFF
--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -71,6 +71,23 @@ use crate::{
     ExecutorVariable, VariablePosition,
 };
 
+macro_rules! trace_plan {
+    ($decision:literal, $plan:ident) => {
+        event!(
+            Level::TRACE,
+            "{INDENT:8}[{}]PLAN: {:?} ONGOING: {:?} STASH: {:?} COST: {:?} + {:?} = {:?} HEURISTIC: {:?}",
+            $decision,
+            $plan.vertex_ordering,
+            $plan.ongoing_step,
+            $plan.ongoing_step_stash,
+            $plan.cumulative_cost,
+            $plan.ongoing_step_cost,
+            $plan.cumulative_cost.chain($plan.ongoing_step_cost),
+            $plan.heuristic
+        );
+    }
+}
+
 pub const MAX_BEAM_WIDTH: usize = 96;
 pub const MIN_BEAM_WIDTH: usize = 1;
 pub const AVERAGE_QUERY_OUTPUT_SIZE: f64 = 1.0; // replace with actual statistical estimate
@@ -614,6 +631,44 @@ impl<'a> ConjunctionPlanBuilder<'a> {
         }
     }
 
+    pub(super) fn plan(self) -> Result<ConjunctionPlan<'a>, QueryPlanningError> {
+        let search_patterns: HashSet<_> = self.graph.pattern_to_variable.keys().copied().collect();
+        let input_variables = self.graph
+            .variable_index
+            .values()
+            .copied()
+            .filter(|&v| self.graph.elements[&VertexId::Variable(v)].as_variable().is_some_and(|v| v.is_input()));
+        let initial_empty_plan = PartialCostPlan::new(
+            self.graph.elements.len(),
+            search_patterns.clone(),
+            input_variables,
+        );
+        let (ordering, metadata, cost) = Self::beam_search_plan(&self.graph, initial_empty_plan)?;
+        self.build_conjunction_plan(ordering, metadata, cost)
+    }
+
+    fn build_conjunction_plan(self, ordering: Vec<VertexId>, metadata: HashMap<PatternVertexId, CostMetaData>, cost: Cost) -> Result<ConjunctionPlan<'a>, QueryPlanningError> {
+        event!(
+            Level::TRACE,
+            "\n Final plan (before lowering):\n --> Order: {:?} --> MetaData \n {:?}",
+            ordering,
+            metadata
+        );
+        let element_to_order = ordering.iter().copied().enumerate().map(|(order, index)| (index, order)).collect();
+
+        let Self { graph, local_annotations: type_annotations, mut planner_statistics, .. } = self;
+
+        planner_statistics.finalize(cost);
+        Ok(ConjunctionPlan {
+            graph,
+            local_annotations: type_annotations,
+            ordering,
+            metadata,
+            element_to_order,
+            planner_statistics,
+        })
+    }
+
     // New approach to planning:
     //
     // In our pattern graph, vertices are variables and patterns; edges indicate which patterns contain which variables.
@@ -624,24 +679,16 @@ impl<'a> ConjunctionPlanBuilder<'a> {
     // We record directionality information for each pattern in the plan, indicating which prefix index to use for pattern retrieval
 
     fn beam_search_plan(
-        &self,
+        graph: &Graph<'_>, initial_empty_plan: PartialCostPlan
     ) -> Result<(Vec<VertexId>, HashMap<PatternVertexId, CostMetaData>, Cost), QueryPlanningError> {
         const INDENT: &str = "";
-
-        let search_patterns: HashSet<_> = self.graph.pattern_to_variable.keys().copied().collect();
-        let num_patterns = search_patterns.len();
-
         const BEAM_REDUCTION_CYCLE: usize = 2;
         const EXTENSION_REDUCTION_CYCLE: usize = 2;
+        let num_patterns = graph.pattern_to_variable.len();
         let mut beam_width = (num_patterns * 2).clamp(2, MAX_BEAM_WIDTH);
         let mut extension_width = (num_patterns / 2) + 5; // ensure this is larger than (num_patterns / 2) or change narrowing logic (note, join options means patterns may appear twice as extensions)
-
         let mut best_partial_plans = Vec::with_capacity(beam_width);
-        best_partial_plans.push(PartialCostPlan::new(
-            self.graph.elements.len(),
-            search_patterns.clone(),
-            self.input_variables(),
-        ));
+        best_partial_plans.push(initial_empty_plan);
 
         let mut extension_heap = BinaryHeap::with_capacity(extension_width); // reused
         let mut new_plans_heap = BinaryHeap::with_capacity(beam_width);
@@ -659,23 +706,12 @@ impl<'a> ConjunctionPlanBuilder<'a> {
 
             new_plans_heap.clear();
             for plan in best_partial_plans.drain(..) {
-                event!(
-                    Level::TRACE,
-                    "{INDENT:8}PLAN: {:?} ONGOING: {:?} STASH: {:?} COST: {:?} + {:?} = {:?} HEURISTIC: {:?}",
-                    plan.vertex_ordering,
-                    plan.ongoing_step,
-                    plan.ongoing_step_stash,
-                    plan.cumulative_cost,
-                    plan.ongoing_step_cost,
-                    plan.cumulative_cost.chain(plan.ongoing_step_cost),
-                    plan.heuristic
-                );
-
+                trace_plan!("pop", plan);
                 debug_assert!(extension_heap.is_empty());
                 // Add best k extensions from this plan to new_plan_heap (k = extension_width)
-                for extension in plan.extensions_iter(&self.graph) {
+                for extension in plan.extensions_iter(&graph) {
                     let extension = extension?;
-                    if extension.is_trivial(&self.graph) {
+                    if extension.is_trivial(&graph) {
                         extension_heap.clear();
                         extension_heap.push(Reverse(extension));
                         break;
@@ -684,25 +720,35 @@ impl<'a> ConjunctionPlanBuilder<'a> {
                     }
                 }
                 for Reverse(extension) in drain_sorted(&mut extension_heap).take(extension_width) {
-                    new_plans_heap.push(Reverse(plan.extend_with(&self.graph, extension)));
+                    new_plans_heap.push(Reverse(plan.extend_with(&graph, extension)));
                 }
             }
             // Pick best (k = beam_width) plans to beam.
             debug_assert!(best_partial_plans.is_empty());
             new_plans_hashset.clear();
-            for Reverse(plan) in drain_sorted(&mut new_plans_heap) {
+            let mut draining = drain_sorted(&mut new_plans_heap);
+            while let Some(Reverse(plan)) = draining.next() {
                 if new_plans_hashset.insert(plan.hash()) {
+                    trace_plan!("added", plan);
                     best_partial_plans.push(plan);
                     if best_partial_plans.len() >= beam_width {
                         break;
                     }
+                } else {
+                    trace_plan!("hash collision", plan);
+                }
+            }
+            #[cfg(debug_assertions)]
+            {
+                while let Some(Reverse(plan)) = draining.next() {
+                    trace_plan!("discarded", plan);
                 }
             }
         }
 
         let best_plan =
             best_partial_plans.into_iter().min().ok_or(QueryPlanningError::ExpectedPlannableConjunction {})?;
-        let complete_plan = best_plan.into_complete_plan(&self.graph);
+        let complete_plan = best_plan.into_complete_plan(&graph);
         event!(
             Level::TRACE,
             "\n Final plan (before lowering):\n --> Order: {:?} --> MetaData \n {:?}",
@@ -710,26 +756,6 @@ impl<'a> ConjunctionPlanBuilder<'a> {
             complete_plan.pattern_metadata
         );
         Ok((complete_plan.vertex_ordering, complete_plan.pattern_metadata, complete_plan.cumulative_cost))
-    }
-
-    // Execute plans
-    pub(super) fn plan(self) -> Result<ConjunctionPlan<'a>, QueryPlanningError> {
-        // Beam plan
-        let (ordering, metadata, cost) = self.beam_search_plan()?;
-
-        let element_to_order = ordering.iter().copied().enumerate().map(|(order, index)| (index, order)).collect();
-
-        let Self { graph, local_annotations: type_annotations, mut planner_statistics, .. } = self;
-
-        planner_statistics.finalize(cost);
-        Ok(ConjunctionPlan {
-            graph,
-            local_annotations: type_annotations,
-            ordering,
-            metadata,
-            element_to_order,
-            planner_statistics,
-        })
     }
 }
 

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -97,6 +97,7 @@ pub const VARIABLE_PRODUCTION_ADVANTAGE: f64 = 0.05; // this is a percentage 0.0
 typedb_error! {
     pub QueryPlanningError(component = "Query Planner", prefix = "QPL") {
         ExpectedPlannableConjunction(1, "Planning failed as no valid pattern ordering was found by the query planner (this is a bug!)"),
+        UnimplementedJoinForConstraint(2, "The planner expected a join, but it is not supported for this constraint"),
     }
 }
 
@@ -936,9 +937,9 @@ impl PartialCostPlan {
                         join_var,
                         &self.ongoing_step_produced_vars,
                         &self.all_produced_vars,
-                    ); // TODO: we only allow unbounded regular joins for now
+                    )?; // TODO: we only allow unbounded regular joins for now
                     let (constraint_cost, metadata) =
-                        constraint.cost_and_metadata(&self.vertex_ordering, fixed_direction, graph)?;
+                        constraint.cost_and_metadata(&self.vertex_ordering, Some(fixed_direction), graph)?;
                     let step_cost = self.ongoing_step_cost.join(constraint_cost, total_join_size);
                     (self.cumulative_cost, step_cost, metadata)
                 } else {

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -255,7 +255,7 @@ impl Costed for PlannerVertex<'_> {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CostMetaData {
-    Direction(Direction), // Cheapest direction of individual constraints
+    Direction(Direction, Option<VariableVertexId>), // Cheapest direction of individual constraints + SortVariable
     // Pushdown(Pushdown), // Pushdown constraints from function calls if they are very selective
     // Split(Split), // Split negation into disjunctions if one part expensive and low selectivity
     // Sort(Binding), // Produce sorted iterator for var with binding (easy e.g. for monotone functions)


### PR DESCRIPTION
## Product change and motivation
Updates the metadata tracked by the planner to include the variable which each pattern is sorted on, and can be joined on. Though this can be derived from the direction & bound variables, the code is much simpler when we store it and avoids the planner & lowering independently re-deriving it.

## Implementation
* Updates CostMetaData::Direction to include the join variable alongside the direction.
* Simplifies the code to determine whether two steps can be joined.