### PR TITLE
Improve intersection cost estimate, granular query plan cache eviction

### DIFF
--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -37,6 +37,10 @@ impl BlockAnnotations {
     pub(crate) fn into_parts(self) -> HashMap<ScopeId, TypeAnnotations> {
         self.scope_annotations
     }
+
+    pub(crate) fn referenced_types(&self) -> BTreeSet<Type> {
+        self.scope_annotations.values().flat_map(|ta| ta.vertex.values().map(|v| &**v)).flatten().copied().collect()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -53,6 +53,7 @@ pub mod tests {
     };
 
     use answer::{variable::Variable, Type};
+    use assert as assert_true;
     use encoding::{
         graph::definition::definition_key::{DefinitionID, DefinitionKey},
         layout::prefix::Prefix,
@@ -95,7 +96,6 @@ pub mod tests {
         type_seeder::TypeGraphSeedingContext,
         TypeInferenceError,
     };
-    use assert as assert_true;
 
     #[test]
     fn test_functions() {

--- a/compiler/executable/fetch/executable.rs
+++ b/compiler/executable/fetch/executable.rs
@@ -134,7 +134,7 @@ fn compile_some(
         }
         AnnotatedFetchSome::ListSubFetch(sub_fetch) => {
             let AnnotatedFetchListSubFetch { variable_registry, input_variables, stages, fetch } = sub_fetch;
-            let (input_positions, compiled_stages, compiled_fetch) = compile_stages_and_fetch(
+            let (input_positions, compiled_stages, compiled_fetch, _) = compile_stages_and_fetch(
                 statistics,
                 &variable_registry,
                 available_functions,

--- a/compiler/executable/match_/planner/mod.rs
+++ b/compiler/executable/match_/planner/mod.rs
@@ -27,8 +27,8 @@ use crate::{
             instructions::{CheckInstruction, ConstraintInstruction},
             planner::{
                 conjunction_executable::{
-                    AssignmentStep, CheckStep, DisjunctionStep, ExecutionStep, FunctionCallStep, IntersectionStep,
-                    ConjunctionExecutable, NegationStep,
+                    AssignmentStep, CheckStep, ConjunctionExecutable, DisjunctionStep, ExecutionStep, FunctionCallStep,
+                    IntersectionStep, NegationStep,
                 },
                 plan::{plan_conjunction, PlannerStatistics, QueryPlanningError},
             },

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -194,9 +194,7 @@ impl Cost {
     pub(crate) fn join(self, other: Self, join_size: f64) -> Self {
         let io_ratio = f64::max(self.io_ratio * other.io_ratio / join_size, Cost::MIN_IO_RATIO);
         let num_seeks = f64::min(self.io_ratio, other.io_ratio); // FIXME detect when seeks can be replaced by advancing
-                                                                 // if cost = Ci + Co * io
-                                                                 // cost / io ~ Co
-        let self_out_cost = self.cost / self.io_ratio;
+        let self_out_cost = self.cost / self.io_ratio; // if cost = Ci + Co * io, then cost / io ~ Co
         let other_out_cost = other.cost / other.io_ratio;
         let cost_self = SEEK_ITERATOR_RELATIVE_COST + self_out_cost * num_seeks;
         let cost_other = SEEK_ITERATOR_RELATIVE_COST + other_out_cost * num_seeks;

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -193,15 +193,12 @@ impl Cost {
 
     pub(crate) fn join(self, other: Self, join_size: f64) -> Self {
         let io_ratio = f64::max(self.io_ratio * other.io_ratio / join_size, Cost::MIN_IO_RATIO);
-        let num_seeks = f64::min(self.io_ratio, other.io_ratio); // FIXME detect when seeks can be replaced by advancing
+        let num_seeks_each = f64::min(self.io_ratio, other.io_ratio); // FIXME detect when seeks can be replaced by advancing
         let self_out_cost = self.cost / self.io_ratio; // if cost = Ci + Co * io, then cost / io ~ Co
         let other_out_cost = other.cost / other.io_ratio;
-        let cost_self = SEEK_ITERATOR_RELATIVE_COST + self_out_cost * num_seeks;
-        let cost_other = SEEK_ITERATOR_RELATIVE_COST + other_out_cost * num_seeks;
-        Self {
-            cost: cost_self + cost_other, // We expect to seek once per intersection on average
-            io_ratio,
-        }
+        let cost_self = SEEK_ITERATOR_RELATIVE_COST + self_out_cost * num_seeks_each;
+        let cost_other = SEEK_ITERATOR_RELATIVE_COST + other_out_cost * num_seeks_each;
+        Self { cost: cost_self + cost_other, io_ratio }
     }
 
     pub(crate) fn combine_parallel(self, other: Self) -> Self {

--- a/compiler/executable/match_/planner/vertex/mod.rs
+++ b/compiler/executable/match_/planner/vertex/mod.rs
@@ -194,12 +194,12 @@ impl Cost {
     pub(crate) fn join(self, other: Self, join_size: f64) -> Self {
         let io_ratio = f64::max(self.io_ratio * other.io_ratio / join_size, Cost::MIN_IO_RATIO);
         let num_seeks = f64::min(self.io_ratio, other.io_ratio); // FIXME detect when seeks can be replaced by advancing
-        // if cost = Ci + Co * io
-        // cost / io ~ Co
+                                                                 // if cost = Ci + Co * io
+                                                                 // cost / io ~ Co
         let self_out_cost = self.cost / self.io_ratio;
         let other_out_cost = other.cost / other.io_ratio;
         let cost_self = SEEK_ITERATOR_RELATIVE_COST + self_out_cost * num_seeks;
-        let cost_other = SEEK_ITERATOR_RELATIVE_COST +  other_out_cost * num_seeks;
+        let cost_other = SEEK_ITERATOR_RELATIVE_COST + other_out_cost * num_seeks;
         Self {
             cost: cost_self + cost_other, // We expect to seek once per intersection on average
             io_ratio,

--- a/compiler/executable/pipeline.rs
+++ b/compiler/executable/pipeline.rs
@@ -50,10 +50,10 @@ impl TypePopulations {
     fn update(&mut self, types: &BTreeSet<Type>, statistics: &Statistics) {
         for &ty in types {
             self.counts.entry(ty).or_insert_with(|| match ty {
-                Type::Entity(ty) => statistics.entity_counts[&ty],
-                Type::Relation(ty) => statistics.relation_counts[&ty],
-                Type::Attribute(ty) => statistics.attribute_counts[&ty],
-                Type::RoleType(ty) => statistics.role_counts[&ty],
+                Type::Entity(ty) => statistics.entity_counts.get(&ty).copied().unwrap_or_default(),
+                Type::Relation(ty) => statistics.relation_counts.get(&ty).copied().unwrap_or_default(),
+                Type::Attribute(ty) => statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
+                Type::RoleType(ty) => statistics.role_counts.get(&ty).copied().unwrap_or_default(),
             });
         }
     }

--- a/compiler/executable/put/mod.rs
+++ b/compiler/executable/put/mod.rs
@@ -10,7 +10,8 @@ use answer::variable::Variable;
 
 use crate::{
     executable::{
-        insert::executable::InsertExecutable, match_::planner::conjunction_executable::ConjunctionExecutable, next_executable_id,
+        insert::executable::InsertExecutable, match_::planner::conjunction_executable::ConjunctionExecutable,
+        next_executable_id,
     },
     VariablePosition,
 };

--- a/compiler/query_structure.rs
+++ b/compiler/query_structure.rs
@@ -196,19 +196,24 @@ impl<'a> ParametrisedQueryStructureBuilder<'a> {
                     .stages
                     .push(QueryStructureStage::Delete { block, deleted_variables: vec_from(deleted_variables.iter()) });
             }
-            AnnotatedStage::Select(select) => {
-                self.query_structure.stages.push(QueryStructureStage::Select { variables: vec_from(select.variables.iter()) })
-            }
-            AnnotatedStage::Sort(sort) => {
-                self.query_structure.stages.push(QueryStructureStage::Sort { variables: vec_from(sort.variables.iter()) })
-            }
+            AnnotatedStage::Select(select) => self
+                .query_structure
+                .stages
+                .push(QueryStructureStage::Select { variables: vec_from(select.variables.iter()) }),
+            AnnotatedStage::Sort(sort) => self
+                .query_structure
+                .stages
+                .push(QueryStructureStage::Sort { variables: vec_from(sort.variables.iter()) }),
             AnnotatedStage::Offset(offset) => {
                 self.query_structure.stages.push(QueryStructureStage::Offset { offset: offset.offset() })
             }
-            AnnotatedStage::Limit(limit) => self.query_structure.stages.push(QueryStructureStage::Limit { limit: limit.limit() }),
-            AnnotatedStage::Require(require) => {
-                self.query_structure.stages.push(QueryStructureStage::Require { variables: vec_from(require.variables.iter()) })
+            AnnotatedStage::Limit(limit) => {
+                self.query_structure.stages.push(QueryStructureStage::Limit { limit: limit.limit() })
             }
+            AnnotatedStage::Require(require) => self
+                .query_structure
+                .stages
+                .push(QueryStructureStage::Require { variables: vec_from(require.variables.iter()) }),
             AnnotatedStage::Distinct(_) => self.query_structure.stages.push(QueryStructureStage::Distinct),
             AnnotatedStage::Reduce(reduce, _) => self.query_structure.stages.push(QueryStructureStage::Reduce {
                 reducers: vec_from(reduce.assigned_reductions.iter()),

--- a/concept/type_/mod.rs
+++ b/concept/type_/mod.rs
@@ -304,11 +304,11 @@ impl TypeQLSyntax for StructDefinition {
         type_manager: &TypeManager,
     ) -> Result<(), Box<ConceptReadError>> {
         write!(f, "\n{} {}:", typeql::token::Keyword::Struct, &self.name).map_err(|err| Box::new(err.into()))?;
-        for (name, id) in self.field_names.iter().sorted_by_key(|(field_name, _)| field_name.clone()) {
+        for (name, id) in self.field_names.iter().sorted_by_key(|&(field_name, _)| field_name) {
             let field_definition = self.fields.get(id).unwrap();
             let optional_syntax = if field_definition.optional { typeql::token::Char::Question.as_str() } else { "" };
             write!(f, "\n  {} {} ", name, typeql::token::Keyword::Value).map_err(|err| Box::new(err.into()))?;
-            (&field_definition.value_type).format_syntax(f, snapshot, type_manager)?;
+            field_definition.value_type.format_syntax(f, snapshot, type_manager)?;
             write!(f, "{},", optional_syntax).map_err(|err| Box::new(err.into()))?;
         }
         write!(f, "\n  ;").map_err(|err| Box::new(err.into()))

--- a/database/database.rs
+++ b/database/database.rs
@@ -524,7 +524,7 @@ fn make_update_statistics_fn(
             let _schema_txn_guard = schema_txn_lock.read().unwrap(); // prevent Schema txns from opening during statistics update
             let mut new_statistics = (*schema.read().unwrap().thing_statistics).clone();
             new_statistics.may_synchronise(&storage).expect("Statistics sync failed");
-            query_cache.may_reset(&new_statistics);
+            query_cache.may_evict(&new_statistics);
             schema.write().unwrap().thing_statistics = Arc::new(new_statistics);
         }
     }

--- a/durability/wal.rs
+++ b/durability/wal.rs
@@ -608,12 +608,12 @@ impl Drop for FsyncThread {
 mod test {
     use std::borrow::Cow;
 
+    use assert as assert_true;
     use itertools::Itertools;
     use tempdir::TempDir;
 
     use super::WAL;
     use crate::{DurabilityRecordType, DurabilitySequenceNumber, DurabilityService, RawRecord};
-    use assert as assert_true;
     #[derive(Debug, PartialEq, Eq, Clone, Copy)]
     struct TestRecord {
         bytes: [u8; 4],

--- a/executor/conjunction_executor.rs
+++ b/executor/conjunction_executor.rs
@@ -6,7 +6,9 @@
 
 use std::sync::Arc;
 
-use compiler::executable::{function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable};
+use compiler::executable::{
+    function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
+};
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use lending_iterator::{adaptors::FlatMap, AsLendingIterator, LendingIterator};
 use resource::profile::QueryProfile;
@@ -16,7 +18,9 @@ use crate::{
     batch::{FixedBatch, FixedBatchRowIterator},
     error::ReadExecutionError,
     pipeline::stage::ExecutionContext,
-    read::{create_pattern_executor_for_conjunction, pattern_executor::PatternExecutor, tabled_functions::TabledFunctions},
+    read::{
+        create_pattern_executor_for_conjunction, pattern_executor::PatternExecutor, tabled_functions::TabledFunctions,
+    },
     row::MaybeOwnedRow,
     ExecutionInterrupt,
 };

--- a/executor/instruction/indexed_relation_executor.rs
+++ b/executor/instruction/indexed_relation_executor.rs
@@ -698,10 +698,10 @@ where
             Option<RoleType>,
             Option<RoleType>,
         ) = (
-            self.fixed_bounds.from.clone(),
-            self.fixed_bounds.to.clone(),
-            self.fixed_bounds.relation_type_id.clone(),
-            self.fixed_bounds.relation_id.clone(),
+            self.fixed_bounds.from,
+            self.fixed_bounds.to,
+            self.fixed_bounds.relation_type_id,
+            self.fixed_bounds.relation_id,
             None,
             None,
         );

--- a/executor/lib.rs
+++ b/executor/lib.rs
@@ -14,10 +14,10 @@ use ir::pattern::BranchID;
 use tokio::sync::broadcast::error::TryRecvError;
 
 pub mod batch;
+pub mod conjunction_executor;
 pub mod document;
 pub mod error;
 pub(crate) mod instruction;
-pub mod conjunction_executor;
 pub mod pipeline;
 pub mod read;
 pub(crate) mod reduce_executor;

--- a/executor/pipeline/match_.rs
+++ b/executor/pipeline/match_.rs
@@ -6,14 +6,16 @@
 
 use std::{iter::Peekable, sync::Arc};
 
-use compiler::executable::{function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable};
+use compiler::executable::{
+    function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
+};
 use itertools::{Itertools, UniqueBy};
 use lending_iterator::{adaptors::Map, IntoIter, LendingIterator};
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
-    error::ReadExecutionError,
     conjunction_executor::{ConjunctionExecutor, PatternIterator},
+    error::ReadExecutionError,
     pipeline::{
         stage::{ExecutionContext, StageAPI},
         PipelineExecutionError, StageIterator,

--- a/executor/pipeline/pipeline.rs
+++ b/executor/pipeline/pipeline.rs
@@ -138,8 +138,11 @@ impl<Snapshot: ReadableSnapshot + 'static> Pipeline<Snapshot, ReadPipelineStage<
         for executable_stage in executable_stages {
             match executable_stage {
                 ExecutableStage::Match(conjunction_executable) => {
-                    let match_stage =
-                        MatchStageExecutor::new(conjunction_executable.clone(), last_stage, executable_functions.clone());
+                    let match_stage = MatchStageExecutor::new(
+                        conjunction_executable.clone(),
+                        last_stage,
+                        executable_functions.clone(),
+                    );
                     last_stage = ReadPipelineStage::Match(Box::new(match_stage));
                 }
                 ExecutableStage::Insert(_) => {

--- a/executor/pipeline/put.rs
+++ b/executor/pipeline/put.rs
@@ -15,8 +15,8 @@ use storage::snapshot::{ReadableSnapshot, WritableSnapshot};
 
 use crate::{
     batch::Batch,
-    error::ReadExecutionError,
     conjunction_executor::ConjunctionExecutor,
+    error::ReadExecutionError,
     pipeline::{
         stage::{ExecutionContext, StageAPI, StageIterator},
         PipelineExecutionError, WrittenRowsIterator,

--- a/executor/read/mod.rs
+++ b/executor/read/mod.rs
@@ -6,7 +6,9 @@
 
 use std::sync::Arc;
 
-use compiler::executable::{function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable};
+use compiler::executable::{
+    function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
+};
 use concept::{error::ConceptReadError, thing::thing_manager::ThingManager};
 use resource::profile::QueryProfile;
 use storage::snapshot::ReadableSnapshot;

--- a/executor/read/step_executor.rs
+++ b/executor/read/step_executor.rs
@@ -12,7 +12,7 @@ use compiler::{
             executable::{ExecutableFunction, ExecutableReturn},
             ExecutableFunctionRegistry, FunctionTablingType,
         },
-        match_::planner::conjunction_executable::{ExecutionStep, ConjunctionExecutable},
+        match_::planner::conjunction_executable::{ConjunctionExecutable, ExecutionStep},
         next_executable_id,
         pipeline::ExecutableStage,
     },

--- a/executor/tests/compile_execute.rs
+++ b/executor/tests/compile_execute.rs
@@ -14,7 +14,9 @@ use compiler::{
         expression::block_compiler::compile_expressions, function::EmptyAnnotatedFunctionSignatures,
         match_inference::infer_types,
     },
-    executable::{function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable},
+    executable::{
+        function::ExecutableFunctionRegistry, match_::planner::conjunction_executable::ConjunctionExecutable,
+    },
 };
 use concept::{
     thing::{statistics::Statistics, thing_manager::ThingManager},
@@ -22,7 +24,8 @@ use concept::{
 };
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use executor::{
-    conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow, ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
+    ExecutionInterrupt,
 };
 use function::function_manager::FunctionManager;
 use ir::{
@@ -973,7 +976,8 @@ fn test_mismatched_input_types() {
             select $x;
         ";
         let snapshot = Arc::new(storage.clone().open_snapshot_read());
-        let conjunction_executable = compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
+        let conjunction_executable =
+            compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
         let executor = ConjunctionExecutor::new(
             &conjunction_executable,
             &snapshot,
@@ -1007,7 +1011,8 @@ fn test_mismatched_input_types() {
             distinct;
         ";
         let snapshot = Arc::new(storage.clone().open_snapshot_read());
-        let conjunction_executable = compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
+        let conjunction_executable =
+            compile_query(&*snapshot, &type_manager, thing_manager.clone(), &statistics, query);
         let executor = ConjunctionExecutor::new(
             &conjunction_executable,
             &snapshot,

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -25,7 +25,7 @@ use compiler::{
                 CheckInstruction, CheckVertex, ConstraintInstruction, Inputs,
             },
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -42,8 +42,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::{

--- a/executor/tests/execute_comparison_check.rs
+++ b/executor/tests/execute_comparison_check.rs
@@ -18,7 +18,7 @@ use compiler::{
         match_::{
             instructions::{thing::IsaInstruction, CheckInstruction, CheckVertex, ConstraintInstruction, Inputs},
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -29,8 +29,8 @@ use compiler::{
 use concept::type_::{annotation::AnnotationIndependent, attribute_type::AttributeTypeAnnotation};
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::{Comparator, IsaKind},

--- a/executor/tests/execute_has.rs
+++ b/executor/tests/execute_has.rs
@@ -21,7 +21,7 @@ use compiler::{
                 ConstraintInstruction, Inputs,
             },
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -35,8 +35,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,

--- a/executor/tests/execute_isa.rs
+++ b/executor/tests/execute_isa.rs
@@ -21,7 +21,7 @@ use compiler::{
                 ConstraintInstruction, Inputs,
             },
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -31,8 +31,8 @@ use compiler::{
 };
 use encoding::value::label::Label;
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::{constraint::IsaKind, Vertex},

--- a/executor/tests/execute_links.rs
+++ b/executor/tests/execute_links.rs
@@ -21,7 +21,7 @@ use compiler::{
                 ConstraintInstruction, Inputs,
             },
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -38,8 +38,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,

--- a/executor/tests/execute_relation_index.rs
+++ b/executor/tests/execute_relation_index.rs
@@ -21,7 +21,7 @@ use compiler::{
                 CheckInstruction, CheckVertex, ConstraintInstruction, Inputs,
             },
             planner::{
-                conjunction_executable::{CheckStep, ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{CheckStep, ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -35,8 +35,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::{

--- a/executor/tests/execute_select.rs
+++ b/executor/tests/execute_select.rs
@@ -18,7 +18,7 @@ use compiler::{
         match_::{
             instructions::{thing::HasInstruction, ConstraintInstruction, Inputs},
             planner::{
-                conjunction_executable::{ExecutionStep, IntersectionStep, ConjunctionExecutable},
+                conjunction_executable::{ConjunctionExecutable, ExecutionStep, IntersectionStep},
                 plan::PlannerStatistics,
             },
         },
@@ -32,8 +32,8 @@ use concept::{
 };
 use encoding::value::{label::Label, value::Value, value_type::ValueType};
 use executor::{
-    error::ReadExecutionError, conjunction_executor::ConjunctionExecutor, pipeline::stage::ExecutionContext, row::MaybeOwnedRow,
-    ExecutionInterrupt,
+    conjunction_executor::ConjunctionExecutor, error::ReadExecutionError, pipeline::stage::ExecutionContext,
+    row::MaybeOwnedRow, ExecutionInterrupt,
 };
 use ir::{
     pattern::constraint::IsaKind,

--- a/ir/pattern/disjunction.rs
+++ b/ir/pattern/disjunction.rs
@@ -33,7 +33,7 @@ impl Disjunction {
         Self::default()
     }
 
-    pub fn conjunctions_by_branch_id(&self) -> impl Iterator<Item=(&BranchID, &Conjunction)> {
+    pub fn conjunctions_by_branch_id(&self) -> impl Iterator<Item = (&BranchID, &Conjunction)> {
         self.branch_ids.iter().zip(self.conjunctions.iter())
     }
 

--- a/ir/tests/pattern.rs
+++ b/ir/tests/pattern.rs
@@ -25,11 +25,16 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut PipelineTranslationContext::new(), &mut ParameterRegistry::new(), &empty_function_index, match_)
-            .unwrap()
-            .finish()
-            .unwrap()
-            .conjunction()
+        translate_match(
+            &mut PipelineTranslationContext::new(),
+            &mut ParameterRegistry::new(),
+            &empty_function_index,
+            match_
+        )
+        .unwrap()
+        .finish()
+        .unwrap()
+        .conjunction()
     );
 
     let query = "match
@@ -46,11 +51,16 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut PipelineTranslationContext::new(), &mut ParameterRegistry::new(), &empty_function_index, match_)
-            .unwrap()
-            .finish()
-            .unwrap()
-            .conjunction()
+        translate_match(
+            &mut PipelineTranslationContext::new(),
+            &mut ParameterRegistry::new(),
+            &empty_function_index,
+            match_
+        )
+        .unwrap()
+        .finish()
+        .unwrap()
+        .conjunction()
     );
 
     let query = "match
@@ -69,11 +79,16 @@ fn build_conjunction_constraints() {
     eprintln!("{:#}\n", match_); // TODO
     eprintln!(
         "{}\n",
-        translate_match(&mut PipelineTranslationContext::new(), &mut ParameterRegistry::new(), &empty_function_index, match_)
-            .unwrap()
-            .finish()
-            .unwrap()
-            .conjunction()
+        translate_match(
+            &mut PipelineTranslationContext::new(),
+            &mut ParameterRegistry::new(),
+            &empty_function_index,
+            match_
+        )
+        .unwrap()
+        .finish()
+        .unwrap()
+        .conjunction()
     );
 
     // let mut block = FunctionalBlock::new();

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -136,7 +136,7 @@ fn add_type_statement(
     for constraint in &type_statement.constraints {
         if !constraint.annotations.is_empty() {
             return Err(Box::new(RepresentationError::UnimplementedLanguageFeature {
-                feature: UnimplementedFeature::QueryingAnnotations
+                feature: UnimplementedFeature::QueryingAnnotations,
             }));
         }
         match &constraint.base {

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -457,7 +457,10 @@ fn create_anonymous_function(
 }
 
 // Given a function body, and the _parent_ translation context, we can reconstruct which are arguments
-fn find_function_body_arguments(parent_context: &PipelineTranslationContext, function_body: &FunctionBody) -> Vec<Variable> {
+fn find_function_body_arguments(
+    parent_context: &PipelineTranslationContext,
+    function_body: &FunctionBody,
+) -> Vec<Variable> {
     let mut arguments = HashSet::new();
     // Note: we rely on the fact that named variables that are "the same" become the same Variable, and the logic of
     //       selecting variables in/out is handled by the translation of the stages

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -70,7 +70,7 @@ impl QueryCache {
                         Type::Attribute(ty) => new_statistics.attribute_counts[&ty],
                         Type::RoleType(_) => 1, // uhhh
                     };
-                    match u64::min(type_count, 1) as f64 / u64::min(pop, 1) as f64 {
+                    match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
                         increase @ 1.0.. => total_increase *= increase,
                         decrease @ ..1.0 => total_decrease /= decrease,
                         _ => panic!("NaN?!"),

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -5,9 +5,8 @@
  */
 
 use std::{
-    collections::HashMap,
     hash::{DefaultHasher, Hash, Hasher},
-    sync::{Arc, Mutex},
+    sync::Arc,
 };
 
 use answer::Type;
@@ -63,12 +62,12 @@ impl QueryCache {
             .invalidate_entries_if(move |_, pipeline| {
                 let mut total_increase = 1.0;
                 let mut total_decrease = 1.0;
-                for (&ty, &pop) in &pipeline.type_pop {
+                for (&ty, &pop) in &pipeline.type_populations {
                     let type_count = match ty {
                         Type::Entity(ty) => new_statistics.entity_counts[&ty],
                         Type::Relation(ty) => new_statistics.relation_counts[&ty],
                         Type::Attribute(ty) => new_statistics.attribute_counts[&ty],
-                        Type::RoleType(_) => 1, // uhhh
+                        Type::RoleType(ty) => new_statistics.role_counts[&ty],
                     };
                     match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
                         increase @ 1.0.. => total_increase *= increase,

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -64,10 +64,10 @@ impl QueryCache {
                 let mut total_decrease = 1.0;
                 for (&ty, &pop) in &pipeline.type_populations {
                     let type_count = match ty {
-                        Type::Entity(ty) => new_statistics.entity_counts[&ty],
-                        Type::Relation(ty) => new_statistics.relation_counts[&ty],
-                        Type::Attribute(ty) => new_statistics.attribute_counts[&ty],
-                        Type::RoleType(ty) => new_statistics.role_counts[&ty],
+                        Type::Entity(ty) => new_statistics.entity_counts.get(&ty).copied().unwrap_or_default(),
+                        Type::Relation(ty) => new_statistics.relation_counts.get(&ty).copied().unwrap_or_default(),
+                        Type::Attribute(ty) => new_statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
+                        Type::RoleType(ty) => new_statistics.role_counts.get(&ty).copied().unwrap_or_default(),
                     };
                     match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
                         increase @ 1.0.. => total_increase *= increase,

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -168,7 +168,7 @@ impl QueryManager {
                     &annotated_pipeline.annotated_stages,
                     source_query,
                 )
-                .map(|query_structure| Arc::new(query_structure));
+                .map(Arc::new);
 
                 apply_transformations(snapshot.as_ref(), type_manager, &mut annotated_pipeline).map_err(|err| {
                     QueryError::Transformation { source_query: source_query.to_string(), typedb_source: err }
@@ -199,7 +199,7 @@ impl QueryManager {
             }
         };
 
-        let ExecutablePipeline { executable_functions, executable_stages, executable_fetch, query_structure } =
+        let ExecutablePipeline { executable_functions, executable_stages, executable_fetch, query_structure, .. } =
             executable_pipeline;
 
         // 4: Executor
@@ -318,7 +318,7 @@ impl QueryManager {
                     &annotated_pipeline.annotated_stages,
                     source_query,
                 )
-                .map(|query_structure| Arc::new(query_structure));
+                .map(Arc::new);
 
                 match apply_transformations(&snapshot, type_manager, &mut annotated_pipeline) {
                     Ok(_) => {}
@@ -366,7 +366,7 @@ impl QueryManager {
             }
         };
 
-        let ExecutablePipeline { executable_functions, executable_stages, executable_fetch, query_structure } =
+        let ExecutablePipeline { executable_functions, executable_stages, executable_fetch, query_structure, .. } =
             executable_pipeline;
 
         // 4: Executor

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -89,7 +89,7 @@ pub mod database {
 
     // anything lower than 2.0 will cause too much replanning
     // anything over 8.0 often does not plan frequently enough, as the data scales
-    pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 6.0;
+    pub const QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION: f64 = 3.0;
     pub const QUERY_PLAN_CACHE_SIZE: u64 = 100;
     pub const STATISTICS_DURABLE_WRITE_CHANGE_COUNT: u64 = 10_000;
     pub const STATISTICS_DURABLE_WRITE_SEQ_NUMBERS: usize = 1_000;

--- a/server/parameters/config.rs
+++ b/server/parameters/config.rs
@@ -277,6 +277,7 @@ impl ConfigBuilder {
 pub mod tests {
     use std::path::PathBuf;
 
+    use assert as assert_true;
     use clap::Parser;
 
     use crate::parameters::{
@@ -284,7 +285,6 @@ pub mod tests {
         config::{Config, ConfigBuilder},
         ConfigError,
     };
-    use assert as assert_true;
 
     fn config_path() -> PathBuf {
         #[cfg(feature = "bazel")]

--- a/server/service/http/transaction_service.rs
+++ b/server/service/http/transaction_service.rs
@@ -351,22 +351,14 @@ impl TransactionService {
     async fn handle_next(&mut self, next: Option<(TransactionRequest, TransactionResponder)>) -> ControlFlow<(), ()> {
         match next {
             None => Break(()),
-            Some((request, response_sender)) => {
-                match request {
-                    TransactionRequest::Query(query_options, query) => {
-                        self.handle_query(query_options, query, response_sender).await
-                    }
-                    TransactionRequest::Commit => {
-                        self.handle_commit(response_sender).await
-                    }
-                    TransactionRequest::Rollback => {
-                        self.handle_rollback(response_sender).await
-                    }
-                    TransactionRequest::Close => {
-                        self.handle_close(response_sender).await
-                    }
+            Some((request, response_sender)) => match request {
+                TransactionRequest::Query(query_options, query) => {
+                    self.handle_query(query_options, query, response_sender).await
                 }
-            }
+                TransactionRequest::Commit => self.handle_commit(response_sender).await,
+                TransactionRequest::Rollback => self.handle_rollback(response_sender).await,
+                TransactionRequest::Close => self.handle_close(response_sender).await,
+            },
         }
     }
 

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -851,13 +851,14 @@ mod tests {
         thread::{self, JoinHandle},
     };
 
+    use assert as assert_true;
+
     use crate::{
         isolation_manager::{CommitRecord, CommitStatus, CommitType, Timeline, TIMELINE_WINDOW_SIZE},
         keyspace::{KeyspaceId, KeyspaceSet},
         sequence_number::SequenceNumber,
         snapshot::buffer::OperationsBuffer,
     };
-    use assert as assert_true;
     macro_rules! test_keyspace_set {
         {$($variant:ident => $id:literal : $name: literal),* $(,)?} => {
             #[derive(Clone, Copy)]

--- a/tests/behaviour/steps/concept/thing/relation.rs
+++ b/tests/behaviour/steps/concept/thing/relation.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use std::slice;
+
 use concept::{
     thing::object::{Object, ObjectAPI},
     type_::TypeAPI,

--- a/tests/behaviour/steps/connection/transaction.rs
+++ b/tests/behaviour/steps/connection/transaction.rs
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-use std::{sync::Arc};
+use std::sync::Arc;
 
 use cucumber::gherkin::Step;
 use database::{


### PR DESCRIPTION
## Product change and motivation

We improve the cost estimate of an intersection by factoring in the work required to produce each element of the iterators involved. Previously the cost estimate assumed that said cost was limited to fetching a single key on disk, however when a post-filter is applied to a constraint iterator, we may have to fetch multiple keys to produce one that is accepted by all filters.

Additionally, the query plan cache now takes into account the exact types used in the query to make eviction decisions on a plan-by-plan basis.

## Implementation

Other minor improvements:
- short circuit during an intersection if any iterator is empty,
- reduce allocations when iterating extensions during beam search.