### PR TITLE
Fix Sentry crash reporting by updating dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.99",
 ]
@@ -740,6 +740,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +757,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.0",
 ]
 
 [[package]]
@@ -1273,7 +1279,7 @@ dependencies = [
  "error",
  "futures",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.25.0",
  "logger",
  "resource",
  "sentry",
@@ -1754,8 +1760,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
+ "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 
@@ -2075,7 +2083,7 @@ dependencies = [
  "error",
  "futures",
  "hyper 0.14.32",
- "hyper-rustls",
+ "hyper-rustls 0.25.0",
  "itertools 0.10.5",
  "macro_rules_attribute",
  "options",
@@ -2171,6 +2179,23 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-util",
+ "rustls 0.23.23",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -2476,6 +2501,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
 name = "ir"
 version = "0.0.0"
 dependencies = [
@@ -2716,6 +2747,12 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4"
@@ -3517,6 +3554,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes 1.10.0",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
+ "socket2 0.5.8",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes 1.10.0",
+ "getrandom 0.3.1",
+ "lru-slab",
+ "rand 0.9.0",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.23",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.12",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.8",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3734,6 +3826,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.10.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls 0.23.23",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower 0.5.2",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.26.11",
+ "windows-registry",
+]
+
+[[package]]
 name = "resource"
 version = "0.0.0"
 dependencies = [
@@ -3784,6 +3920,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3889,6 +4031,9 @@ name = "rustls-pki-types"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+dependencies = [
+ "web-time",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4046,12 +4191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7332159e544e34db06b251b1eda5e546bd90285c3f58d9c8ff8450b484e0da"
 dependencies = [
  "httpdate",
+ "reqwest",
+ "rustls 0.23.23",
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
  "sentry-panic",
  "sentry-tracing",
  "ureq",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4623,6 +4771,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4896,6 +5047,21 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5257,7 +5423,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=6e41d40609eea53aeb1bf8733a3269d7e78b662f#6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+source = "git+https://github.com/typedb/typeql?rev=3011a31ae1fd16f4d387bb801dec8b385cebd954#3011a31ae1fd16f4d387bb801dec8b385cebd954"
 dependencies = [
  "chrono",
  "itertools 0.10.5",
@@ -5335,7 +5501,10 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "once_cell",
+ "rustls 0.23.23",
+ "rustls-pki-types",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5549,6 +5718,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5639,7 +5836,7 @@ dependencies = [
  "windows-implement 0.58.0",
  "windows-interface 0.58.0",
  "windows-result 0.2.0",
- "windows-strings",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5694,6 +5891,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result 0.3.1",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,6 +5926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
+dependencies = [
+ "windows-link 0.1.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5719,6 +5942,15 @@ checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result 0.2.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link 0.1.0",
 ]
 
 [[package]]
@@ -5772,11 +6004,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5792,6 +6041,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5802,6 +6057,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5816,10 +6077,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5834,6 +6107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5844,6 +6123,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5858,6 +6143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5868,6 +6159,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ features = {}
 
 	[dev-dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -100,7 +100,7 @@ features = {}
 		default-features = false
 
 	[dependencies.sentry]
-		features = ["backtrace", "contexts", "httpdate", "panic", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq"]
+		features = ["backtrace", "contexts", "httpdate", "panic", "rustls", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq", "webpki-roots"]
 		version = "0.36.0"
 		default-features = false
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -21,7 +21,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -68,7 +68,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -128,7 +128,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -123,7 +123,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -15,7 +15,7 @@ def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
         remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "f6e710f9857b1c30ad1764c1c41afce4e4e02981",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        commit = "9d1aadeb7e3b28362309e0344a69a5eb38e7b2ad",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typeql():

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -66,7 +66,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 
@@ -96,7 +96,7 @@ features = {}
 		default-features = false
 
 	[dependencies.sentry]
-		features = ["backtrace", "contexts", "httpdate", "panic", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq"]
+		features = ["backtrace", "contexts", "httpdate", "panic", "rustls", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq", "webpki-roots"]
 		version = "0.36.0"
 		default-features = false
 

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -113,7 +113,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -138,7 +138,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -93,7 +93,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -133,7 +133,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -74,7 +74,7 @@ dev-dependencies = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -118,7 +118,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -76,7 +76,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/service/http/http_steps/Cargo.toml
+++ b/tests/behaviour/service/http/http_steps/Cargo.toml
@@ -106,7 +106,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -86,7 +86,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/tests/behaviour/steps/params/Cargo.toml
+++ b/tests/behaviour/steps/params/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -46,7 +46,7 @@ features = {}
 
 	[dependencies.typeql]
 		features = []
-		rev = "6e41d40609eea53aeb1bf8733a3269d7e78b662f"
+		rev = "3011a31ae1fd16f4d387bb801dec8b385cebd954"
 		git = "https://github.com/typedb/typeql"
 		default-features = false
 


### PR DESCRIPTION
## Product change and motivation
Update dependencies https://github.com/typedb/typedb-dependencies/pull/595 to use the `rustls` feature of `sentry`, allowing it to always send reports to the protected sentry endpoint. Fixes https://github.com/typedb/typedb/issues/7650.

The ureq HTTP transport used by Sentry requires a TLS backend to make HTTPS requests to sentry.io. Our sentry dependency was configured with `default-features = false` and the ureq feature, which, following the description on the [official docs page](https://crates.io/crates/sentry/0.36.0), enabled `rustls` by default. If built using Bazel, this indeed works correctly. However, when built through Cargo, no actual reports could be sent to the Sentry endpoint, as `rustls` [is not enabled](https://github.com/getsentry/sentry-rust/blob/0.36.0/sentry/Cargo.toml#L81) for `ureq` by default (default features, including `rustls`, are turned off).

## Implementation
Just update the dependencies ref.