### PR TITLE
Optional function returns

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -166,5 +166,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "ee9ab6f7c7997d24d6cc86ae439f24afdde808e7",
+    commit = "0148d83a3a0b06ee21c39f20f0d1772a46d67325",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -165,6 +165,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "d3bb01333c67b41eeac23d2291e243b047cb518d",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "ee9ab6f7c7997d24d6cc86ae439f24afdde808e7",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -165,6 +165,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "0148d83a3a0b06ee21c39f20f0d1772a46d67325",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "489430a5f13056d80fdfc69fb9598a43a56500d6",
 )

--- a/compiler/annotation/mod.rs
+++ b/compiler/annotation/mod.rs
@@ -145,7 +145,7 @@ typedb_error!(
         ),
         SignatureReturnMismatch(
             4,
-            "The types inferred for the return statement of function '{function_name}' did not match those declared in the signature. Mismatching index: {mismatching_index}",
+            "The types inferred for the return statement of function '{function_name}' does not match those declared in the signature. Mismatching index: {mismatching_index}",
             function_name: String,
             mismatching_index: usize,
             source_span: Option<Span>,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -392,7 +392,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub(crate) fn add_builtin_function_binding(
         &mut self,
-        mut assigned: Vec<AssignedVariable>,
+        assigned: Vec<AssignedVariable>,
         builtin_id: super::expression::BuiltinConceptFunctionID,
         arguments: Vec<Variable>,
         source_span: Option<Span>,
@@ -409,18 +409,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Some(variable) = mismatched_optionality_in_assignment {
-            let variable = self.context.get_variable_name_or_unnamed(variable).to_owned();
-            use error::TypeDBError;
-            tracing::warn!(
-                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
-                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
-            );
-            // Fix for now:
-            assigned.iter_mut().zip(callee_signature.returns.iter()).for_each(
-                |(assigned_var, (_, declared_optionality))| {
-                    assigned_var.optionality = *declared_optionality;
-                },
-            );
+            let variable = self
+                .context
+                .get_variable_name(variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
         }
         let function_call =
             self.create_function_call(&assigned, &callee_signature, arguments, builtin_id.name(), source_span)?;
@@ -458,12 +452,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Some(variable) = mismatched_optionality_in_assignment {
-            let variable = self.context.get_variable_name_or_unnamed(variable).to_owned();
-            use error::TypeDBError;
-            tracing::warn!(
-                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
-                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
-            );
+            let variable = self
+                .context
+                .get_variable_name(variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
         }
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -269,13 +269,7 @@ fn validate_optional_returns_recursive(
     if let Some((var, source_span)) = reused_optional_return_opt {
         let variable = context.get_variable_name_or_unnamed(*var).to_owned();
         let source_span = source_span.clone();
-        // Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
-        use error::TypeDBError;
-        tracing::warn!(
-            "Function call reuses optionally assigned variable. This will fail in the next version:\n{}",
-            RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }.format_description()
-        );
-        Ok(())
+        Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
     } else {
         Ok(())
     }

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -464,6 +464,28 @@ fn test_nested_optional() {
 }
 
 #[test]
+fn test_unmarked_optional_return_errors() {
+    let query = r#"
+    with fun first_is_opt() -> {integer?, integer}:
+    match try { let $x = 6; }; let $y = 5;
+    return { $x, $y };
+
+    match let $x, $y in first_is_opt();
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::UnmarkedOptionalAssignment { variable, .. } => {
+            variable == "x"
+        }
+        _ => false,
+    });
+}
+
+#[test]
 fn test_optional_return() {
     let query = r#"
     with fun first_is_opt() -> {integer?, integer}:
@@ -483,4 +505,88 @@ fn test_optional_return() {
     let conjunction = block.conjunction();
     assert_vars!(&translated_pipeline.variable_registry, conjunction, Required[], Bound["x", "y"]);
     assert_optionals!(&translated_pipeline.variable_registry, ["x"]);
+}
+
+#[test]
+fn test_optional_return_must_be_declared() {
+    let query = r#"
+    with fun first_is_opt() -> {integer, integer}:
+    match try { let $x = 6; }; let $y = 5;
+    return { $x, $y };
+
+    match let $x, $y in first_is_opt();
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::FunctionRepresentation {
+            typedb_source: FunctionRepresentationError::InconsistentReturnOptionality { mismatch_index, .. },
+        } => {
+            mismatch_index == 0
+        }
+        _ => false,
+    });
+}
+
+#[test]
+fn test_optional_return_reuse_errors() {
+    let query = r#"
+    with fun age_opt() -> age?:
+    match try { $age isa age; };
+    return first $age;
+
+    match
+        let $age? in age_opt();
+        $person has $age;
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
+            variable == "age"
+        }
+        _ => false,
+    });
+}
+
+#[test]
+fn test_optional_return_reuse_errors_with_disjunctions() {
+    // Just a convoluted case.
+    let query = r#"
+    with fun age_opt() -> age?:
+    match try { $age isa age; };
+    return first $age;
+
+    match
+        $cat isa cat; $dog isa dog;
+        {
+
+            $dog has $name;
+            {
+                let $age? in age_opt();
+            } or {
+                { $cat has $age; } or { $dog has $age; };
+                $cat has name $name;
+            };
+        } or {
+            $dog has $name; $dog has $other_age;
+        };
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
+            variable == "age"
+        }
+        _ => false,
+    });
 }

--- a/ir/tests/structural_equality.rs
+++ b/ir/tests/structural_equality.rs
@@ -119,7 +119,7 @@ fn test_function_non_equivalence() {
 #[test]
 fn test_pipeline_equivalence() {
     let pipeline = "
-with fun avg_salary($x: person) -> double:
+with fun avg_salary($x: person) -> double?:
   match $x has salary $salary;
         let $salary_plus_1 = $salary + 1;
   return mean($salary_plus_1);
@@ -151,7 +151,7 @@ fetch {
     assert!(translated_fetch.equals(&translated_fetch));
 
     let structurally_equivalent_pipeline = "\
-with fun avg_salary($DIFF: person) -> double:
+with fun avg_salary($DIFF: person) -> double?:
   match $DIFF has salary $salary;
         let $salary_plus_2 = $salary + 2;
   return mean($salary_plus_2);
@@ -196,7 +196,7 @@ fetch {
 #[test]
 fn test_pipeline_non_equivalence() {
     let pipeline = "
-with fun avg_salary($x: person) -> double:
+with fun avg_salary($x: person) -> double?:
   match $x has avg_salary $salary;
   return mean($salary);
 match
@@ -227,7 +227,7 @@ fetch {
     assert!(translated_fetch.equals(&translated_fetch));
 
     let different = "\
-with fun avg_age($x: person) -> double:
+with fun avg_age($x: person) -> double?:
   match $x has age $age;
   return mean($age);
 match

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -308,16 +308,11 @@ fn check_consistent_return<T>(
         .enumerate()
         .find_map(|(index, (declared, actual))| (declared != actual).then_some(index));
     if let Some(mismatch_index) = mismatching_index_opt {
-        use error::TypeDBError;
-        tracing::warn!(
-            "Function has inconsistent return optionality. This will fail in the next version:\n{}",
-            FunctionRepresentationError::InconsistentReturnOptionality {
-                signature: signature.clone(),
-                return_: block.return_stmt.clone(),
-                mismatch_index,
-            }
-            .format_description()
-        );
+        return Err(Box::new(FunctionRepresentationError::InconsistentReturnOptionality {
+            signature: signature.clone(),
+            return_: block.return_stmt.clone(),
+            mismatch_index,
+        }));
     }
 
     Ok(())


### PR DESCRIPTION
## Product change and motivation
Handles optional function returns properly. This includes the following errors **which may result in schema functions breaking**:
* A function which returns an optional variable is not declared as doing so
* A variable being assigned an optional return value is not marked with `?`
* A variable which was assigned an optional value is re-used in the same stage (subject to the same rules as regular optional variables).

If you do have stored functions, version `3.10.4` will print warnings to the logs and allow you to update your schema functions to conform to `3.11.0` validation. Going straight to `3.11` with invalid functions in the schema can result in a crash-loop.

## Implementation
BDD: https://github.com/typedb/typedb-behaviour/pull/417 
