### PR TITLE
Fix brew install

### DIFF
--- a/binary/typedb
+++ b/binary/typedb
@@ -4,7 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 # TypeDB global variables
-[[ $(readlink $0) ]] && path=$(readlink $0) || path=$0
+[[ $(readlink -f $0) ]] && path=$(readlink -f $0) || path=$0
 TYPEDB_HOME=$(cd "$(dirname "${path}")" && pwd -P)
 
 

--- a/config/brew/typedb.rb
+++ b/config/brew/typedb.rb
@@ -21,6 +21,6 @@ class Typedb < Formula
 
   def install
     libexec.install Dir["*"]
-    bin.install libexec / "typedb"
+    bin.install_symlink libexec / "typedb"
   end
 end


### PR DESCRIPTION
## Product change and motivation
We now symlink `bin/typedb` to `libexec/typedb` instead of moving. This allows us to maintain the directory structure of the original distribution and allows the `typedb` script to correctly resolve the install directory.

## Implementation
Also needs `readlink -f` to follow the extra hop of symlink.