### PR TITLE
Optional function returns are checked and print WARN log lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2577,6 +2577,7 @@ dependencies = [
  "structural_equality",
  "test_utils",
  "test_utils_storage",
+ "tracing",
  "typeql",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -616,7 +616,7 @@ features = {}
 
 		[workspace.dependencies.chrono]
 			features = ["alloc", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-			version = "0.4.41"
+			version = "0.4.44"
 			default-features = false
 
 		[workspace.dependencies.user]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -616,7 +616,7 @@ features = {}
 
 		[workspace.dependencies.chrono]
 			features = ["alloc", "clock", "default", "iana-time-zone", "js-sys", "now", "oldtime", "serde", "std", "wasm-bindgen", "wasmbind", "winapi", "windows-link"]
-			version = "0.4.44"
+			version = "0.4.41"
 			default-features = false
 
 		[workspace.dependencies.user]

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -156,6 +156,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "e5e4e153bd29f4b60eb721f51140067c5e57cbc0",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "0f894490977360ba7b625517121ce0461c22df7f",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -156,6 +156,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
-    commit = "7aee3487fd432fdb2ae6eb8308aadab40affc9bb",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
+    commit = "8b52237d72058e6c4380b329b0b90cfb21384a5e",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -157,5 +157,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "75419a030b521ce1a1269c01d656a65ef3e5b95c",
+    commit = "e5e4e153bd29f4b60eb721f51140067c5e57cbc0",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -157,5 +157,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "8b52237d72058e6c4380b329b0b90cfb21384a5e",
+    commit = "75419a030b521ce1a1269c01d656a65ef3e5b95c",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -156,6 +156,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/typedb/typedb-behaviour",
+    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
     commit = "7aee3487fd432fdb2ae6eb8308aadab40affc9bb",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -157,5 +157,5 @@ bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
     remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "7aee3487fd432fdb2ae6eb8308aadab40affc9bb",
+    commit = "76624d5880daa383c67c010b7e892acc0011e3e4",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -156,6 +156,6 @@ git_override(
 bazel_dep(name = "typedb_behaviour", version = "0.0.0")
 git_override(
     module_name = "typedb_behaviour",
-    remote = "https://github.com/krishnangovindraj/typedb-behaviour",
-    commit = "76624d5880daa383c67c010b7e892acc0011e3e4",
+    remote = "https://github.com/typedb/typedb-behaviour",
+    commit = "7aee3487fd432fdb2ae6eb8308aadab40affc9bb",
 )

--- a/compiler/annotation/function.rs
+++ b/compiler/annotation/function.rs
@@ -17,7 +17,7 @@ use encoding::{
     graph::definition::definition_key::DefinitionKey,
     value::{label::Label, value_type::ValueType},
 };
-use error::needs_update_when_feature_is_implemented;
+use error::{needs_update_when_feature_is_implemented, todo_must_implement};
 use ir::{
     pattern::{Vertex, expression::BuiltinConceptFunctionID},
     pipeline::{
@@ -578,10 +578,7 @@ fn get_annotations_from_labels(
 ) -> Result<FunctionParameterAnnotation, TypeInferenceError> {
     let named_type = match typeql_label {
         NamedTypeAny::Simple(inner) => inner,
-        NamedTypeAny::Optional(typeql::type_::NamedTypeOptional { .. }) => {
-            needs_update_when_feature_is_implemented!(Optionals);
-            return Err(TypeInferenceError::OptionalTypesUnsupported {});
-        }
+        NamedTypeAny::Optional(typeql::type_::NamedTypeOptional { inner, .. }) => inner,
         NamedTypeAny::List(typeql::type_::NamedTypeList { .. }) => {
             needs_update_when_feature_is_implemented!(Lists);
             return Err(TypeInferenceError::ListTypesUnsupported {});

--- a/compiler/annotation/type_inference.rs
+++ b/compiler/annotation/type_inference.rs
@@ -61,7 +61,7 @@ pub mod tests {
     };
     use ir::{
         pattern::{
-            Vertex,
+            AssignedVariable, Vertex,
             constraint::{Constraint, IsaKind, SubKind},
             variable_category::{VariableCategory, VariableOptionality},
         },
@@ -158,7 +158,13 @@ pub mod tests {
             );
             conjunction
                 .constraints_mut()
-                .add_function_binding(vec![var_animal], &callee_signature, vec![], "test_fn", None)
+                .add_function_binding(
+                    vec![AssignedVariable::new_required(var_animal)],
+                    &callee_signature,
+                    vec![],
+                    "test_fn",
+                    None,
+                )
                 .unwrap();
             let entry = builder.finish().unwrap();
             (entry, entry_context, f_ir)

--- a/ir/BUILD
+++ b/ir/BUILD
@@ -32,6 +32,7 @@ rust_library(
         "@typeql//rust:typeql",
 
         "@crates//:itertools",
+        "@crates//:tracing",
 
         # For the parsing of literals
         "@crates//:chrono",

--- a/ir/Cargo.toml
+++ b/ir/Cargo.toml
@@ -26,6 +26,9 @@ features = {}
 	[dependencies.test_utils]
 		workspace = true
 
+	[dependencies.tracing]
+		workspace = true
+
 	[dependencies.primitive]
 		workspace = true
 
@@ -79,4 +82,8 @@ features = {}
 [[test]]
 	path = "tests/structural_equality.rs"
 	name = "test_structural_equality"
+
+[[test]]
+	path = "tests/binding_modes.rs"
+	name = "binding_modes"
 

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -218,7 +218,7 @@ typedb_error! {
         ),
         OptionalFunctionReturnReferenced(
             33,
-            "The variable '{variable}' is optionally returned by a function, but referenced elsewhere in the same stage.",
+            "The variable '{variable}' is optionally assigned by a function return, and may not be referenced elsewhere in the same stage.",
             variable: String,
             source_span: Option<Span>,
         ),

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -210,8 +210,14 @@ typedb_error! {
             "Specifying a scoped label constraint on a label is not allowed.",
             source_span: Option<Span>,
         ),
-        OptionalFunctionReturnReferenced(
+        UnmarkedOptionalAssignment(
             32,
+            "The variable '{variable}' is assigned an optional value but not marked with a '?'",
+            variable: String,
+            source_span: Option<Span>,
+        ),
+        OptionalFunctionReturnReferenced(
+            33,
             "The variable '{variable}' is optionally returned by a function, but referenced elsewhere in the same stage.",
             variable: String,
         ),

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -319,12 +319,6 @@ typedb_error! {
             "The language feature is not yet implemented: {feature}.",
             feature: error::UnimplementedFeature,
         ),
-        UnimplementedOptionalType(
-            255,
-            "Optional types are not yet implemented.",
-            source_span: Option<Span>,
-            feature: error::UnimplementedFeature
-        ),
         UnimplementedListType(
             256,
             "List types are not yet implemented.",

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -210,6 +210,11 @@ typedb_error! {
             "Specifying a scoped label constraint on a label is not allowed.",
             source_span: Option<Span>,
         ),
+        OptionalFunctionReturnReferenced(
+            32,
+            "The variable '{variable}' is optionally returned by a function, but referenced elsewhere in the same stage.",
+            variable: String,
+        ),
         UpdateVariableUnavailable(
             39,
             "The variable '{variable}' referenced in the update stage is unavailable. It should be bound in the previous stage.",

--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -220,6 +220,7 @@ typedb_error! {
             33,
             "The variable '{variable}' is optionally returned by a function, but referenced elsewhere in the same stage.",
             variable: String,
+            source_span: Option<Span>,
         ),
         UpdateVariableUnavailable(
             39,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -287,7 +287,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub(crate) fn add_builtin_function_binding(
         &mut self,
-        assigned: Vec<AssignedVariable>,
+        mut assigned: Vec<AssignedVariable>,
         builtin_id: super::expression::BuiltinConceptFunctionID,
         arguments: Vec<Variable>,
         source_span: Option<Span>,
@@ -313,7 +313,17 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
                 .get_variable_name(variable)
                 .cloned()
                 .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
-            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
+            use error::TypeDBError;
+            tracing::warn!(
+                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
+                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
+            );
+            // Fix for now:
+            assigned.iter_mut().zip(callee_signature.returns.iter()).for_each(
+                |(assigned_var, (_, declared_optionality))| {
+                    assigned_var.optionality = *declared_optionality;
+                },
+            );
         }
         let function_call =
             self.create_function_call(&assigned, &callee_signature, arguments, builtin_id.name(), source_span)?;
@@ -360,7 +370,11 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
                 .get_variable_name(variable)
                 .cloned()
                 .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
-            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
+            use error::TypeDBError;
+            tracing::warn!(
+                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
+                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
+            );
         }
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -6,7 +6,7 @@
 
 use std::{
     cmp::min,
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     fmt,
     hash::{DefaultHasher, Hash, Hasher},
     iter, mem,
@@ -25,7 +25,8 @@ use crate::{
         conjunction::Conjunction,
         expression::{ExpressionRepresentationError, ExpressionTree},
         function_call::FunctionCall,
-        variable_category::VariableCategory,
+        variable_category::{VariableCategory, VariableOptionality},
+        AssignedVariable, BindingMode, IrID, ParameterID, ScopeId, ValueType, Vertex,
     },
     pipeline::{
         ParameterRegistry, VariableRegistry, block::BlockBuilderContext, function_signature::FunctionSignature,
@@ -287,15 +288,15 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub(crate) fn add_builtin_function_binding(
         &mut self,
-        assigned: Vec<Variable>,
+        assigned: Vec<AssignedVariable>,
         builtin_id: super::expression::BuiltinConceptFunctionID,
         arguments: Vec<Variable>,
         source_span: Option<Span>,
     ) -> Result<&FunctionCallBinding<Variable>, Box<RepresentationError>> {
-        if let Some(variable) = assigned.iter().find(|var| self.context.is_block_input_variable(**var)) {
+        if let Some(variable) = assigned.iter().find(|var| self.context.is_block_input_variable(var.variable)) {
             let variable = self
                 .context
-                .get_variable_name(*variable)
+                .get_variable_name(variable.variable)
                 .cloned()
                 .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
             return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
@@ -309,6 +310,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
+        binding.optionally_assigned.iter().for_each(|var| self.context.set_variable_optionality(*var, true));
         for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
                 caller_var,
@@ -322,16 +324,16 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub fn add_function_binding(
         &mut self,
-        assigned: Vec<Variable>,
+        assigned: Vec<AssignedVariable>,
         callee_signature: &FunctionSignature,
         arguments: Vec<Variable>,
         function_name: &str,
         source_span: Option<Span>,
     ) -> Result<&FunctionCallBinding<Variable>, Box<RepresentationError>> {
-        if let Some(variable) = assigned.iter().find(|var| self.context.is_block_input_variable(**var)) {
+        if let Some(variable) = assigned.iter().find(|var| self.context.is_block_input_variable(var.variable)) {
             let variable = self
                 .context
-                .get_variable_name(*variable)
+                .get_variable_name(variable.variable)
                 .cloned()
                 .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
             return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
@@ -343,6 +345,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         for (index, var) in binding.ids_assigned().enumerate() {
             self.context.set_variable_category(var, callee_signature.returns[index].0, binding.clone().into())?;
         }
+        binding.optionally_assigned.iter().for_each(|var| self.context.set_variable_optionality(*var, true));
         for (callee_arg_index, caller_var) in binding.function_call.argument_ids().enumerate() {
             self.context.set_variable_category(
                 caller_var,
@@ -356,7 +359,7 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     fn create_function_call(
         &mut self,
-        assigned: &[Variable],
+        assigned: &[AssignedVariable],
         callee_signature: &FunctionSignature,
         arguments: Vec<Variable>,
         function_name: &str,
@@ -2106,22 +2109,31 @@ impl<ID: IrID> fmt::Display for ExpressionBinding<ID> {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FunctionCallBinding<ID> {
     assigned: Vec<Vertex<ID>>,
+    optionally_assigned: BTreeSet<ID>,
     function_call: FunctionCall<ID>,
     is_stream: bool,
     source_span: Option<Span>,
 }
 
-impl<ID> FunctionCallBinding<ID> {
-    fn new(left: Vec<ID>, function_call: FunctionCall<ID>, is_stream: bool, source_span: Option<Span>) -> Self {
-        Self { assigned: left.into_iter().map(Vertex::Variable).collect(), function_call, is_stream, source_span }
-    }
-
-    pub fn source_span(&self) -> Option<Span> {
-        self.source_span
+impl FunctionCallBinding<Variable> {
+    fn new(
+        left: Vec<AssignedVariable>,
+        function_call: FunctionCall<Variable>,
+        is_stream: bool,
+        source_span: Option<Span>,
+    ) -> Self {
+        let optionally_assigned =
+            left.iter().filter(|v| v.optionality == VariableOptionality::Optional).map(|a| a.variable).collect();
+        let assigned = left.into_iter().map(|a| Vertex::Variable(a.variable)).collect();
+        Self { assigned, optionally_assigned, function_call, is_stream, source_span }
     }
 }
 
 impl<ID: IrID> FunctionCallBinding<ID> {
+    pub fn source_span(&self) -> Option<Span> {
+        self.source_span
+    }
+
     pub fn assigned(&self) -> &[Vertex<ID>] {
         &self.assigned
     }
@@ -2149,7 +2161,10 @@ impl<ID: IrID> FunctionCallBinding<ID> {
     pub(crate) fn binding_modes(&self) -> impl Iterator<Item = (ID, BindingMode)> + '_ {
         self.ids_assigned()
             .filter(|id| !self.function_call.arguments().contains(id))
-            .map(|id| (id, BindingMode::AlwaysBinding))
+            .map(|id| match self.optionally_assigned.contains(&id) {
+                true => (id, BindingMode::OptionallyBinding),
+                false => (id, BindingMode::AlwaysBinding),
+            })
             .chain(self.function_call_arg_ids().map(|id| (id, BindingMode::RequirePrebound)))
     }
 
@@ -2167,6 +2182,7 @@ impl<ID: IrID> FunctionCallBinding<ID> {
     pub fn map<T: Clone + Ord>(self, mapping: &HashMap<ID, T>) -> FunctionCallBinding<T> {
         FunctionCallBinding {
             assigned: self.assigned.into_iter().map(|v| v.map(mapping)).collect(),
+            optionally_assigned: self.optionally_assigned.into_iter().map(|v| v.map(mapping)).collect(),
             function_call: self.function_call.map(mapping),
             is_stream: self.is_stream,
             source_span: self.source_span,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -21,12 +21,11 @@ use typeql::common::Span;
 use crate::{
     LiteralParseError, RepresentationError,
     pattern::{
-        BindingMode, IrID, ParameterID, ScopeId, ValueType, Vertex,
+        AssignedVariable, BindingMode, IrID, ParameterID, ScopeId, ValueType, Vertex,
         conjunction::Conjunction,
         expression::{ExpressionRepresentationError, ExpressionTree},
         function_call::FunctionCall,
         variable_category::{VariableCategory, VariableOptionality},
-        AssignedVariable, BindingMode, IrID, ParameterID, ScopeId, ValueType, Vertex,
     },
     pipeline::{
         ParameterRegistry, VariableRegistry, block::BlockBuilderContext, function_signature::FunctionSignature,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -303,7 +303,19 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         }
 
         let callee_signature = builtin_id.signature();
-
+        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).find_map(
+            |(assigned_var, (_, declared_optionality))| {
+                (assigned_var.optionality != *declared_optionality).then_some(assigned_var.variable)
+            },
+        );
+        if let Some(variable) = mismatched_optionality_in_assignment {
+            let variable = self
+                .context
+                .get_variable_name(variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
+        }
         let function_call =
             self.create_function_call(&assigned, &callee_signature, arguments, builtin_id.name(), source_span)?;
         let binding = FunctionCallBinding::new(assigned, function_call, callee_signature.return_is_stream, source_span);
@@ -338,7 +350,19 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
                 .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
             return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
         }
-
+        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).find_map(
+            |(assigned_var, (_, declared_optionality))| {
+                (assigned_var.optionality != *declared_optionality).then_some(assigned_var.variable)
+            },
+        );
+        if let Some(variable) = mismatched_optionality_in_assignment {
+            let variable = self
+                .context
+                .get_variable_name(variable)
+                .cloned()
+                .unwrap_or_else(|| VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME.to_string());
+            return Err(Box::new(RepresentationError::UnmarkedOptionalAssignment { variable, source_span }));
+        }
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;
         let binding = FunctionCallBinding::new(assigned, function_call, callee_signature.return_is_stream, source_span);

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -18,7 +18,7 @@ use encoding::value::label::Label;
 use structural_equality::StructuralEquality;
 use typeql::common::Span;
 
-use crate::pipeline::VariableRegistry;
+use crate::{pattern::variable_category::VariableOptionality, pipeline::VariableRegistry};
 
 pub mod conjunction;
 pub mod constraint;
@@ -505,5 +505,17 @@ impl PatternVariables {
 
     pub(crate) fn required_inputs(&self) -> impl Iterator<Item = Variable> + '_ {
         self.0.iter().filter_map(|(v, required)| (*required == IsRequired::Required).then_some(*v))
+    }
+}
+
+#[derive(Clone, Debug, Copy)]
+pub(crate) struct AssignedVariable {
+    pub(crate) variable: Variable,
+    pub(crate) optionality: VariableOptionality,
+}
+
+impl AssignedVariable {
+    pub(crate) fn new_required(variable: Variable) -> Self {
+        Self { variable, optionality: VariableOptionality::Required }
     }
 }

--- a/ir/pattern/mod.rs
+++ b/ir/pattern/mod.rs
@@ -509,13 +509,17 @@ impl PatternVariables {
 }
 
 #[derive(Clone, Debug, Copy)]
-pub(crate) struct AssignedVariable {
+pub struct AssignedVariable {
     pub(crate) variable: Variable,
     pub(crate) optionality: VariableOptionality,
 }
 
 impl AssignedVariable {
-    pub(crate) fn new_required(variable: Variable) -> Self {
+    pub fn new_optional(variable: Variable) -> Self {
+        Self { variable, optionality: VariableOptionality::Optional }
+    }
+
+    pub fn new_required(variable: Variable) -> Self {
         Self { variable, optionality: VariableOptionality::Required }
     }
 }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -272,7 +272,13 @@ fn validate_optional_returns_recursive(
             .map_or(VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME, String::as_str)
             .to_owned();
         let source_span = source_span.clone();
-        Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
+        // Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
+        use error::TypeDBError;
+        tracing::warn!(
+            "Function call reuses optionally assigned variable. This will fail in the next version:\n{}",
+            RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }.format_description()
+        );
+        Ok(())
     } else {
         Ok(())
     }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -233,43 +233,46 @@ fn validate_optional_returns(
     context: &BlockBuilderContext<'_>,
     conjunction: &ConjunctionBuilder,
 ) -> Result<(), Box<RepresentationError>> {
-    let mut optional_assignments = HashSet::new();
-    let result = validate_optional_returns_recursive(conjunction, &mut optional_assignments);
-    result.map_err(|var| {
-        let variable = context
-            .get_variable_name(var)
-            .map_or(VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME, String::as_str)
-            .to_owned();
-        Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable })
-    })
+    let mut optional_assignments = HashMap::new();
+    validate_optional_returns_recursive(context, conjunction, &mut optional_assignments)
 }
 
 fn validate_optional_returns_recursive(
+    context: &BlockBuilderContext<'_>,
     conjunction: &ConjunctionBuilder,
-    acc: &mut HashSet<Variable>,
-) -> Result<(), Variable> {
+    acc: &mut HashMap<Variable, Option<Span>>,
+) -> Result<(), Box<RepresentationError>> {
     let conjunction_binding_modes = conjunction.variable_binding_modes();
     conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
         NestedPatternBuilder::Disjunction(disjunction) => {
-            disjunction.conjunctions().try_for_each(|branch| validate_optional_returns_recursive(branch, acc))
+            disjunction.conjunctions().try_for_each(|branch| validate_optional_returns_recursive(context, branch, acc))
         }
-        NestedPatternBuilder::Negation(negation) => validate_optional_returns_recursive(negation.conjunction(), acc),
-        NestedPatternBuilder::Optional(optional) => validate_optional_returns_recursive(optional.conjunction(), acc),
+        NestedPatternBuilder::Negation(negation) => {
+            validate_optional_returns_recursive(context, negation.conjunction(), acc)
+        }
+        NestedPatternBuilder::Optional(optional) => {
+            validate_optional_returns_recursive(context, optional.conjunction(), acc)
+        }
     })?;
-    acc.extend(
-        conjunction
-            .constraints()
-            .iter()
-            .filter_map(|c| c.as_function_call_binding())
-            .flat_map(|call| call.binding_modes())
-            .filter_map(|(var, mode)| (mode == BindingMode::OptionallyBinding).then_some(var)),
-    );
-    let reused_optional_return_opt = conjunction_binding_modes
-        .iter()
-        .find(|(var, mode)| **mode != BindingMode::OptionallyBinding && acc.contains(var))
-        .map(|(var, mode)| *var);
-    if let Some(var) = reused_optional_return_opt {
-        Err(var)
+    conjunction.constraints().iter().filter_map(|c| c.as_function_call_binding()).for_each(|call| {
+        for (var, mode) in call.binding_modes() {
+            if mode == BindingMode::OptionallyBinding {
+                acc.insert(var, call.source_span());
+            }
+        }
+    });
+    // Check at each level
+    let reused_optional_return_opt = acc.iter().find(|(var, _)| match conjunction_binding_modes.get(var) {
+        None => false,
+        Some(mode) => *mode != BindingMode::OptionallyBinding,
+    });
+    if let Some((var, source_span)) = reused_optional_return_opt {
+        let variable = context
+            .get_variable_name(*var)
+            .map_or(VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME, String::as_str)
+            .to_owned();
+        let source_span = source_span.clone();
+        Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
     } else {
         Ok(())
     }

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -73,6 +73,7 @@ impl<'reg> BlockBuilder<'reg> {
         validate_all_required_variables_can_be_bound(&self, &block_binding_modes, &self.context.variable_registry)?;
         validate_no_unbound_variable_categories(&self.conjunction, &self.context)?;
         validate_is_variables_have_same_category(&self.conjunction, &self.context.variable_registry)?;
+        validate_optional_returns(&self.context, &self.conjunction)?;
 
         // Update
         block_binding_modes
@@ -226,6 +227,52 @@ fn find_constraints_referencing_variable(conjunction: &ConjunctionBuilder, varia
             find_constraints_referencing_variable(optional.conjunction(), variable, spans)
         }
     })
+}
+
+fn validate_optional_returns(
+    context: &BlockBuilderContext<'_>,
+    conjunction: &ConjunctionBuilder,
+) -> Result<(), Box<RepresentationError>> {
+    let mut optional_assignments = HashSet::new();
+    let result = validate_optional_returns_recursive(conjunction, &mut optional_assignments);
+    result.map_err(|var| {
+        let variable = context
+            .get_variable_name(var)
+            .map_or(VariableRegistry::UNNAMED_VARIABLE_DISPLAY_NAME, String::as_str)
+            .to_owned();
+        Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable })
+    })
+}
+
+fn validate_optional_returns_recursive(
+    conjunction: &ConjunctionBuilder,
+    acc: &mut HashSet<Variable>,
+) -> Result<(), Variable> {
+    let conjunction_binding_modes = conjunction.variable_binding_modes();
+    conjunction.nested_patterns().iter().try_for_each(|nested| match nested {
+        NestedPatternBuilder::Disjunction(disjunction) => {
+            disjunction.conjunctions().try_for_each(|branch| validate_optional_returns_recursive(branch, acc))
+        }
+        NestedPatternBuilder::Negation(negation) => validate_optional_returns_recursive(negation.conjunction(), acc),
+        NestedPatternBuilder::Optional(optional) => validate_optional_returns_recursive(optional.conjunction(), acc),
+    })?;
+    acc.extend(
+        conjunction
+            .constraints()
+            .iter()
+            .filter_map(|c| c.as_function_call_binding())
+            .flat_map(|call| call.binding_modes())
+            .filter_map(|(var, mode)| (mode == BindingMode::OptionallyBinding).then_some(var)),
+    );
+    let reused_optional_return_opt = conjunction_binding_modes
+        .iter()
+        .find(|(var, mode)| **mode != BindingMode::OptionallyBinding && acc.contains(var))
+        .map(|(var, mode)| *var);
+    if let Some(var) = reused_optional_return_opt {
+        Err(var)
+    } else {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq)]

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -70,10 +70,10 @@ impl<'reg> BlockBuilder<'reg> {
     pub fn finish(mut self) -> Result<Block, Box<RepresentationError>> {
         let block_binding_modes = self.variable_binding_modes();
         validate_no_optionals_in_negations(&self.conjunction, false)?;
+        validate_optional_returns(&self.context, &self.conjunction)?;
         validate_all_required_variables_can_be_bound(&self, &block_binding_modes, &self.context.variable_registry)?;
         validate_no_unbound_variable_categories(&self.conjunction, &self.context)?;
         validate_is_variables_have_same_category(&self.conjunction, &self.context.variable_registry)?;
-        validate_optional_returns(&self.context, &self.conjunction)?;
 
         // Update
         block_binding_modes

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -109,11 +109,17 @@ typedb_error! {
             "A non-anonymous variable is expected in this context.",
             source_span: Option<Span>,
         ),
-        UnimplementedFunctionOptionals(
-            255,
-            "Functions returning optionals are not yet implemented.",
-            source_span: Option<Span>,
-            feature: error::UnimplementedFeature
+        DeclaresStreamReturnsSingle(
+            11,
+            "The function declares it returns a stream but the implementation returns a single row.\nSignature: {signature}\nDefinition: {return_}",
+            signature: Signature,
+            return_: ReturnStatement,
+        ),
+        DeclaresSingleReturnsStream(
+            12,
+            "The function declares it returns a single row but the implementation returns a stream.\nSignature: {signature}\nDefinition: {return_}",
+            signature: Signature,
+            return_: ReturnStatement,
         ),
     }
 }

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -94,7 +94,7 @@ typedb_error! {
         ),
         InconsistentReturnLengths(
             8,
-            "The size of the tuple returned by the body of the function did not match that declared in the signature. \nSignature: {signature}\nDefinition: {return_}",
+            "The function declares it returns {declared_length} items, but the definition returns {actual_length}. \nSignature: {signature}\nDefinition: {return_}",
             signature: Signature,
             return_: ReturnStatement,
             declared_length: usize,

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -94,7 +94,7 @@ typedb_error! {
         ),
         InconsistentReturnLengths(
             8,
-            "The function declares it returns {declared_length} items, but the definition returns {actual_length}. \nSignature: {signature}\nDefinition: {return_}",
+            "The function declares it returns {declared_length} item(s), but the definition returns {actual_length}. \nSignature: {signature}\nDefinition: {return_}",
             signature: Signature,
             return_: ReturnStatement,
             declared_length: usize,

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -125,7 +125,7 @@ typedb_error! {
         ),
         InconsistentReturnOptionality(
             13,
-            "The optionality of the value returned by the function at index '{mismatch_index}' did not match that declared in the signature. \nSignature: {signature}\nDefinition: {return_}",
+            "The optionality of the value returned by the function at index '{mismatch_index}' does not match that declared in the signature. \nSignature: {signature}\nDefinition: {return_}",
             signature: Signature,
             return_: ReturnStatement,
             mismatch_index: usize,

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -92,11 +92,13 @@ typedb_error! {
             "Functions may not contain write stages.",
             source_span: Option<Span>,
         ),
-        InconsistentReturn(
+        InconsistentReturnLengths(
             8,
-            "The return statement in the body of the function did not match that in the signature. \nSignature: {signature}\nDefinition: {return_}",
+            "The size of the tuple returned by the body of the function did not match that declared in the signature. \nSignature: {signature}\nDefinition: {return_}",
             signature: Signature,
-            return_: ReturnStatement
+            return_: ReturnStatement,
+            declared_length: usize,
+            actual_length: usize,
         ),
         IllegalKeywordAsIdentifier(
             9,
@@ -120,6 +122,13 @@ typedb_error! {
             "The function declares it returns a single row but the implementation returns a stream.\nSignature: {signature}\nDefinition: {return_}",
             signature: Signature,
             return_: ReturnStatement,
+        ),
+        InconsistentReturnOptionality(
+            13,
+            "The optionality of the value returned by the function at index '{mismatch_index}' did not match that declared in the signature. \nSignature: {signature}\nDefinition: {return_}",
+            signature: Signature,
+            return_: ReturnStatement,
+            mismatch_index: usize,
         ),
     }
 }

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -505,6 +505,30 @@ fn test_optional_return() {
 }
 
 #[test]
+fn test_optional_return_must_be_declared() {
+    let query = r#"
+    with fun first_is_opt() -> {integer, integer}:
+    match let $x = 5; try { let $y = 6; };
+    return { $x, $y };
+
+    match let $x, $y in first_is_opt();
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::FunctionRepresentation {
+            typedb_source: FunctionRepresentationError::InconsistentReturnOptionality { mismatch_index, .. },
+        } => {
+            mismatch_index == 0
+        }
+        _ => false,
+    });
+}
+
+#[test]
 fn test_optional_return_reuse_errors() {
     let query = r#"
     with fun age_opt() -> age?:

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -8,7 +8,10 @@ use std::collections::HashSet;
 use ir::{
     RepresentationError,
     pattern::Pattern,
-    pipeline::{ParameterRegistry, VariableRegistry, function_signature::HashMapFunctionSignatureIndex},
+    pipeline::{
+        FunctionRepresentationError, ParameterRegistry, VariableRegistry,
+        function_signature::{FunctionID, HashMapFunctionSignatureIndex},
+    },
     translation::{
         PipelineTranslationContext,
         match_::translate_match,
@@ -464,7 +467,7 @@ fn test_nested_optional() {
 fn test_unmarked_optional_return_errors() {
     let query = r#"
     with fun first_is_opt() -> {integer?, integer}:
-    match let $x = 5; try { let $y = 6; };
+    match try { let $x = 6; }; let $y = 5;
     return { $x, $y };
 
     match let $x, $y in first_is_opt();
@@ -486,7 +489,7 @@ fn test_unmarked_optional_return_errors() {
 fn test_optional_return() {
     let query = r#"
     with fun first_is_opt() -> {integer?, integer}:
-    match let $x = 5; try { let $y = 6; };
+    match let $y = 5; try { let $x = 6; };
     return { $x, $y };
 
     match let $x?, $y in first_is_opt();
@@ -508,7 +511,7 @@ fn test_optional_return() {
 fn test_optional_return_must_be_declared() {
     let query = r#"
     with fun first_is_opt() -> {integer, integer}:
-    match let $x = 5; try { let $y = 6; };
+    match try { let $x = 6; }; let $y = 5;
     return { $x, $y };
 
     match let $x, $y in first_is_opt();
@@ -532,7 +535,7 @@ fn test_optional_return_must_be_declared() {
 fn test_optional_return_reuse_errors() {
     let query = r#"
     with fun age_opt() -> age?:
-    match $age isa age;
+    match try { $age isa age; };
     return first $age;
 
     match
@@ -557,7 +560,7 @@ fn test_optional_return_reuse_errors_with_disjunctions() {
     // Just a convoluted case.
     let query = r#"
     with fun age_opt() -> age?:
-    match $age isa age;
+    match try { $age isa age; };
     return first $age;
 
     match

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -459,3 +459,107 @@ fn test_nested_optional() {
     assert_vars!(&translated_pipeline.variable_registry, inner_optional.conjunction(), Required["x"], Bound["y"]);
     assert_optionals!(&translated_pipeline.variable_registry, ["x", "y"]);
 }
+
+#[test]
+fn test_unmarked_optional_return_errors() {
+    let query = r#"
+    with fun first_is_opt() -> {integer?, integer}:
+    match let $x = 5; try { let $y = 6; };
+    return { $x, $y };
+
+    match let $x, $y in first_is_opt();
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::UnboundRequiredVariable { variable, .. } => {
+            variable == "y"
+        }
+        _ => false,
+    });
+}
+
+#[test]
+fn test_optional_return() {
+    let query = r#"
+    with fun first_is_opt() -> {integer?, integer}:
+    match let $x = 5; try { let $y = 6; };
+    return { $x, $y };
+
+    match let $x?, $y in first_is_opt();
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translated_pipeline = translate_pipeline(&preamble_signatures, &parsed).unwrap();
+    let TranslatedStage::Match { block, .. } = &translated_pipeline.translated_stages[0] else {
+        unreachable!();
+    };
+    let conjunction = block.conjunction();
+    assert_vars!(&translated_pipeline.variable_registry, conjunction, Required[], Bound["x", "y"]);
+    assert_optionals!(&translated_pipeline.variable_registry, ["x"]);
+}
+
+#[test]
+fn test_optional_return_reuse_errors() {
+    let query = r#"
+    with fun age_opt() -> age?:
+    match $age isa age;
+    return first $age;
+
+    match
+        let $age? in age_opt();
+        $person has $age;
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
+            variable == "age"
+        }
+        _ => false,
+    });
+}
+
+#[test]
+fn test_optional_return_reuse_errors_with_disjunctions() {
+    // Just a convoluted case.
+    let query = r#"
+    with fun age_opt() -> age?:
+    match $age isa age;
+    return first $age;
+
+    match
+        $cat isa cat; $dog isa dog;
+        {
+
+            $dog has $name;
+            {
+                let $age? in age_opt();
+            } or {
+                { $cat has $age; } or { $dog has $age; };
+                $cat has name $name;
+            };
+        } or {
+            $dog has $name; $dog has $other_age;
+        };
+    "#;
+    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let preamble_signatures = HashMapFunctionSignatureIndex::build(
+        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
+    );
+    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
+    assert!(match *translation_error {
+        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
+            variable == "age"
+        }
+        _ => false,
+    });
+}

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -464,28 +464,6 @@ fn test_nested_optional() {
 }
 
 #[test]
-fn test_unmarked_optional_return_errors() {
-    let query = r#"
-    with fun first_is_opt() -> {integer?, integer}:
-    match try { let $x = 6; }; let $y = 5;
-    return { $x, $y };
-
-    match let $x, $y in first_is_opt();
-    "#;
-    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
-    let preamble_signatures = HashMapFunctionSignatureIndex::build(
-        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
-    );
-    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
-    assert!(match *translation_error {
-        RepresentationError::UnmarkedOptionalAssignment { variable, .. } => {
-            variable == "x"
-        }
-        _ => false,
-    });
-}
-
-#[test]
 fn test_optional_return() {
     let query = r#"
     with fun first_is_opt() -> {integer?, integer}:
@@ -505,88 +483,4 @@ fn test_optional_return() {
     let conjunction = block.conjunction();
     assert_vars!(&translated_pipeline.variable_registry, conjunction, Required[], Bound["x", "y"]);
     assert_optionals!(&translated_pipeline.variable_registry, ["x"]);
-}
-
-#[test]
-fn test_optional_return_must_be_declared() {
-    let query = r#"
-    with fun first_is_opt() -> {integer, integer}:
-    match try { let $x = 6; }; let $y = 5;
-    return { $x, $y };
-
-    match let $x, $y in first_is_opt();
-    "#;
-    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
-    let preamble_signatures = HashMapFunctionSignatureIndex::build(
-        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
-    );
-    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
-    assert!(match *translation_error {
-        RepresentationError::FunctionRepresentation {
-            typedb_source: FunctionRepresentationError::InconsistentReturnOptionality { mismatch_index, .. },
-        } => {
-            mismatch_index == 0
-        }
-        _ => false,
-    });
-}
-
-#[test]
-fn test_optional_return_reuse_errors() {
-    let query = r#"
-    with fun age_opt() -> age?:
-    match try { $age isa age; };
-    return first $age;
-
-    match
-        let $age? in age_opt();
-        $person has $age;
-    "#;
-    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
-    let preamble_signatures = HashMapFunctionSignatureIndex::build(
-        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
-    );
-    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
-    assert!(match *translation_error {
-        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
-            variable == "age"
-        }
-        _ => false,
-    });
-}
-
-#[test]
-fn test_optional_return_reuse_errors_with_disjunctions() {
-    // Just a convoluted case.
-    let query = r#"
-    with fun age_opt() -> age?:
-    match try { $age isa age; };
-    return first $age;
-
-    match
-        $cat isa cat; $dog isa dog;
-        {
-
-            $dog has $name;
-            {
-                let $age? in age_opt();
-            } or {
-                { $cat has $age; } or { $dog has $age; };
-                $cat has name $name;
-            };
-        } or {
-            $dog has $name; $dog has $other_age;
-        };
-    "#;
-    let parsed = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
-    let preamble_signatures = HashMapFunctionSignatureIndex::build(
-        parsed.preambles.iter().enumerate().map(|(i, preamble)| (FunctionID::Preamble(i), &preamble.function)),
-    );
-    let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
-    assert!(match *translation_error {
-        RepresentationError::OptionalFunctionReturnReferenced { variable, .. } => {
-            variable == "age"
-        }
-        _ => false,
-    });
 }

--- a/ir/tests/binding_modes.rs
+++ b/ir/tests/binding_modes.rs
@@ -475,8 +475,8 @@ fn test_unmarked_optional_return_errors() {
     );
     let translation_error = translate_pipeline(&preamble_signatures, &parsed).unwrap_err();
     assert!(match *translation_error {
-        RepresentationError::UnboundRequiredVariable { variable, .. } => {
-            variable == "y"
+        RepresentationError::UnmarkedOptionalAssignment { variable, .. } => {
+            variable == "x"
         }
         _ => false,
     });

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -55,7 +55,7 @@ fn build_with_functions() {
     let var_person_type = conjunction.constraints_mut().get_or_declare_variable("person_type", None).unwrap();
 
     let var_count = conjunction.constraints_mut().get_or_declare_variable("count", None).unwrap();
-    let var_mean = conjunction.constraints_mut().get_or_declare_variable("sum", None).unwrap();
+    let var_mean = conjunction.constraints_mut().get_or_declare_variable("mean", None).unwrap();
 
     conjunction.constraints_mut().add_isa(IsaKind::Subtype, var_person, var_person_type.into(), None).unwrap();
 
@@ -70,7 +70,7 @@ fn build_with_functions() {
         function_return_categories,
         false,
     );
-    let assigned = vec![AssignedVariable::new_required(var_count), AssignedVariable::new_required(var_mean)];
+    let assigned = vec![AssignedVariable::new_required(var_count), AssignedVariable::new_optional(var_mean)];
     conjunction
         .constraints_mut()
         .add_function_binding(assigned, &function_signature, vec![var_person], "test_fn", None)

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -10,9 +10,9 @@ use encoding::{
 };
 use ir::{
     pattern::{
+        AssignedVariable,
         constraint::IsaKind,
         variable_category::{VariableCategory, VariableOptionality},
-        AssignedVariable,
     },
     pipeline::{
         ParameterRegistry,

--- a/ir/tests/pipeline.rs
+++ b/ir/tests/pipeline.rs
@@ -12,6 +12,7 @@ use ir::{
     pattern::{
         constraint::IsaKind,
         variable_category::{VariableCategory, VariableOptionality},
+        AssignedVariable,
     },
     pipeline::{
         ParameterRegistry,
@@ -20,7 +21,6 @@ use ir::{
     },
     translation::{PipelineTranslationContext, pipeline::translate_pipeline},
 };
-
 // TODO: if we re-instante modifiers/stream operators as part of blocks, then we can bring this test back
 // #[test]
 // fn build_modifiers() {
@@ -70,9 +70,10 @@ fn build_with_functions() {
         function_return_categories,
         false,
     );
+    let assigned = vec![AssignedVariable::new_required(var_count), AssignedVariable::new_required(var_mean)];
     conjunction
         .constraints_mut()
-        .add_function_binding(vec![var_count, var_mean], &function_signature, vec![var_person], "test_fn", None)
+        .add_function_binding(assigned, &function_signature, vec![var_person], "test_fn", None)
         .unwrap();
     let block = builder.finish().unwrap();
     println!("{}", block.conjunction());

--- a/ir/translation/constraints.rs
+++ b/ir/translation/constraints.rs
@@ -24,9 +24,10 @@ use typeql::{
 use crate::{
     RepresentationError,
     pattern::{
-        ValueType, Vertex,
+        AssignedVariable, ValueType, Vertex,
         conjunction::ConjunctionBuilderWithContext,
         constraint::{Comparator, ConstraintsBuilder, IsaKind, SubKind},
+        variable_category::VariableOptionality,
     },
     pipeline::function_signature::FunctionSignatureIndex,
     translation::{
@@ -83,7 +84,8 @@ pub(super) fn add_statement(
                     }));
                 };
                 let expression = build_expression(function_index, constraints, rhs)?;
-                constraints.add_assignment(assigned, expression, *span)?;
+                debug_assert!(assigned.optionality == VariableOptionality::Required);
+                constraints.add_assignment(assigned.variable, expression, *span)?;
             }
         }
         typeql::Statement::Thing(thing) => add_thing_statement(function_index, constraints, thing)?,
@@ -555,7 +557,7 @@ pub(super) fn add_typeql_relation(
 fn add_typeql_iterable_binding(
     function_index: &impl FunctionSignatureIndex,
     constraints: &mut ConstraintsBuilder<'_, '_>,
-    assigned: Vec<Variable>,
+    assigned: Vec<AssignedVariable>,
     rhs: &typeql::Expression,
 ) -> Result<(), Box<RepresentationError>> {
     match rhs {
@@ -618,7 +620,7 @@ fn add_typeql_iterable_binding(
 fn assignment_pattern_to_variables(
     constraints: &mut ConstraintsBuilder<'_, '_>,
     assignment: &AssignmentPattern,
-) -> Result<Vec<Variable>, Box<RepresentationError>> {
+) -> Result<Vec<AssignedVariable>, Box<RepresentationError>> {
     match assignment {
         AssignmentPattern::Variables(vars) => assignment_typeql_vars_to_variables(constraints, vars),
         AssignmentPattern::Deconstruct(struct_deconstruct) => {
@@ -630,8 +632,18 @@ fn assignment_pattern_to_variables(
 fn assignment_typeql_vars_to_variables(
     constraints: &mut ConstraintsBuilder<'_, '_>,
     vars: &[typeql::Variable],
-) -> Result<Vec<Variable>, Box<RepresentationError>> {
-    vars.iter().map(|variable| register_typeql_var(constraints, variable)).collect()
+) -> Result<Vec<AssignedVariable>, Box<RepresentationError>> {
+    vars.iter()
+        .map(|var| {
+            let variable = register_typeql_var(constraints, var)?;
+            let optionality = match var {
+                typeql::Variable::Anonymous { optional, .. } | typeql::Variable::Named { optional, .. } => {
+                    optional.as_ref().map_or(VariableOptionality::Required, |_o| VariableOptionality::Optional)
+                }
+            };
+            Ok(AssignedVariable { variable, optionality })
+        })
+        .collect()
 }
 
 pub(super) fn split_out_inline_expressions(

--- a/ir/translation/expression.rs
+++ b/ir/translation/expression.rs
@@ -15,7 +15,7 @@ use typeql::{
 use crate::{
     RepresentationError,
     pattern::{
-        ParameterID, Vertex,
+        AssignedVariable, ParameterID, Vertex,
         constraint::ConstraintsBuilder,
         expression::{
             BuiltinConceptFunctionID, BuiltinValueFunctionCall, BuiltinValueFunctionID, Expression, ExpressionTree,
@@ -132,7 +132,7 @@ fn add_builtin_function_call(
     function_index: &impl FunctionSignatureIndex,
     constraints: &mut ConstraintsBuilder<'_, '_>,
     builtin_id: BuiltinConceptFunctionID,
-    assigned: Vec<Variable>,
+    assigned: Vec<AssignedVariable>,
     args: &[typeql::Expression],
     source_span: Option<Span>,
 ) -> Result<(), Box<RepresentationError>> {
@@ -145,7 +145,7 @@ pub fn add_user_defined_function_call(
     function_index: &impl FunctionSignatureIndex,
     constraints: &mut ConstraintsBuilder<'_, '_>,
     function_name: &str,
-    assigned: Vec<Variable>,
+    assigned: Vec<AssignedVariable>,
     args: &[typeql::Expression],
     source_span: Option<Span>,
 ) -> Result<(), Box<RepresentationError>> {
@@ -188,7 +188,7 @@ fn build_function(
                 function_index,
                 constraints,
                 to_builtin_concept_function_id(builtin, &function_call.args)?,
-                vec![assign],
+                vec![AssignedVariable::new_required(assign)],
                 &function_call.args,
                 function_call.span(),
             )?;
@@ -200,7 +200,7 @@ fn build_function(
                 function_index,
                 constraints,
                 checked_identifier(identifier)?,
-                vec![assign],
+                vec![AssignedVariable::new_required(assign)],
                 &function_call.args,
                 function_call.span(),
             )?;

--- a/ir/translation/fetch.rs
+++ b/ir/translation/fetch.rs
@@ -28,7 +28,7 @@ use typeql::{
 
 use crate::{
     RepresentationError,
-    pattern::ParameterID,
+    pattern::{AssignedVariable, ParameterID},
     pipeline::{
         FunctionReadError, FunctionRepresentationError, ParameterRegistry,
         block::{Block, BlockBuilder, BlockBuilderContext},
@@ -408,7 +408,7 @@ fn translate_inline_user_function_call<'a>(
         function_index,
         &mut conjunction.constraints_mut(),
         function_name,
-        assign_vars.clone(),
+        assign_vars.iter().map(|var| AssignedVariable::new_required(*var)).collect(),
         &call.args,
         call.span(),
     )

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -70,17 +70,6 @@ pub fn translate_function_from(
         Output::Single(single) => &single.types,
     };
 
-    if let Some((source, _)) = output_types
-        .iter()
-        .map(|output_type| (output_type.span(), named_type_any_to_category_and_optionality(output_type)))
-        .find(|(source, (_, optionality))| *optionality == VariableOptionality::Optional)
-    {
-        Err(FunctionRepresentationError::UnimplementedFunctionOptionals {
-            source_span: source,
-            feature: UnimplementedFeature::OptionalFunctions,
-        })?;
-    }
-
     let argument_labels = signature.args.iter().map(|arg| arg.type_.clone()).collect();
     let args_sources_categories = signature
         .args

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -5,7 +5,7 @@
  */
 
 use answer::variable::Variable;
-use error::{UnimplementedFeature, needs_update_when_feature_is_implemented};
+use error::needs_update_when_feature_is_implemented;
 use itertools::Itertools;
 use typeql::{
     common::Spanned,
@@ -28,7 +28,7 @@ use crate::{
     translation::{
         PipelineTranslationContext,
         pipeline::{TranslatedStage, translate_pipeline_stages},
-        reduce::build_reducer,
+        reduce::{build_reducer, resolve_category_optionality},
     },
 };
 
@@ -114,23 +114,39 @@ pub fn translate_function_from(
     // Check return declaration aligns with definition
     let returns_consistent = match (&signature.output, &body.return_operation) {
         (Output::Stream(declared_vars), ReturnOperation::Stream(defined_vars, _)) => {
-            defined_vars.len() == declared_vars.types.len()
+            check_consistent_return(signature, block, &declared_vars.types, &defined_vars, |v| {
+                context.variable_registry.is_variable_optional(*v)
+            })
         }
         (Output::Single(declared_vars), ReturnOperation::Single(_, defined_vars, _)) => {
-            defined_vars.len() == declared_vars.types.len()
+            check_consistent_return(signature, block, &declared_vars.types, &defined_vars, |v| {
+                context.variable_registry.is_variable_optional(*v)
+            })
         }
         (Output::Single(declared_vars), ReturnOperation::ReduceReducer(reducers, _)) => {
-            reducers.len() == declared_vars.types.len()
+            check_consistent_return(signature, block, &declared_vars.types, &reducers, |reducer| {
+                resolve_category_optionality(reducer).1
+            })
         }
-        (Output::Single(declared_vars), ReturnOperation::ReduceCheck(_)) => declared_vars.types.len() == 1,
-        _ => false,
-    };
-    if !returns_consistent {
-        return Err(Box::new(FunctionRepresentationError::InconsistentReturn {
-            signature: signature.clone(),
-            return_: block.return_stmt.clone(),
-        }));
-    }
+        (Output::Single(declared_vars), ReturnOperation::ReduceCheck(_)) => {
+            check_consistent_return(signature, block, &declared_vars.types, &[false], |x| *x)
+        }
+        (Output::Single(declared_vars), ReturnOperation::Stream(..)) => {
+            Err(Box::new(FunctionRepresentationError::DeclaresSingleReturnsStream {
+                signature: signature.clone(),
+                return_: block.return_stmt.clone(),
+            }))
+        }
+        (Output::Stream(_), ReturnOperation::Single(..))
+        | (Output::Stream(_), ReturnOperation::ReduceCheck(..))
+        | (Output::Stream(_), ReturnOperation::ReduceReducer(..)) => {
+            Err(Box::new(FunctionRepresentationError::DeclaresStreamReturnsSingle {
+                signature: signature.clone(),
+                return_: block.return_stmt.clone(),
+            }))
+        }
+    }?;
+
     Ok(Function::new(
         checked_name,
         context,
@@ -268,4 +284,36 @@ fn build_return_reduce(
             Ok(ReturnOperation::ReduceReducer(reducers, reduction.span()))
         }
     }
+}
+
+fn check_consistent_return<T>(
+    signature: &typeql::schema::definable::function::Signature,
+    block: &FunctionBlock,
+    declared_types: &[NamedTypeAny],
+    actual_return: &[T],
+    is_optional: impl Fn(&T) -> bool,
+) -> Result<(), Box<FunctionRepresentationError>> {
+    if declared_types.len() != actual_return.len() {
+        return Err(Box::new(FunctionRepresentationError::InconsistentReturnLengths {
+            signature: signature.clone(),
+            return_: block.return_stmt.clone(),
+            declared_length: declared_types.len(),
+            actual_length: actual_return.len(),
+        }));
+    }
+    let mismatching_index_opt = declared_types
+        .iter()
+        .map(|t| named_type_any_to_category_and_optionality(t).1 == VariableOptionality::Optional)
+        .zip(actual_return.iter().map(is_optional))
+        .enumerate()
+        .find_map(|(index, (declared, actual))| (declared == actual).then_some(index));
+    if let Some(mismatch_index) = mismatching_index_opt {
+        return Err(Box::new(FunctionRepresentationError::InconsistentReturnOptionality {
+            signature: signature.clone(),
+            return_: block.return_stmt.clone(),
+            mismatch_index,
+        }));
+    }
+
+    Ok(())
 }

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -306,7 +306,7 @@ fn check_consistent_return<T>(
         .map(|t| named_type_any_to_category_and_optionality(t).1 == VariableOptionality::Optional)
         .zip(actual_return.iter().map(is_optional))
         .enumerate()
-        .find_map(|(index, (declared, actual))| (declared == actual).then_some(index));
+        .find_map(|(index, (declared, actual))| (declared != actual).then_some(index));
     if let Some(mismatch_index) = mismatching_index_opt {
         return Err(Box::new(FunctionRepresentationError::InconsistentReturnOptionality {
             signature: signature.clone(),

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -308,11 +308,16 @@ fn check_consistent_return<T>(
         .enumerate()
         .find_map(|(index, (declared, actual))| (declared != actual).then_some(index));
     if let Some(mismatch_index) = mismatching_index_opt {
-        return Err(Box::new(FunctionRepresentationError::InconsistentReturnOptionality {
-            signature: signature.clone(),
-            return_: block.return_stmt.clone(),
-            mismatch_index,
-        }));
+        use error::TypeDBError;
+        tracing::warn!(
+            "Function has inconsistent return optionality. This will fail in the next version:\n{}",
+            FunctionRepresentationError::InconsistentReturnOptionality {
+                signature: signature.clone(),
+                return_: block.return_stmt.clone(),
+                mismatch_index,
+            }
+            .format_description()
+        );
     }
 
     Ok(())

--- a/ir/translation/match_.rs
+++ b/ir/translation/match_.rs
@@ -4,6 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use error::todo_must_implement;
+
 use crate::{
     RepresentationError,
     pattern::conjunction::ConjunctionBuilderWithContext,

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -35,7 +35,7 @@ pub fn translate_reduce(
     let mut reductions = Vec::with_capacity(typeql_reduce.reduce_assignments.len());
     for reduce_assign in &typeql_reduce.reduce_assignments {
         let reducer = build_reducer(context, &reduce_assign.reducer)?;
-        let (category, is_optional) = resolve_category_optionality(&reducer, &context.variable_registry);
+        let (category, is_optional) = resolve_category_optionality(&reducer);
         let var_name =
             reduce_assign.variable.name().ok_or(Box::new(RepresentationError::NonAnonymousVariableExpected {
                 source_span: reduce_assign.variable.span(),
@@ -56,7 +56,7 @@ pub fn translate_reduce(
     Ok(Reduce::new(reductions, group, typeql_reduce.span()))
 }
 
-fn resolve_category_optionality(reduce: &Reducer, variable_registry: &VariableRegistry) -> (VariableCategory, bool) {
+pub(super) fn resolve_category_optionality(reduce: &Reducer) -> (VariableCategory, bool) {
     match reduce {
         Reducer::Count => (VariableCategory::Value, false),
         Reducer::CountVar(_) => (VariableCategory::Value, false),

--- a/query/tests/unimplemented.rs
+++ b/query/tests/unimplemented.rs
@@ -173,37 +173,6 @@ fn structs_lists_optionals() {
         let Either::Left(err) = run_read_query(&context, query).unwrap_err() else { unreachable!() };
         check_unimplemented_language_feature(&err, &error::UnimplementedFeature::Lists);
     }
-
-    {
-        let query = r#"
-        with
-        fun return_optional() -> { integer? }:
-        match
-            try {
-                let $x = 5;
-            };
-        return { $x };
-
-        match
-            let $y in return_optional();
-
-        "#;
-        let mut matches = false;
-        let outer_err = run_read_query(&context, query).unwrap_err();
-        if let Either::Left(err) = &outer_err {
-            if let QueryError::Representation { typedb_source: err, .. } = err.as_ref() {
-                if let RepresentationError::FunctionRepresentation {
-                    typedb_source: FunctionRepresentationError::UnimplementedFunctionOptionals { feature, .. },
-                } = err.as_ref()
-                {
-                    matches = feature == &error::UnimplementedFeature::OptionalFunctions
-                }
-            }
-        }
-        if !matches {
-            Err::<(), _>(outer_err).unwrap();
-        }
-    }
 }
 
 fn check_unimplemented_language_feature(err: &QueryError, expected: &UnimplementedFeature) {


### PR DESCRIPTION
## Product change and motivation
Optional function returns are checked and any errors result in warnings being printed to the log. This is **temporary** to provide a path to non-breaking update and **will be escalated to query-compilation errors in a future release**.

The following cases are checked:
* A function which returns an optional variable is not declared as doing so. 
* A variable being assigned an optional return value is not marked with `?`
* A variable which was assigned an optional value is re-used in the same stage (subject to the same rules as regular optional variables).

## Implementation
```
with fun max_of() -> integer:
match let $x = 5; $x < 3;
return max($x);

match  let $m = max_of();

# prints
2026-04-23T15:50:53.906974Z  WARN ThreadId(22) ir/translation/function.rs:312: Function has inconsistent return optionality. This will fail in the next version:
The optionality of the value returned by the function at index '0' did not match that declared in the signature. 
Signature: max_of() -> integer
Definition: return max($x);
```

```
with fun max_of() -> integer?:
match let $x = 5; $x < 3;
return max($x);

match  let $m = max_of();

# prints 

2026-04-23T15:54:05.685366Z  WARN ThreadId(21) ir/pattern/constraint.rs:374: Function call assigns to unmarked optional variable. This will fail in the next version:
The variable 'm' is assigned an optional value but not marked with a '?'
```

The optional variable reuse case is likely to be erroring already in the pipeline already.