### PR TITLE
Simplify merge iterator seek

### DIFF
--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -69,6 +69,7 @@ build:
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
         bazel test //common/cache:test_crate_cache --test_output=streamed
+        bazel test //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
         bazel test //common/logger:test_crate_logger --test_output=streamed
         bazel test //compiler:test_crate_compiler --test_output=streamed
         bazel test //concept:test_crate_concept --test_output=streamed

--- a/common/lending_iterator/BUILD
+++ b/common/lending_iterator/BUILD
@@ -3,7 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 load("@typedb_dependencies//tool/checkstyle:rules.bzl", "checkstyle_test")
-load("@rules_rust//rust:defs.bzl", "rust_library", "rustfmt_test")
+load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test", "rustfmt_test")
 package(default_visibility = ["//visibility:public"])
 
 rust_library(
@@ -12,6 +12,12 @@ rust_library(
     srcs = glob([
         "*.rs",
     ])
+)
+
+rust_test(
+    name = "test_crate_lending_iterator",
+    crate = ":lending_iterator",
+    deps = [],
 )
 
 rustfmt_test(

--- a/common/lending_iterator/Cargo.toml
+++ b/common/lending_iterator/Cargo.toml
@@ -3,6 +3,7 @@
 # Do not modify this file.
 
 features = {}
+dev-dependencies = {}
 dependencies = {}
 
 [package]

--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -4,14 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, marker::PhantomData, mem};
+use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, mem};
 
 use crate::{higher_order::FnHktHelper, LendingIterator, Peekable, Seekable};
 
 pub struct KMergeBy<I: LendingIterator, F> {
     pub iterators: BinaryHeap<PeekWrapper<I, F>>,
     pub next_iterator: Option<PeekWrapper<I, F>>,
-    phantom_compare: PhantomData<F>,
 }
 
 impl<I: LendingIterator, F> KMergeBy<I, F>
@@ -31,7 +30,7 @@ where
             .map(|peekable| PeekWrapper { iter: peekable, cmp_fn: cmp });
         // Peek wrapper reverses the comparator to create a min heap
         let queue = BinaryHeap::from_iter(iters);
-        Self { iterators: queue, next_iterator: None, phantom_compare: PhantomData }
+        Self { iterators: queue, next_iterator: None }
     }
 
     pub fn find_next_state(&mut self) -> Option<()> {

--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -17,7 +17,7 @@ pub struct KMergeBy<I: LendingIterator, F> {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum State {
-    Init,
+    Pending,
     Used,
     Ready,
     Done,
@@ -40,7 +40,7 @@ where
             .map(|peekable| PeekWrapper { iter: peekable, cmp_fn: cmp });
         // Peek wrapper reverses the comparator to create a min heap
         let queue = BinaryHeap::from_iter(iters);
-        Self { iterators: queue, next_iterator: None, state: State::Init, phantom_compare: PhantomData }
+        Self { iterators: queue, next_iterator: None, state: State::Pending, phantom_compare: PhantomData }
     }
 
     pub fn find_next_state(&mut self) {
@@ -72,7 +72,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
         match self.state {
-            State::Init | State::Used => {
+            State::Pending | State::Used => {
                 self.find_next_state();
                 self.next()
             }
@@ -96,7 +96,7 @@ where
         }
 
         // force recomputation of heap element
-        self.state = State::Init;
+        self.state = State::Pending;
         self.iterators = self
             .iterators
             .drain()

--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, marker::PhantomData, mem};
+use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, marker::PhantomData};
 
 use crate::{higher_order::FnHktHelper, LendingIterator, Peekable, Seekable};
 

--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -33,7 +33,7 @@ where
         Self { iterators: queue, next_iterator: None }
     }
 
-    pub fn find_next_state(&mut self) -> Option<()> {
+    fn find_next_state(&mut self) -> Option<()> {
         if let Some(mut last_iterator) = self.next_iterator.take() {
             if last_iterator.iter.peek().is_some() {
                 self.iterators.push(last_iterator);

--- a/common/lending_iterator/kmerge.rs
+++ b/common/lending_iterator/kmerge.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, marker::PhantomData};
+use std::{borrow::Borrow, cmp::Ordering, collections::BinaryHeap, marker::PhantomData, mem};
 
 use crate::{higher_order::FnHktHelper, LendingIterator, Peekable, Seekable};
 
@@ -97,9 +97,8 @@ where
 
         // force recomputation of heap element
         self.state = State::Pending;
-        self.iterators = self
-            .iterators
-            .drain()
+        self.iterators = mem::take(&mut self.iterators)
+            .into_iter()
             .chain(self.next_iterator.take())
             .filter_map(|mut it| {
                 it.iter.peek();

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -17,7 +17,7 @@ use compiler::{
 };
 use concept::error::ConceptReadError;
 use itertools::zip_eq;
-use lending_iterator::{adaptors::Inspect, kmerge, kmerge::KMergeBy, LendingIterator, Peekable};
+use lending_iterator::{adaptors::Inspect, kmerge::KMergeBy, LendingIterator, Peekable};
 
 use crate::{
     instruction::{
@@ -113,12 +113,11 @@ impl<I: for<'a> LendingIterator<Item<'a> = TupleResult<'static>> + TupleSeekable
 {
     fn seek(&mut self, target: &Tuple<'_>) -> Result<(), Box<ConceptReadError>> {
         // TODO: this is close to a copy-paste of the Seek() implementation for seekable KMergeBy<I>
-        if self.state == kmerge::State::Done {
+        if self.is_done() {
             return Ok(());
         }
 
         // force recomputation of heap element
-        self.state = kmerge::State::Pending;
         self.iterators = mem::take(&mut self.iterators)
             .into_iter()
             .chain(self.next_iterator.take())

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -7,6 +7,7 @@
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
+    mem,
 };
 
 use answer::variable_value::VariableValue;
@@ -118,9 +119,8 @@ impl<I: for<'a> LendingIterator<Item<'a> = TupleResult<'static>> + TupleSeekable
 
         // force recomputation of heap element
         self.state = kmerge::State::Pending;
-        self.iterators = self
-            .iterators
-            .drain()
+        self.iterators = mem::take(&mut self.iterators)
+            .into_iter()
             .chain(self.next_iterator.take())
             .filter_map(|mut it| {
                 if let Some(Ok(item)) = it.iter.peek() {

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -117,7 +117,7 @@ impl<I: for<'a> LendingIterator<Item<'a> = TupleResult<'static>> + TupleSeekable
         }
 
         // force recomputation of heap element
-        self.state = kmerge::State::Init;
+        self.state = kmerge::State::Pending;
         self.iterators = self
             .iterators
             .drain()

--- a/executor/instruction/iterator.rs
+++ b/executor/instruction/iterator.rs
@@ -7,7 +7,6 @@
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter},
-    mem,
 };
 
 use answer::variable_value::VariableValue;


### PR DESCRIPTION
## Product change and motivation

We simplify the implementation of merge iterators by removing explicit tracking of the iterator state. The iterator queue fully determines the state instead.

We also resolve the issue where a seek on a just-initialized merge iterators would cause a crash.

## Implementation

