### PR TITLE
Add default advertise-address retrieved from listen-address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5769,7 +5769,7 @@ dependencies = [
 [[package]]
 name = "typedb-protocol"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typedb-protocol?rev=bbe3d61970817b34687eeb145890af6712b7eec6#bbe3d61970817b34687eeb145890af6712b7eec6"
+source = "git+https://github.com/typedb/typedb-protocol?rev=25ab3fb02715062bd036f8b83908de92b106a202#25ab3fb02715062bd036f8b83908de92b106a202"
 dependencies = [
  "prost",
  "tonic",
@@ -5830,7 +5830,7 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 [[package]]
 name = "typeql"
 version = "0.0.0"
-source = "git+https://github.com/typedb/typeql?rev=42ba8021d028e03b8a63f983b50997cd99d983c7#42ba8021d028e03b8a63f983b50997cd99d983c7"
+source = "git+https://github.com/typedb/typeql?rev=a1fae91ebd68ed2d7b2eb5035c1287c3bc66789b#a1fae91ebd68ed2d7b2eb5035c1287c3bc66789b"
 dependencies = [
  "chrono",
  "itertools 0.14.0",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -119,7 +119,7 @@ native_artifact_files.artifact(
     name = "typedb_console_artifact",
     group_name = "typedb-console-{platform}",
     artifact_name = "typedb-console-{platform}-{version}.{ext}",
-    tag = "3.10.0-alpha-1",
+    commit = "e8e5a70125f86250268e30cd22d25312ca89e46b",
 )
 use_repo(
     native_artifact_files,

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -12364,7 +12364,7 @@
     "@@typedb_dependencies+//distribution/artifact:rules.bzl%native_artifact_files": {
       "general": {
         "bzlTransitiveDigest": "yWzTgvDt8fBQR7Nqh9/tbk6sCtvxjbcgODtEIg/m+Nw=",
-        "usagesDigest": "k14Z2uvBMkHdEkPHvRwuTfzPJ4SRA2gg13NpASfxRmQ=",
+        "usagesDigest": "ZLsW6rzEo9tuDXuH34GLeDsHHVnHchqZeFgBEzSOEFw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -12373,45 +12373,45 @@
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-arm64/versions/3.10.0-alpha-1/typedb-console-linux-arm64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-console-linux-arm64/versions/e8e5a70125f86250268e30cd22d25312ca89e46b/typedb-console-linux-arm64-e8e5a70125f86250268e30cd22d25312ca89e46b.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-arm64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-arm64-e8e5a70125f86250268e30cd22d25312ca89e46b.tar.gz"
             }
           },
           "typedb_console_artifact_linux-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-linux-x86_64/versions/3.10.0-alpha-1/typedb-console-linux-x86_64-3.10.0-alpha-1.tar.gz"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-console-linux-x86_64/versions/e8e5a70125f86250268e30cd22d25312ca89e46b/typedb-console-linux-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.tar.gz"
               ],
-              "downloaded_file_path": "typedb-console-linux-x86_64-3.10.0-alpha-1.tar.gz"
+              "downloaded_file_path": "typedb-console-linux-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.tar.gz"
             }
           },
           "typedb_console_artifact_mac-arm64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-arm64/versions/3.10.0-alpha-1/typedb-console-mac-arm64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-console-mac-arm64/versions/e8e5a70125f86250268e30cd22d25312ca89e46b/typedb-console-mac-arm64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-arm64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-console-mac-arm64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
             }
           },
           "typedb_console_artifact_mac-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-mac-x86_64/versions/3.10.0-alpha-1/typedb-console-mac-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-console-mac-x86_64/versions/e8e5a70125f86250268e30cd22d25312ca89e46b/typedb-console-mac-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
               ],
-              "downloaded_file_path": "typedb-console-mac-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-console-mac-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
             }
           },
           "typedb_console_artifact_windows-x86_64": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
               "urls": [
-                "https://repo.typedb.com/public/public-release/raw/names/typedb-console-windows-x86_64/versions/3.10.0-alpha-1/typedb-console-windows-x86_64-3.10.0-alpha-1.zip"
+                "https://repo.typedb.com/public/public-snapshot/raw/names/typedb-console-windows-x86_64/versions/e8e5a70125f86250268e30cd22d25312ca89e46b/typedb-console-windows-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
               ],
-              "downloaded_file_path": "typedb-console-windows-x86_64-3.10.0-alpha-1.zip"
+              "downloaded_file_path": "typedb-console-windows-x86_64-e8e5a70125f86250268e30cd22d25312ca89e46b.zip"
             }
           }
         },

--- a/server/config.yml
+++ b/server/config.yml
@@ -4,11 +4,11 @@
 
 server:
     listen-address: 0.0.0.0:1729
-    advertise-address: 127.0.0.1:1729
+    advertise-address:
     http:
         enabled: true
         listen-address: 0.0.0.0:8000
-        advertise-address: http://127.0.0.1:8000
+        advertise-address:
     admin:
         enabled: true
         port: 1728

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -9,7 +9,12 @@ pub mod server_operator;
 pub mod transaction_operator;
 pub mod user_operator;
 
-use std::{collections::HashSet, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    path::PathBuf,
+    sync::Arc,
+};
 
 use concurrency::{IntervalRunner, TokioTaskSpawner};
 use database::database_manager::DatabaseManager;
@@ -219,17 +224,29 @@ impl ServerState {
             .ok_or_else(|| ServerOpenError::AddressResolutionEmpty { address: address.to_string() })
     }
 
+    fn default_advertise_address(listen: SocketAddr) -> String {
+        if listen.ip().is_unspecified() {
+            let loopback = if listen.is_ipv4() { IpAddr::V4(Ipv4Addr::LOCALHOST) } else { IpAddr::V6(Ipv6Addr::LOCALHOST) };
+            SocketAddr::new(loopback, listen.port()).to_string()
+        } else {
+            listen.to_string()
+        }
+    }
+
     async fn resolve_endpoints(
         config: &crate::parameters::config::ServerConfig,
     ) -> Result<(SocketAddr, Option<SocketAddr>, LocalServerStatus), ServerOpenError> {
         let grpc_listen_address = Self::resolve_address(&config.listen_address).await?;
-        let grpc_advertise_address =
-            config.advertise_address.clone().unwrap_or_else(|| grpc_listen_address.to_string());
+        let grpc_advertise_address = config
+            .advertise_address
+            .clone()
+            .unwrap_or_else(|| Self::default_advertise_address(grpc_listen_address));
 
         let http_listen_address =
             if config.http.enabled { Some(Self::resolve_address(&config.http.listen_address).await?) } else { None };
-        let http_advertise_address = http_listen_address
-            .map(|listen| config.http.advertise_address.clone().unwrap_or_else(|| listen.to_string()));
+        let http_advertise_address = http_listen_address.map(|listen| {
+            config.http.advertise_address.clone().unwrap_or_else(|| Self::default_advertise_address(listen))
+        });
 
         let admin_address = if config.admin.enabled {
             Some(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, config.admin.port)))
@@ -349,5 +366,34 @@ impl ServerStateBuilder {
             transaction_operator,
             user_operator,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+
+    use super::ServerState;
+
+    fn default_advertise_address(input: &str) -> String {
+        ServerState::default_advertise_address(input.parse::<SocketAddr>().unwrap())
+    }
+
+    #[test]
+    fn ipv4_wildcard_resolves_to_loopback() {
+        assert_eq!(default_advertise_address("0.0.0.0:1729"), "127.0.0.1:1729");
+        assert_eq!(default_advertise_address("0.0.0.0:8000"), "127.0.0.1:8000");
+    }
+
+    #[test]
+    fn ipv6_wildcard_resolves_to_loopback() {
+        assert_eq!(default_advertise_address("[::]:1729"), "[::1]:1729");
+    }
+
+    #[test]
+    fn explicit_listen_address_is_kept_as_is() {
+        assert_eq!(default_advertise_address("127.0.0.1:1729"), "127.0.0.1:1729");
+        assert_eq!(default_advertise_address("192.168.1.10:1729"), "192.168.1.10:1729");
+        assert_eq!(default_advertise_address("[2001:db8::1]:1729"), "[2001:db8::1]:1729");
     }
 }

--- a/server/state/mod.rs
+++ b/server/state/mod.rs
@@ -226,7 +226,8 @@ impl ServerState {
 
     fn default_advertise_address(listen: SocketAddr) -> String {
         if listen.ip().is_unspecified() {
-            let loopback = if listen.is_ipv4() { IpAddr::V4(Ipv4Addr::LOCALHOST) } else { IpAddr::V6(Ipv6Addr::LOCALHOST) };
+            let loopback =
+                if listen.is_ipv4() { IpAddr::V4(Ipv4Addr::LOCALHOST) } else { IpAddr::V6(Ipv6Addr::LOCALHOST) };
             SocketAddr::new(loopback, listen.port()).to_string()
         } else {
             listen.to_string()
@@ -237,10 +238,8 @@ impl ServerState {
         config: &crate::parameters::config::ServerConfig,
     ) -> Result<(SocketAddr, Option<SocketAddr>, LocalServerStatus), ServerOpenError> {
         let grpc_listen_address = Self::resolve_address(&config.listen_address).await?;
-        let grpc_advertise_address = config
-            .advertise_address
-            .clone()
-            .unwrap_or_else(|| Self::default_advertise_address(grpc_listen_address));
+        let grpc_advertise_address =
+            config.advertise_address.clone().unwrap_or_else(|| Self::default_advertise_address(grpc_listen_address));
 
         let http_listen_address =
             if config.http.enabled { Some(Self::resolve_address(&config.http.listen_address).await?) } else { None };


### PR DESCRIPTION
## Product change and motivation

Remove pre-inserted `advertise-address` values from server endpoints configuration. Instead, auto-generate the advertise addresses based on the listen addresses following these rules:
* if the listen address is an unspecified address (`0.0.0.0`), substitute the IP with loopback `127.0.0.1`, preserving the original port -- this allows the clients to use `127.0.0.1` instead of `0.0.0.0` for connections, which is usually the intention;
* otherwise, use the listen address for advertising as is.

This reduces the amount of fields required for modifications in case the user wants to change the default server ports and helps avoid sudden misconfigurations while operating with local servers.

Nothing changed for default configuration:

```
./typedb server

=====================================================================================
     ________ __      __ _____    _______  _____    _____       _______  _______
    |__    __|\  \  /  /|   _  \ |   _   ||   _  \ |   _  \    |   _   ||   _   |
       |  |    \  \/  / |  | |  ||  | |__||  | |  ||  | |  |   |  | |  ||  | |__|
       |  |     \    /  |  |/  / |  |___  |  | |  ||  |/  /    |  | |__||  |___
       |  |      |  |   |   __/  |   ___| |  | |  ||   _  \    |  |  __ |   ___|
       |  |      |  |   |  |     |  |  __ |  | |  ||  | |  |   |  | |  ||  |  __
       |  |      |  |   |  |     |  |_|  ||  |/  / |  |/  /    |  |_|  ||  |_|  |
       |__|      |__|   |__|     |_______||_____/  |_____/     |_______||_______|

=====================================================================================

Running TypeDB CE 3.10.4 in development mode.
Serving:
  gRPC:  0.0.0.0:1729 (connect via 127.0.0.1:1729)
  HTTP:  0.0.0.0:8000 (connect via 127.0.0.1:8000)
  Admin: 127.0.0.1:1728 (localhost only)
TLS: disabled
  WARNING: TLS NOT ENABLED. Credentials are transmitted unencrypted in plaintext.
  Drivers must be configured to connect *without TLS*.
```

## Implementation

Enhance the `unwrap_or_else` logic when building the server state.