### PR TITLE
Fix statistics records reading

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -12580,7 +12580,7 @@
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
         "bzlTransitiveDigest": "yWzTgvDt8fBQR7Nqh9/tbk6sCtvxjbcgODtEIg/m+Nw=",
-        "usagesDigest": "UE84GHh8gifFMlqRVsH/zxdvcfQygI5GBjEwDjrJwcE=",
+        "usagesDigest": "bSGsYEwP42O7nRHFYAYhpzzGU5JfXwhda2QnX0H+eHA=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -12589,45 +12589,45 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.8.4-rc1/typedb-console-linux-arm64-3.8.4-rc1.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.10.1/typedb-console-linux-arm64-3.10.1.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-arm64-3.8.4-rc1.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-arm64-3.10.1.tar.gz"
             }
           },
           "typedb_console_artifact_linux-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.8.4-rc1/typedb-console-linux-x86_64-3.8.4-rc1.tar.gz"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.10.1/typedb-console-linux-x86_64-3.10.1.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-x86_64-3.8.4-rc1.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-x86_64-3.10.1.tar.gz"
             }
           },
           "typedb_console_artifact_mac-arm64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.8.4-rc1/typedb-console-mac-arm64-3.8.4-rc1.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.10.1/typedb-console-mac-arm64-3.10.1.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-arm64-3.8.4-rc1.zip"
+              "downloaded_file_path": "typedb-console-mac-arm64-3.10.1.zip"
             }
           },
           "typedb_console_artifact_mac-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.8.4-rc1/typedb-console-mac-x86_64-3.8.4-rc1.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.10.1/typedb-console-mac-x86_64-3.10.1.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-x86_64-3.8.4-rc1.zip"
+              "downloaded_file_path": "typedb-console-mac-x86_64-3.10.1.zip"
             }
           },
           "typedb_console_artifact_windows-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.8.4-rc1/typedb-console-windows-x86_64-3.8.4-rc1.zip"
+                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.10.1/typedb-console-windows-x86_64-3.10.1.zip"
               ],
-              "downloaded_file_path": "typedb-console-windows-x86_64-3.8.4-rc1.zip"
+              "downloaded_file_path": "typedb-console-windows-x86_64-3.10.1.zip"
             }
           }
         },

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -4,13 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{collections::BTreeMap, error::Error, sync::Arc};
-
-use durability::RawRecord;
-use error::typedb_error;
-use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
-use tracing::{Level, event, trace};
-
+use crate::recovery::commit_recovery::StorageRecoveryError::DurabilityRecordDeserialize;
 use crate::{
     MVCCStorage,
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
@@ -19,6 +13,13 @@ use crate::{
     sequence_number::SequenceNumber,
     write_batches::WriteBatches,
 };
+use bytes::Bytes;
+use durability::RawRecord;
+use error::typedb_error;
+use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
+use std::borrow::Cow;
+use std::{collections::BTreeMap, error::Error, sync::Arc};
+use tracing::{Level, event, trace};
 
 /// Load commit data from the start onwards. Ignores any statuses that are not paired with commit data.
 pub fn load_commit_data_from(
@@ -77,9 +78,11 @@ pub fn load_commit_data_from_with_context(
                 let StatusRecord { commit_record_sequence_number, was_committed } =
                     StatusRecord::deserialise_from(&mut &*bytes)
                         .map_err(|error| DurabilityRecordDeserialize { source: Arc::new(error) })?;
-                if commit_record_sequence_number < start {
+
+                if !recovered_commits.contains_key(&commit_record_sequence_number) {
                     continue;
                 }
+
                 if was_committed {
                     let record = recovered_commits.remove(&commit_record_sequence_number).unwrap();
                     let RecoveryCommitStatus::Pending(record) = record else {

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -6,20 +6,20 @@
 
 use crate::recovery::commit_recovery::StorageRecoveryError::DurabilityRecordDeserialize;
 use crate::{
-    MVCCStorage,
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
     isolation_manager::{CommitRecord, IsolationManager, StatusRecord, ValidatedCommit},
     keyspace::{KeyspaceError, Keyspaces},
     sequence_number::SequenceNumber,
     write_batches::WriteBatches,
+    MVCCStorage,
 };
 use bytes::Bytes;
 use durability::RawRecord;
 use error::typedb_error;
-use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
+use fail_point::{fail_point, RECOVERY_PARTIAL_WRITE};
 use std::borrow::Cow;
 use std::{collections::BTreeMap, error::Error, sync::Arc};
-use tracing::{Level, event, trace};
+use tracing::{event, trace, Level};
 
 /// Load commit data from the start onwards. Ignores any statuses that are not paired with commit data.
 pub fn load_commit_data_from(

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -4,22 +4,23 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use crate::recovery::commit_recovery::StorageRecoveryError::DurabilityRecordDeserialize;
-use crate::{
-    durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
-    isolation_manager::{CommitRecord, IsolationManager, StatusRecord, ValidatedCommit},
-    keyspace::{KeyspaceError, Keyspaces},
-    sequence_number::SequenceNumber,
-    write_batches::WriteBatches,
-    MVCCStorage,
-};
+use std::{borrow::Cow, collections::BTreeMap, error::Error, sync::Arc};
+
 use bytes::Bytes;
 use durability::RawRecord;
 use error::typedb_error;
-use fail_point::{fail_point, RECOVERY_PARTIAL_WRITE};
-use std::borrow::Cow;
-use std::{collections::BTreeMap, error::Error, sync::Arc};
-use tracing::{event, trace, Level};
+use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
+use tracing::{Level, event, trace};
+
+use crate::{
+    MVCCStorage,
+    durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
+    isolation_manager::{CommitRecord, IsolationManager, StatusRecord, ValidatedCommit},
+    keyspace::{KeyspaceError, Keyspaces},
+    recovery::commit_recovery::StorageRecoveryError::DurabilityRecordDeserialize,
+    sequence_number::SequenceNumber,
+    write_batches::WriteBatches,
+};
 
 /// Load commit data from the start onwards. Ignores any statuses that are not paired with commit data.
 pub fn load_commit_data_from(

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -4,9 +4,8 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{borrow::Cow, collections::BTreeMap, error::Error, sync::Arc};
+use std::{collections::BTreeMap, error::Error, sync::Arc};
 
-use bytes::Bytes;
 use durability::RawRecord;
 use error::typedb_error;
 use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
@@ -17,7 +16,6 @@ use crate::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
     isolation_manager::{CommitRecord, IsolationManager, StatusRecord, ValidatedCommit},
     keyspace::{KeyspaceError, Keyspaces},
-    recovery::commit_recovery::StorageRecoveryError::DurabilityRecordDeserialize,
     sequence_number::SequenceNumber,
     write_batches::WriteBatches,
 };


### PR DESCRIPTION
## Product change and motivation

We fix a bug in statistics synchronization that led to out-of-sync statistics, which ultimately led to bad query planning.

## Implementation

- The old code skipped StatusRecords for any commit before `start`, leaving context commits as Pending. And, our statistics synchronization thread stops at the first pending commit!
--> The fix only skips StatusRecords for commits that aren't in the map at all (either never loaded or already evicted by the memory limit).

