### PR TITLE
Disable all warnings on optional return mismatches

### DIFF
--- a/ir/lib.rs
+++ b/ir/lib.rs
@@ -216,8 +216,14 @@ typedb_error! {
             variable: String,
             source_span: Option<Span>,
         ),
-        OptionalFunctionReturnReferenced(
+        WronglyMarkedOptionalAssignment(
             33,
+            "The variable '{variable}' was marked with a '?' but the assigned value is not optional",
+            variable: String,
+            source_span: Option<Span>,
+        ),
+        OptionalFunctionReturnReferenced(
+            34,
             "The variable '{variable}' is optionally assigned by a function return, and may not be referenced elsewhere in the same stage.",
             variable: String,
             source_span: Option<Span>,

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -423,11 +423,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Err(err) = mismatched_optionality_in_assignment {
-            use error::TypeDBError;
-            tracing::warn!(
-                "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
-                err.format_description()
-            );
+            // TODO: This has to wait till we finalize the spec
+            // use error::TypeDBError;
+            // tracing::warn!(
+            //     "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
+            //     err.format_description()
+            // );
         }
 
         let function_call =
@@ -477,11 +478,12 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             },
         );
         if let Err(err) = mismatched_optionality_in_assignment {
-            use error::TypeDBError;
-            tracing::warn!(
-                "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
-                err.format_description()
-            );
+            // TODO: This has to wait till we finalize the spec
+            // use error::TypeDBError;
+            // tracing::warn!(
+            //     "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
+            //     err.format_description()
+            // );
         }
         let function_call =
             self.create_function_call(&assigned, callee_signature, arguments, function_name, source_span)?;

--- a/ir/pattern/constraint.rs
+++ b/ir/pattern/constraint.rs
@@ -25,7 +25,10 @@ use crate::{
         conjunction::Conjunction,
         expression::{ExpressionRepresentationError, ExpressionTree},
         function_call::FunctionCall,
-        variable_category::{VariableCategory, VariableOptionality},
+        variable_category::{
+            VariableCategory, VariableOptionality,
+            VariableOptionality::{Optional, Required},
+        },
     },
     pipeline::{
         ParameterRegistry, VariableRegistry, block::BlockBuilderContext, function_signature::FunctionSignature,
@@ -403,25 +406,30 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
         }
 
         let callee_signature = builtin_id.signature();
-        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).find_map(
-            |(assigned_var, (_, declared_optionality))| {
-                (assigned_var.optionality != *declared_optionality).then_some(assigned_var.variable)
+        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).try_for_each(
+            |(assigned_var, (_, returned_optionality))| {
+                use crate::pattern::variable_category::VariableOptionality::{Optional, Required};
+                match (assigned_var.optionality, returned_optionality) {
+                    (Optional, Optional) | (Required, Required) => Ok(()),
+                    (Optional, Required) => Err(RepresentationError::WronglyMarkedOptionalAssignment {
+                        variable: self.context.get_variable_name_or_unnamed(assigned_var.variable).to_owned(),
+                        source_span,
+                    }),
+                    (Required, Optional) => Err(RepresentationError::UnmarkedOptionalAssignment {
+                        variable: self.context.get_variable_name_or_unnamed(assigned_var.variable).to_owned(),
+                        source_span,
+                    }),
+                }
             },
         );
-        if let Some(variable) = mismatched_optionality_in_assignment {
-            let variable = self.context.get_variable_name_or_unnamed(variable).to_owned();
+        if let Err(err) = mismatched_optionality_in_assignment {
             use error::TypeDBError;
             tracing::warn!(
-                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
-                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
-            );
-            // Fix for now:
-            assigned.iter_mut().zip(callee_signature.returns.iter()).for_each(
-                |(assigned_var, (_, declared_optionality))| {
-                    assigned_var.optionality = *declared_optionality;
-                },
+                "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
+                err.format_description()
             );
         }
+
         let function_call =
             self.create_function_call(&assigned, &callee_signature, arguments, builtin_id.name(), source_span)?;
         let binding = FunctionCallBinding::new(assigned, function_call, callee_signature.return_is_stream, source_span);
@@ -452,17 +460,27 @@ impl<'cx, 'reg> ConstraintsBuilder<'cx, 'reg> {
             let variable = self.context.get_variable_name_or_unnamed(variable.variable).to_owned();
             return Err(Box::new(RepresentationError::AssigningToInputVariable { variable, source_span }));
         }
-        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).find_map(
-            |(assigned_var, (_, declared_optionality))| {
-                (assigned_var.optionality != *declared_optionality).then_some(assigned_var.variable)
+        let mismatched_optionality_in_assignment = assigned.iter().zip(callee_signature.returns.iter()).try_for_each(
+            |(assigned_var, (_, returned_optionality))| {
+                use crate::pattern::variable_category::VariableOptionality::{Optional, Required};
+                match (assigned_var.optionality, returned_optionality) {
+                    (Optional, Optional) | (Required, Required) => Ok(()),
+                    (Optional, Required) => Err(RepresentationError::WronglyMarkedOptionalAssignment {
+                        variable: self.context.get_variable_name_or_unnamed(assigned_var.variable).to_owned(),
+                        source_span,
+                    }),
+                    (Required, Optional) => Err(RepresentationError::UnmarkedOptionalAssignment {
+                        variable: self.context.get_variable_name_or_unnamed(assigned_var.variable).to_owned(),
+                        source_span,
+                    }),
+                }
             },
         );
-        if let Some(variable) = mismatched_optionality_in_assignment {
-            let variable = self.context.get_variable_name_or_unnamed(variable).to_owned();
+        if let Err(err) = mismatched_optionality_in_assignment {
             use error::TypeDBError;
             tracing::warn!(
-                "Function call assigns to unmarked optional variable. This will fail in the next version:\n{}",
-                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
+                "The declared optionality of a variable assigned to by a function call did not match the optionality of the function return. This will fail in the next version:\n{}",
+                err.format_description()
             );
         }
         let function_call =

--- a/ir/pipeline/block.rs
+++ b/ir/pipeline/block.rs
@@ -269,12 +269,13 @@ fn validate_optional_returns_recursive(
     if let Some((var, source_span)) = reused_optional_return_opt {
         let variable = context.get_variable_name_or_unnamed(*var).to_owned();
         let source_span = source_span.clone();
-        // Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
-        use error::TypeDBError;
-        tracing::warn!(
-            "Function call reuses optionally assigned variable. This will fail in the next version:\n{}",
-            RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }.format_description()
-        );
+        // TODO: This has to wait till we finalize the spec
+        // // Err(Box::new(RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }))
+        // use error::TypeDBError;
+        // tracing::warn!(
+        //     "Function call reuses optionally assigned variable. This will fail in the next version:\n{}",
+        //     RepresentationError::OptionalFunctionReturnReferenced { variable, source_span }.format_description()
+        // );
         Ok(())
     } else {
         Ok(())

--- a/ir/translation/function.rs
+++ b/ir/translation/function.rs
@@ -308,16 +308,17 @@ fn check_consistent_return<T>(
         .enumerate()
         .find_map(|(index, (declared, actual))| (declared != actual).then_some(index));
     if let Some(mismatch_index) = mismatching_index_opt {
-        use error::TypeDBError;
-        tracing::warn!(
-            "Function has inconsistent return optionality. This will fail in the next version:\n{}",
-            FunctionRepresentationError::InconsistentReturnOptionality {
-                signature: signature.clone(),
-                return_: block.return_stmt.clone(),
-                mismatch_index,
-            }
-            .format_description()
-        );
+        // TODO: This has to wait till we finalize the spec
+        // use error::TypeDBError;
+        // tracing::warn!(
+        //     "Function has inconsistent return optionality. This will fail in the next version:\n{}",
+        //     FunctionRepresentationError::InconsistentReturnOptionality {
+        //         signature: signature.clone(),
+        //         return_: block.return_stmt.clone(),
+        //         mismatch_index,
+        //     }
+        //     .format_description()
+        // );
     }
 
     Ok(())

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -52,11 +52,12 @@ pub fn translate_reduce(
             }),
         };
         if let Err(err) = optionality_mismatch_check {
-            use error::TypeDBError;
-            tracing::warn!(
-                "The declared optionality of a variable assigned in a reduce stage did not match the optionality of the reducer result. This will fail in the next version:\n{}",
-                err.format_description()
-            );
+            // TODO: This has to wait till we finalize the spec
+            // use error::TypeDBError;
+            // tracing::warn!(
+            //     "The declared optionality of a variable assigned in a reduce stage did not match the optionality of the reducer result. This will fail in the next version:\n{}",
+            //     err.format_description()
+            // );
         }
         let assigned_var = context.register_reduced_variable(
             var_name,

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -4,7 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use error::TypeDBError;
 use typeql::{
+    Variable,
     common::Spanned,
     query::stage::reduce::Reducer as TypeQLReducer,
     token::{ReduceOperatorCollect as TypeQLReduceOperatorCollect, ReduceOperatorStat as TypeQLReduceOperatorStat},
@@ -13,10 +15,7 @@ use typeql::{
 use crate::{
     RepresentationError,
     pattern::variable_category::VariableCategory,
-    pipeline::{
-        VariableRegistry,
-        reduce::{AssignedReduction, Reduce, Reducer},
-    },
+    pipeline::reduce::{AssignedReduction, Reduce, Reducer},
     translation::{PipelineTranslationContext, verify_variable_available},
 };
 
@@ -36,10 +35,22 @@ pub fn translate_reduce(
     for reduce_assign in &typeql_reduce.reduce_assignments {
         let reducer = build_reducer(context, &reduce_assign.reducer)?;
         let (category, is_optional) = resolve_category_optionality(&reducer);
-        let var_name =
-            reduce_assign.variable.name().ok_or(Box::new(RepresentationError::NonAnonymousVariableExpected {
-                source_span: reduce_assign.variable.span(),
-            }))?;
+        let var_name = reduce_assign.variable.name().ok_or_else(|| {
+            Box::new(RepresentationError::NonAnonymousVariableExpected { source_span: reduce_assign.variable.span() })
+        })?;
+        let optionality_matches = match &reduce_assign.variable {
+            Variable::Anonymous { optional, .. } | Variable::Named { optional, .. } => {
+                optional.is_some() == is_optional
+            }
+        };
+        if !optionality_matches {
+            let source_span = reduce_assign.variable.span();
+            let variable = var_name.to_owned();
+            tracing::warn!(
+                "Reduce result is optional, but assigned a variable not marked with a '?'. This will fail in the next version:\n{}",
+                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
+            );
+        }
         let assigned_var = context.register_reduced_variable(
             var_name,
             category,

--- a/ir/translation/reduce.rs
+++ b/ir/translation/reduce.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use error::TypeDBError;
 use typeql::{
     Variable,
     common::Spanned,
@@ -34,27 +33,35 @@ pub fn translate_reduce(
     let mut reductions = Vec::with_capacity(typeql_reduce.reduce_assignments.len());
     for reduce_assign in &typeql_reduce.reduce_assignments {
         let reducer = build_reducer(context, &reduce_assign.reducer)?;
-        let (category, is_optional) = resolve_category_optionality(&reducer);
+        let (category, returned_is_optional) = resolve_category_optionality(&reducer);
         let var_name = reduce_assign.variable.name().ok_or_else(|| {
             Box::new(RepresentationError::NonAnonymousVariableExpected { source_span: reduce_assign.variable.span() })
         })?;
-        let optionality_matches = match &reduce_assign.variable {
-            Variable::Anonymous { optional, .. } | Variable::Named { optional, .. } => {
-                optional.is_some() == is_optional
-            }
+        let assigned_is_optional = match &reduce_assign.variable {
+            Variable::Anonymous { optional, .. } | Variable::Named { optional, .. } => optional.is_some(),
         };
-        if !optionality_matches {
-            let source_span = reduce_assign.variable.span();
-            let variable = var_name.to_owned();
+        let optionality_mismatch_check = match (assigned_is_optional, returned_is_optional) {
+            (true, true) | (false, false) => Ok(()),
+            (true, false) => Err(RepresentationError::WronglyMarkedOptionalAssignment {
+                variable: var_name.to_owned(),
+                source_span: reduce_assign.variable.span(),
+            }),
+            (false, true) => Err(RepresentationError::UnmarkedOptionalAssignment {
+                variable: var_name.to_owned(),
+                source_span: reduce_assign.variable.span(),
+            }),
+        };
+        if let Err(err) = optionality_mismatch_check {
+            use error::TypeDBError;
             tracing::warn!(
-                "Reduce result is optional, but assigned a variable not marked with a '?'. This will fail in the next version:\n{}",
-                RepresentationError::UnmarkedOptionalAssignment { variable, source_span }.format_description()
+                "The declared optionality of a variable assigned in a reduce stage did not match the optionality of the reducer result. This will fail in the next version:\n{}",
+                err.format_description()
             );
         }
         let assigned_var = context.register_reduced_variable(
             var_name,
             category,
-            is_optional,
+            returned_is_optional,
             reduce_assign.variable.span(),
             reducer,
         )?;


### PR DESCRIPTION
## Product change and motivation
Disable all warnings on optional return mismatches, till the spec is finalised


## Implementation
Adds (disabled) log warning when a variable that is assigned an optional value by a reducer is not marked with '?'.
Makes reducer assignments consistent with the warnings we already have for optional function returns in match stages.