### PR TITLE
Reject query pipelines exceeding 1000 stages

### DIFF
--- a/query/error.rs
+++ b/query/error.rs
@@ -35,5 +35,6 @@ typedb_error! {
         ReadPipelineExecution(15, "Error while executing read pipeline.",  source_query: String, typedb_source: Box<PipelineExecutionError>),
         QueryExecutionClosedEarly(16, "Query execution was closed before it finished, possibly due to transaction close, rollback, commit, or a server-side error (these should be visible in the server logs)."),
         QueryAnalysisFailed(17, "Error while analysing the query.", source_query: String, typedb_source: Box<ConceptReadError>),
+        PipelineStagesLimitExceeded(18, "Query pipeline has {actual} stages, which exceeds the maximum allowed {max}.", source_query: String, actual: usize, max: usize),
     }
 }

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -45,6 +45,8 @@ use crate::{
     redefine, undefine,
 };
 
+pub const MAX_PIPELINE_STAGES: usize = 1000;
+
 #[derive(Debug, Clone)]
 pub struct QueryManager {
     cache: Option<Arc<QueryCache>>,
@@ -367,6 +369,13 @@ fn translate_pipeline<Snapshot: ReadableSnapshot>(
     query: &typeql::query::Pipeline,
     source_query: &str,
 ) -> Result<TranslatedPipeline, Box<QueryError>> {
+    if query.stages.len() > MAX_PIPELINE_STAGES {
+        return Err(Box::new(QueryError::PipelineStagesLimitExceeded {
+            source_query: source_query.to_string(),
+            actual: query.stages.len(),
+            max: MAX_PIPELINE_STAGES,
+        }));
+    }
     let preamble_signatures = HashMapFunctionSignatureIndex::build(
         query.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
     );

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -28,6 +28,7 @@ use ir::{
     translation::pipeline::{TranslatedPipeline, TranslatedStage},
 };
 use resource::{
+    constants::query::MAX_PIPELINE_STAGES,
     perf_counters::{QUERY_CACHE_HITS, QUERY_CACHE_MISSES},
     profile::{CompileProfile, QueryProfile},
 };
@@ -44,8 +45,6 @@ use crate::{
     query_cache::QueryCache,
     redefine, undefine,
 };
-
-pub const MAX_PIPELINE_STAGES: usize = 1000;
 
 #[derive(Debug, Clone)]
 pub struct QueryManager {

--- a/query/tests/BUILD
+++ b/query/tests/BUILD
@@ -51,12 +51,20 @@ rust_test(
     deps = deps,
 )
 
+rust_test(
+    name = "test_pipeline_stages_limit",
+    crate_root = "pipeline_stages_limit.rs",
+    srcs = ["pipeline_stages_limit.rs"],
+    deps = deps,
+)
+
 rustfmt_test(
     name = "rustfmt_test",
     targets = [
         ":test_define",
         ":test_fetch",
         ":test_unimplemented",
+        ":test_pipeline_stages_limit",
     ],
     size = "small",
 )

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -8,11 +8,8 @@ use std::sync::Arc;
 
 use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
 use function::function_manager::FunctionManager;
-use query::{
-    error::QueryError,
-    query_manager::{QueryManager, MAX_PIPELINE_STAGES},
-};
-use resource::profile::CommitProfile;
+use query::{error::QueryError, query_manager::QueryManager};
+use resource::{constants::query::MAX_PIPELINE_STAGES, profile::CommitProfile};
 use storage::snapshot::CommittableSnapshot;
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -11,6 +11,7 @@ use function::function_manager::FunctionManager;
 use query::{error::QueryError, query_manager::QueryManager};
 use resource::{constants::query::MAX_PIPELINE_STAGES, profile::CommitProfile};
 use storage::snapshot::CommittableSnapshot;
+use test_utils::assert_matches;
 use test_utils_concept::{load_managers, setup_concept_storage};
 use test_utils_encoding::create_core_storage;
 
@@ -66,13 +67,7 @@ fn pipeline_at_limit_is_accepted() {
         &query_str,
     );
 
-    if let Err(err) = &result {
-        assert!(
-            !matches!(err.as_ref(), QueryError::PipelineStagesLimitExceeded { .. }),
-            "expected no stages-limit error at the limit, got: {:?}",
-            err
-        );
-    }
+    assert!(result.is_ok());
 }
 
 #[test]

--- a/query/tests/pipeline_stages_limit.rs
+++ b/query/tests/pipeline_stages_limit.rs
@@ -1,0 +1,111 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::sync::Arc;
+
+use encoding::graph::definition::definition_key_generator::DefinitionKeyGenerator;
+use function::function_manager::FunctionManager;
+use query::{
+    error::QueryError,
+    query_manager::{QueryManager, MAX_PIPELINE_STAGES},
+};
+use resource::profile::CommitProfile;
+use storage::snapshot::CommittableSnapshot;
+use test_utils_concept::{load_managers, setup_concept_storage};
+use test_utils_encoding::create_core_storage;
+
+fn build_pipeline_query(stage_count: usize) -> String {
+    let mut query = String::from("match $x isa person;\n");
+    for _ in 0..stage_count.saturating_sub(1) {
+        query.push_str("select $x;\n");
+    }
+    query
+}
+
+fn setup() -> (
+    test_utils::TempDir,
+    Arc<storage::MVCCStorage<storage::durability_client::WALClient>>,
+    Arc<concept::type_::type_manager::TypeManager>,
+    Arc<concept::thing::thing_manager::ThingManager>,
+    FunctionManager,
+    QueryManager,
+) {
+    let (tmp_dir, mut storage) = create_core_storage();
+    setup_concept_storage(&mut storage);
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+    let function_manager = FunctionManager::new(Arc::new(DefinitionKeyGenerator::new()), None);
+    let query_manager = QueryManager::new(None);
+
+    let schema = "define entity person;";
+    let mut snapshot = storage.clone().open_snapshot_schema();
+    let schema_query = typeql::parse_query(schema).unwrap().into_structure().into_schema();
+    query_manager
+        .execute_schema(&mut snapshot, &type_manager, &thing_manager, &function_manager, schema_query, schema)
+        .unwrap();
+    snapshot.commit(&mut CommitProfile::DISABLED).unwrap();
+
+    let (type_manager, thing_manager) = load_managers(storage.clone(), None);
+    (tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager)
+}
+
+#[test]
+fn pipeline_at_limit_is_accepted() {
+    let (_tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager) = setup();
+
+    let query_str = build_pipeline_query(MAX_PIPELINE_STAGES);
+    let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
+    assert_eq!(pipeline.stages.len(), MAX_PIPELINE_STAGES);
+
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let result = query_manager.prepare_read_pipeline(
+        snapshot,
+        &type_manager,
+        thing_manager.clone(),
+        &function_manager,
+        &pipeline,
+        &query_str,
+    );
+
+    if let Err(err) = &result {
+        assert!(
+            !matches!(err.as_ref(), QueryError::PipelineStagesLimitExceeded { .. }),
+            "expected no stages-limit error at the limit, got: {:?}",
+            err
+        );
+    }
+}
+
+#[test]
+fn pipeline_over_limit_is_rejected() {
+    let (_tmp_dir, storage, type_manager, thing_manager, function_manager, query_manager) = setup();
+
+    let over = MAX_PIPELINE_STAGES + 1;
+    let query_str = build_pipeline_query(over);
+    let pipeline = typeql::parse_query(&query_str).unwrap().into_structure().into_pipeline();
+    assert_eq!(pipeline.stages.len(), over);
+
+    let snapshot = Arc::new(storage.clone().open_snapshot_read());
+    let result = query_manager.prepare_read_pipeline(
+        snapshot,
+        &type_manager,
+        thing_manager.clone(),
+        &function_manager,
+        &pipeline,
+        &query_str,
+    );
+    let err = match result {
+        Ok(_) => panic!("query with too many stages should fail"),
+        Err(err) => err,
+    };
+
+    match err.as_ref() {
+        QueryError::PipelineStagesLimitExceeded { actual, max, .. } => {
+            assert_eq!(*actual, over);
+            assert_eq!(*max, MAX_PIPELINE_STAGES);
+        }
+        other => panic!("expected PipelineStagesLimitExceeded, got: {:?}", other),
+    }
+}

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -122,6 +122,10 @@ pub mod concept {
     pub const RELATION_INDEX_THRESHOLD: u64 = 5;
 }
 
+pub mod query {
+    pub const MAX_PIPELINE_STAGES: usize = 1000;
+}
+
 pub mod traversal {
     pub const CONSTANT_CONCEPT_LIMIT: usize = 1000;
     pub const FIXED_BATCH_ROWS_MAX: u32 = 64;


### PR DESCRIPTION
## Product change and motivation

Add MAX_PIPELINE_STAGES limit enforced in translate_pipeline, covering read, write, and analyse paths. New QueryError::PipelineStagesLimitExceeded variant reports the offending stage count.

## Implementation

- Limit pipeline stages
- add tests for errors too large error pipelines (as an integration test, not BDD, to avoid massive BDD files!)

