### PR TITLE
Improve start up resilience

### DIFF
--- a/database/database.rs
+++ b/database/database.rs
@@ -43,7 +43,7 @@ use query::query_cache::QueryCache;
 use resource::constants::database::{CHECKPOINT_INTERVAL, STATISTICS_UPDATE_INTERVAL};
 use storage::{
     durability_client::{DurabilityClient, DurabilityClientError, WALClient},
-    recovery::checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError, CheckpointWriter},
+    recovery::checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
     sequence_number::SequenceNumber,
     MVCCStorage, StorageDeleteError, StorageOpenError, StorageResetError,
 };
@@ -328,7 +328,7 @@ impl Database<WALClient> {
         wal_client.register_record_type::<Statistics>();
 
         event!(Level::TRACE, "Loading last database '{}' checkpoint", &name);
-        let checkpoint = Checkpoint::open_latest::<EncodingKeyspace>(path)
+        let checkpoint = CheckpointReader::open_latest::<EncodingKeyspace>(path)
             .map_err(|err| CheckpointLoad { name: name.to_string(), typedb_source: err })?;
         let storage = Arc::new(
             MVCCStorage::load::<EncodingKeyspace>(&name, path, wal_client, &checkpoint)

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -20,7 +20,6 @@ use crate::{database::DatabaseCreateError, Database, DatabaseDeleteError, Databa
 
 type DatabasesMap = HashMap<String, Arc<Database<WALClient>>>;
 type Databases = RwLock<DatabasesMap>;
-type DatabasesReadLock<'a> = RwLockReadGuard<'a, DatabasesMap>;
 type DatabasesWriteLock<'a> = RwLockWriteGuard<'a, DatabasesMap>;
 
 #[derive(Debug)]
@@ -275,7 +274,7 @@ impl DatabaseManager {
     }
 
     pub fn database_names(&self) -> Vec<String> {
-        self.databases.read().unwrap().keys().cloned().filter(|db| Self::is_user_database(db)).collect()
+        self.databases.read().unwrap().keys().filter(|&db| Self::is_user_database(db)).cloned().collect()
     }
 
     pub fn databases(&self) -> RwLockReadGuard<'_, HashMap<String, Arc<Database<WALClient>>>> {
@@ -332,7 +331,7 @@ impl DatabaseManager {
             .map_err(|source| DatabaseCreateError::DirectoryWrite { name: name.to_string(), source: Arc::new(source) })
     }
 
-    fn file_name_lossy(path: &PathBuf) -> String {
+    fn file_name_lossy(path: &Path) -> String {
         path.file_name().unwrap_or("".as_ref()).to_string_lossy().to_string()
     }
 

--- a/database/database_manager.rs
+++ b/database/database_manager.rs
@@ -73,7 +73,7 @@ impl DatabaseManager {
             }
 
             let database_name = entry_path.file_name().unwrap().to_string_lossy();
-            if Self::is_internal_database(&database_name) {
+            if Self::validate_user_database_name(&database_name).is_err() {
                 continue;
             }
 
@@ -133,7 +133,7 @@ impl DatabaseManager {
     }
 
     pub fn put_database(&self, name: impl AsRef<str>) -> Result<(), DatabaseCreateError> {
-        Self::validate_database_name(name.as_ref())?;
+        Self::validate_user_database_name(name.as_ref())?;
         self.put_database_unrestricted(name)
     }
 
@@ -184,7 +184,7 @@ impl DatabaseManager {
             })?;
         }
 
-        Self::validate_database_name(&name)?;
+        Self::validate_user_database_name(&name)?;
 
         let databases = self.databases.write().map_err(|_| DatabaseCreateError::WriteAccessDenied {})?;
         if self.exists_public(&databases, &name) {
@@ -336,7 +336,7 @@ impl DatabaseManager {
         path.file_name().unwrap_or("".as_ref()).to_string_lossy().to_string()
     }
 
-    fn validate_database_name(name: &str) -> Result<(), DatabaseCreateError> {
+    fn validate_user_database_name(name: &str) -> Result<(), DatabaseCreateError> {
         if Self::is_internal_database(name) {
             return Err(DatabaseCreateError::InternalDatabaseCreationProhibited {});
         }

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -23,7 +23,7 @@ use resource::profile::CommitProfile;
 use storage::{
     durability_client::WALClient,
     key_value::StorageKeyReference,
-    recovery::checkpoint::{Checkpoint, CheckpointWriter},
+    recovery::checkpoint::{CheckpointReader, CheckpointWriter},
     snapshot::{CommittableSnapshot, WritableSnapshot},
     MVCCStorage,
 };

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -23,7 +23,7 @@ use resource::profile::CommitProfile;
 use storage::{
     durability_client::WALClient,
     key_value::StorageKeyReference,
-    recovery::checkpoint::Checkpoint,
+    recovery::checkpoint::{Checkpoint, CheckpointWriter},
     snapshot::{CommittableSnapshot, WritableSnapshot},
     MVCCStorage,
 };
@@ -200,10 +200,9 @@ fn loading_storage_assigns_next_vertex() {
         assert_eq!(i, vertex.type_id_().as_u16());
         snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
 
-        let check = Checkpoint::new(&storage_path).unwrap();
+        let check = CheckpointWriter::new(&storage_path).unwrap();
         storage.checkpoint(&check).unwrap();
-        check.finish().unwrap();
-        checkpoint = Some(check);
+        checkpoint = Some(check.finish().unwrap());
     }
 
     for i in 0..create_till {

--- a/encoding/tests/test_type_vertex.rs
+++ b/encoding/tests/test_type_vertex.rs
@@ -23,7 +23,7 @@ use resource::profile::CommitProfile;
 use storage::{
     durability_client::WALClient,
     key_value::StorageKeyReference,
-    recovery::checkpoint::{CheckpointReader, CheckpointWriter},
+    recovery::checkpoint::CheckpointWriter,
     snapshot::{CommittableSnapshot, WritableSnapshot},
     MVCCStorage,
 };

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -60,7 +60,7 @@ impl Checkpoint {
                     }
 
                     let checkpoint = Checkpoint { directory: path };
-                    if checkpoint.is_consistent::<KS>()? {
+                    if checkpoint.is_complete::<KS>()? {
                         Ok(Some(checkpoint))
                     } else {
                         Ok(cur)
@@ -133,7 +133,7 @@ impl Checkpoint {
         ))
     }
 
-    fn is_consistent<KS: KeyspaceSet>(&self) -> io::Result<bool> {
+    fn is_complete<KS: KeyspaceSet>(&self) -> io::Result<bool> {
         if !self.directory.is_dir() {
             return Ok(false);
         }

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -13,11 +13,11 @@ use std::{
     sync::Arc,
 };
 
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use error::typedb_error;
 use itertools::Itertools;
 use same_file::is_same_file;
-use tracing::trace;
+use tracing::{debug, trace};
 
 use crate::{
     durability_client::DurabilityClient,
@@ -47,26 +47,7 @@ impl CheckpointReader {
         }
 
         fs::read_dir(&checkpoint_dir)
-            .and_then(|mut entries| {
-                entries.try_fold(None, |cur, entry| {
-                    let path = entry?.path();
-                    if path.extension() == Some(TEMP_FILE_EXTENSION.as_ref()) {
-                        // skip unfinished checkpoint
-                        return Ok(cur);
-                    }
-
-                    if cur.as_ref().is_some_and(|cur: &CheckpointReader| cur.directory > path) {
-                        return Ok(cur);
-                    }
-
-                    let checkpoint = CheckpointReader { directory: path };
-                    if checkpoint.is_complete::<KS>()? {
-                        Ok(Some(checkpoint))
-                    } else {
-                        Ok(cur)
-                    }
-                })
-            })
+            .and_then(latest_complete_checkpoint::<KS>)
             .map_err(|error| CheckpointRead { dir: checkpoint_dir, source: Arc::new(error) })
     }
 
@@ -149,6 +130,61 @@ impl CheckpointReader {
         let metadata_file_path = self.directory.join(STORAGE_METADATA_FILE_NAME);
         fs::exists(metadata_file_path)
     }
+}
+
+fn latest_complete_checkpoint<KS: KeyspaceSet>(mut entries: fs::ReadDir) -> io::Result<Option<CheckpointReader>> {
+    let latest: io::Result<_> = entries.try_fold(None, |cur, entry| {
+        let path = entry?.path();
+        if path.extension() == Some(TEMP_FILE_EXTENSION.as_ref()) {
+            // skip unfinished checkpoint
+            return Ok(cur);
+        }
+
+        let Some(timestamp) = parse_directory_name_timestamp(&path) else {
+            // skip unparseable checkpoint
+            return Ok(cur);
+        };
+
+        if cur.as_ref().is_some_and(|(cur_timestamp, _)| cur_timestamp > &timestamp) {
+            return Ok(cur);
+        }
+
+        let checkpoint = CheckpointReader { directory: path };
+        if checkpoint.is_complete::<KS>()? {
+            Ok(Some((timestamp, checkpoint)))
+        } else {
+            Ok(cur)
+        }
+    });
+
+    match latest? {
+        Some((_, checkpoint_reader)) => Ok(Some(checkpoint_reader)),
+        None => Ok(None),
+    }
+}
+
+fn parse_directory_name_timestamp(path: &PathBuf) -> Option<DateTime<Utc>> {
+    let Some(dir_name) = path.file_name() else {
+        debug!("Encountered path with no directory name during checkpoint recovery: {path:?}, skipping");
+        return None;
+    };
+
+    let Some(dir_name) = dir_name.to_str() else {
+        debug!("Encountered directory with non-UTF8 name during checkpoint recovery: {path:?}, skipping");
+        return None;
+    };
+
+    let Ok(micros) = dir_name.parse() else {
+        debug!("Encountered directory with non-timestamp name during checkpoint recovery: {path:?}, skipping");
+        return None;
+    };
+
+    let Some(timestamp) = DateTime::from_timestamp_micros(micros) else {
+        debug!("Encountered directory with timestamp name outside the range of UTC datetimes: {path:?}, skipping");
+        return None;
+    };
+
+    Some(timestamp)
 }
 
 fn restore_storage_from_checkpoint(keyspace_dir: PathBuf, keyspace_checkpoint_dir: PathBuf) -> io::Result<()> {

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -26,6 +26,10 @@ use crate::{
     sequence_number::SequenceNumber,
 };
 
+const CHECKPOINT_DIR_NAME: &str = "checkpoint";
+const STORAGE_METADATA_FILE_NAME: &str = "STORAGE_METADATA";
+const TEMP_FILE_EXTENSION: &str = "tmp";
+
 /// A checkpoint is a directory, which contains at least the storage checkpointing data: keyspaces + the watermark.
 /// The watermark represents a sequence number that is guaranteed to be in all the keyspaces, and after which we may
 /// have to reapply commits to the keyspaces from the WAL.
@@ -34,85 +38,36 @@ pub struct Checkpoint {
 }
 
 impl Checkpoint {
-    const CHECKPOINT_DIR_NAME: &'static str = "checkpoint";
-    const STORAGE_METADATA_FILE_NAME: &'static str = "STORAGE_METADATA";
+    pub fn open_latest<KS: KeyspaceSet>(storage_path: &Path) -> Result<Option<Self>, CheckpointLoadError> {
+        use CheckpointLoadError::CheckpointRead;
 
-    pub fn new(storage_path: &Path) -> Result<Self, CheckpointCreateError> {
-        use CheckpointCreateError::CheckpointDirCreate;
-
-        let checkpoint_dir = storage_path.join(Self::CHECKPOINT_DIR_NAME);
+        let checkpoint_dir = storage_path.join(CHECKPOINT_DIR_NAME);
         if !checkpoint_dir.exists() {
-            fs::create_dir_all(&checkpoint_dir)
-                .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?
+            return Ok(None);
         }
 
-        let current_checkpoint_dir = checkpoint_dir.join(format!("{}", Utc::now().timestamp_micros()));
-        fs::create_dir_all(&current_checkpoint_dir)
-            .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?;
+        fs::read_dir(&checkpoint_dir)
+            .and_then(|mut entries| {
+                entries.try_fold(None, |cur, entry| {
+                    let path = entry?.path();
+                    if path.extension() == Some(TEMP_FILE_EXTENSION.as_ref()) {
+                        // skip unfinished checkpoint
+                        return Ok(cur);
+                    }
 
-        Ok(Checkpoint { directory: current_checkpoint_dir })
-    }
+                    if cur.as_ref().is_some_and(|cur: &Checkpoint| cur.directory > path) {
+                        return Ok(cur);
+                    }
 
-    pub fn add_storage(&self, keyspaces: &Keyspaces, watermark: SequenceNumber) -> Result<(), CheckpointCreateError> {
-        use CheckpointCreateError::{KeyspaceCheckpoint, MetadataFileCreate, MetadataWrite};
-        keyspaces
-            .checkpoint(&self.directory)
-            .map_err(|error| KeyspaceCheckpoint { dir: self.directory.clone(), source: error })?;
-
-        let metadata_file_path = self.directory.join(Self::STORAGE_METADATA_FILE_NAME);
-        let mut metadata_file = File::create(&metadata_file_path)
-            .map_err(|error| MetadataFileCreate { file_path: metadata_file_path.clone(), source: Arc::new(error) })?;
-        metadata_file
-            .write_all(watermark.number().to_string().as_bytes())
-            .and_then(|()| metadata_file.sync_all())
-            .map_err(|error| MetadataWrite { file_path: metadata_file_path.clone(), source: Arc::new(error) })?;
-        Ok(())
-    }
-
-    pub fn add_extension<T: CheckpointAdditionalData>(&self, data: &T) -> Result<(), CheckpointCreateError> {
-        use CheckpointCreateError::{ExtensionDuplicate, ExtensionIO, ExtensionSerialise};
-        let file_name = T::NAME;
-        let path = self.directory.join(file_name);
-        if path.exists() {
-            return Err(ExtensionDuplicate { name: T::NAME.to_string() });
-        }
-
-        let mut file =
-            File::create(path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: Arc::new(err) })?;
-
-        data.serialise_into(&mut file)
-            .map_err(|err| ExtensionSerialise { name: T::NAME.to_string(), source: Arc::new(err) })?;
-
-        Ok(())
-    }
-
-    pub fn finish(&self) -> Result<(), CheckpointCreateError> {
-        use CheckpointCreateError::{CheckpointDirRead, MissingStorageData, OldCheckpointRemove};
-
-        if !self.directory.join(Self::STORAGE_METADATA_FILE_NAME).exists() {
-            return Err(MissingStorageData { dir: self.directory.clone() });
-        }
-
-        let previous_checkpoints: Vec<_> = fs::read_dir(self.directory.parent().unwrap())
-            .and_then(|entries| {
-                entries
-                    .map_ok(|entry| entry.path())
-                    .filter(|path| path.is_ok() && path.as_ref().unwrap() != &self.directory)
-                    .try_collect()
+                    let checkpoint = Checkpoint { directory: path };
+                    if checkpoint.is_consistent::<KS>()? {
+                        Ok(Some(checkpoint))
+                    } else {
+                        Ok(cur)
+                    }
+                })
             })
-            .map_err(|error| CheckpointDirRead { dir: self.directory.clone(), source: Arc::new(error) })?;
-
-        for previous_checkpoint in previous_checkpoints {
-            fs::remove_dir_all(&previous_checkpoint)
-                .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: Arc::new(error) })?
-        }
-
-        Ok(())
-    }
-
-    pub fn open_latest(storage_path: &Path) -> Result<Option<Self>, CheckpointLoadError> {
-        let checkpoint_dir = storage_path.join(Self::CHECKPOINT_DIR_NAME);
-        find_latest_checkpoint(&checkpoint_dir).map(|path| path.map(|p| Checkpoint { directory: p }))
+            .map_err(|error| CheckpointRead { dir: checkpoint_dir, source: Arc::new(error) })
     }
 
     pub fn get_additional_data<T: CheckpointAdditionalData>(&self) -> Result<T, CheckpointLoadError> {
@@ -170,12 +125,29 @@ impl Checkpoint {
     pub fn read_sequence_number(&self) -> Result<SequenceNumber, CheckpointLoadError> {
         use CheckpointLoadError::MetadataRead;
 
-        let metadata_file_path = self.directory.join(Self::STORAGE_METADATA_FILE_NAME);
+        let metadata_file_path = self.directory.join(STORAGE_METADATA_FILE_NAME);
         let metadata = fs::read_to_string(metadata_file_path)
             .map_err(|error| MetadataRead { dir: self.directory.clone(), source: Arc::new(error) })?;
         Ok(SequenceNumber::new(
             metadata.parse().expect("Could not read METADATA file (could try to restore from previous checkpoint)"),
         ))
+    }
+
+    fn is_consistent<KS: KeyspaceSet>(&self) -> io::Result<bool> {
+        if !self.directory.is_dir() {
+            return Ok(false);
+        }
+        if !self.directory.join(STORAGE_METADATA_FILE_NAME).exists() {
+            return Ok(false);
+        }
+        for keyspace in KS::iter() {
+            let keyspace_checkpoint_dir = self.directory.join(keyspace.name());
+            if !fs::exists(keyspace_checkpoint_dir)? {
+                return Ok(false);
+            }
+        }
+        let metadata_file_path = self.directory.join(STORAGE_METADATA_FILE_NAME);
+        fs::exists(metadata_file_path)
     }
 }
 
@@ -194,24 +166,114 @@ fn restore_storage_from_checkpoint(keyspace_dir: PathBuf, keyspace_checkpoint_di
         let checkpoint_file = entry?.path();
         let storage_file = keyspace_dir.join(checkpoint_file.file_name().unwrap());
         if !storage_file.exists() || !is_same_file(&storage_file, &checkpoint_file)? {
-            fs::copy(checkpoint_file, storage_file)?;
+            copy_file(&checkpoint_file, &storage_file)?;
         }
     }
 
     Ok(())
 }
 
-fn find_latest_checkpoint(checkpoint_dir: &Path) -> Result<Option<PathBuf>, CheckpointLoadError> {
-    if !checkpoint_dir.exists() {
-        return Ok(None);
+/// A checkpoint is a directory, which contains at least the storage checkpointing data: keyspaces + the watermark.
+/// The watermark represents a sequence number that is guaranteed to be in all the keyspaces, and after which we may
+/// have to reapply commits to the keyspaces from the WAL.
+pub struct CheckpointWriter {
+    pub checkpoint_directory: PathBuf,
+    pub temporary_directory: PathBuf,
+}
+
+impl CheckpointWriter {
+    pub fn new(storage_path: &Path) -> Result<Self, CheckpointCreateError> {
+        use CheckpointCreateError::CheckpointDirCreate;
+
+        let checkpoint_dir = storage_path.join(CHECKPOINT_DIR_NAME);
+        if !checkpoint_dir.exists() {
+            fs::create_dir_all(&checkpoint_dir)
+                .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?
+        }
+
+        let checkpoint_directory = checkpoint_dir.join(format!("{}", Utc::now().timestamp_micros(),));
+        let temporary_directory = checkpoint_directory.with_extension(TEMP_FILE_EXTENSION);
+        fs::create_dir_all(&temporary_directory)
+            .map_err(|error| CheckpointDirCreate { dir: checkpoint_dir.clone(), source: Arc::new(error) })?;
+
+        Ok(Self { checkpoint_directory, temporary_directory })
     }
 
-    fs::read_dir(checkpoint_dir)
-        .and_then(|mut entries| entries.try_fold(None, |cur, entry| Ok(cur.max(Some(entry?.path())))))
-        .map_err(|error| CheckpointLoadError::CheckpointRead {
-            dir: checkpoint_dir.to_owned(),
-            source: Arc::new(error),
-        })
+    pub fn add_storage(&self, keyspaces: &Keyspaces, watermark: SequenceNumber) -> Result<(), CheckpointCreateError> {
+        use CheckpointCreateError::{KeyspaceCheckpoint, MetadataWrite};
+
+        keyspaces
+            .checkpoint(&self.temporary_directory)
+            .map_err(|error| KeyspaceCheckpoint { dir: self.temporary_directory.clone(), source: error })?;
+
+        let metadata_file_path = self.temporary_directory.join(STORAGE_METADATA_FILE_NAME);
+        write_file(&metadata_file_path, watermark.number().to_string().as_bytes())
+            .map_err(|e| MetadataWrite { file_path: metadata_file_path, source: Arc::new(e) })?;
+
+        Ok(())
+    }
+
+    pub fn add_extension<T: CheckpointAdditionalData>(&self, data: &T) -> Result<(), CheckpointCreateError> {
+        use CheckpointCreateError::{ExtensionDuplicate, ExtensionIO, ExtensionSerialise};
+        let file_name = T::NAME;
+        let path = self.temporary_directory.join(file_name);
+        if path.exists() {
+            return Err(ExtensionDuplicate { name: T::NAME.to_string() });
+        }
+
+        let tmp = path.with_extension(TEMP_FILE_EXTENSION);
+        {
+            let mut file =
+                File::create(&tmp).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: Arc::new(err) })?;
+            data.serialise_into(&mut file)
+                .map_err(|err| ExtensionSerialise { name: T::NAME.to_string(), source: Arc::new(err) })?;
+        }
+        fs::rename(&tmp, &path).map_err(|err| ExtensionIO { name: T::NAME.to_string(), source: Arc::new(err) })?;
+
+        Ok(())
+    }
+
+    pub fn finish(self) -> Result<(), CheckpointCreateError> {
+        use CheckpointCreateError::{CheckpointDirCreate, CheckpointDirRead, MissingStorageData, OldCheckpointRemove};
+
+        if !self.temporary_directory.join(STORAGE_METADATA_FILE_NAME).exists() {
+            return Err(MissingStorageData { dir: self.temporary_directory.clone() });
+        }
+
+        let previous_checkpoints: Vec<_> = fs::read_dir(self.temporary_directory.parent().unwrap())
+            .and_then(|entries| {
+                entries
+                    .map_ok(|entry| entry.path())
+                    .filter(|path| path.is_ok() && path.as_ref().unwrap() != &self.temporary_directory)
+                    .try_collect()
+            })
+            .map_err(|error| CheckpointDirRead { dir: self.temporary_directory.clone(), source: Arc::new(error) })?;
+
+        for previous_checkpoint in previous_checkpoints {
+            fs::remove_dir_all(&previous_checkpoint)
+                .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: Arc::new(error) })?
+        }
+
+        fs::rename(self.temporary_directory, &self.checkpoint_directory)
+            .map_err(|error| CheckpointDirCreate { dir: self.checkpoint_directory, source: Arc::new(error) })?;
+
+        Ok(())
+    }
+}
+
+fn write_file(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let mut file = File::create(path)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn copy_file(source: &Path, destination: &Path) -> io::Result<()> {
+    let mut source_file = File::open(source)?;
+    let mut destination_file = File::create(destination)?;
+    io::copy(&mut source_file, &mut destination_file)?;
+    destination_file.sync_all()?;
+    Ok(())
 }
 
 pub trait CheckpointAdditionalData: Sized {

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -240,22 +240,22 @@ impl CheckpointWriter {
             return Err(MissingStorageData { dir: self.temporary_directory.clone() });
         }
 
-        let previous_checkpoints: Vec<_> = fs::read_dir(self.temporary_directory.parent().unwrap())
+        fs::rename(&self.temporary_directory, &self.checkpoint_directory)
+            .map_err(|error| CheckpointDirCreate { dir: self.checkpoint_directory.clone(), source: Arc::new(error) })?;
+
+        let previous_checkpoints: Vec<_> = fs::read_dir(self.checkpoint_directory.parent().unwrap())
             .and_then(|entries| {
                 entries
                     .map_ok(|entry| entry.path())
-                    .filter(|path| path.is_ok() && path.as_ref().unwrap() != &self.temporary_directory)
+                    .filter(|path| path.is_ok() && path.as_ref().unwrap() != &self.checkpoint_directory)
                     .try_collect()
             })
-            .map_err(|error| CheckpointDirRead { dir: self.temporary_directory.clone(), source: Arc::new(error) })?;
+            .map_err(|error| CheckpointDirRead { dir: self.checkpoint_directory.clone(), source: Arc::new(error) })?;
 
         for previous_checkpoint in previous_checkpoints {
             fs::remove_dir_all(&previous_checkpoint)
                 .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: Arc::new(error) })?
         }
-
-        fs::rename(self.temporary_directory, &self.checkpoint_directory)
-            .map_err(|error| CheckpointDirCreate { dir: self.checkpoint_directory.clone(), source: Arc::new(error) })?;
 
         Ok(Checkpoint { directory: self.checkpoint_directory })
     }

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -233,7 +233,7 @@ impl CheckpointWriter {
         Ok(())
     }
 
-    pub fn finish(self) -> Result<(), CheckpointCreateError> {
+    pub fn finish(self) -> Result<Checkpoint, CheckpointCreateError> {
         use CheckpointCreateError::{CheckpointDirCreate, CheckpointDirRead, MissingStorageData, OldCheckpointRemove};
 
         if !self.temporary_directory.join(STORAGE_METADATA_FILE_NAME).exists() {
@@ -255,9 +255,9 @@ impl CheckpointWriter {
         }
 
         fs::rename(self.temporary_directory, &self.checkpoint_directory)
-            .map_err(|error| CheckpointDirCreate { dir: self.checkpoint_directory, source: Arc::new(error) })?;
+            .map_err(|error| CheckpointDirCreate { dir: self.checkpoint_directory.clone(), source: Arc::new(error) })?;
 
-        Ok(())
+        Ok(Checkpoint { directory: self.checkpoint_directory })
     }
 }
 

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -33,11 +33,11 @@ const TEMP_FILE_EXTENSION: &str = "tmp";
 /// A checkpoint is a directory, which contains at least the storage checkpointing data: keyspaces + the watermark.
 /// The watermark represents a sequence number that is guaranteed to be in all the keyspaces, and after which we may
 /// have to reapply commits to the keyspaces from the WAL.
-pub struct Checkpoint {
+pub struct CheckpointReader {
     pub directory: PathBuf,
 }
 
-impl Checkpoint {
+impl CheckpointReader {
     pub fn open_latest<KS: KeyspaceSet>(storage_path: &Path) -> Result<Option<Self>, CheckpointLoadError> {
         use CheckpointLoadError::CheckpointRead;
 
@@ -55,11 +55,11 @@ impl Checkpoint {
                         return Ok(cur);
                     }
 
-                    if cur.as_ref().is_some_and(|cur: &Checkpoint| cur.directory > path) {
+                    if cur.as_ref().is_some_and(|cur: &CheckpointReader| cur.directory > path) {
                         return Ok(cur);
                     }
 
-                    let checkpoint = Checkpoint { directory: path };
+                    let checkpoint = CheckpointReader { directory: path };
                     if checkpoint.is_complete::<KS>()? {
                         Ok(Some(checkpoint))
                     } else {
@@ -233,7 +233,7 @@ impl CheckpointWriter {
         Ok(())
     }
 
-    pub fn finish(self) -> Result<Checkpoint, CheckpointCreateError> {
+    pub fn finish(self) -> Result<CheckpointReader, CheckpointCreateError> {
         use CheckpointCreateError::{CheckpointDirCreate, CheckpointDirRead, MissingStorageData, OldCheckpointRemove};
 
         if !self.temporary_directory.join(STORAGE_METADATA_FILE_NAME).exists() {
@@ -257,7 +257,7 @@ impl CheckpointWriter {
                 .map_err(|error| OldCheckpointRemove { dir: previous_checkpoint, source: Arc::new(error) })?
         }
 
-        Ok(Checkpoint { directory: self.checkpoint_directory })
+        Ok(CheckpointReader { directory: self.checkpoint_directory })
     }
 }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -42,7 +42,7 @@ use crate::{
         KeyspaceSet, Keyspaces,
     },
     recovery::{
-        checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError, CheckpointWriter},
+        checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
         commit_recovery::{apply_recovered, load_commit_data_from, StorageRecoveryError},
     },
     sequence_number::SequenceNumber,
@@ -116,7 +116,7 @@ impl<Durability> MVCCStorage<Durability> {
         name: impl AsRef<str>,
         path: &Path,
         mut durability_client: Durability,
-        checkpoint: &Option<Checkpoint>,
+        checkpoint: &Option<CheckpointReader>,
     ) -> Result<Self, StorageOpenError>
     where
         Durability: DurabilityClient,

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -42,7 +42,7 @@ use crate::{
         KeyspaceSet, Keyspaces,
     },
     recovery::{
-        checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError},
+        checkpoint::{Checkpoint, CheckpointCreateError, CheckpointLoadError, CheckpointWriter},
         commit_recovery::{apply_recovered, load_commit_data_from, StorageRecoveryError},
     },
     sequence_number::SequenceNumber,
@@ -345,7 +345,7 @@ impl<Durability> MVCCStorage<Durability> {
         self.keyspaces.get(keyspace_id)
     }
 
-    pub fn checkpoint(&self, checkpoint: &Checkpoint) -> Result<(), CheckpointCreateError> {
+    pub fn checkpoint(&self, checkpoint: &CheckpointWriter) -> Result<(), CheckpointCreateError> {
         checkpoint.add_storage(&self.keyspaces, self.snapshot_watermark())
     }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -127,25 +127,24 @@ impl<Durability> MVCCStorage<Durability> {
         let storage_dir = path.join(Self::STORAGE_DIR_NAME);
 
         Self::register_durability_record_types(&mut durability_client);
-        let (keyspaces, next_sequence_number) = match checkpoint {
-            None => {
-                fs::remove_dir_all(&storage_dir)
-                    .map_err(|err| StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) })?;
-                fs::create_dir_all(&storage_dir)
-                    .map_err(|err| StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) })?;
-                let keyspaces = Self::create_keyspaces::<KS>(name, &storage_dir)?;
-                trace!("No checkpoint found, loading from WAL");
-                let commits = load_commit_data_from(SequenceNumber::MIN.next(), &durability_client, usize::MAX)
-                    .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
-                let next_sequence_number = commits.keys().max().cloned().unwrap_or(SequenceNumber::MIN).next();
-                apply_recovered(name, commits, &durability_client, &keyspaces)
-                    .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
-                trace!("Finished applying commits from WAL.");
-                (keyspaces, next_sequence_number)
-            }
-            Some(checkpoint) => checkpoint
+        let (keyspaces, next_sequence_number) = if let Some(checkpoint) = checkpoint {
+            checkpoint
                 .recover_storage::<KS, _>(name, &storage_dir, &durability_client)
-                .map_err(|error| RecoverFromCheckpoint { name: name.to_owned(), typedb_source: error })?,
+                .map_err(|error| RecoverFromCheckpoint { name: name.to_owned(), typedb_source: error })?
+        } else {
+            fs::remove_dir_all(&storage_dir)
+                .map_err(|err| StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) })?;
+            fs::create_dir_all(&storage_dir)
+                .map_err(|err| StorageDirectoryRecreate { name: name.to_owned(), source: Arc::new(err) })?;
+            let keyspaces = Self::create_keyspaces::<KS>(name, &storage_dir)?;
+            trace!("No checkpoint found, loading from WAL");
+            let commits = load_commit_data_from(SequenceNumber::MIN.next(), &durability_client, usize::MAX)
+                .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
+            let next_sequence_number = commits.keys().max().cloned().unwrap_or(SequenceNumber::MIN).next();
+            apply_recovered(name, commits, &durability_client, &keyspaces)
+                .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
+            trace!("Finished applying commits from WAL.");
+            (keyspaces, next_sequence_number)
         };
 
         let isolation_manager = IsolationManager::new(next_sequence_number);

--- a/storage/tests/test_utils_storage/lib.rs
+++ b/storage/tests/test_utils_storage/lib.rs
@@ -8,8 +8,10 @@ use std::{path::Path, sync::Arc};
 
 use durability::wal::WAL;
 use storage::{
-    durability_client::WALClient, keyspace::KeyspaceSet, recovery::checkpoint::Checkpoint, MVCCStorage,
-    StorageOpenError,
+    durability_client::WALClient,
+    keyspace::KeyspaceSet,
+    recovery::checkpoint::{Checkpoint, CheckpointWriter},
+    MVCCStorage, StorageOpenError,
 };
 
 pub mod mock_snapshot;
@@ -41,10 +43,9 @@ pub fn create_storage<KS: KeyspaceSet>(path: &Path) -> Result<Arc<MVCCStorage<WA
 }
 
 pub fn checkpoint_storage(storage: &MVCCStorage<WALClient>) -> Checkpoint {
-    let checkpoint = Checkpoint::new(storage.path().parent().unwrap()).unwrap();
+    let checkpoint = CheckpointWriter::new(storage.path().parent().unwrap()).unwrap();
     storage.checkpoint(&checkpoint).unwrap();
-    checkpoint.finish().unwrap();
-    checkpoint
+    checkpoint.finish().unwrap()
 }
 
 pub fn load_storage<KS: KeyspaceSet>(

--- a/storage/tests/test_utils_storage/lib.rs
+++ b/storage/tests/test_utils_storage/lib.rs
@@ -10,7 +10,7 @@ use durability::wal::WAL;
 use storage::{
     durability_client::WALClient,
     keyspace::KeyspaceSet,
-    recovery::checkpoint::{Checkpoint, CheckpointWriter},
+    recovery::checkpoint::{CheckpointReader, CheckpointWriter},
     MVCCStorage, StorageOpenError,
 };
 
@@ -42,7 +42,7 @@ pub fn create_storage<KS: KeyspaceSet>(path: &Path) -> Result<Arc<MVCCStorage<WA
     Ok(Arc::new(storage))
 }
 
-pub fn checkpoint_storage(storage: &MVCCStorage<WALClient>) -> Checkpoint {
+pub fn checkpoint_storage(storage: &MVCCStorage<WALClient>) -> CheckpointReader {
     let checkpoint = CheckpointWriter::new(storage.path().parent().unwrap()).unwrap();
     storage.checkpoint(&checkpoint).unwrap();
     checkpoint.finish().unwrap()
@@ -51,7 +51,7 @@ pub fn checkpoint_storage(storage: &MVCCStorage<WALClient>) -> Checkpoint {
 pub fn load_storage<KS: KeyspaceSet>(
     path: &Path,
     wal: WAL,
-    checkpoint: Option<Checkpoint>,
+    checkpoint: Option<CheckpointReader>,
 ) -> Result<Arc<MVCCStorage<WALClient>>, StorageOpenError> {
     let storage = MVCCStorage::load::<KS>("storage", path, WALClient::new(wal), &checkpoint)?;
     Ok(Arc::new(storage))


### PR DESCRIPTION
## Product change and motivation

We reduce the possibility of crashes during startup after an operating system failure by doing the following:

- detect and discard corrupted database checkpoints on startup,
- ignore extraneous (non-database) directories in the data directory,
- separate checkpoints in progress from completed checkpoints. 

## Implementation

