### PR TITLE
Compress the content of docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,17 +422,17 @@ workflows:
       - deploy-docker-snapshot-x86_64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, docker-calf ]
 
       - deploy-docker-snapshot-arm64:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, docker-calf ]
 
       - deploy-docker-snapshot-multiarch:
           filters:
             branches:
-              only: [ master ]
+              only: [ master, docker-calf ]
           requires:
             - deploy-docker-snapshot-x86_64
             - deploy-docker-snapshot-arm64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,17 +422,17 @@ workflows:
       - deploy-docker-snapshot-x86_64:
           filters:
             branches:
-              only: [ master, docker-calf ]
+              only: [ master ]
 
       - deploy-docker-snapshot-arm64:
           filters:
             branches:
-              only: [ master, docker-calf ]
+              only: [ master ]
 
       - deploy-docker-snapshot-multiarch:
           filters:
             branches:
-              only: [ master, docker-calf ]
+              only: [ master ]
           requires:
             - deploy-docker-snapshot-x86_64
             - deploy-docker-snapshot-arm64

--- a/BUILD
+++ b/BUILD
@@ -289,6 +289,7 @@ pkg_tar(
     name = "docker-layer-x86_64",
     deps = [":assemble-server-linux-x86_64-targz"],
     package_dir = "/opt",
+    extension = "tar.gz",
 )
 
 oci_image(
@@ -312,6 +313,7 @@ pkg_tar(
     name = "docker-layer-arm64",
     deps = [":assemble-server-linux-arm64-targz"],
     package_dir = "/opt",
+    extension = "tar.gz",
 )
 
 oci_image(


### PR DESCRIPTION
## Product change and motivation

Reduce the size of the Docker image x2 (93 MB -> 53 MB prod, 361 MB -> 141 MB [snapshot](https://hub.docker.com/r/typedb/typedb-snapshot/tags)) by gzipping its layers explicitly in the Bazel configuration.

This change returns the size of the Docker image to the values of the pre-Bazel 8 releases.

## Implementation

Migration to Bazel 8 changed the rules we use to publish docker images. While using `oci_image`, the layers must be gzipped explicitly, since the rule stores them verbatim, unlike the legacy `rules_docker`'s `container_image`, which did this for us.
