### PR TITLE
Checkpoint statistics after startup recovery

### DIFF
--- a/database/database.rs
+++ b/database/database.rs
@@ -358,9 +358,6 @@ impl Database<WALClient> {
             thing_statistics.sequence_number
         );
         thing_statistics.may_synchronise(&storage).map_err(|err| StatisticsInitialise { typedb_source: err })?;
-        // Checkpoint the post-recovery statistics so subsequent reboots short-circuit
-        // may_synchronise instead of re-deserialising the WAL range we just processed.
-        // The guard skips a redundant write when may_synchronise did not advance the watermark.
         if thing_statistics.sequence_number > thing_statistics.last_durable_write_sequence_number {
             thing_statistics
                 .durably_write(storage.durability())

--- a/database/database.rs
+++ b/database/database.rs
@@ -358,6 +358,14 @@ impl Database<WALClient> {
             thing_statistics.sequence_number
         );
         thing_statistics.may_synchronise(&storage).map_err(|err| StatisticsInitialise { typedb_source: err })?;
+        // Checkpoint the post-recovery statistics so subsequent reboots short-circuit
+        // may_synchronise instead of re-deserialising the WAL range we just processed.
+        // The guard skips a redundant write when may_synchronise did not advance the watermark.
+        if thing_statistics.sequence_number > thing_statistics.last_durable_write_sequence_number {
+            thing_statistics
+                .durably_write(storage.durability())
+                .map_err(|err| StatisticsInitialise { typedb_source: err })?;
+        }
         event!(Level::TRACE, "Thing statistics: {:?}", thing_statistics);
         let thing_statistics = Arc::new(thing_statistics);
 


### PR DESCRIPTION
## Product change and motivation

Improve subsequent boot time by checkpointing statistics on reboot. This in particular alleviates slow bootup caused by large commit records in the WAL that may be scanned as part of the initial synchroniziation process. Without this change, the server pays the same cost of scanning data records on every reboot, until a "large enough" modification of the data occurs.

## Implementation

Checkpoint statistics into the WAL on reboot, if the bootup synchronization process included any new statistics updates at all.