### PR TITLE
Improve docker setup to use /var/lib/typedb/data for data dir

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -290,7 +290,7 @@ docker_container_image(
     operating_system = "linux",
     architecture = "amd64",
     base = "@typedb-ubuntu-x86_64//image",
-    cmd = ["/opt/typedb-server-linux-x86_64/typedb", "server"],
+    cmd = ["/opt/typedb-server-linux-x86_64/typedb", "server", "--storage.data-directory=/var/lib/typedb/data"],
     directory = "opt",
     env = {
         "LANG": "C.UTF-8",
@@ -299,7 +299,7 @@ docker_container_image(
     ports = ["1729", "8000"],
     tars = [":assemble-server-linux-x86_64-targz"],
     visibility = ["//test:__subpackages__"],
-    volumes = ["/opt/typedb-server-linux-x86_64/server/data/"],
+    volumes = ["/var/lib/typedb/data/"],
     workdir = "/opt/typedb-server-linux-x86_64",
     target_compatible_with = constraint_linux_x86_64,
 )
@@ -309,7 +309,7 @@ docker_container_image(
     operating_system = "linux",
     architecture = "arm64",
     base = "@typedb-ubuntu-arm64//image",
-    cmd = ["/opt/typedb-server-linux-arm64/typedb", "server"],
+    cmd = ["/opt/typedb-server-linux-arm64/typedb", "server", "--storage.data-directory=/var/lib/typedb/data"],
     directory = "opt",
     env = {
         "LANG": "C.UTF-8",
@@ -318,7 +318,7 @@ docker_container_image(
     ports = ["1729", "8000"],
     tars = [":assemble-server-linux-arm64-targz"],
     visibility = ["//test:__subpackages__"],
-    volumes = ["/opt/typedb-server-linux-arm64/server/data/"],
+    volumes = ["/var/lib/typedb/data/"],
     workdir = "/opt/typedb-server-linux-arm64",
     target_compatible_with = constraint_linux_arm64,
 )


### PR DESCRIPTION
## Product change and motivation

We improve the TypeDB Docker setup by using `/var/lib/typedb/data` for the architecture-agnostic data directory for TypeDB. This path is hardcoded into the built-in docker command for starting the command.

This means, we now simplify the docker external volume mount to be:

`docker volume create typedb-data` 
and
`docker create --name typedb -v typedb-data:/var/lib/typedb/data -p 1729:1729 -p 8000:8000 typedb/typedb:latest`

Which works for either ARM or x86 builds.

## Implementation

Use a different storage volume path for TypeDB Docker, and configure docker images that we build to use `/var/lib/typedb/data` as the storage directory.
