### PR TITLE
Isolation: only fetch commit data when necessary

### DIFF
--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -573,17 +573,13 @@ impl<const SIZE: usize> TimelineWindow<SIZE> {
     fn get_status(&self, sequence_number: SequenceNumber) -> CommitStatus<'_> {
         let index = sequence_number - self.start;
         let status = SlotMarker::from(self.slot_status[index].load(Ordering::SeqCst));
-        if let SlotMarker::Empty = status {
-            CommitStatus::Empty
-        } else {
-            let record = self.commit_records[index].get().unwrap();
-            match status {
-                SlotMarker::Empty => unreachable!(),
-                SlotMarker::Pending => CommitStatus::Pending(MaybeOwns::Borrowed(record)),
-                SlotMarker::Validated => CommitStatus::Validated(MaybeOwns::Borrowed(record)),
-                SlotMarker::Applied => CommitStatus::Applied(MaybeOwns::Borrowed(record)),
-                SlotMarker::Aborted => CommitStatus::Aborted,
-            }
+        let lazy_record = || self.commit_records[index].get().unwrap();
+        match status {
+            SlotMarker::Empty => CommitStatus::Empty,
+            SlotMarker::Aborted => CommitStatus::Aborted,
+            SlotMarker::Pending => CommitStatus::Pending(MaybeOwns::Borrowed(lazy_record())),
+            SlotMarker::Validated => CommitStatus::Validated(MaybeOwns::Borrowed(lazy_record())),
+            SlotMarker::Applied => CommitStatus::Applied(MaybeOwns::Borrowed(lazy_record())),
         }
     }
 


### PR DESCRIPTION
## Product change and motivation

The data of an aborted commit is never examined again. During recovery, we don't bother putting it into the isolation manager timeline and discard the data immediately.

In the (rare) event isolation manager fetches the status of an aborted commit during recovery, it expects the record of an aborted commit to exist even though it's not used. This change makes it so the commit record is only fetched when needed for status.

## Implementation

