### PR TITLE
Fix distinct stage stack overflow

### DIFF
--- a/executor/pipeline/modifiers.rs
+++ b/executor/pipeline/modifiers.rs
@@ -436,14 +436,15 @@ where
     type Item<'a> = Result<MaybeOwnedRow<'a>, Box<PipelineExecutionError>>;
 
     fn next(&mut self) -> Option<Self::Item<'_>> {
-        match self.input.next() {
-            None => None,
-            Some(Err(err)) => return Some(Err(err)),
-            Some(Ok(row)) => {
-                if self.seen.insert(row.clone().into_owned()) {
-                    Some(Ok(row.clone().into_owned()))
-                } else {
-                    self.next()
+        loop {
+            match self.input.next() {
+                None => return None,
+                Some(Err(err)) => return Some(Err(err)),
+                Some(Ok(row)) => {
+                    if self.seen.insert(row.clone().into_owned()) {
+                        return Some(Ok(row.clone().into_owned()));
+                    }
+                    // duplicate → continue loop instead of recursing
                 }
             }
         }

--- a/executor/read/immediate_executor.rs
+++ b/executor/read/immediate_executor.rs
@@ -287,45 +287,47 @@ impl IntersectionExecutor {
         &mut self,
         context: &ExecutionContext<impl ReadableSnapshot + 'static>,
     ) -> Result<bool, ReadExecutionError> {
-        if self.cartesian_iterator.is_active() {
-            let found = self.cartesian_iterator.find_next(context, &self.instruction_executors)?;
-            if found {
-                Ok(true)
-            } else {
-                // advance the first iterator past the intersection point to move to the next intersection
-                let iter = &mut self.iterators[0];
-                while iter
-                    .peek_first_unbound_value()
-                    .transpose()
-                    .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
-                    .is_some_and(|value| value == &self.intersection_value)
-                {
-                    iter.advance_single().map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?;
-                }
-                self.compute_next_row(context)
-            }
-        } else {
-            while self.input.as_mut().unwrap().peek().is_some() {
-                let found = self.find_intersection()?;
+        loop {
+            if self.cartesian_iterator.is_active() {
+                let found = self.cartesian_iterator.find_next(context, &self.instruction_executors)?;
                 if found {
-                    self.record_intersection()?;
-                    self.advance_intersection_iterators_with_multiplicity()?;
-                    self.may_activate_cartesian(context)?;
                     return Ok(true);
                 } else {
-                    self.iterators.clear();
-                    self.cartesian_iterator.clear();
-                    while self.iterators.is_empty() {
-                        let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone());
-                        if self.input.as_mut().unwrap().peek().is_some() {
-                            self.may_create_intersection_iterators(context)?;
-                        } else {
-                            break;
+                    // advance the first iterator past the intersection point to move to the next intersection
+                    let iter = &mut self.iterators[0];
+                    while iter
+                        .peek_first_unbound_value()
+                        .transpose()
+                        .map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?
+                        .is_some_and(|value| value == &self.intersection_value)
+                    {
+                        iter.advance_single().map_err(|err| ReadExecutionError::ConceptRead { typedb_source: err })?;
+                    }
+                    continue; // don't use recursion: could stack overflow
+                }
+            } else {
+                while self.input.as_mut().unwrap().peek().is_some() {
+                    let found = self.find_intersection()?;
+                    if found {
+                        self.record_intersection()?;
+                        self.advance_intersection_iterators_with_multiplicity()?;
+                        self.may_activate_cartesian(context)?;
+                        return Ok(true);
+                    } else {
+                        self.iterators.clear();
+                        self.cartesian_iterator.clear();
+                        while self.iterators.is_empty() {
+                            let _ = self.input.as_mut().unwrap().next().unwrap().map_err(|err| err.clone());
+                            if self.input.as_mut().unwrap().peek().is_some() {
+                                self.may_create_intersection_iterators(context)?;
+                            } else {
+                                break;
+                            }
                         }
                     }
                 }
+                return Ok(false);
             }
-            Ok(false)
         }
     }
 


### PR DESCRIPTION
## Product change and motivation

Distinct stages relied on recursion instead of a loop, which could rapidly lead to stack overflows. We now use a simple loop instead.

## Implementation

Loop instead of recursion in both the DistinctIterator and the rarely used Cartesian inner iterator.
