### PR TITLE
Add HTTP authentication action diagnostics counts

### DIFF
--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -75,8 +75,6 @@ pub mod server {
 
     pub const DATABASE_METRICS_UPDATE_INTERVAL: Duration = Duration::from_secs(10 * SECONDS_IN_MINUTE);
 
-    pub const DEFAULT_ADDRESS: &str = "0.0.0.0:1729";
-    pub const DEFAULT_HTTP_ADDRESS: &str = "0.0.0.0:8000";
     pub const DEFAULT_USER_NAME: &str = "admin";
     pub const DEFAULT_USER_PASSWORD: &str = "password";
     pub const DEFAULT_DATA_DIR: &str = "data";

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -355,50 +355,15 @@ impl TransactionService {
                 match request {
                     TransactionRequest::Query(query_options, query) => {
                         self.handle_query(query_options, query, response_sender).await
-                        // run_with_diagnostics_async(
-                        //     self.diagnostics_manager.clone(),
-                        //     self.get_database_name().map(|name| name.to_owned()),
-                        //     ActionKind::TransactionQuery,
-                        //     || async { self.handle_query(query, response_sender).await },
-                        // )
-                        //     .await
                     }
                     TransactionRequest::Commit => {
                         self.handle_commit(response_sender).await
-                        // run_with_diagnostics_async(
-                        //     self.diagnostics_manager.clone(),
-                        //     self.get_database_name().map(|name| name.to_owned()),
-                        //     ActionKind::TransactionCommit,
-                        //     || async {
-                        //         // Eagerly executed in main loop
-                        //         self.handle_commit(response_sender).await?;
-                        //         Ok(Break(()))
-                        //     },
-                        // )
-                        //     .await
                     }
                     TransactionRequest::Rollback => {
                         self.handle_rollback(response_sender).await
-                        // run_with_diagnostics_async(
-                        //     self.diagnostics_manager.clone(),
-                        //     self.get_database_name().map(|name| name.to_owned()),
-                        //     ActionKind::TransactionRollback,
-                        //     || async { self.handle_rollback(response_sender).await },
-                        // )
-                        //     .await
                     }
                     TransactionRequest::Close => {
                         self.handle_close(response_sender).await
-                        // run_with_diagnostics_async(
-                        //     self.diagnostics_manager.clone(),
-                        //     self.get_database_name().map(|name| name.to_owned()),
-                        //     ActionKind::TransactionClose,
-                        //     || async {
-                        //         self.handle_close(response_sender).await;
-                        //         Ok(Break(()))
-                        //     },
-                        // )
-                        //     .await
                     }
                 }
             }


### PR DESCRIPTION
## Product change and motivation
Add diagnostics reporting for authentication actions performed through the HTTP endpoint.

Previously, due to its excessive usage for every request and low value, we ignored this method. However, it's the most efficient metric to understand the usage of the HTTP endpoint of the server, so it is a valuable piece of usage metrics for us. 

## Implementation
We additionally cleanup some unused code and comments.