### PR TITLE
Fix connection-level GOAWAY errors under load

### DIFF
--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -274,11 +274,13 @@ impl TransactionService {
                     _ = self.shutdown_receiver.changed() => {
                         event!(Level::TRACE, "Shutdown signal received, closing transaction service.");
                         self.do_close().await;
+                        self.drain_request_stream().await;
                         return;
                     }
                     _ = tokio::time::sleep_until(self.timeout_at) => {
                         event!(Level::TRACE, "Transaction timeout met, closing transaction service.");
                         self.do_close().await;
+                        self.drain_request_stream().await;
                         return;
                     }
                     write_query_result = write_query_worker => {
@@ -302,11 +304,13 @@ impl TransactionService {
                     _ = self.shutdown_receiver.changed() => {
                         event!(Level::TRACE, "Shutdown signal received, closing transaction service.");
                         self.do_close().await;
+                        self.drain_request_stream().await;
                         return;
                     }
                     _ = tokio::time::sleep_until(self.timeout_at) => {
                         event!(Level::TRACE, "Transaction timeout met, closing transaction service.");
                         self.do_close().await;
+                        self.drain_request_stream().await;
                         return;
                     }
                     next = self.request_stream.next() => {
@@ -320,6 +324,7 @@ impl TransactionService {
                 Ok(Break(())) => {
                     event!(Level::TRACE, "Stream ended, closing transaction service.");
                     self.do_close().await;
+                    self.drain_request_stream().await;
                     return;
                 }
                 Err(status) => {
@@ -329,10 +334,41 @@ impl TransactionService {
                         event!(Level::DEBUG, ?send_error, "Failed to send error to client");
                     }
                     self.do_close().await;
+                    self.drain_request_stream().await;
                     return;
                 }
             }
         }
+    }
+
+    // Drain the gRPC request stream until END_STREAM (or a short bound).
+    //
+    // Why: the transaction RPC is a bidirectional stream. If the service drops
+    // its end of the request stream while the client is still streaming (the
+    // typical case after we handle a CloseReq), the stream goes to
+    // `Closed(ScheduledLibraryReset)` and h2 emits a RST_STREAM(NO_ERROR) frame
+    // for that stream. Once the reset expires the stream is forgotten; if the
+    // client then sends any DATA/HEADERS that race the close on the same
+    // stream id, h2 hits `may_have_forgotten_stream` and returns
+    // `Err(Error::Reset(_, STREAM_CLOSED, Library))`, which `Connection::poll`
+    // dispatches to `Actions::send_reset` — and that is what increments
+    // `num_local_error_reset_streams`. Once the counter crosses the per-conn
+    // limit (1024 by default in h2 0.4.x), h2 returns GOAWAY ENHANCE_YOUR_CALM
+    // and the entire client connection is poisoned. Reading the request body
+    // to its END_STREAM lets the stream transition cleanly through
+    // `Closed(EndStream)`, so neither the implicit RST_STREAM nor the
+    // forgotten-stream race ever happens.
+    //
+    // The 500 ms upper bound is a safety net for misbehaving clients that
+    // never half-close: by the time we reach this we've already done
+    // `do_close`, so the transaction state is gone and any further bytes from
+    // the client would be discarded anyway.
+    async fn drain_request_stream(&mut self) {
+        const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+        let _ = timeout(DRAIN_TIMEOUT, async {
+            while self.request_stream.next().await.is_some() {}
+        })
+        .await;
     }
 
     // TODO: any method using `Result<ControlFlow<(), ()>, Status>` should really be `ControlFlow<Result<(), Status>, ()>`

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -365,10 +365,7 @@ impl TransactionService {
     // the client would be discarded anyway.
     async fn drain_request_stream(&mut self) {
         const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
-        let _ = timeout(DRAIN_TIMEOUT, async {
-            while self.request_stream.next().await.is_some() {}
-        })
-        .await;
+        let _ = timeout(DRAIN_TIMEOUT, async { while self.request_stream.next().await.is_some() {} }).await;
     }
 
     // TODO: any method using `Result<ControlFlow<(), ()>, Status>` should really be `ControlFlow<Result<(), Status>, ()>`

--- a/server/service/grpc/transaction_service.rs
+++ b/server/service/grpc/transaction_service.rs
@@ -341,28 +341,6 @@ impl TransactionService {
         }
     }
 
-    // Drain the gRPC request stream until END_STREAM (or a short bound).
-    //
-    // Why: the transaction RPC is a bidirectional stream. If the service drops
-    // its end of the request stream while the client is still streaming (the
-    // typical case after we handle a CloseReq), the stream goes to
-    // `Closed(ScheduledLibraryReset)` and h2 emits a RST_STREAM(NO_ERROR) frame
-    // for that stream. Once the reset expires the stream is forgotten; if the
-    // client then sends any DATA/HEADERS that race the close on the same
-    // stream id, h2 hits `may_have_forgotten_stream` and returns
-    // `Err(Error::Reset(_, STREAM_CLOSED, Library))`, which `Connection::poll`
-    // dispatches to `Actions::send_reset` — and that is what increments
-    // `num_local_error_reset_streams`. Once the counter crosses the per-conn
-    // limit (1024 by default in h2 0.4.x), h2 returns GOAWAY ENHANCE_YOUR_CALM
-    // and the entire client connection is poisoned. Reading the request body
-    // to its END_STREAM lets the stream transition cleanly through
-    // `Closed(EndStream)`, so neither the implicit RST_STREAM nor the
-    // forgotten-stream race ever happens.
-    //
-    // The 500 ms upper bound is a safety net for misbehaving clients that
-    // never half-close: by the time we reach this we've already done
-    // `do_close`, so the transaction state is gone and any further bytes from
-    // the client would be discarded anyway.
     async fn drain_request_stream(&mut self) {
         const DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
         let _ = timeout(DRAIN_TIMEOUT, async { while self.request_stream.next().await.is_some() {} }).await;


### PR DESCRIPTION
## Product change and motivation

Drivers that sustain transaction churn over a single TypeDB driver connection (e.g. several worker threads opening/committing/closing many small write transactions in a row) eventually saw every in-flight request fail at the same moment with `h2 protocol error: too_many_internal_resets` / `broken pipe`. Server logs showed:

    WARN h2/proto/streams/streams.rs:1629:
        locally-reset streams reached limit (1024)

followed by `GOAWAY ENHANCE_YOUR_CALM`. The server itself never panicked however,the gRPC connection was poisoned.

## Implementation

Server side reaction to CommitReq:  
```
  (true, Req::CommitReq(commit_req)) => {
      self.handle_commit(...).await?;                                                                           
      Ok(Break(()))      // <-- forces listen() to exit
  },   
  ``` 
  
  On commit, the server actively returns Break(()) from handle_request. The listen() loop then calls do_close().await and returns — dropping the whole TransactionService, which drops request_stream.                                               

 So:
  - Server already sent the commit response and END_STREAM on the response half → is_send_closed = true                                                                                                                                              
  - Server drops request_stream while it is still in is_recv_streaming = true (client's END_STREAM hasn't arrived yet — it's in flight, racing with this drop)
  - h2's maybe_cancel sees that combination and emits RST_STREAM(NO_ERROR) to abort the half-open stream                                                                                                                                             

At 1024 (h2 0.4.x default), h2 sends GOAWAY ENHANCE_YOUR_CALM and the connection is poisoned. With sustained ~100+ tx/sec across one connection, this is reached within minutes.

The fix drains `request_stream` to END_STREAM (bounded by 500 ms) at every `listen` exit point before the service drops. With both halves closing through `Closed(EndStream)`, h2 emits no implicit RST_STREAM at all and the counter never climbs.

## Verification

* Smoke (1000 queries, 6 workers, 10 transactions, `RUST_LOG=h2=debug`): pre-fix logged 11 `Reset { error_code: NO_ERROR }` frames; post-fix logged 0.


