### PR TITLE
Fix output variables in analyzed structure

### DIFF
--- a/compiler/annotation/pipeline.rs
+++ b/compiler/annotation/pipeline.rs
@@ -103,29 +103,6 @@ pub enum AnnotatedStage {
     Reduce(Reduce, Vec<ReduceInstruction<Variable>>),
 }
 
-impl AnnotatedStage {
-    pub fn named_referenced_variables<'a>(
-        &'a self,
-        variable_registry: &'a VariableRegistry,
-    ) -> impl Iterator<Item = Variable> + 'a {
-        let variables: Box<dyn Iterator<Item = Variable> + '_> = match self {
-            AnnotatedStage::Match { block, .. } => Box::new(block.variables()),
-            AnnotatedStage::Insert { block, .. } => Box::new(block.variables()),
-            AnnotatedStage::Update { block, .. } => Box::new(block.variables()),
-            AnnotatedStage::Put { block, .. } => Box::new(block.variables()),
-            AnnotatedStage::Delete { block, .. } => Box::new(block.variables()),
-            AnnotatedStage::Select(select) => Box::new(select.variables.iter().cloned()),
-            AnnotatedStage::Sort(sort) => Box::new(sort.variables.iter().map(|sort_variable| sort_variable.variable())),
-            AnnotatedStage::Offset(_) => Box::new(iter::empty()),
-            AnnotatedStage::Limit(_) => Box::new(iter::empty()),
-            AnnotatedStage::Require(_) => Box::new(iter::empty()),
-            AnnotatedStage::Distinct(_) => Box::new(iter::empty()),
-            AnnotatedStage::Reduce(reduce, _) => Box::new(reduce.variables()),
-        };
-        variables.filter(move |variable| variable_registry.get_variable_name(*variable).is_some())
-    }
-}
-
 pub fn annotate_preamble_and_pipeline(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,


### PR DESCRIPTION
## Product change and motivation
We were using `named_referenced_variables` of the last stage to determine the output variables of a pipeline. 
We replace this with a method based on `variable_binding_modes` or the retained variables for select & reduce stages.
