### PR TITLE
Only seek iterators in k-way merge when behind

### DIFF
--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -99,7 +99,12 @@ where
             self.find_next_state();
         }
         if let Some(next_iterator) = &mut self.next_iterator {
-            next_iterator.iter.seek(key);
+            next_iterator.iter.peek();
+            if let Some(item) = next_iterator.iter.get_peeked() {
+                if next_iterator.iter.compare_key(item, key) == Ordering::Less {
+                    next_iterator.iter.seek(key);
+                }
+            }
         }
         self.iterators = mem::take(&mut self.iterators)
             .drain()

--- a/common/lending_iterator/lending_iterator.rs
+++ b/common/lending_iterator/lending_iterator.rs
@@ -235,7 +235,7 @@ impl<LI: LendingIterator> Peekable<LI> {
 
     pub(crate) fn get_peeked(&self) -> Option<&LI::Item<'_>> {
         unsafe {
-            // SAFETY: the item reference borrows this iterator mutably. This iterator cannot be advanced while it exists.
+            // SAFETY: the item reference borrows this iterator. This iterator cannot be advanced while it exists.
             transmute::<Option<&LI::Item<'static>>, Option<&LI::Item<'_>>>(self.item.as_ref())
         }
     }

--- a/executor/instruction/indexed_relation_executor.rs
+++ b/executor/instruction/indexed_relation_executor.rs
@@ -795,7 +795,7 @@ where
         + for<'a> LendingIterator<Item<'a> = Result<(IndexedRelationPlayers, u64), Box<ConceptReadError>>>,
 {
     fn seek(&mut self, target: &Tuple<'_>) -> Result<(), Box<ConceptReadError>> {
-        let target = self.tuple_to_indexed(&target);
+        let target = self.tuple_to_indexed(target);
         lending_iterator::Seekable::seek(&mut self.inner, &Ok((target, 0)));
         Ok(())
     }

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -488,11 +488,11 @@ impl<It: for<'a> LendingIterator<Item<'a> = TupleResult<'static>> + TupleSeekabl
                 None => Ok(None),
                 Some(Ok(peek)) => {
                     match peek.values()[first_unbound_index].partial_cmp(&target_tuple.values()[first_unbound_index]) {
-                        None => return Err(Box::new(ConceptReadError::InternalIncomparableTypes {})),
-                        Some(ordering) => return Ok(Some(ordering)),
+                        None => Err(Box::new(ConceptReadError::InternalIncomparableTypes {})),
+                        Some(ordering) => Ok(Some(ordering)),
                     }
                 }
-                Some(Err(err)) => return Err(err.clone()),
+                Some(Err(err)) => Err(err.clone()),
             }
         } else {
             Ok(Some(Ordering::Greater))

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -118,7 +118,11 @@ impl<I: for<'a> LendingIterator<Item<'a> = TupleResult<'static>> + TupleSeekable
             self.find_next_state();
         }
         if let Some(next_iterator) = &mut self.next_iterator {
-            next_iterator.iter.seek(target)?;
+            if let Some(Ok(item)) = next_iterator.iter.peek() {
+                if item < target {
+                    next_iterator.iter.seek(target)?;
+                }
+            }
         }
         self.iterators = mem::take(&mut self.iterators)
             .drain()


### PR DESCRIPTION
## Product change and motivation

Fix intermittent crashes with `Key behind the stored item in a Peekable iterator` when a roleplayer index constraint is part of a join.

## Implementation

In general, it is considered an error to seek an iterator that is already ahead of the seek target. We cannot seek backwards, and we cannot guarantee that the iterator is pointing at the element one after the target, which is what the caller code expects.

In a `Peekable<I>`, if the peeked item is behind the target, but the tip of the iterator `I` is ahead _and_ the `I` can detect that (being another `Peekable` at some level), we run into an issue where this condition is checked multiple times, causing a crash.

We relax this constraint to only apply to `Peekable`. When `seek` is called, it peeks the current item in the iterator (panicking if `seek` was used incorrectly to avoid illegal state), then, if needed, calls `seek` on the inner iterator which advances unconditionally.

Closes #7577, closes #7446.