### PR TITLE
count($var) must count unique instances of $var

### DIFF
--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -35,6 +35,6 @@ def typedb_protocol():
 def typedb_behaviour():
     git_repository(
         name = "typedb_behaviour",
-        remote = "https://github.com/typedb/typedb-behaviour",
-        commit = "0fc98ce347a58db78f2516cbb49c38a0155a7885",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
+        remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+        commit = "8cf185b618ad8dc5d571497b10382ded8cdbb48e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_behaviour
     )

--- a/executor/reduce_executor.rs
+++ b/executor/reduce_executor.rs
@@ -4,7 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Cow, collections::HashMap, sync::Arc};
+use std::{
+    borrow::Cow,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use answer::{variable_value::VariableValue, Thing};
 use chrono::{DateTime, NaiveDate, NaiveDateTime};
@@ -206,12 +210,12 @@ impl ReducerAPI for CountExecutor {
 
 #[derive(Debug, Clone)]
 struct CountVarExecutor {
-    count: u64,
+    values: HashSet<VariableValue<'static>>,
     target: VariablePosition,
 }
 impl CountVarExecutor {
     fn new(target: VariablePosition) -> Self {
-        Self { count: 0, target }
+        Self { values: HashSet::new(), target }
     }
 }
 
@@ -222,13 +226,16 @@ impl ReducerAPI for CountVarExecutor {
         _: &ExecutionContext<Snapshot>,
         _: StorageCounters,
     ) {
-        if &VariableValue::None != row.get(self.target) {
-            self.count += row.multiplicity();
+        match row.get(self.target) {
+            VariableValue::None => (),
+            other => {
+                self.values.insert(other.to_owned());
+            }
         }
     }
 
     fn finalise(self) -> Option<VariableValue<'static>> {
-        Some(VariableValue::Value(Value::Integer(self.count as i64)))
+        Some(VariableValue::Value(Value::Integer(self.values.len() as i64)))
     }
 }
 


### PR DESCRIPTION
## Product change and motivation
We fix `count($var)` to count the unique instances of `$var` - the documented behaviour.

## Implementation
Use a `HashSet<VariableValue>` to collect, instead of a single integer to count.