### PR TITLE
Add state storage counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,8 @@ name = "resource"
 version = "0.0.0"
 dependencies = [
  "itertools 0.14.0",
+ "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,6 +4171,7 @@ dependencies = [
 name = "resource"
 version = "0.0.0"
 dependencies = [
+ "bincode",
  "itertools 0.14.0",
  "serde",
  "tracing",

--- a/database/database.rs
+++ b/database/database.rs
@@ -41,7 +41,10 @@ use error::typedb_error;
 use fail_point::{UNFINISHED_CHECKPOINT, fail_point};
 use function::{FunctionError, function_cache::FunctionCache};
 use query::query_cache::QueryCache;
-use resource::constants::database::{CHECKPOINT_INTERVAL, STATISTICS_UPDATE_INTERVAL};
+use resource::{
+    constants::database::{CHECKPOINT_INTERVAL, STATISTICS_UPDATE_INTERVAL},
+    state_counter::CounterId,
+};
 use storage::{
     MVCCStorage, StorageDeleteError, StorageOpenError, StorageResetError,
     durability_client::{DurabilityClient, DurabilityClientError, WALClient},
@@ -100,6 +103,10 @@ impl<D> Database<D> {
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    pub fn apply_counter_advances(&self, advances: &[(CounterId, u64)]) {
+        self.storage.state_counters().apply_advances(advances);
     }
 
     pub(super) fn reserve_write_transaction(&self, timeout_millis: u64) -> Result<(), TransactionError> {
@@ -487,10 +494,6 @@ impl Database<WALClient> {
         match Arc::get_mut(&mut self.type_vertex_generator) {
             None => return Err(CorruptionPartialResetTypeVertexGeneratorInUse {}),
             Some(type_vertex_generator) => type_vertex_generator.reset(),
-        }
-        match Arc::get_mut(&mut self.thing_vertex_generator) {
-            None => return Err(CorruptionPartialResetThingVertexGeneratorInUse {}),
-            Some(thing_vertex_generator) => thing_vertex_generator.reset(),
         }
 
         let thing_statistics = Arc::get_mut(&mut locked_schema.thing_statistics).unwrap();

--- a/database/tools/read_wal.rs
+++ b/database/tools/read_wal.rs
@@ -11,7 +11,7 @@ use concept::thing::statistics::Statistics;
 use durability::{DurabilitySequenceNumber, RawRecord, wal::WAL};
 use storage::{
     durability_client::{DurabilityClient, DurabilityRecord, WALClient},
-    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, LegacyCommitRecordV2, StatusRecord},
 };
 
 #[derive(Parser)]
@@ -67,6 +67,10 @@ fn print_record(record: RawRecord<'_>) {
             let legacy: LegacyCommitRecordV1 = deserialise_record(&record.bytes);
             print_commit(record.sequence_number, CommitRecord::from(legacy));
         }
+        LegacyCommitRecordV2::RECORD_TYPE => {
+            let legacy: LegacyCommitRecordV2 = deserialise_record(&record.bytes);
+            print_commit(record.sequence_number, CommitRecord::from(legacy));
+        }
         CommitRecord::RECORD_TYPE => print_commit(record.sequence_number, deserialise_record(&record.bytes)),
         StatusRecord::RECORD_TYPE => print_status(record.sequence_number, deserialise_record(&record.bytes)),
         Statistics::RECORD_TYPE => print_statistics(record.sequence_number, deserialise_record(&record.bytes)),
@@ -112,6 +116,7 @@ fn print_range(path: PathBuf, from: u64, to: Option<u64>) {
     let mut wal = WALClient::new(wal);
     wal.register_record_type::<Statistics>();
     wal.register_record_type::<LegacyCommitRecordV1>();
+    wal.register_record_type::<LegacyCommitRecordV2>();
     wal.register_record_type::<CommitRecord>();
     wal.register_record_type::<StatusRecord>();
 
@@ -132,6 +137,7 @@ fn print_at(path: PathBuf, sequence_number: Option<u64>) {
     let mut wal = WALClient::new(wal);
     wal.register_record_type::<Statistics>();
     wal.register_record_type::<LegacyCommitRecordV1>();
+    wal.register_record_type::<LegacyCommitRecordV2>();
     wal.register_record_type::<CommitRecord>();
     wal.register_record_type::<StatusRecord>();
 

--- a/database/tools/replay_wal.rs
+++ b/database/tools/replay_wal.rs
@@ -11,7 +11,7 @@ use concept::thing::statistics::Statistics;
 use durability::{DurabilitySequenceNumber, wal::WAL};
 use storage::{
     durability_client::{DurabilityClient, DurabilityRecord, WALClient},
-    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, LegacyCommitRecordV2, StatusRecord},
 };
 
 #[derive(Parser)]
@@ -41,6 +41,8 @@ struct Cli {
 #[derive(ValueEnum, Clone, Copy, PartialEq, Eq)]
 enum RecordKind {
     CommitRecord,
+    LegacyCommitRecordV1,
+    LegacyCommitRecordV2,
     CommitStatus,
     Statistics,
 }
@@ -53,6 +55,7 @@ fn main() {
     let mut source_wal = WALClient::new(source_wal);
     source_wal.register_record_type::<Statistics>();
     source_wal.register_record_type::<LegacyCommitRecordV1>();
+    source_wal.register_record_type::<LegacyCommitRecordV2>();
     source_wal.register_record_type::<CommitRecord>();
     source_wal.register_record_type::<StatusRecord>();
 
@@ -65,6 +68,7 @@ fn main() {
     let mut target_wal = WALClient::new(WAL::load(cli.target_directory).unwrap());
     target_wal.register_record_type::<Statistics>();
     target_wal.register_record_type::<LegacyCommitRecordV1>();
+    target_wal.register_record_type::<LegacyCommitRecordV2>();
     target_wal.register_record_type::<CommitRecord>();
     target_wal.register_record_type::<StatusRecord>();
 
@@ -77,9 +81,14 @@ fn main() {
         }
         match record.record_type {
             LegacyCommitRecordV1::RECORD_TYPE
-                if cli.kind.is_empty() || cli.kind.contains(&RecordKind::CommitRecord) =>
+                if cli.kind.is_empty() || cli.kind.contains(&RecordKind::LegacyCommitRecordV1) =>
             {
                 _ = target_wal.sequenced_write::<LegacyCommitRecordV1>(&deserialise_record(&record.bytes)).unwrap()
+            }
+            LegacyCommitRecordV2::RECORD_TYPE
+                if cli.kind.is_empty() || cli.kind.contains(&RecordKind::LegacyCommitRecordV2) =>
+            {
+                _ = target_wal.sequenced_write::<LegacyCommitRecordV2>(&deserialise_record(&record.bytes)).unwrap()
             }
             CommitRecord::RECORD_TYPE if cli.kind.is_empty() || cli.kind.contains(&RecordKind::CommitRecord) => {
                 _ = target_wal.sequenced_write::<CommitRecord>(&deserialise_record(&record.bytes)).unwrap()
@@ -91,6 +100,7 @@ fn main() {
                 target_wal.unsequenced_write::<Statistics>(&deserialise_record(&record.bytes)).unwrap()
             }
             LegacyCommitRecordV1::RECORD_TYPE
+            | LegacyCommitRecordV2::RECORD_TYPE
             | CommitRecord::RECORD_TYPE
             | StatusRecord::RECORD_TYPE
             | Statistics::RECORD_TYPE => (), // filtered out

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -71,6 +71,9 @@ impl ThingVertexGenerator {
         storage: Arc<MVCCStorage<D>>,
         large_value_hasher: fn(&[u8]) -> u64,
     ) -> Result<Self, EncodingError> {
+        // All counters are loaded from WAL commit records. However, legacy commit records do not
+        // contain state counters for this generator, so we must check the storage on load
+        // as far as there are legacy records on disk.
         Self::seed_state_counters_from_storage(storage)?;
         Ok(ThingVertexGenerator { large_value_hasher })
     }

--- a/encoding/graph/thing/vertex_generator.rs
+++ b/encoding/graph/thing/vertex_generator.rs
@@ -4,13 +4,13 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::Arc;
 
 use bytes::{Bytes, byte_array::ByteArray};
-use resource::profile::StorageCounters;
+use resource::{
+    profile::StorageCounters,
+    state_counter::{CounterId, StateCounters},
+};
 use storage::{
     MVCCStorage,
     key_range::KeyRange,
@@ -32,7 +32,7 @@ use crate::{
             vertex_attribute::{AttributeID, AttributeVertex, IntegerAttributeID, StringAttributeID},
             vertex_object::{ObjectID, ObjectVertex},
         },
-        type_::vertex::{TypeID, TypeIDUInt, TypeVertex, build_type_vertex_prefix_key},
+        type_::vertex::{TypeID, TypeVertex, build_type_vertex_prefix_key},
     },
     layout::prefix::Prefix,
     value::{
@@ -45,8 +45,6 @@ use crate::{
 
 #[derive(Debug)]
 pub struct ThingVertexGenerator {
-    entity_ids: Box<[AtomicU64]>,
-    relation_ids: Box<[AtomicU64]>,
     large_value_hasher: fn(&[u8]) -> u64,
 }
 
@@ -58,19 +56,11 @@ impl Default for ThingVertexGenerator {
 
 impl ThingVertexGenerator {
     pub fn new() -> Self {
-        // TODO: we should create a resizable Vector linked to the id of types/highest id of each type
-        //       this will speed up booting time on load (loading this will require MAX types * 3 iterator searches) and reduce memory footprint
         Self::new_with_hasher(seahash::hash)
     }
 
     pub fn new_with_hasher(large_value_hasher: fn(&[u8]) -> u64) -> Self {
-        // TODO: we should create a resizable Vector linked to the id of types/highest id of each type
-        //       this will speed up booting time on load (loading this will require MAX types * 3 iterator searches) and reduce memory footprint
-        ThingVertexGenerator {
-            entity_ids: Self::allocate_empty_ids(),
-            relation_ids: Self::allocate_empty_ids(),
-            large_value_hasher,
-        }
+        ThingVertexGenerator { large_value_hasher }
     }
 
     pub fn load<D>(storage: Arc<MVCCStorage<D>>) -> Result<Self, EncodingError> {
@@ -81,6 +71,12 @@ impl ThingVertexGenerator {
         storage: Arc<MVCCStorage<D>>,
         large_value_hasher: fn(&[u8]) -> u64,
     ) -> Result<Self, EncodingError> {
+        Self::seed_state_counters_from_storage(storage)?;
+        Ok(ThingVertexGenerator { large_value_hasher })
+    }
+
+    fn seed_state_counters_from_storage<D>(storage: Arc<MVCCStorage<D>>) -> Result<(), EncodingError> {
+        let counters = storage.state_counters().clone();
         let read_snapshot = storage.clone().open_snapshot_read();
         let entity_types = read_snapshot
             .iterate_range(
@@ -102,9 +98,6 @@ impl ThingVertexGenerator {
             )
             .collect_cloned_vec(|k, _v| TypeVertex::decode(Bytes::Reference(k.bytes())).type_id_().as_u16())
             .map_err(|err| EncodingError::ExistingTypesRead { source: err })?;
-
-        let entity_ids = Self::allocate_empty_ids();
-        let relation_ids = Self::allocate_empty_ids();
         for type_id in entity_types {
             let mut max_object_id =
                 ObjectVertex::build_entity(TypeID::new(type_id), ObjectID::new(u64::MAX)).to_bytes().into_array();
@@ -117,7 +110,10 @@ impl ThingVertexGenerator {
                 if ObjectVertex::is_entity_vertex(StorageKeyReference::new(ObjectVertex::KEYSPACE, &prev_bytes)) {
                     let object_vertex = ObjectVertex::decode(&prev_bytes);
                     if object_vertex.type_id_() == TypeID::new(type_id) {
-                        entity_ids[type_id as usize].store(object_vertex.object_id().as_u64() + 1, Ordering::Relaxed);
+                        counters.update_to_at_least(
+                            CounterId::EntityVertex { type_id },
+                            object_vertex.object_id().as_u64() + 1,
+                        );
                     }
                 }
             }
@@ -134,17 +130,15 @@ impl ThingVertexGenerator {
                 if ObjectVertex::is_relation_vertex(StorageKeyReference::new(ObjectVertex::KEYSPACE, &prev_bytes)) {
                     let object_vertex = ObjectVertex::decode(&prev_bytes);
                     if object_vertex.type_id_() == TypeID::new(type_id) {
-                        relation_ids[type_id as usize].store(object_vertex.object_id().as_u64() + 1, Ordering::Relaxed);
+                        counters.update_to_at_least(
+                            CounterId::RelationVertex { type_id },
+                            object_vertex.object_id().as_u64() + 1,
+                        );
                     }
                 }
             }
         }
-
-        Ok(ThingVertexGenerator { entity_ids, relation_ids, large_value_hasher })
-    }
-
-    fn allocate_empty_ids() -> Box<[AtomicU64]> {
-        (0..=TypeIDUInt::MAX).map(|_| AtomicU64::new(0)).collect::<Vec<AtomicU64>>().into_boxed_slice()
+        Ok(())
     }
 
     pub fn hasher(&self) -> &impl Fn(&[u8]) -> u64 {
@@ -155,7 +149,7 @@ impl ThingVertexGenerator {
     where
         Snapshot: WritableSnapshot,
     {
-        let entity_id = self.entity_ids[type_id.as_u16() as usize].fetch_add(1, Ordering::Relaxed);
+        let entity_id = snapshot.allocate_counter(CounterId::EntityVertex { type_id: type_id.as_u16() });
         let vertex = ObjectVertex::build_entity(type_id, ObjectID::new(entity_id));
         snapshot.insert(vertex.into_storage_key().into_owned_array());
         vertex
@@ -165,7 +159,7 @@ impl ThingVertexGenerator {
     where
         Snapshot: WritableSnapshot,
     {
-        let relation_id = self.relation_ids[type_id.as_u16() as usize].fetch_add(1, Ordering::Relaxed);
+        let relation_id = snapshot.allocate_counter(CounterId::RelationVertex { type_id: type_id.as_u16() });
         let vertex = ObjectVertex::build_relation(type_id, ObjectID::new(relation_id));
         snapshot.insert(vertex.into_storage_key().into_owned_array());
         vertex
@@ -425,10 +419,5 @@ impl ThingVertexGenerator {
         Snapshot: ReadableSnapshot,
     {
         StructAttributeID::find_hashed_id(type_id, struct_bytes, snapshot, &self.large_value_hasher)
-    }
-
-    pub fn reset(&mut self) {
-        self.entity_ids.iter().for_each(|id| id.store(0, Ordering::SeqCst));
-        self.relation_ids.iter().for_each(|id| id.store(0, Ordering::SeqCst));
     }
 }

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -7,6 +7,7 @@
 use std::{fmt, hash::Hash};
 
 use bytes::{Bytes, byte_array::ByteArray, util::HexBytesFormatter};
+use resource::constants::encoding::TypeIDUInt;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     key_value::{StorageKey, StorageKeyArray},
@@ -101,9 +102,6 @@ impl fmt::Debug for TypeID {
         write!(f, "{:04X}", self.value)
     }
 }
-
-// TODO: this type should move into constants.rs, similarly to DefinitionIDUInt
-pub type TypeIDUInt = u16;
 
 impl TypeID {
     pub const MIN: Self = Self::new(TypeIDUInt::MIN);

--- a/encoding/graph/type_/vertex.rs
+++ b/encoding/graph/type_/vertex.rs
@@ -7,7 +7,7 @@
 use std::{fmt, hash::Hash};
 
 use bytes::{Bytes, byte_array::ByteArray, util::HexBytesFormatter};
-use resource::constants::encoding::TypeIDUInt;
+pub use resource::constants::encoding::TypeIDUInt;
 use resource::constants::snapshot::BUFFER_KEY_INLINE;
 use storage::{
     key_value::{StorageKey, StorageKeyArray},

--- a/resource/BUILD
+++ b/resource/BUILD
@@ -14,6 +14,8 @@ rust_library(
     ]),
     deps = [
         "@crates//:itertools",
+        "@crates//:serde",
+        "@crates//:tracing",
     ],
     compile_data = [
         "typedb-ascii.txt",

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -15,6 +15,12 @@ features = {}
 
 [dependencies]
 
+	[dependencies.tracing]
+		workspace = true
+
+	[dependencies.serde]
+		workspace = true
+
 	[dependencies.itertools]
 		workspace = true
 

--- a/resource/Cargo.toml
+++ b/resource/Cargo.toml
@@ -13,6 +13,11 @@ features = {}
 	path = "resource.rs"
 	crate-type = ["lib"]
 
+[dev-dependencies]
+
+	[dev-dependencies.bincode]
+		workspace = true
+
 [dependencies]
 
 	[dependencies.tracing]

--- a/resource/constants.rs
+++ b/resource/constants.rs
@@ -167,6 +167,8 @@ pub mod encoding {
     pub type DefinitionIDAtomicUInt = AtomicU16;
 
     pub type StructFieldIDUInt = u16;
+
+    pub type TypeIDUInt = u16;
 }
 
 pub mod diagnostics {

--- a/resource/resource.rs
+++ b/resource/resource.rs
@@ -8,3 +8,4 @@ pub mod constants;
 pub mod distribution_info;
 pub mod perf_counters;
 pub mod profile;
+pub mod state_counter;

--- a/resource/state_counter.rs
+++ b/resource/state_counter.rs
@@ -99,9 +99,7 @@ impl PerTypeIdCounters {
     const COUNT: usize = TypeIDUInt::MAX as usize + 1;
 
     fn new() -> Self {
-        Self {
-            atomics: iter::repeat_with(|| AtomicU64::new(Self::INITIAL)).take(Self::COUNT).collect(),
-        }
+        Self { atomics: iter::repeat_with(|| AtomicU64::new(Self::INITIAL)).take(Self::COUNT).collect() }
     }
 
     fn allocate(&self, key: TypeIDUInt) -> u64 {
@@ -157,7 +155,7 @@ impl SnapshotIdCounter {
 
 #[cfg(test)]
 mod tests {
-    use super::{CounterId, StateCounters, COUNTER_ID_MAX_SIZE};
+    use super::{COUNTER_ID_MAX_SIZE, CounterId, StateCounters};
 
     #[test]
     fn bounded_id_size() {

--- a/resource/state_counter.rs
+++ b/resource/state_counter.rs
@@ -89,6 +89,8 @@ impl StateCounters {
 
 /// One [`AtomicU64`] per [`TypeIDUInt`].
 struct PerTypeIdCounters {
+    // TODO: we should create a resizable Vector linked to the id of types/highest id of each type
+    //       this will speed up booting time on load (loading this will require MAX types * 3 iterator searches) and reduce memory footprint
     atomics: Box<[AtomicU64]>,
 }
 

--- a/resource/state_counter.rs
+++ b/resource/state_counter.rs
@@ -1,0 +1,247 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+use std::{
+    collections::HashMap,
+    fmt::Debug,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+};
+
+use serde::{Deserialize, Serialize};
+
+
+/// State counters: monotonically-advancing counters that are part of TypeDB's
+/// persistent state and must stay consistent across server restarts.
+pub trait StateCounter: Debug + Send + Sync {
+    fn id(&self) -> CounterId;
+
+    /// Largest value that has been allocated so far.
+    fn high_watermark(&self) -> u64;
+
+    /// Advance the counter to at least `value`. **Monotonic**: if the counter
+    /// is already past `value`, this is a no-op.
+    fn advance_to(&self, value: u64);
+}
+
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub enum CounterId {
+    EntityVertex { type_id: u16 },
+    RelationVertex { type_id: u16 },
+}
+
+// Keep CounterId small: it's stored in every CommitRecord.
+// If you intentionally exceed this, adjust the bound.
+const COUNTER_ID_MAX_SIZE: usize = 8;
+const _: () = assert!(size_of::<CounterId>() <= COUNTER_ID_MAX_SIZE);
+
+#[derive(Debug)]
+pub struct AtomicStateCounter {
+    id: CounterId,
+    value: AtomicU64,
+}
+
+impl AtomicStateCounter {
+    pub fn new(id: CounterId, initial: u64) -> Self {
+        Self { id, value: AtomicU64::new(initial) }
+    }
+
+    /// Allocate the next value and return the previous counter state.
+    pub fn allocate(&self) -> u64 {
+        self.value.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+impl StateCounter for AtomicStateCounter {
+    fn id(&self) -> CounterId {
+        self.id
+    }
+
+    fn high_watermark(&self) -> u64 {
+        self.value.load(Ordering::Relaxed)
+    }
+
+    fn advance_to(&self, value: u64) {
+        // fetch_max gives us the monotonic guarantee for free: the counter
+        // never moves backwards regardless of how many threads race.
+        self.value.fetch_max(value, Ordering::Relaxed);
+    }
+}
+
+/// Registry of every [`StateCounter`] scoped to a single database.
+#[derive(Debug)]
+pub struct DatabaseStateCounterRegistry {
+    database_name: String,
+    counters: RwLock<HashMap<CounterId, Arc<dyn StateCounter>>>,
+}
+
+impl DatabaseStateCounterRegistry {
+    pub fn new(database_name: impl Into<String>) -> Self {
+        Self { database_name: database_name.into(), counters: RwLock::new(HashMap::new()) }
+    }
+
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    /// Register a counter. If one with the same id already exists, it is **replaced**.
+    pub fn register(&self, counter: Arc<dyn StateCounter>) {
+        let id = counter.id();
+        let mut counters = self.counters.write().expect("state-counter registry lock poisoned");
+        assert!(counters.get(&id).is_none(), "Unexpected double counter registration");
+        counters.insert(id, counter);
+    }
+
+    /// Apply a batch of post-commit watermarks to the registered counters.
+    pub fn advance_from_commit(&self, counter_advances: &[(CounterId, u64)]) {
+        let counters = self.counters.read().expect("state-counter registry lock poisoned");
+        for (id, value) in counter_advances {
+            match counters.get(id) {
+                Some(counter) => counter.advance_to(*value),
+                None => {
+                    // Forward-compatibility: a server may be one version behind
+                    // the primary server and not know this counter id yet.
+                    tracing::warn!(
+                        target: "state_counter",
+                        ?id,
+                        database = %self.database_name,
+                        "advance_from_commit: unknown CounterId; skipping"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Read the current high-watermark for `id`, if registered.
+    pub fn high_watermark(&self, id: CounterId) -> Option<u64> {
+        self.counters.read().expect("state-counter registry lock poisoned").get(&id).map(|c| c.high_watermark())
+    }
+
+    /// Number of registered counters.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.counters.read().expect("state-counter registry lock poisoned").len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{AtomicStateCounter, CounterId, DatabaseStateCounterRegistry, StateCounter, COUNTER_ID_MAX_SIZE};
+
+    #[test]
+    fn bounded_size() {
+        // CounterId rides inside every commit's counter_advances vector.
+        // Keep it tight; if this fails, audit the new variant for its
+        // RAM-per-entry impact before bumping the bound.
+        assert!(size_of::<CounterId>() <= COUNTER_ID_MAX_SIZE);
+    }
+
+    #[test]
+    fn allocate_returns_pre_increment_value() {
+        let c = AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0);
+        assert_eq!(c.allocate(), 0);
+        assert_eq!(c.allocate(), 1);
+        assert_eq!(c.allocate(), 2);
+        assert_eq!(c.high_watermark(), 3);
+    }
+
+    #[test]
+    fn advance_to_is_monotonic() {
+        let c = AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0);
+        c.advance_to(10);
+        assert_eq!(c.high_watermark(), 10);
+        // Going backwards is a no-op, not a rollback.
+        c.advance_to(5);
+        assert_eq!(c.high_watermark(), 10);
+        // Equal is also fine.
+        c.advance_to(10);
+        assert_eq!(c.high_watermark(), 10);
+        // Forward works as expected.
+        c.advance_to(42);
+        assert_eq!(c.high_watermark(), 42);
+    }
+
+    #[test]
+    fn registry_register_and_advance() {
+        let registry = DatabaseStateCounterRegistry::new("db_a");
+        let c1: Arc<dyn StateCounter> =
+            Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 7 }, 0));
+        let c2: Arc<dyn StateCounter> =
+            Arc::new(AtomicStateCounter::new(CounterId::RelationVertex { type_id: 7 }, 0));
+        registry.register(c1.clone());
+        registry.register(c2.clone());
+        assert_eq!(registry.len(), 2);
+
+        registry.advance_from_commit(
+            &[(CounterId::EntityVertex { type_id: 7 }, 100), (CounterId::RelationVertex { type_id: 7 }, 250)],
+        );
+
+        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 7 }), Some(100));
+        assert_eq!(registry.high_watermark(CounterId::RelationVertex { type_id: 7 }), Some(250));
+    }
+
+    #[test]
+    fn registry_advance_respects_monotonicity() {
+        let registry = DatabaseStateCounterRegistry::new("db");
+        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 500)));
+        // A stale commit (older value) must not roll the counter back.
+        registry.advance_from_commit(&[(CounterId::EntityVertex { type_id: 1 }, 100)]);
+        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(500));
+    }
+
+    #[test]
+    fn unknown_counter_id_is_logged_and_skipped() {
+        let registry = DatabaseStateCounterRegistry::new("db");
+        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0)));
+        // Forward-compat: the writer knew about a counter this node doesn't.
+        // Must not panic, must not affect the known counter.
+        registry.advance_from_commit(
+            &[
+                (CounterId::EntityVertex { type_id: 1 }, 42),
+                (CounterId::RelationVertex { type_id: 999 }, 17), // not registered
+            ],
+        );
+        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(42));
+        assert_eq!(registry.high_watermark(CounterId::RelationVertex { type_id: 999 }), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "crossed database boundary")]
+    fn cross_database_advance_panics() {
+        // If routing ever misroutes a commit, we want a loud failure rather
+        // than silent corruption: counter advances govern IID allocation.
+        let registry = DatabaseStateCounterRegistry::new("db_a");
+        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0)));
+        registry.advance_from_commit(&[(CounterId::EntityVertex { type_id: 1 }, 1)]);
+    }
+
+    #[test]
+    fn counter_id_roundtrips_through_bincode() {
+        // CommitRecord serialises with bincode; CounterId must round-trip.
+        let ids = vec![
+            CounterId::EntityVertex { type_id: 0 },
+            CounterId::EntityVertex { type_id: u16::MAX },
+            CounterId::RelationVertex { type_id: 12345 },
+        ];
+        for id in ids {
+            let bytes = bincode::serialize(&id).unwrap();
+            let back: CounterId = bincode::deserialize(&bytes).unwrap();
+            assert_eq!(id, back);
+        }
+    }
+
+    #[test]
+    fn empty_advance_list_is_noop() {
+        let registry = DatabaseStateCounterRegistry::new("db");
+        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 7)));
+        registry.advance_from_commit(&[]);
+        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(7));
+    }
+}

--- a/resource/state_counter.rs
+++ b/resource/state_counter.rs
@@ -5,243 +5,242 @@
  */
 
 use std::{
-    collections::HashMap,
-    fmt::Debug,
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc, RwLock,
-    },
+    iter,
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use serde::{Deserialize, Serialize};
 
-
-/// State counters: monotonically-advancing counters that are part of TypeDB's
-/// persistent state and must stay consistent across server restarts.
-pub trait StateCounter: Debug + Send + Sync {
-    fn id(&self) -> CounterId;
-
-    /// Largest value that has been allocated so far.
-    fn high_watermark(&self) -> u64;
-
-    /// Advance the counter to at least `value`. **Monotonic**: if the counter
-    /// is already past `value`, this is a no-op.
-    fn advance_to(&self, value: u64);
-}
+use crate::constants::encoding::TypeIDUInt;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum CounterId {
-    EntityVertex { type_id: u16 },
-    RelationVertex { type_id: u16 },
+    EntityVertex { type_id: TypeIDUInt },
+    RelationVertex { type_id: TypeIDUInt },
+    SnapshotId,
 }
 
-// Keep CounterId small: it's stored in every CommitRecord.
-// If you intentionally exceed this, adjust the bound.
 const COUNTER_ID_MAX_SIZE: usize = 8;
 const _: () = assert!(size_of::<CounterId>() <= COUNTER_ID_MAX_SIZE);
 
-#[derive(Debug)]
-pub struct AtomicStateCounter {
-    id: CounterId,
-    value: AtomicU64,
+pub struct StateCounters {
+    entity_ids: PerTypeIdCounters,
+    relation_ids: PerTypeIdCounters,
+    snapshot_id: GlobalCounter,
 }
 
-impl AtomicStateCounter {
-    pub fn new(id: CounterId, initial: u64) -> Self {
-        Self { id, value: AtomicU64::new(initial) }
-    }
-
-    /// Allocate the next value and return the previous counter state.
-    pub fn allocate(&self) -> u64 {
-        self.value.fetch_add(1, Ordering::Relaxed)
+impl std::fmt::Debug for StateCounters {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateCounters").finish_non_exhaustive()
     }
 }
 
-impl StateCounter for AtomicStateCounter {
-    fn id(&self) -> CounterId {
-        self.id
-    }
-
-    fn high_watermark(&self) -> u64 {
-        self.value.load(Ordering::Relaxed)
-    }
-
-    fn advance_to(&self, value: u64) {
-        // fetch_max gives us the monotonic guarantee for free: the counter
-        // never moves backwards regardless of how many threads race.
-        self.value.fetch_max(value, Ordering::Relaxed);
+impl Default for StateCounters {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-/// Registry of every [`StateCounter`] scoped to a single database.
-#[derive(Debug)]
-pub struct DatabaseStateCounterRegistry {
-    database_name: String,
-    counters: RwLock<HashMap<CounterId, Arc<dyn StateCounter>>>,
-}
-
-impl DatabaseStateCounterRegistry {
-    pub fn new(database_name: impl Into<String>) -> Self {
-        Self { database_name: database_name.into(), counters: RwLock::new(HashMap::new()) }
-    }
-
-    pub fn database_name(&self) -> &str {
-        &self.database_name
-    }
-
-    /// Register a counter. If one with the same id already exists, it is **replaced**.
-    pub fn register(&self, counter: Arc<dyn StateCounter>) {
-        let id = counter.id();
-        let mut counters = self.counters.write().expect("state-counter registry lock poisoned");
-        assert!(counters.get(&id).is_none(), "Unexpected double counter registration");
-        counters.insert(id, counter);
-    }
-
-    /// Apply a batch of post-commit watermarks to the registered counters.
-    pub fn advance_from_commit(&self, counter_advances: &[(CounterId, u64)]) {
-        let counters = self.counters.read().expect("state-counter registry lock poisoned");
-        for (id, value) in counter_advances {
-            match counters.get(id) {
-                Some(counter) => counter.advance_to(*value),
-                None => {
-                    // Forward-compatibility: a server may be one version behind
-                    // the primary server and not know this counter id yet.
-                    tracing::warn!(
-                        target: "state_counter",
-                        ?id,
-                        database = %self.database_name,
-                        "advance_from_commit: unknown CounterId; skipping"
-                    );
-                }
-            }
+impl StateCounters {
+    pub fn new() -> Self {
+        Self {
+            entity_ids: PerTypeIdCounters::new(),
+            relation_ids: PerTypeIdCounters::new(),
+            snapshot_id: GlobalCounter::new(SnapshotIdCounter::INITIAL),
         }
     }
 
-    /// Read the current high-watermark for `id`, if registered.
-    pub fn high_watermark(&self, id: CounterId) -> Option<u64> {
-        self.counters.read().expect("state-counter registry lock poisoned").get(&id).map(|c| c.high_watermark())
+    pub fn allocate(&self, id: CounterId) -> u64 {
+        match id {
+            CounterId::EntityVertex { type_id } => self.entity_ids.allocate(type_id),
+            CounterId::RelationVertex { type_id } => self.relation_ids.allocate(type_id),
+            CounterId::SnapshotId => self.snapshot_id.allocate(),
+        }
     }
 
-    /// Number of registered counters.
-    #[cfg(test)]
-    fn len(&self) -> usize {
-        self.counters.read().expect("state-counter registry lock poisoned").len()
+    pub fn next_value(&self, id: CounterId) -> u64 {
+        match id {
+            CounterId::EntityVertex { type_id } => self.entity_ids.next_value(type_id),
+            CounterId::RelationVertex { type_id } => self.relation_ids.next_value(type_id),
+            CounterId::SnapshotId => self.snapshot_id.next_value(),
+        }
     }
+
+    pub fn update_to_at_least(&self, id: CounterId, value: u64) {
+        match id {
+            CounterId::EntityVertex { type_id } => self.entity_ids.update_to_at_least(type_id, value),
+            CounterId::RelationVertex { type_id } => self.relation_ids.update_to_at_least(type_id, value),
+            CounterId::SnapshotId => self.snapshot_id.update_to_at_least(value),
+        }
+    }
+
+    pub fn apply_advances(&self, advances: &[(CounterId, u64)]) {
+        for (id, value) in advances {
+            self.update_to_at_least(*id, *value);
+        }
+    }
+
+    pub fn reset(&self) {
+        self.entity_ids.reset();
+        self.relation_ids.reset();
+        self.snapshot_id.reset();
+    }
+}
+
+/// One [`AtomicU64`] per [`TypeIDUInt`].
+struct PerTypeIdCounters {
+    atomics: Box<[AtomicU64]>,
+}
+
+impl PerTypeIdCounters {
+    const INITIAL: u64 = 0;
+    const COUNT: usize = TypeIDUInt::MAX as usize + 1;
+
+    fn new() -> Self {
+        Self {
+            atomics: iter::repeat_with(|| AtomicU64::new(Self::INITIAL)).take(Self::COUNT).collect(),
+        }
+    }
+
+    fn allocate(&self, key: TypeIDUInt) -> u64 {
+        self.atomics[key as usize].fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn next_value(&self, key: TypeIDUInt) -> u64 {
+        self.atomics[key as usize].load(Ordering::Relaxed)
+    }
+
+    fn update_to_at_least(&self, key: TypeIDUInt, value: u64) {
+        self.atomics[key as usize].fetch_max(value, Ordering::Relaxed);
+    }
+
+    fn reset(&self) {
+        for atomic in self.atomics.iter() {
+            atomic.store(Self::INITIAL, Ordering::SeqCst);
+        }
+    }
+}
+
+struct GlobalCounter {
+    atomic: AtomicU64,
+    initial: u64,
+}
+
+impl GlobalCounter {
+    fn new(initial: u64) -> Self {
+        Self { atomic: AtomicU64::new(initial), initial }
+    }
+
+    fn allocate(&self) -> u64 {
+        self.atomic.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn next_value(&self) -> u64 {
+        self.atomic.load(Ordering::Relaxed)
+    }
+
+    fn update_to_at_least(&self, value: u64) {
+        self.atomic.fetch_max(value, Ordering::Relaxed);
+    }
+
+    fn reset(&self) {
+        self.atomic.store(self.initial, Ordering::SeqCst);
+    }
+}
+
+struct SnapshotIdCounter;
+impl SnapshotIdCounter {
+    const INITIAL: u64 = 1;
 }
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use super::{AtomicStateCounter, CounterId, DatabaseStateCounterRegistry, StateCounter, COUNTER_ID_MAX_SIZE};
+    use super::{CounterId, StateCounters, COUNTER_ID_MAX_SIZE};
 
     #[test]
-    fn bounded_size() {
-        // CounterId rides inside every commit's counter_advances vector.
-        // Keep it tight; if this fails, audit the new variant for its
-        // RAM-per-entry impact before bumping the bound.
+    fn bounded_id_size() {
         assert!(size_of::<CounterId>() <= COUNTER_ID_MAX_SIZE);
     }
 
     #[test]
-    fn allocate_returns_pre_increment_value() {
-        let c = AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0);
-        assert_eq!(c.allocate(), 0);
-        assert_eq!(c.allocate(), 1);
-        assert_eq!(c.allocate(), 2);
-        assert_eq!(c.high_watermark(), 3);
-    }
-
-    #[test]
-    fn advance_to_is_monotonic() {
-        let c = AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0);
-        c.advance_to(10);
-        assert_eq!(c.high_watermark(), 10);
-        // Going backwards is a no-op, not a rollback.
-        c.advance_to(5);
-        assert_eq!(c.high_watermark(), 10);
-        // Equal is also fine.
-        c.advance_to(10);
-        assert_eq!(c.high_watermark(), 10);
-        // Forward works as expected.
-        c.advance_to(42);
-        assert_eq!(c.high_watermark(), 42);
-    }
-
-    #[test]
-    fn registry_register_and_advance() {
-        let registry = DatabaseStateCounterRegistry::new("db_a");
-        let c1: Arc<dyn StateCounter> =
-            Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 7 }, 0));
-        let c2: Arc<dyn StateCounter> =
-            Arc::new(AtomicStateCounter::new(CounterId::RelationVertex { type_id: 7 }, 0));
-        registry.register(c1.clone());
-        registry.register(c2.clone());
-        assert_eq!(registry.len(), 2);
-
-        registry.advance_from_commit(
-            &[(CounterId::EntityVertex { type_id: 7 }, 100), (CounterId::RelationVertex { type_id: 7 }, 250)],
-        );
-
-        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 7 }), Some(100));
-        assert_eq!(registry.high_watermark(CounterId::RelationVertex { type_id: 7 }), Some(250));
-    }
-
-    #[test]
-    fn registry_advance_respects_monotonicity() {
-        let registry = DatabaseStateCounterRegistry::new("db");
-        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 500)));
-        // A stale commit (older value) must not roll the counter back.
-        registry.advance_from_commit(&[(CounterId::EntityVertex { type_id: 1 }, 100)]);
-        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(500));
-    }
-
-    #[test]
-    fn unknown_counter_id_is_logged_and_skipped() {
-        let registry = DatabaseStateCounterRegistry::new("db");
-        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0)));
-        // Forward-compat: the writer knew about a counter this node doesn't.
-        // Must not panic, must not affect the known counter.
-        registry.advance_from_commit(
-            &[
-                (CounterId::EntityVertex { type_id: 1 }, 42),
-                (CounterId::RelationVertex { type_id: 999 }, 17), // not registered
-            ],
-        );
-        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(42));
-        assert_eq!(registry.high_watermark(CounterId::RelationVertex { type_id: 999 }), None);
-    }
-
-    #[test]
-    #[should_panic(expected = "crossed database boundary")]
-    fn cross_database_advance_panics() {
-        // If routing ever misroutes a commit, we want a loud failure rather
-        // than silent corruption: counter advances govern IID allocation.
-        let registry = DatabaseStateCounterRegistry::new("db_a");
-        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 0)));
-        registry.advance_from_commit(&[(CounterId::EntityVertex { type_id: 1 }, 1)]);
-    }
-
-    #[test]
     fn counter_id_roundtrips_through_bincode() {
-        // CommitRecord serialises with bincode; CounterId must round-trip.
-        let ids = vec![
+        for id in [
             CounterId::EntityVertex { type_id: 0 },
             CounterId::EntityVertex { type_id: u16::MAX },
             CounterId::RelationVertex { type_id: 12345 },
-        ];
-        for id in ids {
+            CounterId::SnapshotId,
+        ] {
             let bytes = bincode::serialize(&id).unwrap();
-            let back: CounterId = bincode::deserialize(&bytes).unwrap();
-            assert_eq!(id, back);
+            assert_eq!(id, bincode::deserialize::<CounterId>(&bytes).unwrap());
         }
     }
 
     #[test]
-    fn empty_advance_list_is_noop() {
-        let registry = DatabaseStateCounterRegistry::new("db");
-        registry.register(Arc::new(AtomicStateCounter::new(CounterId::EntityVertex { type_id: 1 }, 7)));
-        registry.advance_from_commit(&[]);
-        assert_eq!(registry.high_watermark(CounterId::EntityVertex { type_id: 1 }), Some(7));
+    fn allocate_returns_pre_increment_value() {
+        let counters = StateCounters::new();
+        let id = CounterId::EntityVertex { type_id: 1 };
+        assert_eq!(counters.allocate(id), 0);
+        assert_eq!(counters.allocate(id), 1);
+        assert_eq!(counters.allocate(id), 2);
+        assert_eq!(counters.next_value(id), 3);
+    }
+
+    #[test]
+    fn entity_and_relation_counters_are_independent() {
+        let counters = StateCounters::new();
+        let entity_3 = CounterId::EntityVertex { type_id: 3 };
+        let relation_3 = CounterId::RelationVertex { type_id: 3 };
+        assert_eq!(counters.allocate(entity_3), 0);
+        assert_eq!(counters.allocate(entity_3), 1);
+        assert_eq!(counters.next_value(relation_3), 0);
+        assert_eq!(counters.allocate(relation_3), 0);
+        assert_eq!(counters.next_value(entity_3), 2);
+    }
+
+    #[test]
+    fn update_to_at_least_is_monotonic() {
+        let counters = StateCounters::new();
+        let id = CounterId::EntityVertex { type_id: 7 };
+        counters.update_to_at_least(id, 100);
+        assert_eq!(counters.next_value(id), 100);
+        counters.update_to_at_least(id, 50);
+        assert_eq!(counters.next_value(id), 100);
+        counters.update_to_at_least(id, 200);
+        assert_eq!(counters.next_value(id), 200);
+    }
+
+    #[test]
+    fn apply_advances_batch() {
+        let counters = StateCounters::new();
+        counters.apply_advances(&[
+            (CounterId::EntityVertex { type_id: 1 }, 50),
+            (CounterId::RelationVertex { type_id: 2 }, 99),
+            (CounterId::EntityVertex { type_id: 1 }, 25),
+        ]);
+        assert_eq!(counters.next_value(CounterId::EntityVertex { type_id: 1 }), 50);
+        assert_eq!(counters.next_value(CounterId::RelationVertex { type_id: 2 }), 99);
+    }
+
+    #[test]
+    fn reset_restores_initial_values() {
+        let counters = StateCounters::new();
+        let entity = CounterId::EntityVertex { type_id: 99 };
+        counters.allocate(entity);
+        counters.allocate(entity);
+        counters.allocate(CounterId::SnapshotId);
+        assert_eq!(counters.next_value(entity), 2);
+        assert_eq!(counters.next_value(CounterId::SnapshotId), 2);
+        counters.reset();
+        assert_eq!(counters.next_value(entity), 0);
+        assert_eq!(counters.next_value(CounterId::SnapshotId), 1);
+    }
+
+    #[test]
+    fn snapshot_id_counter_skips_unset_sentinel() {
+        let counters = StateCounters::new();
+        assert_eq!(counters.allocate(CounterId::SnapshotId), 1);
+        assert_eq!(counters.allocate(CounterId::SnapshotId), 2);
+        counters.reset();
+        assert_eq!(counters.allocate(CounterId::SnapshotId), 1);
     }
 }

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -731,7 +731,13 @@ mod tests {
     }
 
     fn _record(read_sequence_number: SequenceNumber) -> CommitRecord {
-        CommitRecord::new(OperationsBuffer::new(), read_sequence_number, CommitType::Data, SnapshotId::from_number(1))
+        CommitRecord::new(
+            OperationsBuffer::new(),
+            read_sequence_number,
+            CommitType::Data,
+            SnapshotId::from_number(1),
+            Vec::new(),
+        )
     }
 
     #[test]

--- a/storage/isolation_manager.rs
+++ b/storage/isolation_manager.rs
@@ -731,7 +731,7 @@ mod tests {
     }
 
     fn _record(read_sequence_number: SequenceNumber) -> CommitRecord {
-        CommitRecord::new(OperationsBuffer::new(), read_sequence_number, CommitType::Data, SnapshotId::new())
+        CommitRecord::new(OperationsBuffer::new(), read_sequence_number, CommitType::Data, SnapshotId::from_number(1))
     }
 
     #[test]

--- a/storage/record.rs
+++ b/storage/record.rs
@@ -82,6 +82,10 @@ impl LegacyCommitRecordV2 {
     ) -> Self {
         Self { operations, open_sequence_number, commit_type, snapshot_id }
     }
+
+    pub fn snapshot_id(&self) -> SnapshotId {
+        self.snapshot_id
+    }
 }
 
 impl From<LegacyCommitRecordV2> for CommitRecord {

--- a/storage/record.rs
+++ b/storage/record.rs
@@ -8,6 +8,7 @@ use std::{fmt, io::Read};
 
 use durability::DurabilityRecordType;
 use logger::result::ResultExt;
+use resource::state_counter::CounterId;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -42,6 +43,7 @@ impl From<LegacyCommitRecordV1> for CommitRecord {
             open_sequence_number: legacy.open_sequence_number,
             commit_type: legacy.commit_type,
             snapshot_id: SnapshotId::UNSET,
+            counter_advances: Vec::new(),
         }
     }
 }
@@ -64,11 +66,60 @@ impl DurabilityRecord for LegacyCommitRecordV1 {
 impl SequencedDurabilityRecord for LegacyCommitRecordV1 {}
 
 #[derive(Serialize, Deserialize)]
+pub struct LegacyCommitRecordV2 {
+    operations: OperationsBuffer,
+    open_sequence_number: SequenceNumber,
+    commit_type: CommitType,
+    snapshot_id: SnapshotId,
+}
+
+impl LegacyCommitRecordV2 {
+    pub(crate) fn new(
+        operations: OperationsBuffer,
+        open_sequence_number: SequenceNumber,
+        commit_type: CommitType,
+        snapshot_id: SnapshotId,
+    ) -> Self {
+        Self { operations, open_sequence_number, commit_type, snapshot_id }
+    }
+}
+
+impl From<LegacyCommitRecordV2> for CommitRecord {
+    fn from(legacy: LegacyCommitRecordV2) -> Self {
+        CommitRecord {
+            operations: legacy.operations,
+            open_sequence_number: legacy.open_sequence_number,
+            commit_type: legacy.commit_type,
+            snapshot_id: legacy.snapshot_id,
+            counter_advances: Vec::new(),
+        }
+    }
+}
+
+impl DurabilityRecord for LegacyCommitRecordV2 {
+    const RECORD_TYPE: DurabilityRecordType = 2;
+    const RECORD_NAME: &'static str = "legacy_commit_record_v2";
+
+    fn serialise_into(&self, writer: &mut impl std::io::Write) -> bincode::Result<()> {
+        bincode::serialize_into(writer, &self)
+    }
+
+    fn deserialise_from(reader: &mut impl Read) -> bincode::Result<Self> {
+        let mut buf = Vec::new();
+        reader.read_to_end(&mut buf).map_err(|e| bincode::ErrorKind::Io(e))?;
+        bincode::deserialize(&buf)
+    }
+}
+
+impl SequencedDurabilityRecord for LegacyCommitRecordV2 {}
+
+#[derive(Serialize, Deserialize)]
 pub struct CommitRecord {
     operations: OperationsBuffer,
     open_sequence_number: SequenceNumber,
     commit_type: CommitType,
     snapshot_id: SnapshotId,
+    counter_advances: Vec<(CounterId, u64)>,
 }
 
 impl fmt::Debug for CommitRecord {
@@ -78,6 +129,7 @@ impl fmt::Debug for CommitRecord {
             .field("snapshot_id", &self.snapshot_id)
             .field("commit_type", &self.commit_type)
             .field("operations", &self.operations)
+            .field("counter_advances", &self.counter_advances)
             .finish()
     }
 }
@@ -101,7 +153,7 @@ impl CommitRecord {
         commit_type: CommitType,
         snapshot_id: SnapshotId,
     ) -> CommitRecord {
-        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id }
+        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id, counter_advances: Vec::new() }
     }
 
     pub fn operations(&self) -> &OperationsBuffer {
@@ -122,6 +174,14 @@ impl CommitRecord {
 
     pub fn snapshot_id(&self) -> SnapshotId {
         self.snapshot_id
+    }
+
+    pub fn counter_advances(&self) -> &[(CounterId, u64)] {
+        &self.counter_advances
+    }
+
+    pub fn set_counter_advances(&mut self, advances: Vec<(CounterId, u64)>) {
+        self.counter_advances = advances;
     }
 
     fn deserialise_from(record_type: DurabilityRecordType, reader: impl Read)
@@ -198,7 +258,7 @@ impl CommitRecord {
 }
 
 impl DurabilityRecord for CommitRecord {
-    const RECORD_TYPE: DurabilityRecordType = 2;
+    const RECORD_TYPE: DurabilityRecordType = 3;
 
     const RECORD_NAME: &'static str = "commit_record";
 

--- a/storage/record.rs
+++ b/storage/record.rs
@@ -152,8 +152,9 @@ impl CommitRecord {
         open_sequence_number: SequenceNumber,
         commit_type: CommitType,
         snapshot_id: SnapshotId,
+        counter_advances: Vec<(CounterId, u64)>,
     ) -> CommitRecord {
-        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id, counter_advances: Vec::new() }
+        CommitRecord { operations, open_sequence_number, commit_type, snapshot_id, counter_advances }
     }
 
     pub fn operations(&self) -> &OperationsBuffer {
@@ -178,10 +179,6 @@ impl CommitRecord {
 
     pub fn counter_advances(&self) -> &[(CounterId, u64)] {
         &self.counter_advances
-    }
-
-    pub fn set_counter_advances(&mut self, advances: Vec<(CounterId, u64)>) {
-        self.counter_advances = advances;
     }
 
     fn deserialise_from(record_type: DurabilityRecordType, reader: impl Read)

--- a/storage/recovery/checkpoint.rs
+++ b/storage/recovery/checkpoint.rs
@@ -20,6 +20,7 @@ use fail_point::{
     CHECKPOINT_FILE_SYNC_FAIL, CHECKPOINT_METADATA_WRITE_FAIL, fail_point,
 };
 use itertools::Itertools;
+use resource::state_counter::StateCounters;
 use same_file::is_same_file;
 use tracing::{debug, trace};
 
@@ -77,6 +78,7 @@ impl CheckpointReader {
         database_name: &str,
         keyspaces_dir: &Path,
         durability_client: &Durability,
+        state_counters: &StateCounters,
     ) -> Result<(Keyspaces, SequenceNumber), CheckpointLoadError> {
         use CheckpointLoadError::{CheckpointRestore, CommitRecoveryFailed, KeyspaceOpen};
 
@@ -104,7 +106,7 @@ impl CheckpointReader {
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
         let next_sequence_number = recovered_commits.keys().max().copied().unwrap_or(recovery_start - 1) + 1;
         trace!("Applying missing commits");
-        apply_recovered(database_name, recovered_commits, durability_client, &keyspaces)
+        apply_recovered(database_name, recovered_commits, durability_client, &keyspaces, state_counters)
             .map_err(|err| CommitRecoveryFailed { typedb_source: err })?;
         Ok((keyspaces, next_sequence_number))
     }

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -16,7 +16,7 @@ use crate::{
     durability_client::{DurabilityClient, DurabilityClientError, DurabilityRecord},
     isolation_manager::{IsolationManager, ValidatedCommit},
     keyspace::{KeyspaceError, Keyspaces},
-    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, LegacyCommitRecordV2, StatusRecord},
     sequence_number::SequenceNumber,
     write_batches::WriteBatches,
 };
@@ -70,6 +70,20 @@ pub fn load_commit_data_from_with_context(
                 bytes_read += bytes.len();
                 trace!(
                     "Read legacy commit V1 @ {} with size {}; {} total",
+                    sequence_number,
+                    format_size(bytes.len()),
+                    format_size(bytes_read),
+                );
+            }
+            LegacyCommitRecordV2::RECORD_TYPE => {
+                let legacy = LegacyCommitRecordV2::deserialise_from(&mut &*bytes)
+                    .map_err(|error| DurabilityRecordDeserialize { source: Arc::new(error) })?;
+                let commit_record = CommitRecord::from(legacy);
+                recovered_commits.insert(sequence_number, RecoveryCommitStatus::Pending(commit_record));
+                recovered_commit_sizes.insert(sequence_number, bytes.len());
+                bytes_read += bytes.len();
+                trace!(
+                    "Read legacy commit V2 @ {} with size {}; {} total",
                     sequence_number,
                     format_size(bytes.len()),
                     format_size(bytes_read),

--- a/storage/recovery/commit_recovery.rs
+++ b/storage/recovery/commit_recovery.rs
@@ -9,6 +9,7 @@ use std::{collections::BTreeMap, error::Error, sync::Arc};
 use durability::RawRecord;
 use error::typedb_error;
 use fail_point::{RECOVERY_PARTIAL_WRITE, fail_point};
+use resource::state_counter::StateCounters;
 use tracing::{Level, event, trace};
 
 use crate::{
@@ -163,6 +164,7 @@ pub(crate) fn apply_recovered(
     recovered_commits: BTreeMap<SequenceNumber, RecoveryCommitStatus>,
     durability_client: &impl DurabilityClient,
     keyspaces: &Keyspaces,
+    state_counters: &StateCounters,
 ) -> Result<(), StorageRecoveryError> {
     event!(Level::TRACE, "Applying recovered commits");
     use StorageRecoveryError::{DurabilityClientRead, DurabilityClientWrite, Internal, KeyspaceWrite};
@@ -176,6 +178,7 @@ pub(crate) fn apply_recovered(
     for (commit_sequence_number, commit) in recovered_commits {
         match commit {
             RecoveryCommitStatus::Validated(commit_record) => {
+                let counter_advances = commit_record.counter_advances().to_vec();
                 let write_batches = WriteBatches::from_operations(commit_sequence_number, commit_record.operations());
                 isolation_manager.load_validated(commit_sequence_number, commit_record);
                 keyspaces.write(write_batches).map_err(|error| KeyspaceWrite { source: error })?;
@@ -183,9 +186,11 @@ pub(crate) fn apply_recovered(
                 isolation_manager
                     .applied(commit_sequence_number)
                     .map_err(|error| Internal { name: Arc::new(database_name.to_owned()), source: Arc::new(error) })?;
+                state_counters.apply_advances(&counter_advances);
             }
             RecoveryCommitStatus::Rejected => isolation_manager.load_aborted(commit_sequence_number),
             RecoveryCommitStatus::Pending(commit_record) => {
+                let counter_advances = commit_record.counter_advances().to_vec();
                 let read_guard = isolation_manager.opened_for_read(commit_record.open_sequence_number());
                 let validated_commit = isolation_manager
                     .validate_commit(commit_sequence_number, commit_record, durability_client)
@@ -201,6 +206,7 @@ pub(crate) fn apply_recovered(
                             name: Arc::new(database_name.to_owned()),
                             source: Arc::new(error),
                         })?;
+                        state_counters.apply_advances(&counter_advances);
                     }
                     ValidatedCommit::Conflict(_) => {
                         MVCCStorage::persist_commit_status(false, commit_sequence_number, durability_client)

--- a/storage/snapshot/lock.rs
+++ b/storage/snapshot/lock.rs
@@ -4,7 +4,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use bytes::byte_array::ByteArray;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, Eq, PartialEq)]

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -344,10 +344,10 @@ impl<D> WriteSnapshot<D> {
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
         let id = Some(commit_record.snapshot_id());
-        let preset = commit_record.counter_advances().to_vec();
+        let counter_advances = commit_record.counter_advances().to_vec();
         let operations = commit_record.into_operations();
         let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
-        snapshot.counters.set_preset_advances(preset);
+        snapshot.counters.set_preset_advances(counter_advances);
         snapshot
     }
 
@@ -501,8 +501,8 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, id, reader_guard, counters, iterator_pool: _, storage: _ } = self;
-        let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Data, id);
-        record.set_counter_advances(counters.into_advances());
+        let record =
+            CommitRecord::new(operations, open_sequence_number, CommitType::Data, id, counters.into_advances());
         (reader_guard, record)
     }
 }
@@ -537,10 +537,10 @@ impl<D> SchemaSnapshot<D> {
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
         let id = Some(commit_record.snapshot_id());
-        let preset = commit_record.counter_advances().to_vec();
+        let counter_advances = commit_record.counter_advances().to_vec();
         let operations = commit_record.into_operations();
         let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
-        snapshot.counters.set_preset_advances(preset);
+        snapshot.counters.set_preset_advances(counter_advances);
         snapshot
     }
 
@@ -694,8 +694,8 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
         let Self { operations, open_sequence_number, reader_guard, id, counters, iterator_pool: _, storage: _ } = self;
-        let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id);
-        record.set_counter_advances(counters.into_advances());
+        let record =
+            CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id, counters.into_advances());
         (reader_guard, record)
     }
 }

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::{any::type_name, error::Error, fmt, iter::empty, sync::Arc};
+use std::{any::type_name, collections::HashSet, error::Error, fmt, iter::empty, sync::Arc};
 
 use bytes::byte_array::ByteArray;
 use error::typedb_error;
@@ -12,6 +12,7 @@ use lending_iterator::LendingIterator;
 use resource::{
     constants::snapshot::{BUFFER_KEY_INLINE, BUFFER_VALUE_INLINE},
     profile::{CommitProfile, StorageCounters},
+    state_counter::{CounterId, StateCounters},
 };
 
 use crate::{
@@ -106,6 +107,8 @@ pub trait WritableSnapshot: ReadableSnapshot {
     fn operations(&self) -> &OperationsBuffer;
 
     fn operations_mut(&mut self) -> &mut OperationsBuffer;
+
+    fn allocate_counter(&mut self, id: CounterId) -> u64;
 
     /// Insert a key with a new version
     fn insert(&mut self, key: StorageKeyArray<BUFFER_KEY_INLINE>) {
@@ -231,7 +234,8 @@ impl<D: fmt::Debug> fmt::Debug for ReadSnapshot<D> {
 impl<D> ReadSnapshot<D> {
     pub(crate) fn new(storage: Arc<MVCCStorage<D>>, open_sequence_number: SequenceNumber) -> Self {
         // Note: for serialisability, we would need to register the open transaction to the IsolationManager
-        ReadSnapshot { open_sequence_number, id: SnapshotId::new(), iterator_pool: IteratorPool::new(), storage }
+        let id = SnapshotId::from_number(storage.state_counters().allocate(CounterId::SnapshotId));
+        ReadSnapshot { open_sequence_number, id, iterator_pool: IteratorPool::new(), storage }
     }
 }
 
@@ -317,6 +321,10 @@ pub struct WriteSnapshot<D> {
     iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
     reader_guard: ReaderDropGuard,
+    // TODO: Compress?
+    counters: Arc<StateCounters>,
+    touched_counters: HashSet<CounterId>,
+    preset_counter_advances: Vec<(CounterId, u64)>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
@@ -339,7 +347,11 @@ impl<D> WriteSnapshot<D> {
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
         let id = Some(commit_record.snapshot_id());
-        Self::new(storage, commit_record.into_operations(), open_sequence_number, id)
+        let preset = commit_record.counter_advances().to_vec();
+        let operations = commit_record.into_operations();
+        let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
+        snapshot.preset_counter_advances = preset;
+        snapshot
     }
 
     fn new(
@@ -349,13 +361,18 @@ impl<D> WriteSnapshot<D> {
         id: Option<SnapshotId>,
     ) -> Self {
         let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
+        let counters = storage.state_counters().clone();
+        let (id, touched_counters) = allocate_or_reuse_snapshot_id(&counters, id);
         WriteSnapshot {
             storage,
             operations,
             open_sequence_number,
-            id: id.unwrap_or_else(|| SnapshotId::new()),
+            id,
             iterator_pool: IteratorPool::new(),
             reader_guard,
+            counters,
+            touched_counters,
+            preset_counter_advances: Vec::new(),
         }
     }
 }
@@ -468,6 +485,11 @@ impl<D> WritableSnapshot for WriteSnapshot<D> {
     fn operations_mut(&mut self) -> &mut OperationsBuffer {
         &mut self.operations
     }
+
+    fn allocate_counter(&mut self, id: CounterId) -> u64 {
+        self.touched_counters.insert(id);
+        self.counters.allocate(id)
+    }
 }
 
 impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
@@ -484,8 +506,21 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
     }
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
-        let Self { operations, open_sequence_number, id, reader_guard, iterator_pool: _, storage: _ } = self;
-        (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Data, id))
+        let Self {
+            operations,
+            open_sequence_number,
+            id,
+            reader_guard,
+            counters,
+            touched_counters,
+            preset_counter_advances,
+            iterator_pool: _,
+            storage: _,
+        } = self;
+        let advances = resolve_counter_advances(&counters, touched_counters, preset_counter_advances);
+        let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Data, id);
+        record.set_counter_advances(advances);
+        (reader_guard, record)
     }
 }
 
@@ -496,6 +531,9 @@ pub struct SchemaSnapshot<D> {
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
     reader_guard: ReaderDropGuard,
+    counters: Arc<StateCounters>,
+    touched_counters: HashSet<CounterId>,
+    preset_counter_advances: Vec<(CounterId, u64)>,
 }
 
 impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
@@ -518,7 +556,11 @@ impl<D> SchemaSnapshot<D> {
     pub fn new_with_commit_record(storage: Arc<MVCCStorage<D>>, commit_record: CommitRecord) -> Self {
         let open_sequence_number = commit_record.open_sequence_number();
         let id = Some(commit_record.snapshot_id());
-        Self::new(storage, commit_record.into_operations(), open_sequence_number, id)
+        let preset = commit_record.counter_advances().to_vec();
+        let operations = commit_record.into_operations();
+        let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
+        snapshot.preset_counter_advances = preset;
+        snapshot
     }
 
     fn new(
@@ -528,13 +570,18 @@ impl<D> SchemaSnapshot<D> {
         id: Option<SnapshotId>,
     ) -> Self {
         let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
+        let counters = storage.state_counters().clone();
+        let (id, touched_counters) = allocate_or_reuse_snapshot_id(&counters, id);
         SchemaSnapshot {
             storage,
             operations,
             open_sequence_number,
-            id: id.unwrap_or_else(|| SnapshotId::new()),
+            id,
             iterator_pool: IteratorPool::new(),
             reader_guard,
+            counters,
+            touched_counters,
+            preset_counter_advances: Vec::new(),
         }
     }
 }
@@ -647,6 +694,11 @@ impl<D> WritableSnapshot for SchemaSnapshot<D> {
     fn operations_mut(&mut self) -> &mut OperationsBuffer {
         &mut self.operations
     }
+
+    fn allocate_counter(&mut self, id: CounterId) -> u64 {
+        self.touched_counters.insert(id);
+        self.counters.allocate(id)
+    }
 }
 
 impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
@@ -663,9 +715,49 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
     }
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
-        let Self { operations, open_sequence_number, reader_guard, id, iterator_pool: _, storage: _ } = self;
-        (reader_guard, CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id))
+        let Self {
+            operations,
+            open_sequence_number,
+            reader_guard,
+            id,
+            counters,
+            touched_counters,
+            preset_counter_advances,
+            iterator_pool: _,
+            storage: _,
+        } = self;
+        let advances = resolve_counter_advances(&counters, touched_counters, preset_counter_advances);
+        let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id);
+        record.set_counter_advances(advances);
+        (reader_guard, record)
     }
+}
+
+fn allocate_or_reuse_snapshot_id(
+    counters: &StateCounters,
+    id: Option<SnapshotId>,
+) -> (SnapshotId, HashSet<CounterId>) {
+    match id {
+        Some(id) => (id, HashSet::new()),
+        None => {
+            let value = counters.allocate(CounterId::SnapshotId);
+            let mut touched = HashSet::new();
+            touched.insert(CounterId::SnapshotId);
+            (SnapshotId::from_number(value), touched)
+        }
+    }
+}
+
+fn resolve_counter_advances(
+    counters: &StateCounters,
+    touched: HashSet<CounterId>,
+    preset: Vec<(CounterId, u64)>,
+) -> Vec<(CounterId, u64)> {
+    debug_assert!(touched.is_empty() || preset.is_empty());
+    if !preset.is_empty() {
+        return preset;
+    }
+    touched.into_iter().map(|id| (id, counters.next_value(id))).collect()
 }
 
 typedb_error! {

--- a/storage/snapshot/snapshot.rs
+++ b/storage/snapshot/snapshot.rs
@@ -321,10 +321,7 @@ pub struct WriteSnapshot<D> {
     iterator_pool: IteratorPool, // Pool must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
     reader_guard: ReaderDropGuard,
-    // TODO: Compress?
-    counters: Arc<StateCounters>,
-    touched_counters: HashSet<CounterId>,
-    preset_counter_advances: Vec<(CounterId, u64)>,
+    counters: SnapshotCounters,
 }
 
 impl<D: fmt::Debug> fmt::Debug for WriteSnapshot<D> {
@@ -350,7 +347,7 @@ impl<D> WriteSnapshot<D> {
         let preset = commit_record.counter_advances().to_vec();
         let operations = commit_record.into_operations();
         let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
-        snapshot.preset_counter_advances = preset;
+        snapshot.counters.set_preset_advances(preset);
         snapshot
     }
 
@@ -361,8 +358,8 @@ impl<D> WriteSnapshot<D> {
         id: Option<SnapshotId>,
     ) -> Self {
         let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
-        let counters = storage.state_counters().clone();
-        let (id, touched_counters) = allocate_or_reuse_snapshot_id(&counters, id);
+        let mut counters = SnapshotCounters::new(storage.state_counters().clone());
+        let id = id.unwrap_or_else(|| SnapshotId::from_number(counters.allocate(CounterId::SnapshotId)));
         WriteSnapshot {
             storage,
             operations,
@@ -371,8 +368,6 @@ impl<D> WriteSnapshot<D> {
             iterator_pool: IteratorPool::new(),
             reader_guard,
             counters,
-            touched_counters,
-            preset_counter_advances: Vec::new(),
         }
     }
 }
@@ -487,7 +482,6 @@ impl<D> WritableSnapshot for WriteSnapshot<D> {
     }
 
     fn allocate_counter(&mut self, id: CounterId) -> u64 {
-        self.touched_counters.insert(id);
         self.counters.allocate(id)
     }
 }
@@ -506,20 +500,9 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for WriteSnapshot<D> {
     }
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
-        let Self {
-            operations,
-            open_sequence_number,
-            id,
-            reader_guard,
-            counters,
-            touched_counters,
-            preset_counter_advances,
-            iterator_pool: _,
-            storage: _,
-        } = self;
-        let advances = resolve_counter_advances(&counters, touched_counters, preset_counter_advances);
+        let Self { operations, open_sequence_number, id, reader_guard, counters, iterator_pool: _, storage: _ } = self;
         let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Data, id);
-        record.set_counter_advances(advances);
+        record.set_counter_advances(counters.into_advances());
         (reader_guard, record)
     }
 }
@@ -531,9 +514,7 @@ pub struct SchemaSnapshot<D> {
     iterator_pool: IteratorPool, // Must be declared & dropped before storage
     storage: Arc<MVCCStorage<D>>,
     reader_guard: ReaderDropGuard,
-    counters: Arc<StateCounters>,
-    touched_counters: HashSet<CounterId>,
-    preset_counter_advances: Vec<(CounterId, u64)>,
+    counters: SnapshotCounters,
 }
 
 impl<D: fmt::Debug> fmt::Debug for SchemaSnapshot<D> {
@@ -559,7 +540,7 @@ impl<D> SchemaSnapshot<D> {
         let preset = commit_record.counter_advances().to_vec();
         let operations = commit_record.into_operations();
         let mut snapshot = Self::new(storage, operations, open_sequence_number, id);
-        snapshot.preset_counter_advances = preset;
+        snapshot.counters.set_preset_advances(preset);
         snapshot
     }
 
@@ -570,8 +551,8 @@ impl<D> SchemaSnapshot<D> {
         id: Option<SnapshotId>,
     ) -> Self {
         let reader_guard = storage.isolation_manager.opened_for_read(open_sequence_number);
-        let counters = storage.state_counters().clone();
-        let (id, touched_counters) = allocate_or_reuse_snapshot_id(&counters, id);
+        let mut counters = SnapshotCounters::new(storage.state_counters().clone());
+        let id = id.unwrap_or_else(|| SnapshotId::from_number(counters.allocate(CounterId::SnapshotId)));
         SchemaSnapshot {
             storage,
             operations,
@@ -580,8 +561,6 @@ impl<D> SchemaSnapshot<D> {
             iterator_pool: IteratorPool::new(),
             reader_guard,
             counters,
-            touched_counters,
-            preset_counter_advances: Vec::new(),
         }
     }
 }
@@ -696,7 +675,6 @@ impl<D> WritableSnapshot for SchemaSnapshot<D> {
     }
 
     fn allocate_counter(&mut self, id: CounterId) -> u64 {
-        self.touched_counters.insert(id);
         self.counters.allocate(id)
     }
 }
@@ -715,49 +693,40 @@ impl<D: DurabilityClient> CommittableSnapshot<D> for SchemaSnapshot<D> {
     }
 
     fn into_commit_record(self) -> (ReaderDropGuard, CommitRecord) {
-        let Self {
-            operations,
-            open_sequence_number,
-            reader_guard,
-            id,
-            counters,
-            touched_counters,
-            preset_counter_advances,
-            iterator_pool: _,
-            storage: _,
-        } = self;
-        let advances = resolve_counter_advances(&counters, touched_counters, preset_counter_advances);
+        let Self { operations, open_sequence_number, reader_guard, id, counters, iterator_pool: _, storage: _ } = self;
         let mut record = CommitRecord::new(operations, open_sequence_number, CommitType::Schema, id);
-        record.set_counter_advances(advances);
+        record.set_counter_advances(counters.into_advances());
         (reader_guard, record)
     }
 }
 
-fn allocate_or_reuse_snapshot_id(
-    counters: &StateCounters,
-    id: Option<SnapshotId>,
-) -> (SnapshotId, HashSet<CounterId>) {
-    match id {
-        Some(id) => (id, HashSet::new()),
-        None => {
-            let value = counters.allocate(CounterId::SnapshotId);
-            let mut touched = HashSet::new();
-            touched.insert(CounterId::SnapshotId);
-            (SnapshotId::from_number(value), touched)
-        }
-    }
+struct SnapshotCounters {
+    shared: Arc<StateCounters>,
+    touched: HashSet<CounterId>,
+    preset_advances: Vec<(CounterId, u64)>,
 }
 
-fn resolve_counter_advances(
-    counters: &StateCounters,
-    touched: HashSet<CounterId>,
-    preset: Vec<(CounterId, u64)>,
-) -> Vec<(CounterId, u64)> {
-    debug_assert!(touched.is_empty() || preset.is_empty());
-    if !preset.is_empty() {
-        return preset;
+impl SnapshotCounters {
+    fn new(shared: Arc<StateCounters>) -> Self {
+        Self { shared, touched: HashSet::new(), preset_advances: Vec::new() }
     }
-    touched.into_iter().map(|id| (id, counters.next_value(id))).collect()
+
+    fn allocate(&mut self, id: CounterId) -> u64 {
+        self.touched.insert(id);
+        self.shared.allocate(id)
+    }
+
+    fn set_preset_advances(&mut self, advances: Vec<(CounterId, u64)>) {
+        self.preset_advances = advances;
+    }
+
+    fn into_advances(self) -> Vec<(CounterId, u64)> {
+        debug_assert!(self.touched.is_empty() || self.preset_advances.is_empty());
+        if !self.preset_advances.is_empty() {
+            return self.preset_advances;
+        }
+        self.touched.into_iter().map(|id| (id, self.shared.next_value(id))).collect()
+    }
 }
 
 typedb_error! {

--- a/storage/snapshot/snapshot_id.rs
+++ b/storage/snapshot/snapshot_id.rs
@@ -4,18 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::sync::atomic::{AtomicU64, Ordering};
-
 use serde::{Deserialize, Serialize};
-
-// Safety: this process-local generator produces unique SnapshotIds within a single process
-// lifetime. The (open_sequence_number, snapshot_id) pair used for commit idempotency is unique
-// across process restarts because open_sequence_number advances through WAL replay.
-// Invariants:
-//   - Only one process is responsible for opening committable snapshots at a time
-//   - Committable snapshots always open at the latest WAL sequence number
-//   - Read-only snapshots (possibly at historical positions) do not produce CommitRecords
-static UNIQUE_ID_GEN: AtomicU64 = AtomicU64::new(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SnapshotId {
@@ -25,8 +14,8 @@ pub struct SnapshotId {
 impl SnapshotId {
     pub const UNSET: Self = Self { number: 0 };
 
-    pub fn new() -> Self {
-        Self { number: UNIQUE_ID_GEN.fetch_add(1, Ordering::Relaxed) }
+    pub const fn from_number(number: u64) -> Self {
+        Self { number }
     }
 
     pub fn number(&self) -> u64 {

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -1084,6 +1084,46 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_commits_in_reverse_order_do_not_roll_back_the_counter() {
+        use resource::state_counter::CounterId;
+
+        use crate::snapshot::{CommittableSnapshot, WritableSnapshot};
+
+        test_keyspace_set! { TestKeyspace => 0: "test", }
+        init_logging();
+        let mut profile = CommitProfile::DISABLED;
+
+        let storage_path = create_tmp_storage_dir();
+        let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
+        durability_client.register_record_type::<CommitRecord>();
+        durability_client.register_record_type::<StatusRecord>();
+        let storage = Arc::new(
+            MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
+        );
+
+        let counter = CounterId::EntityVertex { type_id: 11 };
+        let mut s1 = storage.clone().open_snapshot_write();
+        let mut s2 = storage.clone().open_snapshot_write();
+        let a1 = s1.allocate_counter(counter);
+        let a2 = s2.allocate_counter(counter);
+        assert_ne!(a1, a2, "concurrent allocations must be distinct");
+
+        // Real writes so the snapshots are committable (no-op snapshots short-circuit `has_changes`).
+        s1.put(StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"a")));
+        s2.put(StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"b")));
+
+        // Commit in reverse allocation order: s2 first (later allocator), then s1.
+        s2.commit(&mut profile).expect("s2 commit").expect("s2 had changes");
+        s1.commit(&mut profile).expect("s1 commit").expect("s1 had changes");
+
+        let mut s3 = storage.clone().open_snapshot_write();
+        let a3 = s3.allocate_counter(counter);
+        assert!(a3 > a1, "post-commit allocation {a3} must exceed earlier {a1}");
+        assert!(a3 > a2, "post-commit allocation {a3} must exceed earlier {a2}");
+    }
+
+    #[test]
     fn test_mixed_v2_and_v3_commit_records() {
         test_keyspace_set! { TestKeyspace => 0: "test", }
 

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -1048,8 +1048,8 @@ mod tests {
 
     #[test]
     fn snapshot_from_commit_record_preserves_advances() {
-        use resource::state_counter::CounterId;
         use crate::snapshot::CommittableSnapshot;
+        use resource::state_counter::CounterId;
 
         test_keyspace_set! { TestKeyspace => 0: "test", }
         init_logging();
@@ -1069,10 +1069,8 @@ mod tests {
             CommitType::Data,
             SnapshotId::from_number(42),
         );
-        let preset = vec![
-            (CounterId::EntityVertex { type_id: 3 }, 100),
-            (CounterId::RelationVertex { type_id: 4 }, 200),
-        ];
+        let preset =
+            vec![(CounterId::EntityVertex { type_id: 3 }, 100), (CounterId::RelationVertex { type_id: 4 }, 200)];
         incoming.set_counter_advances(preset.clone());
 
         let snapshot = WriteSnapshot::new_with_commit_record(storage.clone(), incoming);
@@ -1140,15 +1138,15 @@ mod tests {
         let mut v2_ops = OperationsBuffer::new();
         v2_ops.writes_in_mut(key_v2.keyspace_id()).insert(key_v2.byte_array().clone(), ByteArray::empty());
         let v2_snapshot_id = SnapshotId::from_number(11);
-        let v2_record =
-            LegacyCommitRecordV2::new(v2_ops, wal_client.previous(), CommitType::Data, v2_snapshot_id);
+        let v2_record = LegacyCommitRecordV2::new(v2_ops, wal_client.previous(), CommitType::Data, v2_snapshot_id);
         wal_client.sequenced_write(&v2_record).unwrap();
 
         // Write a V3 record carrying counter_advances.
         let key_v3 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v3"));
         let mut v3_ops = OperationsBuffer::new();
         v3_ops.writes_in_mut(key_v3.keyspace_id()).insert(key_v3.byte_array().clone(), ByteArray::empty());
-        let mut v3_record = CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::from_number(12));
+        let mut v3_record =
+            CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::from_number(12));
         v3_record.set_counter_advances(vec![
             (resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123),
             (resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456),
@@ -1183,11 +1181,15 @@ mod tests {
         // V3 round-trips advances faithfully.
         let v3_back = &v3_records[0].1;
         assert_eq!(v3_back.counter_advances().len(), 2);
-        assert!(v3_back
-            .counter_advances()
-            .contains(&(resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123)));
-        assert!(v3_back
-            .counter_advances()
-            .contains(&(resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456)));
+        assert!(
+            v3_back
+                .counter_advances()
+                .contains(&(resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123))
+        );
+        assert!(
+            v3_back
+                .counter_advances()
+                .contains(&(resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456))
+        );
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -50,7 +50,7 @@ use crate::{
         IteratorPool, Keyspace, KeyspaceError, KeyspaceId, KeyspaceOpenError, KeyspaceSet, Keyspaces,
         iterator::KeyspaceRangeIterator,
     },
-    record::{CommitRecord, LegacyCommitRecordV1, StatusRecord},
+    record::{CommitRecord, LegacyCommitRecordV1, LegacyCommitRecordV2, StatusRecord},
     recovery::{
         checkpoint::{CheckpointCreateError, CheckpointLoadError, CheckpointReader, CheckpointWriter},
         commit_recovery::{StorageRecoveryError, apply_recovered, load_commit_data_from},
@@ -186,6 +186,7 @@ impl<Durability> MVCCStorage<Durability> {
 
     fn register_durability_record_types(durability_client: &mut impl DurabilityClient) {
         durability_client.register_record_type::<LegacyCommitRecordV1>();
+        durability_client.register_record_type::<LegacyCommitRecordV2>();
         durability_client.register_record_type::<CommitRecord>();
         durability_client.register_record_type::<StatusRecord>();
     }
@@ -799,7 +800,6 @@ mod tests {
                 .insert(key_1.byte_array().clone(), ByteArray::empty());
 
             let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-            durability_client.register_record_type::<LegacyCommitRecordV1>();
             durability_client.register_record_type::<CommitRecord>();
             let seq = durability_client
                 .sequenced_write(&CommitRecord::new(
@@ -823,7 +823,6 @@ mod tests {
         };
 
         let mut durability_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         let storage =
             MVCCStorage::<WALClient>::load::<TestKeyspaceSet>("storage", &storage_path, durability_client, &None)
@@ -846,7 +845,6 @@ mod tests {
 
         let storage_path = create_tmp_storage_dir();
         let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         let storage = Arc::new(
             MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
@@ -962,6 +960,7 @@ mod tests {
 
         let mut wal_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
         wal_client.register_record_type::<LegacyCommitRecordV1>();
+        wal_client.register_record_type::<LegacyCommitRecordV2>();
         wal_client.register_record_type::<CommitRecord>();
         wal_client.register_record_type::<StatusRecord>();
 
@@ -972,10 +971,21 @@ mod tests {
         let legacy_record = LegacyCommitRecordV1::new(legacy_ops, wal_client.previous(), CommitType::Data);
         let legacy_seqnum = wal_client.sequenced_write(&legacy_record).unwrap();
 
+        let key_legacy_2 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"legacy_v2"));
+        let mut legacy_ops_2 = OperationsBuffer::new();
+        legacy_ops_2
+            .writes_in_mut(key_legacy_2.keyspace_id())
+            .insert(key_legacy_2.byte_array().clone(), ByteArray::empty());
+        let legacy_snapshot_id = SnapshotId::from_number(1);
+        let legacy_record_2 =
+            LegacyCommitRecordV2::new(legacy_ops_2, wal_client.previous(), CommitType::Data, legacy_snapshot_id);
+        let legacy_seqnum_2 = wal_client.sequenced_write(&legacy_record_2).unwrap();
+
         // Load WAL back
         drop(wal_client);
         let mut wal_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
         wal_client.register_record_type::<LegacyCommitRecordV1>();
+        wal_client.register_record_type::<LegacyCommitRecordV2>();
         wal_client.register_record_type::<CommitRecord>();
         wal_client.register_record_type::<StatusRecord>();
 
@@ -983,7 +993,7 @@ mod tests {
         let key_new = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"new"));
         let mut new_ops = OperationsBuffer::new();
         new_ops.writes_in_mut(key_new.keyspace_id()).insert(key_new.byte_array().clone(), ByteArray::empty());
-        let new_snapshot_id = SnapshotId::from_number(1);
+        let new_snapshot_id = SnapshotId::from_number(2);
         let new_record =
             CommitRecord::new(new_ops, wal_client.previous(), CommitType::Data, new_snapshot_id, Vec::new());
         let new_seqnum = wal_client.sequenced_write(&new_record).unwrap();
@@ -992,12 +1002,23 @@ mod tests {
 
         // Read both record types back from WAL
         // Legacy records are read as LegacyCommitRecordV1 and can be converted
-        let legacy_records: Vec<_> = wal_client
+        let legacy_records_v1: Vec<_> = wal_client
             .iter_sequenced_type_from::<LegacyCommitRecordV1>(SequenceNumber::MIN)
             .unwrap()
             .collect::<Result<Vec<_>, _>>()
             .unwrap();
-        assert_eq!(legacy_records.len(), 1, "Expected exactly one legacy record");
+        assert_eq!(legacy_records_v1.len(), 1, "Expected exactly one legacy record v1");
+        // Legacy records convert to CommitRecord with UNSET snapshot_id
+        let converted = CommitRecord::from(legacy_records_v1.into_iter().next().unwrap().1);
+        assert_eq!(converted.snapshot_id(), SnapshotId::UNSET);
+
+        let legacy_records_v2: Vec<_> = wal_client
+            .iter_sequenced_type_from::<LegacyCommitRecordV2>(SequenceNumber::MIN)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(legacy_records_v2.len(), 1, "Expected exactly one legacy record v2");
+        assert_eq!(legacy_records_v2[0].1.snapshot_id(), legacy_snapshot_id);
 
         // New records are read as CommitRecord
         let new_records: Vec<_> = wal_client
@@ -1007,10 +1028,6 @@ mod tests {
             .unwrap();
         assert_eq!(new_records.len(), 1, "Expected exactly one new-format record");
         assert_eq!(new_records[0].1.snapshot_id(), new_snapshot_id);
-
-        // Legacy records convert to CommitRecord with UNSET snapshot_id
-        let converted = CommitRecord::from(legacy_records.into_iter().next().unwrap().1);
-        assert_eq!(converted.snapshot_id(), SnapshotId::UNSET);
     }
 
     #[test]
@@ -1024,7 +1041,6 @@ mod tests {
 
         let storage_path = create_tmp_storage_dir();
         let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         durability_client.register_record_type::<StatusRecord>();
         let storage = Arc::new(
@@ -1063,7 +1079,6 @@ mod tests {
 
         let storage_path = create_tmp_storage_dir();
         let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         durability_client.register_record_type::<StatusRecord>();
         let storage = Arc::new(
@@ -1100,7 +1115,6 @@ mod tests {
 
         let storage_path = create_tmp_storage_dir();
         let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
-        durability_client.register_record_type::<LegacyCommitRecordV1>();
         durability_client.register_record_type::<CommitRecord>();
         durability_client.register_record_type::<StatusRecord>();
         let storage = Arc::new(

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -35,6 +35,7 @@ use logger::{error, result::ResultExt};
 use resource::{
     constants::{snapshot::BUFFER_VALUE_INLINE, storage::WATERMARK_WAIT_INTERVAL_MICROSECONDS},
     profile::{CommitProfile, StorageCounters},
+    state_counter::StateCounters,
 };
 use tracing::trace;
 
@@ -81,6 +82,7 @@ pub struct MVCCStorage<Durability> {
     durability_client: Durability,
     isolation_manager: IsolationManager,
     highest_committed_snapshot: AtomicU64,
+    state_counters: Arc<StateCounters>,
 }
 
 impl<Durability> MVCCStorage<Durability> {
@@ -116,6 +118,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
+            state_counters: Arc::new(StateCounters::new()),
         })
     }
 
@@ -177,6 +180,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
+            state_counters: Arc::new(StateCounters::new()),
         })
     }
 
@@ -196,6 +200,10 @@ impl<Durability> MVCCStorage<Durability> {
 
     pub fn durability(&self) -> &Durability {
         &self.durability_client
+    }
+
+    pub fn state_counters(&self) -> &Arc<StateCounters> {
+        &self.state_counters
     }
 
     pub fn durability_mut(&mut self) -> &mut Durability {
@@ -574,6 +582,7 @@ impl<Durability> MVCCStorage<Durability> {
         self.durability_client
             .reset()
             .map_err(|err| StorageResetError::Durability { name: self.name.clone(), typedb_source: err })?;
+        self.state_counters.reset();
         Ok(())
     }
 
@@ -797,7 +806,7 @@ mod tests {
                     full_operations,
                     durability_client.previous(),
                     CommitType::Data,
-                    SnapshotId::new(),
+                    SnapshotId::from_number(1),
                 ))
                 .unwrap();
 
@@ -851,7 +860,7 @@ mod tests {
             snapshot1_operations,
             storage.durability_client.previous(),
             CommitType::Data,
-            SnapshotId::new(),
+            SnapshotId::from_number(1),
         );
         let snapshot_id1 = commit_record1.snapshot_id();
         let seqnum1 = commit_record1.open_sequence_number();
@@ -863,7 +872,7 @@ mod tests {
             snapshot2_operations,
             storage.durability_client.previous(),
             CommitType::Data,
-            SnapshotId::new(),
+            SnapshotId::from_number(2),
         );
         let snapshot_id2 = commit_record2.snapshot_id();
         let seqnum2 = commit_record2.open_sequence_number();
@@ -892,7 +901,7 @@ mod tests {
             snapshot3_operations,
             storage.durability_client.previous(),
             CommitType::Schema,
-            SnapshotId::new(),
+            SnapshotId::from_number(3),
         );
         let snapshot_id3 = commit_record3.snapshot_id();
         let seqnum3 = commit_record3.open_sequence_number();
@@ -969,7 +978,7 @@ mod tests {
         let key_new = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"new"));
         let mut new_ops = OperationsBuffer::new();
         new_ops.writes_in_mut(key_new.keyspace_id()).insert(key_new.byte_array().clone(), ByteArray::empty());
-        let new_snapshot_id = SnapshotId::new();
+        let new_snapshot_id = SnapshotId::from_number(1);
         let new_record = CommitRecord::new(new_ops, wal_client.previous(), CommitType::Data, new_snapshot_id);
         let new_seqnum = wal_client.sequenced_write(&new_record).unwrap();
 
@@ -999,6 +1008,82 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_into_commit_record_resolves_touched_counters_at_commit_time() {
+        use resource::state_counter::CounterId;
+
+        use crate::snapshot::{CommittableSnapshot, WritableSnapshot};
+
+        test_keyspace_set! { TestKeyspace => 0: "test", }
+        init_logging();
+
+        let storage_path = create_tmp_storage_dir();
+        let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
+        durability_client.register_record_type::<CommitRecord>();
+        durability_client.register_record_type::<StatusRecord>();
+        let storage = Arc::new(
+            MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
+        );
+
+        let mut s1 = storage.clone().open_snapshot_write();
+        let mut s2 = storage.clone().open_snapshot_write();
+
+        let a1 = s1.allocate_counter(CounterId::EntityVertex { type_id: 7 });
+        let a2 = s2.allocate_counter(CounterId::EntityVertex { type_id: 7 });
+        let r1 = s1.allocate_counter(CounterId::RelationVertex { type_id: 9 });
+        assert_ne!(a1, a2);
+
+        let (_g2, rec2) = CommittableSnapshot::<WALClient>::into_commit_record(s2);
+        let (_g1, rec1) = CommittableSnapshot::<WALClient>::into_commit_record(s1);
+
+        let find_advance = |rec: &CommitRecord, id: CounterId| -> u64 {
+            rec.counter_advances().iter().find(|(c, _)| *c == id).expect("counter is touched").1
+        };
+        // Both snapshots observe the post-allocation watermark (>=2) at commit time.
+        assert!(find_advance(&rec1, CounterId::EntityVertex { type_id: 7 }) >= 2);
+        assert!(find_advance(&rec2, CounterId::EntityVertex { type_id: 7 }) >= 2);
+        assert_eq!(find_advance(&rec1, CounterId::RelationVertex { type_id: 9 }), r1 + 1);
+        assert!(!rec2.counter_advances().iter().any(|(id, _)| matches!(id, CounterId::RelationVertex { type_id: 9 })));
+    }
+
+    #[test]
+    fn snapshot_from_commit_record_preserves_advances() {
+        use resource::state_counter::CounterId;
+        use crate::snapshot::CommittableSnapshot;
+
+        test_keyspace_set! { TestKeyspace => 0: "test", }
+        init_logging();
+
+        let storage_path = create_tmp_storage_dir();
+        let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
+        durability_client.register_record_type::<CommitRecord>();
+        durability_client.register_record_type::<StatusRecord>();
+        let storage = Arc::new(
+            MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
+        );
+
+        let mut incoming = CommitRecord::new(
+            OperationsBuffer::new(),
+            storage.durability_client.previous(),
+            CommitType::Data,
+            SnapshotId::from_number(42),
+        );
+        let preset = vec![
+            (CounterId::EntityVertex { type_id: 3 }, 100),
+            (CounterId::RelationVertex { type_id: 4 }, 200),
+        ];
+        incoming.set_counter_advances(preset.clone());
+
+        let snapshot = WriteSnapshot::new_with_commit_record(storage.clone(), incoming);
+        let (_g, rebuilt) = CommittableSnapshot::<WALClient>::into_commit_record(snapshot);
+        for entry in &preset {
+            assert!(rebuilt.counter_advances().contains(entry));
+        }
+        assert_eq!(rebuilt.counter_advances().len(), preset.len());
+    }
+
+    #[test]
     fn test_mixed_v2_and_v3_commit_records() {
         test_keyspace_set! { TestKeyspace => 0: "test", }
 
@@ -1014,7 +1099,7 @@ mod tests {
         let key_v2 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v2"));
         let mut v2_ops = OperationsBuffer::new();
         v2_ops.writes_in_mut(key_v2.keyspace_id()).insert(key_v2.byte_array().clone(), ByteArray::empty());
-        let v2_snapshot_id = SnapshotId::new();
+        let v2_snapshot_id = SnapshotId::from_number(11);
         let v2_record =
             LegacyCommitRecordV2::new(v2_ops, wal_client.previous(), CommitType::Data, v2_snapshot_id);
         wal_client.sequenced_write(&v2_record).unwrap();
@@ -1023,7 +1108,7 @@ mod tests {
         let key_v3 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v3"));
         let mut v3_ops = OperationsBuffer::new();
         v3_ops.writes_in_mut(key_v3.keyspace_id()).insert(key_v3.byte_array().clone(), ByteArray::empty());
-        let mut v3_record = CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::new());
+        let mut v3_record = CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::from_number(12));
         v3_record.set_counter_advances(vec![
             (resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123),
             (resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456),

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -742,7 +742,7 @@ mod tests {
         durability_client::{DurabilityClient, WALClient},
         key_value::StorageKeyArray,
         keyspace::{IteratorPool, KeyspaceId, KeyspaceSet, Keyspaces},
-        record::{CommitRecord, CommitType, LegacyCommitRecordV1, StatusRecord},
+        record::{CommitRecord, CommitType, LegacyCommitRecordV1, LegacyCommitRecordV2, StatusRecord},
         sequence_number::SequenceNumber,
         snapshot::{WriteSnapshot, buffer::OperationsBuffer},
         write_batches::WriteBatches,
@@ -996,5 +996,73 @@ mod tests {
         // Legacy records convert to CommitRecord with UNSET snapshot_id
         let converted = CommitRecord::from(legacy_records.into_iter().next().unwrap().1);
         assert_eq!(converted.snapshot_id(), SnapshotId::UNSET);
+    }
+
+    #[test]
+    fn test_mixed_v2_and_v3_commit_records() {
+        test_keyspace_set! { TestKeyspace => 0: "test", }
+
+        init_logging();
+        let storage_path = create_tmp_storage_dir();
+
+        let mut wal_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        wal_client.register_record_type::<LegacyCommitRecordV2>();
+        wal_client.register_record_type::<CommitRecord>();
+        wal_client.register_record_type::<StatusRecord>();
+
+        // Write a V2 record directly to WAL (pre-StateCounter shape).
+        let key_v2 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v2"));
+        let mut v2_ops = OperationsBuffer::new();
+        v2_ops.writes_in_mut(key_v2.keyspace_id()).insert(key_v2.byte_array().clone(), ByteArray::empty());
+        let v2_snapshot_id = SnapshotId::new();
+        let v2_record =
+            LegacyCommitRecordV2::new(v2_ops, wal_client.previous(), CommitType::Data, v2_snapshot_id);
+        wal_client.sequenced_write(&v2_record).unwrap();
+
+        // Write a V3 record carrying counter_advances.
+        let key_v3 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v3"));
+        let mut v3_ops = OperationsBuffer::new();
+        v3_ops.writes_in_mut(key_v3.keyspace_id()).insert(key_v3.byte_array().clone(), ByteArray::empty());
+        let mut v3_record = CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::new());
+        v3_record.set_counter_advances(vec![
+            (resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123),
+            (resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456),
+        ]);
+        wal_client.sequenced_write(&v3_record).unwrap();
+
+        // Reload and read both back.
+        drop(wal_client);
+        let mut wal_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        wal_client.register_record_type::<LegacyCommitRecordV2>();
+        wal_client.register_record_type::<CommitRecord>();
+        wal_client.register_record_type::<StatusRecord>();
+
+        let v2_records: Vec<_> = wal_client
+            .iter_sequenced_type_from::<LegacyCommitRecordV2>(SequenceNumber::MIN)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(v2_records.len(), 1);
+        let v3_records: Vec<_> = wal_client
+            .iter_sequenced_type_from::<CommitRecord>(SequenceNumber::MIN)
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(v3_records.len(), 1);
+
+        // V2 converts cleanly, preserving the snapshot_id, with empty advances.
+        let converted = CommitRecord::from(v2_records.into_iter().next().unwrap().1);
+        assert_eq!(converted.snapshot_id(), v2_snapshot_id);
+        assert!(converted.counter_advances().is_empty());
+
+        // V3 round-trips advances faithfully.
+        let v3_back = &v3_records[0].1;
+        assert_eq!(v3_back.counter_advances().len(), 2);
+        assert!(v3_back
+            .counter_advances()
+            .contains(&(resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123)));
+        assert!(v3_back
+            .counter_advances()
+            .contains(&(resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456)));
     }
 }

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -1048,8 +1048,9 @@ mod tests {
 
     #[test]
     fn snapshot_from_commit_record_preserves_advances() {
-        use crate::snapshot::CommittableSnapshot;
         use resource::state_counter::CounterId;
+
+        use crate::snapshot::CommittableSnapshot;
 
         test_keyspace_set! { TestKeyspace => 0: "test", }
         init_logging();

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -807,6 +807,7 @@ mod tests {
                     durability_client.previous(),
                     CommitType::Data,
                     SnapshotId::from_number(1),
+                    Vec::new(),
                 ))
                 .unwrap();
 
@@ -861,6 +862,7 @@ mod tests {
             storage.durability_client.previous(),
             CommitType::Data,
             SnapshotId::from_number(1),
+            Vec::new(),
         );
         let snapshot_id1 = commit_record1.snapshot_id();
         let seqnum1 = commit_record1.open_sequence_number();
@@ -873,6 +875,7 @@ mod tests {
             storage.durability_client.previous(),
             CommitType::Data,
             SnapshotId::from_number(2),
+            Vec::new(),
         );
         let snapshot_id2 = commit_record2.snapshot_id();
         let seqnum2 = commit_record2.open_sequence_number();
@@ -902,6 +905,7 @@ mod tests {
             storage.durability_client.previous(),
             CommitType::Schema,
             SnapshotId::from_number(3),
+            Vec::new(),
         );
         let snapshot_id3 = commit_record3.snapshot_id();
         let seqnum3 = commit_record3.open_sequence_number();
@@ -927,6 +931,7 @@ mod tests {
             storage.durability_client.previous(),
             CommitType::Schema,
             snapshot_id2,
+            Vec::new(),
         );
         let snapshot_id4 = commit_record4.snapshot_id();
         let seqnum4 = commit_record4.open_sequence_number();
@@ -979,7 +984,8 @@ mod tests {
         let mut new_ops = OperationsBuffer::new();
         new_ops.writes_in_mut(key_new.keyspace_id()).insert(key_new.byte_array().clone(), ByteArray::empty());
         let new_snapshot_id = SnapshotId::from_number(1);
-        let new_record = CommitRecord::new(new_ops, wal_client.previous(), CommitType::Data, new_snapshot_id);
+        let new_record =
+            CommitRecord::new(new_ops, wal_client.previous(), CommitType::Data, new_snapshot_id, Vec::new());
         let new_seqnum = wal_client.sequenced_write(&new_record).unwrap();
 
         assert_ne!(legacy_seqnum, new_seqnum);
@@ -1064,15 +1070,15 @@ mod tests {
             MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client).unwrap(),
         );
 
-        let mut incoming = CommitRecord::new(
+        let preset =
+            vec![(CounterId::EntityVertex { type_id: 3 }, 100), (CounterId::RelationVertex { type_id: 4 }, 200)];
+        let incoming = CommitRecord::new(
             OperationsBuffer::new(),
             storage.durability_client.previous(),
             CommitType::Data,
             SnapshotId::from_number(42),
+            preset.clone(),
         );
-        let preset =
-            vec![(CounterId::EntityVertex { type_id: 3 }, 100), (CounterId::RelationVertex { type_id: 4 }, 200)];
-        incoming.set_counter_advances(preset.clone());
 
         let snapshot = WriteSnapshot::new_with_commit_record(storage.clone(), incoming);
         let (_g, rebuilt) = CommittableSnapshot::<WALClient>::into_commit_record(snapshot);
@@ -1146,12 +1152,16 @@ mod tests {
         let key_v3 = StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"v3"));
         let mut v3_ops = OperationsBuffer::new();
         v3_ops.writes_in_mut(key_v3.keyspace_id()).insert(key_v3.byte_array().clone(), ByteArray::empty());
-        let mut v3_record =
-            CommitRecord::new(v3_ops, wal_client.previous(), CommitType::Data, SnapshotId::from_number(12));
-        v3_record.set_counter_advances(vec![
-            (resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123),
-            (resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456),
-        ]);
+        let v3_record = CommitRecord::new(
+            v3_ops,
+            wal_client.previous(),
+            CommitType::Data,
+            SnapshotId::from_number(12),
+            vec![
+                (resource::state_counter::CounterId::EntityVertex { type_id: 7 }, 123),
+                (resource::state_counter::CounterId::RelationVertex { type_id: 12 }, 456),
+            ],
+        );
         wal_client.sequenced_write(&v3_record).unwrap();
 
         // Reload and read both back.

--- a/storage/storage.rs
+++ b/storage/storage.rs
@@ -146,9 +146,10 @@ impl<Durability> MVCCStorage<Durability> {
         let storage_dir = path.join(Self::STORAGE_DIR_NAME);
 
         Self::register_durability_record_types(&mut durability_client);
+        let state_counters = Arc::new(StateCounters::new());
         let (keyspaces, next_sequence_number) = if let Some(checkpoint) = checkpoint {
             checkpoint
-                .recover_storage::<KS, _>(name, &storage_dir, &durability_client)
+                .recover_storage::<KS, _>(name, &storage_dir, &durability_client, &state_counters)
                 .map_err(|error| RecoverFromCheckpoint { name: name.to_owned(), typedb_source: error })?
         } else {
             match fs::remove_dir_all(&storage_dir) {
@@ -166,7 +167,7 @@ impl<Durability> MVCCStorage<Durability> {
             let commits = load_commit_data_from(SequenceNumber::MIN.next(), &durability_client)
                 .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
             let next_sequence_number = commits.keys().max().cloned().unwrap_or(SequenceNumber::MIN).next();
-            apply_recovered(name, commits, &durability_client, &keyspaces)
+            apply_recovered(name, commits, &durability_client, &keyspaces, &state_counters)
                 .map_err(|err| RecoverFromDurability { name: name.to_owned(), typedb_source: err })?;
             trace!("Finished applying commits from WAL.");
             (keyspaces, next_sequence_number)
@@ -180,7 +181,7 @@ impl<Durability> MVCCStorage<Durability> {
             keyspaces,
             isolation_manager,
             highest_committed_snapshot: AtomicU64::new(next_sequence_number.number() - 1),
-            state_counters: Arc::new(StateCounters::new()),
+            state_counters,
         })
     }
 
@@ -1140,6 +1141,71 @@ mod tests {
         let a3 = s3.allocate_counter(counter);
         assert!(a3 > a1, "post-commit allocation {a3} must exceed earlier {a1}");
         assert!(a3 > a2, "post-commit allocation {a3} must exceed earlier {a2}");
+    }
+
+    #[test]
+    fn state_counters_are_seeded_from_wal_during_recovery() {
+        use resource::state_counter::CounterId;
+
+        use crate::snapshot::{CommittableSnapshot, WritableSnapshot};
+
+        test_keyspace_set! { TestKeyspace => 0: "test", }
+        init_logging();
+        let mut profile = CommitProfile::DISABLED;
+
+        let storage_path = create_tmp_storage_dir();
+        let entity_counter = CounterId::EntityVertex { type_id: 13 };
+
+        // Allocate and commit some IIDs through the normal snapshot path, capturing
+        // both the entity-IID watermark and the SnapshotId watermark observed at commit time.
+        let (entity_watermark, snapshot_id_watermark) = {
+            let mut durability_client = WALClient::new(WAL::create(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+            durability_client.register_record_type::<LegacyCommitRecordV1>();
+            durability_client.register_record_type::<LegacyCommitRecordV2>();
+            durability_client.register_record_type::<CommitRecord>();
+            durability_client.register_record_type::<StatusRecord>();
+            let storage = Arc::new(
+                MVCCStorage::<WALClient>::create::<TestKeyspaceSet>("storage", &storage_path, durability_client)
+                    .unwrap(),
+            );
+            let mut snapshot = storage.clone().open_snapshot_write();
+            for _ in 0..7 {
+                snapshot.allocate_counter(entity_counter);
+            }
+            // Add a real write so the commit isn't a no-op (otherwise has_changes short-circuits).
+            snapshot.put(StorageKeyArray::from((TestKeyspaceSet::TestKeyspace, b"sentinel".as_slice())));
+            let snapshot_id_at_commit = storage.state_counters().next_value(CounterId::SnapshotId);
+            let entity_at_commit = storage.state_counters().next_value(entity_counter);
+            snapshot.commit(&mut profile).expect("commit").expect("had changes");
+            (entity_at_commit, snapshot_id_at_commit)
+        };
+        assert!(entity_watermark >= 7);
+        assert!(snapshot_id_watermark >= 1);
+
+        // Now "restart": load fresh storage from the WAL.
+        let mut durability_client = WALClient::new(WAL::load(storage_path.join(WAL::WAL_DIR_NAME)).unwrap());
+        durability_client.register_record_type::<LegacyCommitRecordV1>();
+        durability_client.register_record_type::<LegacyCommitRecordV2>();
+        durability_client.register_record_type::<CommitRecord>();
+        durability_client.register_record_type::<StatusRecord>();
+        let reloaded = Arc::new(
+            MVCCStorage::<WALClient>::load::<TestKeyspaceSet>("storage", &storage_path, durability_client, &None)
+                .unwrap(),
+        );
+
+        // After recovery, state_counters must be >= the watermarks recorded before restart.
+        // (Storage-scan seeding is performed by ThingVertexGenerator on the Database side,
+        // so for raw MVCCStorage we rely solely on WAL counter_advances here)
+        assert_eq!(
+            reloaded.state_counters().next_value(entity_counter),
+            entity_watermark,
+            "entity counter must be restored from WAL counter_advances"
+        );
+        assert_eq!(
+            reloaded.state_counters().next_value(CounterId::SnapshotId),
+            snapshot_id_watermark,
+            "SnapshotId must be restored from WAL counter_advances"
+        );
     }
 
     #[test]

--- a/storage/tests/test_utils_storage/mock_snapshot.rs
+++ b/storage/tests/test_utils_storage/mock_snapshot.rs
@@ -4,7 +4,10 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-use std::iter::empty;
+use std::{
+    iter::empty,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 use bytes::byte_array::ByteArray;
 use resource::profile::StorageCounters;
@@ -26,7 +29,9 @@ pub struct MockSnapshot {
 
 impl MockSnapshot {
     pub fn new() -> Self {
-        Self { id: SnapshotId::new(), iterator_pool: IteratorPool::default() }
+        static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+        let id = SnapshotId::from_number(NEXT_ID.fetch_add(1, Ordering::Relaxed));
+        Self { id, iterator_pool: IteratorPool::default() }
     }
 }
 


### PR DESCRIPTION
## Product change and motivation

Introduce a small set of state counters that ride alongside every `CommitRecord` and are preserved in the storage and replicated between nodes of a distributed cluster to ensure the synchronization of these counters between any possible primary node. 

**This change makes the storage not forward-compatible, making it unable to downgrade the server version with new WAL records from this commit.**

## Implementation

### Locally generated counters analysis

**State counters:**
* Entity / Relation IIDs per `type_id`: generated locally, `fetch_add` value is encoded directly into the entity vertex on disk. Require replication so every new leader replica knows about the previous values.
* `SnapshotId`: Part of the `(open_seq, snapshot_id)` commit-idempotency key. Currently, their replication is not required, but it is a nice protective measure in case some of the invariants break. Now, `SnapshotId`s are unique even if you use an `open_seq` from the past.

**Not state counters:**
* Attribute IDs: content-derived based on the value, not a server state.
* TypeIDs and struct/function keys: allocators scan the storage for the first unused ID, so they do not require a separate state.
* WAL seqnum-based numbers: not a separately generated state.

State counters are saved in `CommitRecord`s so they could be shared with other replicas on commit and restored on load. **This leads to the following expectation:** The state must be restored, and since it's in the WAL, the WAL must contain all the recent counter updates. We may need to put these counters into the storage separately if we consider introducing WAL truncation.

**Important**: legacy commit records do not contain entity/relation IID values, so they still must check the storage for their values.

Also, for simplification, counters are updated regardless of the state of concurrent snapshots. E.g.:
1. You open Tx1, Tx2, and Tx3.
2. Tx1 inserts data
3. Tx2 inserts data
4. Tx2 commits data
5. Tx3 inserts data
6. Tx1 commits data
7. Tx3 closes

In the end, the state will have the counters INCLUDING TX3, because Tx1's commit will use Tx3 updates. This is simple and safe, and we must have enough counters to support this mechanism.

### Architecture

- Introduce a new `CommitRecord` of version 3 to store the state counters.
- `resource::state_counter` introduces `CounterId` (the wire-format discriminator, bincode-serialized) and `StateCounters` (the per-database backing store). `StateCounters` is composed of two small inner types: `PerTypeIdCounters` (dense `Box<[AtomicU64]>` indexed by `TypeIDUInt`) for the IID counters, and `GlobalCounter` for single-valued counters like `SnapshotId`.
- `MVCCStorage` owns the `Arc<StateCounters>` and exposes it via `state_counters()`. `Database::apply_counter_advances` is the replica's catch-up hook.
- Snapshots now hold a new `SnapshotCounters` struct consisting of an `Arc<StateCounters>`, a `HashSet<CounterId>` of touched counters, and a preset advances vector (non-empty only when the snapshot was reconstructed from an incoming `CommitRecord`). `WritableSnapshot::allocate_counter` is the single allocation entry point.
- At commit time, `SnapshotCounters::into_advances` reads each touched counter's *live* `next_value` and stamps `Vec<(CounterId, u64)>` onto the `CommitRecord` (a vector for serializability).
- `ThingVertexGenerator` no longer owns atomics: `create_entity` / `create_relation` route through `snapshot.allocate_counter`. `Database::load` respects the new structure as well.

`apply_counter_advances` uses `fetch_max`, so order (tx1 can allocate counters before tx2, but get committed after tx2) doesn't matter.

Used in https://github.com/typedb/typedb-cluster/pull/691

