### PR TITLE
Escalate concurrent key and unique writes to transaction failure

### DIFF
--- a/common/bytes/util.rs
+++ b/common/bytes/util.rs
@@ -11,6 +11,8 @@ use std::{
 
 use base64::Engine;
 
+use crate::byte_array::ByteArray;
+
 // TODO: this needs to be optimised using bigger strides than a single byte!
 ///
 /// Performs a big-endian +1 operation that errors on overflow
@@ -60,6 +62,21 @@ impl fmt::Display for BytesError {
             }
         }
     }
+}
+
+pub fn concat_bytes<'a, I, const SIZE: usize>(key_items: I) -> ByteArray<SIZE>
+where
+    I: Iterator<Item = &'a [u8]> + Clone,
+{
+    let total_len = key_items.clone().map(|item| item.len()).sum();
+    let mut bytes = ByteArray::zeros(total_len);
+    let mut start = 0;
+    for item in key_items {
+        let end = start + item.len();
+        bytes[start..end].copy_from_slice(item);
+        start = end;
+    }
+    bytes
 }
 
 #[derive(Clone)]

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1809,6 +1809,7 @@ impl ThingManager {
         self.cleanup_relations(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
         self.cleanup_attributes(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
 
+        println!("Creating commit locks next");
         match self.create_commit_locks(snapshot, storage_counters) {
             Ok(_) => Ok(()),
             Err(error) => Err(vec![ConceptWriteError::ConceptRead { typedb_source: error }]),
@@ -1822,6 +1823,7 @@ impl ThingManager {
     ) -> Result<(), Box<ConceptReadError>> {
         // TODO: Should not collect here (iterate_writes() already copies)
         for (key, _write) in snapshot.iterate_writes().collect_vec() {
+            println!("Creating locks");
             if ThingEdgeHas::is_has(&key) {
                 let has = ThingEdgeHas::decode(Bytes::Reference(key.bytes()));
                 let object = Object::new(has.from());
@@ -1849,30 +1851,31 @@ impl ThingManager {
         snapshot: &mut impl WritableSnapshot,
         owner: &Object,
         attribute: Attribute,
-        storage_counters: StorageCounters,
+        _storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptReadError>> {
         let unique_constraint_opt = owner.type_().get_owned_attribute_type_constraint_unique(
             snapshot,
             self.type_manager(),
             attribute.type_(),
         )?;
+        dbg!("Unique constraint", &unique_constraint_opt);
         if let Some(unique_constraint) = unique_constraint_opt {
             let attribute_key = attribute.vertex();
-            let attribute_value = snapshot
-                .get_last_existing::<BUFFER_VALUE_INLINE>(
-                    attribute_key.into_storage_key().as_reference(),
-                    storage_counters,
-                )
-                .map_err(|error| Box::new(ConceptReadError::SnapshotGet { source: error }))?
-                .ok_or(ConceptReadError::InternalMissingAttributeValue {})?;
+            // let attribute_value = snapshot
+            //     .get_last_existing::<BUFFER_VALUE_INLINE>(
+            //         attribute_key.into_storage_key().as_reference(),
+            //         storage_counters,
+            //     )
+            //     .map_err(|error| Box::new(ConceptReadError::SnapshotGet { source: error }))?
+            //     .ok_or(ConceptReadError::InternalMissingAttributeValue {})?;
 
+            // Note: trade much smaller locks (eg. not entire string) for rare concurrent lock conflicts when
+            //       two different values has to the same hash
             let lock_key = create_custom_lock_key(
                 [
                     &Infix::PropertyAnnotationUnique.infix_id().bytes(),
                     &*unique_constraint.source().attribute().vertex().to_bytes(),
-                    attribute_key.attribute_id().bytes(),
-                    &attribute_value,
-                    &*owner.vertex().to_bytes(),
+                    attribute_key.attribute_id().deterministic_bytes(),
                     &*unique_constraint.source().owner().vertex().to_bytes(),
                 ]
                 .into_iter(),

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1809,7 +1809,6 @@ impl ThingManager {
         self.cleanup_relations(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
         self.cleanup_attributes(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
 
-        println!("Creating commit locks next");
         match self.create_commit_locks(snapshot, storage_counters) {
             Ok(_) => Ok(()),
             Err(error) => Err(vec![ConceptWriteError::ConceptRead { typedb_source: error }]),
@@ -1823,7 +1822,6 @@ impl ThingManager {
     ) -> Result<(), Box<ConceptReadError>> {
         // TODO: Should not collect here (iterate_writes() already copies)
         for (key, _write) in snapshot.iterate_writes().collect_vec() {
-            println!("Creating locks");
             if ThingEdgeHas::is_has(&key) {
                 let has = ThingEdgeHas::decode(Bytes::Reference(key.bytes()));
                 let object = Object::new(has.from());
@@ -1858,7 +1856,6 @@ impl ThingManager {
             self.type_manager(),
             attribute.type_(),
         )?;
-        dbg!("Unique constraint", &unique_constraint_opt);
         if let Some(unique_constraint) = unique_constraint_opt {
             let attribute_key = attribute.vertex();
             // let attribute_value = snapshot

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -12,7 +12,11 @@ use std::{
     sync::Arc,
 };
 
-use bytes::{Bytes, byte_array::ByteArray, util::increment};
+use bytes::{
+    Bytes,
+    byte_array::ByteArray,
+    util::{concat_bytes, increment},
+};
 use encoding::{
     AsBytes, EncodingKeyspace, Keyable, Prefixed,
     graph::{
@@ -62,7 +66,7 @@ use resource::{
 use storage::{
     key_range::{KeyRange, RangeEnd, RangeStart},
     key_value::{StorageKey, StorageKeyArray, StorageKeyReference},
-    snapshot::{ReadableSnapshot, WritableSnapshot, lock::create_custom_lock_key, write::Write},
+    snapshot::{ReadableSnapshot, WritableSnapshot, write::Write},
 };
 
 use crate::{
@@ -1809,17 +1813,13 @@ impl ThingManager {
         self.cleanup_relations(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
         self.cleanup_attributes(snapshot, storage_counters.clone()).map_err(|err| vec![*err])?;
 
-        match self.create_commit_locks(snapshot, storage_counters) {
+        match self.create_commit_locks(snapshot) {
             Ok(_) => Ok(()),
             Err(error) => Err(vec![ConceptWriteError::ConceptRead { typedb_source: error }]),
         }
     }
 
-    fn create_commit_locks(
-        &self,
-        snapshot: &mut impl WritableSnapshot,
-        storage_counters: StorageCounters,
-    ) -> Result<(), Box<ConceptReadError>> {
+    fn create_commit_locks(&self, snapshot: &mut impl WritableSnapshot) -> Result<(), Box<ConceptReadError>> {
         // TODO: Should not collect here (iterate_writes() already copies)
         for (key, _write) in snapshot.iterate_writes().collect_vec() {
             if ThingEdgeHas::is_has(&key) {
@@ -1828,7 +1828,7 @@ impl ThingManager {
                 let attribute = Attribute::new(has.to());
                 let attribute_type = attribute.type_();
 
-                self.add_exclusive_lock_for_unique_constraint(snapshot, &object, attribute, storage_counters.clone())?;
+                self.add_exclusive_lock_for_unique_constraint(snapshot, &object, attribute)?;
                 self.add_exclusive_lock_for_owns_cardinality_constraint(snapshot, &object, attribute_type)?;
             } else if ThingEdgeLinks::is_links(&key) {
                 let role_player = ThingEdgeLinks::decode(Bytes::Reference(key.bytes()));
@@ -1849,7 +1849,6 @@ impl ThingManager {
         snapshot: &mut impl WritableSnapshot,
         owner: &Object,
         attribute: Attribute,
-        _storage_counters: StorageCounters,
     ) -> Result<(), Box<ConceptReadError>> {
         let unique_constraint_opt = owner.type_().get_owned_attribute_type_constraint_unique(
             snapshot,
@@ -1858,17 +1857,9 @@ impl ThingManager {
         )?;
         if let Some(unique_constraint) = unique_constraint_opt {
             let attribute_key = attribute.vertex();
-            // let attribute_value = snapshot
-            //     .get_last_existing::<BUFFER_VALUE_INLINE>(
-            //         attribute_key.into_storage_key().as_reference(),
-            //         storage_counters,
-            //     )
-            //     .map_err(|error| Box::new(ConceptReadError::SnapshotGet { source: error }))?
-            //     .ok_or(ConceptReadError::InternalMissingAttributeValue {})?;
-
             // Note: trade much smaller locks (eg. not entire string) for rare concurrent lock conflicts when
             //       two different values has to the same hash
-            let lock_key = create_custom_lock_key(
+            let lock_key = concat_bytes(
                 [
                     &Infix::PropertyAnnotationUnique.infix_id().bytes(),
                     &*unique_constraint.source().attribute().vertex().to_bytes(),
@@ -1899,7 +1890,7 @@ impl ThingManager {
         }
 
         for constraint in cardinality_constraints {
-            let lock_key = create_custom_lock_key(
+            let lock_key = concat_bytes(
                 [
                     &Infix::PropertyAnnotationCardinality.infix_id().bytes(),
                     &*owner.vertex().to_bytes(),
@@ -1927,7 +1918,7 @@ impl ThingManager {
         }
 
         for constraint in cardinality_constraints {
-            let lock_key = create_custom_lock_key(
+            let lock_key = concat_bytes(
                 [
                     &Infix::PropertyAnnotationCardinality.infix_id().bytes(),
                     &*player.vertex().to_bytes(),
@@ -1955,7 +1946,7 @@ impl ThingManager {
         }
 
         for constraint in cardinality_constraints {
-            let lock_key = create_custom_lock_key(
+            let lock_key = concat_bytes(
                 [
                     &Infix::PropertyAnnotationCardinality.infix_id().bytes(),
                     &*relation.vertex().to_bytes(),

--- a/concept/thing/thing_manager.rs
+++ b/concept/thing/thing_manager.rs
@@ -1857,7 +1857,7 @@ impl ThingManager {
         )?;
         if let Some(unique_constraint) = unique_constraint_opt {
             let attribute_key = attribute.vertex();
-            // Note: trade much smaller locks (eg. not entire string) for rare concurrent lock conflicts when
+            // Note: trade much smaller locks (eg. hashed large values) for rare concurrent lock conflicts when
             //       two different values has to the same hash
             let lock_key = concat_bytes(
                 [

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -58,12 +58,29 @@ rust_test(
     ]
 )
 
+rust_test(
+    name = "test_transaction_isolation",
+    srcs = glob([
+        "test_transaction_isolation.rs",
+    ]),
+    deps = [
+        "//common/options",
+        "//database",
+        "//executor",
+        "//storage",
+        "//util/test:test_utils",
+
+        "@typeql//rust:typeql",
+    ]
+)
+
 rustfmt_test(
     name = "rustfmt_test",
     targets = [
         ":test_database",
         ":test_transaction",
         ":test_statistics_synchronization",
+        ":test_transaction_isolation",
     ],
     size = "small",
 )

--- a/database/tests/BUILD
+++ b/database/tests/BUILD
@@ -66,6 +66,7 @@ rust_test(
     deps = [
         "//common/options",
         "//database",
+        "//encoding",
         "//executor",
         "//storage",
         "//util/test:test_utils",

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -4,14 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-//! Concurrency / isolation regression tests.
-//!
-//! Each test opens two write transactions whose snapshots were taken before either commits, runs
-//! conflicting (or deliberately non-conflicting) writes in each, then commits both and asserts on
-//! the outcomes. This is the canonical pattern for exercising commit-time isolation locks: lock-key
-//! contention surfaces only when both transactions reach commit with overlapping write sets, so the
-//! ordering of `open / write / write / commit / commit` matters.
-
 use std::sync::Arc;
 
 use database::{
@@ -133,7 +125,7 @@ fn concurrent_deletes_of_identical_entity_one_fails() {
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; delete $p;"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -163,7 +155,7 @@ fn concurrent_deletes_of_identical_relation_one_fails() {
     tx2 = run_write(tx2, r#"match $f isa friendship, has rid 100; delete $f;"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 /////////////////////////////////
@@ -190,6 +182,7 @@ fn concurrent_has_writes_with_owns_cardinality_one_fails() {
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
     get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -198,7 +191,7 @@ fn concurrent_has_deletes_violating_owns_cardinality_lower_bound_one_fails() {
     // with two names. Two concurrent has-deletes from different snapshots, each removing one of
     // them, would drop the owner to 0 names if both committed - falling below the lower bound.
     // The cardinality commit lock must serialise them and reject one.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -214,8 +207,8 @@ fn concurrent_has_deletes_violating_owns_cardinality_lower_bound_one_fails() {
     tx1 = run_write(tx1, r#"match $p isa person, has id 1; $n isa name "alice"; delete has $n of $p;"#);
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; $n isa name "bob"; delete has $n of $p;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -243,7 +236,7 @@ fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -280,7 +273,7 @@ fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
     // type's instance must still serialise on the (instance, owns) commit lock - the constraint
     // is sourced from the parent owns and the lock-key composition uses the constraint's source
     // attribute type, so subtypes inherit both the constraint and the lock identity.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -297,8 +290,8 @@ fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
     tx1 = run_write(tx1, r#"match $s isa student, has id 1; insert $s has name "alice";"#);
     tx2 = run_write(tx2, r#"match $s isa student, has id 1; insert $s has name "bob";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -352,7 +345,7 @@ fn concurrent_has_writes_violating_unique_one_fails() {
     tx2 = run_write(tx2, r#"match $p isa person, has id 2; insert $p has email "shared@example.com";"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -362,7 +355,7 @@ fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() 
     // The unique commit lock is keyed by `unique_constraint.source().owner().vertex()` and
     // `source().attribute().vertex()` - both resolve to the parent's owns - so the lock key is
     // identical regardless of which subtype the runtime instance has. One transaction must fail.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -386,8 +379,8 @@ fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() 
     tx1 = run_write(tx1, r#"match $s isa student, has id 1; insert $s has email "shared@example.com";"#);
     tx2 = run_write(tx2, r#"match $t isa teacher, has id 2; insert $t has email "shared@example.com";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 ////////////////////////////
@@ -411,7 +404,7 @@ fn concurrent_has_writes_violating_inline_key_one_fails() {
     tx2 = run_write(tx2, r#"insert $p isa person, has ref 1;"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -439,7 +432,7 @@ fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
     tx2 = run_write(tx2, &query);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -448,7 +441,7 @@ fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
     // Two concurrent inserts each create a different subtype (student, teacher) but with the
     // same key value. The conflict is on the parent type's interpretation of (type + key value):
     // the unique commit lock keyed by the source Owns serialises them and rejects one.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -464,8 +457,8 @@ fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
     tx1 = run_write(tx1, r#"insert $s isa student, has ref 1;"#);
     tx2 = run_write(tx2, r#"insert $t isa teacher, has ref 1;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 ////////////////////////////////////////
@@ -508,7 +501,7 @@ fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
     );
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 #[test]
@@ -546,7 +539,7 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
     );
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
 ////////////////////////////////////////////////
@@ -572,12 +565,13 @@ fn concurrent_has_write_and_owner_delete_one_fails() {
     tx_write = run_write(tx_write, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
 
     let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
+// TODO: ideally, this wouldn't fail. In fact, if we were to insert the attribute rather than match-insert it,
+//       this should always succeed as we always create the attribtue
 #[test]
 fn concurrent_has_write_and_attribute_delete_one_fails() {
-    // TODO: verify this should fail?
     let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
@@ -601,7 +595,7 @@ fn concurrent_has_write_and_attribute_delete_one_fails() {
     tx_write = run_write(tx_write, r#"match $p isa person, has id 1; $n isa name "alice"; insert $p has $n;"#);
 
     let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
 #[test]
@@ -634,7 +628,7 @@ fn concurrent_player_link_and_relation_delete_one_fails() {
     );
 
     let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
 #[test]
@@ -667,5 +661,5 @@ fn concurrent_player_link_and_player_delete_one_fails() {
     );
 
     let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
-    get_isolation_conflict(&err);
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -598,6 +598,40 @@ fn concurrent_has_write_and_attribute_delete_one_fails() {
     assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
+// Companion of the test above for the alternative (no-match) write formulation called out in the
+// TODO: tx_write uses `insert $p has name "alice"` without first `match`-ing the existing
+// attribute. Each insert independently materialises (or finds) the attribute by its value-encoded
+// vertex, so the write does not "require" the existing key. Pinning the actual behaviour here -
+// if a future change makes pure-insert succeed (the noted ideal), this test will fail and prompt
+// updating the assertion.
+#[test]
+fn concurrent_has_insert_without_match_and_attribute_delete_one_fails() {
+    let (_tmp, database) = create_reset_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..);
+            attribute id, value integer;
+            attribute name @independent, value string;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $p isa person, has id 1;
+            $n isa name "alice";
+        "#,
+    );
+
+    let mut tx_delete = open_write(database.clone());
+    let mut tx_write = open_write(database.clone());
+    tx_delete = run_write(tx_delete, r#"match $n isa name "alice"; delete $n;"#);
+    tx_write = run_write(tx_write, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+
+    let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
+}
+
 #[test]
 fn concurrent_player_link_and_relation_delete_one_fails() {
     let (_tmp, database) = create_reset_database();

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -568,8 +568,6 @@ fn concurrent_has_write_and_owner_delete_one_fails() {
     assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
-// TODO: ideally, this wouldn't fail. In fact, if we were to insert the attribute rather than match-insert it,
-//       this should always succeed as we always create the attribtue
 #[test]
 fn concurrent_has_write_and_attribute_delete_one_fails() {
     let (_tmp, database) = create_reset_database();
@@ -598,14 +596,9 @@ fn concurrent_has_write_and_attribute_delete_one_fails() {
     assert_eq!(get_isolation_conflict(&err), &IsolationConflict::RequireDeletedKey);
 }
 
-// Companion of the test above for the alternative (no-match) write formulation called out in the
-// TODO: tx_write uses `insert $p has name "alice"` without first `match`-ing the existing
-// attribute. Each insert independently materialises (or finds) the attribute by its value-encoded
-// vertex, so the write does not "require" the existing key. Pinning the actual behaviour here -
-// if a future change makes pure-insert succeed (the noted ideal), this test will fail and prompt
-// updating the assertion.
+// TODO: We in the past used to have this be allowed? Slightly more lax - not a large difference
 #[test]
-fn concurrent_has_insert_without_match_and_attribute_delete_one_fails() {
+fn concurrent_has_insert_new_attribute_deleting_attribute() {
     let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -203,6 +203,32 @@ fn concurrent_has_writes_violating_owns_cardinality_one_fails() {
 }
 
 #[test]
+fn concurrent_has_deletes_violating_owns_cardinality_lower_bound_one_fails() {
+    // Mirror of the upper-bound test: owner cardinality is 1..2 for `name`. The owner starts
+    // with two names. Two concurrent has-deletes from different snapshots, each removing one of
+    // them, would drop the owner to 0 names if both committed - falling below the lower bound.
+    // The cardinality commit lock must serialise them and reject one.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(1..2);
+            attribute id, value integer;
+            attribute name @independent, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1, has name "alice", has name "bob";"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; $n isa name "alice"; delete has $n of $p;"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 1; $n isa name "bob"; delete has $n of $p;"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
 fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_within_bound() {
     // Owner cardinality is 0..2: combined writes would stay within the bound, so the constraint
     // is not actually violated. But the cardinality commit lock is intentionally coarse - it is

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -20,6 +20,7 @@ use database::{
     query::{execute_schema_query, execute_write_query_in_write},
     transaction::{CommitIntent, DataCommitError, TransactionSchema, TransactionWrite},
 };
+use encoding::graph::thing::vertex_attribute::StringAttributeID;
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions};
 use storage::{
@@ -29,7 +30,7 @@ use test_utils::{TempDir, init_logging};
 
 const DB_NAME: &str = "isolation-test";
 
-fn fresh_database() -> (TempDir, Arc<Database<WALClient>>) {
+fn create_reset_database() -> (TempDir, Arc<Database<WALClient>>) {
     init_logging();
     let tmp_dir = test_utils::create_tmp_storage_dir();
     let dbm = DatabaseManager::new(&tmp_dir).unwrap();
@@ -76,9 +77,7 @@ fn try_commit(tx: TransactionWrite<WALClient>) -> Result<(), DataCommitError> {
     intent.and_then(|intent| intent.commit(profile.commit_profile()))
 }
 
-/// Assert exactly one of two commit outcomes succeeded and the other failed. Returns the failure
-/// for the caller to inspect.
-fn assert_exactly_one_failed(a: Result<(), DataCommitError>, b: Result<(), DataCommitError>) -> DataCommitError {
+fn get_only_commit_error(a: Result<(), DataCommitError>, b: Result<(), DataCommitError>) -> DataCommitError {
     match (a, b) {
         (Ok(()), Err(err)) | (Err(err), Ok(())) => err,
         (Ok(()), Ok(())) => panic!("expected one commit to fail with isolation conflict; both succeeded"),
@@ -86,11 +85,7 @@ fn assert_exactly_one_failed(a: Result<(), DataCommitError>, b: Result<(), DataC
     }
 }
 
-/// Match the full error chain down to `StorageCommitError::Isolation` and return the inner
-/// `IsolationConflict`. Uses the most specific (deepest) variants in each layer rather than a
-/// substring match on `Debug`, so a refactor of higher-level error types or unrelated error
-/// variants won't silently mask a regression in commit-time isolation.
-fn assert_isolation_conflict(err: &DataCommitError) -> &IsolationConflict {
+fn get_isolation_conflict(err: &DataCommitError) -> &IsolationConflict {
     match err {
         DataCommitError::SnapshotError {
             typedb_source: SnapshotError::Commit { typedb_source: StorageCommitError::Isolation { conflict, .. } },
@@ -107,10 +102,8 @@ fn assert_isolation_conflict(err: &DataCommitError) -> &IsolationConflict {
 //////////////////////////////////////////
 
 #[test]
-fn concurrent_inserts_of_identical_type_entity_and_relation_both_succeed() {
-    // Inserts of fresh entities/relations of identical type from concurrent transactions both
-    // succeed: each transaction allocates its own IIDs, so the lock keys never overlap.
-    let (_tmp, database) = fresh_database();
+fn concurrent_inserts_of_new_entity_and_relation_both_succeed() {
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -130,7 +123,7 @@ fn concurrent_inserts_of_identical_type_entity_and_relation_both_succeed() {
 
 #[test]
 fn concurrent_deletes_of_identical_entity_one_fails() {
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(database.clone(), "define entity person, owns id @key; attribute id, value integer;");
     commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
 
@@ -139,13 +132,13 @@ fn concurrent_deletes_of_identical_entity_one_fails() {
     tx1 = run_write(tx1, r#"match $p isa person, has id 1; delete $p;"#);
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; delete $p;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_deletes_of_identical_relation_one_fails() {
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -169,8 +162,8 @@ fn concurrent_deletes_of_identical_relation_one_fails() {
     tx1 = run_write(tx1, r#"match $f isa friendship, has rid 100; delete $f;"#);
     tx2 = run_write(tx2, r#"match $f isa friendship, has rid 100; delete $f;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 /////////////////////////////////
@@ -178,11 +171,8 @@ fn concurrent_deletes_of_identical_relation_one_fails() {
 /////////////////////////////////
 
 #[test]
-fn concurrent_has_writes_violating_owns_cardinality_one_fails() {
-    // Owner cardinality is 0..1 for `name`. Two concurrent has-writes from different snapshots,
-    // each adding a name to the same person, would push the owner to 2 names if both committed -
-    // exceeding the upper bound. The cardinality commit lock must serialise them and reject one.
-    let (_tmp, database) = fresh_database();
+fn concurrent_has_writes_with_owns_cardinality_one_fails() {
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -198,8 +188,8 @@ fn concurrent_has_writes_violating_owns_cardinality_one_fails() {
     tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
@@ -236,11 +226,7 @@ fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_
     // transaction validates against its own snapshot and would otherwise both pass through and
     // commit a sum that violates the bound. So both writes contend on the same lock and one is
     // rejected as an isolation conflict, even though the resulting state would be valid.
-    //
-    // This test pins that behaviour: if it ever changes (e.g., to a finer-grained scheme that
-    // permits non-violating concurrent writes), this test will fail and prompt review of the
-    // cardinality lock-key composition.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -256,16 +242,13 @@ fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_
     tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
     tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_has_writes_to_different_owners_with_bounded_cardinality_both_succeed() {
-    // Bounded cardinality on owns, but the two concurrent writes target *different* owners. The
-    // cardinality lock is keyed by owner + owns, so the two transactions take disjoint locks and
-    // never contend.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -319,11 +302,8 @@ fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
 }
 
 #[test]
-fn concurrent_has_writes_without_owns_cardinality_both_succeed() {
-    // `@card(0..)` is treated as unchecked - no validation is required and no commit lock is
-    // taken. Concurrent has-writes against the same owner and attribute type therefore never
-    // contend, regardless of how many entries each transaction adds.
-    let (_tmp, database) = fresh_database();
+fn concurrent_has_writes_with_unlimited_cardinality_both_succeed() {
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -349,11 +329,7 @@ fn concurrent_has_writes_without_owns_cardinality_both_succeed() {
 
 #[test]
 fn concurrent_has_writes_violating_unique_one_fails() {
-    // @unique requires the (attribute_value, owner_type) pair to map to a single owner instance.
-    // Two persons each acquiring `has email "x"` in concurrent snapshots would result in two
-    // owners of the same value-of-attribute - violating @unique. The unique commit lock must
-    // serialise them.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -375,8 +351,8 @@ fn concurrent_has_writes_violating_unique_one_fails() {
     tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has email "shared@example.com";"#);
     tx2 = run_write(tx2, r#"match $p isa person, has id 2; insert $p has email "shared@example.com";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
@@ -420,10 +396,7 @@ fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() 
 
 #[test]
 fn concurrent_has_writes_violating_inline_key_one_fails() {
-    // @key = @card(1..1) + @unique. Two new entities each claiming the same key value race; the
-    // commit lock on the key value must reject one. Integer attributes are inlineable, so this
-    // exercises the inline branch of the unique commit lock.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -437,17 +410,14 @@ fn concurrent_has_writes_violating_inline_key_one_fails() {
     tx1 = run_write(tx1, r#"insert $p isa person, has ref 1;"#);
     tx2 = run_write(tx2, r#"insert $p isa person, has ref 1;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
-    // String @key with a value longer than the inline threshold (16 bytes) - the AttributeID
-    // routes through the hashed encoding (prefix+hash+disambiguator), so the commit lock is
-    // built from `attribute_id().deterministic_bytes()` which strips the disambiguator. Two
-    // concurrent inserts of the same hashed string-keyed value must contend.
-    let (_tmp, database) = fresh_database();
+    // String @key with a value longer than the inline threshold (16 bytes)
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -457,7 +427,10 @@ fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
     );
 
     let key_value = "a-string-key-long-enough-to-force-hashed-encoding";
-    debug_assert!(key_value.len() > 16, "must exceed StringAttributeID inline threshold to hit the hashed path");
+    debug_assert!(
+        key_value.len() > StringAttributeID::INLINE_OR_PREFIXED_HASH_LENGTH,
+        "must exceed StringAttributeID inline threshold to hit the hashed path"
+    );
     let query = format!(r#"insert $p isa person, has ref "{key_value}";"#);
 
     let mut tx1 = open_write(database.clone());
@@ -465,8 +438,8 @@ fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
     tx1 = run_write(tx1, &query);
     tx2 = run_write(tx2, &query);
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
@@ -501,15 +474,9 @@ fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
 
 #[test]
 fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
-    // Bounded @card on `relates`: two concurrent transactions each link a different new player
-    // to the same role of the same relation. Each transaction's snapshot sees the relation with
-    // a single padding player and adds one - within the 0..2 bound. The relates cardinality
-    // commit lock is keyed by (relation, role_type) and serialises them; one is rejected.
-    //
     // The padding player is needed so `cleanup_relations` doesn't auto-delete an empty
-    // friendship at setup-commit time (TypeQL has no surface syntax to mark a relation type as
-    // independent).
-    let (_tmp, database) = fresh_database();
+    // friendship at setup-commit time
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -540,17 +507,13 @@ fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
         r#"match $f isa friendship, has rid 100; $p isa person, has id 2; insert $f links (friend: $p);"#,
     );
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
-    // Bounded @card on `plays`: a single player is linked into the role from two concurrent
-    // transactions but in different relations. Each transaction sees zero existing links for the
-    // player, so operation-time validation passes; the plays cardinality lock keyed by
-    // (player, role_type) must reject one at commit.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -582,8 +545,8 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
         r#"match $g isa friendship, has rid 200; $p isa person, has id 1; insert $g links (friend: $p);"#,
     );
 
-    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    get_isolation_conflict(&err);
 }
 
 ////////////////////////////////////////////////
@@ -592,10 +555,7 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
 
 #[test]
 fn concurrent_has_write_and_owner_delete_one_fails() {
-    // Entity-vs-edge: tx1 deletes the owner; tx2 (snapshot taken before tx1's commit) inserts a
-    // `has` on that owner. The owner's existence is read by tx2 (via the match) and deleted by
-    // tx1 - storage MVCC reports `DeletingRequiredKey` / `RequireDeletedKey` depending on order.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -611,15 +571,14 @@ fn concurrent_has_write_and_owner_delete_one_fails() {
     tx_delete = run_write(tx_delete, r#"match $p isa person, has id 1; delete $p;"#);
     tx_write = run_write(tx_write, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_has_write_and_attribute_delete_one_fails() {
-    // Attribute-vs-edge: tx1 deletes an independent attribute; tx2 inserts a `has` referencing
-    // that attribute. The `has` edge points to a key tx1 deletes - one commit must fail.
-    let (_tmp, database) = fresh_database();
+    // TODO: verify this should fail?
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -641,15 +600,13 @@ fn concurrent_has_write_and_attribute_delete_one_fails() {
     tx_delete = run_write(tx_delete, r#"match $n isa name "alice"; delete $n;"#);
     tx_write = run_write(tx_write, r#"match $p isa person, has id 1; $n isa name "alice"; insert $p has $n;"#);
 
-    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_player_link_and_relation_delete_one_fails() {
-    // Relation-vs-edge: tx_delete deletes the relation, tx_write links a player to it. The
-    // padding player keeps the friendship alive past the setup commit's `cleanup_relations`.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -676,15 +633,13 @@ fn concurrent_player_link_and_relation_delete_one_fails() {
         r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
     );
 
-    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
+    get_isolation_conflict(&err);
 }
 
 #[test]
 fn concurrent_player_link_and_player_delete_one_fails() {
-    // Entity-vs-edge (player side): tx_delete deletes the player entity, tx_write links the same
-    // player into a relation.
-    let (_tmp, database) = fresh_database();
+    let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
         r#"define
@@ -711,6 +666,6 @@ fn concurrent_player_link_and_player_delete_one_fails() {
         r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
     );
 
-    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
-    assert_isolation_conflict(&err);
+    let err = get_only_commit_error(try_commit(tx_delete), try_commit(tx_write));
+    get_isolation_conflict(&err);
 }

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -1,0 +1,344 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Concurrency / isolation regression tests.
+//!
+//! Each test opens two write transactions whose snapshots were taken before either commits, runs
+//! conflicting (or deliberately non-conflicting) writes in each, then commits both and asserts on
+//! the outcomes. This is the canonical pattern for exercising commit-time isolation locks: lock-key
+//! contention surfaces only when both transactions reach commit with overlapping write sets, so the
+//! ordering of `open / write / write / commit / commit` matters.
+
+use std::sync::Arc;
+
+use database::{
+    Database,
+    database_manager::DatabaseManager,
+    query::{execute_schema_query, execute_write_query_in_write},
+    transaction::{CommitIntent, DataCommitError, TransactionSchema, TransactionWrite},
+};
+use executor::ExecutionInterrupt;
+use options::{QueryOptions, TransactionOptions};
+use storage::durability_client::WALClient;
+use test_utils::{TempDir, init_logging};
+
+const DB_NAME: &str = "isolation-test";
+
+fn fresh_database() -> (TempDir, Arc<Database<WALClient>>) {
+    init_logging();
+    let tmp_dir = test_utils::create_tmp_storage_dir();
+    let dbm = DatabaseManager::new(&tmp_dir).unwrap();
+    dbm.put_database(DB_NAME).unwrap();
+    let database = dbm.database(DB_NAME).unwrap();
+    (tmp_dir, database)
+}
+
+fn commit_schema(database: Arc<Database<WALClient>>, schema: &str) {
+    let parsed = typeql::parse_query(schema).unwrap().into_structure().into_schema();
+    let tx = TransactionSchema::open(database, TransactionOptions::default()).unwrap();
+    let (tx, result) = execute_schema_query(tx, parsed, schema.to_string());
+    result.unwrap();
+    let (mut profile, intent) = tx.finalise();
+    intent.unwrap().commit(profile.commit_profile()).unwrap();
+}
+
+fn commit_write_query(database: Arc<Database<WALClient>>, query: &str) {
+    let mut tx = TransactionWrite::open(database, TransactionOptions::default()).unwrap();
+    tx = run_write(tx, query);
+    let (mut profile, intent) = tx.finalise();
+    intent.unwrap().commit(profile.commit_profile()).unwrap();
+}
+
+fn open_write(database: Arc<Database<WALClient>>) -> TransactionWrite<WALClient> {
+    TransactionWrite::open(database, TransactionOptions::default()).unwrap()
+}
+
+fn run_write(tx: TransactionWrite<WALClient>, query: &str) -> TransactionWrite<WALClient> {
+    let pipeline = typeql::parse_query(query).unwrap().into_structure().into_pipeline();
+    let (tx, result) = execute_write_query_in_write(
+        tx,
+        QueryOptions::default_grpc(),
+        pipeline,
+        query.to_string(),
+        ExecutionInterrupt::new_uninterruptible(),
+    );
+    result.unwrap_or_else(|err| panic!("write query failed: {query:?}: {err:?}"));
+    tx
+}
+
+fn try_commit(tx: TransactionWrite<WALClient>) -> Result<(), DataCommitError> {
+    let (mut profile, intent) = tx.finalise();
+    intent.and_then(|intent| intent.commit(profile.commit_profile()))
+}
+
+/// Assert exactly one of two commit outcomes succeeded and the other failed. Returns the failure
+/// for the caller to inspect.
+fn assert_exactly_one_failed(a: Result<(), DataCommitError>, b: Result<(), DataCommitError>) -> DataCommitError {
+    match (a, b) {
+        (Ok(()), Err(err)) | (Err(err), Ok(())) => err,
+        (Ok(()), Ok(())) => panic!("expected one commit to fail with isolation conflict; both succeeded"),
+        (Err(a), Err(b)) => panic!("expected exactly one commit to fail; both failed: a={a:?} b={b:?}"),
+    }
+}
+
+fn assert_isolation_conflict(err: &DataCommitError) {
+    let formatted = format!("{err:?}");
+    assert!(
+        formatted.contains("Isolation") || formatted.contains("isolation conflict"),
+        "expected an isolation conflict error, got: {formatted}"
+    );
+}
+
+//////////////////////////////////////////
+// Concurrent insert/delete of the same //
+// identical entity and relation        //
+//////////////////////////////////////////
+
+#[test]
+fn concurrent_inserts_of_identical_type_entity_and_relation_both_succeed() {
+    // Inserts of fresh entities/relations of identical type from concurrent transactions both
+    // succeed: each transaction allocates its own IIDs, so the lock keys never overlap.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person;
+            relation friendship, relates friend @card(0..);
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, "insert $p isa person; $f isa friendship;");
+    tx2 = run_write(tx2, "insert $p isa person; $f isa friendship;");
+
+    try_commit(tx1).expect("tx1 commit");
+    try_commit(tx2).expect("tx2 commit");
+}
+
+#[test]
+fn concurrent_deletes_of_identical_entity_one_fails() {
+    let (_tmp, database) = fresh_database();
+    commit_schema(database.clone(), "define entity person, owns id @key; attribute id, value integer;");
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; delete $p;"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 1; delete $p;"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_deletes_of_identical_relation_one_fails() {
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, plays friendship:friend, owns id @key;
+            relation friendship, relates friend @card(0..), owns rid @key;
+            attribute id, value integer;
+            attribute rid, value integer;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $a isa person, has id 1;
+            $b isa person, has id 2;
+            $f isa friendship, links (friend: $a, friend: $b), has rid 100;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $f isa friendship, has rid 100; delete $f;"#);
+    tx2 = run_write(tx2, r#"match $f isa friendship, has rid 100; delete $f;"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+/////////////////////////////////
+// Concurrent owns cardinality //
+/////////////////////////////////
+
+#[test]
+fn concurrent_has_writes_violating_owns_cardinality_one_fails() {
+    // Owner cardinality is 0..1 for `name`. Two concurrent has-writes from different snapshots,
+    // each adding a name to the same person, would push the owner to 2 names if both committed -
+    // exceeding the upper bound. The cardinality commit lock must serialise them and reject one.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..1);
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_has_writes_with_bounded_owns_cardinality_always_contend_even_when_within_bound() {
+    // Owner cardinality is 0..2: combined writes would stay within the bound, so the constraint
+    // is not actually violated. But the cardinality commit lock is intentionally coarse - it is
+    // keyed by (owner, owns(attribute_type)) without inspecting current counts, because each
+    // transaction validates against its own snapshot and would otherwise both pass through and
+    // commit a sum that violates the bound. So both writes contend on the same lock and one is
+    // rejected as an isolation conflict, even though the resulting state would be valid.
+    //
+    // This test pins that behaviour: if it ever changes (e.g., to a finer-grained scheme that
+    // permits non-violating concurrent writes), this test will fail and prompt review of the
+    // cardinality lock-key composition.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..2);
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_has_writes_to_different_owners_with_bounded_cardinality_both_succeed() {
+    // Bounded cardinality on owns, but the two concurrent writes target *different* owners. The
+    // cardinality lock is keyed by owner + owns, so the two transactions take disjoint locks and
+    // never contend.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..1);
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $a isa person, has id 1;
+            $b isa person, has id 2;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 2; insert $p has name "bob";"#);
+
+    try_commit(tx1).expect("tx1 commit");
+    try_commit(tx2).expect("tx2 commit");
+}
+
+#[test]
+fn concurrent_has_writes_without_owns_cardinality_both_succeed() {
+    // `@card(0..)` is treated as unchecked - no validation is required and no commit lock is
+    // taken. Concurrent has-writes against the same owner and attribute type therefore never
+    // contend, regardless of how many entries each transaction adds.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..);
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 1; insert $p has name "bob";"#);
+
+    try_commit(tx1).expect("tx1 commit");
+    try_commit(tx2).expect("tx2 commit");
+}
+
+///////////////////////////////
+// Concurrent @unique on has //
+///////////////////////////////
+
+#[test]
+fn concurrent_has_writes_violating_unique_one_fails() {
+    // @unique requires the (attribute_value, owner_type) pair to map to a single owner instance.
+    // Two persons each acquiring `has email "x"` in concurrent snapshots would result in two
+    // owners of the same value-of-attribute - violating @unique. The unique commit lock must
+    // serialise them.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns email @unique;
+            attribute id, value integer;
+            attribute email, value string;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $a isa person, has id 1;
+            $b isa person, has id 2;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $p isa person, has id 1; insert $p has email "shared@example.com";"#);
+    tx2 = run_write(tx2, r#"match $p isa person, has id 2; insert $p has email "shared@example.com";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+////////////////////////////
+// Concurrent @key on has //
+////////////////////////////
+
+#[test]
+fn concurrent_has_writes_violating_key_one_fails() {
+    // @key = @card(1..1) + @unique. Two new entities each claiming the same key value race; the
+    // commit lock on the key value must reject one.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns ref @key;
+            attribute ref, value integer;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"insert $p isa person, has ref 1;"#);
+    tx2 = run_write(tx2, r#"insert $p isa person, has ref 1;"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -292,6 +292,33 @@ fn concurrent_has_writes_to_different_owners_with_bounded_cardinality_both_succe
 }
 
 #[test]
+fn concurrent_has_writes_violating_inherited_owns_cardinality_one_fails() {
+    // Cardinality constraint is declared on the parent's owns. Two concurrent writes on a child
+    // type's instance must still serialise on the (instance, owns) commit lock - the constraint
+    // is sourced from the parent owns and the lock-key composition uses the constraint's source
+    // attribute type, so subtypes inherit both the constraint and the lock identity.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..1);
+            entity student sub person;
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $s isa student, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $s isa student, has id 1; insert $s has name "alice";"#);
+    tx2 = run_write(tx2, r#"match $s isa student, has id 1; insert $s has name "bob";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
 fn concurrent_has_writes_without_owns_cardinality_both_succeed() {
     // `@card(0..)` is treated as unchecked - no validation is required and no commit lock is
     // taken. Concurrent has-writes against the same owner and attribute type therefore never
@@ -352,6 +379,41 @@ fn concurrent_has_writes_violating_unique_one_fails() {
     assert_isolation_conflict(&err);
 }
 
+#[test]
+fn concurrent_has_writes_violating_inherited_unique_across_subtypes_one_fails() {
+    // @unique is declared on the parent (`person owns email @unique`). Two concurrent writes
+    // each insert the same email value but on *different* subtype instances (student, teacher).
+    // The unique commit lock is keyed by `unique_constraint.source().owner().vertex()` and
+    // `source().attribute().vertex()` - both resolve to the parent's owns - so the lock key is
+    // identical regardless of which subtype the runtime instance has. One transaction must fail.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns email @unique;
+            entity student sub person;
+            entity teacher sub person;
+            attribute id, value integer;
+            attribute email, value string;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $s isa student, has id 1;
+            $t isa teacher, has id 2;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $s isa student, has id 1; insert $s has email "shared@example.com";"#);
+    tx2 = run_write(tx2, r#"match $t isa teacher, has id 2; insert $t has email "shared@example.com";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
 ////////////////////////////
 // Concurrent @key on has //
 ////////////////////////////
@@ -402,6 +464,32 @@ fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
     let mut tx2 = open_write(database.clone());
     tx1 = run_write(tx1, &query);
     tx2 = run_write(tx2, &query);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_has_writes_violating_inherited_key_across_subtypes_one_fails() {
+    // @key is declared on the parent (`person owns ref @key`) and inherited by both subtypes.
+    // Two concurrent inserts each create a different subtype (student, teacher) but with the
+    // same key value. The conflict is on the parent type's interpretation of (type + key value):
+    // the unique commit lock keyed by the source Owns serialises them and rejects one.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns ref @key;
+            entity student sub person;
+            entity teacher sub person;
+            attribute ref, value integer;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"insert $s isa student, has ref 1;"#);
+    tx2 = run_write(tx2, r#"insert $t isa teacher, has ref 1;"#);
 
     let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
     assert_isolation_conflict(&err);

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -22,7 +22,9 @@ use database::{
 };
 use executor::ExecutionInterrupt;
 use options::{QueryOptions, TransactionOptions};
-use storage::durability_client::WALClient;
+use storage::{
+    StorageCommitError, durability_client::WALClient, isolation_manager::IsolationConflict, snapshot::SnapshotError,
+};
 use test_utils::{TempDir, init_logging};
 
 const DB_NAME: &str = "isolation-test";
@@ -84,12 +86,19 @@ fn assert_exactly_one_failed(a: Result<(), DataCommitError>, b: Result<(), DataC
     }
 }
 
-fn assert_isolation_conflict(err: &DataCommitError) {
-    let formatted = format!("{err:?}");
-    assert!(
-        formatted.contains("Isolation") || formatted.contains("isolation conflict"),
-        "expected an isolation conflict error, got: {formatted}"
-    );
+/// Match the full error chain down to `StorageCommitError::Isolation` and return the inner
+/// `IsolationConflict`. Uses the most specific (deepest) variants in each layer rather than a
+/// substring match on `Debug`, so a refactor of higher-level error types or unrelated error
+/// variants won't silently mask a regression in commit-time isolation.
+fn assert_isolation_conflict(err: &DataCommitError) -> &IsolationConflict {
+    match err {
+        DataCommitError::SnapshotError {
+            typedb_source: SnapshotError::Commit { typedb_source: StorageCommitError::Isolation { conflict, .. } },
+        } => conflict,
+        other => panic!(
+            "expected DataCommitError::SnapshotError(SnapshotError::Commit(StorageCommitError::Isolation)), got: {other:?}"
+        ),
+    }
 }
 
 //////////////////////////////////////////
@@ -322,9 +331,10 @@ fn concurrent_has_writes_violating_unique_one_fails() {
 ////////////////////////////
 
 #[test]
-fn concurrent_has_writes_violating_key_one_fails() {
+fn concurrent_has_writes_violating_inline_key_one_fails() {
     // @key = @card(1..1) + @unique. Two new entities each claiming the same key value race; the
-    // commit lock on the key value must reject one.
+    // commit lock on the key value must reject one. Integer attributes are inlineable, so this
+    // exercises the inline branch of the unique commit lock.
     let (_tmp, database) = fresh_database();
     commit_schema(
         database.clone(),
@@ -340,5 +350,253 @@ fn concurrent_has_writes_violating_key_one_fails() {
     tx2 = run_write(tx2, r#"insert $p isa person, has ref 1;"#);
 
     let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_has_writes_violating_hashed_string_key_one_fails() {
+    // String @key with a value longer than the inline threshold (16 bytes) - the AttributeID
+    // routes through the hashed encoding (prefix+hash+disambiguator), so the commit lock is
+    // built from `attribute_id().deterministic_bytes()` which strips the disambiguator. Two
+    // concurrent inserts of the same hashed string-keyed value must contend.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns ref @key;
+            attribute ref, value string;
+        "#,
+    );
+
+    let key_value = "a-string-key-long-enough-to-force-hashed-encoding";
+    debug_assert!(key_value.len() > 16, "must exceed StringAttributeID inline threshold to hit the hashed path");
+    let query = format!(r#"insert $p isa person, has ref "{key_value}";"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, &query);
+    tx2 = run_write(tx2, &query);
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+////////////////////////////////////////
+// Concurrent relates/plays @card     //
+////////////////////////////////////////
+
+#[test]
+fn concurrent_player_links_with_bounded_relates_cardinality_one_fails() {
+    // Bounded @card on `relates`: two concurrent transactions each link a different new player
+    // to the same role of the same relation. Each transaction's snapshot sees the relation with
+    // a single padding player and adds one - within the 0..2 bound. The relates cardinality
+    // commit lock is keyed by (relation, role_type) and serialises them; one is rejected.
+    //
+    // The padding player is needed so `cleanup_relations` doesn't auto-delete an empty
+    // friendship at setup-commit time (TypeQL has no surface syntax to mark a relation type as
+    // independent).
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, plays friendship:friend;
+            relation friendship, relates friend @card(0..2), owns rid @key;
+            attribute id, value integer;
+            attribute rid, value integer;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $pad isa person, has id 0;
+            $a isa person, has id 1;
+            $b isa person, has id 2;
+            $f isa friendship, links (friend: $pad), has rid 100;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(
+        tx1,
+        r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
+    );
+    tx2 = run_write(
+        tx2,
+        r#"match $f isa friendship, has rid 100; $p isa person, has id 2; insert $f links (friend: $p);"#,
+    );
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
+    // Bounded @card on `plays`: a single player is linked into the role from two concurrent
+    // transactions but in different relations. Each transaction sees zero existing links for the
+    // player, so operation-time validation passes; the plays cardinality lock keyed by
+    // (player, role_type) must reject one at commit.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, plays friendship:friend @card(0..1);
+            relation friendship, relates friend @card(0..), owns rid @key;
+            attribute id, value integer;
+            attribute rid, value integer;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $pad1 isa person, has id 1001;
+            $pad2 isa person, has id 1002;
+            $p isa person, has id 1;
+            $f isa friendship, links (friend: $pad1), has rid 100;
+            $g isa friendship, links (friend: $pad2), has rid 200;
+        "#,
+    );
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(
+        tx1,
+        r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
+    );
+    tx2 = run_write(
+        tx2,
+        r#"match $g isa friendship, has rid 200; $p isa person, has id 1; insert $g links (friend: $p);"#,
+    );
+
+    let err = assert_exactly_one_failed(try_commit(tx1), try_commit(tx2));
+    assert_isolation_conflict(&err);
+}
+
+////////////////////////////////////////////////
+// Concurrent write/delete crossover          //
+////////////////////////////////////////////////
+
+#[test]
+fn concurrent_has_write_and_owner_delete_one_fails() {
+    // Entity-vs-edge: tx1 deletes the owner; tx2 (snapshot taken before tx1's commit) inserts a
+    // `has` on that owner. The owner's existence is read by tx2 (via the match) and deleted by
+    // tx1 - storage MVCC reports `DeletingRequiredKey` / `RequireDeletedKey` depending on order.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..);
+            attribute id, value integer;
+            attribute name, value string;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $p isa person, has id 1;"#);
+
+    let mut tx_delete = open_write(database.clone());
+    let mut tx_write = open_write(database.clone());
+    tx_delete = run_write(tx_delete, r#"match $p isa person, has id 1; delete $p;"#);
+    tx_write = run_write(tx_write, r#"match $p isa person, has id 1; insert $p has name "alice";"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_has_write_and_attribute_delete_one_fails() {
+    // Attribute-vs-edge: tx1 deletes an independent attribute; tx2 inserts a `has` referencing
+    // that attribute. The `has` edge points to a key tx1 deletes - one commit must fail.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, owns name @card(0..);
+            attribute id, value integer;
+            attribute name @independent, value string;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $p isa person, has id 1;
+            $n isa name "alice";
+        "#,
+    );
+
+    let mut tx_delete = open_write(database.clone());
+    let mut tx_write = open_write(database.clone());
+    tx_delete = run_write(tx_delete, r#"match $n isa name "alice"; delete $n;"#);
+    tx_write = run_write(tx_write, r#"match $p isa person, has id 1; $n isa name "alice"; insert $p has $n;"#);
+
+    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_player_link_and_relation_delete_one_fails() {
+    // Relation-vs-edge: tx_delete deletes the relation, tx_write links a player to it. The
+    // padding player keeps the friendship alive past the setup commit's `cleanup_relations`.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, plays friendship:friend;
+            relation friendship, relates friend @card(0..), owns rid @key;
+            attribute id, value integer;
+            attribute rid, value integer;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $pad isa person, has id 1001;
+            $p isa person, has id 1;
+            $f isa friendship, links (friend: $pad), has rid 100;
+        "#,
+    );
+
+    let mut tx_delete = open_write(database.clone());
+    let mut tx_write = open_write(database.clone());
+    tx_delete = run_write(tx_delete, r#"match $f isa friendship, has rid 100; delete $f;"#);
+    tx_write = run_write(
+        tx_write,
+        r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
+    );
+
+    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
+    assert_isolation_conflict(&err);
+}
+
+#[test]
+fn concurrent_player_link_and_player_delete_one_fails() {
+    // Entity-vs-edge (player side): tx_delete deletes the player entity, tx_write links the same
+    // player into a relation.
+    let (_tmp, database) = fresh_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            entity person, owns id @key, plays friendship:friend;
+            relation friendship, relates friend @card(0..), owns rid @key;
+            attribute id, value integer;
+            attribute rid, value integer;
+        "#,
+    );
+    commit_write_query(
+        database.clone(),
+        r#"insert
+            $pad isa person, has id 1001;
+            $p isa person, has id 1;
+            $f isa friendship, links (friend: $pad), has rid 100;
+        "#,
+    );
+
+    let mut tx_delete = open_write(database.clone());
+    let mut tx_write = open_write(database.clone());
+    tx_delete = run_write(tx_delete, r#"match $p isa person, has id 1; delete $p;"#);
+    tx_write = run_write(
+        tx_write,
+        r#"match $f isa friendship, has rid 100; $p isa person, has id 1; insert $f links (friend: $p);"#,
+    );
+
+    let err = assert_exactly_one_failed(try_commit(tx_delete), try_commit(tx_write));
     assert_isolation_conflict(&err);
 }

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -555,7 +555,7 @@ fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
             attribute id, value integer;
         "#,
     );
-    commit_write_query(database.clone(), r#"insert $t isa tsub, has id 1;"#);
+    commit_write_query(database.clone(), r#"insert $t isa t, has id 1;"#);
 
     let mut tx1 = open_write(database.clone());
     let mut tx2 = open_write(database.clone());

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -542,6 +542,52 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
     assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
 }
 
+#[test]
+fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
+    // tsub inherits `plays r_base:super_role @card(0..2)` from tbase and additionally declares
+    // `plays r:sub_role @card(0..1)`, where `r:sub_role` specialises `r_base:super_role`
+    // (via `r sub r_base` and `relates sub_role as super_role`). Playing the sub role
+    // specialises playing super, so the inherited super-cardinality constraint applies on
+    // either insert path.
+    //
+    // The plays-cardinality commit-lock loop in `add_exclusive_lock_for_plays_cardinality_constraint`
+    // emits one lock per applicable cardinality constraint - keyed by source role type - rather
+    // than a single lock per (player, role_type). So TX1 (linking via the specialised sub role)
+    // emits both the (tsub, sub_role) and the inherited (tbase, super_role) locks; TX2 (linking
+    // via the super role on the parent relation) emits the (tbase, super_role) lock. They
+    // overlap on the inherited constraint and one transaction is rejected.
+    //
+    // Pinned because the conflict relies entirely on that loop. A future "single lock per
+    // (player, role_type)" shortcut would silently let both transactions through, since
+    // `sub_role` and `super_role` are different role types - even though playing them on the
+    // same player can together violate the inherited super bound.
+    //
+    // Note: TX2 inserts via `r_base` (not `r`) because role specialization replaces the parent
+    // role on the child relation - `r` only exposes `sub_role`, while `super_role` remains
+    // available on `r_base`. The lock identity is determined by the source role type, not the
+    // relation type the link is created on.
+    let (_tmp, database) = create_reset_database();
+    commit_schema(
+        database.clone(),
+        r#"define
+            relation r_base, relates super_role @card(0..);
+            relation r sub r_base, relates sub_role as super_role @card(0..);
+            entity tbase, owns id @key, plays r_base:super_role @card(0..2);
+            entity tsub sub tbase, plays r:sub_role @card(0..1);
+            attribute id, value integer;
+        "#,
+    );
+    commit_write_query(database.clone(), r#"insert $t isa tsub, has id 1;"#);
+
+    let mut tx1 = open_write(database.clone());
+    let mut tx2 = open_write(database.clone());
+    tx1 = run_write(tx1, r#"match $t isa tsub, has id 1; insert $_ isa r, links (sub_role: $t);"#);
+    tx2 = run_write(tx2, r#"match $t isa tsub, has id 1; insert $_ isa r_base, links (super_role: $t);"#);
+
+    let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
+    assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);
+}
+
 ////////////////////////////////////////////////
 // Concurrent write/delete crossover          //
 ////////////////////////////////////////////////

--- a/database/tests/test_transaction_isolation.rs
+++ b/database/tests/test_transaction_isolation.rs
@@ -544,28 +544,6 @@ fn concurrent_player_links_with_bounded_plays_cardinality_one_fails() {
 
 #[test]
 fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
-    // tsub inherits `plays r_base:super_role @card(0..2)` from tbase and additionally declares
-    // `plays r:sub_role @card(0..1)`, where `r:sub_role` specialises `r_base:super_role`
-    // (via `r sub r_base` and `relates sub_role as super_role`). Playing the sub role
-    // specialises playing super, so the inherited super-cardinality constraint applies on
-    // either insert path.
-    //
-    // The plays-cardinality commit-lock loop in `add_exclusive_lock_for_plays_cardinality_constraint`
-    // emits one lock per applicable cardinality constraint - keyed by source role type - rather
-    // than a single lock per (player, role_type). So TX1 (linking via the specialised sub role)
-    // emits both the (tsub, sub_role) and the inherited (tbase, super_role) locks; TX2 (linking
-    // via the super role on the parent relation) emits the (tbase, super_role) lock. They
-    // overlap on the inherited constraint and one transaction is rejected.
-    //
-    // Pinned because the conflict relies entirely on that loop. A future "single lock per
-    // (player, role_type)" shortcut would silently let both transactions through, since
-    // `sub_role` and `super_role` are different role types - even though playing them on the
-    // same player can together violate the inherited super bound.
-    //
-    // Note: TX2 inserts via `r_base` (not `r`) because role specialization replaces the parent
-    // role on the child relation - `r` only exposes `sub_role`, while `super_role` remains
-    // available on `r_base`. The lock identity is determined by the source role type, not the
-    // relation type the link is created on.
     let (_tmp, database) = create_reset_database();
     commit_schema(
         database.clone(),
@@ -573,7 +551,7 @@ fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
             relation r_base, relates super_role @card(0..);
             relation r sub r_base, relates sub_role as super_role @card(0..);
             entity tbase, owns id @key, plays r_base:super_role @card(0..2);
-            entity tsub sub tbase, plays r:sub_role @card(0..1);
+            entity t sub tbase, plays r:sub_role @card(0..1);
             attribute id, value integer;
         "#,
     );
@@ -581,8 +559,8 @@ fn concurrent_player_links_via_super_and_specialised_sub_role_one_fails() {
 
     let mut tx1 = open_write(database.clone());
     let mut tx2 = open_write(database.clone());
-    tx1 = run_write(tx1, r#"match $t isa tsub, has id 1; insert $_ isa r, links (sub_role: $t);"#);
-    tx2 = run_write(tx2, r#"match $t isa tsub, has id 1; insert $_ isa r_base, links (super_role: $t);"#);
+    tx1 = run_write(tx1, r#"match $t isa t, has id 1; insert $_ isa r, links (sub_role: $t);"#);
+    tx2 = run_write(tx2, r#"match $t isa t, has id 1; insert $_ isa r_base, links (super_role: $t);"#);
 
     let err = get_only_commit_error(try_commit(tx1), try_commit(tx2));
     assert_eq!(get_isolation_conflict(&err), &IsolationConflict::ExclusiveLock);

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -180,7 +180,6 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 
     pub fn finalise(self) -> (TransactionProfile, Result<DataCommitIntent<D>, DataCommitError>) {
-        println!("HELLO - finalising write txn");
         let mut profile = self.profile;
         let commit_profile = profile.commit_profile();
         commit_profile.start();

--- a/database/transaction.rs
+++ b/database/transaction.rs
@@ -180,6 +180,7 @@ impl<D: DurabilityClient> TransactionWrite<D> {
     }
 
     pub fn finalise(self) -> (TransactionProfile, Result<DataCommitIntent<D>, DataCommitError>) {
+        println!("HELLO - finalising write txn");
         let mut profile = self.profile;
         let commit_profile = profile.commit_profile();
         commit_profile.start();

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -329,6 +329,45 @@ impl AttributeID {
         }
     }
 
+    pub fn deterministic_bytes(&self) -> &[u8] {
+        match self {
+            AttributeID::Boolean(boolean_id) => {
+                debug_assert!(BooleanAttributeID::is_inlineable());
+                boolean_id.bytes_ref()
+            }
+            AttributeID::Integer(integer_id) => {
+                debug_assert!(IntegerAttributeID::is_inlineable());
+                integer_id.bytes_ref()
+            }
+            AttributeID::Double(double_id) => {
+                debug_assert!(DoubleAttributeID::is_inlineable());
+                double_id.bytes_ref()
+            },
+            AttributeID::Decimal(decimal_id) => {
+                debug_assert!(DecimalAttributeID::is_inlineable());
+                decimal_id.bytes_ref()
+            },
+            AttributeID::Date(date_id) => {
+                debug_assert!(DateAttributeID::is_inlineable());
+                date_id.bytes_ref()
+            },
+            AttributeID::DateTime(date_time_id) => {
+                debug_assert!(DateTimeAttributeID::is_inlineable());
+                date_time_id.bytes_ref()
+            },
+            AttributeID::DateTimeTZ(date_time_tz_id) => {
+                debug_assert!(DateTimeTZAttributeID::is_inlineable());
+                date_time_tz_id.bytes_ref()
+            },
+            AttributeID::Duration(duration_id) => {
+                debug_assert!(DurationAttributeID::is_inlineable());
+                duration_id.bytes_ref()
+            },
+            AttributeID::String(string_id) => string_id.deterministic_bytes_ref(),
+            AttributeID::Struct(struct_id) => struct_id.deterministic_bytes_ref(),
+        }
+    }
+
     pub fn value_type_encoding_length(value_type_category: ValueTypeCategory) -> usize {
         match value_type_category {
             ValueTypeCategory::Boolean => BooleanAttributeID::LENGTH,
@@ -582,14 +621,9 @@ impl StringAttributeID {
         Self::HASHED_PREFIX_RANGE.end..Self::HASHED_PREFIX_RANGE.end + Self::HASHED_HASH_LENGTH;
     pub const HASHED_DISAMBIGUATED_HASH_RANGE: Range<usize> =
         Self::HASHED_HASH_RANGE.start..Self::HASHED_HASH_RANGE.end + 1;
-    // const HASHED_PREFIX_HASH_RANGE: Range<usize> =
-    //     Self::VALUE_TYPE_LENGTH..Self::VALUE_TYPE_LENGTH + Self::HASHED_ENCODING_LENGTH;
 
     const TAIL_IS_HASH_MASK: u8 = 0b1000_0000;
     const TAIL_INDEX: usize = Self::LENGTH - 1;
-
-    // pub const HASHED_ID_STRING_PREFIX_LENGTH: usize =
-    //     { StringAttributeID::INLINE_OR_PREFIXED_HASH_LENGTH - StringAttributeID::HASH_LENGTH };
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
         Self { bytes }
@@ -776,6 +810,14 @@ impl StringAttributeID {
     pub fn bytes_ref(&self) -> &[u8] {
         &self.bytes
     }
+
+    pub fn deterministic_bytes_ref(&self) -> &[u8] {
+        if self.is_inline() {
+            self.bytes_ref()
+        } else {
+            &self.bytes_ref()[0..Self::HASHED_HASH_RANGE.end]
+        }
+    }
 }
 
 impl HashedID<{ StringAttributeID::HASHED_HASH_LENGTH + 1 }> for StringAttributeID {
@@ -795,14 +837,6 @@ impl StructAttributeID {
 
     pub fn new(bytes: [u8; Self::LENGTH]) -> Self {
         Self { bytes }
-    }
-
-    pub fn bytes(&self) -> [u8; Self::LENGTH] {
-        self.bytes
-    }
-
-    pub fn bytes_ref(&self) -> &[u8] {
-        &self.bytes
     }
 
     pub(crate) fn build_hashed_id<const INLINE_LENGTH: usize, Snapshot>(
@@ -894,6 +928,18 @@ impl StructAttributeID {
 
     pub(crate) const fn is_inlineable() -> bool {
         false
+    }
+
+    pub fn bytes(&self) -> [u8; Self::LENGTH] {
+        self.bytes
+    }
+
+    pub fn bytes_ref(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    pub fn deterministic_bytes_ref(&self) -> &[u8] {
+        &self.bytes[0..Self::TAIL_INDEX]
     }
 }
 

--- a/encoding/graph/thing/vertex_attribute.rs
+++ b/encoding/graph/thing/vertex_attribute.rs
@@ -342,27 +342,27 @@ impl AttributeID {
             AttributeID::Double(double_id) => {
                 debug_assert!(DoubleAttributeID::is_inlineable());
                 double_id.bytes_ref()
-            },
+            }
             AttributeID::Decimal(decimal_id) => {
                 debug_assert!(DecimalAttributeID::is_inlineable());
                 decimal_id.bytes_ref()
-            },
+            }
             AttributeID::Date(date_id) => {
                 debug_assert!(DateAttributeID::is_inlineable());
                 date_id.bytes_ref()
-            },
+            }
             AttributeID::DateTime(date_time_id) => {
                 debug_assert!(DateTimeAttributeID::is_inlineable());
                 date_time_id.bytes_ref()
-            },
+            }
             AttributeID::DateTimeTZ(date_time_tz_id) => {
                 debug_assert!(DateTimeTZAttributeID::is_inlineable());
                 date_time_tz_id.bytes_ref()
-            },
+            }
             AttributeID::Duration(duration_id) => {
                 debug_assert!(DurationAttributeID::is_inlineable());
                 duration_id.bytes_ref()
-            },
+            }
             AttributeID::String(string_id) => string_id.deterministic_bytes_ref(),
             AttributeID::Struct(struct_id) => struct_id.deterministic_bytes_ref(),
         }
@@ -610,7 +610,7 @@ impl StringAttributeID {
     const VALUE_LENGTH_ID: ValueEncodingLength = ValueEncodingLength::Long;
     const LENGTH: usize = Self::VALUE_TYPE_LENGTH + Self::VALUE_LENGTH_ID.length();
 
-    const INLINE_OR_PREFIXED_HASH_LENGTH: usize = Self::VALUE_LENGTH_ID.length() - 1;
+    pub const INLINE_OR_PREFIXED_HASH_LENGTH: usize = Self::VALUE_LENGTH_ID.length() - 1;
 
     pub const HASHED_PREFIX_LENGTH: usize = Self::INLINE_OR_PREFIXED_HASH_LENGTH - Self::HASHED_HASH_LENGTH;
     pub const HASHED_HASH_LENGTH: usize = 8;
@@ -812,11 +812,7 @@ impl StringAttributeID {
     }
 
     pub fn deterministic_bytes_ref(&self) -> &[u8] {
-        if self.is_inline() {
-            self.bytes_ref()
-        } else {
-            &self.bytes_ref()[0..Self::HASHED_HASH_RANGE.end]
-        }
+        if self.is_inline() { self.bytes_ref() } else { &self.bytes_ref()[0..Self::HASHED_HASH_RANGE.end] }
     }
 }
 

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -303,6 +303,92 @@ fn attribute_id_deterministic_bytes() {
 }
 
 #[test]
+fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() {
+    // The unique/key commit-lock keys are derived from `AttributeID::deterministic_bytes()`. For
+    // two concurrent transactions writing `has X "shared"` to land on the same lock, the
+    // AttributeID computed independently by each snapshot for the same string value must produce
+    // equal `deterministic_bytes`. This test pins that property at the encoding layer:
+    // independently-opened snapshots, sharing only the underlying storage, must agree on the
+    // deterministic prefix - both for the easy case (no prior collisions) and for the
+    // forced-collision case where the disambiguator could otherwise diverge.
+    let (_tmp_dir, storage) = create_core_storage();
+    let type_id = TypeID::new(0);
+
+    // Inline string: trivially equal (the entire ID is the value bytes).
+    {
+        let mut snapshot_a = storage.clone().open_snapshot_write();
+        let mut snapshot_b = storage.clone().open_snapshot_write();
+        let generator = ThingVertexGenerator::new();
+        let s = "hi";
+        let s_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s);
+        let id_a = generator
+            .create_attribute_string(type_id, s_bytes.as_reference(), &mut snapshot_a)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        let id_b = generator
+            .create_attribute_string(type_id, s_bytes.as_reference(), &mut snapshot_b)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        assert_eq!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
+    }
+
+    // Hashed string, default hasher, no prior collisions: each snapshot independently arrives at
+    // disambiguator=0 and prefix+hash bytes are deterministic from the input alone. Full IDs are
+    // also equal here, but the property the lock relies on is the deterministic-bytes equality.
+    {
+        let mut snapshot_a = storage.clone().open_snapshot_write();
+        let mut snapshot_b = storage.clone().open_snapshot_write();
+        let generator = ThingVertexGenerator::new();
+        let s = "Hello world, this is a long attribute string to be encoded.";
+        let s_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s);
+        let id_a = generator
+            .create_attribute_string(type_id, s_bytes.as_reference(), &mut snapshot_a)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        let id_b = generator
+            .create_attribute_string(type_id, s_bytes.as_reference(), &mut snapshot_b)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        assert!(!id_a.is_inline() && !id_b.is_inline());
+        assert_eq!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
+    }
+
+    // Forced hash collision: two snapshots, each independently inserts a different long string
+    // sharing the same hash prefix. Each snapshot allocates disambiguator=0 (since neither sees
+    // the other's pending writes). The full IDs may differ in disambiguator across runs, but
+    // `deterministic_bytes_ref` strips that byte and must be equal.
+    {
+        const CONSTANT_HASH: u64 = 0;
+        let generator = ThingVertexGenerator::new_with_hasher(|_bytes| CONSTANT_HASH);
+        let mut snapshot_a = storage.clone().open_snapshot_write();
+        let mut snapshot_b = storage.clone().open_snapshot_write();
+        let s_a = "Hello world, this is using the same prefix - alpha branch.";
+        let s_b = "Hello world, this is using the same prefix - bravo branch.";
+        let s_a_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_a);
+        let s_b_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_b);
+        let id_a = generator
+            .create_attribute_string(type_id, s_a_bytes.as_reference(), &mut snapshot_a)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        let id_b = generator
+            .create_attribute_string(type_id, s_b_bytes.as_reference(), &mut snapshot_b)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        assert_eq!(
+            id_a.deterministic_bytes_ref(),
+            id_b.deterministic_bytes_ref(),
+            "hash-collided strings encoded in independent snapshots must agree on deterministic_bytes"
+        );
+    }
+}
+
+#[test]
 fn next_entity_and_relation_ids_are_determined_from_storage() {
     init_logging();
     let storage_path = create_tmp_storage_dir();

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -191,22 +191,13 @@ fn generate_struct_attribute_vertex() {
 }
 
 #[test]
-fn attribute_id_deterministic_bytes_strips_disambiguator_for_hashed_ids() {
-    // For inlineable value types (boolean, integer, ..., inline strings, ...) deterministic_bytes()
-    // must equal bytes() - the entire ID identifies the value.
-    //
-    // For hashed types (long strings, structs) deterministic_bytes() must drop the trailing
-    // disambiguator byte so that different hash-collided values produce equal lock keys. This is
-    // load-bearing for the unique-constraint commit lock - if disambiguator were included, two
-    // concurrent writes of two different values with equal hashes wouldn't contend on the same
-    // lock and could both pass through.
-
+fn attribute_id_deterministic_bytes() {
     let (_tmp_dir, storage) = create_core_storage();
     let mut snapshot = storage.clone().open_snapshot_write();
     let type_id = TypeID::new(0);
 
-    // 1. Inline value types and short strings (built via the public AttributeID::build_inline):
-    //    deterministic_bytes == bytes (the entire ID identifies the value).
+    // Inline value types and short strings (built via the public AttributeID::build_inline):
+    // deterministic_bytes == bytes (the entire ID identifies the value).
     {
         let inline_cases = [
             Value::Boolean(true),
@@ -230,7 +221,7 @@ fn attribute_id_deterministic_bytes_strips_disambiguator_for_hashed_ids() {
         assert!(short_id.unwrap_string().is_inline());
     }
 
-    // 3. Hashed strings, default hasher: deterministic_bytes drops the disambiguator byte.
+    // Hashed strings, default hasher: deterministic_bytes drops the disambiguator byte.
     {
         let long = "Hello world, this is a long attribute string to be encoded.";
         let long_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(long);
@@ -245,8 +236,8 @@ fn attribute_id_deterministic_bytes_strips_disambiguator_for_hashed_ids() {
         assert!(id.deterministic_bytes_ref().len() < id.bytes_ref().len());
     }
 
-    // 4. Hashed strings, forced hash collision: deterministic_bytes are equal for distinct
-    //    values that share the prefix and (forced) hash, even though disambiguators differ.
+    // Hashed strings, forced hash collision: deterministic_bytes are equal for distinct
+    // values that share the prefix and (forced) hash, even though disambiguators differ.
     {
         const CONSTANT_HASH: u64 = 0;
         let generator = ThingVertexGenerator::new_with_hasher(|_bytes| CONSTANT_HASH);
@@ -280,27 +271,7 @@ fn attribute_id_deterministic_bytes_strips_disambiguator_for_hashed_ids() {
         );
     }
 
-    // 5. Hashed strings, distinct hashes: deterministic_bytes differ.
-    {
-        let s_a = "Long alpha string used to distinguish hashes - branch A.";
-        let s_b = "Different long bravo content for a different hash - branch B.";
-        let s_a_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_a);
-        let s_b_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_b);
-        let generator = ThingVertexGenerator::new();
-        let id_a = generator
-            .create_attribute_string(type_id, s_a_bytes.as_reference(), &mut snapshot)
-            .unwrap()
-            .attribute_id()
-            .unwrap_string();
-        let id_b = generator
-            .create_attribute_string(type_id, s_b_bytes.as_reference(), &mut snapshot)
-            .unwrap()
-            .attribute_id()
-            .unwrap_string();
-        assert_ne!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
-    }
-
-    // 6. Structs, forced collision: deterministic_bytes are equal across disambiguators.
+    // Structs, forced collision: deterministic_bytes are equal across disambiguators.
     {
         const CONSTANT_HASH: u64 = 0;
         let generator = ThingVertexGenerator::new_with_hasher(|_bytes| CONSTANT_HASH);

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -15,12 +15,12 @@ use encoding::{
     graph::{
         Typed,
         thing::{
-            vertex_attribute::{StringAttributeID, StructAttributeID},
+            vertex_attribute::{AttributeID, StringAttributeID, StructAttributeID},
             vertex_generator::ThingVertexGenerator,
         },
         type_::{vertex::TypeID, vertex_generator::TypeVertexGenerator},
     },
-    value::{string_bytes::StringBytes, struct_bytes::StructBytes},
+    value::{string_bytes::StringBytes, struct_bytes::StructBytes, value::Value},
 };
 use resource::{constants::snapshot::BUFFER_KEY_INLINE, profile::CommitProfile};
 use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
@@ -187,6 +187,147 @@ fn generate_struct_attribute_vertex() {
             assert_eq!(collide_id.get_hash_hash(), CONSTANT_HASH.to_be_bytes()[0..StructAttributeID::HASH_LENGTH]);
             assert_eq!(collide_id.get_hash_disambiguator(), 2u8);
         }
+    }
+}
+
+#[test]
+fn attribute_id_deterministic_bytes_strips_disambiguator_for_hashed_ids() {
+    // For inlineable value types (boolean, integer, ..., inline strings, ...) deterministic_bytes()
+    // must equal bytes() - the entire ID identifies the value.
+    //
+    // For hashed types (long strings, structs) deterministic_bytes() must drop the trailing
+    // disambiguator byte so that different hash-collided values produce equal lock keys. This is
+    // load-bearing for the unique-constraint commit lock - if disambiguator were included, two
+    // concurrent writes of two different values with equal hashes wouldn't contend on the same
+    // lock and could both pass through.
+
+    let (_tmp_dir, storage) = create_core_storage();
+    let mut snapshot = storage.clone().open_snapshot_write();
+    let type_id = TypeID::new(0);
+
+    // 1. Inline value types and short strings (built via the public AttributeID::build_inline):
+    //    deterministic_bytes == bytes (the entire ID identifies the value).
+    {
+        let inline_cases = [
+            Value::Boolean(true),
+            Value::Boolean(false),
+            Value::Integer(42),
+            Value::Integer(-1),
+            Value::Double(3.14),
+            Value::String(std::borrow::Cow::Borrowed("hi")),
+        ];
+        for value in inline_cases {
+            let id = AttributeID::build_inline(value.as_reference());
+            assert_eq!(
+                id.deterministic_bytes(),
+                id.bytes(),
+                "inline value {:?} must have deterministic_bytes == bytes",
+                value
+            );
+        }
+        // The short-string case must hit the inline branch of StringAttributeID.
+        let short_id = AttributeID::build_inline(Value::String(std::borrow::Cow::Borrowed("hi")));
+        assert!(short_id.unwrap_string().is_inline());
+    }
+
+    // 3. Hashed strings, default hasher: deterministic_bytes drops the disambiguator byte.
+    {
+        let long = "Hello world, this is a long attribute string to be encoded.";
+        let long_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(long);
+        let vertex = ThingVertexGenerator::new()
+            .create_attribute_string(type_id, long_bytes.as_reference(), &mut snapshot)
+            .unwrap();
+        let id = vertex.attribute_id().unwrap_string();
+        assert!(!id.is_inline());
+        assert_eq!(id.deterministic_bytes_ref().len(), StringAttributeID::HASHED_HASH_RANGE.end);
+        assert_eq!(id.deterministic_bytes_ref(), &id.bytes_ref()[..StringAttributeID::HASHED_HASH_RANGE.end]);
+        // The trailing disambiguator byte must be excluded.
+        assert!(id.deterministic_bytes_ref().len() < id.bytes_ref().len());
+    }
+
+    // 4. Hashed strings, forced hash collision: deterministic_bytes are equal for distinct
+    //    values that share the prefix and (forced) hash, even though disambiguators differ.
+    {
+        const CONSTANT_HASH: u64 = 0;
+        let generator = ThingVertexGenerator::new_with_hasher(|_bytes| CONSTANT_HASH);
+
+        let s_a = "Hello world, this is using the same prefix - alpha branch.";
+        let s_b = "Hello world, this is using the same prefix - bravo branch.";
+        let s_a_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_a);
+        let s_b_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_b);
+        // Sanity: prefixes are equal so the hashed IDs share everything but the disambiguator.
+        assert_eq!(
+            s_a_bytes.bytes()[..StringAttributeID::HASHED_PREFIX_LENGTH],
+            s_b_bytes.bytes()[..StringAttributeID::HASHED_PREFIX_LENGTH]
+        );
+
+        let id_a = generator
+            .create_attribute_string(type_id, s_a_bytes.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        let id_b = generator
+            .create_attribute_string(type_id, s_b_bytes.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        assert_ne!(id_a.get_hash_disambiguator(), id_b.get_hash_disambiguator());
+        assert_ne!(id_a.bytes_ref(), id_b.bytes_ref());
+        assert_eq!(
+            id_a.deterministic_bytes_ref(),
+            id_b.deterministic_bytes_ref(),
+            "hash-collided strings with equal prefixes must produce equal deterministic_bytes"
+        );
+    }
+
+    // 5. Hashed strings, distinct hashes: deterministic_bytes differ.
+    {
+        let s_a = "Long alpha string used to distinguish hashes - branch A.";
+        let s_b = "Different long bravo content for a different hash - branch B.";
+        let s_a_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_a);
+        let s_b_bytes: StringBytes<BUFFER_KEY_INLINE> = StringBytes::build_ref(s_b);
+        let generator = ThingVertexGenerator::new();
+        let id_a = generator
+            .create_attribute_string(type_id, s_a_bytes.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        let id_b = generator
+            .create_attribute_string(type_id, s_b_bytes.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_string();
+        assert_ne!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
+    }
+
+    // 6. Structs, forced collision: deterministic_bytes are equal across disambiguators.
+    {
+        const CONSTANT_HASH: u64 = 0;
+        let generator = ThingVertexGenerator::new_with_hasher(|_bytes| CONSTANT_HASH);
+
+        let raw_a: [u8; 4] = [1, 2, 3, 4];
+        let raw_b: [u8; 4] = [9, 8, 7, 6];
+        let bytes_a: StructBytes<'_, BUFFER_KEY_INLINE> = StructBytes::new(Bytes::Array(ByteArray::copy(&raw_a)));
+        let bytes_b: StructBytes<'_, BUFFER_KEY_INLINE> = StructBytes::new(Bytes::Array(ByteArray::copy(&raw_b)));
+
+        let id_a = generator
+            .create_attribute_struct(type_id, bytes_a.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_struct();
+        let id_b = generator
+            .create_attribute_struct(type_id, bytes_b.as_reference(), &mut snapshot)
+            .unwrap()
+            .attribute_id()
+            .unwrap_struct();
+        assert_ne!(id_a.get_hash_disambiguator(), id_b.get_hash_disambiguator());
+        assert_ne!(id_a.bytes_ref(), id_b.bytes_ref());
+        assert_eq!(
+            id_a.deterministic_bytes_ref(),
+            id_b.deterministic_bytes_ref(),
+            "hash-collided structs must produce equal deterministic_bytes"
+        );
+        assert_eq!(id_a.deterministic_bytes_ref().len(), id_a.bytes_ref().len() - 1);
     }
 }
 

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -8,24 +8,27 @@
 
 use std::sync::Arc;
 
-use bytes::{byte_array::ByteArray, Bytes};
+use bytes::{Bytes, byte_array::ByteArray};
 use durability::wal::WAL;
 use encoding::{
+    EncodingKeyspace,
     graph::{
+        Typed,
         thing::{
             vertex_attribute::{AttributeID, StringAttributeID, StructAttributeID},
             vertex_generator::ThingVertexGenerator,
         },
         type_::{vertex::TypeID, vertex_generator::TypeVertexGenerator},
-        Typed,
     },
     value::{string_bytes::StringBytes, struct_bytes::StructBytes, value::Value},
-    EncodingKeyspace,
 };
 use resource::{constants::snapshot::BUFFER_KEY_INLINE, profile::CommitProfile};
-use storage::isolation_manager::IsolationConflict;
-use storage::snapshot::SnapshotError;
-use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage, StorageCommitError};
+use storage::{
+    MVCCStorage, StorageCommitError,
+    durability_client::WALClient,
+    isolation_manager::IsolationConflict,
+    snapshot::{CommittableSnapshot, SnapshotError},
+};
 use test_utils::{create_tmp_storage_dir, init_logging};
 use test_utils_encoding::create_core_storage;
 
@@ -336,10 +339,8 @@ fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() 
         assert_eq!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
     }
 
-
-    // Hashed string, default hasher, no prior collisions: each snapshot independently arrives at
-    // disambiguator=0 and prefix+hash bytes are deterministic from the input alone. Full IDs are
-    // also equal here, but the property the lock relies on is the deterministic-bytes equality.
+    // Hashed identical strings, default hasher should have identical prefixes and hashes,
+    // However, only one can commit to prevent races in setting the disambiguator
     {
         let mut snapshot_a = storage.clone().open_snapshot_write();
         let mut snapshot_b = storage.clone().open_snapshot_write();
@@ -358,6 +359,19 @@ fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() 
             .unwrap_string();
         assert!(!id_a.is_inline() && !id_b.is_inline());
         assert_eq!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
+
+        snapshot_a.commit(&mut CommitProfile::DISABLED).expect("First commit should succeed");
+        match snapshot_b.commit(&mut CommitProfile::DISABLED) {
+            Ok(_) => panic!("Expected hash collision to cause isolation error"),
+            Err(err) => {
+                assert!(matches!(
+                    err,
+                    SnapshotError::Commit {
+                        typedb_source: StorageCommitError::Isolation { conflict: IsolationConflict::ExclusiveLock, .. }
+                    }
+                ));
+            }
+        }
     }
 
     // Forced hash collision: two snapshots, each independently inserts a different long string
@@ -393,12 +407,12 @@ fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() 
         match snapshot_b.commit(&mut CommitProfile::DISABLED) {
             Ok(_) => panic!("Expected hash collision to cause isolation error"),
             Err(err) => {
-                assert!(
-                    matches!(
-                        err,
-                        SnapshotError::Commit { typedb_source: StorageCommitError::Isolation { conflict: IsolationConflict::ExclusiveLock, .. } }
-                    )
-                );
+                assert!(matches!(
+                    err,
+                    SnapshotError::Commit {
+                        typedb_source: StorageCommitError::Isolation { conflict: IsolationConflict::ExclusiveLock, .. }
+                    }
+                ));
             }
         }
     }

--- a/encoding/tests/test_attribute_vertex.rs
+++ b/encoding/tests/test_attribute_vertex.rs
@@ -8,22 +8,24 @@
 
 use std::sync::Arc;
 
-use bytes::{Bytes, byte_array::ByteArray};
+use bytes::{byte_array::ByteArray, Bytes};
 use durability::wal::WAL;
 use encoding::{
-    EncodingKeyspace,
     graph::{
-        Typed,
         thing::{
             vertex_attribute::{AttributeID, StringAttributeID, StructAttributeID},
             vertex_generator::ThingVertexGenerator,
         },
         type_::{vertex::TypeID, vertex_generator::TypeVertexGenerator},
+        Typed,
     },
     value::{string_bytes::StringBytes, struct_bytes::StructBytes, value::Value},
+    EncodingKeyspace,
 };
 use resource::{constants::snapshot::BUFFER_KEY_INLINE, profile::CommitProfile};
-use storage::{MVCCStorage, durability_client::WALClient, snapshot::CommittableSnapshot};
+use storage::isolation_manager::IsolationConflict;
+use storage::snapshot::SnapshotError;
+use storage::{durability_client::WALClient, snapshot::CommittableSnapshot, MVCCStorage, StorageCommitError};
 use test_utils::{create_tmp_storage_dir, init_logging};
 use test_utils_encoding::create_core_storage;
 
@@ -334,6 +336,7 @@ fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() 
         assert_eq!(id_a.deterministic_bytes_ref(), id_b.deterministic_bytes_ref());
     }
 
+
     // Hashed string, default hasher, no prior collisions: each snapshot independently arrives at
     // disambiguator=0 and prefix+hash bytes are deterministic from the input alone. Full IDs are
     // also equal here, but the property the lock relies on is the deterministic-bytes equality.
@@ -385,6 +388,19 @@ fn same_string_in_two_concurrent_snapshots_produces_equal_deterministic_bytes() 
             id_b.deterministic_bytes_ref(),
             "hash-collided strings encoded in independent snapshots must agree on deterministic_bytes"
         );
+
+        snapshot_a.commit(&mut CommitProfile::DISABLED).expect("First commit should succeed");
+        match snapshot_b.commit(&mut CommitProfile::DISABLED) {
+            Ok(_) => panic!("Expected hash collision to cause isolation error"),
+            Err(err) => {
+                assert!(
+                    matches!(
+                        err,
+                        SnapshotError::Commit { typedb_source: StorageCommitError::Isolation { conflict: IsolationConflict::ExclusiveLock, .. } }
+                    )
+                );
+            }
+        }
     }
 }
 

--- a/encoding/value/value_type.rs
+++ b/encoding/value/value_type.rs
@@ -182,6 +182,7 @@ pub enum ValueTypeCategory {
 
 impl ValueTypeCategory {
     pub const fn to_bytes(&self) -> [u8; ValueTypeBytes::CATEGORY_LENGTH] {
+        // WARNING: Order here must align with AttributeID enum ordering!!
         match self {
             Self::Boolean => [0],
             Self::Integer => [1],

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -302,7 +302,7 @@ pub(crate) enum CommitDependency {
     Conflict(IsolationConflict),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum IsolationConflict {
     DeletingRequiredKey,
     RequireDeletedKey,

--- a/storage/snapshot/lock.rs
+++ b/storage/snapshot/lock.rs
@@ -14,18 +14,3 @@ pub enum LockType {
     // Lock a new key to be written exclusively by one snapshot
     Exclusive,
 }
-
-pub fn create_custom_lock_key<'a, I, const SIZE: usize>(key_items: I) -> ByteArray<SIZE>
-where
-    I: Iterator<Item = &'a [u8]> + Clone,
-{
-    let total_len = key_items.clone().map(|item| item.len()).sum();
-    let mut bytes = ByteArray::zeros(total_len);
-    let mut start = 0;
-    for item in key_items {
-        let end = start + item.len();
-        bytes[start..end].copy_from_slice(item);
-        start = end;
-    }
-    bytes
-}


### PR DESCRIPTION
## Product change and motivation

TypeDB failed to validate race conditions between transactions writing attributes covered by `@key` or `@unique` ownerships. Now, a concurrent transaction creating an ownership of a keyed or uniquely-owned attribute will cause one of them to fail with an isolation conflict error, like:

```
Commit in database 'test' failed with isolation conflict: Transaction uses a lock held by a concurrent commit
```

## Implementation

- Update the byte array created in the storage-layer locks that cause subsequent transactions to fail
- Implement a series of isolation tests for transactions, including update-delete, key races, unique races, cardinality conflicts
- Add tests for attribute concept generation based on hashed values to ensure that concurrently committed attribute values that hash to the same prefix + hash also race and cause one transaction to fail (this was succeeding before)