### PR TITLE
Optimize isolation checks - 5-20% multithreaded insert performance

### DIFF
--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -760,16 +760,12 @@ impl CommitRecord {
 
             // Check for conflicts: our Unmodifiable locks vs predecessor Delete writes.
             // Iterate the smaller collection and point-lookup into the larger one.
-            // Cost analysis: iterating N items with lookups into M-sized BTreeMap = O(N log M).
-            // Choosing min(L, W) as the iteration side gives O(min(L,W) * log(max(L,W))).
-            let locks_len = locks.len();
-            let pred_writes_len = predecessor_writes.len();
-            if locks_len <= pred_writes_len {
+            if locks.len() <= predecessor_writes.len() {
                 for (key, lock) in locks.iter() {
-                    if matches!(lock, LockType::Unmodifiable) {
-                        if matches!(predecessor_writes.get(key), Some(Write::Delete)) {
-                            return CommitDependency::Conflict(IsolationConflict::RequireDeletedKey);
-                        }
+                    if matches!(lock, LockType::Unmodifiable)
+                        && matches!(predecessor_writes.get(key), Some(Write::Delete))
+                    {
+                        return CommitDependency::Conflict(IsolationConflict::RequireDeletedKey);
                     }
                 }
             } else {


### PR DESCRIPTION
## Product change and motivation

We update one loop in the isolation manager on the hot path, which improves throughput under heavily contended write workloads with many threads by 5-20%, and is in the noise at other thread counts. 

Benchmarked using an embedded TypeDB benchmark to exclude network and driver noise.


```
  PureInsert batch=1000                                       

Query >>

insert $p isa person, has name "person_{N}", has age {random};        
                                                                                                                                                                 
  ┌─────────┬──────────────┬────────────────┬────────────────────┐   
  │ Threads │ master       │ adaptive       │ adaptive vs master │                                
  ├─────────┼──────────────┼────────────────┼────────────────────┤                        
  │       1 │       11,739 │         11,520 │              -1.9% │                                                                                                                                                                                   
  ├─────────┼──────────────┼────────────────┼────────────────────┤
  │       2 │       21,880 │         22,160 │              +1.3% │
  ├─────────┼──────────────┼────────────────┼────────────────────┤
  │       4 │       41,510 │         39,779 │              -4.2% │
  ├─────────┼──────────────┼────────────────┼────────────────────┤
  │       8 │       67,245 │         64,519 │              -4.1% │
  ├─────────┼──────────────┼────────────────┼────────────────────┤
  │      16 │       60,863 │         65,620 │              +7.8% │
  ├─────────┼──────────────┼────────────────┼────────────────────┤
  │      32 │       57,827 │         72,347 │             +25.1% │
  └─────────┴──────────────┴────────────────┴────────────────────┘
```

## Implementation

Write an adaptive loop that decides the direction iterate and check for key conflicts based on the smaller set.
