### PR TITLE
Tag parameters with value type

### DIFF
--- a/compiler/annotation/expression/expression_compiler.rs
+++ b/compiler/annotation/expression/expression_compiler.rs
@@ -89,7 +89,7 @@ impl<'this> ExpressionCompilationContext<'this> {
 
     fn compile_recursive(&mut self, expression: &Expression<Variable>) -> Result<(), Box<ExpressionCompileError>> {
         match expression {
-            Expression::Constant(constant) => self.compile_constant(*constant),
+            Expression::Constant(constant) => self.compile_constant(constant),
             Expression::Variable(variable) => self.compile_variable(variable),
             Expression::Operation(op) => self.compile_op(op),
             Expression::BuiltinValueFunctionCall(builtin) => self.compile_value_builtin(builtin),
@@ -99,8 +99,8 @@ impl<'this> ExpressionCompilationContext<'this> {
         }
     }
 
-    fn compile_constant(&mut self, constant: ParameterID) -> Result<(), Box<ExpressionCompileError>> {
-        self.constant_stack.push(constant);
+    fn compile_constant(&mut self, constant: &ParameterID) -> Result<(), Box<ExpressionCompileError>> {
+        self.constant_stack.push(constant.clone());
 
         self.push_type_single(self.parameters.value_unchecked(constant).value_type());
         self.append_instruction(LoadConstant::OP_CODE);

--- a/compiler/annotation/fetch.rs
+++ b/compiler/annotation/fetch.rs
@@ -144,7 +144,7 @@ fn annotated_object_entries(
             source_span,
         )
         .map_err(|err| AnnotationError::FetchEntry {
-            key: parameters.fetch_key(key).unwrap().clone(),
+            key: parameters.fetch_key(&key).unwrap().clone(),
             typedb_source: Box::new(err),
         })?;
         annotated_entries.insert(key, annotated_value);

--- a/compiler/executable/insert/executable.rs
+++ b/compiler/executable/insert/executable.rs
@@ -238,11 +238,11 @@ pub(crate) fn add_inserted_concepts(
                 variable_registry,
                 stage_source_span,
             )?;
-            let value = if let Some(&constant) = value_bindings.get(&value_variable) {
+            let value = if let Some(constant) = value_bindings.get(&value_variable) {
                 debug_assert!(!value_variable
                     .as_variable()
                     .is_some_and(|variable| input_variables.contains_key(&variable)));
-                ValueSource::Parameter(constant)
+                ValueSource::Parameter(constant.clone())
             } else if let &Vertex::Variable(variable) = value_variable {
                 if let Some(&position) = input_variables.get(&variable) {
                     ValueSource::Variable(position)
@@ -435,7 +435,7 @@ fn collect_value_bindings(
 
     filter_variants!(Constraint::ExpressionBinding : constraints)
         .map(|expr| {
-            let &Expression::Constant(constant) = expr.expression().get_root() else {
+            let Expression::Constant(constant) = expr.expression().get_root() else {
                 return Err(Box::new(WriteCompilationError::UnsupportedCompoundExpressions {
                     source_span: expr.source_span(),
                 }));
@@ -446,13 +446,13 @@ fn collect_value_bindings(
                 seen.insert(expr.left());
             }
 
-            Ok((expr.left(), constant))
+            Ok((expr.left(), constant.clone()))
         })
         .chain(
             constraints
                 .iter()
                 .flat_map(|con| con.vertices().filter(|v| v.is_parameter()))
-                .map(|param| Ok((param, param.as_parameter().unwrap()))),
+                .map(|param| Ok((param, param.as_parameter().unwrap().clone()))),
         )
         .collect()
 }

--- a/compiler/executable/insert/mod.rs
+++ b/compiler/executable/insert/mod.rs
@@ -23,7 +23,7 @@ pub enum TypeSource {
     Constant(answer::Type),
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum ValueSource {
     Variable(VariablePosition),
     Parameter(ParameterID),

--- a/compiler/executable/match_/instructions/mod.rs
+++ b/compiler/executable/match_/instructions/mod.rs
@@ -528,8 +528,8 @@ impl<ID: IrID> CheckVertex<ID> {
         matches!(self, Self::Parameter(..))
     }
 
-    pub fn as_parameter(&self) -> Option<ParameterID> {
-        if let &Self::Parameter(v) = self {
+    pub fn as_parameter(&self) -> Option<&ParameterID> {
+        if let Self::Parameter(v) = self {
             Some(v)
         } else {
             None

--- a/compiler/executable/match_/planner/plan.rs
+++ b/compiler/executable/match_/planner/plan.rs
@@ -1879,7 +1879,7 @@ impl ConjunctionPlan<'_> {
 
             ConstraintVertex::Iid(iid) => {
                 let var = iid.iid().var().as_variable().unwrap();
-                let instruction = CheckInstruction::Iid { var, iid: iid.iid().iid().as_parameter().unwrap() };
+                let instruction = CheckInstruction::Iid { var, iid: iid.iid().iid().as_parameter().unwrap().clone() };
                 conjunction_builder.push_check(instruction.map(conjunction_builder.position_mapping()));
             }
 

--- a/executor/instruction/checker.rs
+++ b/executor/instruction/checker.rs
@@ -215,7 +215,7 @@ impl<T> Checker<T> {
     ) -> Result<bool, Box<ConceptReadError>> {
         for check in &self.checks {
             let passes = match check {
-                CheckInstruction::Iid { var, iid } => self.filter_iid(context, row, *var, &source, *iid),
+                CheckInstruction::Iid { var, iid } => self.filter_iid(context, row, *var, &source, iid),
                 CheckInstruction::TypeList { type_var, types } => {
                     self.filter_type_list(context, row, *type_var, &source, types)
                 }
@@ -283,7 +283,7 @@ impl<T> Checker<T> {
 
         for check in &self.checks {
             let filter = match check {
-                &CheckInstruction::Iid { var, iid } => self.filter_iid_fn(context, row, var, iid),
+                CheckInstruction::Iid { var, iid } => self.filter_iid_fn(context, row, *var, iid),
                 &CheckInstruction::TypeList { type_var, ref types } => {
                     self.filter_type_list_fn(context, row, type_var, types)
                 }
@@ -350,7 +350,7 @@ impl<T> Checker<T> {
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
         row: &MaybeOwnedRow<'_>,
         var: ExecutorVariable,
-        iid: ir::pattern::ParameterID,
+        iid: &ir::pattern::ParameterID,
     ) -> Box<dyn Fn(&T) -> Result<bool, Box<ConceptReadError>>> {
         let var: BoxExtractor<T> = match self.extractors.get(&var) {
             Some(&function) => Box::new(function),
@@ -366,7 +366,7 @@ impl<T> Checker<T> {
         row: &MaybeOwnedRow<'_>,
         var: ExecutorVariable,
         source: &T,
-        iid: ir::pattern::ParameterID,
+        iid: &ir::pattern::ParameterID,
     ) -> bool {
         let extracted = match self.extractors.get(&var) {
             Some(function) => function(source),
@@ -1135,7 +1135,7 @@ impl<T> Checker<T> {
         let rhs = match rhs {
             &CheckVertex::Variable(ExecutorVariable::RowPosition(pos)) => row.get(pos).as_reference(),
             &CheckVertex::Variable(_) => unreachable!(),
-            &CheckVertex::Parameter(param) => {
+            CheckVertex::Parameter(param) => {
                 VariableValue::Value(context.parameters().value_unchecked(param).as_reference())
             }
             CheckVertex::Type(_) => unreachable!(),
@@ -1189,7 +1189,7 @@ impl<T> Checker<T> {
         let rhs = match rhs {
             &CheckVertex::Variable(ExecutorVariable::RowPosition(pos)) => row.get(pos).as_reference(),
             &CheckVertex::Variable(_) => unreachable!(),
-            &CheckVertex::Parameter(param) => {
+            CheckVertex::Parameter(param) => {
                 VariableValue::Value(context.parameters().value_unchecked(param).as_reference())
             }
             CheckVertex::Type(_) => unreachable!(),
@@ -1268,7 +1268,7 @@ fn get_vertex_value<'a, 'b>(
         },
         CheckVertex::Type(type_) => VariableValue::Type(*type_),
         CheckVertex::Parameter(parameter_id) => {
-            VariableValue::Value(parameters.value_unchecked(*parameter_id).as_reference())
+            VariableValue::Value(parameters.value_unchecked(parameter_id).as_reference())
         }
     }
 }

--- a/executor/pipeline/fetch.rs
+++ b/executor/pipeline/fetch.rs
@@ -585,7 +585,7 @@ fn execute_object_entries(
     let mut map = HashMap::with_capacity(entries.len());
     for (id, fetch_some) in entries {
         map.insert(
-            *id,
+            id.clone(),
             execute_fetch_some(
                 fetch_some,
                 snapshot.clone(),

--- a/executor/read/expression_executor.rs
+++ b/executor/read/expression_executor.rs
@@ -142,7 +142,7 @@ impl<'this> ExpressionExecutorState<'this> {
     }
 
     fn next_constant(&mut self) -> Value<'static> {
-        let constant = self.parameter_registry.value_unchecked(self.constants[self.next_constant_index]).clone();
+        let constant = self.parameter_registry.value_unchecked(&self.constants[self.next_constant_index]).clone();
         self.next_constant_index += 1;
         constant
     }

--- a/executor/tests/efficiency.rs
+++ b/executor/tests/efficiency.rs
@@ -502,7 +502,7 @@ fn value_int_equality_isa_reads() {
     conjunction.constraints_mut().add_label(var_id_type, ID_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_attr), Vertex::Parameter(value_int_2_id), Comparator::Equal, None)
+        .add_comparison(Vertex::Variable(var_attr), Vertex::Parameter(value_int_2_id.clone()), Comparator::Equal, None)
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -606,7 +606,12 @@ fn value_int_equality_has_reverse_reads() {
     conjunction.constraints_mut().add_label(var_gov_id_type, GOV_ID_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_1_id), Comparator::Equal, None)
+        .add_comparison(
+            Vertex::Variable(var_gov_id),
+            Vertex::Parameter(value_int_1_id.clone()),
+            Comparator::Equal,
+            None,
+        )
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -694,7 +699,12 @@ fn value_int_equality_has_bound_owner() {
     conjunction.constraints_mut().add_label(var_gov_id_type, GOV_ID_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_1_id), Comparator::Equal, None)
+        .add_comparison(
+            Vertex::Variable(var_gov_id),
+            Vertex::Parameter(value_int_1_id.clone()),
+            Comparator::Equal,
+            None,
+        )
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -797,14 +807,14 @@ fn value_int_inequality_has_bound_owner() {
         .constraints_mut()
         .add_comparison(
             Vertex::Variable(var_gov_id),
-            Vertex::Parameter(value_int_1_id),
+            Vertex::Parameter(value_int_1_id.clone()),
             Comparator::GreaterOrEqual,
             None,
         )
         .unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_3_id), Comparator::Less, None)
+        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_3_id.clone()), Comparator::Less, None)
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -909,7 +919,12 @@ fn value_inline_string_equality_has_bound_owner() {
     conjunction.constraints_mut().add_label(var_name_type, NAME_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_name), Vertex::Parameter(value_string_abby), Comparator::Equal, None)
+        .add_comparison(
+            Vertex::Variable(var_name),
+            Vertex::Parameter(value_string_abby.clone()),
+            Comparator::Equal,
+            None,
+        )
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -1009,7 +1024,12 @@ fn value_hashed_string_equality_has_bound_owner() {
     conjunction.constraints_mut().add_label(var_name_type, NAME_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_name), Vertex::Parameter(value_string_hashed), Comparator::Equal, None)
+        .add_comparison(
+            Vertex::Variable(var_name),
+            Vertex::Parameter(value_string_hashed.clone()),
+            Comparator::Equal,
+            None,
+        )
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -1112,14 +1132,19 @@ fn value_string_inequality_reduces_has_reads_bound_owner() {
         .constraints_mut()
         .add_comparison(
             Vertex::Variable(var_name),
-            Vertex::Parameter(value_string_bolton),
+            Vertex::Parameter(value_string_bolton.clone()),
             Comparator::GreaterOrEqual,
             None,
         )
         .unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_name), Vertex::Parameter(value_string_willow), Comparator::Less, None)
+        .add_comparison(
+            Vertex::Variable(var_name),
+            Vertex::Parameter(value_string_willow.clone()),
+            Comparator::Less,
+            None,
+        )
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -1236,7 +1261,7 @@ fn intersection_seeks() {
 
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_age), Vertex::Parameter(value_int_10), Comparator::Equal, None)
+        .add_comparison(Vertex::Variable(var_age), Vertex::Parameter(value_int_10.clone()), Comparator::Equal, None)
         .unwrap();
 
     let entry = builder.finish().unwrap();
@@ -1418,11 +1443,11 @@ fn intersections_seeks_with_extra_values() {
 
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_age), Vertex::Parameter(value_int_12), Comparator::Equal, None)
+        .add_comparison(Vertex::Variable(var_age), Vertex::Parameter(value_int_12.clone()), Comparator::Equal, None)
         .unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_2), Comparator::Greater, None)
+        .add_comparison(Vertex::Variable(var_gov_id), Vertex::Parameter(value_int_2.clone()), Comparator::Greater, None)
         .unwrap();
 
     let entry = builder.finish().unwrap();

--- a/executor/tests/execute_relation_index.rs
+++ b/executor/tests/execute_relation_index.rs
@@ -585,7 +585,7 @@ fn traverse_index_from_bound() {
     conjunction.constraints_mut().add_label(var_casting_actor_type, CASTING_ACTOR_LABEL.clone()).unwrap();
     conjunction
         .constraints_mut()
-        .add_comparison(Vertex::Variable(var_id), Vertex::Parameter(id_0_parameter), Comparator::Equal, None)
+        .add_comparison(Vertex::Variable(var_id), Vertex::Parameter(id_0_parameter.clone()), Comparator::Equal, None)
         .unwrap();
 
     let entry = builder.finish().unwrap();

--- a/executor/write/write_instruction.rs
+++ b/executor/write/write_instruction.rs
@@ -45,17 +45,17 @@ fn get_value<'a>(
     storage_counters: StorageCounters,
     input: &'a Row<'_>,
     parameters: &'a ParameterRegistry,
-    source: ValueSource,
+    source: &ValueSource,
 ) -> Result<Value<'a>, Box<WriteError>> {
     match source {
-        ValueSource::Variable(position) => match input.get(position) {
+        &ValueSource::Variable(position) => match input.get(position) {
             VariableValue::Thing(Thing::Attribute(attribute)) => attribute
                 .get_value(snapshot, thing_manager, storage_counters)
                 .map_err(|typedb_source| Box::new(WriteError::ConceptRead { typedb_source })),
             VariableValue::Value(value) => Ok(value.as_reference()),
             _ => unreachable!("Expected value or attribute"),
         },
-        ValueSource::Parameter(id) => Ok(parameters.value_unchecked(id).as_reference()),
+        ValueSource::Parameter(id) => Ok(parameters.value_unchecked(&id).as_reference()),
     }
 }
 
@@ -92,7 +92,7 @@ impl AsWriteInstruction for PutAttribute {
             .create_attribute(
                 snapshot,
                 attribute_type,
-                get_value(snapshot, thing_manager, storage_counters, row, parameters, self.value)?.clone(),
+                get_value(snapshot, thing_manager, storage_counters, row, parameters, &self.value)?.clone(),
             )
             .map_err(|typedb_source| WriteError::ConceptWrite { typedb_source })?;
         let ThingPosition(write_to) = &self.write_to;

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -2313,7 +2313,7 @@ impl Comparator {
             | Comparator::LessOrEqual
             | Comparator::GreaterOrEqual
             | Comparator::Contains => Ok(()),
-            Comparator::Like => match rhs.as_parameter().and_then(|pid| parameters.value(pid)) {
+            Comparator::Like => match rhs.as_parameter().and_then(|pid| parameters.value(&pid)) {
                 Some(encoding::value::value::Value::String(value)) => {
                     regex::Regex::new(value).map(|_| ()).map_err(|source| {
                         Box::new(RepresentationError::RegexFailedCompilation {

--- a/ir/pattern/expression.rs
+++ b/ir/pattern/expression.rs
@@ -85,7 +85,7 @@ impl<ID: IrID> ExpressionTree<ID> {
                 Expression::ListIndexRange(list_index_range) => {
                     Expression::ListIndexRange(list_index_range.map(mapping))
                 }
-                Expression::Constant(inner) => Expression::Constant(*inner),
+                Expression::Constant(inner) => Expression::Constant(inner.clone()),
                 Expression::Operation(inner) => Expression::Operation(inner.clone()),
                 Expression::BuiltinValueFunctionCall(inner) => Expression::BuiltinValueFunctionCall(inner.clone()),
                 Expression::List(inner) => Expression::List(inner.clone()),
@@ -444,8 +444,8 @@ impl ListConstructor {
         &self.item_expression_ids
     }
 
-    pub fn len_id(&self) -> ParameterID {
-        self.len_id
+    pub fn len_id(&self) -> &ParameterID {
+        &self.len_id
     }
 
     pub fn source_span(&self) -> Option<Span> {

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -8,7 +8,10 @@ use std::{collections::HashMap, fmt, sync::Arc};
 
 use answer::variable::Variable;
 use bytes::byte_array::ByteArray;
-use encoding::{graph::thing::THING_VERTEX_MAX_LENGTH, value::value::Value};
+use encoding::{
+    graph::thing::THING_VERTEX_MAX_LENGTH,
+    value::{value::Value, ValueEncodable},
+};
 use error::typedb_error;
 use itertools::Itertools;
 use storage::snapshot::{iterator::SnapshotIteratorError, SnapshotGetError};
@@ -21,7 +24,7 @@ use crate::{
     pattern::{
         constraint::Constraint,
         variable_category::{VariableCategory, VariableOptionality},
-        BranchID, ParameterID,
+        BranchID, ParameterID, ValueType,
     },
     pipeline::{function_signature::FunctionID, reduce::Reducer},
     RepresentationError,
@@ -355,39 +358,39 @@ impl ParameterRegistry {
     }
 
     pub fn register_value(&mut self, value: Value<'static>, source_span: Span) -> ParameterID {
-        let id = ParameterID::Value(self.value_registry.len(), source_span);
-        let _prev = self.value_registry.insert(id, value);
+        let id = ParameterID::Value(self.value_registry.len(), ValueType::Builtin(value.value_type()), source_span);
+        let _prev = self.value_registry.insert(id.clone(), value);
         debug_assert_eq!(_prev, None);
         id
     }
 
     pub(crate) fn register_iid(&mut self, iid: ByteArray<THING_VERTEX_MAX_LENGTH>, source_span: Span) -> ParameterID {
         let id = ParameterID::Iid(self.iid_registry.len(), source_span);
-        let _prev = self.iid_registry.insert(id, iid);
+        let _prev = self.iid_registry.insert(id.clone(), iid);
         debug_assert_eq!(_prev, None);
         id
     }
 
     pub(crate) fn register_fetch_key(&mut self, key: String, source_span: Span) -> ParameterID {
         let id = ParameterID::FetchKey(self.fetch_key_registry.len(), source_span);
-        let _prev = self.fetch_key_registry.insert(id, key);
+        let _prev = self.fetch_key_registry.insert(id.clone(), key);
         debug_assert_eq!(_prev, None);
         id
     }
 
-    pub fn value(&self, id: ParameterID) -> Option<&Value<'static>> {
-        self.value_registry.get(&id)
+    pub fn value(&self, id: &ParameterID) -> Option<&Value<'static>> {
+        self.value_registry.get(id)
     }
 
-    pub fn value_unchecked(&self, id: ParameterID) -> &Value<'static> {
-        self.value_registry.get(&id).unwrap()
+    pub fn value_unchecked(&self, id: &ParameterID) -> &Value<'static> {
+        self.value_registry.get(id).unwrap()
     }
 
-    pub fn iid(&self, id: ParameterID) -> Option<&ByteArray<THING_VERTEX_MAX_LENGTH>> {
-        self.iid_registry.get(&id)
+    pub fn iid(&self, id: &ParameterID) -> Option<&ByteArray<THING_VERTEX_MAX_LENGTH>> {
+        self.iid_registry.get(id)
     }
 
-    pub fn fetch_key(&self, id: ParameterID) -> Option<&String> {
-        self.fetch_key_registry.get(&id)
+    pub fn fetch_key(&self, id: &ParameterID) -> Option<&String> {
+        self.fetch_key_registry.get(id)
     }
 }

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -353,11 +353,11 @@ pub mod tests {
         assert_eq!(lhs, &Vertex::Variable(var_y));
 
         assert_eq!(rhs.len(), 5);
-        let Expression::Constant(id) = rhs[0] else { panic!("Expected Constant, found: {:?}", rhs[0]) };
+        let Expression::Constant(id) = &rhs[0] else { panic!("Expected Constant, found: {:?}", rhs[0]) };
         assert_eq!(value_parameters.value(id), Some(&Value::Integer(5)));
-        let Expression::Constant(id) = rhs[1] else { panic!("Expected Constant, found: {:?}", rhs[1]) };
+        let Expression::Constant(id) = &rhs[1] else { panic!("Expected Constant, found: {:?}", rhs[1]) };
         assert_eq!(value_parameters.value(id), Some(&Value::Integer(9)));
-        let Expression::Constant(id) = rhs[2] else { panic!("Expected Constant, found: {:?}", rhs[2]) };
+        let Expression::Constant(id) = &rhs[2] else { panic!("Expected Constant, found: {:?}", rhs[2]) };
         assert_eq!(value_parameters.value(id), Some(&Value::Integer(6)));
         assert_eq!(rhs[3], Expression::Operation(Operation::new(Operator::Multiply, 1, 2, None)));
         assert_eq!(rhs[4], Expression::Operation(Operation::new(Operator::Add, 0, 3, None)));

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -89,7 +89,7 @@ fn translate_fetch_object(
                     key,
                     entry.span().expect("Parser did not provide Fetch key-value text range."),
                 );
-                source_spans.insert(key_id, entry.span());
+                source_spans.insert(key_id.clone(), entry.span());
                 object.insert(key_id, translate_fetch_some(parent_context, value_parameters, function_index, value)?);
             }
             Ok(FetchObject::Entries(object, source_spans))

--- a/ir/translation/literal.rs
+++ b/ir/translation/literal.rs
@@ -396,7 +396,7 @@ pub mod tests {
                     .finish()
                     .unwrap();
             let x = block.conjunction().constraints()[0].as_expression_binding().unwrap().expression().get_root();
-            match *x {
+            match x {
                 Expression::Constant(id) => Ok(value_parameters.value_unchecked(id).to_owned()),
                 _ => unreachable!(),
             }

--- a/query/analyse.rs
+++ b/query/analyse.rs
@@ -288,7 +288,7 @@ fn build_fetch_entries_annotations<Snapshot: ReadableSnapshot>(
     entries: &HashMap<ParameterID, AnnotatedFetchSome>,
 ) -> Result<FetchStructureAnnotationsFields, Box<ConceptReadError>> {
     entries.iter().map(|(parameter_id, fetch_object)| {
-        let key = parameters.fetch_key(*parameter_id).expect("Expected fetch key to be present").to_owned();
+        let key = parameters.fetch_key(parameter_id).expect("Expected fetch key to be present").to_owned();
         let fetch_object_annotations_maybe_list = match fetch_object {
             AnnotatedFetchSome::SingleVar(var) => {
                 let as_vertex = Vertex::Variable(*var);

--- a/server/service/grpc/analyze.rs
+++ b/server/service/grpc/analyze.rs
@@ -22,7 +22,6 @@ use ir::pattern::{
     constraint::{Comparator, Constraint, IsaKind, SubKind},
     ParameterID, Vertex,
 };
-use itertools::Itertools;
 use query::analyse::{
     AnalysedQuery, FetchStructureAnnotations, FetchStructureAnnotationsFields, FunctionStructureAnnotations,
 };
@@ -49,12 +48,12 @@ pub(crate) struct PipelineStructureContext<'a, Snapshot: ReadableSnapshot> {
 }
 impl<'a, Snapshot: ReadableSnapshot> PipelineStructureContext<'a, Snapshot> {
     pub(crate) fn get_parameter_value(&self, param: &ParameterID) -> Option<Value<'static>> {
-        debug_assert!(matches!(param, ParameterID::Value(_, _)));
-        self.pipeline_structure.parameters.value(*param).cloned()
+        debug_assert!(matches!(param, ParameterID::Value { .. }));
+        self.pipeline_structure.parameters.value(param).cloned()
     }
 
     pub fn get_parameter_iid(&self, param: &ParameterID) -> Option<&[u8]> {
-        self.pipeline_structure.parameters.iid(*param).map(|iid| iid.as_ref())
+        self.pipeline_structure.parameters.iid(param).map(|iid| iid.as_ref())
     }
 
     pub(crate) fn get_type(&self, label: &Label) -> Option<answer::Type> {

--- a/server/service/grpc/document.rs
+++ b/server/service/grpc/document.rs
@@ -85,7 +85,7 @@ fn encode_map(
         DocumentMap::UserKeys(map) => {
             let mut encoded_map = HashMap::with_capacity(map.len());
             for (key, value) in map.into_iter() {
-                let key_name = parameters.fetch_key(key).expect("Expected key in parameters to get its name");
+                let key_name = parameters.fetch_key(&key).expect("Expected key in parameters to get its name");
                 let encoded_value =
                     encode_node(value, snapshot, type_manager, thing_manager, parameters, storage_counters.clone())?;
                 encoded_map.insert(key_name.to_owned(), encoded_value);

--- a/server/service/http/message/analyze/structure.rs
+++ b/server/service/http/message/analyze/structure.rs
@@ -207,12 +207,12 @@ struct PipelineStructureContext<'a, Snapshot: ReadableSnapshot> {
 
 impl<'a, Snapshot: ReadableSnapshot> PipelineStructureContext<'a, Snapshot> {
     pub fn get_parameter_value(&self, param: &ParameterID) -> Option<Value<'static>> {
-        debug_assert!(matches!(param, ParameterID::Value(_, _)));
-        self.structure.parameters.value(*param).cloned()
+        debug_assert!(matches!(param, ParameterID::Value { .. }));
+        self.structure.parameters.value(param).cloned()
     }
 
     pub fn get_parameter_iid(&self, param: &ParameterID) -> Option<&[u8]> {
-        self.structure.parameters.iid(*param).map(|iid| iid.as_ref())
+        self.structure.parameters.iid(param).map(|iid| iid.as_ref())
     }
 
     pub fn get_variable_name(&self, variable: &StructureVariableId) -> Option<String> {

--- a/server/service/http/message/query/document.rs
+++ b/server/service/http/message/query/document.rs
@@ -64,7 +64,7 @@ fn encode_map(
         DocumentMap::UserKeys(map) => {
             let mut encoded_map = HashMap::with_capacity(map.len());
             for (key, value) in map.into_iter() {
-                let key_name = parameters.fetch_key(key).expect("Expected key in parameters to get its name");
+                let key_name = parameters.fetch_key(&key).expect("Expected key in parameters to get its name");
                 let encoded_value =
                     encode_node(value, snapshot, type_manager, thing_manager, parameters, storage_counters.clone())?;
                 encoded_map.insert(key_name.to_owned(), encoded_value);

--- a/tests/behaviour/steps/query_answer_context.rs
+++ b/tests/behaviour/steps/query_answer_context.rs
@@ -127,7 +127,7 @@ impl QueryAnswer {
             DocumentMap::UserKeys(user_keys_map) => user_keys_map
                 .iter()
                 .map(|(parameter_id, node)| {
-                    let key_name = match parameters.fetch_key(*parameter_id) {
+                    let key_name = match parameters.fetch_key(parameter_id) {
                         Some(name) => name,
                         None => panic!("Expected parameter {parameter_id:?} string in {parameters:?}"),
                     };


### PR DESCRIPTION
## Product change and motivation

We tag extracted parameters in queries with their value type. Previously the plan cache would not be able to distinguish queries with integer literals from ones with datetime literals, e.g., which would cause it to retrieve a wrong compiled plan from the cache, causing a server crash.

## Implementation

