### PR TITLE
Implement abs and rounding functions for Decimal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5216,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=ce6ffc5b25670dd3f35bdb0fcefdf7374eed4638#ce6ffc5b25670dd3f35bdb0fcefdf7374eed4638"
+source = "git+https://github.com/typedb/typedb-protocol?tag=3.7.0-rc0#5235ce7711e43c4895e9bfa3498d740961700adf"
 dependencies = [
  "prost",
  "tonic",
@@ -5256,7 +5256,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=170183b8c1fa2f4d61b11828b17f2a711e3c35f6#170183b8c1fa2f4d61b11828b17f2a711e3c35f6"
+source = "git+https://github.com/typedb/typeql?tag=3.7.0-rc0#6d96bdfed9724faf21ab14025ecc17d0483947ce"
 dependencies = [
  "chrono",
  "itertools 0.10.5",

--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -33,7 +33,10 @@ use crate::annotation::expression::{
         },
         op_codes::ExpressionOpCode,
         operators,
-        unary::{MathAbsDouble, MathAbsInteger, MathCeilDouble, MathFloorDouble, MathRoundDouble},
+        unary::{
+            MathAbsDecimal, MathAbsDouble, MathAbsInteger, MathCeilDecimal, MathCeilDouble, MathFloorDecimal,
+            MathFloorDouble, MathRoundDecimal, MathRoundDouble,
+        },
         CompilableExpression, ExpressionInstruction,
     },
     ExpressionCompileError,
@@ -488,7 +491,7 @@ impl<'this> ExpressionCompilationContext<'this> {
                 match self.peek_type_single()?.category() {
                     ValueTypeCategory::Integer => MathAbsInteger::validate_and_append(self)?,
                     ValueTypeCategory::Double => MathAbsDouble::validate_and_append(self)?,
-                    // TODO: ValueTypeCategory::Decimal ?
+                    ValueTypeCategory::Decimal => MathAbsDecimal::validate_and_append(self)?,
                     _ => Err(ExpressionCompileError::UnsupportedArgumentsForBuiltin {
                         function: builtin.builtin_id(),
                         category: self.peek_type_single()?.category(),
@@ -500,7 +503,7 @@ impl<'this> ExpressionCompilationContext<'this> {
                 self.compile_recursive(self.expression_tree.get(builtin.argument_expression_ids()[0]))?;
                 match self.peek_type_single()?.category() {
                     ValueTypeCategory::Double => MathCeilDouble::validate_and_append(self)?,
-                    // TODO: ValueTypeCategory::Decimal ?
+                    ValueTypeCategory::Decimal => MathCeilDecimal::validate_and_append(self)?,
                     _ => Err(ExpressionCompileError::UnsupportedArgumentsForBuiltin {
                         function: builtin.builtin_id(),
                         category: self.peek_type_single()?.category(),
@@ -512,7 +515,7 @@ impl<'this> ExpressionCompilationContext<'this> {
                 self.compile_recursive(self.expression_tree.get(builtin.argument_expression_ids()[0]))?;
                 match self.peek_type_single()?.category() {
                     ValueTypeCategory::Double => MathFloorDouble::validate_and_append(self)?,
-                    // TODO: ValueTypeCategory::Decimal ?
+                    ValueTypeCategory::Decimal => MathFloorDecimal::validate_and_append(self)?,
                     _ => Err(ExpressionCompileError::UnsupportedArgumentsForBuiltin {
                         function: builtin.builtin_id(),
                         category: self.peek_type_single()?.category(),
@@ -524,7 +527,7 @@ impl<'this> ExpressionCompilationContext<'this> {
                 self.compile_recursive(self.expression_tree.get(builtin.argument_expression_ids()[0]))?;
                 match self.peek_type_single()?.category() {
                     ValueTypeCategory::Double => MathRoundDouble::validate_and_append(self)?,
-                    // TODO: ValueTypeCategory::Decimal ?
+                    ValueTypeCategory::Decimal => MathRoundDecimal::validate_and_append(self)?,
                     _ => Err(ExpressionCompileError::UnsupportedArgumentsForBuiltin {
                         function: builtin.builtin_id(),
                         category: self.peek_type_single()?.category(),

--- a/compiler/annotation/expression/instructions/op_codes.rs
+++ b/compiler/annotation/expression/instructions/op_codes.rs
@@ -51,11 +51,18 @@ pub enum ExpressionOpCode {
 
     // BuiltIns, maybe by domain?
     MathAbsDouble,
+    MathAbsDecimal,
     MathAbsInteger,
+
     MathRemainderInteger,
+
     MathRoundDouble,
     MathCeilDouble,
     MathFloorDouble,
+
+    MathRoundDecimal,
+    MathCeilDecimal,
+    MathFloorDecimal,
 }
 
 impl fmt::Display for ExpressionOpCode {
@@ -90,12 +97,16 @@ impl fmt::Display for ExpressionOpCode {
             ExpressionOpCode::OpDecimalAddDecimal => write!(f, "add-decimal"),
             ExpressionOpCode::OpDecimalSubtractDecimal => write!(f, "subtract-decimal"),
             ExpressionOpCode::OpDecimalMultiplyDecimal => write!(f, "multiply-decimal"),
+            ExpressionOpCode::MathAbsDouble => write!(f, "abs-double"),
+            ExpressionOpCode::MathAbsDecimal => write!(f, "abs-decimal"),
             ExpressionOpCode::MathAbsInteger => write!(f, "abs-integer"),
             ExpressionOpCode::MathRemainderInteger => write!(f, "remainder-integer"),
-            ExpressionOpCode::MathAbsDouble => write!(f, "abs-double"),
             ExpressionOpCode::MathRoundDouble => write!(f, "round-double"),
             ExpressionOpCode::MathCeilDouble => write!(f, "ceil-double"),
             ExpressionOpCode::MathFloorDouble => write!(f, "floor-double"),
+            ExpressionOpCode::MathRoundDecimal => write!(f, "round-decimal"),
+            ExpressionOpCode::MathCeilDecimal => write!(f, "ceil-decimal"),
+            ExpressionOpCode::MathFloorDecimal => write!(f, "floor-decimal"),
         }
     }
 }

--- a/compiler/annotation/expression/instructions/unary.rs
+++ b/compiler/annotation/expression/instructions/unary.rs
@@ -6,7 +6,7 @@
 
 use std::marker::PhantomData;
 
-use encoding::value::{value::NativeValueConvertible, value_type::ValueTypeCategory};
+use encoding::value::{decimal_value::Decimal, value::NativeValueConvertible, value_type::ValueTypeCategory};
 
 use crate::annotation::expression::{
     expression_compiler::ExpressionCompilationContext,
@@ -82,7 +82,13 @@ pub(crate) use unary_instruction;
 unary_instruction! {
     MathAbsInteger = MathAbsIntegerImpl(a1: i64) -> i64 { Ok(i64::abs(a1)) }
     MathAbsDouble = MathAbsDoubleImpl(a1: f64) -> f64 { Ok(f64::abs(a1)) }
-    MathRoundDouble = MathRoundDoubleImpl(a1: f64) -> i64 { Ok(f64::round_ties_even(a1) as i64) } // TODO: Should this be round_ties_even?
+    MathAbsDecimal = MathAbsDecimalImpl(a1: Decimal) -> Decimal { Ok(Decimal::abs(a1)) }
+
+    MathRoundDouble = MathRoundDoubleImpl(a1: f64) -> i64 { Ok(f64::round_ties_even(a1) as i64) }
     MathCeilDouble = MathCeilDoubleImpl(a1: f64) -> i64 { Ok(f64::ceil(a1) as i64) }
     MathFloorDouble = MathFloorDoubleImpl(a1: f64) -> i64 { Ok(f64::floor(a1) as i64) }
+
+    MathRoundDecimal = MathRoundDecimalImpl(a1: Decimal) -> i64 { Ok(Decimal::round(a1)) }
+    MathCeilDecimal = MathCeilDecimalImpl(a1: Decimal) -> i64 { Ok(Decimal::ceil(a1)) }
+    MathFloorDecimal = MathFloorDecimalImpl(a1: Decimal) -> i64 { Ok(Decimal::floor(a1)) }
 }

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "a66405c982f7d266a9f07af025c670533258ea38",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
+        commit = "c22019bbd80a379eb1d790eec7257aabaf98a154",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/dmitrii-ubskii/typedb-behaviour",
-        commit = "c22019bbd80a379eb1d790eec7257aabaf98a154",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/typedb/typedb-behaviour",
+        commit = "328e1b08deda8cab66601ee63235922543eb02f9",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/encoding/value/decimal_value.rs
+++ b/encoding/value/decimal_value.rs
@@ -5,6 +5,7 @@
  */
 
 use std::{
+    cmp::Ordering,
     fmt,
     num::ParseIntError,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign},
@@ -52,12 +53,42 @@ impl Decimal {
         Self::new(integer, fractional_parts_ceil)
     }
 
-    pub fn integer_part(&self) -> i64 {
+    pub fn integer_part(self) -> i64 {
         self.integer
     }
 
-    pub fn fractional_part(&self) -> u64 {
+    pub fn fractional_part(self) -> u64 {
         self.fractional
+    }
+
+    pub fn abs(self) -> Self {
+        if self.integer >= 0 {
+            self
+        } else if self.fractional == 0 {
+            Self { integer: -self.integer, fractional: 0 }
+        } else {
+            Self { integer: -self.integer - 1, fractional: FRACTIONAL_PART_DENOMINATOR - self.fractional }
+        }
+    }
+
+    pub fn floor(self) -> i64 {
+        self.integer
+    }
+
+    pub fn ceil(self) -> i64 {
+        if self.fractional == 0 {
+            self.integer
+        } else {
+            self.integer + 1
+        }
+    }
+
+    pub fn round(self) -> i64 {
+        match Ord::cmp(&self.fractional, &(FRACTIONAL_PART_DENOMINATOR / 2)) {
+            Ordering::Less => self.integer,
+            Ordering::Equal => self.integer + self.integer % 2, // round ties to even
+            Ordering::Greater => self.integer + 1,
+        }
     }
 
     pub fn to_f64(self) -> f64 {

--- a/encoding/value/decimal_value.rs
+++ b/encoding/value/decimal_value.rs
@@ -86,7 +86,7 @@ impl Decimal {
     pub fn round(self) -> i64 {
         match Ord::cmp(&self.fractional, &(FRACTIONAL_PART_DENOMINATOR / 2)) {
             Ordering::Less => self.integer,
-            Ordering::Equal => self.integer + self.integer % 2, // round ties to even
+            Ordering::Equal => self.integer + self.integer.rem_euclid(2), // round ties to even
             Ordering::Greater => self.integer + 1,
         }
     }

--- a/executor/read/expression_executor.rs
+++ b/executor/read/expression_executor.rs
@@ -21,7 +21,8 @@ use compiler::annotation::expression::{
         op_codes::ExpressionOpCode,
         operators,
         unary::{
-            MathAbsDouble, MathAbsInteger, MathCeilDouble, MathFloorDouble, MathRoundDouble, Unary, UnaryExpression,
+            MathAbsDecimal, MathAbsDouble, MathAbsInteger, MathCeilDecimal, MathCeilDouble, MathFloorDecimal,
+            MathFloorDouble, MathRoundDecimal, MathRoundDouble, Unary, UnaryExpression,
         },
         ExpressionEvaluationError,
     },
@@ -202,12 +203,19 @@ fn evaluate_instruction(
         ExpressionOpCode::OpDecimalSubtractDecimal => operators::OpDecimalSubtractDecimal::evaluate(state),
         ExpressionOpCode::OpDecimalMultiplyDecimal => operators::OpDecimalMultiplyDecimal::evaluate(state),
 
+        ExpressionOpCode::MathAbsDouble => MathAbsDouble::evaluate(state),
+        ExpressionOpCode::MathAbsDecimal => MathAbsDecimal::evaluate(state),
+        ExpressionOpCode::MathAbsInteger => MathAbsInteger::evaluate(state),
+
         ExpressionOpCode::MathRemainderInteger => MathRemainderInteger::evaluate(state),
+
         ExpressionOpCode::MathRoundDouble => MathRoundDouble::evaluate(state),
         ExpressionOpCode::MathCeilDouble => MathCeilDouble::evaluate(state),
         ExpressionOpCode::MathFloorDouble => MathFloorDouble::evaluate(state),
-        ExpressionOpCode::MathAbsInteger => MathAbsInteger::evaluate(state),
-        ExpressionOpCode::MathAbsDouble => MathAbsDouble::evaluate(state),
+
+        ExpressionOpCode::MathRoundDecimal => MathRoundDecimal::evaluate(state),
+        ExpressionOpCode::MathCeilDecimal => MathCeilDecimal::evaluate(state),
+        ExpressionOpCode::MathFloorDecimal => MathFloorDecimal::evaluate(state),
     }
 }
 


### PR DESCRIPTION
## Product change and motivation

We implement the following functions for `Decimal`:
- `abs`,
- `round`,
- `ceil`,
- `floor`.

This completes the value type coverage for implemented intrinsic functions.

## Implementation

