### PR TITLE
Use Box in InitialIterator to shrink pipeline stage iterator sizes

### DIFF
--- a/executor/pipeline/initial.rs
+++ b/executor/pipeline/initial.rs
@@ -47,13 +47,13 @@ impl<Snapshot> StageAPI<Snapshot> for InitialStage<Snapshot> {
 }
 
 pub struct InitialIterator {
-    iterator: FixedBatchRowIterator,
+    iterator: Box<FixedBatchRowIterator>,
     index: u32,
 }
 
 impl InitialIterator {
     fn new(batch: FixedBatch) -> Self {
-        Self { iterator: FixedBatchRowIterator::new(Ok(batch)), index: 0 }
+        Self { iterator: Box::new(FixedBatchRowIterator::new(Ok(batch))), index: 0 }
     }
 }
 


### PR DESCRIPTION
## Product change and motivation
Shrinks the size of InitialIterator by using a Box around its inner iterator. This reduces the size of the pipeline stage iterator enums, leading to smaller stack frames during execution and supporting longer pipelines.

## Implementation
InitialIterator holds a 
Query pipelines are implemented as a stage's iterator consuming the iterator of the previous stage.
This can lead to some very large stack sizes when a large number of stages are involved.
Most of our stages are small, with the exception of `InitialIterator` eventually holds a `FixedBatch`:
```
pub struct FixedBatch {
    width: u32,
    entries: u32,
    data: Vec<VariableValue<'static>>,
    multiplicities: [u64; FIXED_BATCH_ROWS_MAX as usize],
    provenance: [Provenance; FIXED_BATCH_ROWS_MAX as usize],
}
```
This makes it much larger than other iterators at roughly 1k ( 64 * 8 * 2). Boxing this brings it down to the size of a few Arcs & pointers.
