### PR TITLE
Introduce a new RECORD_TYPE for the new type of commit records

### DIFF
--- a/database/tools/read_wal.rs
+++ b/database/tools/read_wal.rs
@@ -11,7 +11,7 @@ use concept::thing::statistics::Statistics;
 use durability::{wal::WAL, DurabilitySequenceNumber, RawRecord};
 use storage::{
     durability_client::{DurabilityClient, DurabilityRecord, WALClient},
-    record::{CommitRecord, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
 };
 
 #[derive(Parser)]
@@ -63,6 +63,10 @@ fn deserialise_record<Record: DurabilityRecord>(raw_bytes: &[u8]) -> Record {
 
 fn print_record(record: RawRecord<'_>) {
     match record.record_type {
+        LegacyCommitRecordV1::RECORD_TYPE => {
+            let legacy: LegacyCommitRecordV1 = deserialise_record(&record.bytes);
+            print_commit(record.sequence_number, CommitRecord::from(legacy));
+        }
         CommitRecord::RECORD_TYPE => print_commit(record.sequence_number, deserialise_record(&record.bytes)),
         StatusRecord::RECORD_TYPE => print_status(record.sequence_number, deserialise_record(&record.bytes)),
         Statistics::RECORD_TYPE => print_statistics(record.sequence_number, deserialise_record(&record.bytes)),
@@ -107,6 +111,7 @@ fn print_range(path: PathBuf, from: u64, to: Option<u64>) {
 
     let mut wal = WALClient::new(wal);
     wal.register_record_type::<Statistics>();
+    wal.register_record_type::<LegacyCommitRecordV1>();
     wal.register_record_type::<CommitRecord>();
     wal.register_record_type::<StatusRecord>();
 
@@ -126,6 +131,7 @@ fn print_at(path: PathBuf, sequence_number: Option<u64>) {
 
     let mut wal = WALClient::new(wal);
     wal.register_record_type::<Statistics>();
+    wal.register_record_type::<LegacyCommitRecordV1>();
     wal.register_record_type::<CommitRecord>();
     wal.register_record_type::<StatusRecord>();
 

--- a/database/tools/replay_wal.rs
+++ b/database/tools/replay_wal.rs
@@ -11,7 +11,7 @@ use concept::thing::statistics::Statistics;
 use durability::{wal::WAL, DurabilitySequenceNumber};
 use storage::{
     durability_client::{DurabilityClient, DurabilityRecord, WALClient},
-    record::{CommitRecord, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
 };
 
 #[derive(Parser)]
@@ -52,6 +52,7 @@ fn main() {
 
     let mut source_wal = WALClient::new(source_wal);
     source_wal.register_record_type::<Statistics>();
+    source_wal.register_record_type::<LegacyCommitRecordV1>();
     source_wal.register_record_type::<CommitRecord>();
     source_wal.register_record_type::<StatusRecord>();
 
@@ -63,6 +64,7 @@ fn main() {
 
     let mut target_wal = WALClient::new(WAL::load(cli.target_directory).unwrap());
     target_wal.register_record_type::<Statistics>();
+    target_wal.register_record_type::<LegacyCommitRecordV1>();
     target_wal.register_record_type::<CommitRecord>();
     target_wal.register_record_type::<StatusRecord>();
 

--- a/database/tools/replay_wal.rs
+++ b/database/tools/replay_wal.rs
@@ -76,6 +76,11 @@ fn main() {
             break;
         }
         match record.record_type {
+            LegacyCommitRecordV1::RECORD_TYPE
+                if cli.kind.is_empty() || cli.kind.contains(&RecordKind::CommitRecord) =>
+            {
+                _ = target_wal.sequenced_write::<LegacyCommitRecordV1>(&deserialise_record(&record.bytes)).unwrap()
+            }
             CommitRecord::RECORD_TYPE if cli.kind.is_empty() || cli.kind.contains(&RecordKind::CommitRecord) => {
                 _ = target_wal.sequenced_write::<CommitRecord>(&deserialise_record(&record.bytes)).unwrap()
             }
@@ -85,7 +90,10 @@ fn main() {
             Statistics::RECORD_TYPE if cli.kind.is_empty() || cli.kind.contains(&RecordKind::Statistics) => {
                 target_wal.unsequenced_write::<Statistics>(&deserialise_record(&record.bytes)).unwrap()
             }
-            CommitRecord::RECORD_TYPE | StatusRecord::RECORD_TYPE | Statistics::RECORD_TYPE => (), // filtered out
+            LegacyCommitRecordV1::RECORD_TYPE
+            | CommitRecord::RECORD_TYPE
+            | StatusRecord::RECORD_TYPE
+            | Statistics::RECORD_TYPE => (), // filtered out
             unrecognized => panic!("Unrecognized record type: {unrecognized}"),
         }
     }

--- a/storage/record.rs
+++ b/storage/record.rs
@@ -25,6 +25,16 @@ pub struct LegacyCommitRecordV1 {
     commit_type: CommitType,
 }
 
+impl LegacyCommitRecordV1 {
+    pub(crate) fn new(
+        operations: OperationsBuffer,
+        open_sequence_number: SequenceNumber,
+        commit_type: CommitType,
+    ) -> Self {
+        Self { operations, open_sequence_number, commit_type }
+    }
+}
+
 impl From<LegacyCommitRecordV1> for CommitRecord {
     fn from(legacy: LegacyCommitRecordV1) -> Self {
         CommitRecord {
@@ -40,8 +50,8 @@ impl DurabilityRecord for LegacyCommitRecordV1 {
     const RECORD_TYPE: DurabilityRecordType = 0;
     const RECORD_NAME: &'static str = "legacy_commit_record_v1";
 
-    fn serialise_into(&self, _writer: &mut impl std::io::Write) -> bincode::Result<()> {
-        unreachable!("LegacyCommitRecordV1 is read-only — new records use CommitRecord")
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        bincode::serialize_into(writer, &self)
     }
 
     fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self> {

--- a/storage/record.rs
+++ b/storage/record.rs
@@ -17,22 +17,9 @@ use crate::{
     snapshot::{buffer::OperationsBuffer, lock::LockType, snapshot_id::SnapshotId, write::Write},
 };
 
+/// Legacy records are kept for reading old WAL entries written before TypeDB version upgrade.
 #[derive(Serialize, Deserialize)]
-pub struct CommitRecord {
-    // TODO: this could read-through to the WAL if we have to save memory?
-    operations: OperationsBuffer,
-    open_sequence_number: SequenceNumber,
-    commit_type: CommitType,
-
-    /// Transaction identifier used for efficient referencing to commit records in the WAL,
-    /// avoiding excessive lookups through the whole filesystem.
-    /// Should be set for all new commit records, but is set to None for old loaded records.
-    #[serde(default)]
-    snapshot_id: Option<SnapshotId>,
-}
-
-#[derive(Serialize, Deserialize)]
-struct LegacyCommitRecordV1 {
+pub struct LegacyCommitRecordV1 {
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
     commit_type: CommitType,
@@ -44,9 +31,34 @@ impl From<LegacyCommitRecordV1> for CommitRecord {
             operations: legacy.operations,
             open_sequence_number: legacy.open_sequence_number,
             commit_type: legacy.commit_type,
-            snapshot_id: None,
+            snapshot_id: SnapshotId::UNSET,
         }
     }
+}
+
+impl DurabilityRecord for LegacyCommitRecordV1 {
+    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_NAME: &'static str = "legacy_commit_record_v1";
+
+    fn serialise_into(&self, _writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        unreachable!("LegacyCommitRecordV1 is read-only — new records use CommitRecord")
+    }
+
+    fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self> {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map_err(|e| bincode::ErrorKind::Io(e))?;
+        bincode::deserialize(&buf)
+    }
+}
+
+impl SequencedDurabilityRecord for LegacyCommitRecordV1 {}
+
+#[derive(Serialize, Deserialize)]
+pub struct CommitRecord {
+    operations: OperationsBuffer,
+    open_sequence_number: SequenceNumber,
+    commit_type: CommitType,
+    snapshot_id: SnapshotId,
 }
 
 impl fmt::Debug for CommitRecord {
@@ -79,7 +91,7 @@ impl CommitRecord {
         commit_type: CommitType,
         snapshot_id: SnapshotId,
     ) -> CommitRecord {
-        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id: Some(snapshot_id) }
+        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id }
     }
 
     pub fn operations(&self) -> &OperationsBuffer {
@@ -98,7 +110,7 @@ impl CommitRecord {
         self.open_sequence_number
     }
 
-    pub fn snapshot_id(&self) -> Option<SnapshotId> {
+    pub fn snapshot_id(&self) -> SnapshotId {
         self.snapshot_id
     }
 
@@ -117,10 +129,6 @@ impl CommitRecord {
         // TODO: can be optimised with an intersection of two sorted iterators instead of iterate + gets
 
         let mut puts_to_update = Vec::new();
-
-        // we check self operations against predecessor operations.
-        //   if our buffer contains a delete, we check the predecessor doesn't have an Existing lock on it
-        // We check
 
         let locks = self.operations().locks();
         let predecessor_locks = predecessor.operations().locks();
@@ -180,7 +188,7 @@ impl CommitRecord {
 }
 
 impl DurabilityRecord for CommitRecord {
-    const RECORD_TYPE: DurabilityRecordType = 0;
+    const RECORD_TYPE: DurabilityRecordType = 2;
 
     const RECORD_NAME: &'static str = "commit_record";
 
@@ -199,13 +207,7 @@ impl DurabilityRecord for CommitRecord {
         // https://github.com/bincode-org/bincode/issues/633
         let mut buf = Vec::new();
         reader.read_to_end(&mut buf).map_err(|e| bincode::ErrorKind::Io(e))?;
-        match bincode::deserialize::<CommitRecord>(&buf) {
-            Ok(record) => Ok(record),
-            Err(_error) => {
-                // fallback to legacy
-                bincode::deserialize::<LegacyCommitRecordV1>(&buf).map(|legacy| CommitRecord::from(legacy))
-            }
-        }
+        bincode::deserialize(&buf)
     }
 }
 
@@ -243,7 +245,7 @@ impl DurabilityRecord for StatusRecord {
     fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self> {
         // https://github.com/bincode-org/bincode/issues/633
         let mut buf = Vec::new();
-        reader.read_to_end(&mut buf).unwrap();
+        reader.read_to_end(&mut buf).map_err(|e| bincode::ErrorKind::Io(e))?;
         bincode::deserialize(&buf)
     }
 }

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -14,7 +14,7 @@ use crate::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
     isolation_manager::{IsolationManager, ValidatedCommit},
     keyspace::{KeyspaceError, Keyspaces},
-    record::{CommitRecord, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
     sequence_number::SequenceNumber,
     write_batches::WriteBatches,
     MVCCStorage,
@@ -60,6 +60,20 @@ pub fn load_commit_data_from_with_context(
         }
 
         match record_type {
+            LegacyCommitRecordV1::RECORD_TYPE => {
+                let legacy = LegacyCommitRecordV1::deserialise_from(&mut &*bytes)
+                    .map_err(|error| DurabilityRecordDeserialize { source: Arc::new(error) })?;
+                let commit_record = CommitRecord::from(legacy);
+                recovered_commits.insert(sequence_number, RecoveryCommitStatus::Pending(commit_record));
+                recovered_commit_sizes.insert(sequence_number, bytes.len());
+                bytes_read += bytes.len();
+                trace!(
+                    "Read legacy commit V1 @ {} with size {}; {} total",
+                    sequence_number,
+                    format_size(bytes.len()),
+                    format_size(bytes_read),
+                );
+            }
             CommitRecord::RECORD_TYPE => {
                 let commit_record = CommitRecord::deserialise_from(&mut &*bytes)
                     .map_err(|error| DurabilityRecordDeserialize { source: Arc::new(error) })?;

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -338,7 +338,7 @@ impl<D> WriteSnapshot<D> {
 
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
-        let id = commit_record.snapshot_id();
+        let id = Some(commit_record.snapshot_id());
         Self::new(storage, commit_record.into_operations(), open_sequence_number, id)
     }
 
@@ -515,7 +515,7 @@ impl<D> SchemaSnapshot<D> {
 
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
-        let id = commit_record.snapshot_id();
+        let id = Some(commit_record.snapshot_id());
         Self::new(storage, commit_record.into_operations(), open_sequence_number, id)
     }
 

--- a/storage/snapshot/snapshot_id.rs
+++ b/storage/snapshot/snapshot_id.rs
@@ -23,6 +23,8 @@ pub struct SnapshotId {
 }
 
 impl SnapshotId {
+    pub const UNSET: Self = Self { number: 0 };
+
     pub fn new() -> Self {
         Self { number: UNIQUE_ID_GEN.fetch_add(1, Ordering::Relaxed) }
     }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -695,7 +695,8 @@ mod tests {
         durability_client::{DurabilityClient, WALClient},
         key_value::StorageKeyArray,
         keyspace::{IteratorPool, KeyspaceId, KeyspaceSet, Keyspaces},
-        record::{CommitRecord, CommitType, LegacyCommitRecordV1},
+        record::{CommitRecord, CommitType, LegacyCommitRecordV1, StatusRecord},
+        sequence_number::SequenceNumber,
         snapshot::{buffer::OperationsBuffer, WriteSnapshot},
         write_batches::WriteBatches,
         Arc, MVCCStorage, SnapshotId,
@@ -888,5 +889,66 @@ mod tests {
         assert!(storage.commit_record_exists(seqnum2, snapshot_id2).unwrap());
         assert!(storage.commit_record_exists(seqnum3, snapshot_id3).unwrap());
         assert!(storage.commit_record_exists(seqnum4, snapshot_id4).unwrap());
+    }
+
+    #[test]
+    fn test_mixed_legacy_and_current_commit_records() {
+        test_keyspace_set! {
+            TestKeyspace => 0: "test",
+        }
+
+        init_logging();
+        let storage_path = create_tmp_storage_dir();
+
+        let mut wal_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        wal_client.register_record_type::<LegacyCommitRecordV1>();
+        wal_client.register_record_type::<CommitRecord>();
+        wal_client.register_record_type::<StatusRecord>();
+
+        // Write legacy records (RECORD_TYPE=0) directly to WAL
+        let key_legacy = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"legacy"));
+        let mut legacy_ops = OperationsBuffer::new();
+        legacy_ops.writes_in_mut(key_legacy.keyspace_id()).insert(key_legacy.byte_array().clone(), ByteArray::empty());
+        let legacy_record = LegacyCommitRecordV1::new(legacy_ops, wal_client.previous(), CommitType::Data);
+        let legacy_seqnum = wal_client.sequenced_write(&legacy_record).unwrap();
+
+        // Load WAL back
+        drop(wal_client);
+        let mut wal_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        wal_client.register_record_type::<LegacyCommitRecordV1>();
+        wal_client.register_record_type::<CommitRecord>();
+        wal_client.register_record_type::<StatusRecord>();
+
+        // Write a new-format record
+        let key_new = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"new"));
+        let mut new_ops = OperationsBuffer::new();
+        new_ops.writes_in_mut(key_new.keyspace_id()).insert(key_new.byte_array().clone(), ByteArray::empty());
+        let new_snapshot_id = SnapshotId::new();
+        let new_record = CommitRecord::new(new_ops, wal_client.previous(), CommitType::Data, new_snapshot_id);
+        let new_seqnum = wal_client.sequenced_write(&new_record).unwrap();
+
+        assert_ne!(legacy_seqnum, new_seqnum);
+
+        // Read both record types back from WAL
+        // Legacy records are read as LegacyCommitRecordV1 and can be converted
+        let legacy_records: Vec<_> = wal_client
+            .iter_sequenced_type_from::<LegacyCommitRecordV1>(SequenceNumber::MIN)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(legacy_records.len(), 1, "Expected exactly one legacy record");
+
+        // New records are read as CommitRecord
+        let new_records: Vec<_> = wal_client
+            .iter_sequenced_type_from::<CommitRecord>(SequenceNumber::MIN)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(new_records.len(), 1, "Expected exactly one new-format record");
+        assert_eq!(new_records[0].1.snapshot_id(), new_snapshot_id);
+
+        // Legacy records convert to CommitRecord with UNSET snapshot_id
+        let converted = CommitRecord::from(legacy_records.into_iter().next().unwrap().1);
+        assert_eq!(converted.snapshot_id(), SnapshotId::UNSET);
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -42,7 +42,7 @@ use crate::{
         iterator::KeyspaceRangeIterator, IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError,
         KeyspaceSet, Keyspaces,
     },
-    record::{CommitRecord, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
     recovery::{
         checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
         commit_recovery::{apply_recovered, load_commit_data_from, StorageRecoveryError},
@@ -157,6 +157,7 @@ impl<Durability> MVCCStorage<Durability> {
     }
 
     fn register_durability_record_types(durability_client: &mut impl DurabilityClient) {
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         durability_client.register_record_type::<StatusRecord>();
     }
@@ -354,10 +355,8 @@ impl<Durability> MVCCStorage<Durability> {
         let mut iter = self.durability_client.iter_sequenced_type_from::<CommitRecord>(open_sequence_number)?;
         while let Some(entry) = iter.next() {
             let (_, iter_record) = entry?;
-            if let Some(iter_record_id) = iter_record.snapshot_id() {
-                if iter_record_id == snapshot_id && iter_record.open_sequence_number() == open_sequence_number {
-                    return Ok(true);
-                }
+            if iter_record.snapshot_id() == snapshot_id && iter_record.open_sequence_number() == open_sequence_number {
+                return Ok(true);
             }
         }
         Ok(false)
@@ -696,7 +695,7 @@ mod tests {
         durability_client::{DurabilityClient, WALClient},
         key_value::StorageKeyArray,
         keyspace::{IteratorPool, KeyspaceId, KeyspaceSet, Keyspaces},
-        record::{CommitRecord, CommitType},
+        record::{CommitRecord, CommitType, LegacyCommitRecordV1},
         snapshot::{buffer::OperationsBuffer, WriteSnapshot},
         write_batches::WriteBatches,
         Arc, MVCCStorage, SnapshotId,
@@ -744,6 +743,7 @@ mod tests {
                 .insert(key_1.byte_array().clone(), ByteArray::empty());
 
             let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+            durability_client.register_record_type::<LegacyCommitRecordV1>();
             durability_client.register_record_type::<CommitRecord>();
             let seq = durability_client
                 .sequenced_write(&CommitRecord::new(
@@ -766,6 +766,7 @@ mod tests {
         };
 
         let mut durability_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         let storage =
             MVCCStorage::<WALClient>::load::<TestKeyspaceSet>("storage", &storage_path, durability_client, &None)
@@ -788,6 +789,7 @@ mod tests {
 
         let storage_path = create_tmp_storage_dir();
         let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         let storage = Arc::new(
             MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
@@ -804,7 +806,7 @@ mod tests {
             CommitType::Data,
             SnapshotId::new(),
         );
-        let snapshot_id1 = commit_record1.snapshot_id().unwrap();
+        let snapshot_id1 = commit_record1.snapshot_id();
         let seqnum1 = commit_record1.open_sequence_number();
 
         let key_2 = StorageKeyArray::from((TestKeyspaceSet::PersistedKeyspace, b"world"));
@@ -816,7 +818,7 @@ mod tests {
             CommitType::Data,
             SnapshotId::new(),
         );
-        let snapshot_id2 = commit_record2.snapshot_id().unwrap();
+        let snapshot_id2 = commit_record2.snapshot_id();
         let seqnum2 = commit_record2.open_sequence_number();
 
         assert!(!storage.commit_record_exists(seqnum1, snapshot_id1).unwrap());
@@ -845,7 +847,7 @@ mod tests {
             CommitType::Schema,
             SnapshotId::new(),
         );
-        let snapshot_id3 = commit_record3.snapshot_id().unwrap();
+        let snapshot_id3 = commit_record3.snapshot_id();
         let seqnum3 = commit_record3.open_sequence_number();
 
         assert!(storage.commit_record_exists(seqnum1, snapshot_id1).unwrap());
@@ -870,7 +872,7 @@ mod tests {
             CommitType::Schema,
             snapshot_id2,
         );
-        let snapshot_id4 = commit_record4.snapshot_id().unwrap();
+        let snapshot_id4 = commit_record4.snapshot_id();
         let seqnum4 = commit_record4.open_sequence_number();
 
         assert_eq!(snapshot_id2, snapshot_id4);


### PR DESCRIPTION
## Product change and motivation

Replace the dynamic deserialization of multiple types of `CommitRecord`s with a separate `RECORD_TYPE` used for the new version of the struct. 

With this approach, we can introduce new versions of `CommitRecord`s with a bit of manual work without worrying about graceful deserialisation of records with essentially different structures but same `RECORD_TYPE`s.

## Implementation

Register `CommitRecord` and `LegacyCommitRecordV1` as separate WAL entry types. Assign a new `RECORD_TYPE` index to `CommitRecord`. Handle all the existing `RECORD_TYPE`s gracefully in the codebase.
