### PR TITLE
Workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,7 +1785,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
@@ -2221,7 +2221,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5076,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -5759,14 +5759,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.4",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ features = {}
 		[workspace.dependencies.typeql]
 			features = []
 			git = "https://github.com/typedb/typeql"
-			tag = "3.7.0"
+			tag = "3.8.0"
 			default-features = false
 
 		[workspace.dependencies.serde_with]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,97 +12,60 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.http_steps]
-		path = "tests/behaviour/service/http/http_steps"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.answer]
-		path = "answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.executor]
-		path = "executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.function]
-		path = "function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.query]
-		path = "query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.options]
-		path = "common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.storage]
-		path = "storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.steps]
-		path = "tests/behaviour/steps"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.lending_iterator]
-		path = "common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.server]
-		path = "./server"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.database]
-		path = "./database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "./resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.clap]
-		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
-		version = "4.5.45"
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "./common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.sentry]
-		features = ["backtrace", "contexts", "httpdate", "panic", "rustls", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq", "webpki-roots"]
-		version = "0.36.0"
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/assembly/assembly.rs"
@@ -168,4 +131,473 @@ features = {}
 [workspace]
 	resolver = "2"
 	members = ["database/tools", "database", "answer", "util/test", "util/project", "durability/tests/crash/streamer", "durability/tests/crash/recoverer", "durability/tests/common", "durability", "ir", "tests/behaviour/steps", "tests/behaviour/steps/params", "tests/behaviour/service/http/http_steps", "encoding/tests", "encoding", "server", "user", "function", "storage/tests", "storage", "system", "common/options", "common/structural_equality", "common/logger", "common/cache", "common/bytes", "common/lending_iterator", "common/primitive", "common/concurrency", "common/iterator", "common/error", "concept/tests", "concept", "diagnostics", "executor", "resource", "query", "compiler"]
+
+	[workspace.dependencies]
+
+		[workspace.dependencies.xoshiro]
+			features = []
+			version = "0.0.5"
+			default-features = false
+
+		[workspace.dependencies.smol]
+			features = []
+			version = "1.3.0"
+			default-features = false
+
+		[workspace.dependencies.cucumber]
+			features = ["default", "macros"]
+			version = "0.19.1"
+			default-features = false
+
+		[workspace.dependencies.logger]
+			path = "common/logger"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.test_utils_storage]
+			path = "storage/tests"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.base64]
+			features = ["alloc", "default", "std"]
+			version = "0.22.1"
+			default-features = false
+
+		[workspace.dependencies.uuid]
+			features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
+			version = "1.18.0"
+			default-features = false
+
+		[workspace.dependencies.rand]
+			features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
+			version = "0.8.5"
+			default-features = false
+
+		[workspace.dependencies.seahash]
+			features = ["default"]
+			version = "4.1.0"
+			default-features = false
+
+		[workspace.dependencies.prost]
+			features = ["default", "derive", "prost-derive", "std"]
+			version = "0.13.5"
+			default-features = false
+
+		[workspace.dependencies.iterator]
+			path = "common/iterator"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.tokio-rustls]
+			features = ["logging", "ring", "tls12"]
+			version = "0.26.2"
+			default-features = false
+
+		[workspace.dependencies.executor]
+			path = "executor"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.function]
+			path = "function"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.rustls-pemfile]
+			features = ["default", "std"]
+			version = "2.2.0"
+			default-features = false
+
+		[workspace.dependencies.xxhash-rust]
+			features = ["xxh3"]
+			version = "0.8.15"
+			default-features = false
+
+		[workspace.dependencies.pprof]
+			features = ["cpp", "criterion", "default", "flamegraph", "inferno"]
+			version = "0.13.0"
+			default-features = false
+
+		[workspace.dependencies.sysinfo]
+			features = ["component", "default", "disk", "multithread", "network", "system", "user"]
+			version = "0.33.1"
+			default-features = false
+
+		[workspace.dependencies.options]
+			path = "common/options"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.same-file]
+			features = []
+			version = "1.0.6"
+			default-features = false
+
+		[workspace.dependencies.typeql]
+			features = []
+			git = "https://github.com/typedb/typeql"
+			tag = "3.7.0"
+			default-features = false
+
+		[workspace.dependencies.serde_with]
+			features = ["alloc", "default", "macros", "std"]
+			version = "3.14.0"
+			default-features = false
+
+		[workspace.dependencies.hyper]
+			features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
+			version = "0.14.32"
+			default-features = false
+
+		[workspace.dependencies.tower]
+			features = ["__common", "balance", "buffer", "default", "discover", "filter", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "tokio", "tokio-util", "tracing", "util"]
+			version = "0.4.13"
+			default-features = false
+
+		[workspace.dependencies.tracing]
+			features = ["attributes", "default", "log", "std", "tracing-attributes"]
+			version = "0.1.41"
+			default-features = false
+
+		[workspace.dependencies.cache]
+			path = "common/cache"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.axum]
+			features = ["default", "form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "tracing", "ws"]
+			version = "0.7.9"
+			default-features = false
+
+		[workspace.dependencies.typedb-protocol]
+			features = []
+			git = "https://github.com/typedb/typedb-protocol"
+			tag = "3.7.0"
+			default-features = false
+
+		[workspace.dependencies.resource]
+			path = "resource"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.query]
+			path = "query"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.durability]
+			path = "durability"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.ir]
+			path = "ir"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.macro_rules_attribute]
+			features = ["default"]
+			version = "0.2.2"
+			default-features = false
+
+		[workspace.dependencies.encoding]
+			path = "encoding"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.params]
+			path = "tests/behaviour/steps/params"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.steps]
+			path = "tests/behaviour/steps"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.regex]
+			features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
+			version = "1.11.1"
+			default-features = false
+
+		[workspace.dependencies.system]
+			path = "system"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.axum-extra]
+			features = ["default", "multipart", "tracing", "typed-header"]
+			version = "0.9.6"
+			default-features = false
+
+		[workspace.dependencies.rocksdb]
+			features = ["bindgen-runtime", "lz4"]
+			version = "0.23.0"
+			default-features = false
+
+		[workspace.dependencies.http]
+			features = ["default", "std"]
+			version = "1.3.1"
+			default-features = false
+
+		[workspace.dependencies.tonic]
+			features = ["channel", "codegen", "default", "prost", "router", "server", "tls", "tls-native-roots", "tls-roots", "transport"]
+			version = "0.12.3"
+			default-features = false
+
+		[workspace.dependencies.durability_test_common]
+			path = "durability/tests/common"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.hyper-rustls]
+			features = ["acceptor", "default", "http1", "log", "logging", "native-tokio", "ring", "rustls-native-certs", "tls12", "tokio-runtime"]
+			version = "0.25.0"
+			default-features = false
+
+		[workspace.dependencies.lending_iterator]
+			path = "common/lending_iterator"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.rand_core]
+			features = ["default", "std"]
+			version = "0.3.1"
+			default-features = false
+
+		[workspace.dependencies.test_utils]
+			path = "util/test"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.server]
+			path = "server"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.criterion]
+			features = ["cargo_bench_support", "default", "plotters", "rayon"]
+			version = "0.5.1"
+			default-features = false
+
+		[workspace.dependencies.primitive]
+			path = "common/primitive"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.unicase]
+			features = []
+			version = "2.8.1"
+			default-features = false
+
+		[workspace.dependencies.yaml-rust2]
+			features = ["default", "encoding"]
+			version = "0.10.3"
+			default-features = false
+
+		[workspace.dependencies.concept]
+			path = "concept"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.tracing-subscriber]
+			features = ["alloc", "ansi", "default", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"]
+			version = "0.3.19"
+			default-features = false
+
+		[workspace.dependencies.pwhash]
+			features = []
+			version = "1.0.0"
+			default-features = false
+
+		[workspace.dependencies.storage]
+			path = "storage"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.moka]
+			features = ["default", "sync"]
+			version = "0.12.10"
+			default-features = false
+
+		[workspace.dependencies.paste]
+			features = []
+			version = "1.0.15"
+			default-features = false
+
+		[workspace.dependencies.error]
+			path = "common/error"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.itertools]
+			features = ["default", "use_alloc", "use_std"]
+			version = "0.10.5"
+			default-features = false
+
+		[workspace.dependencies.jsonwebtoken]
+			features = ["default", "pem", "simple_asn1", "use_pem"]
+			version = "9.3.1"
+			default-features = false
+
+		[workspace.dependencies.database]
+			path = "database"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.chrono-tz]
+			features = ["case-insensitive", "default", "std"]
+			version = "0.9.0"
+			default-features = false
+
+		[workspace.dependencies.async-trait]
+			features = []
+			version = "0.1.89"
+			default-features = false
+
+		[workspace.dependencies.tracing-appender]
+			features = []
+			version = "0.2.3"
+			default-features = false
+
+		[workspace.dependencies.tempdir]
+			features = []
+			version = "0.3.7"
+			default-features = false
+
+		[workspace.dependencies.compiler]
+			path = "compiler"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.sentry]
+			features = ["backtrace", "contexts", "httpdate", "panic", "rustls", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq", "webpki-roots"]
+			version = "0.36.0"
+			default-features = false
+
+		[workspace.dependencies.tokio]
+			features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
+			version = "1.47.1"
+			default-features = false
+
+		[workspace.dependencies.serde_yaml2]
+			features = []
+			version = "0.1.3"
+			default-features = false
+
+		[workspace.dependencies.test_utils_encoding]
+			path = "encoding/tests"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.tower-http]
+			features = ["cors", "default"]
+			version = "0.6.6"
+			default-features = false
+
+		[workspace.dependencies.serde]
+			features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
+			version = "1.0.219"
+			default-features = false
+
+		[workspace.dependencies.structural_equality]
+			path = "common/structural_equality"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.lz4]
+			features = []
+			version = "1.28.1"
+			default-features = false
+
+		[workspace.dependencies.tokio-stream]
+			features = ["default", "net", "time"]
+			version = "0.1.17"
+			default-features = false
+
+		[workspace.dependencies.test_utils_concept]
+			path = "concept/tests"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.futures]
+			features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
+			version = "0.3.31"
+			default-features = false
+
+		[workspace.dependencies.url]
+			features = ["default", "serde", "std"]
+			version = "2.5.4"
+			default-features = false
+
+		[workspace.dependencies.concurrency]
+			path = "common/concurrency"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.http_steps]
+			path = "tests/behaviour/service/http/http_steps"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.diagnostics]
+			path = "diagnostics"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.tonic-types]
+			features = []
+			version = "0.12.3"
+			default-features = false
+
+		[workspace.dependencies.answer]
+			path = "answer"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.smallvec]
+			features = ["const_generics", "const_new"]
+			version = "1.15.1"
+			default-features = false
+
+		[workspace.dependencies.clap]
+			features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
+			version = "4.5.45"
+			default-features = false
+
+		[workspace.dependencies.bytes]
+			path = "common/bytes"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.async-std]
+			features = ["alloc", "async-attributes", "async-channel", "async-global-executor", "async-io", "async-lock", "attributes", "crossbeam-utils", "default", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "wasm-bindgen-futures"]
+			version = "1.13.2"
+			default-features = false
+
+		[workspace.dependencies.axum-server]
+			features = ["arc-swap", "default", "rustls", "rustls-pemfile", "rustls-pki-types", "tls-rustls-no-provider", "tokio-rustls"]
+			version = "0.7.2"
+			default-features = false
+
+		[workspace.dependencies.bincode]
+			features = []
+			version = "1.3.3"
+			default-features = false
+
+		[workspace.dependencies.chrono]
+			features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
+			version = "0.4.41"
+			default-features = false
+
+		[workspace.dependencies.user]
+			path = "user"
+			features = []
+			default-features = false
+
+		[workspace.dependencies.serde_json]
+			features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
+			version = "1.0.143"
+			default-features = false
 

--- a/answer/Cargo.toml
+++ b/answer/Cargo.toml
@@ -15,9 +15,7 @@ features = {}
 [dependencies]
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
 		path = "../resource"
@@ -25,32 +23,20 @@ features = {}
 		default-features = false
 
 	[dependencies.structural_equality]
-		path = "../common/structural_equality"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/answer/Cargo.toml
+++ b/answer/Cargo.toml
@@ -18,9 +18,7 @@ features = {}
 		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.structural_equality]
 		workspace = true

--- a/common/bytes/Cargo.toml
+++ b/common/bytes/Cargo.toml
@@ -15,22 +15,14 @@ features = {}
 [dependencies]
 
 	[dependencies.primitive]
-		path = "../../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.base64]
-		features = ["alloc", "default", "std"]
-		version = "0.22.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/common/cache/Cargo.toml
+++ b/common/cache/Cargo.toml
@@ -15,39 +15,25 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.rocksdb]
-		features = ["bindgen-runtime", "lz4"]
-		version = "0.23.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.uuid]
-		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.18.0"
-		default-features = false
+		workspace = true
 

--- a/common/concurrency/Cargo.toml
+++ b/common/concurrency/Cargo.toml
@@ -15,7 +15,5 @@ features = {}
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 

--- a/common/error/Cargo.toml
+++ b/common/error/Cargo.toml
@@ -15,13 +15,8 @@ features = {}
 [dependencies]
 
 	[dependencies.resource]
-		path = "../../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 

--- a/common/logger/Cargo.toml
+++ b/common/logger/Cargo.toml
@@ -16,17 +16,11 @@ dev-dependencies = {}
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing-appender]
-		features = []
-		version = "0.2.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing-subscriber]
-		features = ["alloc", "ansi", "default", "env-filter", "fmt", "matchers", "nu-ansi-term", "once_cell", "regex", "registry", "sharded-slab", "smallvec", "std", "thread_local", "tracing", "tracing-log"]
-		version = "0.3.19"
-		default-features = false
+		workspace = true
 

--- a/common/options/Cargo.toml
+++ b/common/options/Cargo.toml
@@ -15,7 +15,5 @@ features = {}
 [dependencies]
 
 	[dependencies.resource]
-		path = "../../resource"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/common/primitive/Cargo.toml
+++ b/common/primitive/Cargo.toml
@@ -15,7 +15,5 @@ features = {}
 [dependencies]
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 

--- a/common/structural_equality/Cargo.toml
+++ b/common/structural_equality/Cargo.toml
@@ -15,18 +15,11 @@ features = {}
 [dependencies]
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.paste]
-		features = []
-		version = "1.0.15"
-		default-features = false
+		workspace = true
 

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -15,87 +15,54 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_encoding]
-		path = "../encoding/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_concept]
-		path = "../concept/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/transformation.rs"

--- a/concept/Cargo.toml
+++ b/concept/Cargo.toml
@@ -15,132 +15,81 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_encoding]
-		path = "../encoding/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.criterion]
-		features = ["cargo_bench_support", "default", "plotters", "rayon"]
-		version = "0.5.1"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.pprof]
-		features = ["cpp", "criterion", "default", "flamegraph", "inferno"]
-		version = "0.13.0"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_concept]
-		path = "../concept/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.paste]
-		features = []
-		version = "1.0.15"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.iterator]
-		path = "../common/iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bench]]
 	name = "bench_thing_write"

--- a/concept/tests/Cargo.toml
+++ b/concept/tests/Cargo.toml
@@ -15,22 +15,14 @@ features = {}
 [dependencies]
 
 	[dependencies.durability]
-		path = "../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../../encoding"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/database/Cargo.toml
+++ b/database/Cargo.toml
@@ -15,122 +15,75 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.cache]
-		path = "../common/cache"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.query]
-		path = "../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.concurrency]
-		path = "../common/concurrency"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.diagnostics]
-		path = "../diagnostics"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.function]
-		path = "../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.options]
-		path = "../common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.rocksdb]
-		features = ["bindgen-runtime", "lz4"]
-		version = "0.23.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/database.rs"

--- a/database/tools/Cargo.toml
+++ b/database/tools/Cargo.toml
@@ -12,24 +12,16 @@ features = {}
 [dependencies]
 
 	[dependencies.clap]
-		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
-		version = "4.5.45"
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bin]]
 	path = "replay_wal.rs"

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -15,7 +15,7 @@ def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
         remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "983d337cb58de7e65f25dd5768078aea970f6b3b",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        commit = "81a2b752def92c9e1490e9d67608233f6c1b147e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typeql():

--- a/dependencies/typedb/repositories.bzl
+++ b/dependencies/typedb/repositories.bzl
@@ -15,7 +15,7 @@ def typedb_dependencies():
     git_repository(
         name = "typedb_dependencies",
         remote = "https://github.com/typedb/typedb-dependencies",
-        commit = "81a2b752def92c9e1490e9d67608233f6c1b147e",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
+        commit = "7179b0356b4fd8948190759a35136fdf9c2fdf91",  # sync-marker: do not remove this comment, this is used for sync-dependencies by @typedb_dependencies
     )
 
 def typeql():

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -15,88 +15,53 @@ features = {}
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.31"
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concurrency]
-		path = "../common/concurrency"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.tonic-types]
-		features = []
-		version = "0.12.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.sysinfo]
-		features = ["component", "default", "disk", "multithread", "network", "system", "user"]
-		version = "0.33.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.xxhash-rust]
-		features = ["xxh3"]
-		version = "0.8.15"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.tonic]
-		features = ["channel", "codegen", "default", "prost", "router", "server", "tls", "tls-native-roots", "tls-roots", "transport"]
-		version = "0.12.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.hyper]
-		features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
-		version = "0.14.32"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_json]
-		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.143"
-		default-features = false
+		workspace = true
 
 	[dependencies.hyper-rustls]
-		features = ["acceptor", "default", "http1", "log", "logging", "native-tokio", "ring", "rustls-native-certs", "tls12", "tokio-runtime"]
-		version = "0.25.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.sentry]
-		features = ["backtrace", "contexts", "httpdate", "panic", "rustls", "sentry-backtrace", "sentry-contexts", "sentry-panic", "ureq", "webpki-roots"]
-		version = "0.36.0"
-		default-features = false
+		workspace = true
 

--- a/durability/Cargo.toml
+++ b/durability/Cargo.toml
@@ -15,66 +15,42 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.criterion]
-		features = ["cargo_bench_support", "default", "plotters", "rayon"]
-		version = "0.5.1"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.tempdir]
-		features = []
-		version = "0.3.7"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.durability_test_common]
-		path = "../durability/tests/common"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.lz4]
-		features = []
-		version = "1.28.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 [[bench]]
 	name = "throughput"

--- a/durability/tests/common/Cargo.toml
+++ b/durability/tests/common/Cargo.toml
@@ -15,12 +15,8 @@ features = {}
 [dependencies]
 
 	[dependencies.durability]
-		path = "../../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 

--- a/durability/tests/crash/recoverer/Cargo.toml
+++ b/durability/tests/crash/recoverer/Cargo.toml
@@ -12,19 +12,13 @@ features = {}
 [dependencies]
 
 	[dependencies.durability]
-		path = "../../../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.durability_test_common]
-		path = "../../../../durability/tests/common"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bin]]
 	path = "recoverer.rs"

--- a/durability/tests/crash/streamer/Cargo.toml
+++ b/durability/tests/crash/streamer/Cargo.toml
@@ -12,24 +12,16 @@ features = {}
 [dependencies]
 
 	[dependencies.durability]
-		path = "../../../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.durability_test_common]
-		path = "../../../../durability/tests/common"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bin]]
 	path = "streamer.rs"

--- a/encoding/Cargo.toml
+++ b/encoding/Cargo.toml
@@ -15,117 +15,72 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_encoding]
-		path = "../encoding/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.criterion]
-		features = ["cargo_bench_support", "default", "plotters", "rayon"]
-		version = "0.5.1"
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.structural_equality]
-		path = "../common/structural_equality"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.seahash]
-		features = ["default"]
-		version = "4.1.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.rocksdb]
-		features = ["bindgen-runtime", "lz4"]
-		version = "0.23.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bench]]
 	name = "benchmark"

--- a/encoding/tests/Cargo.toml
+++ b/encoding/tests/Cargo.toml
@@ -15,32 +15,20 @@ features = {}
 [dependencies]
 
 	[dependencies.test_utils]
-		path = "../../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../../encoding"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/executor/Cargo.toml
+++ b/executor/Cargo.toml
@@ -15,147 +15,90 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_encoding]
-		path = "../encoding/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.query]
-		path = "../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.function]
-		path = "../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_concept]
-		path = "../concept/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.unicase]
-		features = []
-		version = "2.8.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.paste]
-		features = []
-		version = "1.0.15"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.iterator]
-		path = "../common/iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.smallvec]
-		features = ["const_generics", "const_new"]
-		version = "1.15.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/execute_function.rs"

--- a/function/Cargo.toml
+++ b/function/Cargo.toml
@@ -15,92 +15,57 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/test_definition.rs"

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -15,92 +15,57 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_storage]
-		path = "../storage/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.structural_equality]
-		path = "../common/structural_equality"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 [[test]]
 	path = "tests/pattern.rs"

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -15,137 +15,84 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_encoding]
-		path = "../encoding/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.criterion]
-		features = ["cargo_bench_support", "default", "plotters", "rayon"]
-		version = "0.5.1"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.pprof]
-		features = ["cpp", "criterion", "default", "flamegraph", "inferno"]
-		version = "0.13.0"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_concept]
-		path = "../concept/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.structural_equality]
-		path = "../common/structural_equality"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.moka]
-		features = ["default", "sync"]
-		version = "0.12.10"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.function]
-		path = "../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bench]]
 	name = "bench_insert_queries"

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -15,7 +15,5 @@ features = {}
 [dependencies]
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,279 +18,167 @@ dev-dependencies = {}
 [dependencies]
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.uuid]
-		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.18.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.prost]
-		features = ["default", "derive", "prost-derive", "std"]
-		version = "0.13.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.tokio-rustls]
-		features = ["logging", "ring", "tls12"]
-		version = "0.26.2"
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.rustls-pemfile]
-		features = ["default", "std"]
-		version = "2.2.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.function]
-		path = "../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.xxhash-rust]
-		features = ["xxh3"]
-		version = "0.8.15"
-		default-features = false
+		workspace = true
 
 	[dependencies.options]
-		path = "../common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_with]
-		features = ["alloc", "default", "macros", "std"]
-		version = "3.14.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.hyper]
-		features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
-		version = "0.14.32"
-		default-features = false
+		workspace = true
 
 	[dependencies.tower]
-		features = ["__common", "balance", "buffer", "default", "discover", "filter", "futures-core", "futures-util", "indexmap", "limit", "load", "log", "make", "pin-project", "pin-project-lite", "rand", "ready-cache", "slab", "tokio", "tokio-util", "tracing", "util"]
-		version = "0.4.13"
-		default-features = false
+		workspace = true
 
 	[dependencies.axum]
-		features = ["default", "form", "http1", "json", "matched-path", "original-uri", "query", "tokio", "tower-log", "tracing", "ws"]
-		version = "0.7.9"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.typedb-protocol]
-		features = []
-		git = "https://github.com/typedb/typedb-protocol"
-		tag = "3.7.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.query]
-		path = "../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.system]
-		path = "../system"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.axum-extra]
-		features = ["default", "multipart", "tracing", "typed-header"]
-		version = "0.9.6"
-		default-features = false
+		workspace = true
 
 	[dependencies.http]
-		features = ["default", "std"]
-		version = "1.3.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.tonic]
-		features = ["channel", "codegen", "default", "prost", "router", "server", "tls", "tls-native-roots", "tls-roots", "transport"]
-		version = "0.12.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.yaml-rust2]
-		features = ["default", "encoding"]
-		version = "0.10.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.pwhash]
-		features = []
-		version = "1.0.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.moka]
-		features = ["default", "sync"]
-		version = "0.12.10"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.jsonwebtoken]
-		features = ["default", "pem", "simple_asn1", "use_pem"]
-		version = "9.3.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.database]
-		path = "../database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.async-trait]
-		features = []
-		version = "0.1.89"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_yaml2]
-		features = []
-		version = "0.1.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.tower-http]
-		features = ["cors", "default"]
-		version = "0.6.6"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.tokio-stream]
-		features = ["default", "net", "time"]
-		version = "0.1.17"
-		default-features = false
+		workspace = true
 
 	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.31"
-		default-features = false
+		workspace = true
 
 	[dependencies.concurrency]
-		path = "../common/concurrency"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.diagnostics]
-		path = "../diagnostics"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.tonic-types]
-		features = []
-		version = "0.12.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.clap]
-		features = ["color", "default", "derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"]
-		version = "4.5.45"
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.axum-server]
-		features = ["arc-swap", "default", "rustls", "rustls-pemfile", "rustls-pki-types", "tls-rustls-no-provider", "tokio-rustls"]
-		version = "0.7.2"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.user]
-		path = "../user"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_json]
-		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.143"
-		default-features = false
+		workspace = true
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -15,122 +15,75 @@ features = {}
 [dev-dependencies]
 
 	[dev-dependencies.test_utils]
-		path = "../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.xoshiro]
-		features = []
-		version = "0.0.5"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.database]
-		path = "../database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.criterion]
-		features = ["cargo_bench_support", "default", "plotters", "rayon"]
-		version = "0.5.1"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.test_utils_storage]
-		path = "../storage/tests"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.pprof]
-		features = ["cpp", "criterion", "default", "flamegraph", "inferno"]
-		version = "0.13.0"
-		default-features = false
+		workspace = true
 
 	[dev-dependencies.rand_core]
-		features = ["default", "std"]
-		version = "0.3.1"
-		default-features = false
+		workspace = true
 
 [dependencies]
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bincode]
-		features = []
-		version = "1.3.3"
-		default-features = false
+		workspace = true
 
 	[dependencies.rocksdb]
-		features = ["bindgen-runtime", "lz4"]
-		version = "0.23.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.same-file]
-		features = []
-		version = "1.0.6"
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 
 [[bench]]
 	name = "bench_rocks"

--- a/storage/tests/Cargo.toml
+++ b/storage/tests/Cargo.toml
@@ -15,27 +15,17 @@ features = {}
 [dependencies]
 
 	[dependencies.resource]
-		path = "../../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.bytes]
-		path = "../../common/bytes"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../storage"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/system/Cargo.toml
+++ b/system/Cargo.toml
@@ -15,78 +15,47 @@ features = {}
 [dependencies]
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.query]
-		path = "../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.pwhash]
-		features = []
-		version = "1.0.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.uuid]
-		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.18.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.database]
-		path = "../database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.function]
-		path = "../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.options]
-		path = "../common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/tests/behaviour/service/http/http_steps/Cargo.toml
+++ b/tests/behaviour/service/http/http_steps/Cargo.toml
@@ -15,118 +15,71 @@ features = {}
 [dependencies]
 
 	[dependencies.test_utils]
-		path = "../../../../../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.server]
-		path = "../../../../../server"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.smol]
-		features = []
-		version = "1.3.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde]
-		features = ["alloc", "default", "derive", "rc", "serde_derive", "std"]
-		version = "1.0.219"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../../../../../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.cucumber]
-		features = ["default", "macros"]
-		version = "0.19.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.macro_rules_attribute]
-		features = ["default"]
-		version = "0.2.2"
-		default-features = false
+		workspace = true
 
 	[dependencies.params]
-		path = "../../../../../tests/behaviour/steps/params"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.31"
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../../../../../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../../../../../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.uuid]
-		features = ["default", "fast-rng", "rng", "serde", "std", "v4"]
-		version = "1.18.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.url]
-		features = ["default", "serde", "std"]
-		version = "2.5.4"
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.async-std]
-		features = ["alloc", "async-attributes", "async-channel", "async-global-executor", "async-io", "async-lock", "attributes", "crossbeam-utils", "default", "futures-channel", "futures-core", "futures-io", "futures-lite", "gloo-timers", "kv-log-macro", "log", "memchr", "once_cell", "pin-project-lite", "pin-utils", "slab", "std", "wasm-bindgen-futures"]
-		version = "1.13.2"
-		default-features = false
+		workspace = true
 
 	[dependencies.options]
-		path = "../../../../../common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.hyper]
-		features = ["client", "default", "full", "h2", "http1", "http2", "runtime", "server", "socket2", "stream", "tcp"]
-		version = "0.14.32"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_json]
-		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.143"
-		default-features = false
+		workspace = true
 
 	[dependencies.hyper-rustls]
-		features = ["acceptor", "default", "http1", "log", "logging", "native-tokio", "ring", "rustls-native-certs", "tls12", "tokio-runtime"]
-		version = "0.25.0"
-		default-features = false
+		workspace = true
 

--- a/tests/behaviour/steps/Cargo.toml
+++ b/tests/behaviour/steps/Cargo.toml
@@ -15,148 +15,89 @@ features = {}
 [dependencies]
 
 	[dependencies.test_utils]
-		path = "../../../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.server]
-		path = "../../../server"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.primitive]
-		path = "../../../common/primitive"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.cucumber]
-		features = ["default", "macros"]
-		version = "0.19.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../../../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../../../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../../../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.database]
-		path = "../../../database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../../../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.function]
-		path = "../../../function"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.options]
-		path = "../../../common/options"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.compiler]
-		path = "../../../compiler"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.tokio]
-		features = ["bytes", "default", "fs", "full", "io-std", "io-util", "libc", "macros", "mio", "net", "parking_lot", "process", "rt", "rt-multi-thread", "signal", "signal-hook-registry", "socket2", "sync", "time", "tokio-macros"]
-		version = "1.47.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../../../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.query]
-		path = "../../../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.durability]
-		path = "../../../durability"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
-		path = "../../../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.macro_rules_attribute]
-		features = ["default"]
-		version = "0.2.2"
-		default-features = false
+		workspace = true
 
 	[dependencies.params]
-		path = "../../../tests/behaviour/steps/params"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.futures]
-		features = ["alloc", "async-await", "default", "executor", "futures-executor", "std", "thread-pool"]
-		version = "0.3.31"
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../../../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../../../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.serde_json]
-		features = ["alloc", "default", "indexmap", "preserve_order", "raw_value", "std"]
-		version = "1.0.143"
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../../../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/tests/behaviour/steps/params/Cargo.toml
+++ b/tests/behaviour/steps/params/Cargo.toml
@@ -30,9 +30,7 @@ features = {}
 		workspace = true
 
 	[dependencies.ir]
-		path = "../../../../ir"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
 		workspace = true

--- a/tests/behaviour/steps/params/Cargo.toml
+++ b/tests/behaviour/steps/params/Cargo.toml
@@ -15,29 +15,19 @@ features = {}
 [dependencies]
 
 	[dependencies.test_utils]
-		path = "../../../../util/test"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.regex]
-		features = ["default", "perf", "perf-backtrack", "perf-cache", "perf-dfa", "perf-inline", "perf-literal", "perf-onepass", "std", "unicode", "unicode-age", "unicode-bool", "unicode-case", "unicode-gencat", "unicode-perl", "unicode-script", "unicode-segment"]
-		version = "1.11.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono-tz]
-		features = ["case-insensitive", "default", "std"]
-		version = "0.9.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.cucumber]
-		features = ["default", "macros"]
-		version = "0.19.1"
-		default-features = false
+		workspace = true
 
 	[dependencies.concept]
-		path = "../../../../concept"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.ir]
 		path = "../../../../ir"
@@ -45,28 +35,17 @@ features = {}
 		default-features = false
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../../../../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.encoding]
-		path = "../../../../encoding"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.chrono]
-		features = ["alloc", "android-tzdata", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-		version = "0.4.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.itertools]
-		features = ["default", "use_alloc", "use_std"]
-		version = "0.10.5"
-		default-features = false
+		workspace = true
 

--- a/user/Cargo.toml
+++ b/user/Cargo.toml
@@ -15,53 +15,32 @@ features = {}
 [dependencies]
 
 	[dependencies.database]
-		path = "../database"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.system]
-		path = "../system"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.answer]
-		path = "../answer"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.resource]
-		path = "../resource"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.executor]
-		path = "../executor"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.query]
-		path = "../query"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.typeql]
-		features = []
-		git = "https://github.com/typedb/typeql"
-		tag = "3.8.0"
-		default-features = false
+		workspace = true
 
 	[dependencies.storage]
-		path = "../storage"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.error]
-		path = "../common/error"
-		features = []
-		default-features = false
+		workspace = true
 
 	[dependencies.lending_iterator]
-		path = "../common/lending_iterator"
-		features = []
-		default-features = false
+		workspace = true
 

--- a/util/test/Cargo.toml
+++ b/util/test/Cargo.toml
@@ -15,17 +15,11 @@ features = {}
 [dependencies]
 
 	[dependencies.rand]
-		features = ["alloc", "default", "getrandom", "libc", "rand_chacha", "small_rng", "std", "std_rng"]
-		version = "0.8.5"
-		default-features = false
+		workspace = true
 
 	[dependencies.tracing]
-		features = ["attributes", "default", "log", "std", "tracing-attributes"]
-		version = "0.1.41"
-		default-features = false
+		workspace = true
 
 	[dependencies.logger]
-		path = "../../common/logger"
-		features = []
-		default-features = false
+		workspace = true
 


### PR DESCRIPTION
## Product change and motivation

Collect all dependencies in a single list under cargo workspace that the individual crates can refer to.

## Implementation

Update dependencies to include https://github.com/typedb/typedb-dependencies/pull/601 and re-sync.
