### PR TITLE
Replace serializable_response macro with available serde annotations

### DIFF
--- a/executor/read/stream_modifier.rs
+++ b/executor/read/stream_modifier.rs
@@ -274,9 +274,7 @@ impl LastMapper {
 impl StreamModifierResultMapperTrait for LastMapper {
     fn map_output(&mut self, subquery_result: Option<FixedBatch>) -> Option<FixedBatch> {
         if let Some(input_batch) = subquery_result {
-            self.last_row = (!input_batch.is_empty()).then(|| {
-                input_batch.get_row(input_batch.len() - 1).into_owned()
-            });
+            self.last_row = (!input_batch.is_empty()).then(|| input_batch.get_row(input_batch.len() - 1).into_owned());
             Some(FixedBatch::EMPTY) // Retry this instruction without returning any rows
         } else {
             self.last_row.take().map(FixedBatch::from)

--- a/tests/behaviour/service/http/http_steps/message.rs
+++ b/tests/behaviour/service/http/http_steps/message.rs
@@ -412,9 +412,9 @@ impl ConceptResponse {
             ConceptResponse::RelationType(relation_type) => Some(relation_type.label.as_str()),
             ConceptResponse::AttributeType(attribute_type) => Some(attribute_type.label.as_str()),
             ConceptResponse::RoleType(role_type) => Some(role_type.label.as_str()),
-            ConceptResponse::Entity(entity) => entity.type_.as_ref().map(|val| val.label.as_str()),
-            ConceptResponse::Relation(relation) => relation.type_.as_ref().map(|val| val.label.as_str()),
-            ConceptResponse::Attribute(attribute) => attribute.type_.as_ref().map(|val| val.label.as_str()),
+            ConceptResponse::Entity(entity) => entity.r#type.as_ref().map(|val| val.label.as_str()),
+            ConceptResponse::Relation(relation) => relation.r#type.as_ref().map(|val| val.label.as_str()),
+            ConceptResponse::Attribute(attribute) => attribute.r#type.as_ref().map(|val| val.label.as_str()),
             ConceptResponse::Value(value) => Some(value.value_type.as_ref()),
         }
     }

--- a/tests/behaviour/service/http/http_steps/query.rs
+++ b/tests/behaviour/service/http/http_steps/query.rs
@@ -92,9 +92,9 @@ fn check_concept_is_kind(concept: &ConceptResponse, concept_kind: ConceptKind, i
 
 fn concept_get_type(concept: &ConceptResponse) -> ConceptResponse {
     match concept {
-        ConceptResponse::Entity(entity) => ConceptResponse::EntityType(entity.type_.clone().unwrap()),
-        ConceptResponse::Relation(relation) => ConceptResponse::RelationType(relation.type_.clone().unwrap()),
-        ConceptResponse::Attribute(attribute) => ConceptResponse::AttributeType(attribute.type_.clone().unwrap()),
+        ConceptResponse::Entity(entity) => ConceptResponse::EntityType(entity.r#type.clone().unwrap()),
+        ConceptResponse::Relation(relation) => ConceptResponse::RelationType(relation.r#type.clone().unwrap()),
+        ConceptResponse::Attribute(attribute) => ConceptResponse::AttributeType(attribute.r#type.clone().unwrap()),
         _ => panic!("Only instances can have types"),
     }
 }


### PR DESCRIPTION
## Product change and motivation
Replace custom implementation of Serialize for concepts in the HTTP API with the derived serialize and serde annotations.
