### PR TITLE
Skip decompressing WAL records unnecessarily

### DIFF
--- a/server/lib.rs
+++ b/server/lib.rs
@@ -227,7 +227,11 @@ impl Server {
         }
     }
 
-    fn print_serving_information(grpc_address: SocketAddr, http_address: Option<SocketAddr>, encryption_config: &EncryptionConfig) {
+    fn print_serving_information(
+        grpc_address: SocketAddr,
+        http_address: Option<SocketAddr>,
+        encryption_config: &EncryptionConfig,
+    ) {
         if encryption_config.enabled {
             print!("Serving gRPC on {grpc_address}");
             if let Some(http_address) = http_address {


### PR DESCRIPTION
When iterating WAL records starting at a given sequence number, the durability service reads each record along the way. This was not an issue until WAL record compression handling was moved into the durability service from durability client.

This PR adds a way to skip a WAL record without decompressing the contents.