### PR TITLE
Poll for server readiness in assembly fail point tests

### DIFF
--- a/tests/assembly/fail_points.rs
+++ b/tests/assembly/fail_points.rs
@@ -37,10 +37,33 @@ fn wait_process_timeout(process: &mut Child, timeout: Duration) -> std::io::Resu
     Ok(())
 }
 
-const BOOT_DURATION: Duration = Duration::from_secs(2);
+// Pattern borrowed from tests/behaviour/service/http/http_steps/lib.rs::wait_server_start.
+const SERVER_START_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+const SERVER_MAX_START_TIME: Duration = Duration::from_secs(30);
 
 fn start_server() -> (Child, u16) {
     start_server_with_env(None, None)
+}
+
+/// Poll for either a server crash or for the gRPC port becoming reachable.
+/// Mirrors the loop shape of `Context::wait_server_start` in http_steps;
+/// uses TCP connect rather than HTTP `/health` to avoid pulling an HTTP client
+/// into the assembly test target. Returns true if the process exited.
+fn wait_server_start(process: &mut Child, port: u16) -> bool {
+    let starting_since = Instant::now();
+    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    loop {
+        if process.try_wait().unwrap().is_some() {
+            return true;
+        }
+        if std::net::TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
+            return false;
+        }
+        if Instant::now().duration_since(starting_since) > SERVER_MAX_START_TIME {
+            panic!("Server has not started in {:?}. Aborting tests!", SERVER_MAX_START_TIME);
+        }
+        thread::sleep(SERVER_START_CHECK_INTERVAL);
+    }
 }
 
 fn start_server_with_env(env: Option<(&str, &str)>, expected_fail: Option<&str>) -> (Child, u16) {
@@ -52,22 +75,21 @@ fn start_server_with_env(env: Option<(&str, &str)>, expected_fail: Option<&str>)
         }
 
         let mut process = cmd.spawn().expect("Failed to run server");
-        thread::sleep(BOOT_DURATION);
+        let crashed = wait_server_start(&mut process, port);
 
-        match process.try_wait().unwrap() {
-            Some(_) => {
-                let mut buf = String::new();
-                process.stderr.as_mut().unwrap().read_to_string(&mut buf).unwrap();
-                if let Some(fail) = expected_fail {
-                    if buf.contains(fail) {
-                        break (process, port);
-                    }
-                }
-                if !buf.contains("SRO11") {
-                    panic!("Server process crashed for an unrelated reason: {buf}");
+        if crashed {
+            let mut buf = String::new();
+            process.stderr.as_mut().unwrap().read_to_string(&mut buf).unwrap();
+            if let Some(fail) = expected_fail {
+                if buf.contains(fail) {
+                    break (process, port);
                 }
             }
-            None => break (process, port),
+            if !buf.contains("SRO11") {
+                panic!("Server process crashed for an unrelated reason: {buf}");
+            }
+        } else {
+            break (process, port);
         }
         port += 1;
     }

--- a/tests/assembly/fail_points.rs
+++ b/tests/assembly/fail_points.rs
@@ -37,7 +37,6 @@ fn wait_process_timeout(process: &mut Child, timeout: Duration) -> std::io::Resu
     Ok(())
 }
 
-// Pattern borrowed from tests/behaviour/service/http/http_steps/lib.rs::wait_server_start.
 const SERVER_START_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 const SERVER_MAX_START_TIME: Duration = Duration::from_secs(30);
 
@@ -45,10 +44,6 @@ fn start_server() -> (Child, u16) {
     start_server_with_env(None, None)
 }
 
-/// Poll for either a server crash or for the gRPC port becoming reachable.
-/// Mirrors the loop shape of `Context::wait_server_start` in http_steps;
-/// uses TCP connect rather than HTTP `/health` to avoid pulling an HTTP client
-/// into the assembly test target. Returns true if the process exited.
 fn wait_server_start(process: &mut Child, port: u16) -> bool {
     let starting_since = Instant::now();
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));


### PR DESCRIPTION
## Product change and motivation

Fix nondeterministic failures in the failpoints test.

## Implementation

The assembly fail point tests slept a fixed BOOT_DURATION = 2s after spawning the typedb server, then proceeded to drive the server via console commands. On slower hosts (CI under load) the gRPC port was not yet bound at the 2s mark, so every console command in setup() and the first Instruction::Command of run_test_against_server failed silently with connection-refused. 

Result: nondeterministic "Fail point CHECKPOINT_CLEANUP_FAIL is never triggered" panics in CI even though the configured fail point would have fired moments later.

Replace the fixed sleep with a polling loop that waits for either the process to exit or for the gRPC port to become reachable, with a 30s deadline. This mirrors the shape of Context::wait_server_start in tests/behaviour/service/http/http_steps/lib.rs 

### Details

Verified by injecting a sleep wrapper around the typedb command to emulate slow boot: with a 3s injected delay the unfixed test reliably reproduces the CI panic at line 96; with the polling fix the same scenario passes. A 100x repeat run with --runs_per_test=100 --test-threads=1 is in flight and so far has 33 consecutive passes with zero never-triggered failures.

