### PR TITLE
Introduce bazel ci config setting

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,6 +4,9 @@
 
 try-import ./.bazel-remote-cache.rc
 
-build --incompatible_strict_action_env --@io_bazel_rules_docker//transitions:enable=false --remote_download_toplevel
+build --incompatible_strict_action_env --@io_bazel_rules_docker//transitions:enable=false --remote_download_toplevel --disk_cache=~/.cache/bazel
 run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
+
+# CI configuration: disables disk cache to prevent cache size issues in CI environments
+build:ci --disk_cache=

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ commands:
       - run: |
           echo 'skipped'
           # bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          # bazel build --jobs=8 //:assemble-typedb-all --compilation_mode=opt
-          # bazel test //tests/assembly:test_assembly --test_output=errors
+          # bazel build --config=ci --jobs=8 //:assemble-typedb-all --compilation_mode=opt
+          # bazel test --config=ci //tests/assembly:test_assembly --test_output=errors
 
   deploy-snapshot-unix:
     steps:
@@ -90,7 +90,7 @@ commands:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --jobs=8 --define version=$(git rev-parse HEAD) //:deploy-typedb-server --compilation_mode=opt -- snapshot
+          bazel run --config=ci --jobs=8 --define version=$(git rev-parse HEAD) //:deploy-typedb-server --compilation_mode=opt -- snapshot
 
   deploy-release-unix:
     steps:
@@ -98,7 +98,7 @@ commands:
           export DEPLOY_ARTIFACT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_ARTIFACT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --jobs=8 --define version=$(cat VERSION) //:deploy-typedb-server --compilation_mode=opt --//server:mode=published -- release
+          bazel run --config=ci --jobs=8 --define version=$(cat VERSION) //:deploy-typedb-server --compilation_mode=opt --//server:mode=published -- release
 
   deploy-release-apt:
     steps:
@@ -106,7 +106,7 @@ commands:
           export DEPLOY_APT_USERNAME=$REPO_TYPEDB_USERNAME
           export DEPLOY_APT_PASSWORD=$REPO_TYPEDB_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --jobs=8 --define version=$(cat VERSION) //:deploy-apt --compilation_mode=opt --//server:mode=published -- release
+          bazel run --config=ci --jobs=8 --define version=$(cat VERSION) //:deploy-apt --compilation_mode=opt --//server:mode=published -- release
 
   deploy-docker-snapshot-for-arch:
     parameters:
@@ -117,7 +117,7 @@ commands:
           docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
           export VERSION=$(git rev-parse HEAD)
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --jobs=8 --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
+          bazel run --config=ci --jobs=8 --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
             --define container-version="$VERSION-<<parameters.image-arch>>" //:deploy-docker-snapshot-<<parameters.image-arch>>
 
   # TODO: Migrate to bazel sh_binary
@@ -141,7 +141,7 @@ commands:
       - run: |
           docker login -u $REPO_DOCKER_USERNAME -p $REPO_DOCKER_PASSWORD
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --jobs=8 --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
+          bazel run --config=ci --jobs=8 --@io_bazel_rules_docker//transitions:enable=false --platforms=//docker:linux-<<parameters.image-arch>> \
             //:deploy-docker-release-<<parameters.image-arch>> --compilation_mode=opt --//server:mode=published
 
   # TODO: Migrate to bazel sh_binary
@@ -303,7 +303,7 @@ jobs:
           sha256sum ~/dist/typedb-all-mac-arm64.zip  | awk '{print $1}' > checksum-arm64
           sha256sum ~/dist/typedb-all-mac-x86_64.zip | awk '{print $1}' > checksum-x86_64
           bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-          bazel run --define version=$(cat VERSION) //:deploy-brew --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 --compilation_mode=opt -- release
+          bazel run --config=ci --define version=$(cat VERSION) //:deploy-brew --//:checksum-mac-arm64=:checksum-arm64 --//:checksum-mac-x86_64=:checksum-x86_64 --compilation_mode=opt -- release
 
   deploy-release-apt-x86_64:
     executor: linux-x86_64-amazonlinux-2

--- a/.circleci/windows/deploy_release.bat
+++ b/.circleci/windows/deploy_release.bat
@@ -14,5 +14,5 @@ copy target\release\typedb_server_bin.exe  .\
 SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 set /p VER=<VERSION
-bazel --windows_enable_symlinks run --define version=%VER% --//server:mode=published --enable_runfiles //:deploy-typedb-server -- release
+bazel --windows_enable_symlinks run --config=ci --define version=%VER% --//server:mode=published --enable_runfiles //:deploy-typedb-server -- release
 

--- a/.circleci/windows/deploy_snapshot.bat
+++ b/.circleci/windows/deploy_snapshot.bat
@@ -16,5 +16,5 @@ SET DEPLOY_ARTIFACT_USERNAME=%REPO_TYPEDB_USERNAME%
 SET DEPLOY_ARTIFACT_PASSWORD=%REPO_TYPEDB_PASSWORD%
 git rev-parse HEAD > version_snapshot.txt
 set /p VER=<version_snapshot.txt
-bazel --windows_enable_symlinks run --define version=%VER% --enable_runfiles //:deploy-typedb-server -- snapshot
+bazel --windows_enable_symlinks run --config=ci --define version=%VER% --enable_runfiles //:deploy-typedb-server -- snapshot
 

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -18,7 +18,7 @@ build:
     dependency-analysis:
       image: typedb-ubuntu-22.04
       command: |
-        bazel run @typedb_dependencies//factory/analysis:dependency-analysis
+        bazel run --config=ci @typedb_dependencies//factory/analysis:dependency-analysis
   correctness:
     build:
       image: typedb-ubuntu-22.04
@@ -26,10 +26,10 @@ build:
         sudo apt update
         sudo apt install -y libclang-dev
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build //... 
-        bazel run @typedb_dependencies//tool/checkstyle:test-coverage
-        bazel test $(bazel query 'kind(checkstyle_test, //...)') 
-        bazel test $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//:rustfmt_config
+        bazel build --config=ci //... 
+        bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
+        bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)') 
+        bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//:rustfmt_config
 
 #    build-dependency:
 #      image: typedb-ubuntu-22.04
@@ -37,7 +37,7 @@ build:
 #        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
 #        dependencies/maven/update.sh
 #        git diff --exit-code dependencies/maven/artifacts.snapshot
-#        bazel run @typedb_dependencies//tool/unuseddeps:unused-deps -- list
+#        bazel run --config=ci @typedb_dependencies//tool/unuseddeps:unused-deps -- list
 
     cargo-check:
       image: typedb-ubuntu-22.04
@@ -68,108 +68,108 @@ build:
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //common/cache:test_crate_cache --test_output=streamed
-        bazel test //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
-        bazel test //common/logger:test_crate_logger --test_output=streamed
-        bazel test //compiler:test_crate_compiler --test_output=streamed
-        bazel test //concept:test_crate_concept --test_output=streamed
-        bazel test //database:test_crate_database --test_output=streamed
-        bazel test //durability:test_crate_durability  --test_output=streamed
-        bazel test //encoding:test_crate_encoding --test_output=streamed
-        bazel test //executor:test_crate_executor --test_output=streamed
-        bazel test //function:test_crate_function --test_output=streamed
-        bazel test //ir:test_crate_ir --test_output=streamed
-        bazel test //query:test_crate_query --test_output=streamed
-        bazel test //server:test_crate_server --test_output=streamed
-        bazel test //storage:test_crate_storage --test_output=streamed
+        bazel test --config=ci //common/cache:test_crate_cache --test_output=streamed
+        bazel test --config=ci //common/lending_iterator:test_crate_lending_iterator --test_output=streamed
+        bazel test --config=ci //common/logger:test_crate_logger --test_output=streamed
+        bazel test --config=ci //compiler:test_crate_compiler --test_output=streamed
+        bazel test --config=ci //concept:test_crate_concept --test_output=streamed
+        bazel test --config=ci //database:test_crate_database --test_output=streamed
+        bazel test --config=ci //durability:test_crate_durability  --test_output=streamed
+        bazel test --config=ci //encoding:test_crate_encoding --test_output=streamed
+        bazel test --config=ci //executor:test_crate_executor --test_output=streamed
+        bazel test --config=ci //function:test_crate_function --test_output=streamed
+        bazel test --config=ci //ir:test_crate_ir --test_output=streamed
+        bazel test --config=ci //query:test_crate_query --test_output=streamed
+        bazel test --config=ci //server:test_crate_server --test_output=streamed
+        bazel test --config=ci //storage:test_crate_storage --test_output=streamed
 
     test-integration:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
-        bazel test $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //compiler/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //concept/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //database/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //durability/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //encoding/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //executor/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //function/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //ir/tests/...)') --test_output=streamed
+        bazel test --config=ci $(bazel query 'kind(rust_test, //query/tests/...)') --test_output=streamed
         # TODO: Uncomment!
-        # bazel test $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
-        bazel test //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
+        # bazel test --config=ci $(bazel query 'kind(rust_test, //storage/tests/...)') --test_output=streamed
+        bazel test --config=ci //storage/tests:test_mvcc //storage/tests:test_snapshot //storage/tests:test_isolation //storage/tests:test_storage --test_output=streamed
 
 #    tests-commented-out-which-fail:
 #      image: typedb-ubuntu-22.04
 #      dependencies: [ build ]
 #      command: |
 #        bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-#        bazel test //storage/tests/... --test_output=streamed
+#        bazel test --config=ci //storage/tests/... --test_output=streamed
 
     test-behaviour-connection:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
+        bazel test --config=ci //tests/behaviour/connection:test_connection --test_output=streamed  --test_arg="--test-threads=1"
 
     test-behaviour-concept:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/concept:test_concept --test_output=errors --test_arg="--test-threads=1"
+        bazel test --config=ci //tests/behaviour/concept:test_concept --test_output=errors --test_arg="--test-threads=1"
 
     test-behaviour-query-read:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_read"
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_read"
 
     test-behaviour-query-write:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_write"
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_write"
 
     test-behaviour-query-analyze:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_analyze"
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_analyze"
 
     test-behaviour-query-definable:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_definable"
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="test_definable"
 
     test-behaviour-functions:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="functions::"
+        bazel test --config=ci //tests/behaviour/query:test_query --test_output=streamed --test_arg="--test-threads=1" --test_arg="functions::"
 
     test-assembly:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test //tests/assembly:test_assembly
+        bazel test --config=ci //tests/assembly:test_assembly
 
     test-behaviour-service:
       image: typedb-ubuntu-22.04
       dependencies: [build]
       command: |
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel test $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed --jobs=1
+        bazel test --config=ci $(bazel query 'kind(rust_test, //tests/behaviour/service/...)') --test_output=streamed --jobs=1
 
 release:
   filter:
@@ -179,13 +179,13 @@ release:
     validate-dependencies:
       image: typedb-ubuntu-22.04
       command: |
-        bazel test //:release-validate-deps --test_output=streamed
+        bazel test --config=ci //:release-validate-deps --test_output=streamed
 
     validate-release-notes:
       image: typedb-ubuntu-22.04
       command: |
         export NOTES_VALIDATE_TOKEN=$REPO_GITHUB_TOKEN
-        bazel run @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
+        bazel run --config=ci @typedb_dependencies//tool/release/notes:validate --test_output=streamed -- $FACTORY_OWNER $FACTORY_REPO RELEASE_NOTES_LATEST.md
 
   deployment:
     trigger-release-circleci:


### PR DESCRIPTION
## Product change and motivation

We add a bazel config profile `ci`, which does not use a local disk cache. Local disk caches can help speed up builds, especially when switching branches or creating new worktrees. However, they can be very large and cause CI systems to run out of disk space, while also not providing any benefits (roughly building once per CI job, and already using the global networked cache).

## Implementation

* Create new `ci` config, which disables the disk-cache
* Apply the `ci` config to all bazel jobs in CircleCI and in Factory

