### PR TITLE
Delete incorrect randomized datetime arithmetic test

### DIFF
--- a/encoding/value/duration_value.rs
+++ b/encoding/value/duration_value.rs
@@ -661,23 +661,6 @@ mod tests {
     }
 
     #[test]
-    fn datetime_subtraction_always_produces_time_delta_less_than_a_day() {
-        let seed = thread_rng().gen();
-        let mut rng = SmallRng::seed_from_u64(seed);
-        eprintln!("Running with seed: {seed}");
-
-        for _ in 0..1_000_000 {
-            let mut date_time_1 = random_datetime(&mut rng);
-            let mut date_time_2 = random_datetime(&mut rng);
-            if date_time_1 > date_time_2 {
-                mem::swap(&mut date_time_1, &mut date_time_2);
-            }
-            let diff = Duration::between_datetimes_tz(date_time_1, date_time_2);
-            assert!(diff.nanos < NANOS_PER_NAIVE_DAY);
-        }
-    }
-
-    #[test]
     fn extreme_timezone_changes_are_respected() {
         // Samoa switched from -10 to +14 later 29th of December, 2011,
         // skipping 30th of December.


### PR DESCRIPTION
## Product change and motivation

The `datetime_subtraction_always_produces_time_delta_less_than_a_day` is incorrect: subtracting across a DST time change can produce time deltas of over 24 hours which are still less than a day.

For example, a DST change occurred in London on 2024-10-27 02:00:00 BST.

```
2024-10-27T01:30:00 Europe/London - 2024-10-26T02:00:00 Europe/London == PT24H30M
```

Adding 24 hours to the earlier date would undershoot the later by 30 minutes:

```
2024-10-26T02:00:00 Europe/London + PT24H == 2024-10-27T01:00:00 Europe/London
```

Adding 1 day overshoots by the same amount:

```
2024-10-26T02:00:00 Europe/London + P1D == 2024-10-27T02:00:00 Europe/London
```

## Implementation

