### PR TITLE
Mark commits applied during recovery

### DIFF
--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -134,6 +134,7 @@ impl Checkpoint {
 
     pub(crate) fn recover_storage<KS: KeyspaceSet, Durability: DurabilityClient>(
         &self,
+        database_name: &str,
         keyspaces_dir: &Path,
         durability_client: &Durability,
     ) -> Result<(Keyspaces, SequenceNumber), CheckpointLoadError> {
@@ -161,7 +162,7 @@ impl Checkpoint {
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
         let next_sequence_number = recovered_commits.keys().max().copied().unwrap_or(recovery_start - 1) + 1;
         trace!("Applying missing commits");
-        apply_recovered(recovered_commits, durability_client, &keyspaces)
+        apply_recovered(database_name, recovered_commits, durability_client, &keyspaces)
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
         Ok((keyspaces, next_sequence_number))
     }

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -107,19 +107,15 @@ pub(crate) fn apply_recovered(
             }
             RecoveryCommitStatus::Rejected => isolation_manager.load_aborted(commit_sequence_number),
             RecoveryCommitStatus::Pending(commit_record) => {
-                while pending_writes
-                    .first_key_value()
-                    .is_some_and(|(&seq, _)| seq <= commit_record.open_sequence_number())
-                {
-                    // must have been applied for a transaction to have been opened on this open_sequence_number
-                    let Some((sequence_number, _)) = pending_writes.pop_first() else {
-                        unreachable!("just checked first is Some(_)")
-                    };
+                let tail = pending_writes.split_off(&commit_record.open_sequence_number().next());
+                for (sequence_number, write_batches) in pending_writes {
+                    keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
                     isolation_manager.applied(sequence_number).map_err(|error| Internal {
                         name: Arc::new(database_name.to_owned()),
                         source: Arc::new(error),
                     })?;
                 }
+                pending_writes = tail;
 
                 let read_guard = isolation_manager.opened_for_read(commit_record.open_sequence_number());
                 let validated_commit = isolation_manager

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -95,28 +95,18 @@ pub(crate) fn apply_recovered(
 
     let isolation_manager = IsolationManager::new(*recovered_commits.first_key_value().unwrap().0);
 
-    let mut pending_writes = BTreeMap::new();
     for (commit_sequence_number, commit) in recovered_commits {
         match commit {
             RecoveryCommitStatus::Validated(commit_record) => {
-                pending_writes.insert(
-                    commit_sequence_number,
-                    WriteBatches::from_operations(commit_sequence_number, commit_record.operations()),
-                );
+                let write_batches = WriteBatches::from_operations(commit_sequence_number, commit_record.operations());
                 isolation_manager.load_validated(commit_sequence_number, commit_record);
+                keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
+                isolation_manager
+                    .applied(commit_sequence_number)
+                    .map_err(|error| Internal { name: Arc::new(database_name.to_owned()), source: Arc::new(error) })?;
             }
             RecoveryCommitStatus::Rejected => isolation_manager.load_aborted(commit_sequence_number),
             RecoveryCommitStatus::Pending(commit_record) => {
-                let tail = pending_writes.split_off(&commit_record.open_sequence_number().next());
-                for (sequence_number, write_batches) in pending_writes {
-                    keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
-                    isolation_manager.applied(sequence_number).map_err(|error| Internal {
-                        name: Arc::new(database_name.to_owned()),
-                        source: Arc::new(error),
-                    })?;
-                }
-                pending_writes = tail;
-
                 let read_guard = isolation_manager.opened_for_read(commit_record.open_sequence_number());
                 let validated_commit = isolation_manager
                     .validate_commit(commit_sequence_number, commit_record, durability_client)
@@ -126,7 +116,11 @@ pub(crate) fn apply_recovered(
                     ValidatedCommit::Write(write_batches) => {
                         MVCCStorage::persist_commit_status(true, commit_sequence_number, durability_client)
                             .map_err(|error| DurabilityClientWrite { typedb_source: error })?;
-                        pending_writes.insert(commit_sequence_number, write_batches);
+                        keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
+                        isolation_manager.applied(commit_sequence_number).map_err(|error| Internal {
+                            name: Arc::new(database_name.to_owned()),
+                            source: Arc::new(error),
+                        })?;
                     }
                     ValidatedCommit::Conflict(_) => {
                         MVCCStorage::persist_commit_status(false, commit_sequence_number, durability_client)
@@ -135,10 +129,6 @@ pub(crate) fn apply_recovered(
                 }
             }
         }
-    }
-
-    for write_batches in pending_writes.into_values() {
-        keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
     }
 
     Ok(())

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, error::Error, sync::Arc};
 
 use durability::RawRecord;
 use error::typedb_error;
@@ -81,12 +81,13 @@ pub fn load_commit_data_from(
 }
 
 pub(crate) fn apply_recovered(
+    database_name: &str,
     recovered_commits: BTreeMap<SequenceNumber, RecoveryCommitStatus>,
     durability_client: &impl DurabilityClient,
     keyspaces: &Keyspaces,
 ) -> Result<(), StorageRecoveryError> {
     event!(Level::TRACE, "Applying recovered commits");
-    use StorageRecoveryError::{DurabilityClientRead, DurabilityClientWrite, KeyspaceWrite};
+    use StorageRecoveryError::{DurabilityClientRead, DurabilityClientWrite, Internal, KeyspaceWrite};
 
     if recovered_commits.is_empty() {
         return Ok(());
@@ -94,15 +95,32 @@ pub(crate) fn apply_recovered(
 
     let isolation_manager = IsolationManager::new(*recovered_commits.first_key_value().unwrap().0);
 
-    let mut pending_writes = Vec::new();
+    let mut pending_writes = BTreeMap::new();
     for (commit_sequence_number, commit) in recovered_commits {
         match commit {
             RecoveryCommitStatus::Validated(commit_record) => {
-                pending_writes.push(WriteBatches::from_operations(commit_sequence_number, commit_record.operations()));
+                pending_writes.insert(
+                    commit_sequence_number,
+                    WriteBatches::from_operations(commit_sequence_number, commit_record.operations()),
+                );
                 isolation_manager.load_validated(commit_sequence_number, commit_record);
             }
             RecoveryCommitStatus::Rejected => isolation_manager.load_aborted(commit_sequence_number),
             RecoveryCommitStatus::Pending(commit_record) => {
+                while pending_writes
+                    .first_key_value()
+                    .is_some_and(|(&seq, _)| seq <= commit_record.open_sequence_number())
+                {
+                    // must have been applied for a transaction to have been opened on this open_sequence_number
+                    let Some((sequence_number, _)) = pending_writes.pop_first() else {
+                        unreachable!("just checked first is Some(_)")
+                    };
+                    isolation_manager.applied(sequence_number).map_err(|error| Internal {
+                        name: Arc::new(database_name.to_owned()),
+                        source: Arc::new(error),
+                    })?;
+                }
+
                 let read_guard = isolation_manager.opened_for_read(commit_record.open_sequence_number());
                 let validated_commit = isolation_manager
                     .validate_commit(commit_sequence_number, commit_record, durability_client)
@@ -112,7 +130,7 @@ pub(crate) fn apply_recovered(
                     ValidatedCommit::Write(write_batches) => {
                         MVCCStorage::persist_commit_status(true, commit_sequence_number, durability_client)
                             .map_err(|error| DurabilityClientWrite { typedb_source: error })?;
-                        pending_writes.push(write_batches);
+                        pending_writes.insert(commit_sequence_number, write_batches);
                     }
                     ValidatedCommit::Conflict(_) => {
                         MVCCStorage::persist_commit_status(false, commit_sequence_number, durability_client)
@@ -123,7 +141,7 @@ pub(crate) fn apply_recovered(
         }
     }
 
-    for write_batches in pending_writes {
+    for write_batches in pending_writes.into_values() {
         keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
     }
 
@@ -147,5 +165,6 @@ typedb_error! {
             expected_sequence_number: SequenceNumber, first_record_sequence_number: SequenceNumber
         ),
         KeyspaceWrite(5, "Error writing recovered commits to keyspace.", source: KeyspaceError),
+        Internal(6, "Storage recovery for database '{name}' failed with internal error.", name: Arc<String>, source: Arc<dyn Error + Send + Sync + 'static>),
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -138,13 +138,13 @@ impl<Durability> MVCCStorage<Durability> {
                 let commits = load_commit_data_from(SequenceNumber::MIN.next(), &durability_client, usize::MAX)
                     .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
                 let next_sequence_number = commits.keys().max().cloned().unwrap_or(SequenceNumber::MIN).next();
-                apply_recovered(commits, &durability_client, &keyspaces)
+                apply_recovered(name, commits, &durability_client, &keyspaces)
                     .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
                 trace!("Finished applying commits from WAL.");
                 (keyspaces, next_sequence_number)
             }
             Some(checkpoint) => checkpoint
-                .recover_storage::<KS, _>(&storage_dir, &durability_client)
+                .recover_storage::<KS, _>(name, &storage_dir, &durability_client)
                 .map_err(|error| RecoverFromCheckpoint { name: name.to_owned(), typedb_source: error })?,
         };
 


### PR DESCRIPTION
## Product change and motivation

Fix crash during recovery when the commit validation result was not persisted in the WAL.

The isolation manager expects that when a commit is opened reading a sequence number, all the commits up to and including the opening number must have been persisted to storage.

Previously the commits were only marked as validated in the isolation manager, and only persisted at the very end of recovery. This meant that if the commit corresponding to the open sequence number of the unvalidated commit was not present in the checkpointed storage, the isolation manager would consider opening the pending commit for validation a violation of the watermark invariant, a fatal error.

## Implementation

Apply commits eagerly (when validated) and commmunicate that to isolation.
