### PR TITLE
Rewrite reused producible variables in transform phase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=bbe3d61970817b34687eeb145890af6712b7eec6#bbe3d61970817b34687eeb145890af6712b7eec6"
+source = "git+https://github.com/typedb/typedb-protocol?rev=25ab3fb02715062bd036f8b83908de92b106a202#25ab3fb02715062bd036f8b83908de92b106a202"
 dependencies = [
  "prost",
  "tonic",
@@ -5830,7 +5830,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=42ba8021d028e03b8a63f983b50997cd99d983c7#42ba8021d028e03b8a63f983b50997cd99d983c7"
+source = "git+https://github.com/typedb/typeql?rev=a1fae91ebd68ed2d7b2eb5035c1287c3bc66789b#a1fae91ebd68ed2d7b2eb5035c1287c3bc66789b"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/compiler/annotation/type_annotations.rs
+++ b/compiler/annotation/type_annotations.rs
@@ -78,12 +78,18 @@ impl TypeAnnotations {
         self.vertex.get(vertex)
     }
 
-    pub(super) fn vertex_annotations_mut(&mut self) -> &mut BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>> {
+    pub(crate) fn vertex_annotations_mut(&mut self) -> &mut BTreeMap<Vertex<Variable>, Arc<BTreeSet<Type>>> {
         &mut self.vertex
     }
 
     pub fn value_annotations(&self) -> &BTreeMap<Vertex<Variable>, ExpressionValueType> {
         self.value_type_annotations.as_ref().expect("Expected value annotations")
+    }
+
+    pub(crate) fn value_type_annotations_mut(
+        &mut self,
+    ) -> Option<&mut BTreeMap<Vertex<Variable>, ExpressionValueType>> {
+        self.value_type_annotations.as_mut()
     }
 
     pub fn value_type_annotations_of(&self, vertex: &Vertex<Variable>) -> Option<&ExpressionValueType> {

--- a/compiler/transformation/mod.rs
+++ b/compiler/transformation/mod.rs
@@ -6,13 +6,14 @@
 
 use concept::error::ConceptReadError;
 use error::typedb_error;
-use ir::pattern::conjunction::Conjunction;
+use ir::{RepresentationError, pattern::conjunction::Conjunction};
 
 use crate::annotation::pipeline::AnnotatedPipeline;
 
 pub mod redundant_constraints;
 pub mod relation_index;
 pub mod transform;
+pub mod unique_constraint_variables;
 
 pub(crate) trait ConjunctionTransformation {
     fn apply(conjunction: &mut Conjunction);
@@ -25,5 +26,6 @@ pub(crate) trait PipelineTransformation {
 typedb_error!(
     pub StaticOptimiserError(component = "Static optimiser", prefix = "SOP") {
         ConceptRead(1, "Error reading concept", typedb_source: Box<ConceptReadError>),
+        Representation(2, "Error in rewriting representation", typedb_source: Box<RepresentationError>),
     }
 );

--- a/compiler/transformation/transform.rs
+++ b/compiler/transformation/transform.rs
@@ -4,6 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 use concept::type_::type_manager::TypeManager;
+use ir::pipeline::VariableRegistry;
 use storage::snapshot::ReadableSnapshot;
 
 use crate::{
@@ -14,12 +15,14 @@ use crate::{
             optimize_away_statically_unsatisfiable_conjunctions, prune_redundant_roleplayer_deduplication,
         },
         relation_index::relation_index_transformation,
+        unique_constraint_variables::make_constraint_variables_unique,
     },
 };
 
 pub fn apply_transformations(
     snapshot: &impl ReadableSnapshot,
     type_manager: &TypeManager,
+    variable_registry: &mut VariableRegistry,
     pipeline: &mut AnnotatedPipeline,
 ) -> Result<(), StaticOptimiserError> {
     for stage in &mut pipeline.annotated_stages {
@@ -27,6 +30,7 @@ pub fn apply_transformations(
             optimize_away_statically_unsatisfiable_conjunctions(block.conjunction_mut(), block_annotations);
             prune_redundant_roleplayer_deduplication(block.conjunction_mut(), block_annotations);
             relation_index_transformation(block.conjunction_mut(), block_annotations, type_manager, snapshot)?;
+            make_constraint_variables_unique(block.conjunction_mut(), variable_registry, block_annotations)?;
         }
     }
     Ok(())

--- a/compiler/transformation/unique_constraint_variables.rs
+++ b/compiler/transformation/unique_constraint_variables.rs
@@ -4,10 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use ir::{
-    pattern::{Vertex, conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
+    pattern::{conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
     pipeline::VariableRegistry,
 };
 
@@ -21,40 +21,37 @@ pub fn make_constraint_variables_unique(
     variable_registry: &mut VariableRegistry,
     block_annotations: &mut BlockAnnotations,
 ) -> Result<(), StaticOptimiserError> {
-    let (new_is_constraints, var_mapping, constraint_mapping) = conjunction
+    let (new_checks, constraint_mapping) = conjunction
         .constraints_mut()
         .make_variables_unique(variable_registry)
         .map_err(|typedb_source| StaticOptimiserError::Representation { typedb_source })?;
     let annotations = block_annotations.type_annotations_mut_of(conjunction).expect("Expected annotated conjunction");
 
-    conjunction.register_copies_of_variables(var_mapping.iter().copied());
-    for (old_var, new_var) in var_mapping {
-        if let Some(old_annotations) = annotations.vertex_annotations_of(&Vertex::Variable(old_var)).cloned() {
-            annotations.vertex_annotations_mut().insert(Vertex::Variable(new_var), old_annotations);
-        } else if let Some(old_annotations) = annotations.value_type_annotations_of(&Vertex::Variable(old_var)).cloned()
-        {
-            annotations
-                .value_type_annotations_mut()
-                .expect("Should be present at this point")
-                .insert(Vertex::Variable(new_var), old_annotations);
+    for check in new_checks {
+        match check {
+            Constraint::Comparison(cmp) => {
+                conjunction.register_variable_copy(cmp.lhs().as_variable().unwrap(), cmp.rhs().as_variable().unwrap());
+                let vertex_annotations = annotations.value_type_annotations_of(&cmp.lhs()).unwrap().clone();
+                annotations
+                    .value_type_annotations_mut()
+                    .expect("ValueTypeAnnotations should be available by now")
+                    .insert(cmp.rhs().clone(), vertex_annotations);
+            }
+            Constraint::Is(is) => {
+                conjunction.register_variable_copy(is.lhs().as_variable().unwrap(), is.rhs().as_variable().unwrap());
+                let vertex_annotations = annotations.vertex_annotations_of(&is.lhs()).unwrap().clone();
+                let lr_annotations: BTreeMap<_, _> = vertex_annotations.iter().map(|t| (*t, vec![*t])).collect();
+                let rl_annotations = lr_annotations.clone();
+                let new_is_annotations =
+                    ConstraintTypeAnnotations::LeftRight(LeftRightAnnotations::new(lr_annotations, rl_annotations));
+                annotations.vertex_annotations_mut().insert(is.rhs().clone(), vertex_annotations);
+                annotations.constraint_annotations_mut().insert(Constraint::Is(is), new_is_annotations);
+            }
+            _ => {
+                unreachable!("Did not expect any other constraint");
+            }
         }
     }
-
-    for new_is in new_is_constraints {
-        let annos = if let Some(annos) = annotations.vertex_annotations_of(new_is.lhs()) {
-            annos
-        } else if let Some(annos) = annotations.vertex_annotations_of(new_is.rhs()) {
-            annos
-        } else {
-            unreachable!("Expected atleast one vertex")
-        };
-        let lr_annotations: BTreeMap<_, _> = annos.iter().map(|t| (*t, vec![*t])).collect();
-        let rl_annotations = lr_annotations.clone();
-        let new_is_annotations =
-            ConstraintTypeAnnotations::LeftRight(LeftRightAnnotations::new(lr_annotations, rl_annotations));
-        annotations.constraint_annotations_mut().insert(Constraint::Is(new_is), new_is_annotations);
-    }
-
     for (old_constraint, new_constraint) in constraint_mapping {
         let old_annos =
             annotations.constraint_annotations_of(old_constraint).cloned().expect("Expected old constraint");

--- a/compiler/transformation/unique_constraint_variables.rs
+++ b/compiler/transformation/unique_constraint_variables.rs
@@ -21,30 +21,39 @@ pub fn make_constraint_variables_unique(
     variable_registry: &mut VariableRegistry,
     block_annotations: &mut BlockAnnotations,
 ) -> Result<(), StaticOptimiserError> {
-    let (new_checks, constraint_mapping) = conjunction
-        .constraints_mut()
-        .make_variables_unique(variable_registry)
+    let (new_checks, constraint_mapping, variable_mapping) = conjunction
+        .make_constraint_variables_unique(variable_registry)
         .map_err(|typedb_source| StaticOptimiserError::Representation { typedb_source })?;
     let annotations = block_annotations.type_annotations_mut_of(conjunction).expect("Expected annotated conjunction");
 
     for check in new_checks {
         match check {
             Constraint::Comparison(cmp) => {
-                conjunction.register_variable_copy(cmp.lhs().as_variable().unwrap(), cmp.rhs().as_variable().unwrap());
-                let vertex_annotations = annotations.value_type_annotations_of(&cmp.lhs()).unwrap().clone();
+                let (new_vertex, old_vertex) = if variable_mapping.contains_key(&cmp.lhs().as_variable().unwrap()) {
+                    (cmp.lhs(), cmp.rhs())
+                } else {
+                    debug_assert!(variable_mapping.contains_key(&cmp.rhs().as_variable().unwrap()));
+                    (cmp.rhs(), cmp.lhs())
+                };
+                let vertex_annotations = annotations.value_type_annotations_of(old_vertex).unwrap().clone();
                 annotations
                     .value_type_annotations_mut()
                     .expect("ValueTypeAnnotations should be available by now")
-                    .insert(cmp.rhs().clone(), vertex_annotations);
+                    .insert(new_vertex.clone(), vertex_annotations);
             }
             Constraint::Is(is) => {
-                conjunction.register_variable_copy(is.lhs().as_variable().unwrap(), is.rhs().as_variable().unwrap());
-                let vertex_annotations = annotations.vertex_annotations_of(&is.lhs()).unwrap().clone();
+                let (new_vertex, old_vertex) = if variable_mapping.contains_key(&is.lhs().as_variable().unwrap()) {
+                    (is.lhs(), is.rhs())
+                } else {
+                    debug_assert!(variable_mapping.contains_key(&is.rhs().as_variable().unwrap()));
+                    (is.rhs(), is.lhs())
+                };
+                let vertex_annotations = annotations.vertex_annotations_of(old_vertex).unwrap().clone();
                 let lr_annotations: BTreeMap<_, _> = vertex_annotations.iter().map(|t| (*t, vec![*t])).collect();
                 let rl_annotations = lr_annotations.clone();
                 let new_is_annotations =
                     ConstraintTypeAnnotations::LeftRight(LeftRightAnnotations::new(lr_annotations, rl_annotations));
-                annotations.vertex_annotations_mut().insert(is.rhs().clone(), vertex_annotations);
+                annotations.vertex_annotations_mut().insert(new_vertex.clone(), vertex_annotations);
                 annotations.constraint_annotations_mut().insert(Constraint::Is(is), new_is_annotations);
             }
             _ => {
@@ -52,7 +61,7 @@ pub fn make_constraint_variables_unique(
             }
         }
     }
-    for (old_constraint, new_constraint) in constraint_mapping {
+    for (new_constraint, old_constraint) in constraint_mapping {
         let old_annos =
             annotations.constraint_annotations_of(old_constraint).cloned().expect("Expected old constraint");
         annotations.constraint_annotations_mut().insert(new_constraint, old_annos);

--- a/compiler/transformation/unique_constraint_variables.rs
+++ b/compiler/transformation/unique_constraint_variables.rs
@@ -1,0 +1,81 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use ir::{
+    pattern::{Vertex, conjunction::Conjunction, constraint::Constraint, nested_pattern::NestedPattern},
+    pipeline::VariableRegistry,
+};
+
+use crate::{
+    annotation::type_annotations::{BlockAnnotations, ConstraintTypeAnnotations, LeftRightAnnotations},
+    transformation::StaticOptimiserError,
+};
+
+pub fn make_constraint_variables_unique(
+    conjunction: &mut Conjunction,
+    variable_registry: &mut VariableRegistry,
+    block_annotations: &mut BlockAnnotations,
+) -> Result<(), StaticOptimiserError> {
+    let (new_is_constraints, var_mapping, constraint_mapping) = conjunction
+        .constraints_mut()
+        .make_variables_unique(variable_registry)
+        .map_err(|typedb_source| StaticOptimiserError::Representation { typedb_source })?;
+    let annotations = block_annotations.type_annotations_mut_of(conjunction).unwrap();
+
+    conjunction.register_copies_of_variables(&var_mapping);
+    for (old_var, new_var) in var_mapping {
+        if let Some(old_annotations) = annotations.vertex_annotations_of(&Vertex::Variable(old_var)).cloned() {
+            annotations.vertex_annotations_mut().insert(Vertex::Variable(new_var), old_annotations);
+        } else if let Some(old_annotations) = annotations.value_type_annotations_of(&Vertex::Variable(old_var)).cloned()
+        {
+            annotations
+                .value_type_annotations_mut()
+                .expect("Should be present at this point")
+                .insert(Vertex::Variable(new_var), old_annotations);
+        }
+    }
+
+    for new_is in new_is_constraints {
+        let annos = if let Some(annos) = annotations.vertex_annotations_of(new_is.lhs()) {
+            annos
+        } else if let Some(annos) = annotations.vertex_annotations_of(new_is.rhs()) {
+            annos
+        } else {
+            unreachable!("Expected atleast one vertex")
+        };
+        let lr_annotations: BTreeMap<_, _> = annos.iter().map(|t| (*t, vec![*t])).collect();
+        let rl_annotations = lr_annotations.clone();
+        let new_is_annotations =
+            ConstraintTypeAnnotations::LeftRight(LeftRightAnnotations::new(lr_annotations, rl_annotations));
+        annotations.constraint_annotations_mut().insert(Constraint::Is(new_is), new_is_annotations);
+    }
+
+    for (old_constraint, new_constraint) in constraint_mapping {
+        let old_annos = annotations.constraint_annotations_of(old_constraint).cloned().unwrap();
+        annotations.constraint_annotations_mut().insert(new_constraint, old_annos);
+    }
+
+    // And recurse
+    for nested in conjunction.nested_patterns_mut() {
+        match nested {
+            NestedPattern::Disjunction(disjunction) => {
+                for conj in disjunction.conjunctions_mut() {
+                    make_constraint_variables_unique(conj, variable_registry, block_annotations)?;
+                }
+            }
+            NestedPattern::Negation(negation) => {
+                make_constraint_variables_unique(negation.conjunction_mut(), variable_registry, block_annotations)?;
+            }
+            NestedPattern::Optional(optional) => {
+                make_constraint_variables_unique(optional.conjunction_mut(), variable_registry, block_annotations)?;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/compiler/transformation/unique_constraint_variables.rs
+++ b/compiler/transformation/unique_constraint_variables.rs
@@ -25,9 +25,9 @@ pub fn make_constraint_variables_unique(
         .constraints_mut()
         .make_variables_unique(variable_registry)
         .map_err(|typedb_source| StaticOptimiserError::Representation { typedb_source })?;
-    let annotations = block_annotations.type_annotations_mut_of(conjunction).unwrap();
+    let annotations = block_annotations.type_annotations_mut_of(conjunction).expect("Expected annotated conjunction");
 
-    conjunction.register_copies_of_variables(&var_mapping);
+    conjunction.register_copies_of_variables(var_mapping.iter().copied());
     for (old_var, new_var) in var_mapping {
         if let Some(old_annotations) = annotations.vertex_annotations_of(&Vertex::Variable(old_var)).cloned() {
             annotations.vertex_annotations_mut().insert(Vertex::Variable(new_var), old_annotations);
@@ -56,7 +56,8 @@ pub fn make_constraint_variables_unique(
     }
 
     for (old_constraint, new_constraint) in constraint_mapping {
-        let old_annos = annotations.constraint_annotations_of(old_constraint).cloned().unwrap();
+        let old_annos =
+            annotations.constraint_annotations_of(old_constraint).cloned().expect("Expected old constraint");
         annotations.constraint_annotations_mut().insert(new_constraint, old_annos);
     }
 

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -5,7 +5,7 @@
  */
 
 use std::{
-    collections::{HashMap, hash_map},
+    collections::HashMap,
     fmt,
     hash::{DefaultHasher, Hasher},
 };
@@ -26,7 +26,7 @@ use crate::{
         nested_pattern::NestedPattern,
         optional::OptionalBuilder,
     },
-    pipeline::block::BlockBuilderContext,
+    pipeline::{VariableRegistry, block::BlockBuilderContext},
 };
 
 #[derive(Debug, Clone)]
@@ -74,10 +74,21 @@ impl Conjunction {
         }
     }
 
-    pub fn register_variable_copy(&mut self, source: Variable, copy: Variable) {
-        if let Some(value) = self.pattern_variables.0.get(&source).cloned() {
-            self.pattern_variables.0.insert(copy, value);
+    pub fn make_constraint_variables_unique(
+        &mut self,
+        variable_registry: &mut VariableRegistry,
+    ) -> Result<
+        (Vec<Constraint<Variable>>, HashMap<Constraint<Variable>, Constraint<Variable>>, HashMap<Variable, Variable>),
+        Box<RepresentationError>,
+    > {
+        let (new_checks, constraint_mapping, variable_mapping) =
+            self.constraints.make_variables_unique(variable_registry)?;
+        for (new_var, old_var) in &variable_mapping {
+            if let Some(value) = self.pattern_variables.0.get(old_var).cloned() {
+                self.pattern_variables.0.insert(*new_var, value);
+            };
         }
+        Ok((new_checks, constraint_mapping, variable_mapping))
     }
 }
 

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -74,10 +74,10 @@ impl Conjunction {
         }
     }
 
-    pub fn register_copies_of_variables(&mut self, copies: &HashMap<Variable, Variable>) {
+    pub fn register_copies_of_variables(&mut self, copies: impl Iterator<Item = (Variable, Variable)>) {
         for (old_var, new_var) in copies {
-            if let Some(value) = self.pattern_variables.0.get(old_var).cloned() {
-                self.pattern_variables.0.insert(*new_var, value);
+            if let Some(value) = self.pattern_variables.0.get(&old_var).cloned() {
+                self.pattern_variables.0.insert(new_var, value);
             }
         }
     }

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -73,6 +73,14 @@ impl Conjunction {
             Ok(_) | Err(_) => false,
         }
     }
+
+    pub fn register_copies_of_variables(&mut self, copies: &HashMap<Variable, Variable>) {
+        for (old_var, new_var) in copies {
+            if let Some(value) = self.pattern_variables.0.get(old_var).cloned() {
+                self.pattern_variables.0.insert(*new_var, value);
+            }
+        }
+    }
 }
 
 impl_pattern_from_pattern_variables!(Conjunction);

--- a/ir/pattern/conjunction.rs
+++ b/ir/pattern/conjunction.rs
@@ -74,11 +74,9 @@ impl Conjunction {
         }
     }
 
-    pub fn register_copies_of_variables(&mut self, copies: impl Iterator<Item = (Variable, Variable)>) {
-        for (old_var, new_var) in copies {
-            if let Some(value) = self.pattern_variables.0.get(&old_var).cloned() {
-                self.pattern_variables.0.insert(new_var, value);
-            }
+    pub fn register_variable_copy(&mut self, source: Variable, copy: Variable) {
+        if let Some(value) = self.pattern_variables.0.get(&source).cloned() {
+            self.pattern_variables.0.insert(copy, value);
         }
     }
 }

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -556,6 +556,137 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
     }
 }
 
+macro_rules! may_replace_reused_variable {
+    ($constraint:expr, $kept:expr, $changed:expr, $reg:expr, $is_collector:ident, $var_mapping:ident , $constraint_mapping:ident) => {
+        if $kept == $changed {
+            let old_constraint = $constraint.clone().into();
+            if let (Vertex::Variable(kept), Vertex::Variable(changed)) = ($kept, $changed) {
+                let kept = *kept;
+                let new_var = $reg.create_anonymous_variable_copying(kept)?;
+                *changed = new_var.clone();
+
+                // Keep old on LHS
+                $is_collector.push(Is::new(kept, new_var, None));
+                $var_mapping.insert(kept, new_var);
+                $constraint_mapping.insert(old_constraint, $constraint.clone().into());
+            }
+        }
+    };
+}
+
+impl Constraints {
+    pub fn make_variables_unique(
+        &mut self,
+        variable_registry: &mut VariableRegistry,
+    ) -> Result<
+        (Vec<Is<Variable>>, HashMap<Variable, Variable>, HashMap<Constraint<Variable>, Constraint<Variable>>),
+        Box<RepresentationError>,
+    > {
+        let mut is_collector = Vec::new();
+        let mut variable_mapping = HashMap::new();
+        let mut constraint_mapping = HashMap::new();
+        for constraint in &mut self.constraints {
+            match constraint {
+                Constraint::Sub(sub) => {
+                    may_replace_reused_variable!(
+                        sub,
+                        &sub.subtype,
+                        &mut sub.supertype,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                }
+                Constraint::Links(links) => {
+                    may_replace_reused_variable!(
+                        links,
+                        &links.player,
+                        &mut links.relation,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                }
+                Constraint::IndexedRelation(indexed) => {
+                    may_replace_reused_variable!(
+                        indexed,
+                        &indexed.player_1,
+                        &mut indexed.player_2,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                    may_replace_reused_variable!(
+                        indexed,
+                        &indexed.player_1,
+                        &mut indexed.relation,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                    may_replace_reused_variable!(
+                        indexed,
+                        &indexed.player_2,
+                        &mut indexed.relation,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                    may_replace_reused_variable!(
+                        indexed,
+                        &indexed.role_type_1,
+                        &mut indexed.role_type_2,
+                        variable_registry,
+                        is_collector,
+                        variable_mapping,
+                        constraint_mapping
+                    );
+                }
+                Constraint::FunctionCallBinding(func_call) => {
+                    for i in 0..func_call.assigned.len() {
+                        for j in i + 1..func_call.assigned.len() {
+                            let lhs: Vertex<Variable> = func_call.assigned[i].clone();
+                            may_replace_reused_variable!(
+                                func_call,
+                                &lhs,
+                                &mut func_call.assigned[j],
+                                variable_registry,
+                                is_collector,
+                                variable_mapping,
+                                constraint_mapping
+                            );
+                        }
+                    }
+                }
+                Constraint::ExpressionBinding(binding) => {
+                    debug_assert!(binding.ids_assigned().count() == 1);
+                }
+                Constraint::Is(_)
+                | Constraint::Has(_)
+                | Constraint::Kind(_)
+                | Constraint::Label(_)
+                | Constraint::RoleName(_)
+                | Constraint::Isa(_)
+                | Constraint::Iid(_)
+                | Constraint::Owns(_)
+                | Constraint::Relates(_)
+                | Constraint::Plays(_)
+                | Constraint::Value(_)
+                | Constraint::Comparison(_)
+                | Constraint::LinksDeduplication(_)
+                | Constraint::Unsatisfiable(_) => {}
+            }
+        }
+        self.constraints.extend(is_collector.iter().map(|is| Constraint::Is(is.clone())));
+        Ok((is_collector, variable_mapping, constraint_mapping))
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub enum Constraint<ID> {
     Is(Is<ID>),

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -122,16 +122,20 @@ impl Constraints {
                 Constraint::IndexedRelation(indexed) => {
                     let mut old_indexed: Option<IndexedRelation<Variable>> = None;
                     if indexed.player_1 == indexed.player_2 {
-                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        old_indexed.get_or_insert_with(|| indexed.clone());
                         replace_with_anonymous_var(&mut indexed.player_2)?;
                     }
                     if indexed.player_1 == indexed.relation {
-                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        old_indexed.get_or_insert_with(|| indexed.clone());
                         replace_with_anonymous_var(&mut indexed.relation)?;
                     }
                     if indexed.player_2 == indexed.relation {
-                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        old_indexed.get_or_insert_with(|| indexed.clone());
                         replace_with_anonymous_var(&mut indexed.relation)?;
+                    }
+                    if indexed.role_type_1 == indexed.role_type_2 {
+                        old_indexed.get_or_insert_with(|| indexed.clone());
+                        replace_with_anonymous_var(&mut indexed.role_type_2)?;
                     }
                     if let Some(old_indexed) = old_indexed {
                         constraint_mapping.insert(old_indexed.into(), indexed.clone().into());

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -76,6 +76,100 @@ impl Constraints {
             acc
         })
     }
+
+    pub fn make_variables_unique(
+        &mut self,
+        variable_registry: &mut VariableRegistry,
+    ) -> Result<
+        (Vec<Is<Variable>>, Vec<(Variable, Variable)>, HashMap<Constraint<Variable>, Constraint<Variable>>),
+        Box<RepresentationError>,
+    > {
+        let mut is_collector = Vec::new();
+        let mut variable_mapping = Vec::new(); // Vec to allow multiple new_var for same old_var
+        let mut constraint_mapping = HashMap::new();
+        let mut replace_with_anonymous_var = |vertex: &mut Vertex<Variable>| {
+            if let Vertex::Variable(var) = vertex {
+                let old_var = *var;
+                *var = variable_registry.create_anonymous_variable_copying(old_var)?;
+                is_collector.push(Is::new(old_var, *var, None));
+                variable_mapping.push((old_var, *var));
+            } else {
+                debug_assert!(false, "");
+            }
+            Ok::<(), Box<RepresentationError>>(())
+        };
+
+        for constraint in &mut self.constraints {
+            match constraint {
+                Constraint::Sub(sub) => {
+                    if sub.subtype == sub.supertype && sub.supertype.is_variable() {
+                        let old_sub = sub.clone();
+                        replace_with_anonymous_var(&mut sub.supertype)?;
+                        constraint_mapping.insert(old_sub.into(), sub.clone().into());
+                    }
+                }
+                Constraint::Links(links) => {
+                    if links.player == links.relation {
+                        let old_links = links.clone();
+                        replace_with_anonymous_var(&mut links.relation)?;
+                        constraint_mapping.insert(old_links.into(), links.clone().into());
+                    }
+                }
+                Constraint::IndexedRelation(indexed) => {
+                    let mut old_indexed: Option<IndexedRelation<Variable>> = None;
+                    if indexed.player_1 == indexed.player_2 {
+                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        replace_with_anonymous_var(&mut indexed.player_2)?;
+                    }
+                    if indexed.player_1 == indexed.relation {
+                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        replace_with_anonymous_var(&mut indexed.relation)?;
+                    }
+                    if indexed.player_2 == indexed.relation {
+                        old_indexed.get_or_insert_with(|| indexed.clone().into());
+                        replace_with_anonymous_var(&mut indexed.relation)?;
+                    }
+                    if let Some(old_indexed) = old_indexed {
+                        constraint_mapping.insert(old_indexed.into(), indexed.clone().into());
+                    }
+                }
+                Constraint::FunctionCallBinding(func_call) => {
+                    let mut old_call: Option<FunctionCallBinding<Variable>> = None;
+                    for i in 0..func_call.assigned.len() {
+                        for j in i + 1..func_call.assigned.len() {
+                            if func_call.assigned[i] == func_call.assigned[j] {
+                                old_call.get_or_insert_with(|| func_call.clone().into());
+                                replace_with_anonymous_var(&mut func_call.assigned[j])?;
+                            }
+                        }
+                    }
+                    if let Some(old_call) = old_call {
+                        constraint_mapping.insert(old_call.into(), func_call.clone().into());
+                    }
+                }
+                Constraint::ExpressionBinding(binding) => {
+                    debug_assert!(binding.ids_assigned().count() == 1);
+                }
+                Constraint::Is(_)
+                | Constraint::Has(_)
+                | Constraint::Kind(_)
+                | Constraint::Label(_)
+                | Constraint::RoleName(_)
+                | Constraint::Isa(_)
+                | Constraint::Iid(_)
+                | Constraint::Owns(_)
+                | Constraint::Relates(_)
+                | Constraint::Plays(_)
+                | Constraint::Value(_)
+                | Constraint::Comparison(_)
+                | Constraint::LinksDeduplication(_)
+                | Constraint::Unsatisfiable(_) => {}
+            }
+        }
+        self.constraints.extend(is_collector.iter().map(|is| Constraint::Is(is.clone())));
+
+        Ok((is_collector, variable_mapping, constraint_mapping))
+    }
 }
 
 impl StructuralEquality for Constraints {
@@ -553,137 +647,6 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
 
     pub(crate) fn parameters(&mut self) -> &mut ParameterRegistry {
         self.context.parameters()
-    }
-}
-
-macro_rules! may_replace_reused_variable {
-    ($constraint:expr, $kept:expr, $changed:expr, $reg:expr, $is_collector:ident, $var_mapping:ident , $constraint_mapping:ident) => {
-        if $kept == $changed {
-            let old_constraint = $constraint.clone().into();
-            if let (Vertex::Variable(kept), Vertex::Variable(changed)) = ($kept, $changed) {
-                let kept = *kept;
-                let new_var = $reg.create_anonymous_variable_copying(kept)?;
-                *changed = new_var.clone();
-
-                // Keep old on LHS
-                $is_collector.push(Is::new(kept, new_var, None));
-                $var_mapping.insert(kept, new_var);
-                $constraint_mapping.insert(old_constraint, $constraint.clone().into());
-            }
-        }
-    };
-}
-
-impl Constraints {
-    pub fn make_variables_unique(
-        &mut self,
-        variable_registry: &mut VariableRegistry,
-    ) -> Result<
-        (Vec<Is<Variable>>, HashMap<Variable, Variable>, HashMap<Constraint<Variable>, Constraint<Variable>>),
-        Box<RepresentationError>,
-    > {
-        let mut is_collector = Vec::new();
-        let mut variable_mapping = HashMap::new();
-        let mut constraint_mapping = HashMap::new();
-        for constraint in &mut self.constraints {
-            match constraint {
-                Constraint::Sub(sub) => {
-                    may_replace_reused_variable!(
-                        sub,
-                        &sub.subtype,
-                        &mut sub.supertype,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                }
-                Constraint::Links(links) => {
-                    may_replace_reused_variable!(
-                        links,
-                        &links.player,
-                        &mut links.relation,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                }
-                Constraint::IndexedRelation(indexed) => {
-                    may_replace_reused_variable!(
-                        indexed,
-                        &indexed.player_1,
-                        &mut indexed.player_2,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                    may_replace_reused_variable!(
-                        indexed,
-                        &indexed.player_1,
-                        &mut indexed.relation,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                    may_replace_reused_variable!(
-                        indexed,
-                        &indexed.player_2,
-                        &mut indexed.relation,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                    may_replace_reused_variable!(
-                        indexed,
-                        &indexed.role_type_1,
-                        &mut indexed.role_type_2,
-                        variable_registry,
-                        is_collector,
-                        variable_mapping,
-                        constraint_mapping
-                    );
-                }
-                Constraint::FunctionCallBinding(func_call) => {
-                    for i in 0..func_call.assigned.len() {
-                        for j in i + 1..func_call.assigned.len() {
-                            let lhs: Vertex<Variable> = func_call.assigned[i].clone();
-                            may_replace_reused_variable!(
-                                func_call,
-                                &lhs,
-                                &mut func_call.assigned[j],
-                                variable_registry,
-                                is_collector,
-                                variable_mapping,
-                                constraint_mapping
-                            );
-                        }
-                    }
-                }
-                Constraint::ExpressionBinding(binding) => {
-                    debug_assert!(binding.ids_assigned().count() == 1);
-                }
-                Constraint::Is(_)
-                | Constraint::Has(_)
-                | Constraint::Kind(_)
-                | Constraint::Label(_)
-                | Constraint::RoleName(_)
-                | Constraint::Isa(_)
-                | Constraint::Iid(_)
-                | Constraint::Owns(_)
-                | Constraint::Relates(_)
-                | Constraint::Plays(_)
-                | Constraint::Value(_)
-                | Constraint::Comparison(_)
-                | Constraint::LinksDeduplication(_)
-                | Constraint::Unsatisfiable(_) => {}
-            }
-        }
-        self.constraints.extend(is_collector.iter().map(|is| Constraint::Is(is.clone())));
-        Ok((is_collector, variable_mapping, constraint_mapping))
     }
 }
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -81,20 +81,24 @@ impl Constraints {
         &mut self,
         variable_registry: &mut VariableRegistry,
     ) -> Result<
-        (Vec<Is<Variable>>, Vec<(Variable, Variable)>, HashMap<Constraint<Variable>, Constraint<Variable>>),
+        (Vec<Constraint<Variable>>, HashMap<Constraint<Variable>, Constraint<Variable>>),
         Box<RepresentationError>,
     > {
-        let mut is_collector = Vec::new();
-        let mut variable_mapping = Vec::new(); // Vec to allow multiple new_var for same old_var
+        let mut check_collector: Vec<Constraint<Variable>> = Vec::new();
         let mut constraint_mapping = HashMap::new();
         let mut replace_with_anonymous_var = |vertex: &mut Vertex<Variable>| {
+            debug_assert!(vertex.is_variable());
             if let Vertex::Variable(var) = vertex {
                 let old_var = *var;
                 *var = variable_registry.create_anonymous_variable_copying(old_var)?;
-                is_collector.push(Is::new(old_var, *var, None));
-                variable_mapping.push((old_var, *var));
-            } else {
-                debug_assert!(false, "");
+                let category = variable_registry.get_variable_category(old_var).expect("Expected category");
+                let check = if matches!(category, VariableCategory::Value | VariableCategory::ValueList) {
+                    debug_assert!(false, "Unreachable due to earlier checks");
+                    Comparison::new(Vertex::Variable(old_var), Vertex::Variable(*var), Comparator::Equal, None).into()
+                } else {
+                    Is::new(old_var, *var, None).into()
+                };
+                check_collector.push(check);
             }
             Ok::<(), Box<RepresentationError>>(())
         };
@@ -166,9 +170,9 @@ impl Constraints {
                 | Constraint::Unsatisfiable(_) => {}
             }
         }
-        self.constraints.extend(is_collector.iter().map(|is| Constraint::Is(is.clone())));
+        self.constraints.extend_from_slice(&check_collector);
 
-        Ok((is_collector, variable_mapping, constraint_mapping))
+        Ok((check_collector, constraint_mapping))
     }
 }
 

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -154,6 +154,7 @@ impl Constraints {
                         }
                     }
                     if let Some(old_call) = old_call {
+                        debug_assert!(false, "unreachable/add a test since this was banned upstream.");
                         constraint_mapping.insert(func_call.clone().into(), old_call.into());
                     }
                 }

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -77,15 +77,16 @@ impl Constraints {
         })
     }
 
-    pub fn make_variables_unique(
+    pub(super) fn make_variables_unique(
         &mut self,
         variable_registry: &mut VariableRegistry,
     ) -> Result<
-        (Vec<Constraint<Variable>>, HashMap<Constraint<Variable>, Constraint<Variable>>),
+        (Vec<Constraint<Variable>>, HashMap<Constraint<Variable>, Constraint<Variable>>, HashMap<Variable, Variable>),
         Box<RepresentationError>,
     > {
         let mut check_collector: Vec<Constraint<Variable>> = Vec::new();
         let mut constraint_mapping = HashMap::new();
+        let mut variable_mapping = HashMap::new();
         let mut replace_with_anonymous_var = |vertex: &mut Vertex<Variable>| {
             debug_assert!(vertex.is_variable());
             if let Vertex::Variable(var) = vertex {
@@ -98,6 +99,7 @@ impl Constraints {
                 } else {
                     Is::new(old_var, *var, None).into()
                 };
+                variable_mapping.insert(*var, old_var);
                 check_collector.push(check);
             }
             Ok::<(), Box<RepresentationError>>(())
@@ -109,14 +111,14 @@ impl Constraints {
                     if sub.subtype == sub.supertype && sub.supertype.is_variable() {
                         let old_sub = sub.clone();
                         replace_with_anonymous_var(&mut sub.supertype)?;
-                        constraint_mapping.insert(old_sub.into(), sub.clone().into());
+                        constraint_mapping.insert(sub.clone().into(), old_sub.into());
                     }
                 }
                 Constraint::Links(links) => {
                     if links.player == links.relation {
                         let old_links = links.clone();
                         replace_with_anonymous_var(&mut links.relation)?;
-                        constraint_mapping.insert(old_links.into(), links.clone().into());
+                        constraint_mapping.insert(links.clone().into(), old_links.into());
                     }
                 }
                 Constraint::IndexedRelation(indexed) => {
@@ -138,7 +140,7 @@ impl Constraints {
                         replace_with_anonymous_var(&mut indexed.role_type_2)?;
                     }
                     if let Some(old_indexed) = old_indexed {
-                        constraint_mapping.insert(old_indexed.into(), indexed.clone().into());
+                        constraint_mapping.insert(indexed.clone().into(), old_indexed.into());
                     }
                 }
                 Constraint::FunctionCallBinding(func_call) => {
@@ -152,7 +154,7 @@ impl Constraints {
                         }
                     }
                     if let Some(old_call) = old_call {
-                        constraint_mapping.insert(old_call.into(), func_call.clone().into());
+                        constraint_mapping.insert(func_call.clone().into(), old_call.into());
                     }
                 }
                 Constraint::ExpressionBinding(binding) => {
@@ -176,7 +178,7 @@ impl Constraints {
         }
         self.constraints.extend_from_slice(&check_collector);
 
-        Ok((check_collector, constraint_mapping))
+        Ok((check_collector, constraint_mapping, variable_mapping))
     }
 }
 

--- a/ir/pipeline/mod.rs
+++ b/ir/pipeline/mod.rs
@@ -184,6 +184,20 @@ impl VariableRegistry {
         Ok(variable)
     }
 
+    pub(crate) fn create_anonymous_variable_copying(
+        &mut self,
+        variable: Variable,
+    ) -> Result<Variable, Box<RepresentationError>> {
+        let new_var = self.register_anonymous_variable(None)?;
+        if let Some(category) = self.get_variable_category(variable) {
+            self.set_variable_category(new_var, category, VariableCategorySource::Variable(variable))?;
+        }
+        if let Some(optionality) = self.variable_optionality.get(&variable) {
+            self.set_variable_is_optional(new_var, *optionality == VariableOptionality::Optional);
+        }
+        Ok(new_var)
+    }
+
     fn allocate_variable(
         &mut self,
         anonymous: bool,
@@ -354,6 +368,7 @@ pub enum VariableCategorySource {
     Reduce(Reducer),
     Argument,
     Delete,
+    Variable(Variable),
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -448,7 +448,7 @@ fn annotate_and_compile_query(
         source_query,
     ));
 
-    match apply_transformations(snapshot, &type_manager, &mut annotated_pipeline) {
+    match apply_transformations(snapshot, &type_manager, variable_registry, &mut annotated_pipeline) {
         Ok(_) => {}
         Err(err) => {
             return Err(Box::new(QueryError::Transformation {


### PR DESCRIPTION
## Product change and motivation
Introduces a transformation step which rewrites constraints so the variables bound by it are unique.
E.g.: `$r links (some-role: $r);` is rewritten to `$_i links (some-role: $r); $r is $_i;`

## Implementation
Introduces a transformation phase step that modifies all `conjunction.constraints()` in place if any producible variable is repeated. Then updates:
* Vertex annotations for the newly introduced variables
* ConstraintAnnotations for the newly introduced constraints