### PR TITLE
QueryCache replaces cached preamble function parameters on get

### DIFF
--- a/compiler/executable/function/mod.rs
+++ b/compiler/executable/function/mod.rs
@@ -64,9 +64,14 @@ impl ExecutableFunctionRegistry {
         self.schema_functions.clone()
     }
 
-    pub fn replace_preamble_parameters(&mut self, preamble_parameters: impl Iterator<Item = Arc<ParameterRegistry>>) {
-        self.preamble_functions.iter_mut().zip(preamble_parameters.into_iter()).for_each(|(mut func, params)| {
-            (&mut func.1).parameter_registry = params;
+    pub fn replace_preamble_parameters(
+        &mut self,
+        preamble_parameters: impl Iterator<Item = (usize, Arc<ParameterRegistry>)>,
+    ) {
+        preamble_parameters.for_each(|(index, params)| {
+            if let Some(func) = self.preamble_functions.get_mut(&index) {
+                func.parameter_registry = params;
+            }
         })
     }
 }

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -42,7 +42,7 @@ impl QueryCache {
     ) -> Option<ExecutablePipeline> {
         let key = IRQuery::new(preamble.clone(), stages, fetch);
         self.cache.get(&key).map(|mut found| {
-            let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone()));
+            let replacement = preamble.iter().map(|func| Arc::new(func.parameters.clone())).enumerate();
             found.executable_functions.replace_preamble_parameters(replacement);
             found
         })


### PR DESCRIPTION
## Product change and motivation
Fixes a bug where cached queries would use the cached parameters in preamble pipelines, rather than those from the actual query - leading to wrong results when only the parameters in the preamble had been updated (Fixes: #7702)

## Implementation
QueryCache replaces preamble function parameters on `get`