### PR TITLE
Convert CacheError to use typedb_error macro

### DIFF
--- a/common/cache/BUILD
+++ b/common/cache/BUILD
@@ -14,6 +14,7 @@ rust_library(
         "*.rs",
     ]),
     deps = [
+        "//common/error",
         "//resource",
 
         "@crates//:bincode",

--- a/database/migration/database_importer.rs
+++ b/database/migration/database_importer.rs
@@ -1055,6 +1055,6 @@ typedb_error! {
         DoubleFinalisation(22, "Error finalizing import for database '{name}': it was already finalized. It is a sign of a corrupted file or a client bug.", name: String),
         Finalisation(23, "Error finalizing the imported database.", typedb_source: DatabaseCreateError),
         AccessAfterFinalisation(24, "Tried to modify the imported database's state after finalization. It is a sign of a client bug."),
-        CacheError(25, "Error writing import data.", source: CacheError),
+        CacheError(25, "Error writing import data.", typedb_source: CacheError),
     }
 }


### PR DESCRIPTION
## Product change and motivation

Replace manual CacheError enum with typedb_error! macro invocation, cleaning up old, un-macroed errors.

## Implementation

- Add //common/error dependency to BUILD file
- Update DatabaseImportError to use typedb_source instead of source for CacheError since it's now a TypeDB error type
