### PR TITLE
Optimize CI build job by reducing cached artifacts download

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -14,7 +14,7 @@ build --macos_minimum_os=11.0
 try-import ./.bazel-remote-cache.rc
 
 # Allow empty globs (many checkstyle_test patterns may not match)
-common --noincompatible_disallow_empty_glob
+common --noincompatible_disallow_empty_glob --experimental_repository_downloader_retries=5 --http_timeout_scaling=2.0
 
 # Fix Java runfiles path resolution in Bzlmod mode (required by release note validation)
 build --legacy_external_runfiles
@@ -24,7 +24,7 @@ run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
 
 # CI configuration: disables disk cache to prevent cache size issues in CI environments
-build:ci --disk_cache=
+build:ci --disk_cache= --remote_download_minimal --experimental_remote_cache_eviction_retries=5
 
 # Windows: enable proper symlink support
 startup --windows_enable_symlinks

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,7 @@ run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
 
 # CI configuration: disables disk cache to prevent cache size issues in CI environments
-build:ci --remote_download_minimal --disk_cache=
+build:ci --disk_cache=
 
 # Windows: enable proper symlink support
 startup --windows_enable_symlinks

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,7 @@ run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
 
 # CI configuration: disables disk cache to prevent cache size issues in CI environments
-build:ci --disk_cache=
+build:ci --remote_download_minimal --experimental_remote_cache_eviction_retries=5 --disk_cache=
 
 # Windows: enable proper symlink support
 startup --windows_enable_symlinks

--- a/.bazelrc
+++ b/.bazelrc
@@ -24,7 +24,7 @@ run --incompatible_strict_action_env
 test --incompatible_strict_action_env --test_env=PATH
 
 # CI configuration: disables disk cache to prevent cache size issues in CI environments
-build:ci --remote_download_minimal --experimental_remote_cache_eviction_retries=5 --disk_cache=
+build:ci --remote_download_minimal --disk_cache=
 
 # Windows: enable proper symlink support
 startup --windows_enable_symlinks

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -18,7 +18,8 @@ build:
         sudo apt update
         sudo apt install -y libclang-dev
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        bazel build --config=ci //... 
+# note: build job doesn't need to download all packages locally since we aren't testing (speeds up build job)
+        bazel build --config=ci --remote_download_minimal //... 
         bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
         bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)') 
         bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//:rustfmt_config

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -18,8 +18,7 @@ build:
         sudo apt update
         sudo apt install -y libclang-dev
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-        # note: build job doesn't need to download all packages locally since we aren't testing (speeds up build job)
-        bazel build --config=ci --remote_download_minimal //... 
+        bazel build --config=ci //... 
         bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
         bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)') 
         bazel test --config=ci $(bazel query 'kind(rustfmt_test, //...)') --@rules_rust//:rustfmt.toml=//:rustfmt_config

--- a/.factory/automation.yml
+++ b/.factory/automation.yml
@@ -18,7 +18,7 @@ build:
         sudo apt update
         sudo apt install -y libclang-dev
         bazel run @typedb_dependencies//tool/bazelinstall:remote_cache_setup.sh
-# note: build job doesn't need to download all packages locally since we aren't testing (speeds up build job)
+        # note: build job doesn't need to download all packages locally since we aren't testing (speeds up build job)
         bazel build --config=ci --remote_download_minimal //... 
         bazel run --config=ci @typedb_dependencies//tool/checkstyle:test-coverage
         bazel test --config=ci $(bazel query 'kind(checkstyle_test, //...)') 

--- a/RELEASE_NOTES_LATEST.md
+++ b/RELEASE_NOTES_LATEST.md
@@ -8,15 +8,28 @@
 
 
 ## New Features
-
+- **Optional function returns are checked and print WARN log lines**
+  Optional function returns are checked and any errors result in warnings being printed to the log. This is **temporary** to provide a path to non-breaking update and **will be escalated to query-compilation errors in a future release**.
+  
+  The following cases are checked:
+  * A function which returns an optional variable is not declared as doing so. 
+  * A variable being assigned an optional return value is not marked with `?`
+  * A variable which was assigned an optional value is re-used in the same stage (subject to the same rules as regular optional variables).
+  
+  
 
 ## Bugs Fixed
-- **Fix statistics counting**
 
-We fix one tracking error that means that statistics can still on rare occasions skip records that are being counted.- 
 
 ## Code Refactors
 
+
 ## Other Improvements
+- **Bazel java runtime is hermitic (remote) - used for notes creation**
+
+- **Fix statistics counting**
+  
+  We fix one tracking error that means that statistics can still on rare occasions skip records that are being counted.
+  
   
     


### PR DESCRIPTION
## Product change and motivation

We use the `--remote_download_minimal ` in the `ci` config in Bazel, which reduces the number of artifacts downloaded during a build job in FactoryCI.

In particular, this speeds up jobs where little/nothing has changed by hugely reducing the amount of data downloaded. It could also speed up test jobs by reducing number of downloaded artifacts, but the effects seem to be less dramatic.

Have observed a build job of around 8-12 minutes now, instead of up to 20 or 30.

## Implementation

Updates to the bazelrc:
- Add `--remote_download_minimal` to reduce number of downloaded remote artifacts when unnecessary
- Add `--experimental_remote_cache_eviction_retries=5` to prevent build failures when the remote cache has a race condition due to evictions
- Add `--experimental_repository_downloader_retries=5 --http_timeout_scaling=2.0` -- without these, the jobs were generally flaky down to download failures. This fixes download issues and lets us take advantage of the main minimial downloads change without introducing flakiness.
