### PR TITLE
Print ready message only for the same distribution

### DIFF
--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -28,7 +28,7 @@ pub mod server {
         distribution_info::DistributionInfo,
     };
 
-    const DISTRIBUTION: &str = "TypeDB CE";
+    pub const DISTRIBUTION: &str = "TypeDB CE";
     const VERSION: &str = include_str!("../VERSION");
     const ASCII_LOGO: &str = include_str!("typedb-ascii.txt");
     pub const DISTRIBUTION_INFO: DistributionInfo =

--- a/server/lib.rs
+++ b/server/lib.rs
@@ -19,7 +19,8 @@ use database::database_manager::DatabaseManager;
 use rand::prelude::SliceRandom;
 use resource::{
     constants::server::{
-        DISTRIBUTION_INFO, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME, SERVER_ID_LENGTH,
+        DISTRIBUTION, DISTRIBUTION_INFO, GRPC_CONNECTION_KEEPALIVE, SERVER_ID_ALPHABET, SERVER_ID_FILE_NAME,
+        SERVER_ID_LENGTH,
     },
     distribution_info::DistributionInfo,
 };
@@ -205,6 +206,7 @@ impl Server {
                 .server_status()
                 .await
                 .map_err(|typedb_source| ServerOpenError::ServerState { typedb_source })?,
+            self.distribution_info,
             &self.config.server.encryption,
         );
 
@@ -290,7 +292,11 @@ impl Server {
         }
     }
 
-    fn print_serving_information(server_status: BoxServerStatus, encryption_config: &EncryptionConfig) {
+    fn print_serving_information(
+        server_status: BoxServerStatus,
+        distribution_info: DistributionInfo,
+        encryption_config: &EncryptionConfig,
+    ) {
         print!("Serving gRPC on {}", server_status.grpc_address());
         if let Some(http_address) = server_status.http_address() {
             print!(" and HTTP on {http_address}");
@@ -303,7 +309,11 @@ impl Server {
             println!("WARNING: TLS NOT ENABLED. This means connections are insecure and transmit username/password credentials unencrypted over the network.");
             println!("**To allow driver connections, drivers must also be configured to *not* use TLS**")
         }
-        println!("\nReady!");
+
+        if distribution_info.distribution == DISTRIBUTION {
+            // Same distribution -> the initialization is finished.
+            println!("\nReady!");
+        }
     }
 
     fn spawn_shutdown_handler(shutdown_sender: Sender<()>) {

--- a/server/service/typedb_service.rs
+++ b/server/service/typedb_service.rs
@@ -34,7 +34,8 @@ impl TypeDBService {
 
         let user_manager = server_state.user_manager().await.ok_or(LocalServerStateError::NotInitialised {})?;
 
-        let (mut transaction_profile, commit_intent) = user_manager.create(&user, &credential)
+        let (mut transaction_profile, commit_intent) = user_manager
+            .create(&user, &credential)
             .map_err(|(_, typedb_source)| LocalServerStateError::UserCannotBeCreated { typedb_source })?;
 
         let commit_profile = transaction_profile.commit_profile();
@@ -93,7 +94,8 @@ impl TypeDBService {
 
         let user_manager = server_state.user_manager().await.ok_or(LocalServerStateError::NotInitialised {})?;
 
-        let (mut transaction_profile, commit_intent) = user_manager.delete(username)
+        let (mut transaction_profile, commit_intent) = user_manager
+            .delete(username)
             .map_err(|(_, typedb_source)| LocalServerStateError::UserCannotBeDeleted { typedb_source })?;
 
         let commit_profile = transaction_profile.commit_profile();

--- a/server/state.rs
+++ b/server/state.rs
@@ -72,7 +72,10 @@ pub trait ServerState: Debug {
 
     async fn databases_get(&self, name: &str) -> Result<Option<Arc<Database<WALClient>>>, ArcServerStateError>;
 
-    async fn databases_get_unrestricted(&self, name: &str) -> Result<Option<Arc<Database<WALClient>>>, ArcServerStateError>;
+    async fn databases_get_unrestricted(
+        &self,
+        name: &str,
+    ) -> Result<Option<Arc<Database<WALClient>>>, ArcServerStateError>;
 
     async fn databases_contains(&self, name: &str) -> Result<bool, ArcServerStateError>;
 
@@ -388,7 +391,10 @@ impl ServerState for LocalServerState {
         Ok(self.database_manager.database(name))
     }
 
-    async fn databases_get_unrestricted(&self, name: &str) -> Result<Option<Arc<Database<WALClient>>>, ArcServerStateError> {
+    async fn databases_get_unrestricted(
+        &self,
+        name: &str,
+    ) -> Result<Option<Arc<Database<WALClient>>>, ArcServerStateError> {
         Ok(self.database_manager.database_unrestricted(name))
     }
 

--- a/user/user_manager.rs
+++ b/user/user_manager.rs
@@ -128,7 +128,7 @@ impl UserManager {
 
         match delete_result {
             Ok(tuple) => Ok((transaction_profile, tuple)),
-            Err(_) => Err((Some(transaction_profile), UserDeleteError::IllegalUsername {}))
+            Err(_) => Err((Some(transaction_profile), UserDeleteError::IllegalUsername {})),
         }
     }
 }


### PR DESCRIPTION
## Product change and motivation
Restrict the "Ready!" message printed on the bootup to only CE distributions of TypeDB. This allows other distributions with potentially more complicated initialization to handle the readiness notifications themselves.

## Implementation
Comparing `DISTRIBUTION` directly is the easiest path. Introducing another configurable boolean flag is too much for this job. Requiring changing the distribution name for such controls must be a decent tradeoff for such a minor piece, although it's not very clean.