### PR TITLE
QueryCache tracks statistics & schema commit to avoid caching outdated plans

### DIFF
--- a/database/database.rs
+++ b/database/database.rs
@@ -562,8 +562,9 @@ fn make_update_statistics_fn(
             let mut new_statistics = (*schema.read().unwrap().thing_statistics).clone();
             debug!("Starting updating statistics for database {database_name}");
             new_statistics.may_synchronise(&storage).expect("Statistics sync failed");
-            query_cache.may_evict(&new_statistics);
-            schema.write().unwrap().thing_statistics = Arc::new(new_statistics);
+            let new_statistics = Arc::new(new_statistics);
+            query_cache.set_statistics_and_invalidate_outdated(new_statistics.clone());
+            schema.write().unwrap().thing_statistics = new_statistics;
             debug!("Finished updating statistics for database {database_name}");
         }
     }

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -70,7 +70,7 @@ impl QueryCache {
         let read_lock = self.validity_requirements.read().unwrap();
         let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
         let may_insert = latest_schema_commit
-            .map_or(true, |min_sequence_number| statistics_sequence_number >= min_sequence_number)
+            .map_or(true, |latest_schema_commit_number| statistics_sequence_number >= latest_schema_commit_number)
             && latest_statistics
                 .as_ref()
                 .map_or(true, |stats| !is_pipeline_type_populations_outdated(&stats, &pipeline));

--- a/query/query_cache.rs
+++ b/query/query_cache.rs
@@ -6,7 +6,7 @@
 
 use std::{
     hash::{DefaultHasher, Hash, Hasher},
-    sync::Arc,
+    sync::{Arc, RwLock},
 };
 
 use answer::Type;
@@ -21,17 +21,27 @@ use resource::{
     constants::database::{QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION, QUERY_PLAN_CACHE_SIZE},
     perf_counters::QUERY_CACHE_FLUSH,
 };
+use storage::sequence_number::SequenceNumber;
 use structural_equality::StructuralEquality;
+
+#[derive(Debug)]
+struct ValidityRequirements {
+    latest_statistics: Option<Arc<Statistics>>,
+    latest_schema_commit: Option<SequenceNumber>,
+}
 
 #[derive(Debug)]
 pub struct QueryCache {
     cache: Cache<IRQuery, ExecutablePipeline>,
+    validity_requirements: RwLock<ValidityRequirements>,
 }
 
 impl QueryCache {
     pub fn new() -> Self {
         let cache = CacheBuilder::new(QUERY_PLAN_CACHE_SIZE).support_invalidation_closures().build();
-        QueryCache { cache }
+        let validity_requirements =
+            RwLock::new(ValidityRequirements { latest_statistics: None, latest_schema_commit: None });
+        QueryCache { cache, validity_requirements }
     }
 
     pub(crate) fn get(
@@ -48,44 +58,42 @@ impl QueryCache {
         })
     }
 
-    pub(crate) fn insert(
+    pub(crate) fn may_insert(
         &self,
+        statistics_sequence_number: SequenceNumber,
         preamble: Arc<Vec<Function>>,
         stages: Arc<Vec<TranslatedStage>>,
         fetch: Arc<Option<FetchObject>>,
         pipeline: ExecutablePipeline,
     ) {
         let key = IRQuery::new(preamble, stages, fetch);
-        self.cache.insert(key, pipeline);
+        let read_lock = self.validity_requirements.read().unwrap();
+        let ValidityRequirements { latest_schema_commit, latest_statistics } = &*read_lock;
+        let may_insert = latest_schema_commit
+            .map_or(true, |min_sequence_number| statistics_sequence_number >= min_sequence_number)
+            && latest_statistics
+                .as_ref()
+                .map_or(true, |stats| !is_pipeline_type_populations_outdated(&stats, &pipeline));
+        if may_insert {
+            self.cache.insert(key, pipeline);
+        }
+        drop(read_lock);
     }
 
-    pub fn may_evict(&self, new_statistics: &Statistics) {
-        let new_statistics = new_statistics.clone(); // it's either this or clone the entire cache
+    pub fn set_statistics_and_invalidate_outdated(&self, new_statistics: Arc<Statistics>) {
+        let mut write_lock = self.validity_requirements.write().unwrap();
+        (*write_lock).latest_statistics = Some(new_statistics.clone());
+        drop(write_lock);
         let _predicate_id = self
             .cache
-            .invalidate_entries_if(move |_, pipeline| {
-                let mut total_increase = 1.0;
-                let mut total_decrease = 1.0;
-                for (&ty, &pop) in &pipeline.type_populations {
-                    let type_count = match ty {
-                        Type::Entity(ty) => new_statistics.entity_counts.get(&ty).copied().unwrap_or_default(),
-                        Type::Relation(ty) => new_statistics.relation_counts.get(&ty).copied().unwrap_or_default(),
-                        Type::Attribute(ty) => new_statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
-                        Type::RoleType(ty) => new_statistics.role_counts.get(&ty).copied().unwrap_or_default(),
-                    };
-                    match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
-                        increase @ 1.0.. => total_increase *= increase,
-                        decrease @ ..1.0 => total_decrease /= decrease,
-                        _ => panic!("NaN?!"),
-                    }
-                }
-                total_increase >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
-                    || total_decrease >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
-            })
+            .invalidate_entries_if(move |_, pipeline| is_pipeline_type_populations_outdated(&*new_statistics, pipeline))
             .unwrap();
     }
 
-    pub fn force_reset(&self, _statistics: &Statistics) {
+    pub fn force_reset(&self, statistics: &Statistics) {
+        let mut write_lock = self.validity_requirements.write().unwrap();
+        (*write_lock).latest_schema_commit = Some(statistics.sequence_number);
+        drop(write_lock);
         self.cache.invalidate_all();
         QUERY_CACHE_FLUSH.increment();
     }
@@ -95,6 +103,26 @@ impl Default for QueryCache {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn is_pipeline_type_populations_outdated(statistics: &Statistics, pipeline: &ExecutablePipeline) -> bool {
+    let mut total_increase = 1.0;
+    let mut total_decrease = 1.0;
+    for (&ty, &pop) in &pipeline.type_populations {
+        let type_count = match ty {
+            Type::Entity(ty) => statistics.entity_counts.get(&ty).copied().unwrap_or_default(),
+            Type::Relation(ty) => statistics.relation_counts.get(&ty).copied().unwrap_or_default(),
+            Type::Attribute(ty) => statistics.attribute_counts.get(&ty).copied().unwrap_or_default(),
+            Type::RoleType(ty) => statistics.role_counts.get(&ty).copied().unwrap_or_default(),
+        };
+        match u64::max(type_count, 1) as f64 / u64::max(pop, 1) as f64 {
+            increase @ 1.0.. => total_increase *= increase,
+            decrease @ ..1.0 => total_decrease /= decrease,
+            _ => panic!("NaN?!"),
+        }
+    }
+    total_increase >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
+        || total_decrease >= QUERY_PLAN_CACHE_FLUSH_ANY_STATISTIC_CHANGE_FRACTION
 }
 
 #[derive(Debug)]

--- a/query/query_manager.rs
+++ b/query/query_manager.rs
@@ -162,7 +162,8 @@ impl QueryManager {
                     arced_fetch.clone(),
                 )?;
                 if let Some(cache) = self.cache.as_ref() {
-                    cache.insert(arced_preamble, arced_stages, arced_fetch, executable_pipeline.clone())
+                    let seq = thing_manager.statistics().sequence_number;
+                    cache.may_insert(seq, arced_preamble, arced_stages, arced_fetch, executable_pipeline.clone())
                 }
                 QUERY_CACHE_MISSES.increment();
                 executable_pipeline
@@ -247,7 +248,13 @@ impl QueryManager {
                 match executable_pipeline_result {
                     Ok(executable_pipeline) => {
                         if let Some(cache) = self.cache.as_ref() {
-                            cache.insert(arced_preamble, arced_stages, arced_fetch, executable_pipeline.clone())
+                            cache.may_insert(
+                                thing_manager.statistics().sequence_number,
+                                arced_preamble,
+                                arced_stages,
+                                arced_fetch,
+                                executable_pipeline.clone(),
+                            )
                         }
                         QUERY_CACHE_MISSES.increment();
                         executable_pipeline


### PR DESCRIPTION
## Product change and motivation
Updates the QueryCache to explicitly track validity requirements and validate insert calls. By tracking the sequence_number of the latest schema commit, we avoid #7787. By tracking statistics, we avoid #7790 

## Implementation
Fixes #7787, #7790 
Statistics track the latest synchronised statistics. `may_insert` checks the candidate against (1) The sequence number to ensure it is based on the current schema (2) the latest statistics to ensure it was not built on outdated statistics.
